### PR TITLE
3: Adds the IntelliJ project directory to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /*.ipr
 /*.iws
 /.metadata
+/.idea/


### PR DESCRIPTION
I'm trying to move away from Netbeans, so I thought I should ignore this instead of accidentally adding it later on

Signed-off-by: Cruz Julian Bishop cruzjbishop@gmail.com
