### PR TITLE
Potential NullPointException without checking the variable's status

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -121,6 +121,9 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             nextCtx.prev = newCtx;
         }
         head.next = newCtx;
+        if(tail == head)
+            tail = newCtx;
+
         name2ctx.put(name, newCtx);
 
         callAfterAdd(newCtx);

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -15,11 +15,11 @@
  */
 package io.netty.channel;
 
-import static org.junit.Assert.*;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.local.LocalChannel;
-
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class DefaultChannelPipelineTest {
     @Test
@@ -45,6 +45,104 @@ public class DefaultChannelPipelineTest {
         ChannelHandler newHandler2 = newHandler();
         pipeline.replace("handler2", "handler2", newHandler2);
         assertSame(pipeline.get("handler2"), newHandler2);
+    }
+
+    @Test
+    public void testChannelHandlerContextNavigation() {
+        DefaultChannelPipeline pipeline = new DefaultChannelPipeline(new LocalChannel());
+
+        final int HANDLER_ARRAY_LEN = 5;
+        ChannelHandler[] firstHandlers = newHandlers(HANDLER_ARRAY_LEN);
+        ChannelHandler[] lastHandlers = newHandlers(HANDLER_ARRAY_LEN);
+
+        pipeline.addFirst(firstHandlers);
+        pipeline.addLast(lastHandlers);
+
+        verifyContextNumber(pipeline, HANDLER_ARRAY_LEN * 2);
+    }
+
+    @Test
+    public void testPipelineOperation() {
+        DefaultChannelPipeline pipeline = new DefaultChannelPipeline(new LocalChannel());
+        final int handlerNum = 5;
+        ChannelHandler[] handlers1 = newHandlers(handlerNum);
+        ChannelHandler[] handlers2 = newHandlers(handlerNum);
+
+        final String prefixX = "x";
+        for (int i = 0; i < handlerNum; i++) {
+            if (i % 2 == 0)
+                pipeline.addFirst(prefixX + String.valueOf(i), handlers1[i]);
+            else
+                pipeline.addLast(prefixX + String.valueOf(i), handlers1[i]);
+        }
+
+        for (int i = 0; i < handlerNum; i++) {
+            if (i % 2 != 0)
+                pipeline.addBefore(prefixX + String.valueOf(i), String.valueOf(i), handlers2[i]);
+            else
+                pipeline.addAfter(prefixX + String.valueOf(i), String.valueOf(i), handlers2[i]);
+        }
+
+        verifyContextNumber(pipeline, handlerNum * 2);
+    }
+
+    @Test
+    public void testChannelHandlerContextOrder() {
+        DefaultChannelPipeline pipeline = new DefaultChannelPipeline(new LocalChannel());
+        pipeline.addFirst("1", newHandler());
+        pipeline.addLast("10", newHandler());
+
+        pipeline.addBefore("10", "5", newHandler());
+        pipeline.addAfter("1", "3", newHandler());
+        pipeline.addBefore("5", "4", newHandler());
+        pipeline.addAfter("5", "6", newHandler());
+
+        pipeline.addBefore("1", "0", newHandler());
+        pipeline.addAfter("10", "11", newHandler());
+
+        DefaultChannelHandlerContext ctx = (DefaultChannelHandlerContext) pipeline.firstContext();
+        assertNotNull(ctx);
+        while (ctx != null) {
+            int i = toInt(ctx.name());
+            int j = next(ctx);
+
+            assertTrue(i < j);
+            ctx = ctx.next;
+        }
+
+        verifyContextNumber(pipeline, 8);
+    }
+
+    private int next(DefaultChannelHandlerContext ctx) {
+        DefaultChannelHandlerContext next = ctx.next;
+        if (next == null)
+            return Integer.MAX_VALUE;
+
+        return toInt(next.name());
+    }
+
+    private int toInt(String name) {
+        return Integer.parseInt(name);
+    }
+
+    private void verifyContextNumber(DefaultChannelPipeline pipeline, int expectedNumber) {
+        DefaultChannelHandlerContext ctx = (DefaultChannelHandlerContext) pipeline.firstContext();
+        int handlerNumber = 0;
+        while (ctx != null) {
+            handlerNumber++;
+            ctx = ctx.next;
+        }
+        assertEquals(expectedNumber, handlerNumber);
+    }
+
+    private static ChannelHandler[] newHandlers(int num) {
+        assert num > 0;
+
+        ChannelHandler[] handlers = new ChannelHandler[num];
+        for (int i = 0; i < num; i++)
+            handlers[i] = newHandler();
+
+        return handlers;
     }
 
     private static ChannelHandler newHandler() {


### PR DESCRIPTION
if you invoke `ByteBuf nextOutboundByteBuffer(DefaultChannelHandlerContext ctx)` with a `null` parameter, you will get a `NullPointException`.
