### PR TITLE
Added boolean methods to ChannelBuffer in 3.2

### DIFF
--- a/src/main/java/org/jboss/netty/buffer/AbstractChannelBuffer.java
+++ b/src/main/java/org/jboss/netty/buffer/AbstractChannelBuffer.java
@@ -122,6 +122,10 @@ public abstract class AbstractChannelBuffer implements ChannelBuffer {
             throw new IndexOutOfBoundsException();
         }
     }
+    
+    public boolean getBoolean(int index) {
+        return (getByte(index) == 1);
+    }
 
     public short getUnsignedByte(int index) {
         return (short) (getByte(index) & 0xFF);
@@ -169,6 +173,10 @@ public abstract class AbstractChannelBuffer implements ChannelBuffer {
         }
         getBytes(index, dst, dst.writerIndex(), length);
         dst.writerIndex(dst.writerIndex() + length);
+    }
+    
+    public void setBoolean(int index, boolean value) {
+        setByte(index, value ? 1 : 0);
     }
 
     public void setChar(int index, int value) {
@@ -236,6 +244,10 @@ public abstract class AbstractChannelBuffer implements ChannelBuffer {
             throw new IndexOutOfBoundsException();
         }
         return getByte(readerIndex ++);
+    }
+    
+    public boolean readBoolean() {
+        return (readByte() == 1);
     }
 
     public short readUnsignedByte() {
@@ -399,6 +411,10 @@ public abstract class AbstractChannelBuffer implements ChannelBuffer {
         }
         readerIndex(newReaderIndex);
         return newReaderIndex - oldReaderIndex;
+    }
+    
+    public void writeBoolean(boolean value) {
+        writeByte(value ? 1 : 0);
     }
 
     public void writeByte(int value) {

--- a/src/main/java/org/jboss/netty/buffer/ChannelBuffer.java
+++ b/src/main/java/org/jboss/netty/buffer/ChannelBuffer.java
@@ -448,6 +448,17 @@ public interface ChannelBuffer extends Comparable<ChannelBuffer> {
      *         not a dynamic buffer
      */
     void ensureWritableBytes(int writableBytes);
+    
+    /**
+     * Gets a boolean at the specified absolute {@code index} in this buffer.
+     * This method does not modify {@code readerIndex} or {@code writerIndex} of
+     * this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if the specified {@code index} is less than {@code 0} or
+     *         {@code index + 1} is greater than {@code this.capacity}
+     */
+    boolean getBoolean(int index);
 
     /**
      * Gets a byte at the specified absolute {@code index} in this buffer.
@@ -458,7 +469,7 @@ public interface ChannelBuffer extends Comparable<ChannelBuffer> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 1} is greater than {@code this.capacity}
      */
-    byte  getByte(int index);
+    byte getByte(int index);
 
     /**
      * Gets an unsigned byte at the specified absolute {@code index} in this
@@ -718,8 +729,20 @@ public interface ChannelBuffer extends Comparable<ChannelBuffer> {
      * @throws IOException
      *         if the specified channel threw an exception during I/O
      */
-    int   getBytes(int index, GatheringByteChannel out, int length) throws IOException;
+    int getBytes(int index, GatheringByteChannel out, int length) throws IOException;
 
+    /**
+     * Sets the specified boolean at the specified absolute {@code index} in this
+     * buffer.
+     * This method does not modify {@code readerIndex} or {@code writerIndex} of
+     * this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if the specified {@code index} is less than {@code 0} or
+     *         {@code index + 1} is greater than {@code this.capacity}
+     */
+    void setBoolean(int index, boolean value);
+    
     /**
      * Sets the specified byte at the specified absolute {@code index} in this
      * buffer.  The 24 high-order bits of the specified value are ignored.
@@ -730,7 +753,7 @@ public interface ChannelBuffer extends Comparable<ChannelBuffer> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 1} is greater than {@code this.capacity}
      */
-    void setByte(int index, int   value);
+    void setByte(int index, int value);
 
     /**
      * Sets the specified 16-bit short integer at the specified absolute
@@ -969,6 +992,15 @@ public interface ChannelBuffer extends Comparable<ChannelBuffer> {
      *         if {@code index + length} is greater than {@code this.capacity}
      */
     void setZero(int index, int length);
+    
+    /**
+     * Gets a boolean at the current {@code readerIndex} and increases
+     * the {@code readerIndex} by {@code 1} in this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code this.readableBytes} is less than {@code 1}
+     */
+    boolean readBoolean();
 
     /**
      * Gets a byte at the current {@code readerIndex} and increases
@@ -977,7 +1009,7 @@ public interface ChannelBuffer extends Comparable<ChannelBuffer> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.readableBytes} is less than {@code 1}
      */
-    byte  readByte();
+    byte readByte();
 
     /**
      * Gets an unsigned byte at the current {@code readerIndex} and increases
@@ -1245,8 +1277,17 @@ public interface ChannelBuffer extends Comparable<ChannelBuffer> {
      * @deprecated Use {@link #bytesBefore(ChannelBufferIndexFinder)} and {@link #skipBytes(int)} instead.
      */
     @Deprecated
-    int  skipBytes(ChannelBufferIndexFinder indexFinder);
+    int skipBytes(ChannelBufferIndexFinder indexFinder);
 
+    /**
+     * Sets the specified boolean at the current {@code writerIndex}
+     * and increases the {@code writerIndex} by {@code 1} in this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code this.writableBytes} is less than {@code 1}
+     */
+    void writeBoolean(boolean value);
+    
     /**
      * Sets the specified byte at the current {@code writerIndex}
      * and increases the {@code writerIndex} by {@code 1} in this buffer.
@@ -1255,7 +1296,7 @@ public interface ChannelBuffer extends Comparable<ChannelBuffer> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 1}
      */
-    void writeByte(int   value);
+    void writeByte(int value);
 
     /**
      * Sets the specified 16-bit short integer at the current

--- a/src/main/java/org/jboss/netty/handler/codec/replay/ReplayingDecoderBuffer.java
+++ b/src/main/java/org/jboss/netty/handler/codec/replay/ReplayingDecoderBuffer.java
@@ -114,6 +114,11 @@ class ReplayingDecoderBuffer implements ChannelBuffer {
     public ChannelBuffer duplicate() {
         throw new UnreplayableOperationException();
     }
+    
+    public boolean getBoolean(int index) {
+        checkIndex(index);
+        return buffer.getBoolean(index);
+    }
 
     public byte getByte(int index) {
         checkIndex(index);
@@ -312,6 +317,11 @@ class ReplayingDecoderBuffer implements ChannelBuffer {
             return Integer.MAX_VALUE - buffer.readerIndex();
         }
     }
+    
+    public boolean readBoolean() {
+        checkReadableBytes(1);
+        return buffer.readBoolean();
+    }
 
     public byte readByte() {
         checkReadableBytes(1);
@@ -451,6 +461,10 @@ class ReplayingDecoderBuffer implements ChannelBuffer {
     }
 
     public void resetWriterIndex() {
+        throw new UnreplayableOperationException();
+    }
+    
+    public void setBoolean(int index, boolean value) {
         throw new UnreplayableOperationException();
     }
 
@@ -622,6 +636,10 @@ class ReplayingDecoderBuffer implements ChannelBuffer {
 
     public int writableBytes() {
         return 0;
+    }
+    
+    public void writeBoolean(boolean value) {
+        throw new UnreplayableOperationException();
     }
 
     public void writeByte(int value) {

--- a/src/test/java/org/jboss/netty/buffer/AbstractChannelBufferTest.java
+++ b/src/test/java/org/jboss/netty/buffer/AbstractChannelBufferTest.java
@@ -145,6 +145,16 @@ public abstract class AbstractChannelBufferTest {
         buffer.readerIndex(0);
         buffer.writerIndex(CAPACITY);
     }
+    
+    @Test(expected=IndexOutOfBoundsException.class)
+    public void getBooleanBoundaryCheck1() {
+        buffer.getBoolean(-1);
+    }
+
+    @Test(expected=IndexOutOfBoundsException.class)
+    public void getBooleanBoundaryCheck2() {
+        buffer.getBoolean(buffer.capacity());
+    }
 
     @Test(expected=IndexOutOfBoundsException.class)
     public void getByteBoundaryCheck1() {


### PR DESCRIPTION
Same as #46

"Adds getBoolean(index), readBoolean(), writeBoolean(value), and setBoolean(index, value) to ChannelBuffer
Added the corresponding boundary tests
Fixed a few spacing issues, nothing big"
