### PR TITLE
Bug in BufferedWriteHandler fixed

### DIFF
--- a/src/main/java/org/jboss/netty/handler/queue/BufferedWriteHandler.java
+++ b/src/main/java/org/jboss/netty/handler/queue/BufferedWriteHandler.java
@@ -254,6 +254,7 @@ public class BufferedWriteHandler extends SimpleChannelHandler implements LifeCy
             final Queue<MessageEvent> queue = getQueue();
             if (consolidateOnFlush) {
                 if (queue.isEmpty()) {
+                    flush.set(false);
                     return;
                 }
 
@@ -283,7 +284,8 @@ public class BufferedWriteHandler extends SimpleChannelHandler implements LifeCy
                     ctx.sendDownstream(e);
                 }
             }
-        }
+           flush.set(false);
+       }
 
         if (acquired && (!channel.isConnected() || channel.isWritable() && !queue.isEmpty())) {
             flush(consolidateOnFlush);


### PR DESCRIPTION
flush variable in BufferedWriteHandler was never reset. This caused the buffer to only be flushed once and then never again. Bug was introduced in commit 88124d8. Without this fix BufferedWriteHandler is completely broken and useless as it doesn't work at all.
