### PR TITLE
Small fix for LocalAddress.compareTo

### DIFF
--- a/src/main/java/org/jboss/netty/channel/local/LocalAddress.java
+++ b/src/main/java/org/jboss/netty/channel/local/LocalAddress.java
@@ -115,7 +115,7 @@ public final class LocalAddress extends SocketAddress implements Comparable<Loca
                 }
 
                 int a = System.identityHashCode(this);
-                int b = System.identityHashCode(this);
+                int b = System.identityHashCode(o);
                 if (a < b) {
                     return -1;
                 } else if (a > b) {


### PR DESCRIPTION
Previously, if both the local address ("this") and the other local address ("o") were both ephermal but were not exactly equal, an error was always generated. 

This is because the hash code of "this" was being compared with "this", not with "o"; Therefore, the addresses were different but the hash codes being checked were always the same. This is checked a few lines down, and generated an error if the hash codes were the same.

This pull request fixes that by comparing the hash code of "this" with "o", not with itself.
