### PR TITLE
CookieEncoder encode throws StringIndexOutOfBoundsException if no cookie is present

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/CookieEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/CookieEncoder.java
@@ -204,8 +204,9 @@ public class CookieEncoder {
                 }
             }
         }
-
-        sb.setLength(sb.length() - 1);
+        if (sb.length() > 0) {
+            sb.setLength(sb.length() - 1);
+        }
         return sb.toString();
     }
 


### PR DESCRIPTION
If there are no cookie's set, then calling encode() will result in throwing "java.lang.StringIndexOutOfBoundsException" as it sets the length to  -1

This is a minor fix to check whether string builder length is > 0. If yes, then set the length for string builder
