### PR TITLE
Detect LinkedTransferQueue explicitly, rather than guessing by a proxy

### DIFF
--- a/src/main/java/org/jboss/netty/util/internal/DetectionUtil.java
+++ b/src/main/java/org/jboss/netty/util/internal/DetectionUtil.java
@@ -36,6 +36,7 @@ public final class DetectionUtil {
 
     private static final int JAVA_VERSION = javaVersion0();
     private static final boolean HAS_UNSAFE = hasUnsafe(AtomicInteger.class.getClassLoader());
+    private static final boolean HAS_LINKED_TRANSFER_QUEUE = hasClass("java.util.concurrent.LinkedTransferQueue");
     private static final boolean IS_WINDOWS;
     static {
         String os = System.getProperty("os.name").toLowerCase();
@@ -59,6 +60,10 @@ public final class DetectionUtil {
         return JAVA_VERSION;
     }
 
+    static boolean hasJava7LinkedTransferQueue() {
+      return HAS_LINKED_TRANSFER_QUEUE;
+    }
+
     private static boolean hasUnsafe(ClassLoader loader) {
         boolean useUnsafe = Boolean.valueOf(SystemPropertyUtil.get("org.jboss.netty.tryUnsafe", "true"));
         if (!useUnsafe) {
@@ -72,6 +77,17 @@ public final class DetectionUtil {
             // Ignore
         }
         return false;
+    }
+
+    private static boolean hasClass(String className) {
+      try {
+        Class.forName(className, false, AtomicInteger.class.getClassLoader());
+        return true;
+      } catch (NoClassDefFoundError ignored) {
+        return false;
+      } catch (ClassNotFoundException ignored) {
+        return false;
+      }
     }
 
     private static boolean hasUnsafeField(final Class<?> unsafeClass) throws PrivilegedActionException {

--- a/src/main/java/org/jboss/netty/util/internal/QueueFactory.java
+++ b/src/main/java/org/jboss/netty/util/internal/QueueFactory.java
@@ -28,6 +28,7 @@ import org.jboss.netty.logging.InternalLoggerFactory;
 public final class QueueFactory {
 
     private static final boolean useUnsafe = DetectionUtil.hasUnsafe();
+    private static final boolean useJava7LinkedTransferQueue = DetectionUtil.hasJava7LinkedTransferQueue();
     private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(QueueFactory.class);
 
     private QueueFactory() {
@@ -44,7 +45,7 @@ public final class QueueFactory {
     public static <T> BlockingQueue<T> createQueue(Class<T> itemClass) {
         // if we run in java >=7 its the best to just use the LinkedTransferQueue which
         // comes with java bundled. See #273
-        if (DetectionUtil.javaVersion() >= 7)  {
+        if (DetectionUtil.hasJava7LinkedTransferQueue()) {
             return new java.util.concurrent.LinkedTransferQueue<T>();
         }
 


### PR DESCRIPTION
Some OpenJDKs have Deflater.SYNC_FLUSH backported.  Rather than guessing
whether LinkedTransferQueue exists based on Deflater.SYNC_FLUSH's
presence, actually detect whether the class exists.

I'd be happy to back the cache in DetectionUtil by a Map<String(className), boolean(exists)> if you think it's worth making more generic.
