### PR TITLE
Generate OGSi manififest only at all-in-one sub module to reduce build complexity

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -319,12 +319,17 @@
               com.sun.nio.sctp;resolution:=optional,
               sun.misc;resolution:=optional,
               sun.net.util;resolution:=optional,
+              !io.netty.*,
               *
             </Import-Package>
             <Export-Package>
               !io.netty.example.*,            
+              !io.netty.*.internal.*,            
               io.netty.*
             </Export-Package>
+            <Private-Package>
+              io.netty.*.internal.*
+            </Private-Package>
           </instructions>
         </configuration>
       </plugin>      

--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <artifactId>netty-buffer</artifactId>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>Netty/Buffer</name>
 
@@ -36,28 +36,4 @@
     </dependency>
   </dependencies>
   
-  <build>
-    <plugins>
-    
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Import-Package>
-              sun.misc;resolution:=optional,              
-              *
-            </Import-Package>
-            <Export-Package>
-              io.netty.buffer
-            </Export-Package>
-          </instructions>
-        </configuration>
-      </plugin>
-      
-    </plugins>
-  </build>
-
 </project>
-

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <artifactId>netty-codec-http</artifactId>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>Netty/Codec/HTTP</name>
 
@@ -41,31 +41,6 @@
     </dependency>
   </dependencies>
   
-  <build>
-    <plugins>
-    
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Import-Package>
-              *
-            </Import-Package>
-            <Export-Package>
-              io.netty.handler.codec.http,
-              io.netty.handler.codec.http.multipart,
-              io.netty.handler.codec.http.websocketx,
-              io.netty.handler.codec.rtsp,
-              io.netty.handler.codec.spdy
-            </Export-Package>
-          </instructions>
-        </configuration>
-      </plugin>
-      
-    </plugins>
-  </build>
   
 </project>
 

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <artifactId>netty-codec</artifactId>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>Netty/Codec</name>
 
@@ -57,36 +57,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
-  <build>
-    <plugins>
-    
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Import-Package>
-              *
-            </Import-Package>
-            <Export-Package>
-              io.netty.handler.codec,
-              io.netty.handler.codec.base64,
-              io.netty.handler.codec.bytes,
-              io.netty.handler.codec.compression,
-              io.netty.handler.codec.marshalling,
-              io.netty.handler.codec.protobuf,
-              io.netty.handler.codec.sctp,
-              io.netty.handler.codec.serialization,
-              io.netty.handler.codec.string
-            </Export-Package>
-          </instructions>
-        </configuration>
-      </plugin>
       
-    </plugins>
-  </build>
-    
 </project>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <artifactId>netty-common</artifactId>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>Netty/Common</name>
 
@@ -68,36 +68,6 @@
       <optional>true</optional>
     </dependency>
   </dependencies>
-  
-  <build>
-    <plugins>
-    
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Import-Package>
-              sun.misc;resolution:=optional,           
-              *
-            </Import-Package>
-            <Export-Package>
-              io.netty.logging,
-              io.netty.monitor,
-              io.netty.monitor.spi,
-              io.netty.util,
-              io.netty.util.internal,
-              io.netty.util.internal.jzlib              
-            </Export-Package>
-          </instructions>
-        </configuration>
-      </plugin>
-      
-    </plugins>
-  </build>
-  
-  
   
 </project>
 

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <artifactId>netty-handler</artifactId>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>Netty/Handler</name>
 
@@ -40,31 +40,5 @@
       <version>${project.version}</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-    
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Import-Package>
-              *
-            </Import-Package>
-            <Export-Package>
-              io.netty.handler.logging,
-              io.netty.handler.ssl,
-              io.netty.handler.stream,
-              io.netty.handler.timeout
-            </Export-Package>
-          </instructions>
-        </configuration>
-      </plugin>
-      
-    </plugins>
-  </build>
   
-  </project>
-
+ </project>

--- a/metrics-yammer/pom.xml
+++ b/metrics-yammer/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <artifactId>netty-metrics-yammer</artifactId>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>Netty/Yammer Metrics Provider</name>
 
@@ -41,27 +41,5 @@
 		<scope>compile</scope>
 	</dependency>
   </dependencies>
-  
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
-        <configuration>
-          <instructions>
-            <Import-Package>
-              *
-            </Import-Package>
-            <Export-Package>
-              io.netty.monitor.yammer,
-              io.netty.monitor.yammer.spi
-            </Export-Package>
-          </instructions>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>  
-    
+      
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,7 @@
           <tagNameFormat>netty-@{project.version}</tagNameFormat>
         </configuration>
       </plugin>
+       
     </plugins>
 
     <pluginManagement>
@@ -425,19 +426,12 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
           <version>1.7</version>
-        </plugin>
+        </plugin>               
         <plugin>
           <groupId>org.apache.felix</groupId>
           <artifactId>maven-bundle-plugin</artifactId>
           <version>2.3.7</version>
-          <configuration>
-            <instructions>
-              <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-              <_versionpolicy>[$(version;==;$(@)),$(version;+;$(@)))</_versionpolicy>
-            </instructions>
-          </configuration>
-        </plugin>
-        
+        </plugin>             
 
         <!-- Workaround for the 'M2E plugin execution not covered' problem.
              See: http://wiki.eclipse.org/M2E_plugin_execution_not_covered -->
@@ -499,6 +493,7 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    
+    
   </build>
 </project>
-

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <artifactId>netty-transport</artifactId>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
 
   <name>Netty/Transport</name>
 
@@ -40,31 +40,13 @@
     <plugins>
     
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
-        <extensions>true</extensions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
         <configuration>
-          <instructions>
-            <Import-Package>
-              com.sun.nio.sctp;resolution:=optional,
-              sun.misc;resolution:=optional,
-              *
-            </Import-Package>
-            <Export-Package>
-              io.netty.bootstrap,
-              io.netty.channel,
-              io.netty.channel.embedded,
-              io.netty.channel.group,
-              io.netty.channel.local,
-              io.netty.channel.socket,
-              io.netty.channel.socket.aio,
-              io.netty.channel.socket.nio,
-              io.netty.channel.socket.oio
-            </Export-Package>
-            <Private-Package>
-              !com.sun.nio.sctp
-            </Private-Package>
-          </instructions>
+          <excludes>
+            <!-- dont want to include com.sun in here -->
+            <exclude>com/**</exclude>
+          </excludes>
         </configuration>
       </plugin>
       
@@ -72,5 +54,5 @@
   
   </build>
   
-  </project>
+</project>
 


### PR DESCRIPTION
Due to the fact that netty sub modules are not OSGi friendly packages:
- internal packages from netty-common get referenced by other modules
- Multiple exportable packages in a sub module

it is best NOT to  provide OSGi manifest file for all modules, except the all-on-one bundle to ease the maintaining of this feature.  
