### PR TITLE
Fix #360, add check for empty string buffer

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ChannelBufferInputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ChannelBufferInputStream.java
@@ -195,7 +195,8 @@ public class ChannelBufferInputStream extends InputStream implements DataInput {
             lineBuf.append((char) b);
         }
 
-        while (lineBuf.charAt(lineBuf.length() - 1) == '\r') {
+        while ( lineBuf.length() > 0 &&
+                lineBuf.charAt(lineBuf.length() - 1) == '\r') {
             lineBuf.setLength(lineBuf.length() - 1);
         }
 

--- a/buffer/src/test/java/io/netty/buffer/ChannelBufferStreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ChannelBufferStreamTest.java
@@ -168,4 +168,15 @@ public class ChannelBufferStreamTest {
 
         assertEquals(buf.readerIndex(), in.readBytes());
     }
+
+    @Test
+    public void testEmptyReadLine() throws Exception {
+        ChannelBuffer buf = ChannelBuffers.buffer(0);
+        ChannelBufferInputStream in = new ChannelBufferInputStream(buf);
+
+        String s = in.readLine();
+        assertEquals(0, s.length());
+
+        in.close();
+    }
 }


### PR DESCRIPTION
At check to prevent index out of bound when checking \r.
