### PR TITLE
Fix NETTY-452, add an option for whether to count length field into packet length or not

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/frame/LengthFieldBasedFrameDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/frame/LengthFieldBasedFrameDecoder.java
@@ -239,7 +239,7 @@ public class LengthFieldBasedFrameDecoder extends FrameDecoder {
             int maxFrameLength,
             int lengthFieldOffset, int lengthFieldLength,
             int lengthAdjustment, int initialBytesToStrip) {
-        this(maxFrameLength, lengthFieldOffset, lengthFieldOffset, lengthAdjustment,
+        this(maxFrameLength, lengthFieldOffset, lengthFieldLength, lengthAdjustment,
                 initialBytesToStrip, false);
     }
 


### PR DESCRIPTION
For some protocols (such as Diameter Protocol), the value of length field means the whole packet size. LengthFieldOffset and LengthFieldLength are counted into that. It conflicts with current LengthFieldBasedFrameDecoder impl. And also I find it difficult to subclass it to add this modification (fields are private, no accessors, decode is rather big). So I think it's better to provide the new option to LengthFieldBasedFrameDecoder.
