### PR TITLE
Add support for method chaining to ByteBuf

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -74,12 +74,13 @@ public abstract class AbstractByteBuf implements ByteBuf {
     }
 
     @Override
-    public void readerIndex(int readerIndex) {
+    public ByteBuf readerIndex(int readerIndex) {
         if (readerIndex < 0 || readerIndex > writerIndex) {
             throw new IndexOutOfBoundsException("Invalid readerIndex: "
                     + readerIndex + " - Maximum is " + writerIndex);
         }
         this.readerIndex = readerIndex;
+        return this;
     }
 
     @Override
@@ -88,16 +89,17 @@ public abstract class AbstractByteBuf implements ByteBuf {
     }
 
     @Override
-    public void writerIndex(int writerIndex) {
+    public ByteBuf writerIndex(int writerIndex) {
         if (writerIndex < readerIndex || writerIndex > capacity()) {
             throw new IndexOutOfBoundsException("Invalid writerIndex: "
                     + writerIndex + " - Maximum is " + readerIndex + " or " + capacity());
         }
         this.writerIndex = writerIndex;
+        return this;
     }
 
     @Override
-    public void setIndex(int readerIndex, int writerIndex) {
+    public ByteBuf setIndex(int readerIndex, int writerIndex) {
         if (readerIndex < 0 || readerIndex > writerIndex || writerIndex > capacity()) {
             throw new IndexOutOfBoundsException("Invalid indexes: readerIndex is "
                     + readerIndex + ", writerIndex is "
@@ -105,11 +107,13 @@ public abstract class AbstractByteBuf implements ByteBuf {
         }
         this.readerIndex = readerIndex;
         this.writerIndex = writerIndex;
+        return this;
     }
 
     @Override
-    public void clear() {
+    public ByteBuf clear() {
         readerIndex = writerIndex = 0;
+        return this;
     }
 
     @Override
@@ -133,29 +137,33 @@ public abstract class AbstractByteBuf implements ByteBuf {
     }
 
     @Override
-    public void markReaderIndex() {
+    public ByteBuf markReaderIndex() {
         markedReaderIndex = readerIndex;
+        return this;
     }
 
     @Override
-    public void resetReaderIndex() {
+    public ByteBuf resetReaderIndex() {
         readerIndex(markedReaderIndex);
+        return this;
     }
 
     @Override
-    public void markWriterIndex() {
+    public ByteBuf markWriterIndex() {
         markedWriterIndex = writerIndex;
+        return this;
     }
 
     @Override
-    public void resetWriterIndex() {
+    public ByteBuf resetWriterIndex() {
         writerIndex = markedWriterIndex;
+        return this;
     }
 
     @Override
-    public void discardReadBytes() {
+    public ByteBuf discardReadBytes() {
         if (readerIndex == 0) {
-            return;
+            return this;
         }
 
         if (readerIndex != writerIndex) {
@@ -167,6 +175,7 @@ public abstract class AbstractByteBuf implements ByteBuf {
             adjustMarkers(readerIndex);
             writerIndex = readerIndex = 0;
         }
+        return this;
     }
 
     protected void adjustMarkers(int decrement) {
@@ -175,14 +184,14 @@ public abstract class AbstractByteBuf implements ByteBuf {
     }
 
     @Override
-    public void ensureWritableBytes(int minWritableBytes) {
+    public ByteBuf ensureWritableBytes(int minWritableBytes) {
         if (minWritableBytes < 0) {
             throw new IllegalArgumentException(String.format(
                     "minWritableBytes: %d (expected: >= 0)", minWritableBytes));
         }
 
         if (minWritableBytes <= writableBytes()) {
-            return;
+            return this;
         }
 
         if (minWritableBytes > maxCapacity - writerIndex) {
@@ -196,6 +205,7 @@ public abstract class AbstractByteBuf implements ByteBuf {
 
         // Adjust to the new capacity.
         capacity(newCapacity);
+        return this;
     }
 
     @Override
@@ -317,69 +327,79 @@ public abstract class AbstractByteBuf implements ByteBuf {
     }
 
     @Override
-    public void getBytes(int index, byte[] dst) {
+    public ByteBuf getBytes(int index, byte[] dst) {
         getBytes(index, dst, 0, dst.length);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, ByteBuf dst) {
+    public ByteBuf getBytes(int index, ByteBuf dst) {
         getBytes(index, dst, dst.writableBytes());
+        return this;
     }
 
     @Override
-    public void getBytes(int index, ByteBuf dst, int length) {
+    public ByteBuf getBytes(int index, ByteBuf dst, int length) {
         if (length > dst.writableBytes()) {
             throw new IndexOutOfBoundsException("Too many bytes to be read: Need "
                     + length + ", maximum is " + dst.writableBytes());
         }
         getBytes(index, dst, dst.writerIndex(), length);
         dst.writerIndex(dst.writerIndex() + length);
+        return this;
     }
 
     @Override
-    public void setBoolean(int index, boolean value) {
+    public ByteBuf setBoolean(int index, boolean value) {
         setByte(index, value ? 1 : 0);
+        return this;
     }
 
     @Override
-    public void setChar(int index, int value) {
+    public ByteBuf setChar(int index, int value) {
         setShort(index, value);
+        return this;
     }
 
     @Override
-    public void setFloat(int index, float value) {
+    public ByteBuf setFloat(int index, float value) {
         setInt(index, Float.floatToRawIntBits(value));
+        return this;
     }
 
     @Override
-    public void setDouble(int index, double value) {
+    public ByteBuf setDouble(int index, double value) {
         setLong(index, Double.doubleToRawLongBits(value));
+        return this;
     }
 
     @Override
-    public void setBytes(int index, byte[] src) {
+    public ByteBuf setBytes(int index, byte[] src) {
         setBytes(index, src, 0, src.length);
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuf src) {
+    public ByteBuf setBytes(int index, ByteBuf src) {
         setBytes(index, src, src.readableBytes());
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuf src, int length) {
+    public ByteBuf setBytes(int index, ByteBuf src, int length) {
         if (length > src.readableBytes()) {
             throw new IndexOutOfBoundsException("Too many bytes to write: Need "
                     + length + ", maximum is " + src.readableBytes());
         }
         setBytes(index, src, src.readerIndex(), length);
         src.readerIndex(src.readerIndex() + length);
+        return this;
     }
 
     @Override
-    public void setZero(int index, int length) {
+    public ByteBuf setZero(int index, int length) {
         if (length == 0) {
-            return;
+            return this;
         }
         if (length < 0) {
             throw new IllegalArgumentException(
@@ -407,6 +427,7 @@ public abstract class AbstractByteBuf implements ByteBuf {
                 index ++;
             }
         }
+        return this;
     }
 
     @Override
@@ -514,45 +535,51 @@ public abstract class AbstractByteBuf implements ByteBuf {
     }
 
     @Override
-    public void readBytes(byte[] dst, int dstIndex, int length) {
+    public ByteBuf readBytes(byte[] dst, int dstIndex, int length) {
         checkReadableBytes(length);
         getBytes(readerIndex, dst, dstIndex, length);
         readerIndex += length;
+        return this;
     }
 
     @Override
-    public void readBytes(byte[] dst) {
+    public ByteBuf readBytes(byte[] dst) {
         readBytes(dst, 0, dst.length);
+        return this;
     }
 
     @Override
-    public void readBytes(ByteBuf dst) {
+    public ByteBuf readBytes(ByteBuf dst) {
         readBytes(dst, dst.writableBytes());
+        return this;
     }
 
     @Override
-    public void readBytes(ByteBuf dst, int length) {
+    public ByteBuf readBytes(ByteBuf dst, int length) {
         if (length > dst.writableBytes()) {
             throw new IndexOutOfBoundsException("Too many bytes to be read: Need "
                     + length + ", maximum is " + dst.writableBytes());
         }
         readBytes(dst, dst.writerIndex(), length);
         dst.writerIndex(dst.writerIndex() + length);
+        return this;
     }
 
     @Override
-    public void readBytes(ByteBuf dst, int dstIndex, int length) {
+    public ByteBuf readBytes(ByteBuf dst, int dstIndex, int length) {
         checkReadableBytes(length);
         getBytes(readerIndex, dst, dstIndex, length);
         readerIndex += length;
+        return this;
     }
 
     @Override
-    public void readBytes(ByteBuffer dst) {
+    public ByteBuf readBytes(ByteBuffer dst) {
         int length = dst.remaining();
         checkReadableBytes(length);
         getBytes(readerIndex, dst);
         readerIndex += length;
+        return this;
     }
 
     @Override
@@ -565,116 +592,133 @@ public abstract class AbstractByteBuf implements ByteBuf {
     }
 
     @Override
-    public void readBytes(OutputStream out, int length) throws IOException {
+    public ByteBuf readBytes(OutputStream out, int length) throws IOException {
         checkReadableBytes(length);
         getBytes(readerIndex, out, length);
         readerIndex += length;
+        return this;
     }
 
     @Override
-    public void skipBytes(int length) {
+    public ByteBuf skipBytes(int length) {
         int newReaderIndex = readerIndex + length;
         if (newReaderIndex > writerIndex) {
             throw new IndexOutOfBoundsException("Readable bytes exceeded - Need "
                     + newReaderIndex + ", maximum is " + writerIndex);
         }
         readerIndex = newReaderIndex;
+        return this;
     }
 
     @Override
-    public void writeBoolean(boolean value) {
+    public ByteBuf writeBoolean(boolean value) {
         writeByte(value ? 1 : 0);
+        return this;
     }
 
     @Override
-    public void writeByte(int value) {
+    public ByteBuf writeByte(int value) {
         ensureWritableBytes(1);
         setByte(writerIndex ++, value);
+        return this;
     }
 
     @Override
-    public void writeShort(int value) {
+    public ByteBuf writeShort(int value) {
         ensureWritableBytes(2);
         setShort(writerIndex, value);
         writerIndex += 2;
+        return this;
     }
 
     @Override
-    public void writeMedium(int value) {
+    public ByteBuf writeMedium(int value) {
         ensureWritableBytes(3);
         setMedium(writerIndex, value);
         writerIndex += 3;
+        return this;
     }
 
     @Override
-    public void writeInt(int value) {
+    public ByteBuf writeInt(int value) {
         ensureWritableBytes(4);
         setInt(writerIndex, value);
         writerIndex += 4;
+        return this;
     }
 
     @Override
-    public void writeLong(long value) {
+    public ByteBuf writeLong(long value) {
         ensureWritableBytes(8);
         setLong(writerIndex, value);
         writerIndex += 8;
+        return this;
     }
 
     @Override
-    public void writeChar(int value) {
+    public ByteBuf writeChar(int value) {
         writeShort(value);
+        return this;
     }
 
     @Override
-    public void writeFloat(float value) {
+    public ByteBuf writeFloat(float value) {
         writeInt(Float.floatToRawIntBits(value));
+        return this;
     }
 
     @Override
-    public void writeDouble(double value) {
+    public ByteBuf writeDouble(double value) {
         writeLong(Double.doubleToRawLongBits(value));
+        return this;
     }
 
     @Override
-    public void writeBytes(byte[] src, int srcIndex, int length) {
+    public ByteBuf writeBytes(byte[] src, int srcIndex, int length) {
         ensureWritableBytes(length);
         setBytes(writerIndex, src, srcIndex, length);
         writerIndex += length;
+        return this;
     }
 
     @Override
-    public void writeBytes(byte[] src) {
+    public ByteBuf writeBytes(byte[] src) {
         writeBytes(src, 0, src.length);
+        return this;
     }
 
     @Override
-    public void writeBytes(ByteBuf src) {
+    public ByteBuf writeBytes(ByteBuf src) {
         writeBytes(src, src.readableBytes());
+        return this;
     }
 
     @Override
-    public void writeBytes(ByteBuf src, int length) {
+    public ByteBuf writeBytes(ByteBuf src, int length) {
         if (length > src.readableBytes()) {
             throw new IndexOutOfBoundsException("Too many bytes to write - Need "
                     + length + ", maximum is " + src.readableBytes());
         }
         writeBytes(src, src.readerIndex(), length);
         src.readerIndex(src.readerIndex() + length);
+        return this;
     }
 
     @Override
-    public void writeBytes(ByteBuf src, int srcIndex, int length) {
+    public ByteBuf writeBytes(ByteBuf src, int srcIndex, int length) {
         ensureWritableBytes(length);
         setBytes(writerIndex, src, srcIndex, length);
         writerIndex += length;
+        return this;
     }
 
     @Override
-    public void writeBytes(ByteBuffer src) {
+    public ByteBuf writeBytes(ByteBuffer src) {
         int length = src.remaining();
         ensureWritableBytes(length);
         setBytes(writerIndex, src);
         writerIndex += length;
+        return this;
     }
 
     @Override
@@ -700,9 +744,9 @@ public abstract class AbstractByteBuf implements ByteBuf {
     }
 
     @Override
-    public void writeZero(int length) {
+    public ByteBuf writeZero(int length) {
         if (length == 0) {
-            return;
+            return this;
         }
         if (length < 0) {
             throw new IllegalArgumentException(
@@ -725,6 +769,7 @@ public abstract class AbstractByteBuf implements ByteBuf {
                 writeByte((byte) 0);
             }
         }
+        return this;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/AbstractWrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractWrappedByteBuf.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.ReadOnlyBufferException;
+
+public abstract class AbstractWrappedByteBuf extends AbstractByteBuf implements WrappedByteBuf {
+
+    protected AbstractWrappedByteBuf(ByteOrder endianness, int maxCapacity) {
+        super(endianness, maxCapacity);
+    }
+
+    @Override
+    public WrappedByteBuf capacity(int newCapacity) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public WrappedByteBuf discardReadBytes() {
+        return (WrappedByteBuf) super.discardReadBytes();
+    }
+
+    @Override
+    public WrappedByteBuf readerIndex(int readerIndex) {
+        return (WrappedByteBuf) super.readerIndex(readerIndex);
+    }
+
+    @Override
+    public WrappedByteBuf writerIndex(int writerIndex) {
+        return (WrappedByteBuf) super.writerIndex(writerIndex);
+    }
+
+    @Override
+    public WrappedByteBuf setIndex(int readerIndex, int writerIndex) {
+        return (WrappedByteBuf) super.setIndex(readerIndex, writerIndex);
+    }
+
+    @Override
+    public WrappedByteBuf clear() {
+        return (WrappedByteBuf) super.clear();
+    }
+
+    @Override
+    public WrappedByteBuf markReaderIndex() {
+        return (WrappedByteBuf) super.markReaderIndex();
+    }
+
+    @Override
+    public WrappedByteBuf resetReaderIndex() {
+        return (WrappedByteBuf) super.resetReaderIndex();
+    }
+
+    @Override
+    public WrappedByteBuf markWriterIndex() {
+        return (WrappedByteBuf) super.markWriterIndex();
+    }
+
+    @Override
+    public WrappedByteBuf resetWriterIndex() {
+        return (WrappedByteBuf) super.resetWriterIndex();
+    }
+
+    @Override
+    public WrappedByteBuf ensureWritableBytes(int minWritableBytes) {
+        return (WrappedByteBuf) super.ensureWritableBytes(minWritableBytes);
+    }
+
+    @Override
+    public WrappedByteBuf getBytes(int index, ByteBuf dst) {
+        return (WrappedByteBuf) super.getBytes(index, dst);
+    }
+
+    @Override
+    public WrappedByteBuf getBytes(int index, ByteBuf dst, int length) {
+        return (WrappedByteBuf) super.getBytes(index, dst, length);
+    }
+
+    @Override
+    public WrappedByteBuf getBytes(int index, byte[] dst) {
+        return (WrappedByteBuf) super.getBytes(index, dst);
+    }
+
+    @Override
+    public WrappedByteBuf setBoolean(int index, boolean value) {
+        return (WrappedByteBuf) super.setBoolean(index, value);
+    }
+
+    @Override
+    public WrappedByteBuf setChar(int index, int value) {
+        return (WrappedByteBuf) super.setChar(index, value);
+    }
+
+    @Override
+    public WrappedByteBuf setFloat(int index, float value) {
+        return (WrappedByteBuf) super.setFloat(index, value);
+    }
+
+    @Override
+    public WrappedByteBuf setDouble(int index, double value) {
+        return (WrappedByteBuf) super.setDouble(index, value);
+    }
+
+    @Override
+    public WrappedByteBuf setBytes(int index, ByteBuf src) {
+        return (WrappedByteBuf) super.setBytes(index, src);
+    }
+
+    @Override
+    public WrappedByteBuf setBytes(int index, ByteBuf src, int length) {
+        return (WrappedByteBuf) super.setBytes(index, src, length);
+    }
+
+    @Override
+    public WrappedByteBuf setBytes(int index, byte[] src) {
+        return (WrappedByteBuf) super.setBytes(index, src);
+    }
+
+
+    @Override
+    public WrappedByteBuf setZero(int index, int length) {
+        return (WrappedByteBuf) super.setZero(index, length);
+    }
+
+    @Override
+    public WrappedByteBuf readBytes(ByteBuf dst) {
+        return (WrappedByteBuf) super.readBytes(dst);
+    }
+
+    @Override
+    public WrappedByteBuf readBytes(ByteBuf dst, int length) {
+        return (WrappedByteBuf) super.readBytes(dst, length);
+    }
+
+    @Override
+    public WrappedByteBuf readBytes(ByteBuf dst, int dstIndex, int length) {
+        return (WrappedByteBuf) super.readBytes(dst, dstIndex, length);
+    }
+
+    @Override
+    public WrappedByteBuf readBytes(byte[] dst) {
+        return (WrappedByteBuf) super.readBytes(dst);
+    }
+
+    @Override
+    public WrappedByteBuf readBytes(byte[] dst, int dstIndex, int length) {
+        return (WrappedByteBuf) super.readBytes(dst, dstIndex, length);
+    }
+
+    @Override
+    public WrappedByteBuf readBytes(ByteBuffer dst) {
+        return (WrappedByteBuf) super.readBytes(dst);
+    }
+
+    @Override
+    public WrappedByteBuf readBytes(OutputStream out, int length) throws IOException {
+        return (WrappedByteBuf) super.readBytes(out, length);
+    }
+
+    @Override
+    public WrappedByteBuf skipBytes(int length) {
+        return (WrappedByteBuf) super.skipBytes(length);
+    }
+
+    @Override
+    public WrappedByteBuf writeBoolean(boolean value) {
+        return (WrappedByteBuf) super.writeBoolean(value);
+    }
+
+    @Override
+    public WrappedByteBuf writeByte(int value) {
+        return (WrappedByteBuf) super.writeByte(value);
+    }
+
+    @Override
+    public WrappedByteBuf writeShort(int value) {
+        return (WrappedByteBuf) super.writeShort(value);
+    }
+
+    @Override
+    public WrappedByteBuf writeMedium(int value) {
+        return (WrappedByteBuf) super.writeMedium(value);
+    }
+
+    @Override
+    public WrappedByteBuf writeInt(int value) {
+        return (WrappedByteBuf) super.writeInt(value);
+    }
+
+    @Override
+    public WrappedByteBuf writeLong(long value) {
+        return (WrappedByteBuf) super.writeLong(value);
+    }
+
+    @Override
+    public WrappedByteBuf writeChar(int value) {
+        return (WrappedByteBuf) super.writeChar(value);
+    }
+
+    @Override
+    public WrappedByteBuf writeFloat(float value) {
+        return (WrappedByteBuf) super.writeFloat(value);
+    }
+
+    @Override
+    public WrappedByteBuf writeDouble(double value) {
+        return (WrappedByteBuf) super.writeDouble(value);
+    }
+
+    @Override
+    public WrappedByteBuf writeBytes(ByteBuf src) {
+        return (WrappedByteBuf) super.writeBytes(src);
+    }
+
+    @Override
+    public WrappedByteBuf writeBytes(ByteBuf src, int length) {
+        return (WrappedByteBuf) super.writeBytes(src, length);
+    }
+
+    @Override
+    public WrappedByteBuf writeBytes(ByteBuf src, int srcIndex, int length) {
+        return (WrappedByteBuf) super.writeBytes(src, srcIndex, length);
+    }
+
+    @Override
+    public WrappedByteBuf writeBytes(byte[] src) {
+        return (WrappedByteBuf) super.writeBytes(src);
+    }
+
+    @Override
+    public WrappedByteBuf writeBytes(byte[] src, int srcIndex, int length) {
+        return (WrappedByteBuf) super.writeBytes(src, srcIndex, length);
+    }
+
+    @Override
+    public WrappedByteBuf writeBytes(ByteBuffer src) {
+        return (WrappedByteBuf) super.writeBytes(src);
+    }
+
+    @Override
+    public WrappedByteBuf writeZero(int length) {
+        return (WrappedByteBuf) super.writeZero(length);
+    }
+
+}

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -241,7 +241,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * than the current capacity, the buffer is appended with unspecified data whose length is
      * {@code (newCapacity - currentCapacity)}.
      */
-    void capacity(int newCapacity);
+    ByteBuf capacity(int newCapacity);
 
     /**
      * Returns the maximum allowed capacity of this buffer.  If a user attempts to increase the
@@ -286,7 +286,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *            less than {@code 0} or
      *            greater than {@code this.writerIndex}
      */
-    void readerIndex(int readerIndex);
+    ByteBuf readerIndex(int readerIndex);
 
     /**
      * Returns the {@code writerIndex} of this buffer.
@@ -301,7 +301,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *            less than {@code this.readerIndex} or
      *            greater than {@code this.capacity}
      */
-    void writerIndex(int writerIndex);
+    ByteBuf writerIndex(int writerIndex);
 
     /**
      * Sets the {@code readerIndex} and {@code writerIndex} of this buffer
@@ -354,7 +354,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         {@code readerIndex} or if the specified {@code writerIndex} is
      *         greater than {@code this.capacity}
      */
-    void setIndex(int readerIndex, int writerIndex);
+    ByteBuf setIndex(int readerIndex, int writerIndex);
 
     /**
      * Returns the number of readable bytes which is equal to
@@ -391,7 +391,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * from that of NIO buffer, which sets the {@code limit} to
      * the {@code capacity} of the buffer.
      */
-    void clear();
+    ByteBuf clear();
 
     /**
      * Marks the current {@code readerIndex} in this buffer.  You can
@@ -399,7 +399,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * {@code readerIndex} by calling {@link #resetReaderIndex()}.
      * The initial value of the marked {@code readerIndex} is {@code 0}.
      */
-    void markReaderIndex();
+    ByteBuf markReaderIndex();
 
     /**
      * Repositions the current {@code readerIndex} to the marked
@@ -409,7 +409,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if the current {@code writerIndex} is less than the marked
      *         {@code readerIndex}
      */
-    void resetReaderIndex();
+    ByteBuf resetReaderIndex();
 
     /**
      * Marks the current {@code writerIndex} in this buffer.  You can
@@ -417,7 +417,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * {@code writerIndex} by calling {@link #resetWriterIndex()}.
      * The initial value of the marked {@code writerIndex} is {@code 0}.
      */
-    void markWriterIndex();
+    ByteBuf markWriterIndex();
 
     /**
      * Repositions the current {@code writerIndex} to the marked
@@ -427,7 +427,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if the current {@code readerIndex} is greater than the marked
      *         {@code writerIndex}
      */
-    void resetWriterIndex();
+    ByteBuf resetWriterIndex();
 
     /**
      * Discards the bytes between the 0th index and {@code readerIndex}.
@@ -437,7 +437,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * <p>
      * Please refer to the class documentation for more detailed explanation.
      */
-    void discardReadBytes();
+    ByteBuf discardReadBytes();
 
     /**
      * Makes sure the number of {@linkplain #writableBytes() the writable bytes}
@@ -450,7 +450,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@link #writerIndex()} + {@code minWritableBytes} > {@link #maxCapacity()}
      */
-    void ensureWritableBytes(int minWritableBytes);
+    ByteBuf ensureWritableBytes(int minWritableBytes);
 
     /**
      * Tries to make sure the number of {@linkplain #writableBytes() the writable bytes}
@@ -632,7 +632,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code index + dst.writableBytes} is greater than
      *            {@code this.capacity}
      */
-    void  getBytes(int index, ByteBuf dst);
+    ByteBuf getBytes(int index, ByteBuf dst);
 
     /**
      * Transfers this buffer's data to the specified destination starting at
@@ -652,7 +652,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *            {@code this.capacity}, or
      *         if {@code length} is greater than {@code dst.writableBytes}
      */
-    void  getBytes(int index, ByteBuf dst, int length);
+    ByteBuf getBytes(int index, ByteBuf dst, int length);
 
     /**
      * Transfers this buffer's data to the specified destination starting at
@@ -671,7 +671,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code dstIndex + length} is greater than
      *            {@code dst.capacity}
      */
-    void  getBytes(int index, ByteBuf dst, int dstIndex, int length);
+    ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length);
 
     /**
      * Transfers this buffer's data to the specified destination starting at
@@ -684,7 +684,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code index + dst.length} is greater than
      *            {@code this.capacity}
      */
-    void  getBytes(int index, byte[] dst);
+    ByteBuf getBytes(int index, byte[] dst);
 
     /**
      * Transfers this buffer's data to the specified destination starting at
@@ -703,7 +703,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code dstIndex + length} is greater than
      *            {@code dst.length}
      */
-    void getBytes(int index, byte[] dst, int dstIndex, int length);
+    ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length);
 
     /**
      * Transfers this buffer's data to the specified destination starting at
@@ -717,7 +717,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code index + dst.remaining()} is greater than
      *            {@code this.capacity}
      */
-    void getBytes(int index, ByteBuffer dst);
+    ByteBuf getBytes(int index, ByteBuffer dst);
 
     /**
      * Transfers this buffer's data to the specified stream starting at the
@@ -734,7 +734,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IOException
      *         if the specified stream threw an exception during I/O
      */
-    void getBytes(int index, OutputStream out, int length) throws IOException;
+    ByteBuf getBytes(int index, OutputStream out, int length) throws IOException;
 
     /**
      * Transfers this buffer's data to the specified channel starting at the
@@ -765,7 +765,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 1} is greater than {@code this.capacity}
      */
-    void setBoolean(int index, boolean value);
+    ByteBuf setBoolean(int index, boolean value);
 
     /**
      * Sets the specified byte at the specified absolute {@code index} in this
@@ -777,7 +777,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 1} is greater than {@code this.capacity}
      */
-    void setByte(int index, int value);
+    ByteBuf setByte(int index, int value);
 
     /**
      * Sets the specified 16-bit short integer at the specified absolute
@@ -790,7 +790,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 2} is greater than {@code this.capacity}
      */
-    void setShort(int index, int value);
+    ByteBuf setShort(int index, int value);
 
     /**
      * Sets the specified 24-bit medium integer at the specified absolute
@@ -803,7 +803,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 3} is greater than {@code this.capacity}
      */
-    void setMedium(int index, int   value);
+    ByteBuf setMedium(int index, int   value);
 
     /**
      * Sets the specified 32-bit integer at the specified absolute
@@ -815,7 +815,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 4} is greater than {@code this.capacity}
      */
-    void setInt(int index, int   value);
+    ByteBuf setInt(int index, int   value);
 
     /**
      * Sets the specified 64-bit long integer at the specified absolute
@@ -827,7 +827,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 8} is greater than {@code this.capacity}
      */
-    void setLong(int index, long  value);
+    ByteBuf setLong(int index, long  value);
 
     /**
      * Sets the specified 2-byte UTF-16 character at the specified absolute
@@ -840,7 +840,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 2} is greater than {@code this.capacity}
      */
-    void setChar(int index, int value);
+    ByteBuf setChar(int index, int value);
 
     /**
      * Sets the specified 32-bit floating-point number at the specified
@@ -852,7 +852,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 4} is greater than {@code this.capacity}
      */
-    void setFloat(int index, float value);
+    ByteBuf setFloat(int index, float value);
 
     /**
      * Sets the specified 64-bit floating-point number at the specified
@@ -864,7 +864,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 8} is greater than {@code this.capacity}
      */
-    void setDouble(int index, double value);
+    ByteBuf setDouble(int index, double value);
 
     /**
      * Transfers the specified source buffer's data to this buffer starting at
@@ -882,7 +882,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code index + src.readableBytes} is greater than
      *            {@code this.capacity}
      */
-    void setBytes(int index, ByteBuf src);
+    ByteBuf setBytes(int index, ByteBuf src);
 
     /**
      * Transfers the specified source buffer's data to this buffer starting at
@@ -902,7 +902,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *            {@code this.capacity}, or
      *         if {@code length} is greater than {@code src.readableBytes}
      */
-    void setBytes(int index, ByteBuf src, int length);
+    ByteBuf setBytes(int index, ByteBuf src, int length);
 
     /**
      * Transfers the specified source buffer's data to this buffer starting at
@@ -921,7 +921,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code srcIndex + length} is greater than
      *            {@code src.capacity}
      */
-    void setBytes(int index, ByteBuf src, int srcIndex, int length);
+    ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length);
 
     /**
      * Transfers the specified source array's data to this buffer starting at
@@ -934,7 +934,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code index + src.length} is greater than
      *            {@code this.capacity}
      */
-    void setBytes(int index, byte[] src);
+    ByteBuf setBytes(int index, byte[] src);
 
     /**
      * Transfers the specified source array's data to this buffer starting at
@@ -949,7 +949,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *            {@code this.capacity}, or
      *         if {@code srcIndex + length} is greater than {@code src.length}
      */
-    void setBytes(int index, byte[] src, int srcIndex, int length);
+    ByteBuf setBytes(int index, byte[] src, int srcIndex, int length);
 
     /**
      * Transfers the specified source buffer's data to this buffer starting at
@@ -963,7 +963,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code index + src.remaining()} is greater than
      *            {@code this.capacity}
      */
-    void setBytes(int index, ByteBuffer src);
+    ByteBuf setBytes(int index, ByteBuffer src);
 
     /**
      * Transfers the content of the specified source stream to this buffer
@@ -1015,7 +1015,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         if {@code index + length} is greater than {@code this.capacity}
      */
-    void setZero(int index, int length);
+    ByteBuf setZero(int index, int length);
 
     /**
      * Gets a boolean at the current {@code readerIndex} and increases
@@ -1178,7 +1178,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code dst.writableBytes} is greater than
      *            {@code this.readableBytes}
      */
-    void readBytes(ByteBuf dst);
+    ByteBuf readBytes(ByteBuf dst);
 
     /**
      * Transfers this buffer's data to the specified destination starting at
@@ -1193,7 +1193,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code length} is greater than {@code this.readableBytes} or
      *         if {@code length} is greater than {@code dst.writableBytes}
      */
-    void readBytes(ByteBuf dst, int length);
+    ByteBuf readBytes(ByteBuf dst, int length);
 
     /**
      * Transfers this buffer's data to the specified destination starting at
@@ -1209,7 +1209,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code dstIndex + length} is greater than
      *            {@code dst.capacity}
      */
-    void readBytes(ByteBuf dst, int dstIndex, int length);
+    ByteBuf readBytes(ByteBuf dst, int dstIndex, int length);
 
     /**
      * Transfers this buffer's data to the specified destination starting at
@@ -1219,7 +1219,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code dst.length} is greater than {@code this.readableBytes}
      */
-    void readBytes(byte[] dst);
+    ByteBuf readBytes(byte[] dst);
 
     /**
      * Transfers this buffer's data to the specified destination starting at
@@ -1234,7 +1234,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code length} is greater than {@code this.readableBytes}, or
      *         if {@code dstIndex + length} is greater than {@code dst.length}
      */
-    void readBytes(byte[] dst, int dstIndex, int length);
+    ByteBuf readBytes(byte[] dst, int dstIndex, int length);
 
     /**
      * Transfers this buffer's data to the specified destination starting at
@@ -1246,7 +1246,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code dst.remaining()} is greater than
      *            {@code this.readableBytes}
      */
-    void readBytes(ByteBuffer dst);
+    ByteBuf readBytes(ByteBuffer dst);
 
     /**
      * Transfers this buffer's data to the specified stream starting at the
@@ -1259,7 +1259,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IOException
      *         if the specified stream threw an exception during I/O
      */
-    void readBytes(OutputStream out, int length) throws IOException;
+    ByteBuf readBytes(OutputStream out, int length) throws IOException;
 
     /**
      * Transfers this buffer's data to the specified stream starting at the
@@ -1283,7 +1283,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code length} is greater than {@code this.readableBytes}
      */
-    void skipBytes(int length);
+    ByteBuf skipBytes(int length);
 
     /**
      * Sets the specified boolean at the current {@code writerIndex}
@@ -1292,7 +1292,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 1}
      */
-    void writeBoolean(boolean value);
+    ByteBuf writeBoolean(boolean value);
 
     /**
      * Sets the specified byte at the current {@code writerIndex}
@@ -1302,7 +1302,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 1}
      */
-    void writeByte(int value);
+    ByteBuf writeByte(int value);
 
     /**
      * Sets the specified 16-bit short integer at the current
@@ -1312,7 +1312,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 2}
      */
-    void writeShort(int value);
+    ByteBuf writeShort(int value);
 
     /**
      * Sets the specified 24-bit medium integer at the current
@@ -1322,7 +1322,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 3}
      */
-    void writeMedium(int   value);
+    ByteBuf writeMedium(int   value);
 
     /**
      * Sets the specified 32-bit integer at the current {@code writerIndex}
@@ -1331,7 +1331,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 4}
      */
-    void writeInt(int   value);
+    ByteBuf writeInt(int   value);
 
     /**
      * Sets the specified 64-bit long integer at the current
@@ -1341,7 +1341,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 8}
      */
-    void writeLong(long  value);
+    ByteBuf writeLong(long  value);
 
     /**
      * Sets the specified 2-byte UTF-16 character at the current
@@ -1351,7 +1351,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 2}
      */
-    void writeChar(int value);
+    ByteBuf writeChar(int value);
 
     /**
      * Sets the specified 32-bit floating point number at the current
@@ -1361,7 +1361,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 4}
      */
-    void writeFloat(float value);
+    ByteBuf writeFloat(float value);
 
     /**
      * Sets the specified 64-bit floating point number at the current
@@ -1371,7 +1371,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 8}
      */
-    void writeDouble(double value);
+    ByteBuf writeDouble(double value);
 
     /**
      * Transfers the specified source buffer's data to this buffer starting at
@@ -1387,7 +1387,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code src.readableBytes} is greater than
      *            {@code this.writableBytes}
      */
-    void writeBytes(ByteBuf src);
+    ByteBuf writeBytes(ByteBuf src);
 
     /**
      * Transfers the specified source buffer's data to this buffer starting at
@@ -1404,7 +1404,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code length} is greater than {@code this.writableBytes} or
      *         if {@code length} is greater then {@code src.readableBytes}
      */
-    void writeBytes(ByteBuf src, int length);
+    ByteBuf writeBytes(ByteBuf src, int length);
 
     /**
      * Transfers the specified source buffer's data to this buffer starting at
@@ -1420,7 +1420,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *            {@code src.capacity}, or
      *         if {@code length} is greater than {@code this.writableBytes}
      */
-    void writeBytes(ByteBuf src, int srcIndex, int length);
+    ByteBuf writeBytes(ByteBuf src, int srcIndex, int length);
 
     /**
      * Transfers the specified source array's data to this buffer starting at
@@ -1430,7 +1430,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code src.length} is greater than {@code this.writableBytes}
      */
-    void writeBytes(byte[] src);
+    ByteBuf writeBytes(byte[] src);
 
     /**
      * Transfers the specified source array's data to this buffer starting at
@@ -1446,7 +1446,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *            {@code src.length}, or
      *         if {@code length} is greater than {@code this.writableBytes}
      */
-    void writeBytes(byte[] src, int srcIndex, int length);
+    ByteBuf writeBytes(byte[] src, int srcIndex, int length);
 
     /**
      * Transfers the specified source buffer's data to this buffer starting at
@@ -1458,7 +1458,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      *         if {@code src.remaining()} is greater than
      *            {@code this.writableBytes}
      */
-    void writeBytes(ByteBuffer src);
+    ByteBuf writeBytes(ByteBuffer src);
 
     /**
      * Transfers the content of the specified stream to this buffer
@@ -1502,7 +1502,7 @@ public interface ByteBuf extends ChannelBuf, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code length} is greater than {@code this.writableBytes}
      */
-    void writeZero(int length);
+    ByteBuf writeZero(int length);
 
     /**
      * Locates the first occurrence of the specified {@code value} in this

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -15,20 +15,23 @@
  */
 package io.netty.buffer;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.util.List;
 
 public interface CompositeByteBuf extends ByteBuf, Iterable<ByteBuf> {
 
-    void addComponent(ByteBuf buffer);
-    void addComponent(int cIndex, ByteBuf buffer);
+    CompositeByteBuf addComponent(ByteBuf buffer);
+    CompositeByteBuf addComponent(int cIndex, ByteBuf buffer);
 
-    void addComponents(ByteBuf... buffers);
-    void addComponents(Iterable<ByteBuf> buffers);
-    void addComponents(int cIndex, ByteBuf... buffers);
-    void addComponents(int cIndex, Iterable<ByteBuf> buffers);
+    CompositeByteBuf addComponents(ByteBuf... buffers);
+    CompositeByteBuf addComponents(Iterable<ByteBuf> buffers);
+    CompositeByteBuf addComponents(int cIndex, ByteBuf... buffers);
+    CompositeByteBuf addComponents(int cIndex, Iterable<ByteBuf> buffers);
 
-    void removeComponent(int cIndex);
-    void removeComponents(int cIndex, int numComponents);
+    CompositeByteBuf removeComponent(int cIndex);
+    CompositeByteBuf removeComponents(int cIndex, int numComponents);
 
     int numComponents();
     int maxNumComponents();
@@ -36,9 +39,9 @@ public interface CompositeByteBuf extends ByteBuf, Iterable<ByteBuf> {
     ByteBuf component(int cIndex);
     ByteBuf componentAtOffset(int offset);
 
-    void discardReadComponents();
-    void consolidate();
-    void consolidate(int cIndex, int numComponents);
+    CompositeByteBuf discardReadComponents();
+    CompositeByteBuf consolidate();
+    CompositeByteBuf consolidate(int cIndex, int numComponents);
 
     int toComponentIndex(int offset);
     int toByteIndex(int cIndex);
@@ -47,4 +50,179 @@ public interface CompositeByteBuf extends ByteBuf, Iterable<ByteBuf> {
      * Same with {@link #slice(int, int)} except that this method returns a list.
      */
     List<ByteBuf> decompose(int offset, int length);
+
+    @Override
+    CompositeByteBuf capacity(int newCapacity);
+
+    @Override
+    CompositeByteBuf readerIndex(int readerIndex);
+
+    @Override
+    CompositeByteBuf writerIndex(int writerIndex);
+
+    @Override
+    CompositeByteBuf setIndex(int readerIndex, int writerIndex);
+
+    @Override
+    CompositeByteBuf clear();
+
+    @Override
+    CompositeByteBuf markReaderIndex();
+
+    @Override
+    CompositeByteBuf resetReaderIndex();
+
+    @Override
+    CompositeByteBuf markWriterIndex();
+
+    @Override
+    CompositeByteBuf resetWriterIndex();
+
+    @Override
+    CompositeByteBuf discardReadBytes();
+
+    @Override
+    CompositeByteBuf ensureWritableBytes(int minWritableBytes);
+
+    @Override
+    CompositeByteBuf getBytes(int index, ByteBuf dst);
+
+    @Override
+    CompositeByteBuf getBytes(int index, ByteBuf dst, int length);
+
+    @Override
+    CompositeByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length);
+
+    @Override
+    CompositeByteBuf getBytes(int index, byte[] dst);
+
+    @Override
+    CompositeByteBuf getBytes(int index, byte[] dst, int dstIndex, int length);
+
+    @Override
+    CompositeByteBuf getBytes(int index, ByteBuffer dst);
+
+    @Override
+    CompositeByteBuf getBytes(int index, OutputStream out, int length) throws IOException;
+
+    @Override
+    CompositeByteBuf setBoolean(int index, boolean value);
+
+    @Override
+    CompositeByteBuf setByte(int index, int value);
+
+    @Override
+    CompositeByteBuf setShort(int index, int value);
+
+    @Override
+    CompositeByteBuf setMedium(int index, int value);
+
+    @Override
+    CompositeByteBuf setInt(int index, int value);
+
+    @Override
+    CompositeByteBuf setLong(int index, long value);
+
+    @Override
+    CompositeByteBuf setChar(int index, int value);
+
+    @Override
+    CompositeByteBuf setFloat(int index, float value);
+
+    @Override
+    CompositeByteBuf setDouble(int index, double value);
+
+    @Override
+    CompositeByteBuf setBytes(int index, ByteBuf src);
+
+    @Override
+    CompositeByteBuf setBytes(int index, ByteBuf src, int length);
+
+    @Override
+    CompositeByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length);
+
+    @Override
+    CompositeByteBuf setBytes(int index, byte[] src);
+
+    @Override
+    CompositeByteBuf setBytes(int index, byte[] src, int srcIndex, int length);
+
+    @Override
+    CompositeByteBuf setBytes(int index, ByteBuffer src);
+
+    @Override
+    CompositeByteBuf setZero(int index, int length);
+
+    @Override
+    CompositeByteBuf readBytes(ByteBuf dst);
+
+    @Override
+    CompositeByteBuf readBytes(ByteBuf dst, int length);
+
+    @Override
+    CompositeByteBuf readBytes(ByteBuf dst, int dstIndex, int length);
+
+    @Override
+    CompositeByteBuf readBytes(byte[] dst);
+
+    @Override
+    CompositeByteBuf readBytes(byte[] dst, int dstIndex, int length);
+
+    @Override
+    CompositeByteBuf readBytes(ByteBuffer dst);
+
+    @Override
+    CompositeByteBuf readBytes(OutputStream out, int length) throws IOException;
+
+    @Override
+    CompositeByteBuf skipBytes(int length);
+
+    @Override
+    CompositeByteBuf writeBoolean(boolean value);
+
+    @Override
+    CompositeByteBuf writeByte(int value);
+
+    @Override
+    CompositeByteBuf writeShort(int value);
+
+    @Override
+    CompositeByteBuf writeMedium(int value);
+
+    @Override
+    CompositeByteBuf writeInt(int value);
+
+    @Override
+    CompositeByteBuf writeLong(long value);
+
+    @Override
+    CompositeByteBuf writeChar(int value);
+
+    @Override
+    CompositeByteBuf writeFloat(float value);
+
+    @Override
+    CompositeByteBuf writeDouble(double value);
+
+    @Override
+    CompositeByteBuf writeBytes(ByteBuf src);
+
+    @Override
+    CompositeByteBuf writeBytes(ByteBuf src, int length);
+
+    @Override
+    CompositeByteBuf writeBytes(ByteBuf src, int srcIndex, int length);
+
+    @Override
+    CompositeByteBuf writeBytes(byte[] src);
+
+    @Override
+    CompositeByteBuf writeBytes(byte[] src, int srcIndex, int length);
+
+    @Override
+    CompositeByteBuf writeBytes(ByteBuffer src);
+
+    @Override
+    CompositeByteBuf writeZero(int length);
+
 }

--- a/buffer/src/main/java/io/netty/buffer/DefaultCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DefaultCompositeByteBuf.java
@@ -79,22 +79,25 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
     }
 
     @Override
-    public void addComponent(ByteBuf buffer) {
+    public CompositeByteBuf addComponent(ByteBuf buffer) {
         addComponent(components.size(), buffer);
+        return this;
     }
 
     @Override
-    public void addComponents(ByteBuf... buffers) {
+    public CompositeByteBuf addComponents(ByteBuf... buffers) {
         addComponents(components.size(), buffers);
+        return this;
     }
 
     @Override
-    public void addComponents(Iterable<ByteBuf> buffers) {
+    public CompositeByteBuf addComponents(Iterable<ByteBuf> buffers) {
         addComponents(components.size(), buffers);
+        return this;
     }
 
     @Override
-    public void addComponent(int cIndex, ByteBuf buffer) {
+    public CompositeByteBuf addComponent(int cIndex, ByteBuf buffer) {
         checkComponentIndex(cIndex);
 
         if (buffer == null) {
@@ -105,12 +108,12 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             @SuppressWarnings("unchecked")
             Iterable<ByteBuf> composite = (Iterable<ByteBuf>) buffer;
             addComponents(cIndex, composite);
-            return;
+            return this;
         }
 
         int readableBytes = buffer.readableBytes();
         if (readableBytes == 0) {
-            return;
+            return this;
         }
 
         // Consolidate if the number of components will exceed the allowed maximum by the current
@@ -131,7 +134,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             c.endOffset = c.length;
             components.clear();
             components.add(c);
-            return;
+            return this;
         }
 
         // No need to consolidate - just add a component to the list.
@@ -149,10 +152,11 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             components.add(cIndex, c);
             updateComponentOffsets(cIndex);
         }
+        return this;
     }
 
     @Override
-    public void addComponents(int cIndex, ByteBuf... buffers) {
+    public CompositeByteBuf addComponents(int cIndex, ByteBuf... buffers) {
         checkComponentIndex(cIndex);
 
         if (buffers == null) {
@@ -172,7 +176,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
         }
 
         if (readableBytes == 0) {
-            return;
+            return this;
         }
 
         // Consolidate if the number of components will exceed the maximum by this operation.
@@ -215,7 +219,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             components.clear();
             components.add(c);
             updateComponentOffsets(0);
-            return;
+            return this;
         }
 
         // No need for consolidation
@@ -228,10 +232,11 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
                 addComponent(cIndex ++, b);
             }
         }
+        return this;
     }
 
     @Override
-    public void addComponents(int cIndex, Iterable<ByteBuf> buffers) {
+    public CompositeByteBuf addComponents(int cIndex, Iterable<ByteBuf> buffers) {
         if (buffers == null) {
             throw new NullPointerException("buffers");
         }
@@ -243,7 +248,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
                 array[i] = list.get(i).buf;
             }
             addComponents(cIndex, array);
-            return;
+            return this;
         }
 
         if (buffers instanceof List) {
@@ -253,7 +258,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
                 array[i] = list.get(i);
             }
             addComponents(cIndex, array);
-            return;
+            return this;
         }
 
         if (buffers instanceof Collection) {
@@ -264,7 +269,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
                 array[i ++] = b;
             }
             addComponents(cIndex, array);
-            return;
+            return this;
         }
 
         List<ByteBuf> list = new ArrayList<ByteBuf>();
@@ -272,6 +277,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             list.add(b);
         }
         addComponents(cIndex, list.toArray(new ByteBuf[list.size()]));
+        return this;
     }
 
     private void checkComponentIndex(int cIndex) {
@@ -312,17 +318,19 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
     }
 
     @Override
-    public void removeComponent(int cIndex) {
+    public CompositeByteBuf removeComponent(int cIndex) {
         checkComponentIndex(cIndex);
         components.remove(cIndex);
         updateComponentOffsets(cIndex);
+        return this;
     }
 
     @Override
-    public void removeComponents(int cIndex, int numComponents) {
+    public CompositeByteBuf removeComponents(int cIndex, int numComponents) {
         checkComponentIndex(cIndex, numComponents);
         components.subList(cIndex, cIndex + numComponents).clear();
         updateComponentOffsets(cIndex);
+        return this;
     }
 
     @Override
@@ -422,7 +430,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
     }
 
     @Override
-    public void capacity(int newCapacity) {
+    public CompositeByteBuf capacity(int newCapacity) {
         if (newCapacity < 0 || newCapacity > maxCapacity()) {
             throw new IllegalArgumentException("newCapacity: " + newCapacity);
         }
@@ -464,6 +472,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
                 writerIndex(newCapacity);
             }
         }
+        return this;
     }
 
     @Override
@@ -577,7 +586,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
     }
 
     @Override
-    public void getBytes(int index, byte[] dst, int dstIndex, int length) {
+    public CompositeByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
         if (index > capacity() - length || dstIndex > dst.length - length) {
             throw new IndexOutOfBoundsException("Too many bytes to read - Needs "
                     + (index + length) + ", maximum is " + capacity() + " or "
@@ -587,7 +596,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             throw new IndexOutOfBoundsException("index must be >= 0");
         }
         if (length == 0) {
-            return;
+            return this;
         }
         int i = toComponentIndex(index);
 
@@ -602,10 +611,11 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             length -= localLength;
             i ++;
         }
+        return this;
     }
 
     @Override
-    public void getBytes(int index, ByteBuffer dst) {
+    public CompositeByteBuf getBytes(int index, ByteBuffer dst) {
         int limit = dst.limit();
         int length = dst.remaining();
 
@@ -617,7 +627,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             throw new IndexOutOfBoundsException("index must be >= 0");
         }
         if (length == 0) {
-            return;
+            return this;
         }
         int i = toComponentIndex(index);
         try {
@@ -635,10 +645,11 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
         } finally {
             dst.limit(limit);
         }
+        return this;
     }
 
     @Override
-    public void getBytes(int index, ByteBuf dst, int dstIndex, int length) {
+    public CompositeByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
         if (index > capacity() - length || dstIndex > dst.capacity() - length) {
             throw new IndexOutOfBoundsException("Too many bytes to be read - Needs "
                     + (index + length) + " or " + (dstIndex + length) + ", maximum is "
@@ -648,7 +659,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             throw new IndexOutOfBoundsException("index must be >= 0");
         }
         if (length == 0) {
-            return;
+            return this;
         }
         int i = toComponentIndex(index);
         while (length > 0) {
@@ -662,6 +673,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             length -= localLength;
             i ++;
         }
+        return this;
     }
 
     @Override
@@ -682,7 +694,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
     }
 
     @Override
-    public void getBytes(int index, OutputStream out, int length)
+    public CompositeByteBuf getBytes(int index, OutputStream out, int length)
             throws IOException {
         if (index > capacity() - length) {
             throw new IndexOutOfBoundsException("Too many bytes to be read - needs "
@@ -692,7 +704,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             throw new IndexOutOfBoundsException("index must be >= 0");
         }
         if (length == 0) {
-            return;
+            return this;
         }
 
         int i = toComponentIndex(index);
@@ -706,16 +718,18 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             length -= localLength;
             i ++;
         }
+        return this;
     }
 
     @Override
-    public void setByte(int index, int value) {
+    public CompositeByteBuf setByte(int index, int value) {
         Component c = findComponent(index);
         c.buf.setByte(index - c.offset, value);
+        return this;
     }
 
     @Override
-    public void setShort(int index, int value) {
+    public CompositeByteBuf setShort(int index, int value) {
         Component c = findComponent(index);
         if (index + 2 <= c.endOffset) {
             c.buf.setShort(index - c.offset, value);
@@ -726,10 +740,11 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             setByte(index    , (byte) value);
             setByte(index + 1, (byte) (value >>> 8));
         }
+        return this;
     }
 
     @Override
-    public void setMedium(int index, int value) {
+    public CompositeByteBuf setMedium(int index, int value) {
         Component c = findComponent(index);
         if (index + 3 <= c.endOffset) {
             c.buf.setMedium(index - c.offset, value);
@@ -740,10 +755,11 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             setShort(index    , (short) value);
             setByte(index + 2, (byte) (value >>> 16));
         }
+        return this;
     }
 
     @Override
-    public void setInt(int index, int value) {
+    public CompositeByteBuf setInt(int index, int value) {
         Component c = findComponent(index);
         if (index + 4 <= c.endOffset) {
             c.buf.setInt(index - c.offset, value);
@@ -754,10 +770,11 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             setShort(index    , (short) value);
             setShort(index + 2, (short) (value >>> 16));
         }
+        return this;
     }
 
     @Override
-    public void setLong(int index, long value) {
+    public CompositeByteBuf setLong(int index, long value) {
         Component c = findComponent(index);
         if (index + 8 <= c.endOffset) {
             c.buf.setLong(index - c.offset, value);
@@ -768,10 +785,11 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             setInt(index    , (int) value);
             setInt(index + 4, (int) (value >>> 32));
         }
+        return this;
     }
 
     @Override
-    public void setBytes(int index, byte[] src, int srcIndex, int length) {
+    public CompositeByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
         int componentId = toComponentIndex(index);
         if (index > capacity() - length || srcIndex > src.length - length) {
             throw new IndexOutOfBoundsException("Too many bytes to read - needs "
@@ -791,10 +809,11 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             length -= localLength;
             i ++;
         }
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuffer src) {
+    public CompositeByteBuf setBytes(int index, ByteBuffer src) {
         int componentId = toComponentIndex(index);
         int limit = src.limit();
         int length = src.remaining();
@@ -819,10 +838,11 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
         } finally {
             src.limit(limit);
         }
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuf src, int srcIndex, int length) {
+    public CompositeByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
         int componentId = toComponentIndex(index);
         if (index > capacity() - length || srcIndex > src.capacity() - length) {
             throw new IndexOutOfBoundsException("Too many bytes to be written - Needs "
@@ -842,6 +862,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             length -= localLength;
             i ++;
         }
+        return this;
     }
 
     @Override
@@ -1088,10 +1109,10 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
     }
 
     @Override
-    public void consolidate() {
+    public CompositeByteBuf consolidate() {
         final int numComponents = numComponents();
         if (numComponents <= 1) {
-            return;
+            return this;
         }
 
         final Component last = components.get(numComponents - 1);
@@ -1107,13 +1128,14 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
         components.clear();
         components.add(new Component(consolidated));
         updateComponentOffsets(0);
+        return this;
     }
 
     @Override
-    public void consolidate(int cIndex, int numComponents) {
+    public CompositeByteBuf consolidate(int cIndex, int numComponents) {
         checkComponentIndex(cIndex, numComponents);
         if (numComponents <= 1) {
-            return;
+            return this;
         }
 
         final int endCIndex = cIndex + numComponents;
@@ -1130,13 +1152,14 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
         components.subList(cIndex + 1, endCIndex).clear();
         components.set(cIndex, new Component(consolidated));
         updateComponentOffsets(cIndex);
+        return this;
     }
 
     @Override
-    public void discardReadComponents() {
+    public CompositeByteBuf discardReadComponents() {
         final int readerIndex = readerIndex();
         if (readerIndex == 0) {
-            return;
+            return this;
         }
 
         // Discard everything if (readerIndex = writerIndex = capacity).
@@ -1148,7 +1171,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             components.clear();
             setIndex(0, 0);
             adjustMarkers(readerIndex);
-            return;
+            return this;
         }
 
         // Remove read components.
@@ -1163,13 +1186,14 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
         updateComponentOffsets(0);
         setIndex(readerIndex - first.offset, writerIndex - first.offset);
         adjustMarkers(first.offset);
+        return this;
     }
 
     @Override
-    public void discardReadBytes() {
+    public CompositeByteBuf discardReadBytes() {
         final int readerIndex = readerIndex();
         if (readerIndex == 0) {
-            return;
+            return this;
         }
 
         // Discard everything if (readerIndex = writerIndex = capacity).
@@ -1181,7 +1205,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             components.clear();
             setIndex(0, 0);
             adjustMarkers(readerIndex);
-            return;
+            return this;
         }
 
         // Remove read components.
@@ -1207,6 +1231,7 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
         updateComponentOffsets(0);
         setIndex(0, writerIndex - readerIndex);
         adjustMarkers(readerIndex);
+        return this;
     }
 
     @Override
@@ -1226,6 +1251,228 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             this.buf = buf;
             length = buf.readableBytes();
         }
+    }
+
+
+    @Override
+    public CompositeByteBuf readerIndex(int readerIndex) {
+        return (CompositeByteBuf) super.readerIndex(readerIndex);
+    }
+
+    @Override
+    public CompositeByteBuf writerIndex(int writerIndex) {
+        return (CompositeByteBuf) super.writerIndex(writerIndex);
+    }
+
+    @Override
+    public CompositeByteBuf setIndex(int readerIndex, int writerIndex) {
+        return (CompositeByteBuf) super.setIndex(readerIndex, writerIndex);
+    }
+
+    @Override
+    public CompositeByteBuf clear() {
+        return (CompositeByteBuf) super.clear();
+    }
+
+    @Override
+    public CompositeByteBuf markReaderIndex() {
+        return (CompositeByteBuf) super.markReaderIndex();
+    }
+
+    @Override
+    public CompositeByteBuf resetReaderIndex() {
+        return (CompositeByteBuf) super.resetReaderIndex();
+    }
+
+    @Override
+    public CompositeByteBuf markWriterIndex() {
+        return (CompositeByteBuf) super.markWriterIndex();
+    }
+
+    @Override
+    public CompositeByteBuf resetWriterIndex() {
+        return (CompositeByteBuf) super.resetWriterIndex();
+    }
+
+    @Override
+    public CompositeByteBuf ensureWritableBytes(int minWritableBytes) {
+        return (CompositeByteBuf) super.ensureWritableBytes(minWritableBytes);
+    }
+
+    @Override
+    public CompositeByteBuf getBytes(int index, ByteBuf dst) {
+        return (CompositeByteBuf) super.getBytes(index, dst);
+    }
+
+    @Override
+    public CompositeByteBuf getBytes(int index, ByteBuf dst, int length) {
+        return (CompositeByteBuf) super.getBytes(index, dst, length);
+    }
+
+    @Override
+    public CompositeByteBuf getBytes(int index, byte[] dst) {
+        return (CompositeByteBuf) super.getBytes(index, dst);
+    }
+
+    @Override
+    public CompositeByteBuf setBoolean(int index, boolean value) {
+        return (CompositeByteBuf) super.setBoolean(index, value);
+    }
+
+    @Override
+    public CompositeByteBuf setChar(int index, int value) {
+        return (CompositeByteBuf) super.setChar(index, value);
+    }
+
+    @Override
+    public CompositeByteBuf setFloat(int index, float value) {
+        return (CompositeByteBuf) super.setFloat(index, value);
+    }
+
+    @Override
+    public CompositeByteBuf setDouble(int index, double value) {
+        return (CompositeByteBuf) super.setDouble(index, value);
+    }
+
+    @Override
+    public CompositeByteBuf setBytes(int index, ByteBuf src) {
+        return (CompositeByteBuf) super.setBytes(index, src);
+    }
+
+    @Override
+    public CompositeByteBuf setBytes(int index, ByteBuf src, int length) {
+        return (CompositeByteBuf) super.setBytes(index, src, length);
+    }
+
+    @Override
+    public CompositeByteBuf setBytes(int index, byte[] src) {
+        return (CompositeByteBuf) super.setBytes(index, src);
+    }
+
+
+    @Override
+    public CompositeByteBuf setZero(int index, int length) {
+        return (CompositeByteBuf) super.setZero(index, length);
+    }
+
+    @Override
+    public CompositeByteBuf readBytes(ByteBuf dst) {
+        return (CompositeByteBuf) super.readBytes(dst);
+    }
+
+    @Override
+    public CompositeByteBuf readBytes(ByteBuf dst, int length) {
+        return (CompositeByteBuf) super.readBytes(dst, length);
+    }
+
+    @Override
+    public CompositeByteBuf readBytes(ByteBuf dst, int dstIndex, int length) {
+        return (CompositeByteBuf) super.readBytes(dst, dstIndex, length);
+    }
+
+    @Override
+    public CompositeByteBuf readBytes(byte[] dst) {
+        return (CompositeByteBuf) super.readBytes(dst);
+    }
+
+    @Override
+    public CompositeByteBuf readBytes(byte[] dst, int dstIndex, int length) {
+        return (CompositeByteBuf) super.readBytes(dst, dstIndex, length);
+    }
+
+    @Override
+    public CompositeByteBuf readBytes(ByteBuffer dst) {
+        return (CompositeByteBuf) super.readBytes(dst);
+    }
+
+    @Override
+    public CompositeByteBuf readBytes(OutputStream out, int length) throws IOException {
+        return (CompositeByteBuf) super.readBytes(out, length);
+    }
+
+    @Override
+    public CompositeByteBuf skipBytes(int length) {
+        return (CompositeByteBuf) super.skipBytes(length);
+    }
+
+    @Override
+    public CompositeByteBuf writeBoolean(boolean value) {
+        return (CompositeByteBuf) super.writeBoolean(value);
+    }
+
+    @Override
+    public CompositeByteBuf writeByte(int value) {
+        return (CompositeByteBuf) super.writeByte(value);
+    }
+
+    @Override
+    public CompositeByteBuf writeShort(int value) {
+        return (CompositeByteBuf) super.writeShort(value);
+    }
+
+    @Override
+    public CompositeByteBuf writeMedium(int value) {
+        return (CompositeByteBuf) super.writeMedium(value);
+    }
+
+    @Override
+    public CompositeByteBuf writeInt(int value) {
+        return (CompositeByteBuf) super.writeInt(value);
+    }
+
+    @Override
+    public CompositeByteBuf writeLong(long value) {
+        return (CompositeByteBuf) super.writeLong(value);
+    }
+
+    @Override
+    public CompositeByteBuf writeChar(int value) {
+        return (CompositeByteBuf) super.writeChar(value);
+    }
+
+    @Override
+    public CompositeByteBuf writeFloat(float value) {
+        return (CompositeByteBuf) super.writeFloat(value);
+    }
+
+    @Override
+    public CompositeByteBuf writeDouble(double value) {
+        return (CompositeByteBuf) super.writeDouble(value);
+    }
+
+    @Override
+    public CompositeByteBuf writeBytes(ByteBuf src) {
+        return (CompositeByteBuf) super.writeBytes(src);
+    }
+
+    @Override
+    public CompositeByteBuf writeBytes(ByteBuf src, int length) {
+        return (CompositeByteBuf) super.writeBytes(src, length);
+    }
+
+    @Override
+    public CompositeByteBuf writeBytes(ByteBuf src, int srcIndex, int length) {
+        return (CompositeByteBuf) super.writeBytes(src, srcIndex, length);
+    }
+
+    @Override
+    public CompositeByteBuf writeBytes(byte[] src) {
+        return (CompositeByteBuf) super.writeBytes(src);
+    }
+
+    @Override
+    public CompositeByteBuf writeBytes(byte[] src, int srcIndex, int length) {
+        return (CompositeByteBuf) super.writeBytes(src, srcIndex, length);
+    }
+
+    @Override
+    public CompositeByteBuf writeBytes(ByteBuffer src) {
+        return (CompositeByteBuf) super.writeBytes(src);
+    }
+
+    @Override
+    public CompositeByteBuf writeZero(int length) {
+        return (CompositeByteBuf) super.writeZero(length);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/DirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DirectByteBuf.java
@@ -145,7 +145,7 @@ public class DirectByteBuf extends AbstractByteBuf {
     }
 
     @Override
-    public void capacity(int newCapacity) {
+    public ByteBuf capacity(int newCapacity) {
         if (newCapacity < 0 || newCapacity > maxCapacity()) {
             throw new IllegalArgumentException("newCapacity: " + newCapacity);
         }
@@ -178,6 +178,7 @@ public class DirectByteBuf extends AbstractByteBuf {
             }
             setByteBuffer(newBuffer);
         }
+        return this;
     }
 
     @Override
@@ -222,7 +223,7 @@ public class DirectByteBuf extends AbstractByteBuf {
     }
 
     @Override
-    public void getBytes(int index, ByteBuf dst, int dstIndex, int length) {
+    public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
         if (dst instanceof DirectByteBuf) {
             DirectByteBuf bbdst = (DirectByteBuf) dst;
             ByteBuffer data = bbdst.tmpBuf;
@@ -233,10 +234,11 @@ public class DirectByteBuf extends AbstractByteBuf {
         } else {
             dst.setBytes(dstIndex, this, index, length);
         }
+        return this;
     }
 
     @Override
-    public void getBytes(int index, byte[] dst, int dstIndex, int length) {
+    public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
         try {
             tmpBuf.clear().position(index).limit(index + length);
         } catch (IllegalArgumentException e) {
@@ -244,10 +246,11 @@ public class DirectByteBuf extends AbstractByteBuf {
                     (index + length) + ", maximum is " + buffer.limit());
         }
         tmpBuf.get(dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, ByteBuffer dst) {
+    public ByteBuf getBytes(int index, ByteBuffer dst) {
         int bytesToCopy = Math.min(capacity() - index, dst.remaining());
         try {
             tmpBuf.clear().position(index).limit(index + bytesToCopy);
@@ -256,37 +259,43 @@ public class DirectByteBuf extends AbstractByteBuf {
                     (index + bytesToCopy) + ", maximum is " + buffer.limit());
         }
         dst.put(tmpBuf);
+        return this;
     }
 
     @Override
-    public void setByte(int index, int value) {
+    public ByteBuf setByte(int index, int value) {
         buffer.put(index, (byte) value);
+        return this;
     }
 
     @Override
-    public void setShort(int index, int value) {
+    public ByteBuf setShort(int index, int value) {
         buffer.putShort(index, (short) value);
+        return this;
     }
 
     @Override
-    public void setMedium(int index, int value) {
+    public ByteBuf setMedium(int index, int value) {
         setByte(index, (byte) (value >>> 16));
         setByte(index + 1, (byte) (value >>> 8));
         setByte(index + 2, (byte) (value >>> 0));
+        return this;
     }
 
     @Override
-    public void setInt(int index, int value) {
+    public ByteBuf setInt(int index, int value) {
         buffer.putInt(index, value);
+        return this;
     }
 
     @Override
-    public void setLong(int index, long value) {
+    public ByteBuf setLong(int index, long value) {
         buffer.putLong(index, value);
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuf src, int srcIndex, int length) {
+    public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
         if (src instanceof DirectByteBuf) {
             DirectByteBuf bbsrc = (DirectByteBuf) src;
             ByteBuffer data = bbsrc.tmpBuf;
@@ -298,28 +307,31 @@ public class DirectByteBuf extends AbstractByteBuf {
         } else {
             src.getBytes(srcIndex, this, index, length);
         }
+        return this;
     }
 
     @Override
-    public void setBytes(int index, byte[] src, int srcIndex, int length) {
+    public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
         tmpBuf.clear().position(index).limit(index + length);
         tmpBuf.put(src, srcIndex, length);
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuffer src) {
+    public ByteBuf setBytes(int index, ByteBuffer src) {
         if (src == tmpBuf) {
             src = src.duplicate();
         }
 
         tmpBuf.clear().position(index).limit(index + src.remaining());
         tmpBuf.put(src);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, OutputStream out, int length) throws IOException {
+    public ByteBuf getBytes(int index, OutputStream out, int length) throws IOException {
         if (length == 0) {
-            return;
+            return this;
         }
 
         if (buffer.hasArray()) {
@@ -330,6 +342,7 @@ public class DirectByteBuf extends AbstractByteBuf {
             tmpBuf.get(tmp);
             out.write(tmp);
         }
+        return this;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/DuplicatedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DuplicatedByteBuf.java
@@ -28,7 +28,7 @@ import java.nio.channels.ScatteringByteChannel;
  * parent.  It is recommended to use {@link ByteBuf#duplicate()} instead
  * of calling the constructor explicitly.
  */
-public class DuplicatedByteBuf extends AbstractByteBuf implements WrappedByteBuf {
+public class DuplicatedByteBuf extends AbstractWrappedByteBuf {
 
     private final Unsafe unsafe = new DuplicatedUnsafe();
     final ByteBuf buffer;
@@ -63,8 +63,9 @@ public class DuplicatedByteBuf extends AbstractByteBuf implements WrappedByteBuf
     }
 
     @Override
-    public void capacity(int newCapacity) {
+    public WrappedByteBuf capacity(int newCapacity) {
         buffer.capacity(newCapacity);
+        return this;
     }
 
     @Override
@@ -123,64 +124,76 @@ public class DuplicatedByteBuf extends AbstractByteBuf implements WrappedByteBuf
     }
 
     @Override
-    public void getBytes(int index, ByteBuf dst, int dstIndex, int length) {
+    public WrappedByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
         buffer.getBytes(index, dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, byte[] dst, int dstIndex, int length) {
+    public WrappedByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
         buffer.getBytes(index, dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, ByteBuffer dst) {
+    public WrappedByteBuf getBytes(int index, ByteBuffer dst) {
         buffer.getBytes(index, dst);
+        return this;
     }
 
     @Override
-    public void setByte(int index, int value) {
+    public WrappedByteBuf setByte(int index, int value) {
         buffer.setByte(index, value);
+        return this;
     }
 
     @Override
-    public void setShort(int index, int value) {
+    public WrappedByteBuf setShort(int index, int value) {
         buffer.setShort(index, value);
+        return this;
     }
 
     @Override
-    public void setMedium(int index, int value) {
+    public WrappedByteBuf setMedium(int index, int value) {
         buffer.setMedium(index, value);
+        return this;
     }
 
     @Override
-    public void setInt(int index, int value) {
+    public WrappedByteBuf setInt(int index, int value) {
         buffer.setInt(index, value);
+        return this;
     }
 
     @Override
-    public void setLong(int index, long value) {
+    public WrappedByteBuf setLong(int index, long value) {
         buffer.setLong(index, value);
+        return this;
     }
 
     @Override
-    public void setBytes(int index, byte[] src, int srcIndex, int length) {
+    public WrappedByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
         buffer.setBytes(index, src, srcIndex, length);
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuf src, int srcIndex, int length) {
+    public WrappedByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
         buffer.setBytes(index, src, srcIndex, length);
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuffer src) {
+    public WrappedByteBuf setBytes(int index, ByteBuffer src) {
         buffer.setBytes(index, src);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, OutputStream out, int length)
+    public WrappedByteBuf getBytes(int index, OutputStream out, int length)
             throws IOException {
         buffer.getBytes(index, out, length);
+        return this;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/HeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/HeapByteBuf.java
@@ -84,7 +84,7 @@ public class HeapByteBuf extends AbstractByteBuf {
     }
 
     @Override
-    public void capacity(int newCapacity) {
+    public ByteBuf capacity(int newCapacity) {
         if (newCapacity < 0 || newCapacity > maxCapacity()) {
             throw new IllegalArgumentException("newCapacity: " + newCapacity);
         }
@@ -108,6 +108,7 @@ public class HeapByteBuf extends AbstractByteBuf {
             }
             setArray(newArray);
         }
+        return this;
     }
 
     @Override
@@ -131,28 +132,32 @@ public class HeapByteBuf extends AbstractByteBuf {
     }
 
     @Override
-    public void getBytes(int index, ByteBuf dst, int dstIndex, int length) {
+    public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
         if (dst instanceof HeapByteBuf) {
             getBytes(index, ((HeapByteBuf) dst).array, dstIndex, length);
         } else {
             dst.setBytes(dstIndex, array, index, length);
         }
+        return this;
     }
 
     @Override
-    public void getBytes(int index, byte[] dst, int dstIndex, int length) {
+    public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
         System.arraycopy(array, index, dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, ByteBuffer dst) {
+    public ByteBuf getBytes(int index, ByteBuffer dst) {
         dst.put(array, index, Math.min(capacity() - index, dst.remaining()));
+        return this;
     }
 
     @Override
-    public void getBytes(int index, OutputStream out, int length)
+    public ByteBuf getBytes(int index, OutputStream out, int length)
             throws IOException {
         out.write(array, index, length);
+        return this;
     }
 
     @Override
@@ -162,27 +167,31 @@ public class HeapByteBuf extends AbstractByteBuf {
     }
 
     @Override
-    public void setByte(int index, int value) {
+    public ByteBuf setByte(int index, int value) {
         array[index] = (byte) value;
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuf src, int srcIndex, int length) {
+    public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
         if (src instanceof HeapByteBuf) {
             setBytes(index, ((HeapByteBuf) src).array, srcIndex, length);
         } else {
             src.getBytes(srcIndex, array, index, length);
         }
+        return this;
     }
 
     @Override
-    public void setBytes(int index, byte[] src, int srcIndex, int length) {
+    public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
         System.arraycopy(src, srcIndex, array, index, length);
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuffer src) {
+    public ByteBuf setBytes(int index, ByteBuffer src) {
         src.get(array, index, src.remaining());
+        return this;
     }
 
     @Override
@@ -252,28 +261,31 @@ public class HeapByteBuf extends AbstractByteBuf {
     }
 
     @Override
-    public void setShort(int index, int value) {
+    public ByteBuf setShort(int index, int value) {
         array[index]     = (byte) (value >>> 8);
         array[index + 1] = (byte) (value >>> 0);
+        return this;
     }
 
     @Override
-    public void setMedium(int index, int   value) {
+    public ByteBuf setMedium(int index, int   value) {
         array[index]     = (byte) (value >>> 16);
         array[index + 1] = (byte) (value >>> 8);
         array[index + 2] = (byte) (value >>> 0);
+        return this;
     }
 
     @Override
-    public void setInt(int index, int   value) {
+    public ByteBuf setInt(int index, int   value) {
         array[index]     = (byte) (value >>> 24);
         array[index + 1] = (byte) (value >>> 16);
         array[index + 2] = (byte) (value >>> 8);
         array[index + 3] = (byte) (value >>> 0);
+        return this;
     }
 
     @Override
-    public void setLong(int index, long  value) {
+    public ByteBuf setLong(int index, long  value) {
         array[index]     = (byte) (value >>> 56);
         array[index + 1] = (byte) (value >>> 48);
         array[index + 2] = (byte) (value >>> 40);
@@ -282,6 +294,7 @@ public class HeapByteBuf extends AbstractByteBuf {
         array[index + 5] = (byte) (value >>> 16);
         array[index + 6] = (byte) (value >>> 8);
         array[index + 7] = (byte) (value >>> 0);
+        return this;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
@@ -28,7 +28,7 @@ import java.nio.channels.ScatteringByteChannel;
  * recommended to use {@link Unpooled#unmodifiableBuffer(ByteBuf)}
  * instead of calling the constructor explicitly.
  */
-public class ReadOnlyByteBuf extends AbstractByteBuf implements WrappedByteBuf {
+public class ReadOnlyByteBuf extends AbstractWrappedByteBuf {
 
     private final ByteBuf buffer;
 
@@ -70,47 +70,47 @@ public class ReadOnlyByteBuf extends AbstractByteBuf implements WrappedByteBuf {
     }
 
     @Override
-    public void discardReadBytes() {
+    public WrappedByteBuf discardReadBytes() {
         throw new ReadOnlyBufferException();
     }
 
     @Override
-    public void setByte(int index, int value) {
+    public WrappedByteBuf setByte(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
-    public void setBytes(int index, ByteBuf src, int srcIndex, int length) {
+    public WrappedByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
-    public void setBytes(int index, byte[] src, int srcIndex, int length) {
+    public WrappedByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
-    public void setBytes(int index, ByteBuffer src) {
+    public WrappedByteBuf setBytes(int index, ByteBuffer src) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
-    public void setShort(int index, int value) {
+    public WrappedByteBuf setShort(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
-    public void setMedium(int index, int value) {
+    public WrappedByteBuf setMedium(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
-    public void setInt(int index, int value) {
+    public WrappedByteBuf setInt(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
-    public void setLong(int index, long value) {
+    public WrappedByteBuf setLong(int index, long value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -133,24 +133,28 @@ public class ReadOnlyByteBuf extends AbstractByteBuf implements WrappedByteBuf {
     }
 
     @Override
-    public void getBytes(int index, OutputStream out, int length)
+    public WrappedByteBuf getBytes(int index, OutputStream out, int length)
             throws IOException {
         buffer.getBytes(index, out, length);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, byte[] dst, int dstIndex, int length) {
+    public WrappedByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
         buffer.getBytes(index, dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, ByteBuf dst, int dstIndex, int length) {
+    public WrappedByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
         buffer.getBytes(index, dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, ByteBuffer dst) {
+    public WrappedByteBuf getBytes(int index, ByteBuffer dst) {
         buffer.getBytes(index, dst);
+        return this;
     }
 
     @Override
@@ -219,7 +223,7 @@ public class ReadOnlyByteBuf extends AbstractByteBuf implements WrappedByteBuf {
     }
 
     @Override
-    public void capacity(int newCapacity) {
+    public WrappedByteBuf capacity(int newCapacity) {
         throw new ReadOnlyBufferException();
     }
 

--- a/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
@@ -29,7 +29,7 @@ import java.nio.channels.ScatteringByteChannel;
  * {@link ByteBuf#slice(int, int)} instead of calling the constructor
  * explicitly.
  */
-public class SlicedByteBuf extends AbstractByteBuf implements WrappedByteBuf {
+public class SlicedByteBuf extends AbstractWrappedByteBuf {
 
     private final Unsafe unsafe = new SlicedUnsafe();
     private final ByteBuf buffer;
@@ -81,7 +81,7 @@ public class SlicedByteBuf extends AbstractByteBuf implements WrappedByteBuf {
     }
 
     @Override
-    public void capacity(int newCapacity) {
+    public WrappedByteBuf capacity(int newCapacity) {
         throw new UnsupportedOperationException("sliced buffer");
     }
 
@@ -153,76 +153,88 @@ public class SlicedByteBuf extends AbstractByteBuf implements WrappedByteBuf {
     }
 
     @Override
-    public void getBytes(int index, ByteBuf dst, int dstIndex, int length) {
+    public WrappedByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
         checkIndex(index, length);
         buffer.getBytes(index + adjustment, dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, byte[] dst, int dstIndex, int length) {
+    public WrappedByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
         checkIndex(index, length);
         buffer.getBytes(index + adjustment, dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, ByteBuffer dst) {
+    public WrappedByteBuf getBytes(int index, ByteBuffer dst) {
         checkIndex(index, dst.remaining());
         buffer.getBytes(index + adjustment, dst);
+        return this;
     }
 
     @Override
-    public void setByte(int index, int value) {
+    public WrappedByteBuf setByte(int index, int value) {
         checkIndex(index);
         buffer.setByte(index + adjustment, value);
+        return this;
     }
 
     @Override
-    public void setShort(int index, int value) {
+    public WrappedByteBuf setShort(int index, int value) {
         checkIndex(index, 2);
         buffer.setShort(index + adjustment, value);
+        return this;
     }
 
     @Override
-    public void setMedium(int index, int value) {
+    public WrappedByteBuf setMedium(int index, int value) {
         checkIndex(index, 3);
         buffer.setMedium(index + adjustment, value);
+        return this;
     }
 
     @Override
-    public void setInt(int index, int value) {
+    public WrappedByteBuf setInt(int index, int value) {
         checkIndex(index, 4);
         buffer.setInt(index + adjustment, value);
+        return this;
     }
 
     @Override
-    public void setLong(int index, long value) {
+    public WrappedByteBuf setLong(int index, long value) {
         checkIndex(index, 8);
         buffer.setLong(index + adjustment, value);
+        return this;
     }
 
     @Override
-    public void setBytes(int index, byte[] src, int srcIndex, int length) {
+    public WrappedByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
         checkIndex(index, length);
         buffer.setBytes(index + adjustment, src, srcIndex, length);
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuf src, int srcIndex, int length) {
+    public WrappedByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
         checkIndex(index, length);
         buffer.setBytes(index + adjustment, src, srcIndex, length);
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuffer src) {
+    public WrappedByteBuf setBytes(int index, ByteBuffer src) {
         checkIndex(index, src.remaining());
         buffer.setBytes(index + adjustment, src);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, OutputStream out, int length)
+    public WrappedByteBuf getBytes(int index, OutputStream out, int length)
             throws IOException {
         checkIndex(index, length);
         buffer.getBytes(index + adjustment, out, length);
+        return this;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -78,8 +78,9 @@ public class SwappedByteBuf implements WrappedByteBuf {
     }
 
     @Override
-    public void capacity(int newCapacity) {
+    public WrappedByteBuf capacity(int newCapacity) {
         buf.capacity(newCapacity);
+        return this;
     }
 
     @Override
@@ -98,8 +99,9 @@ public class SwappedByteBuf implements WrappedByteBuf {
     }
 
     @Override
-    public void readerIndex(int readerIndex) {
+    public WrappedByteBuf readerIndex(int readerIndex) {
         buf.readerIndex(readerIndex);
+        return this;
     }
 
     @Override
@@ -108,13 +110,15 @@ public class SwappedByteBuf implements WrappedByteBuf {
     }
 
     @Override
-    public void writerIndex(int writerIndex) {
+    public WrappedByteBuf writerIndex(int writerIndex) {
         buf.writerIndex(writerIndex);
+        return this;
     }
 
     @Override
-    public void setIndex(int readerIndex, int writerIndex) {
+    public WrappedByteBuf setIndex(int readerIndex, int writerIndex) {
         buf.setIndex(readerIndex, writerIndex);
+        return this;
     }
 
     @Override
@@ -138,38 +142,45 @@ public class SwappedByteBuf implements WrappedByteBuf {
     }
 
     @Override
-    public void clear() {
+    public WrappedByteBuf clear() {
         buf.clear();
+        return this;
     }
 
     @Override
-    public void markReaderIndex() {
+    public WrappedByteBuf markReaderIndex() {
         buf.markReaderIndex();
+        return this;
     }
 
     @Override
-    public void resetReaderIndex() {
+    public WrappedByteBuf resetReaderIndex() {
         buf.resetReaderIndex();
+        return this;
     }
 
     @Override
-    public void markWriterIndex() {
+    public WrappedByteBuf markWriterIndex() {
         buf.markWriterIndex();
+        return this;
     }
 
     @Override
-    public void resetWriterIndex() {
+    public WrappedByteBuf resetWriterIndex() {
         buf.resetWriterIndex();
+        return this;
     }
 
     @Override
-    public void discardReadBytes() {
+    public WrappedByteBuf discardReadBytes() {
         buf.discardReadBytes();
+        return this;
     }
 
     @Override
-    public void ensureWritableBytes(int writableBytes) {
+    public WrappedByteBuf ensureWritableBytes(int writableBytes) {
         buf.ensureWritableBytes(writableBytes);
+        return this;
     }
 
     @Override
@@ -243,38 +254,45 @@ public class SwappedByteBuf implements WrappedByteBuf {
     }
 
     @Override
-    public void getBytes(int index, ByteBuf dst) {
+    public WrappedByteBuf getBytes(int index, ByteBuf dst) {
         buf.getBytes(index, dst);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, ByteBuf dst, int length) {
+    public WrappedByteBuf getBytes(int index, ByteBuf dst, int length) {
         buf.getBytes(index, dst, length);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, ByteBuf dst, int dstIndex, int length) {
+    public WrappedByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
         buf.getBytes(index, dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, byte[] dst) {
+    public WrappedByteBuf getBytes(int index, byte[] dst) {
         buf.getBytes(index, dst);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, byte[] dst, int dstIndex, int length) {
+    public WrappedByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
         buf.getBytes(index, dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, ByteBuffer dst) {
+    public WrappedByteBuf getBytes(int index, ByteBuffer dst) {
         buf.getBytes(index, dst);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, OutputStream out, int length) throws IOException {
+    public WrappedByteBuf getBytes(int index, OutputStream out, int length) throws IOException {
         buf.getBytes(index, out, length);
+        return this;
     }
 
     @Override
@@ -283,78 +301,93 @@ public class SwappedByteBuf implements WrappedByteBuf {
     }
 
     @Override
-    public void setBoolean(int index, boolean value) {
+    public WrappedByteBuf setBoolean(int index, boolean value) {
         buf.setBoolean(index, value);
+        return this;
     }
 
     @Override
-    public void setByte(int index, int value) {
+    public WrappedByteBuf setByte(int index, int value) {
         buf.setByte(index, value);
+        return this;
     }
 
     @Override
-    public void setShort(int index, int value) {
+    public WrappedByteBuf setShort(int index, int value) {
         buf.setShort(index, ByteBufUtil.swapShort((short) value));
+        return this;
     }
 
     @Override
-    public void setMedium(int index, int value) {
+    public WrappedByteBuf setMedium(int index, int value) {
         buf.setMedium(index, ByteBufUtil.swapMedium(value));
+        return this;
     }
 
     @Override
-    public void setInt(int index, int value) {
+    public WrappedByteBuf setInt(int index, int value) {
         buf.setInt(index, ByteBufUtil.swapInt(value));
+        return this;
     }
 
     @Override
-    public void setLong(int index, long value) {
+    public WrappedByteBuf setLong(int index, long value) {
         buf.setLong(index, ByteBufUtil.swapLong(value));
+        return this;
     }
 
     @Override
-    public void setChar(int index, int value) {
+    public WrappedByteBuf setChar(int index, int value) {
         setShort(index, value);
+        return this;
     }
 
     @Override
-    public void setFloat(int index, float value) {
+    public WrappedByteBuf setFloat(int index, float value) {
         setInt(index, Float.floatToRawIntBits(value));
+        return this;
     }
 
     @Override
-    public void setDouble(int index, double value) {
+    public WrappedByteBuf setDouble(int index, double value) {
         setLong(index, Double.doubleToRawLongBits(value));
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuf src) {
+    public WrappedByteBuf setBytes(int index, ByteBuf src) {
         buf.setBytes(index, src);
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuf src, int length) {
+    public WrappedByteBuf setBytes(int index, ByteBuf src, int length) {
         buf.setBytes(index, src, length);
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuf src, int srcIndex, int length) {
+    public WrappedByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
         buf.setBytes(index, src, srcIndex, length);
+        return this;
     }
 
     @Override
-    public void setBytes(int index, byte[] src) {
+    public WrappedByteBuf setBytes(int index, byte[] src) {
         buf.setBytes(index, src);
+        return this;
     }
 
     @Override
-    public void setBytes(int index, byte[] src, int srcIndex, int length) {
+    public WrappedByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
         buf.setBytes(index, src, srcIndex, length);
+        return this;
     }
 
     @Override
-    public void setBytes(int index, ByteBuffer src) {
+    public WrappedByteBuf setBytes(int index, ByteBuffer src) {
         buf.setBytes(index, src);
+        return this;
     }
 
     @Override
@@ -368,8 +401,9 @@ public class SwappedByteBuf implements WrappedByteBuf {
     }
 
     @Override
-    public void setZero(int index, int length) {
+    public WrappedByteBuf setZero(int index, int length) {
         buf.setZero(index, length);
+        return this;
     }
 
     @Override
@@ -448,38 +482,45 @@ public class SwappedByteBuf implements WrappedByteBuf {
     }
 
     @Override
-    public void readBytes(ByteBuf dst) {
+    public WrappedByteBuf readBytes(ByteBuf dst) {
         buf.readBytes(dst);
+        return this;
     }
 
     @Override
-    public void readBytes(ByteBuf dst, int length) {
+    public WrappedByteBuf readBytes(ByteBuf dst, int length) {
         buf.readBytes(dst, length);
+        return this;
     }
 
     @Override
-    public void readBytes(ByteBuf dst, int dstIndex, int length) {
+    public WrappedByteBuf readBytes(ByteBuf dst, int dstIndex, int length) {
         buf.readBytes(dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void readBytes(byte[] dst) {
+    public WrappedByteBuf readBytes(byte[] dst) {
         buf.readBytes(dst);
+        return this;
     }
 
     @Override
-    public void readBytes(byte[] dst, int dstIndex, int length) {
+    public WrappedByteBuf readBytes(byte[] dst, int dstIndex, int length) {
         buf.readBytes(dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void readBytes(ByteBuffer dst) {
+    public WrappedByteBuf readBytes(ByteBuffer dst) {
         buf.readBytes(dst);
+        return this;
     }
 
     @Override
-    public void readBytes(OutputStream out, int length) throws IOException {
+    public WrappedByteBuf readBytes(OutputStream out, int length) throws IOException {
         buf.readBytes(out, length);
+        return this;
     }
 
     @Override
@@ -488,83 +529,99 @@ public class SwappedByteBuf implements WrappedByteBuf {
     }
 
     @Override
-    public void skipBytes(int length) {
+    public WrappedByteBuf skipBytes(int length) {
         buf.skipBytes(length);
+        return this;
     }
 
     @Override
-    public void writeBoolean(boolean value) {
+    public WrappedByteBuf writeBoolean(boolean value) {
         buf.writeBoolean(value);
+        return this;
     }
 
     @Override
-    public void writeByte(int value) {
+    public WrappedByteBuf writeByte(int value) {
         buf.writeByte(value);
+        return this;
     }
 
     @Override
-    public void writeShort(int value) {
+    public WrappedByteBuf writeShort(int value) {
         buf.writeShort(ByteBufUtil.swapShort((short) value));
+        return this;
     }
 
     @Override
-    public void writeMedium(int value) {
+    public WrappedByteBuf writeMedium(int value) {
         buf.writeMedium(ByteBufUtil.swapMedium(value));
+        return this;
     }
 
     @Override
-    public void writeInt(int value) {
+    public WrappedByteBuf writeInt(int value) {
         buf.writeInt(ByteBufUtil.swapInt(value));
+        return this;
     }
 
     @Override
-    public void writeLong(long value) {
+    public WrappedByteBuf writeLong(long value) {
         buf.writeLong(ByteBufUtil.swapLong(value));
+        return this;
     }
 
     @Override
-    public void writeChar(int value) {
+    public WrappedByteBuf writeChar(int value) {
         writeShort(value);
+        return this;
     }
 
     @Override
-    public void writeFloat(float value) {
+    public WrappedByteBuf writeFloat(float value) {
         writeInt(Float.floatToRawIntBits(value));
+        return this;
     }
 
     @Override
-    public void writeDouble(double value) {
+    public WrappedByteBuf writeDouble(double value) {
         writeLong(Double.doubleToRawLongBits(value));
+        return this;
     }
 
     @Override
-    public void writeBytes(ByteBuf src) {
+    public WrappedByteBuf writeBytes(ByteBuf src) {
         buf.writeBytes(src);
+        return this;
     }
 
     @Override
-    public void writeBytes(ByteBuf src, int length) {
+    public WrappedByteBuf writeBytes(ByteBuf src, int length) {
         buf.writeBytes(src, length);
+        return this;
     }
 
     @Override
-    public void writeBytes(ByteBuf src, int srcIndex, int length) {
+    public WrappedByteBuf writeBytes(ByteBuf src, int srcIndex, int length) {
         buf.writeBytes(src, srcIndex, length);
+        return this;
     }
 
     @Override
-    public void writeBytes(byte[] src) {
+    public WrappedByteBuf writeBytes(byte[] src) {
         buf.writeBytes(src);
+        return this;
     }
 
     @Override
-    public void writeBytes(byte[] src, int srcIndex, int length) {
+    public WrappedByteBuf writeBytes(byte[] src, int srcIndex, int length) {
         buf.writeBytes(src, srcIndex, length);
+        return this;
     }
 
     @Override
-    public void writeBytes(ByteBuffer src) {
+    public WrappedByteBuf writeBytes(ByteBuffer src) {
         buf.writeBytes(src);
+        return this;
     }
 
     @Override
@@ -578,8 +635,9 @@ public class SwappedByteBuf implements WrappedByteBuf {
     }
 
     @Override
-    public void writeZero(int length) {
+    public WrappedByteBuf writeZero(int length) {
         buf.writeZero(length);
+        return this;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -15,6 +15,10 @@
  */
 package io.netty.buffer;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
 /**
  * The common interface for buffer wrappers and derived buffers.  Most users won't
  * need to use this interface.  It is used internally in most cases.
@@ -24,4 +28,178 @@ public interface WrappedByteBuf extends ByteBuf {
      * Returns this buffer's parent that this buffer is wrapping.
      */
     ByteBuf unwrap();
+
+    @Override
+    WrappedByteBuf capacity(int newCapacity);
+
+    @Override
+    WrappedByteBuf readerIndex(int readerIndex);
+
+    @Override
+    WrappedByteBuf writerIndex(int writerIndex);
+
+    @Override
+    WrappedByteBuf setIndex(int readerIndex, int writerIndex);
+
+    @Override
+    WrappedByteBuf clear();
+
+    @Override
+    WrappedByteBuf markReaderIndex();
+
+    @Override
+    WrappedByteBuf resetReaderIndex();
+
+    @Override
+    WrappedByteBuf markWriterIndex();
+
+    @Override
+    WrappedByteBuf resetWriterIndex();
+
+    @Override
+    WrappedByteBuf discardReadBytes();
+
+    @Override
+    WrappedByteBuf ensureWritableBytes(int minWritableBytes);
+
+    @Override
+    WrappedByteBuf getBytes(int index, ByteBuf dst);
+
+    @Override
+    WrappedByteBuf getBytes(int index, ByteBuf dst, int length);
+
+    @Override
+    WrappedByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length);
+
+    @Override
+    WrappedByteBuf getBytes(int index, byte[] dst);
+
+    @Override
+    WrappedByteBuf getBytes(int index, byte[] dst, int dstIndex, int length);
+
+    @Override
+    WrappedByteBuf getBytes(int index, ByteBuffer dst);
+
+    @Override
+    WrappedByteBuf getBytes(int index, OutputStream out, int length) throws IOException;
+
+    @Override
+    WrappedByteBuf setBoolean(int index, boolean value);
+
+    @Override
+    WrappedByteBuf setByte(int index, int value);
+
+    @Override
+    WrappedByteBuf setShort(int index, int value);
+
+    @Override
+    WrappedByteBuf setMedium(int index, int value);
+
+    @Override
+    WrappedByteBuf setInt(int index, int value);
+
+    @Override
+    WrappedByteBuf setLong(int index, long value);
+
+    @Override
+    WrappedByteBuf setChar(int index, int value);
+
+    @Override
+    WrappedByteBuf setFloat(int index, float value);
+
+    @Override
+    WrappedByteBuf setDouble(int index, double value);
+
+    @Override
+    WrappedByteBuf setBytes(int index, ByteBuf src);
+
+    @Override
+    WrappedByteBuf setBytes(int index, ByteBuf src, int length);
+
+    @Override
+    WrappedByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length);
+
+    @Override
+    WrappedByteBuf setBytes(int index, byte[] src);
+
+    @Override
+    WrappedByteBuf setBytes(int index, byte[] src, int srcIndex, int length);
+
+    @Override
+    WrappedByteBuf setBytes(int index, ByteBuffer src);
+
+    @Override
+    WrappedByteBuf setZero(int index, int length);
+
+    @Override
+    WrappedByteBuf readBytes(ByteBuf dst);
+
+    @Override
+    WrappedByteBuf readBytes(ByteBuf dst, int length);
+
+    @Override
+    WrappedByteBuf readBytes(ByteBuf dst, int dstIndex, int length);
+
+    @Override
+    WrappedByteBuf readBytes(byte[] dst);
+
+    @Override
+    WrappedByteBuf readBytes(byte[] dst, int dstIndex, int length);
+
+    @Override
+    WrappedByteBuf readBytes(ByteBuffer dst);
+
+    @Override
+    WrappedByteBuf readBytes(OutputStream out, int length) throws IOException;
+
+    @Override
+    WrappedByteBuf skipBytes(int length);
+
+    @Override
+    WrappedByteBuf writeBoolean(boolean value);
+
+    @Override
+    WrappedByteBuf writeByte(int value);
+
+    @Override
+    WrappedByteBuf writeShort(int value);
+
+    @Override
+    WrappedByteBuf writeMedium(int value);
+
+    @Override
+    WrappedByteBuf writeInt(int value);
+
+    @Override
+    WrappedByteBuf writeLong(long value);
+
+    @Override
+    WrappedByteBuf writeChar(int value);
+
+    @Override
+    WrappedByteBuf writeFloat(float value);
+
+    @Override
+    WrappedByteBuf writeDouble(double value);
+
+    @Override
+    WrappedByteBuf writeBytes(ByteBuf src);
+
+    @Override
+    WrappedByteBuf writeBytes(ByteBuf src, int length);
+
+    @Override
+    WrappedByteBuf writeBytes(ByteBuf src, int srcIndex, int length);
+
+    @Override
+    WrappedByteBuf writeBytes(byte[] src);
+
+    @Override
+    WrappedByteBuf writeBytes(byte[] src, int srcIndex, int length);
+
+    @Override
+    WrappedByteBuf writeBytes(ByteBuffer src);
+
+    @Override
+    WrappedByteBuf writeZero(int length);
 }

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyChannelBufferTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyChannelBufferTest.java
@@ -82,10 +82,10 @@ public class ReadOnlyChannelBufferTest {
         expect(buf.capacity()).andReturn(0).anyTimes();
 
         expect(buf.getBytes(1, (GatheringByteChannel) null, 2)).andReturn(3);
-        buf.getBytes(4, (OutputStream) null, 5);
-        buf.getBytes(6, (byte[]) null, 7, 8);
-        buf.getBytes(9, (ByteBuf) null, 10, 11);
-        buf.getBytes(12, (ByteBuffer) null);
+        expect(buf.getBytes(4, (OutputStream) null, 5)).andReturn(buf);
+        expect(buf.getBytes(6, (byte[]) null, 7, 8)).andReturn(buf);
+        expect(buf.getBytes(9, (ByteBuf) null, 10, 11)).andReturn(buf);
+        expect(buf.getBytes(12, (ByteBuffer) null)).andReturn(buf);
         expect(buf.getByte(13)).andReturn(Byte.valueOf((byte) 14));
         expect(buf.getShort(15)).andReturn(Short.valueOf((short) 16));
         expect(buf.getUnsignedMedium(17)).andReturn(18);

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderBuffer.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderBuffer.java
@@ -64,7 +64,7 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
-    public void capacity(int newCapacity) {
+    public ByteBuf capacity(int newCapacity) {
         throw new UnreplayableOperationException();
     }
 
@@ -104,7 +104,7 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
-    public void clear() {
+    public ByteBuf clear() {
         throw new UnreplayableOperationException();
     }
 
@@ -130,12 +130,12 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
-    public void discardReadBytes() {
+    public ByteBuf discardReadBytes() {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void ensureWritableBytes(int writableBytes) {
+    public ByteBuf ensureWritableBytes(int writableBytes) {
         throw new UnreplayableOperationException();
     }
 
@@ -168,35 +168,38 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
-    public void getBytes(int index, byte[] dst, int dstIndex, int length) {
+    public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
         checkIndex(index, length);
         buffer.getBytes(index, dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, byte[] dst) {
+    public ByteBuf getBytes(int index, byte[] dst) {
         checkIndex(index, dst.length);
         buffer.getBytes(index, dst);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, ByteBuffer dst) {
+    public ByteBuf getBytes(int index, ByteBuffer dst) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void getBytes(int index, ByteBuf dst, int dstIndex, int length) {
+    public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
         checkIndex(index, length);
         buffer.getBytes(index, dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void getBytes(int index, ByteBuf dst, int length) {
+    public ByteBuf getBytes(int index, ByteBuf dst, int length) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void getBytes(int index, ByteBuf dst) {
+    public ByteBuf getBytes(int index, ByteBuf dst) {
         throw new UnreplayableOperationException();
     }
 
@@ -207,7 +210,7 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
-    public void getBytes(int index, OutputStream out, int length)
+    public ByteBuf getBytes(int index, OutputStream out, int length)
             throws IOException {
         throw new UnreplayableOperationException();
     }
@@ -354,12 +357,13 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
-    public void markReaderIndex() {
+    public ByteBuf markReaderIndex() {
         buffer.markReaderIndex();
+        return this;
     }
 
     @Override
-    public void markWriterIndex() {
+    public ByteBuf markWriterIndex() {
         throw new UnreplayableOperationException();
     }
 
@@ -412,35 +416,38 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
-    public void readBytes(byte[] dst, int dstIndex, int length) {
+    public ByteBuf readBytes(byte[] dst, int dstIndex, int length) {
         checkReadableBytes(length);
         buffer.readBytes(dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void readBytes(byte[] dst) {
+    public ByteBuf readBytes(byte[] dst) {
         checkReadableBytes(dst.length);
         buffer.readBytes(dst);
+        return this;
     }
 
     @Override
-    public void readBytes(ByteBuffer dst) {
+    public ByteBuf readBytes(ByteBuffer dst) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void readBytes(ByteBuf dst, int dstIndex, int length) {
+    public ByteBuf readBytes(ByteBuf dst, int dstIndex, int length) {
         checkReadableBytes(length);
         buffer.readBytes(dst, dstIndex, length);
+        return this;
     }
 
     @Override
-    public void readBytes(ByteBuf dst, int length) {
+    public ByteBuf readBytes(ByteBuf dst, int length) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void readBytes(ByteBuf dst) {
+    public ByteBuf readBytes(ByteBuf dst) {
         throw new UnreplayableOperationException();
     }
 
@@ -463,7 +470,7 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
-    public void readBytes(OutputStream out, int length) throws IOException {
+    public ByteBuf readBytes(OutputStream out, int length) throws IOException {
         throw new UnreplayableOperationException();
     }
 
@@ -473,8 +480,9 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
-    public void readerIndex(int readerIndex) {
+    public ByteBuf readerIndex(int readerIndex) {
         buffer.readerIndex(readerIndex);
+        return this;
     }
 
     @Override
@@ -538,52 +546,53 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
-    public void resetReaderIndex() {
+    public ByteBuf resetReaderIndex() {
         buffer.resetReaderIndex();
+        return this;
     }
 
     @Override
-    public void resetWriterIndex() {
+    public ByteBuf resetWriterIndex() {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void setBoolean(int index, boolean value) {
+    public ByteBuf setBoolean(int index, boolean value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void setByte(int index, int value) {
+    public ByteBuf setByte(int index, int value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void setBytes(int index, byte[] src, int srcIndex, int length) {
+    public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void setBytes(int index, byte[] src) {
+    public ByteBuf setBytes(int index, byte[] src) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void setBytes(int index, ByteBuffer src) {
+    public ByteBuf setBytes(int index, ByteBuffer src) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void setBytes(int index, ByteBuf src, int srcIndex, int length) {
+    public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void setBytes(int index, ByteBuf src, int length) {
+    public ByteBuf setBytes(int index, ByteBuf src, int length) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void setBytes(int index, ByteBuf src) {
+    public ByteBuf setBytes(int index, ByteBuf src) {
         throw new UnreplayableOperationException();
     }
 
@@ -594,7 +603,7 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
-    public void setZero(int index, int length) {
+    public ByteBuf setZero(int index, int length) {
         throw new UnreplayableOperationException();
     }
 
@@ -605,49 +614,50 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
-    public void setIndex(int readerIndex, int writerIndex) {
+    public ByteBuf setIndex(int readerIndex, int writerIndex) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void setInt(int index, int value) {
+    public ByteBuf setInt(int index, int value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void setLong(int index, long value) {
+    public ByteBuf setLong(int index, long value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void setMedium(int index, int value) {
+    public ByteBuf setMedium(int index, int value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void setShort(int index, int value) {
+    public ByteBuf setShort(int index, int value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void setChar(int index, int value) {
+    public ByteBuf setChar(int index, int value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void setFloat(int index, float value) {
+    public ByteBuf setFloat(int index, float value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void setDouble(int index, double value) {
+    public ByteBuf setDouble(int index, double value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void skipBytes(int length) {
+    public ByteBuf skipBytes(int length) {
         checkReadableBytes(length);
         buffer.skipBytes(length);
+        return this;
     }
 
     @Override
@@ -726,42 +736,42 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
-    public void writeBoolean(boolean value) {
+    public ByteBuf writeBoolean(boolean value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void writeByte(int value) {
+    public ByteBuf writeByte(int value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void writeBytes(byte[] src, int srcIndex, int length) {
+    public ByteBuf writeBytes(byte[] src, int srcIndex, int length) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void writeBytes(byte[] src) {
+    public ByteBuf writeBytes(byte[] src) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void writeBytes(ByteBuffer src) {
+    public ByteBuf writeBytes(ByteBuffer src) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void writeBytes(ByteBuf src, int srcIndex, int length) {
+    public ByteBuf writeBytes(ByteBuf src, int srcIndex, int length) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void writeBytes(ByteBuf src, int length) {
+    public ByteBuf writeBytes(ByteBuf src, int length) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void writeBytes(ByteBuf src) {
+    public ByteBuf writeBytes(ByteBuf src) {
         throw new UnreplayableOperationException();
     }
 
@@ -777,22 +787,22 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
-    public void writeInt(int value) {
+    public ByteBuf writeInt(int value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void writeLong(long value) {
+    public ByteBuf writeLong(long value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void writeMedium(int value) {
+    public ByteBuf writeMedium(int value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void writeZero(int length) {
+    public ByteBuf writeZero(int length) {
         throw new UnreplayableOperationException();
     }
 
@@ -802,27 +812,27 @@ class ReplayingDecoderBuffer implements ByteBuf {
     }
 
     @Override
-    public void writerIndex(int writerIndex) {
+    public ByteBuf writerIndex(int writerIndex) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void writeShort(int value) {
+    public ByteBuf writeShort(int value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void writeChar(int value) {
+    public ByteBuf writeChar(int value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void writeFloat(float value) {
+    public ByteBuf writeFloat(float value) {
         throw new UnreplayableOperationException();
     }
 
     @Override
-    public void writeDouble(double value) {
+    public ByteBuf writeDouble(double value) {
         throw new UnreplayableOperationException();
     }
 


### PR DESCRIPTION
This commit add support for method chaining to ByteBuf.

So before you wrote:

``` java
    ByteBuf buf = ..
    buf.writeInt(1);
    buf.writeInt(2);
    buf.writeInt(3);
    ....
```

Now you can write:

``` java
    ByteBuf buf = ..
    buf.writeInt(1).writeInt(2).writeInt(3);
    ....
```

@trustin please review..
