### PR TITLE
HttpContentEncoder produces a response body even if initial body is empty.

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/HttpContentEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/HttpContentEncoder.java
@@ -102,7 +102,8 @@ public abstract class HttpContentEncoder extends SimpleChannelHandler {
                 throw new IllegalStateException("cannot send more responses than requests");
             }
 
-            if ((encoder = newContentEncoder(acceptEncoding)) != null) {
+            boolean hasContent = m.isChunked() || m.getContent().readable();
+            if (hasContent && (encoder = newContentEncoder(acceptEncoding)) != null) {
                 // Encode the content and remove or replace the existing headers
                 // so that the message looks like a decoded message.
                 m.setHeader(


### PR DESCRIPTION
Hi Trustin,

If the HTTP response content is empty but the HttpContentCompressor handler is in the pipeline, it creates a 26 byte response body (gzip headers) which is sent to the client.

Reused the same logic as in the HttpContentDecompressor to encode only if there is content.

Thanks,

Felix
