### PR TITLE
Support for the FATAL log level

### DIFF
--- a/common/src/main/java/io/netty/logging/AbstractInternalLogger.java
+++ b/common/src/main/java/io/netty/logging/AbstractInternalLogger.java
@@ -39,6 +39,8 @@ public abstract class AbstractInternalLogger implements InternalLogger {
             return isWarnEnabled();
         case ERROR:
             return isErrorEnabled();
+        case FATAL:
+            return isFatalEnabled();
         default:
             throw new Error();
         }
@@ -59,6 +61,9 @@ public abstract class AbstractInternalLogger implements InternalLogger {
         case ERROR:
             error(msg, cause);
             break;
+        case FATAL:
+            fatal(msg, cause);
+            break;
         default:
             throw new Error();
         }
@@ -78,6 +83,9 @@ public abstract class AbstractInternalLogger implements InternalLogger {
             break;
         case ERROR:
             error(msg);
+            break;
+        case FATAL:
+            fatal(msg);
             break;
         default:
             throw new Error();

--- a/common/src/main/java/io/netty/logging/CommonsLogger.java
+++ b/common/src/main/java/io/netty/logging/CommonsLogger.java
@@ -60,6 +60,16 @@ class CommonsLogger extends AbstractInternalLogger {
     public void info(String msg, Throwable cause) {
         logger.info(msg, cause);
     }
+    
+    @Override
+    public void fatal(String msg) {
+        logger.fatal(msg);
+    }
+    
+    @Override
+    public void fatal(String msg, Throwable cause) {
+        logger.fatal(msg, cause);
+    }
 
     @Override
     public boolean isDebugEnabled() {
@@ -79,6 +89,11 @@ class CommonsLogger extends AbstractInternalLogger {
     @Override
     public boolean isWarnEnabled() {
         return logger.isWarnEnabled();
+    }
+    
+    @Override
+    public boolean isFatalEnabled() {
+        return logger.isFatalEnabled();
     }
 
     @Override

--- a/common/src/main/java/io/netty/logging/InternalLogLevel.java
+++ b/common/src/main/java/io/netty/logging/InternalLogLevel.java
@@ -34,5 +34,9 @@ public enum InternalLogLevel {
     /**
      * 'ERROR' log level.
      */
-    ERROR
+    ERROR,
+    /**
+     * 'FATAL' log level.
+     */
+    FATAL
 }

--- a/common/src/main/java/io/netty/logging/InternalLogger.java
+++ b/common/src/main/java/io/netty/logging/InternalLogger.java
@@ -39,6 +39,11 @@ public interface InternalLogger {
      * Returns {@code true} if an ERROR level message is logged.
      */
     boolean isErrorEnabled();
+    
+    /**
+     * Returns (@code true} if a FATAL error message is logged.
+     */
+    boolean isFatalEnabled();
 
     /**
      * Returns {@code true} if the specified log level message is logged.
@@ -84,6 +89,16 @@ public interface InternalLogger {
      * Logs an ERROR level message.
      */
     void error(String msg, Throwable cause);
+    
+    /**
+     * Logs a FATAL level message.
+     */
+    void fatal(String msg);
+    
+    /**
+     * Logs a FATAL level message.
+     */
+    void fatal(String msg, Throwable cause);
 
     /**
      * Logs a message.

--- a/common/src/main/java/io/netty/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/logging/InternalLoggerFactory.java
@@ -85,6 +85,16 @@ public abstract class InternalLoggerFactory {
             public void error(String msg, Throwable cause) {
                 logger.error(msg, cause);
             }
+            
+            @Override
+            public void fatal(String msg) {
+                logger.fatal(msg);
+            }
+            
+            @Override
+            public void fatal(String msg, Throwable cause) {
+                logger.fatal(msg, cause);
+            }
 
             @Override
             public void info(String msg) {
@@ -114,6 +124,11 @@ public abstract class InternalLoggerFactory {
             @Override
             public boolean isWarnEnabled() {
                 return logger.isWarnEnabled();
+            }
+            
+            @Override
+            public boolean isFatalEnabled() {
+                return logger.isFatalEnabled();
             }
 
             @Override

--- a/common/src/main/java/io/netty/logging/JBossLogger.java
+++ b/common/src/main/java/io/netty/logging/JBossLogger.java
@@ -58,6 +58,16 @@ class JBossLogger extends AbstractInternalLogger {
     public void info(String msg, Throwable cause) {
         logger.info(msg, cause);
     }
+    
+    @Override
+    public void fatal(String msg) {
+        logger.fatal(msg);
+    }
+    
+    @Override
+    public void fatal(String msg, Throwable cause) {
+        logger.fatal(msg, cause);
+    }
 
     @Override
     @SuppressWarnings("deprecation")
@@ -78,6 +88,11 @@ class JBossLogger extends AbstractInternalLogger {
 
     @Override
     public boolean isWarnEnabled() {
+        return true;
+    }
+    
+    @Override
+    public boolean isFatalEnabled() {
         return true;
     }
 

--- a/common/src/main/java/io/netty/logging/JdkLogger.java
+++ b/common/src/main/java/io/netty/logging/JdkLogger.java
@@ -61,6 +61,16 @@ class JdkLogger extends AbstractInternalLogger {
     public void info(String msg, Throwable cause) {
         logger.logp(Level.INFO, loggerName, null, msg, cause);
     }
+    
+    @Override
+    public void fatal(String msg) {
+        logger.logp(Level.SEVERE, loggerName, null, msg);
+    }
+    
+    @Override
+    public void fatal(String msg, Throwable cause) {
+        logger.logp(Level.SEVERE, loggerName, null, msg, cause);
+    }
 
     @Override
     public boolean isDebugEnabled() {
@@ -80,6 +90,11 @@ class JdkLogger extends AbstractInternalLogger {
     @Override
     public boolean isWarnEnabled() {
         return logger.isLoggable(Level.WARNING);
+    }
+    
+    @Override
+    public boolean isFatalEnabled() {
+        return logger.isLoggable(Level.SEVERE);
     }
 
     @Override

--- a/common/src/main/java/io/netty/logging/Log4JLogger.java
+++ b/common/src/main/java/io/netty/logging/Log4JLogger.java
@@ -58,6 +58,16 @@ class Log4JLogger extends AbstractInternalLogger {
     public void info(String msg, Throwable cause) {
         logger.info(msg, cause);
     }
+    
+    @Override
+    public void fatal(String msg) {
+        logger.fatal(msg);
+    }
+    
+    @Override
+    public void fatal(String msg, Throwable cause) {
+        logger.fatal(msg, cause);
+    }
 
     @Override
     public boolean isDebugEnabled() {
@@ -76,6 +86,11 @@ class Log4JLogger extends AbstractInternalLogger {
 
     @Override
     public boolean isWarnEnabled() {
+        return true;
+    }
+    
+    @Override
+    public boolean isFatalEnabled() {
         return true;
     }
 

--- a/common/src/main/java/io/netty/logging/OsgiLogger.java
+++ b/common/src/main/java/io/netty/logging/OsgiLogger.java
@@ -73,6 +73,26 @@ class OsgiLogger extends AbstractInternalLogger {
             fallback.error(msg, cause);
         }
     }
+    
+    @Override
+    public void fatal(String msg) {
+        LogService logService = parent.getLogService();
+        if (logService != null) {
+            logService.log(LogService.LOG_ERROR, prefix + msg);
+        } else {
+            fallback.fatal(msg);
+        }
+    }
+
+    @Override
+    public void fatal(String msg, Throwable cause) {
+        LogService logService = parent.getLogService();
+        if (logService != null) {
+            logService.log(LogService.LOG_ERROR, prefix + msg, cause);
+        } else {
+            fallback.fatal(msg, cause);
+        }
+    }
 
     @Override
     public void info(String msg) {
@@ -111,6 +131,11 @@ class OsgiLogger extends AbstractInternalLogger {
 
     @Override
     public boolean isWarnEnabled() {
+        return true;
+    }
+    
+    @Override
+    public boolean isFatalEnabled() {
         return true;
     }
 

--- a/common/src/main/java/io/netty/logging/Slf4JLogger.java
+++ b/common/src/main/java/io/netty/logging/Slf4JLogger.java
@@ -57,6 +57,16 @@ class Slf4JLogger extends AbstractInternalLogger {
     public void info(String msg, Throwable cause) {
         logger.info(msg, cause);
     }
+    
+    @Override
+    public void fatal(String msg) {
+        logger.error(msg);
+    }
+    
+    @Override
+    public void fatal(String msg, Throwable cause) {
+        logger.error(msg, cause);
+    }
 
     @Override
     public boolean isDebugEnabled() {
@@ -76,6 +86,11 @@ class Slf4JLogger extends AbstractInternalLogger {
     @Override
     public boolean isWarnEnabled() {
         return logger.isWarnEnabled();
+    }
+    
+    @Override
+    public boolean isFatalEnabled() {
+        return logger.isErrorEnabled();
     }
 
     @Override

--- a/common/src/test/java/io/netty/logging/CommonsLoggerTest.java
+++ b/common/src/test/java/io/netty/logging/CommonsLoggerTest.java
@@ -74,6 +74,19 @@ public class CommonsLoggerTest {
         assertTrue(logger.isErrorEnabled());
         verify(mock);
     }
+    
+    @Test
+    public void testIsFatalEnabled() {
+        org.apache.commons.logging.Log mock =
+            createStrictMock(org.apache.commons.logging.Log.class);
+
+        expect(mock.isFatalEnabled()).andReturn(true);
+        replay(mock);
+
+        InternalLogger logger = new CommonsLogger(mock, "foo");
+        assertTrue(logger.isFatalEnabled());
+        verify(mock);
+    }
 
     @Test
     public void testDebug() {
@@ -176,6 +189,32 @@ public class CommonsLoggerTest {
 
         InternalLogger logger = new CommonsLogger(mock, "foo");
         logger.error("a", e);
+        verify(mock);
+    }
+    
+    @Test
+    public void testFatal() {
+        org.apache.commons.logging.Log mock =
+            createStrictMock(org.apache.commons.logging.Log.class);
+
+        mock.fatal("a");
+        replay(mock);
+
+        InternalLogger logger = new CommonsLogger(mock, "foo");
+        logger.fatal("a");
+        verify(mock);
+    }
+
+    @Test
+    public void testFatalWithException() {
+        org.apache.commons.logging.Log mock =
+            createStrictMock(org.apache.commons.logging.Log.class);
+
+        mock.fatal("a", e);
+        replay(mock);
+
+        InternalLogger logger = new CommonsLogger(mock, "foo");
+        logger.fatal("a", e);
         verify(mock);
     }
 }

--- a/common/src/test/java/io/netty/logging/InternalLoggerFactoryTest.java
+++ b/common/src/test/java/io/netty/logging/InternalLoggerFactoryTest.java
@@ -93,6 +93,16 @@ public class InternalLoggerFactoryTest {
         assertTrue(logger.isErrorEnabled());
         verify(mock);
     }
+    
+    @Test
+    public void testIsFatalEnabled() {
+        expect(mock.isFatalEnabled()).andReturn(true);
+        replay(mock);
+
+        InternalLogger logger = InternalLoggerFactory.getInstance("mock");
+        assertTrue(logger.isFatalEnabled());
+        verify(mock);
+    }
 
     @Test
     public void testDebug() {
@@ -171,6 +181,26 @@ public class InternalLoggerFactoryTest {
 
         InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         logger.error("a", e);
+        verify(mock);
+    }
+    
+    @Test
+    public void testFatal() {
+        mock.fatal("a");
+        replay(mock);
+
+        InternalLogger logger = InternalLoggerFactory.getInstance("mock");
+        logger.fatal("a");
+        verify(mock);
+    }
+
+    @Test
+    public void testFatalWithException() {
+        mock.fatal("a", e);
+        replay(mock);
+
+        InternalLogger logger = InternalLoggerFactory.getInstance("mock");
+        logger.fatal("a", e);
         verify(mock);
     }
 }

--- a/common/src/test/java/io/netty/logging/JBossLoggerTest.java
+++ b/common/src/test/java/io/netty/logging/JBossLoggerTest.java
@@ -72,6 +72,17 @@ public class JBossLoggerTest {
         assertTrue(logger.isErrorEnabled());
         verify(mock);
     }
+    
+    @Test
+    public void testIsFatalEnabled() {
+        org.jboss.logging.Logger mock =
+            createStrictMock(org.jboss.logging.Logger.class);
+        replay(mock);
+
+        InternalLogger logger = new JBossLogger(mock);
+        assertTrue(logger.isFatalEnabled());
+        verify(mock);
+    }
 
     @Test
     public void testDebug() {
@@ -174,6 +185,32 @@ public class JBossLoggerTest {
 
         InternalLogger logger = new JBossLogger(mock);
         logger.error("a", e);
+        verify(mock);
+    }
+    
+    @Test
+    public void testFatal() {
+        org.jboss.logging.Logger mock =
+            createStrictMock(org.jboss.logging.Logger.class);
+
+        mock.fatal("a");
+        replay(mock);
+
+        InternalLogger logger = new JBossLogger(mock);
+        logger.fatal("a");
+        verify(mock);
+    }
+
+    @Test
+    public void testFatalWithException() {
+        org.jboss.logging.Logger mock =
+            createStrictMock(org.jboss.logging.Logger.class);
+
+        mock.fatal("a", e);
+        replay(mock);
+
+        InternalLogger logger = new JBossLogger(mock);
+        logger.fatal("a", e);
         verify(mock);
     }
 }

--- a/common/src/test/java/io/netty/logging/JdkLoggerTest.java
+++ b/common/src/test/java/io/netty/logging/JdkLoggerTest.java
@@ -77,6 +77,19 @@ public class JdkLoggerTest {
         assertTrue(logger.isErrorEnabled());
         verify(mock);
     }
+    
+    @Test
+    public void testIsFatalEnabled() {
+        java.util.logging.Logger mock =
+            createStrictMock(java.util.logging.Logger.class);
+
+        expect(mock.isLoggable(Level.SEVERE)).andReturn(true);
+        replay(mock);
+
+        InternalLogger logger = new JdkLogger(mock, "foo");
+        assertTrue(logger.isFatalEnabled());
+        verify(mock);
+    }
 
     @Test
     public void testDebug() {
@@ -179,6 +192,32 @@ public class JdkLoggerTest {
 
         InternalLogger logger = new JdkLogger(mock, "foo");
         logger.error("a", e);
+        verify(mock);
+    }
+    
+    @Test
+    public void testFatal() {
+        java.util.logging.Logger mock =
+            createStrictMock(java.util.logging.Logger.class);
+
+        mock.logp(Level.SEVERE, "foo", null, "a");
+        replay(mock);
+
+        InternalLogger logger = new JdkLogger(mock, "foo");
+        logger.fatal("a");
+        verify(mock);
+    }
+
+    @Test
+    public void testFatalWithException() {
+        java.util.logging.Logger mock =
+            createStrictMock(java.util.logging.Logger.class);
+
+        mock.logp(Level.SEVERE, "foo", null, "a", e);
+        replay(mock);
+
+        InternalLogger logger = new JdkLogger(mock, "foo");
+        logger.fatal("a", e);
         verify(mock);
     }
 }

--- a/common/src/test/java/io/netty/logging/Log4JLoggerTest.java
+++ b/common/src/test/java/io/netty/logging/Log4JLoggerTest.java
@@ -72,6 +72,17 @@ public class Log4JLoggerTest {
         assertTrue(logger.isErrorEnabled());
         verify(mock);
     }
+    
+    @Test
+    public void testIsFatalEnabled() {
+        org.apache.log4j.Logger mock =
+            createStrictMock(org.apache.log4j.Logger.class);
+        replay(mock);
+
+        InternalLogger logger = new Log4JLogger(mock);
+        assertTrue(logger.isFatalEnabled());
+        verify(mock);
+    }
 
     @Test
     public void testDebug() {
@@ -174,6 +185,32 @@ public class Log4JLoggerTest {
 
         InternalLogger logger = new Log4JLogger(mock);
         logger.error("a", e);
+        verify(mock);
+    }
+    
+    @Test
+    public void testFatal() {
+        org.apache.log4j.Logger mock =
+            createStrictMock(org.apache.log4j.Logger.class);
+
+        mock.fatal("a");
+        replay(mock);
+
+        InternalLogger logger = new Log4JLogger(mock);
+        logger.fatal("a");
+        verify(mock);
+    }
+
+    @Test
+    public void testFatalWithException() {
+        org.apache.log4j.Logger mock =
+            createStrictMock(org.apache.log4j.Logger.class);
+
+        mock.fatal("a", e);
+        replay(mock);
+
+        InternalLogger logger = new Log4JLogger(mock);
+        logger.fatal("a", e);
         verify(mock);
     }
 }

--- a/common/src/test/java/io/netty/logging/Slf4JLoggerTest.java
+++ b/common/src/test/java/io/netty/logging/Slf4JLoggerTest.java
@@ -74,6 +74,19 @@ public class Slf4JLoggerTest {
         assertTrue(logger.isErrorEnabled());
         verify(mock);
     }
+    
+    @Test
+    public void testIsFatalEnabled() {
+        org.slf4j.Logger mock =
+            createStrictMock(org.slf4j.Logger.class);
+
+        expect(mock.isErrorEnabled()).andReturn(true);
+        replay(mock);
+
+        InternalLogger logger = new Slf4JLogger(mock);
+        assertTrue(logger.isFatalEnabled());
+        verify(mock);
+    }
 
     @Test
     public void testDebug() {
@@ -176,6 +189,32 @@ public class Slf4JLoggerTest {
 
         InternalLogger logger = new Slf4JLogger(mock);
         logger.error("a", e);
+        verify(mock);
+    }
+    
+    @Test
+    public void testFatal() {
+        org.slf4j.Logger mock =
+            createStrictMock(org.slf4j.Logger.class);
+
+        mock.error("a");
+        replay(mock);
+
+        InternalLogger logger = new Slf4JLogger(mock);
+        logger.fatal("a");
+        verify(mock);
+    }
+
+    @Test
+    public void testFatalWithException() {
+        org.slf4j.Logger mock =
+            createStrictMock(org.slf4j.Logger.class);
+
+        mock.error("a", e);
+        replay(mock);
+
+        InternalLogger logger = new Slf4JLogger(mock);
+        logger.fatal("a", e);
         verify(mock);
     }
 }


### PR DESCRIPTION
This pull requests adds InternalLogLevel.FATAL, allowing access to the fatal logging capabilities of most loggers. 

Only JDKLogger, SLF4J, and OSGI do not have support. All of the others, however, do.

In these cases, FATAL is logged as SEVERE or ERROR, depending on which logger supports what.
