### PR TITLE
Master fix for issue #456 related to payload in WebSocket08FrameEncoder

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -166,7 +166,7 @@ public class WebSocket08FrameEncoder extends MessageToByteEncoder<WebSocketFrame
         if (maskPayload) {
             int random = (int) (Math.random() * Integer.MAX_VALUE);
             mask = ByteBuffer.allocate(4).putInt(random).array();
-            out.writeInt(random);
+            header.writeBytes(mask);
 
             int counter = 0;
             for (int i = data.readerIndex(); i < data.writerIndex(); i ++) {


### PR DESCRIPTION
Fix for issue #456 related to payload using 2 differents RANDOM while only one should be used.
writesBytes as in V3 instead of writeInt (RFC says 0 to 4 bytes)
