### PR TITLE
SPDY: fix header block values truncation in decompression

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/spdy/SpdyFrameDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/spdy/SpdyFrameDecoder.java
@@ -544,8 +544,13 @@ public class SpdyFrameDecoder extends FrameDecoder {
             return true;
         }
         // Perhaps last call to decode filled output buffer
-        headerBlockDecompressor.decode(decompressed);
-        return decompressed.readableBytes() >= bytes;
+        int numBytes;
+        boolean done;
+        do {
+            numBytes = headerBlockDecompressor.decode(decompressed);
+            done = decompressed.readableBytes() >= bytes;
+        } while (!done && numBytes > 0);
+        return done;
     }
 
     private int readLengthField() {

--- a/src/main/java/org/jboss/netty/handler/codec/spdy/SpdyHeaderBlockDecompressor.java
+++ b/src/main/java/org/jboss/netty/handler/codec/spdy/SpdyHeaderBlockDecompressor.java
@@ -24,6 +24,6 @@ abstract class SpdyHeaderBlockDecompressor {
     }
 
     abstract void setInput(ChannelBuffer compressed);
-    abstract void decode(ChannelBuffer decompressed) throws Exception;
+    abstract int decode(ChannelBuffer decompressed) throws Exception;
     abstract void end();
 }

--- a/src/main/java/org/jboss/netty/handler/codec/spdy/SpdyHeaderBlockZlibDecompressor.java
+++ b/src/main/java/org/jboss/netty/handler/codec/spdy/SpdyHeaderBlockZlibDecompressor.java
@@ -44,7 +44,7 @@ class SpdyHeaderBlockZlibDecompressor extends SpdyHeaderBlockDecompressor {
     }
 
     @Override
-    public void decode(ChannelBuffer decompressed) throws Exception {
+    public int decode(ChannelBuffer decompressed) throws Exception {
         try {
             int numBytes = decompressor.inflate(out);
             if (numBytes == 0 && decompressor.needsDictionary()) {
@@ -56,6 +56,7 @@ class SpdyHeaderBlockZlibDecompressor extends SpdyHeaderBlockDecompressor {
                 numBytes = decompressor.inflate(out);
             }
             decompressed.writeBytes(out, 0, numBytes);
+            return numBytes;
         } catch (DataFormatException e) {
             throw new SpdyProtocolException(
                     "Received invalid header block", e);


### PR DESCRIPTION
Alternative version of #754.
