### PR TITLE
Add support for AIO scattering reads and gathering writes (see #492)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -727,6 +727,11 @@ public abstract class AbstractByteBuf implements ByteBuf {
     }
 
     @Override
+    public ByteBuffer[] nioBuffers() {
+        return nioBuffers(readerIndex, readableBytes());
+    }
+
+    @Override
     public String toString(Charset charset) {
         return toString(readerIndex, readableBytes(), charset);
     }

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -1702,6 +1702,39 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
     ByteBuffer nioBuffer(int index, int length);
 
     /**
+     * Returns {@code true} if and only if {@link #nioBuffers()} method will not fail.
+     */
+    boolean hasNioBuffers();
+
+    /**
+     * Exposes this buffer's readable bytes as an NIO {@link ByteBuffer}'s.  The returned buffer
+     * shares the content with this buffer, while changing the position and limit of the returned
+     * NIO buffer does not affect the indexes and marks of this buffer. This method does not
+     * modify {@code readerIndex} or {@code writerIndex} of this buffer.  Please note that the
+     * returned NIO buffer will not see the changes of this buffer if this buffer is a dynamic
+     * buffer and it adjusted its capacity.
+     *
+     *
+     * @throws UnsupportedOperationException
+     *         if this buffer cannot create a {@link ByteBuffer} that shares the content with itself
+     */
+    ByteBuffer[] nioBuffers();
+
+    /**
+     * Exposes this buffer's bytes as an NIO {@link ByteBuffer}'s for the specified offset and length
+     * The returned buffer shares the content with this buffer, while changing the position and limit
+     * of the returned NIO buffer does not affect the indexes and marks of this buffer. This method does
+     * not modify {@code readerIndex} or {@code writerIndex} of this buffer.  Please note that the
+     * returned NIO buffer will not see the changes of this buffer if this buffer is a dynamic
+     * buffer and it adjusted its capacity.
+     *
+     *
+     * @throws UnsupportedOperationException
+     *         if this buffer cannot create a {@link ByteBuffer} that shares the content with itself
+     */
+    ByteBuffer[] nioBuffers(int offset, int length);
+
+    /**
      * Returns {@code true} if and only if this buffer has a backing byte array.
      * If this method returns true, you can safely call {@link #array()} and
      * {@link #arrayOffset()}.
@@ -1800,6 +1833,13 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
          * @throws UnsupportedOperationException if the buffer has no internal NIO buffer
          */
         ByteBuffer nioBuffer();
+
+        /**
+         * Returns the internal NIO buffer array that is reused for I/O.
+         *
+         * @throws UnsupportedOperationException if the buffer has no internal NIO buffer array
+         */
+        ByteBuffer[] nioBuffers();
 
         /**
          * Returns a new buffer whose type is identical to the callee.

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -15,7 +15,6 @@
  */
 package io.netty.buffer;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 
 public interface CompositeByteBuf extends ByteBuf, Iterable<ByteBuf> {
@@ -48,32 +47,4 @@ public interface CompositeByteBuf extends ByteBuf, Iterable<ByteBuf> {
      * Same with {@link #slice(int, int)} except that this method returns a list.
      */
     List<ByteBuf> decompose(int offset, int length);
-
-    /**
-     * Exposes this buffer's readable bytes as an NIO {@link ByteBuffer}'s.  The returned buffer
-     * shares the content with this buffer, while changing the position and limit of the returned
-     * NIO buffer does not affect the indexes and marks of this buffer. This method does not
-     * modify {@code readerIndex} or {@code writerIndex} of this buffer.  Please note that the
-     * returned NIO buffer will not see the changes of this buffer if this buffer is a dynamic
-     * buffer and it adjusted its capacity.
-     *
-     *
-     * @throws UnsupportedOperationException
-     *         if this buffer cannot create a {@link ByteBuffer} that shares the content with itself
-     */
-    ByteBuffer[] nioBuffers();
-
-    /**
-     * Exposes this buffer's bytes as an NIO {@link ByteBuffer}'s for the specified offset and length
-     * The returned buffer shares the content with this buffer, while changing the position and limit
-     * of the returned NIO buffer does not affect the indexes and marks of this buffer. This method does
-     * not modify {@code readerIndex} or {@code writerIndex} of this buffer.  Please note that the
-     * returned NIO buffer will not see the changes of this buffer if this buffer is a dynamic
-     * buffer and it adjusted its capacity.
-     *
-     *
-     * @throws UnsupportedOperationException
-     *         if this buffer cannot create a {@link ByteBuffer} that shares the content with itself
-     */
-    ByteBuffer[] nioBuffers(int offset, int length);
 }

--- a/buffer/src/main/java/io/netty/buffer/DefaultCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DefaultCompositeByteBuf.java
@@ -1001,6 +1001,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
         }
         return false;
     }
+
     @Override
     public ByteBuffer nioBuffer(int index, int length) {
         if (components.size() == 1) {
@@ -1021,6 +1022,11 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
         }
         merged.flip();
         return merged;
+    }
+
+    @Override
+    public boolean hasNioBuffers() {
+        return true;
     }
 
     @Override
