### PR TITLE
Possible fix for HttpContentEncoder so it can be used Client or Server side

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/HttpContentEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/HttpContentEncoder.java
@@ -94,6 +94,7 @@ public abstract class HttpContentEncoder extends SimpleChannelHandler {
         } else  if (msg instanceof HttpMessage) {
             HttpMessage m = (HttpMessage) msg;
 
+            encoder = null;
             String encoding;
             if(msg instanceof HttpResponse) {
                 // Determine the content encoding.


### PR DESCRIPTION
Hi Trustin,

While working on client side HTTP code, I stumble upon the fact that the HttpContentEncoder is coded with Server side channel in mind (and fails with a exception if used on client side channel). I thought it would be fairly easy make it work for both client and server channel.

While doing the testing though, we discovered that this is not the mechanism we needed, so we ended up not using it.

Here are the changes I propose in case you would like to add it to Netty.

Some explanations on the change...

In the messageReceived method, we ignore anything that is not a HttpRequest, so the code only offer a content encoding to the queue for HttpRequests.

In the writeRequested method, we get the encoding from either the queue if it's a HttpResponse or from the headers if it is a HttpRequest.

For HTTP chunks I think the code is generic.

Felix
