### PR TITLE
Use safe-construction when calling fireChannelOpen()

### DIFF
--- a/src/main/java/org/jboss/netty/channel/local/DefaultLocalChannel.java
+++ b/src/main/java/org/jboss/netty/channel/local/DefaultLocalChannel.java
@@ -59,7 +59,16 @@ final class DefaultLocalChannel extends AbstractChannel implements LocalChannel 
     volatile LocalAddress localAddress;
     volatile LocalAddress remoteAddress;
 
-    DefaultLocalChannel(LocalServerChannel parent, ChannelFactory factory, ChannelPipeline pipeline, ChannelSink sink, DefaultLocalChannel pairedChannel) {
+    static DefaultLocalChannel create(LocalServerChannel parent,
+            ChannelFactory factory, ChannelPipeline pipeline, ChannelSink sink,
+            DefaultLocalChannel pairedChannel) {
+        DefaultLocalChannel instance = new DefaultLocalChannel(parent, factory, pipeline, sink,
+                        pairedChannel);
+        fireChannelOpen(instance);
+        return instance;
+    }
+
+    private DefaultLocalChannel(LocalServerChannel parent, ChannelFactory factory, ChannelPipeline pipeline, ChannelSink sink, DefaultLocalChannel pairedChannel) {
         super(parent, factory, pipeline, sink);
         this.pairedChannel = pairedChannel;
         config = new DefaultChannelConfig();
@@ -73,7 +82,6 @@ final class DefaultLocalChannel extends AbstractChannel implements LocalChannel 
             }
         });
 
-        fireChannelOpen(this);
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/local/DefaultLocalClientChannelFactory.java
+++ b/src/main/java/org/jboss/netty/channel/local/DefaultLocalClientChannelFactory.java
@@ -41,7 +41,7 @@ public class DefaultLocalClientChannelFactory implements LocalClientChannelFacto
 
     @Override
     public LocalChannel newChannel(ChannelPipeline pipeline) {
-        return new DefaultLocalChannel(null, this, pipeline, sink, null);
+        return DefaultLocalChannel.create(null, this, pipeline, sink, null);
     }
 
     /**

--- a/src/main/java/org/jboss/netty/channel/local/DefaultLocalServerChannel.java
+++ b/src/main/java/org/jboss/netty/channel/local/DefaultLocalServerChannel.java
@@ -32,17 +32,27 @@ import org.jboss.netty.channel.DefaultServerChannelConfig;
  * @author <a href="http://gleamynode.net/">Trustin Lee</a>
  * @version $Rev$, $Date$
  */
