### PR TITLE
Return "Connection: keep-alive" header in the HTTP response

### DIFF
--- a/example/src/main/java/io/netty/example/http/file/HttpStaticFileServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/file/HttpStaticFileServerHandler.java
@@ -160,6 +160,9 @@ public class HttpStaticFileServerHandler extends SimpleChannelUpstreamHandler {
         setContentLength(response, fileLength);
         setContentTypeHeader(response, file);
         setDateAndCacheHeaders(response, file);
+        if (isKeepAlive(request)) {
+            response.setHeader(CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+        }
         
         Channel ch = e.getChannel();
 

--- a/example/src/main/java/io/netty/example/http/snoop/HttpSnoopServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/snoop/HttpSnoopServerHandler.java
@@ -39,6 +39,7 @@ import io.netty.handler.codec.http.CookieEncoder;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpChunk;
 import io.netty.handler.codec.http.HttpChunkTrailer;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.QueryStringDecoder;
@@ -131,6 +132,8 @@ public class HttpSnoopServerHandler extends SimpleChannelUpstreamHandler {
         if (keepAlive) {
             // Add 'Content-Length' header only for a keep-alive connection.
             response.setHeader(CONTENT_LENGTH, response.getContent().readableBytes());
+            // Add keep alive header as per http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01.html#Connection
+            response.setHeader(CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
         }
 
         // Encode the cookie.


### PR DESCRIPTION
Unless the "Connection: keep-alive" header is present in the HTTP response, apache benchmark (ab) hangs on keep alive connections.

This is as per HTTP 1.1 spec:  http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01.html#Connection
