### PR TITLE
Cleanup maven-bundle-plugin warnings

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -318,6 +318,7 @@
             <Import-Package>
               com.sun.nio.sctp;resolution:=optional,
               sun.misc;resolution:=optional,
+              sun.net.util;resolution:=optional,
               *
             </Import-Package>
             <Export-Package>


### PR DESCRIPTION
This change has maven-bundle-plugin to handler the merging of classes file and remove the need to pre unpack the class files. and therefore remove the warnings
