### PR TITLE
Return "Connection: keep-alive" header in the HTTP response (v3 branch)

### DIFF
--- a/src/main/java/org/jboss/netty/example/http/snoop/HttpSnoopServerHandler.java
+++ b/src/main/java/org/jboss/netty/example/http/snoop/HttpSnoopServerHandler.java
@@ -39,6 +39,7 @@ import org.jboss.netty.handler.codec.http.CookieEncoder;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpChunk;
 import org.jboss.netty.handler.codec.http.HttpChunkTrailer;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.QueryStringDecoder;
@@ -131,6 +132,8 @@ public class HttpSnoopServerHandler extends SimpleChannelUpstreamHandler {
         if (keepAlive) {
             // Add 'Content-Length' header only for a keep-alive connection.
             response.setHeader(CONTENT_LENGTH, response.getContent().readableBytes());
+            // Add keep alive header as per http://www.w3.org/Protocols/HTTP/1.1/draft-ietf-http-v11-spec-01.html#Connection
+            response.setHeader(CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
         }
 
         // Encode the cookie.


### PR DESCRIPTION
Apache benchmark (ab) hangs on keep alive connections.

Also, added http caching header code from master to HttpStaticFileServerHandler

This is a duplicate of #241 for the "3" branch
