### PR TITLE
Don't require HttpChunkAggregator to be present in pipeline for WS

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
@@ -164,7 +164,9 @@ public class WebSocketServerHandshaker00 extends WebSocketServerHandshaker {
 
         // Upgrade the connection and send the handshake response.
         ChannelPipeline p = channel.getPipeline();
-        p.remove(HttpChunkAggregator.class);
+        if (p.get(HttpChunkAggregator.class) != null) {
+            p.remove(HttpChunkAggregator.class);
+        }
         p.replace(HttpRequestDecoder.class, "wsdecoder", new WebSocket00FrameDecoder());
 
         ChannelFuture future = channel.write(res);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08.java
@@ -138,7 +138,10 @@ public class WebSocketServerHandshaker08 extends WebSocketServerHandshaker {
 
         // Upgrade the connection and send the handshake response.
         ChannelPipeline p = channel.getPipeline();
-        p.remove(HttpChunkAggregator.class);
+        if (p.get(HttpChunkAggregator.class) != null) {
+            p.remove(HttpChunkAggregator.class);
+        }
+
         p.replace(HttpRequestDecoder.class, "wsdecoder", new WebSocket08FrameDecoder(true, allowExtensions));
         p.replace(HttpResponseEncoder.class, "wsencoder", new WebSocket08FrameEncoder(false));
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
@@ -139,7 +139,10 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
 
         // Upgrade the connection and send the handshake response.
         ChannelPipeline p = channel.getPipeline();
-        p.remove(HttpChunkAggregator.class);
+        if (p.get(HttpChunkAggregator.class) != null) {
+            p.remove(HttpChunkAggregator.class);
+        }
+
         p.replace(HttpRequestDecoder.class, "wsdecoder", new WebSocket13FrameDecoder(true, allowExtensions));
         p.replace(HttpResponseEncoder.class, "wsencoder", new WebSocket13FrameEncoder(false));
 


### PR DESCRIPTION
Handshaking a web socket fails since I am missing HttpChunkAggregator in pipeline. But since I don't need it in my app I have purposely not added it to my pipeline. This patch addresses that.
