### PR TITLE
Invalid NioClientSocketChannelFactory constructor used in WebSocketClient example.

### DIFF
--- a/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
@@ -74,8 +74,7 @@ public class WebSocketClient {
     public void run() throws Exception {
         ClientBootstrap bootstrap =
                 new ClientBootstrap(
-                        new NioClientSocketChannelFactory(
-                                Executors.newCachedThreadPool()));
+                        new NioClientSocketChannelFactory());
 
         Channel ch = null;
         


### PR DESCRIPTION
...achedThreadPool()). NioClientSocketChannelFactory uses Executors.newCachedThreadPool() in the default constructor.
