### PR TITLE
Fix SpdyHttpHeaders.setScheme setting the wrong header

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/spdy/SpdyHttpHeaders.java
+++ b/src/main/java/org/jboss/netty/handler/codec/spdy/SpdyHttpHeaders.java
@@ -215,6 +215,6 @@ public final class SpdyHttpHeaders {
      * Sets the {@code "X-SPDY-Scheme"} header.
      */
     public static void setScheme(HttpMessage message, String scheme) {
-        message.setHeader(Names.URL, scheme);
+        message.setHeader(Names.SCHEME, scheme);
     }
 }


### PR DESCRIPTION
Looks like a copy-paste typo.
