### PR TITLE
Fix race in SslHandler

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -300,9 +300,10 @@ public class SslHandler
                     }
 
                     SSLException e = new SSLException("handshake timed out");
-                    future.setFailure(e);
-                    ctx.fireExceptionCaught(e);
-                    ctx.close();
+                    if ( future.setFailure(e) ){
+                    	ctx.fireExceptionCaught(e);
+                    	ctx.close();
+                    }
                 }
             }, handshakeTimeoutMillis, TimeUnit.MILLISECONDS);
         } else {
@@ -320,9 +321,10 @@ public class SslHandler
                     handshakeFutures.add(future);
                     flush(ctx, ctx.newFuture());
                 } catch (Exception e) {
-                    future.setFailure(e);
-                    ctx.fireExceptionCaught(e);
-                    ctx.close();
+                    if ( future.setFailure(e) ) {
+                    	ctx.fireExceptionCaught(e);
+                    	ctx.close();
+                    }
                 }
             }
         });


### PR DESCRIPTION
Ensure that either SslHandler's handshake timeout or the handshake
itself (or its failure) take place but not both.
