### PR TITLE
Do not write compressed SPDY frames out-of-band in another thread

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/spdy/SpdyFrameEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/spdy/SpdyFrameEncoder.java
@@ -159,11 +159,7 @@ public class SpdyFrameEncoder implements ChannelDownstreamHandler {
                 }
                 // Writes of compressed data must occur in order
                 final ChannelBuffer buffer = ChannelBuffers.wrappedBuffer(frame, data);
-                e.getChannel().getPipeline().execute(new Runnable() {
-                    public void run() {
-                        Channels.write(ctx, e.getFuture(), buffer, e.getRemoteAddress());
-                    }
-                });
+                Channels.write(ctx, e.getFuture(), buffer, e.getRemoteAddress());
             }
             return;
 
@@ -197,11 +193,7 @@ public class SpdyFrameEncoder implements ChannelDownstreamHandler {
                 }
                 // Writes of compressed data must occur in order
                 final ChannelBuffer buffer = ChannelBuffers.wrappedBuffer(frame, data);
-                e.getChannel().getPipeline().execute(new Runnable() {
-                    public void run() {
-                        Channels.write(ctx, e.getFuture(), buffer, e.getRemoteAddress());
-                    }
-                });
+                Channels.write(ctx, e.getFuture(), buffer, e.getRemoteAddress());
             }
             return;
 
@@ -323,11 +315,7 @@ public class SpdyFrameEncoder implements ChannelDownstreamHandler {
                 }
                 // Writes of compressed data must occur in order
                 final ChannelBuffer buffer = ChannelBuffers.wrappedBuffer(frame, data);
-                e.getChannel().getPipeline().execute(new Runnable() {
-                    public void run() {
-                        Channels.write(ctx, e.getFuture(), buffer, e.getRemoteAddress());
-                    }
-                });
+                Channels.write(ctx, e.getFuture(), buffer, e.getRemoteAddress());
             }
             return;
 


### PR DESCRIPTION
The fix in #448 for issue #442 introduces another, even more sinister bug.

Since uncompressed frames and compressed frames from a single originating thread are eventually written from different threads, there is a race condition between sending eg. a SpdySynReplyFrame and SpdyDataFrame, meaning frames can get re-ordered and written to a stream before it is "open", violating the SPDY spec.

(this actually happens with my production code)
