### PR TITLE
Change Timeout.cancel() to return a boolean value

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -501,13 +501,13 @@ public class HashedWheelTimer implements Timer {
         }
 
         @Override
-        public void cancel() {
+        public boolean cancel() {
             if (!state.compareAndSet(ST_INIT, ST_CANCELLED)) {
-                // TODO return false
-                return;
+                return false;
             }
 
             wheel[stopIndex].remove(this);
+            return true;
         }
 
         @Override

--- a/common/src/main/java/io/netty/util/Timeout.java
+++ b/common/src/main/java/io/netty/util/Timeout.java
@@ -44,9 +44,11 @@ public interface Timeout {
     boolean isCancelled();
 
     /**
-     * Cancels the {@link TimerTask} associated with this handle.  It the
-     * task has been executed or cancelled already, it will return with no
-     * side effect.
+     * Attempts to cancel the {@link TimerTask} associated with this handle.
+     * If the task has been executed or cancelled already, it will return with
+     * no side effect.
+     *
+     * @return True if the cancellation completed successfully, otherwise false
      */
-    void cancel();
+    boolean cancel();
 }


### PR DESCRIPTION
True on a successful cancel, false when unsuccessful

As requested in the javadoc for HashedWheelTimer
