### PR TITLE
Prevent exception in HTTP tunnel

### DIFF
--- a/src/main/java/org/jboss/netty/channel/socket/http/ServerMessageSwitch.java
+++ b/src/main/java/org/jboss/netty/channel/socket/http/ServerMessageSwitch.java
@@ -165,7 +165,8 @@ class ServerMessageSwitch implements ServerMessageSwitchUpstreamInterface,
         TunnelInfo tunnel = tunnelsById.get(tunnelId);
         if (tunnel == null) {
             if (LOG.isWarnEnabled()) {
-                LOG.warn("attempt made to close tunnel id " + tunnelId + " which is unknown or closed");
+                LOG.warn("attempt made to close tunnel id " +
+                        tunnelId + " which is unknown or closed");
             }
 
             return;
@@ -180,7 +181,8 @@ class ServerMessageSwitch implements ServerMessageSwitchUpstreamInterface,
         TunnelInfo tunnel = tunnelsById.get(tunnelId);
         if (tunnel == null) {
             if (LOG.isWarnEnabled()) {
-                LOG.warn("attempt made to close tunnel id " + tunnelId + " which is unknown or closed");
+                LOG.warn("attempt made to close tunnel id " +
+                        tunnelId + " which is unknown or closed");
             }
 
             return;


### PR DESCRIPTION
This change prevents a null pointer exception in the HTTP tunnel when attempting to close a channel more than once.
