### PR TITLE
Fix possible JavaDoc error in QueryStringEncoder. Type mismatch.

### DIFF
--- a/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
+++ b/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
@@ -29,7 +29,7 @@ import java.util.List;
  * This encoder is for one time use only.  Create a new instance for each URI.
  *
  * <pre>
- * {@link QueryStringEncoder} encoder = new {@link QueryStringDecoder}("/hello");
+ * {@link QueryStringEncoder} encoder = new {@link QueryStringEncoder}("/hello");
  * encoder.addParam("recipient", "world");
  * assert encoder.toString().equals("/hello?recipient=world");
  * </pre>


### PR DESCRIPTION
Old javadoc instantiated object of QueryStringDecoder. This seems like a type mismatch, copy-and-paste issue, but I might be missing something.
