### PR TITLE
Udp client timeout issue

### DIFF
--- a/src/test/java/org/jboss/netty/channel/socket/nio/NioDatagramChannelTest.java
+++ b/src/test/java/org/jboss/netty/channel/socket/nio/NioDatagramChannelTest.java
@@ -112,7 +112,7 @@ public class NioDatagramChannelTest {
         assertFalse("The payload should have been cleared", expectedPayload
                 .equals(new String(dp.getData())));
 
-        udpClient.receive(dp);
+        udpClient.receive(dp, 4000);
 
         assertEquals(expectedPayload, new String(dp.getData()));
         udpClient.close();

--- a/src/test/java/org/jboss/netty/channel/socket/nio/UdpClient.java
+++ b/src/test/java/org/jboss/netty/channel/socket/nio/UdpClient.java
@@ -48,7 +48,8 @@ public class UdpClient {
         return dp;
     }
 
-    public void receive(final DatagramPacket dp) throws IOException {
+    public void receive(final DatagramPacket dp, final int timeout) throws IOException {
+        clientSocket.setSoTimeout(timeout);
         clientSocket.receive(dp);
     }
 


### PR DESCRIPTION
I noticed an issue when running the cobertura code coverage plugin from within Eclipse. I was experiencing that that the test blocked (when running all tests) on the method sendReciveMultiple. Adding a timeout to the UdpClient's receive method to make sure that this method does not block for ever. 
