### PR TITLE
Support Java 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,31 @@
         </configuration>
       </plugin>
       <plugin>
+        <!-- ensure that only methods available in java 1.5 can
+             be used even when compiling with java 1.6+ -->
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.7</version>
+        <configuration>
+          <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>java15</artifactId>
+            <version>1.0</version>
+          </signature>
+          <ignores>
+            <ignore>sun.misc.Unsafe</ignore>
+          </ignores>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-resources-plugin</artifactId>
         <version>2.5</version>
         <configuration>

--- a/src/main/java/org/jboss/netty/example/http/websocketx/sslserver/WebSocketSslServer.java
+++ b/src/main/java/org/jboss/netty/example/http/websocketx/sslserver/WebSocketSslServer.java
@@ -71,13 +71,13 @@ public class WebSocketSslServer {
         }
 
         String keyStoreFilePath = System.getProperty("keystore.file.path");
-        if (keyStoreFilePath == null || keyStoreFilePath.isEmpty()) {
+        if (keyStoreFilePath == null || keyStoreFilePath.length() == 0) {
             System.out.println("ERROR: System property keystore.file.path not set. Exiting now!");
             System.exit(1);
         }
 
         String keyStoreFilePassword = System.getProperty("keystore.file.password");
-        if (keyStoreFilePassword == null || keyStoreFilePassword.isEmpty()) {
+        if (keyStoreFilePassword == null || keyStoreFilePassword.length() == 0) {
             System.out.println("ERROR: System property keystore.file.password not set. Exiting now!");
             System.exit(1);
         }

--- a/src/main/java/org/jboss/netty/handler/codec/http/QueryStringDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/QueryStringDecoder.java
@@ -15,6 +15,7 @@
  */
 package org.jboss.netty.handler.codec.http;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
@@ -219,7 +220,7 @@ public class QueryStringDecoder {
                 }
                 decodeParams(uri.substring(pathLength + 1));
             } else {
-                if (uri.isEmpty()) {
+                if (uri.length() == 0) {
                     return Collections.emptyMap();
                 }
                 decodeParams(uri);
@@ -387,7 +388,11 @@ public class QueryStringDecoder {
                     break;
             }
         }
-        return new String(buf, 0, pos, charset);
+        try {
+            return new String(buf, 0, pos, charset.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalArgumentException("unsupported encoding: " + charset.name());
+        }
     }
 
     /**

--- a/src/main/java/org/jboss/netty/handler/codec/http/websocketx/ContinuationWebSocketFrame.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/websocketx/ContinuationWebSocketFrame.java
@@ -112,7 +112,7 @@ public class ContinuationWebSocketFrame extends WebSocketFrame {
      *            text to store
      */
     public void setText(String text) {
-        if (text == null || text.isEmpty()) {
+        if (text == null || text.length() == 0) {
             setBinaryData(ChannelBuffers.EMPTY_BUFFER);
         } else {
             setBinaryData(ChannelBuffers.copiedBuffer(text, CharsetUtil.UTF_8));

--- a/src/main/java/org/jboss/netty/handler/codec/http/websocketx/TextWebSocketFrame.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/websocketx/TextWebSocketFrame.java
@@ -38,7 +38,7 @@ public class TextWebSocketFrame extends WebSocketFrame {
      *            String to put in the frame
      */
     public TextWebSocketFrame(String text) {
-        if (text == null || text.isEmpty()) {
+        if (text == null || text.length() == 0) {
             setBinaryData(ChannelBuffers.EMPTY_BUFFER);
         } else {
             setBinaryData(ChannelBuffers.copiedBuffer(text, CharsetUtil.UTF_8));
@@ -68,7 +68,7 @@ public class TextWebSocketFrame extends WebSocketFrame {
     public TextWebSocketFrame(boolean finalFragment, int rsv, String text) {
         setFinalFragment(finalFragment);
         setRsv(rsv);
-        if (text == null || text.isEmpty()) {
+        if (text == null || text.length() == 0) {
             setBinaryData(ChannelBuffers.EMPTY_BUFFER);
         } else {
             setBinaryData(ChannelBuffers.copiedBuffer(text, CharsetUtil.UTF_8));

--- a/src/main/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
@@ -109,7 +109,7 @@ public abstract class WebSocketClientHandshaker {
      * @param channel
      *            Channel
      */
-    public abstract ChannelFuture handshake(Channel channel);
+    public abstract ChannelFuture handshake(Channel channel) throws Exception;
 
     /**
      * Validates and finishes the opening handshake initiated by {@link #handshake}}.

--- a/src/main/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketClientHandshaker08.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketClientHandshaker08.java
@@ -95,7 +95,7 @@ public class WebSocketClientHandshaker08 extends WebSocketClientHandshaker {
      *            Channel into which we can write our request
      */
     @Override
-    public ChannelFuture handshake(Channel channel) {
+    public ChannelFuture handshake(Channel channel) throws Exception {
         // Get path
         URI wsURL = getWebSocketUrl();
         String path = wsURL.getPath();
@@ -108,7 +108,7 @@ public class WebSocketClientHandshaker08 extends WebSocketClientHandshaker {
         String key = WebSocketUtil.base64(nonce);
 
         String acceptSeed = key + MAGIC_GUID;
-        byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII));
+        byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII.name()));
         expectedChallengeResponseString = WebSocketUtil.base64(sha1);
 
         if (logger.isDebugEnabled()) {

--- a/src/main/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
@@ -95,7 +95,7 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
      *            Channel into which we can write our request
      */
     @Override
-    public ChannelFuture handshake(Channel channel) {
+    public ChannelFuture handshake(Channel channel) throws Exception {
         // Get path
         URI wsURL = getWebSocketUrl();
         String path = wsURL.getPath();
@@ -108,7 +108,7 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
         String key = WebSocketUtil.base64(nonce);
 
         String acceptSeed = key + MAGIC_GUID;
-        byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII));
+        byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII.name()));
         expectedChallengeResponseString = WebSocketUtil.base64(sha1);
 
         if (logger.isDebugEnabled()) {

--- a/src/main/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -92,7 +92,7 @@ public abstract class WebSocketServerHandshaker {
      * @param req
      *            HTTP Request
      */
-    public abstract ChannelFuture handshake(Channel channel, HttpRequest req);
+    public abstract ChannelFuture handshake(Channel channel, HttpRequest req) throws Exception;
 
     /**
      * Performs the closing handshake

--- a/src/main/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08.java
@@ -105,7 +105,7 @@ public class WebSocketServerHandshaker08 extends WebSocketServerHandshaker {
      *            HTTP request
      */
     @Override
-    public ChannelFuture handshake(Channel channel, HttpRequest req) {
+    public ChannelFuture handshake(Channel channel, HttpRequest req) throws Exception {
 
         if (logger.isDebugEnabled()) {
             logger.debug(String.format("Channel %s WS Version 8 server handshake", channel.getId()));
@@ -118,7 +118,7 @@ public class WebSocketServerHandshaker08 extends WebSocketServerHandshaker {
             throw new WebSocketHandshakeException("not a WebSocket request: missing key");
         }
         String acceptSeed = key + WEBSOCKET_08_ACCEPT_GUID;
-        byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII));
+        byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII.name()));
         String accept = WebSocketUtil.base64(sha1);
 
         if (logger.isDebugEnabled()) {

--- a/src/main/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
@@ -106,7 +106,7 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
      *            HTTP request
      */
     @Override
-    public ChannelFuture handshake(Channel channel, HttpRequest req) {
+    public ChannelFuture handshake(Channel channel, HttpRequest req) throws Exception {
 
         if (logger.isDebugEnabled()) {
             logger.debug(String.format("Channel %s WS Version 13 server handshake", channel.getId()));
@@ -119,7 +119,7 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
             throw new WebSocketHandshakeException("not a WebSocket request: missing key");
         }
         String acceptSeed = key + WEBSOCKET_13_ACCEPT_GUID;
-        byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII));
+        byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII.name()));
         String accept = WebSocketUtil.base64(sha1);
 
         if (logger.isDebugEnabled()) {


### PR DESCRIPTION
A couple of Java 1.6-only String methods have been used recently.
Changed these back to their Java 1.5 equivalent and added
animal-sniffer-maven-plugin in the pom.xml (bound to process-classes)
to check that only Java 1.5 methods are used.