-final class DefaultLocalServerChannel extends AbstractServerChannel
-                                      implements LocalServerChannel {
+final class DefaultLocalServerChannel extends AbstractServerChannel implements
+        LocalServerChannel {
 
     final ChannelConfig channelConfig;
+
     final AtomicBoolean bound = new AtomicBoolean();
+
     volatile LocalAddress localAddress;
 
-    DefaultLocalServerChannel(ChannelFactory factory, ChannelPipeline pipeline, ChannelSink sink) {
+    static DefaultLocalServerChannel create(ChannelFactory factory,
+            ChannelPipeline pipeline, ChannelSink sink) {
+        DefaultLocalServerChannel instance =
+                new DefaultLocalServerChannel(factory, pipeline, sink);
+        fireChannelOpen(instance);
+        return instance;
+    }
+
+    private DefaultLocalServerChannel(ChannelFactory factory,
+            ChannelPipeline pipeline, ChannelSink sink) {
         super(factory, pipeline, sink);
         channelConfig = new DefaultServerChannelConfig();
-        fireChannelOpen(this);
     }
 
     @Override
@@ -57,7 +67,7 @@ final class DefaultLocalServerChannel extends AbstractServerChannel
 
     @Override
     public LocalAddress getLocalAddress() {
-        return isBound()? localAddress : null;
+        return isBound() ? localAddress : null;
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/local/DefaultLocalServerChannelFactory.java
+++ b/src/main/java/org/jboss/netty/channel/local/DefaultLocalServerChannelFactory.java
@@ -41,7 +41,7 @@ public class DefaultLocalServerChannelFactory implements LocalServerChannelFacto
 
     @Override
     public LocalServerChannel newChannel(ChannelPipeline pipeline) {
-        return new DefaultLocalServerChannel(this, pipeline, sink);
+        return DefaultLocalServerChannel.create(this, pipeline, sink);
     }
 
     /**

--- a/src/main/java/org/jboss/netty/channel/local/LocalClientChannelSink.java
+++ b/src/main/java/org/jboss/netty/channel/local/LocalClientChannelSink.java
@@ -128,8 +128,7 @@ final class LocalClientChannelSink extends AbstractChannelSink {
         }
 
         future.setSuccess();
-        DefaultLocalChannel acceptedChannel = new DefaultLocalChannel(
-                serverChannel, serverChannel.getFactory(), pipeline, this, channel);
+        DefaultLocalChannel acceptedChannel = DefaultLocalChannel.create(serverChannel, serverChannel.getFactory(), pipeline, this, channel);
         channel.pairedChannel = acceptedChannel;
 
         bind(channel, succeededFuture(channel), new LocalAddress(LocalAddress.EPHEMERAL));

--- a/src/main/java/org/jboss/netty/channel/socket/http/HttpTunnelAcceptedChannel.java
+++ b/src/main/java/org/jboss/netty/channel/socket/http/HttpTunnelAcceptedChannel.java
@@ -42,13 +42,27 @@ import org.jboss.netty.channel.socket.SocketChannelConfig;
  */
 class HttpTunnelAcceptedChannel extends AbstractChannel implements
         SocketChannel, HttpTunnelAcceptedChannelReceiver {
+
     private final HttpTunnelAcceptedChannelConfig config;
 
     private final HttpTunnelAcceptedChannelSink sink;
 
     private final InetSocketAddress remoteAddress;
 
-    protected HttpTunnelAcceptedChannel(HttpTunnelServerChannel parent,
+    protected static HttpTunnelAcceptedChannel create(
+            HttpTunnelServerChannel parent, ChannelFactory factory,
+            ChannelPipeline pipeline, HttpTunnelAcceptedChannelSink sink,
+            InetSocketAddress remoteAddress,
+            HttpTunnelAcceptedChannelConfig config) {
+        HttpTunnelAcceptedChannel instance = new HttpTunnelAcceptedChannel(parent, factory, pipeline, sink,
+                        remoteAddress, config);
+        fireChannelOpen(instance);
+        fireChannelBound(instance, instance.getLocalAddress());
+        fireChannelConnected(instance, instance.getRemoteAddress());
+        return instance;
+    }
+
+    private HttpTunnelAcceptedChannel(HttpTunnelServerChannel parent,
             ChannelFactory factory, ChannelPipeline pipeline,
             HttpTunnelAcceptedChannelSink sink,
             InetSocketAddress remoteAddress,
@@ -57,9 +71,6 @@ class HttpTunnelAcceptedChannel extends AbstractChannel implements
         this.config = config;
         this.sink = sink;
         this.remoteAddress = remoteAddress;
-        fireChannelOpen(this);
-        fireChannelBound(this, getLocalAddress());
-        fireChannelConnected(this, getRemoteAddress());
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/socket/http/HttpTunnelClientChannel.java
+++ b/src/main/java/org/jboss/netty/channel/socket/http/HttpTunnelClientChannel.java
@@ -73,10 +73,20 @@ public class HttpTunnelClientChannel extends AbstractChannel implements
 
     private final SaturationManager saturationManager;
 
+    protected static HttpTunnelClientChannel create(ChannelFactory factory,
+            ChannelPipeline pipeline, HttpTunnelClientChannelSink sink,
+            ClientSocketChannelFactory outboundFactory,
+            ChannelGroup realConnections) {
+        HttpTunnelClientChannel instance = new HttpTunnelClientChannel(factory, pipeline, sink,
+                        outboundFactory, realConnections);
+        Channels.fireChannelOpen(instance);
+        return instance;
+    }
+
     /**
      * @see HttpTunnelClientChannelFactory#newChannel(ChannelPipeline)
      */
-    protected HttpTunnelClientChannel(ChannelFactory factory,
+    private HttpTunnelClientChannel(ChannelFactory factory,
             ChannelPipeline pipeline, HttpTunnelClientChannelSink sink,
             ClientSocketChannelFactory outboundFactory,
             ChannelGroup realConnections) {
@@ -97,7 +107,6 @@ public class HttpTunnelClientChannel extends AbstractChannel implements
         realConnections.add(sendChannel);
         realConnections.add(pollChannel);
 
-        Channels.fireChannelOpen(this);
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/socket/http/HttpTunnelClientChannelFactory.java
+++ b/src/main/java/org/jboss/netty/channel/socket/http/HttpTunnelClientChannelFactory.java
@@ -43,8 +43,8 @@ public class HttpTunnelClientChannelFactory implements
 
     @Override
     public HttpTunnelClientChannel newChannel(ChannelPipeline pipeline) {
-        return new HttpTunnelClientChannel(this, pipeline,
-                new HttpTunnelClientChannelSink(), factory, realConnections);
+        return HttpTunnelClientChannel.create(this, pipeline, new HttpTunnelClientChannelSink(), factory,
+                realConnections);
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/socket/http/HttpTunnelServerChannel.java
+++ b/src/main/java/org/jboss/netty/channel/socket/http/HttpTunnelServerChannel.java
@@ -49,18 +49,25 @@ public class HttpTunnelServerChannel extends AbstractServerChannel implements
                 }
             };
 
-    protected HttpTunnelServerChannel(HttpTunnelServerChannelFactory factory,
+    protected static HttpTunnelServerChannel create(
+            HttpTunnelServerChannelFactory factory, ChannelPipeline pipeline) {
+        HttpTunnelServerChannel instance = new HttpTunnelServerChannel(factory, pipeline);
+        Channels.fireChannelOpen(instance);
+        return instance;
+    }
+
+    private HttpTunnelServerChannel(HttpTunnelServerChannelFactory factory,
             ChannelPipeline pipeline) {
         super(factory, pipeline, new HttpTunnelServerChannelSink());
 
         messageSwitch = new ServerMessageSwitch(new TunnelCreator());
         realChannel = factory.createRealChannel(this, messageSwitch);
+        // TODO fix calling of overrideable getPipeline() from constructor
         HttpTunnelServerChannelSink sink =
                 (HttpTunnelServerChannelSink) getPipeline().getSink();
         sink.setRealChannel(realChannel);
         sink.setCloseListener(CLOSE_FUTURE_PROXY);
         config = new HttpTunnelServerChannelConfig(realChannel);
-        Channels.fireChannelOpen(this);
     }
 
     @Override
@@ -114,8 +121,8 @@ public class HttpTunnelServerChannel extends AbstractServerChannel implements
             HttpTunnelAcceptedChannelSink sink =
                     new HttpTunnelAcceptedChannelSink(messageSwitch,
                             newTunnelId, config);
-            return new HttpTunnelAcceptedChannel(HttpTunnelServerChannel.this,
-                    getFactory(), childPipeline, sink, remoteAddress, config);
+            return HttpTunnelAcceptedChannel.create(HttpTunnelServerChannel.this, getFactory(), childPipeline, sink,
+                    remoteAddress, config);
         }
 
         @Override

--- a/src/main/java/org/jboss/netty/channel/socket/http/HttpTunnelServerChannelFactory.java
+++ b/src/main/java/org/jboss/netty/channel/socket/http/HttpTunnelServerChannelFactory.java
@@ -42,7 +42,7 @@ public class HttpTunnelServerChannelFactory implements
 
     @Override
     public HttpTunnelServerChannel newChannel(ChannelPipeline pipeline) {
-        return new HttpTunnelServerChannel(this, pipeline);
+        return HttpTunnelServerChannel.create(this, pipeline);
     }
 
     ServerSocketChannel createRealChannel(HttpTunnelServerChannel channel,

--- a/src/main/java/org/jboss/netty/channel/socket/nio/NioAcceptedSocketChannel.java
+++ b/src/main/java/org/jboss/netty/channel/socket/nio/NioAcceptedSocketChannel.java
@@ -36,7 +36,20 @@ final class NioAcceptedSocketChannel extends NioSocketChannel {
 
     final Thread bossThread;
 
-    NioAcceptedSocketChannel(
+    static NioAcceptedSocketChannel create(ChannelFactory factory,
+            ChannelPipeline pipeline, Channel parent, ChannelSink sink,
+            SocketChannel socket, NioWorker worker, Thread bossThread) {
+        NioAcceptedSocketChannel instance =
+                new NioAcceptedSocketChannel(factory, pipeline, parent, sink,
+                        socket, worker, bossThread);
+        instance.setConnected();
+        fireChannelOpen(instance);
+        fireChannelBound(instance, instance.getLocalAddress());
+        fireChannelConnected(instance, instance.getRemoteAddress());
+        return instance;
+    }
+
+    private NioAcceptedSocketChannel(
             ChannelFactory factory, ChannelPipeline pipeline,
             Channel parent, ChannelSink sink,
             SocketChannel socket, NioWorker worker, Thread bossThread) {
@@ -44,10 +57,5 @@ final class NioAcceptedSocketChannel extends NioSocketChannel {
         super(parent, factory, pipeline, sink, socket, worker);
 
         this.bossThread = bossThread;
-
-        setConnected();
-        fireChannelOpen(this);
-        fireChannelBound(this, getLocalAddress());
-        fireChannelConnected(this, getRemoteAddress());
     }
 }

--- a/src/main/java/org/jboss/netty/channel/socket/nio/NioClientSocketChannel.java
+++ b/src/main/java/org/jboss/netty/channel/socket/nio/NioClientSocketChannel.java
@@ -76,11 +76,18 @@ final class NioClientSocketChannel extends NioSocketChannel {
     // Does not need to be volatile as it's accessed by only one thread.
     long connectDeadlineNanos;
 
-    NioClientSocketChannel(
+    static NioClientSocketChannel create(ChannelFactory factory,
+            ChannelPipeline pipeline, ChannelSink sink, NioWorker worker) {
+        NioClientSocketChannel instance =
+                new NioClientSocketChannel(factory, pipeline, sink, worker);
+        fireChannelOpen(instance);
+        return instance;
+    }
+
+    private NioClientSocketChannel(
             ChannelFactory factory, ChannelPipeline pipeline,
             ChannelSink sink, NioWorker worker) {
 
         super(null, factory, pipeline, sink, newSocket(), worker);
-        fireChannelOpen(this);
     }
 }

--- a/src/main/java/org/jboss/netty/channel/socket/nio/NioClientSocketChannelFactory.java
+++ b/src/main/java/org/jboss/netty/channel/socket/nio/NioClientSocketChannelFactory.java
@@ -137,7 +137,7 @@ public class NioClientSocketChannelFactory implements ClientSocketChannelFactory
 
     @Override
     public SocketChannel newChannel(ChannelPipeline pipeline) {
-        return new NioClientSocketChannel(this, pipeline, sink, sink.nextWorker());
+        return NioClientSocketChannel.create(this, pipeline, sink, sink.nextWorker());
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/src/main/java/org/jboss/netty/channel/socket/nio/NioDatagramChannel.java
@@ -119,15 +119,21 @@ class NioDatagramChannel extends AbstractChannel
     private volatile InetSocketAddress localAddress;
     volatile InetSocketAddress remoteAddress;
 
-    NioDatagramChannel(final ChannelFactory factory,
+    static NioDatagramChannel create(ChannelFactory factory,
+            ChannelPipeline pipeline, ChannelSink sink, NioDatagramWorker worker) {
+        NioDatagramChannel instance =
+                new NioDatagramChannel(factory, pipeline, sink, worker);
+        fireChannelOpen(instance);
+        return instance;
+    }
+
+    private NioDatagramChannel(final ChannelFactory factory,
             final ChannelPipeline pipeline, final ChannelSink sink,
             final NioDatagramWorker worker) {
         super(null, factory, pipeline, sink);
         this.worker = worker;
         datagramChannel = openNonBlockingChannel();
         config = new DefaultNioDatagramChannelConfig(datagramChannel.socket());
-
-        fireChannelOpen(this);
     }
 
     private DatagramChannel openNonBlockingChannel() {

--- a/src/main/java/org/jboss/netty/channel/socket/nio/NioDatagramChannelFactory.java
+++ b/src/main/java/org/jboss/netty/channel/socket/nio/NioDatagramChannelFactory.java
@@ -125,7 +125,7 @@ public class NioDatagramChannelFactory implements DatagramChannelFactory {
 
     @Override
     public DatagramChannel newChannel(final ChannelPipeline pipeline) {
-        return new NioDatagramChannel(this, pipeline, sink, sink.nextWorker());
+        return NioDatagramChannel.create(this, pipeline, sink, sink.nextWorker());
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/socket/nio/NioServerSocketChannel.java
+++ b/src/main/java/org/jboss/netty/channel/socket/nio/NioServerSocketChannel.java
@@ -53,7 +53,15 @@ class NioServerSocketChannel extends AbstractServerChannel
     volatile Selector selector;
     private final ServerSocketChannelConfig config;
 
-    NioServerSocketChannel(
+    static NioServerSocketChannel create(ChannelFactory factory,
+            ChannelPipeline pipeline, ChannelSink sink) {
+        NioServerSocketChannel instance =
+                new NioServerSocketChannel(factory, pipeline, sink);
+        fireChannelOpen(instance);
+        return instance;
+    }
+
+    private NioServerSocketChannel(
             ChannelFactory factory,
             ChannelPipeline pipeline,
             ChannelSink sink) {
@@ -81,8 +89,6 @@ class NioServerSocketChannel extends AbstractServerChannel
         }
 
         config = new DefaultServerSocketChannelConfig(socket.socket());
-
-        fireChannelOpen(this);
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/socket/nio/NioServerSocketChannelFactory.java
+++ b/src/main/java/org/jboss/netty/channel/socket/nio/NioServerSocketChannelFactory.java
@@ -140,7 +140,7 @@ public class NioServerSocketChannelFactory implements ServerSocketChannelFactory
 
     @Override
     public ServerSocketChannel newChannel(ChannelPipeline pipeline) {
-        return new NioServerSocketChannel(this, pipeline, sink);
+        return NioServerSocketChannel.create(this, pipeline, sink);
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/socket/nio/NioServerSocketPipelineSink.java
+++ b/src/main/java/org/jboss/netty/channel/socket/nio/NioServerSocketPipelineSink.java
@@ -271,10 +271,8 @@ class NioServerSocketPipelineSink extends AbstractChannelSink {
                 ChannelPipeline pipeline =
                     channel.getConfig().getPipelineFactory().getPipeline();
                 NioWorker worker = nextWorker();
-                worker.register(new NioAcceptedSocketChannel(
-                        channel.getFactory(), pipeline, channel,
-                        NioServerSocketPipelineSink.this, acceptedSocket,
-                        worker, currentThread), null);
+                worker.register(NioAcceptedSocketChannel.create(channel.getFactory(), pipeline, channel,
+                        NioServerSocketPipelineSink.this, acceptedSocket, worker, currentThread), null);
             } catch (Exception e) {
                 logger.warn(
                         "Failed to initialize an accepted socket.", e);

--- a/src/main/java/org/jboss/netty/channel/socket/oio/OioAcceptedSocketChannel.java
+++ b/src/main/java/org/jboss/netty/channel/socket/oio/OioAcceptedSocketChannel.java
@@ -41,7 +41,19 @@ class OioAcceptedSocketChannel extends OioSocketChannel {
     private final PushbackInputStream in;
     private final OutputStream out;
 
-    OioAcceptedSocketChannel(
+    static OioAcceptedSocketChannel create(Channel parent,
+            ChannelFactory factory, ChannelPipeline pipeline, ChannelSink sink,
+            Socket socket) {
+        OioAcceptedSocketChannel instance =
+                new OioAcceptedSocketChannel(parent, factory, pipeline, sink,
+                        socket);
+        fireChannelOpen(instance);
+        fireChannelBound(instance, instance.getLocalAddress());
+        fireChannelConnected(instance, instance.getRemoteAddress());
+        return instance;
+    }
+
+    private OioAcceptedSocketChannel(
             Channel parent,
             ChannelFactory factory,
             ChannelPipeline pipeline,
@@ -60,10 +72,6 @@ class OioAcceptedSocketChannel extends OioSocketChannel {
         } catch (IOException e) {
             throw new ChannelException("Failed to obtain an OutputStream.", e);
         }
-
-        fireChannelOpen(this);
-        fireChannelBound(this, getLocalAddress());
-        fireChannelConnected(this, getRemoteAddress());
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/socket/oio/OioClientSocketChannel.java
+++ b/src/main/java/org/jboss/netty/channel/socket/oio/OioClientSocketChannel.java
@@ -38,14 +38,20 @@ class OioClientSocketChannel extends OioSocketChannel {
     volatile PushbackInputStream in;
     volatile OutputStream out;
 
-    OioClientSocketChannel(
+    static OioClientSocketChannel create(ChannelFactory factory,
+            ChannelPipeline pipeline, ChannelSink sink) {
+        OioClientSocketChannel instance =
+                new OioClientSocketChannel(factory, pipeline, sink);
+        fireChannelOpen(instance);
+        return instance;
+    }
+
+    private OioClientSocketChannel(
             ChannelFactory factory,
             ChannelPipeline pipeline,
             ChannelSink sink) {
 
         super(null, factory, pipeline, sink, new Socket());
-
-        fireChannelOpen(this);
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/socket/oio/OioClientSocketChannelFactory.java
+++ b/src/main/java/org/jboss/netty/channel/socket/oio/OioClientSocketChannelFactory.java
@@ -97,7 +97,7 @@ public class OioClientSocketChannelFactory implements ClientSocketChannelFactory
 
     @Override
     public SocketChannel newChannel(ChannelPipeline pipeline) {
-        return new OioClientSocketChannel(this, pipeline, sink);
+        return OioClientSocketChannel.create(this, pipeline, sink);
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/socket/oio/OioDatagramChannel.java
+++ b/src/main/java/org/jboss/netty/channel/socket/oio/OioDatagramChannel.java
@@ -53,7 +53,15 @@ final class OioDatagramChannel extends AbstractChannel
     private volatile InetSocketAddress localAddress;
     volatile InetSocketAddress remoteAddress;
 
-    OioDatagramChannel(
+    static OioDatagramChannel create(ChannelFactory factory,
+            ChannelPipeline pipeline, ChannelSink sink) {
+        OioDatagramChannel instance =
+                new OioDatagramChannel(factory, pipeline, sink);
+        fireChannelOpen(instance);
+        return instance;
+    }
+
+    private OioDatagramChannel(
             ChannelFactory factory,
             ChannelPipeline pipeline,
             ChannelSink sink) {
@@ -74,8 +82,6 @@ final class OioDatagramChannel extends AbstractChannel
                     "Failed to configure the datagram socket timeout.", e);
         }
         config = new DefaultDatagramChannelConfig(socket);
-
-        fireChannelOpen(this);
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/socket/oio/OioDatagramChannelFactory.java
+++ b/src/main/java/org/jboss/netty/channel/socket/oio/OioDatagramChannelFactory.java
@@ -96,7 +96,7 @@ public class OioDatagramChannelFactory implements DatagramChannelFactory {
 
     @Override
     public DatagramChannel newChannel(ChannelPipeline pipeline) {
-        return new OioDatagramChannel(this, pipeline, sink);
+        return OioDatagramChannel.create(this, pipeline, sink);
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/socket/oio/OioServerSocketChannel.java
+++ b/src/main/java/org/jboss/netty/channel/socket/oio/OioServerSocketChannel.java
@@ -52,7 +52,15 @@ class OioServerSocketChannel extends AbstractServerChannel
     final Lock shutdownLock = new ReentrantLock();
     private final ServerSocketChannelConfig config;
 
-    OioServerSocketChannel(
+    static OioServerSocketChannel create(ChannelFactory factory,
+            ChannelPipeline pipeline, ChannelSink sink) {
+        OioServerSocketChannel instance =
+                new OioServerSocketChannel(factory, pipeline, sink);
+        fireChannelOpen(instance);
+        return instance;
+    }
+
+    private OioServerSocketChannel(
             ChannelFactory factory,
             ChannelPipeline pipeline,
             ChannelSink sink) {
@@ -80,8 +88,6 @@ class OioServerSocketChannel extends AbstractServerChannel
         }
 
         config = new DefaultServerSocketChannelConfig(socket);
-
-        fireChannelOpen(this);
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/socket/oio/OioServerSocketChannelFactory.java
+++ b/src/main/java/org/jboss/netty/channel/socket/oio/OioServerSocketChannelFactory.java
@@ -117,7 +117,7 @@ public class OioServerSocketChannelFactory implements ServerSocketChannelFactory
 
     @Override
     public ServerSocketChannel newChannel(ChannelPipeline pipeline) {
-        return new OioServerSocketChannel(this, pipeline, sink);
+        return OioServerSocketChannel.create(this, pipeline, sink);
     }
 
     @Override

--- a/src/main/java/org/jboss/netty/channel/socket/oio/OioServerSocketPipelineSink.java
+++ b/src/main/java/org/jboss/netty/channel/socket/oio/OioServerSocketPipelineSink.java
@@ -205,12 +205,8 @@ class OioServerSocketPipelineSink extends AbstractChannelSink {
                             ChannelPipeline pipeline =
                                 channel.getConfig().getPipelineFactory().getPipeline();
                             final OioAcceptedSocketChannel acceptedChannel =
-                                new OioAcceptedSocketChannel(
-                                        channel,
-                                        channel.getFactory(),
-                                        pipeline,
-                                        OioServerSocketPipelineSink.this,
-                                        acceptedSocket);
+                                OioAcceptedSocketChannel.create(channel, channel.getFactory(),
+                                    pipeline, OioServerSocketPipelineSink.this, acceptedSocket);
                             DeadLockProofWorker.start(
                                     workerExecutor,
                                     new OioWorker(acceptedChannel));


### PR DESCRIPTION
I noticed that fireChannelOpen(this) is sometimes called from the constructor.  This means that anything listening for this event (e.g., handlers in the pipeline) could see a channel that is not properly constructed.

This is a problem for thread-safety reasons (see Java Concurrency in Practice by Goetz, page 41).  You may have some reasoning as to why this is actually not a problem, but I find it easier just to use a safe construction idiom and not have think about it!

Secondly, this also improves some cases where overrideable methods were being called from the constructor.  This can lead to handlers seeing the channel in a partially constructed state.  This is not just a thread-safety concern.
