### PR TITLE
fix multipart decode error.support "multipart/mixed" and so on.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -382,6 +382,10 @@ public class HttpHeaders {
          */
         static final String MULTIPART_FORM_DATA = "multipart/form-data";
         /**
+         * {@code "multipart"}
+         */
+        static final String MULTIPART = "multipart";
+        /**
          * {@code "must-revalidate"}
          */
         public static final String MUST_REVALIDATE = "must-revalidate";

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpPostRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpPostRequestDecoder.java
@@ -247,10 +247,11 @@ public class HttpPostRequestDecoder {
      */
     private void checkMultipart(String contentType)
             throws ErrorDataDecoderException {
-        // Check if Post using "multipart/form-data; boundary=--89421926422648"
+        // Check if Post using "multipart/form-data; boundary=--89421926422648" or something like that.
+        // for example "multipart/mixed; boundary=--89421926422648"
         String[] headerContentType = splitHeaderContentType(contentType);
         if (headerContentType[0].toLowerCase().startsWith(
-                HttpHeaders.Values.MULTIPART_FORM_DATA) &&
+                HttpHeaders.Values.MULTIPART) &&
                 headerContentType[1].toLowerCase().startsWith(
                         HttpHeaders.Values.BOUNDARY)) {
             String[] boundary = headerContentType[1].split("=");


### PR DESCRIPTION
xlightweb send multipart/form-data has a bug,the header it set is "multipart/mixed; .....".and netty can not support decode it.xlightweb's version is 2.13.2.

import org.xlightweb.IHttpResponse;
import org.xlightweb.MultipartFormDataRequest;
import org.xlightweb.client.HttpClient;
...
MultipartFormDataRequest request = new MultipartFormDataRequest("http://localhost:9090/push");
for (Map.Entry<String, JsonElement> entry : object.entrySet()) {
    request.addPart(entry.getKey(), "text/html; charset=UTF-8", entry.getValue().getAsString());
}
HttpClient httpClient = new HttpClient();
...
IHttpResponse response = httpClient.call(request);
