### PR TITLE
"StringIndexOutOfBoundsException" in CookieEncoder's encode() if no cookies are present

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/CookieEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/CookieEncoder.java
@@ -167,7 +167,8 @@ public class CookieEncoder {
             }
         }
 
-        sb.setLength(sb.length() - 1);
+        if(sb.length() > 0)
+        	sb.setLength(sb.length() - 1);
         return sb.toString();
     }
 
@@ -205,7 +206,8 @@ public class CookieEncoder {
             }
         }
 
-        sb.setLength(sb.length() - 1);
+        if(sb.length() > 0)
+        	sb.setLength(sb.length() - 1);
         return sb.toString();
     }
 

--- a/src/test/java/org/jboss/netty/handler/codec/http/CookieEncoderTest.java
+++ b/src/test/java/org/jboss/netty/handler/codec/http/CookieEncoderTest.java
@@ -17,6 +17,7 @@ package org.jboss.netty.handler.codec.http;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNotNull;
 
 import java.text.DateFormat;
 import java.util.Date;
@@ -132,4 +133,16 @@ public class CookieEncoderTest {
         String encodedCookie = encoder.encode();
         assertEquals(c1 + c2 + c3, encodedCookie);
     }
+    
+    @Test
+    public void testEncodingWithNoCookies() {
+    	CookieEncoder encoderForServer = new CookieEncoder(true);
+    	String encodedCookie1 = encoderForServer.encode();
+    	CookieEncoder encoderForClient = new CookieEncoder(false);
+    	String encodedCookie2 = encoderForClient.encode();
+    	assertNotNull(encodedCookie1);
+    	assertNotNull(encodedCookie2);   	
+    	
+    }
+    
 }


### PR DESCRIPTION
- Fixed the bug in CookieEncoder if there are no cookie's set while
  calling encode(). Without the fix, it ended up in calling the
  exception "java.lang.StringIndexOutOfBoundsException".
- Also added test case to verify the patch

Change-Id: Ib96425e07ab50be027ade7be0748cceb6438a586
