### PR TITLE
Fix race in AioEventLoopGroup

### DIFF
--- a/transport/src/main/java/io/netty/channel/socket/aio/AioEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/socket/aio/AioEventLoopGroup.java
@@ -28,6 +28,7 @@ import java.nio.channels.AsynchronousChannelGroup;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
@@ -99,10 +100,10 @@ public class AioEventLoopGroup extends MultithreadEventLoopGroup {
             l = next();
         }
 
-        if (l.isShutdown()) {
-            command.run();
-        } else {
-            l.execute(command);
+        try {
+        	l.execute(command);
+        } catch ( RejectedExecutionException e ) {
+        	command.run();
         }
     }
 


### PR DESCRIPTION
The submission of a task after checking isShutdown on the EventLoop might fail as the EventLoop might be shutdown between the call to isShutdown and execute.

Anyhow, the whole thing feels a little bit warm and fuzzy to me. Is it really the right thing to do, to execute channel bound I/O events on the underlying AsynchronousChannelGroup's thread when the
channel's EventLoop is shutdown? The JDK API documentation for AsynchronousChannelGroup#withThreadPool clearly advises against such usage (see http://docs.oracle.com/javase/7/docs/api/java/nio/channels/AsynchronousChannelGroup.html#withThreadPool(java.util.concurrent.ExecutorService))

Should this really happen (Channel is still alive but its EventLoop is shutdown), wouldn't it be better to just close the Channel.
