### PR TITLE
Proposal to fix issue #397

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/DefaultCookie.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/DefaultCookie.java
@@ -19,8 +19,6 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.jboss.netty.util.internal.CaseIgnoringComparator;
-
 
 
 /**


### PR DESCRIPTION
Issue in #397 shows that some RESERVED_NAMES are still in use in some space on the Web.
After analysis RFC and blogs information, in fact it seems the issue comes first from Java Sun Cookie implementation that badly interprets the RFC. No RESERVED_NAMES exists, only '$' as first character should be tested, in addition to all unallowed characters.

So the proposal
