### PR TITLE
#707 Make sure buffers are appended in sequence. Added tests.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/DefaultCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DefaultCompositeByteBuf.java
@@ -229,12 +229,9 @@ public class DefaultCompositeByteBuf extends AbstractByteBuf implements Composit
             }
 
             if (b.readable()) {
-                addComponent(cIndex ++, b);
-                int size = components.size();
-                if (cIndex > size) {
-                    // was consolidated, so adjust index. #707
-                    cIndex = size;
-                }
+                // Always append b to end of components so buffers are sequenced as specified
+                // in the arg list
+                addComponent(components.size(), b);
             }
         }
         return this;

--- a/buffer/src/test/java/io/netty/buffer/ConsolidationTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ConsolidationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import static io.netty.buffer.Unpooled.wrappedBuffer;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Tests buffer consolidation
+ */
+public class ConsolidationTest {
+
+    @Test
+    public void shouldWrapInSequence() {
+        ByteBuf currentBuffer = wrappedBuffer(wrappedBuffer("a".getBytes()), wrappedBuffer("=".getBytes()));
+        currentBuffer = wrappedBuffer(currentBuffer, wrappedBuffer("1".getBytes()), wrappedBuffer("&".getBytes()));
+        
+        String s = new String(currentBuffer.copy().array());
+        assertEquals("a=1&", s);
+    }
+
+    @Test
+    public void shouldConsolidationInSequence() {
+        ByteBuf currentBuffer = wrappedBuffer(wrappedBuffer("a".getBytes()), wrappedBuffer("=".getBytes()));
+        currentBuffer = wrappedBuffer(currentBuffer, wrappedBuffer("1".getBytes()), wrappedBuffer("&".getBytes()));
+        
+        currentBuffer = wrappedBuffer(currentBuffer, wrappedBuffer("b".getBytes()), wrappedBuffer("=".getBytes()));
+        currentBuffer = wrappedBuffer(currentBuffer, wrappedBuffer("2".getBytes()), wrappedBuffer("&".getBytes()));
+
+        currentBuffer = wrappedBuffer(currentBuffer, wrappedBuffer("c".getBytes()), wrappedBuffer("=".getBytes()));
+        currentBuffer = wrappedBuffer(currentBuffer, wrappedBuffer("3".getBytes()), wrappedBuffer("&".getBytes()));
+
+        currentBuffer = wrappedBuffer(currentBuffer, wrappedBuffer("d".getBytes()), wrappedBuffer("=".getBytes()));
+        currentBuffer = wrappedBuffer(currentBuffer, wrappedBuffer("4".getBytes()), wrappedBuffer("&".getBytes()));
+
+        currentBuffer = wrappedBuffer(currentBuffer, wrappedBuffer("e".getBytes()), wrappedBuffer("=".getBytes()));
+        currentBuffer = wrappedBuffer(currentBuffer, wrappedBuffer("5".getBytes()), wrappedBuffer("&".getBytes()));
+
+        String s = new String(currentBuffer.copy().array());
+        assertEquals("a=1&b=2&c=3&d=4&e=5&", s);
+    }    
+}


### PR DESCRIPTION
There was one more problem.  Because cIndex was not being reset, the buffers were not being appended but inserted in the middle.

I've fixed it and added some test case.  Norman and Trustin, please revew and merge.  

If you are happy with this fix, I'll send a pull request for the http multipart package.  With this fix, the example HttpClientUpload and HttpServerUpload are now working.
