### PR TITLE
Very small fix on skipControlCharacters

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpPostRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpPostRequestDecoder.java
@@ -851,7 +851,7 @@ public class HttpPostRequestDecoder {
         }
 
         while (sao.pos < sao.limit) {
-            char c = (char) sao.bytes[sao.pos ++];
+            char c = (char) ()sao.bytes[sao.pos ++] & 0xFF);
             if (!Character.isISOControl(c) && !Character.isWhitespace(c)) {
                 sao.setReadPosition(1);
                 return;


### PR DESCRIPTION
Very small fix on skipControlCharacters where it should be unsigned char (& 0xFF).
