### PR TITLE
Upgrade websocket connection after completed response

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
@@ -22,6 +22,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.DefaultHttpResponse;
 import io.netty.handler.codec.http.HttpChunkAggregator;
@@ -180,7 +181,12 @@ public class WebSocketServerHandshaker00 extends WebSocketServerHandshaker {
 
         ChannelFuture future = channel.write(res);
 
-        p.replace(HttpResponseEncoder.class, "wsencoder", new WebSocket00FrameEncoder());
+        future.addListener(new ChannelFutureListener() {
+            public void operationComplete(ChannelFuture future) {
+                ChannelPipeline p = future.channel().pipeline();
+                p.replace(HttpResponseEncoder.class, "wsencoder", new WebSocket00FrameEncoder());
+            }
+        });
 
         return future;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08.java
@@ -147,14 +147,18 @@ public class WebSocketServerHandshaker08 extends WebSocketServerHandshaker {
         ChannelFuture future = channel.write(res);
 
         // Upgrade the connection and send the handshake response.
-        ChannelPipeline p = channel.pipeline();
-        if (p.get(HttpChunkAggregator.class) != null) {
-            p.remove(HttpChunkAggregator.class);
-        }
+        future.addListener(new ChannelFutureListener() {
+            public void operationComplete(ChannelFuture future) {
+                ChannelPipeline p = future.channel().pipeline();
+                if (p.get(HttpChunkAggregator.class) != null) {
+                    p.remove(HttpChunkAggregator.class);
+                }
 
-        p.replace(HttpRequestDecoder.class, "wsdecoder",
-                new WebSocket08FrameDecoder(true, allowExtensions, getMaxFramePayloadLength()));
-        p.replace(HttpResponseEncoder.class, "wsencoder", new WebSocket08FrameEncoder(false));
+                p.replace(HttpRequestDecoder.class, "wsdecoder",
+                        new WebSocket08FrameDecoder(true, allowExtensions, getMaxFramePayloadLength()));
+                p.replace(HttpResponseEncoder.class, "wsencoder", new WebSocket08FrameEncoder(false));
+            }
+        });
 
         return future;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13.java
@@ -147,14 +147,18 @@ public class WebSocketServerHandshaker13 extends WebSocketServerHandshaker {
         ChannelFuture future = channel.write(res);
 
         // Upgrade the connection and send the handshake response.
-        ChannelPipeline p = channel.pipeline();
-        if (p.get(HttpChunkAggregator.class) != null) {
-            p.remove(HttpChunkAggregator.class);
-        }
+        future.addListener(new ChannelFutureListener() {
+            public void operationComplete(ChannelFuture future) {
+                ChannelPipeline p = future.channel().pipeline();
+                if (p.get(HttpChunkAggregator.class) != null) {
+                    p.remove(HttpChunkAggregator.class);
+                }
 
-        p.replace(HttpRequestDecoder.class, "wsdecoder",
-                new WebSocket13FrameDecoder(true, allowExtensions, getMaxFramePayloadLength()));
-        p.replace(HttpResponseEncoder.class, "wsencoder", new WebSocket13FrameEncoder(false));
+                p.replace(HttpRequestDecoder.class, "wsdecoder",
+                        new WebSocket13FrameDecoder(true, allowExtensions, getMaxFramePayloadLength()));
+                p.replace(HttpResponseEncoder.class, "wsencoder", new WebSocket13FrameEncoder(false));
+            }
+        });
 
         return future;
     }


### PR DESCRIPTION
Channel handlers above the HttpEncoder may delay the repsonse being
written to the socket. We need to wait for the response to complete
before upgrading the pipeline.
