### PR TITLE
113 fix

### DIFF
--- a/src/main/java/org/jboss/netty/channel/DefaultChannelPipeline.java
+++ b/src/main/java/org/jboss/netty/channel/DefaultChannelPipeline.java
@@ -277,8 +277,8 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
             if (!sameName) {
                 name2ctx.remove(ctx.getName());
-                name2ctx.put(newName, newCtx);
             }
+            name2ctx.put(newName, newCtx);
 
             ChannelHandlerLifeCycleException removeException = null;
             ChannelHandlerLifeCycleException addException = null;

--- a/src/test/java/org/jboss/netty/channel/TestDefaultChannelPipeline.java
+++ b/src/test/java/org/jboss/netty/channel/TestDefaultChannelPipeline.java
@@ -1,0 +1,32 @@
+package org.jboss.netty.channel;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class TestDefaultChannelPipeline {
+	@Test
+	public void testReplaceChannelHandler() {
+		DefaultChannelPipeline pipeline = new DefaultChannelPipeline();
+		
+		SimpleChannelHandler handler1 = new SimpleChannelHandler();
+		pipeline.addLast("handler1", handler1);
+		pipeline.addLast("handler2", handler1);
+		pipeline.addLast("handler3", handler1);
+		assertTrue(pipeline.get("handler1") == handler1);
+		assertTrue(pipeline.get("handler2") == handler1);
+		assertTrue(pipeline.get("handler3") == handler1);
+		
+		SimpleChannelHandler newHandler1 = new SimpleChannelHandler();
+		pipeline.replace("handler1", "handler1", newHandler1);
+		assertTrue(pipeline.get("handler1") == newHandler1);
+		
+		SimpleChannelHandler newHandler3 = new SimpleChannelHandler();
+		pipeline.replace("handler3", "handler3", newHandler3);
+		assertTrue(pipeline.get("handler3") == newHandler3);
+		
+		SimpleChannelHandler newHandler2 = new SimpleChannelHandler();
+		pipeline.replace("handler2", "handler2", newHandler2);
+		assertTrue(pipeline.get("handler2") == newHandler2);
+	}
+}


### PR DESCRIPTION
A fix for https://github.com/netty/netty/issues/113

I believe the problem is in DefaultChannelPipeline.java:278-281 . name2ctx will not get updated if the handler name  remains the same.

```
       if (!sameName) {
            name2ctx.remove(ctx.getName());
            name2ctx.put(newName, newCtx);
        }
```

Suggested fix is to move the put() outside the if statement:

```
        if (!sameName) {
            name2ctx.remove(ctx.getName());
        }
        name2ctx.put(newName, newCtx);
```

Commit also contains a unit test to demonstrate the original problem and verify the fix.