@@ -1204,6 +1210,16 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
                 return components.get(0).buf.unsafe().nioBuffer();
             }
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ByteBuffer[] nioBuffers() {
+            ByteBuffer[] nioBuffers = new ByteBuffer[components.size()];
+            int index = 0;
+            for (Component component : components) {
+                nioBuffers[index++] = component.buf.unsafe().nioBuffer();
+            }
+            return nioBuffers;
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/DirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DirectByteBuf.java
@@ -381,6 +381,16 @@ public class DirectByteBuf extends AbstractByteBuf {
     }
 
     @Override
+    public boolean hasNioBuffers() {
+        return false;
+    }
+
+    @Override
+    public ByteBuffer[] nioBuffers(int offset, int length) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public ByteBuf copy(int index, int length) {
         ByteBuffer src;
         try {
@@ -406,6 +416,11 @@ public class DirectByteBuf extends AbstractByteBuf {
         @Override
         public ByteBuffer nioBuffer() {
             return tmpBuf;
+        }
+
+        @Override
+        public ByteBuffer[] nioBuffers() {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/DuplicatedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DuplicatedByteBuf.java
@@ -212,6 +212,16 @@ public class DuplicatedByteBuf extends AbstractByteBuf implements WrappedByteBuf
     }
 
     @Override
+    public boolean hasNioBuffers() {
+        return buffer.hasNioBuffers();
+    }
+
+    @Override
+    public ByteBuffer[] nioBuffers(int offset, int length) {
+        return buffer.nioBuffers(offset, length);
+    }
+
+    @Override
     public Unsafe unsafe() {
         return unsafe;
     }
@@ -221,6 +231,11 @@ public class DuplicatedByteBuf extends AbstractByteBuf implements WrappedByteBuf
         @Override
         public ByteBuffer nioBuffer() {
             return buffer.unsafe().nioBuffer();
+        }
+
+        @Override
+        public ByteBuffer[] nioBuffers() {
+            return buffer.unsafe().nioBuffers();
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/HeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/HeapByteBuf.java
@@ -210,6 +210,16 @@ public class HeapByteBuf extends AbstractByteBuf {
     }
 
     @Override
+    public boolean hasNioBuffers() {
+        return false;
+    }
+
+    @Override
+    public ByteBuffer[] nioBuffers(int offset, int length) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public short getShort(int index) {
         return (short) (array[index] << 8 | array[index + 1] & 0xFF);
     }
@@ -295,6 +305,11 @@ public class HeapByteBuf extends AbstractByteBuf {
         @Override
         public ByteBuffer nioBuffer() {
             return nioBuf;
+        }
+
+        @Override
+        public ByteBuffer[] nioBuffers() {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
@@ -204,6 +204,16 @@ public class ReadOnlyByteBuf extends AbstractByteBuf implements WrappedByteBuf {
     }
 
     @Override
+    public boolean hasNioBuffers() {
+        return buffer.hasNioBuffers();
+    }
+
+    @Override
+    public ByteBuffer[] nioBuffers(int offset, int length) {
+        return buffer.nioBuffers(offset, length);
+    }
+
+    @Override
     public int capacity() {
         return buffer.capacity();
     }

--- a/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
@@ -257,6 +257,17 @@ public class SlicedByteBuf extends AbstractByteBuf implements WrappedByteBuf {
         return buffer.nioBuffer(index + adjustment, length);
     }
 
+    @Override
+    public boolean hasNioBuffers() {
+        return buffer.hasNioBuffers();
+    }
+
+    @Override
+    public ByteBuffer[] nioBuffers(int index, int length) {
+        checkIndex(index, length);
+        return buffer.nioBuffers(index, length);
+    }
+
     private void checkIndex(int index) {
         if (index < 0 || index >= capacity()) {
             throw new IndexOutOfBoundsException("Invalid index: " + index
@@ -288,6 +299,11 @@ public class SlicedByteBuf extends AbstractByteBuf implements WrappedByteBuf {
         @Override
         public ByteBuffer nioBuffer() {
             return buffer.nioBuffer(adjustment, length);
+        }
+
+        @Override
+        public ByteBuffer[] nioBuffers() {
+            return buffer.nioBuffers(adjustment, length);
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -658,6 +658,29 @@ public class SwappedByteBuf implements WrappedByteBuf {
     }
 
     @Override
+    public boolean hasNioBuffers() {
+        return buf.hasNioBuffers();
+    }
+
+    @Override
+    public ByteBuffer[] nioBuffers() {
+        ByteBuffer[] nioBuffers = buf.nioBuffers();
+        for (int i = 0; i < nioBuffers.length; i++) {
+            nioBuffers[i] = nioBuffers[i].order(order);
+        }
+        return nioBuffers;
+    }
+
+    @Override
+    public ByteBuffer[] nioBuffers(int offset, int length) {
+        ByteBuffer[] nioBuffers = buf.nioBuffers(offset, length);
+        for (int i = 0; i < nioBuffers.length; i++) {
+            nioBuffers[i] = nioBuffers[i].order(order);
+        }
+        return nioBuffers;
+    }
+
+    @Override
     public boolean hasArray() {
         return buf.hasArray();
     }

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderBuffer.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderBuffer.java
@@ -673,6 +673,22 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
+    public boolean hasNioBuffers() {
+        return buffer.hasNioBuffers();
+    }
+
+    @Override
+    public ByteBuffer[] nioBuffers() {
+        throw new UnreplayableOperationException();
+    }
+
+    @Override
+    public ByteBuffer[] nioBuffers(int index, int length) {
+        checkIndex(index, length);
+        return buffer.nioBuffers(index, length);
+    }
+
+    @Override
     public String toString(int index, int length, Charset charset) {
         checkIndex(index, length);
         return buffer.toString(index, length, charset);


### PR DESCRIPTION
o Add ByteBuf.hasNioBuffers() method
o Promote CompositeByteBuf.nioBuffers() methods to ByteBuf
o Use ByteBuf.nioBuffers() methods from AioSocketChannel
