### PR TITLE
Reduce the chance of RejectedExecutionException

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultEventExecutor.java
+++ b/transport/src/main/java/io/netty/channel/DefaultEventExecutor.java
@@ -40,16 +40,9 @@ class DefaultEventExecutor extends SingleThreadEventExecutor {
                 // Waken up by interruptThread()
             }
 
-            if (isShutdown() && peekTask() == null) {
+            if (isShutdown() && confirmShutdown()) {
                 break;
             }
-        }
-    }
-
-    @Override
-    protected void wakeup(boolean inEventLoop) {
-        if (!inEventLoop && isShutdown()) {
-            interruptThread();
         }
     }
 }

--- a/transport/src/main/java/io/netty/channel/MultithreadEventExecutorGroup.java
+++ b/transport/src/main/java/io/netty/channel/MultithreadEventExecutorGroup.java
@@ -71,6 +71,10 @@ public abstract class MultithreadEventExecutorGroup implements EventExecutorGrou
 
     @Override
     public void shutdown() {
+        if (isShutdown()) {
+            return;
+        }
+
         scheduler.shutdown();
         for (EventExecutor l: children) {
             l.shutdown();

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -44,6 +44,12 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
 
     @Override
     public ChannelFuture register(final Channel channel, final ChannelFuture future) {
+        if (isShutdown()) {
+            channel.unsafe().closeForcibly();
+            future.setFailure(new EventLoopException("cannot register a channel to a shut down loop"));
+            return future;
+        }
+
         if (inEventLoop()) {
             channel.unsafe().register(this, future);
         } else {

--- a/transport/src/main/java/io/netty/channel/local/LocalEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalEventLoop.java
@@ -38,20 +38,9 @@ final class LocalEventLoop extends SingleThreadEventLoop {
                 // Waken up by interruptThread()
             }
 
-            if (isShutdown()) {
-                task = pollTask();
-                if (task == null) {
-                    break;
-                }
-                task.run();
+            if (isShutdown() && confirmShutdown()) {
+                break;
             }
-        }
-    }
-
-    @Override
-    protected void wakeup(boolean inEventLoop) {
-        if (!inEventLoop && isShutdown()) {
-            interruptThread();
         }
     }
 }

--- a/transport/src/main/java/io/netty/channel/socket/aio/AioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/socket/aio/AioEventLoop.java
@@ -79,11 +79,9 @@ final class AioEventLoop extends SingleThreadEventLoop {
 
             if (isShutdown()) {
                 closeAll();
-                task = pollTask();
-                if (task == null) {
+                if (confirmShutdown()) {
                     break;
                 }
-                task.run();
             }
         }
     }
@@ -96,13 +94,6 @@ final class AioEventLoop extends SingleThreadEventLoop {
 
         for (Channel ch: channels) {
             ch.unsafe().close(ch.unsafe().voidFuture());
-        }
-    }
-
-    @Override
-    protected void wakeup(boolean inEventLoop) {
-        if (!inEventLoop && isShutdown()) {
-            interruptThread();
         }
     }
 }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioEventLoop.java
@@ -249,7 +249,7 @@ public final class NioEventLoop extends SingleThreadEventLoop {
 
                 if (isShutdown()) {
                     closeAll();
-                    if (peekTask() == null) {
+                    if (confirmShutdown()) {
                         break;
                     }
                 }

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioEventLoop.java
@@ -91,17 +91,10 @@ class OioEventLoop extends SingleThreadEventLoop {
                 if (ch != null) {
                     ch.unsafe().close(ch.unsafe().voidFuture());
                 }
-                if (peekTask() == null) {
+                if (confirmShutdown()) {
                     break;
                 }
             }
-        }
-    }
-
-    @Override
-    protected void wakeup(boolean inEventLoop) {
-        if (!inEventLoop && isShutdown()) {
-            interruptThread();
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalTransportThreadModelTest.java
@@ -43,7 +43,6 @@ import java.util.HashSet;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -81,7 +80,7 @@ public class LocalTransportThreadModelTest {
         sb.shutdown();
     }
 
-    @Test(timeout = 5000)
+    @Test(timeout = 30000)
     public void testStagedExecutionMultiple() throws Throwable {
         for (int i = 0; i < 10; i ++) {
             testStagedExecution();
@@ -197,10 +196,10 @@ public class LocalTransportThreadModelTest {
             throw e;
         } finally {
             l.shutdown();
-            l.awaitTermination(5, TimeUnit.SECONDS);
             e1.shutdown();
-            e1.awaitTermination(5, TimeUnit.SECONDS);
             e2.shutdown();
+            l.awaitTermination(5, TimeUnit.SECONDS);
+            e1.awaitTermination(5, TimeUnit.SECONDS);
             e2.awaitTermination(5, TimeUnit.SECONDS);
         }
     }
@@ -319,7 +318,6 @@ public class LocalTransportThreadModelTest {
             }
 
             ch.close().sync();
-            h6.latch.await(); // Wait until channelInactive() is triggered.
 
         } finally {
             l.shutdown();
@@ -662,7 +660,6 @@ public class LocalTransportThreadModelTest {
         private volatile int inCnt;
         private volatile int outCnt;
         private volatile Thread t;
-        final CountDownLatch latch = new CountDownLatch(1);
 
         @Override
         public MessageBuf<Object> newInboundBuffer(ChannelHandlerContext ctx) throws Exception {
@@ -722,11 +719,6 @@ public class LocalTransportThreadModelTest {
                 out.add(msg);
             }
             ctx.flush(future);
-        }
-
-        @Override
-        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-            latch.countDown();
         }
 
         @Override


### PR DESCRIPTION
When a Netty application shuts down, a user often sees a REE
(RejectedExecutionException).

A REE is raised due to various reasons we don't have control over, such
as:
- A client connects to a server while the server is shutting down.
- An event is triggered for a closed Channel while its event loop is
  also shutting down.  Some of them are:
  - channelDeregistered (triggered after a channel is closed)
  - freeIn/OutboundBuffer (triggered after channelDeregistered)
  - userEventTriggered (triggered anytime)

To address this issue, a new method called confirmShutdown() has been
added to SingleThreadEventExecutor.  After a user calls shutdown(),
confirmShutdown() runs any remaining tasks in the task queue and ensures
no events are triggered for last 2 seconds.  If any task are added to
the task queue before 2 seconds passes, confirmShutdown() prevents the
event loop from terminating by returning false.

Now that SingleThreadEventExecutor needs to accept tasks even after
shutdown(), its execute() method only rejects the task after the event
loop is terminated (i.e. isTerminated() returns true.)  Except that,
there's no change in semantics.

SingleThreadEventExecutor also checks if its subclass called
confirmShutdown() in its run() implementation, so that Netty developers
can make sure they shut down their event loop impementation correctly.

It also fixes a bug in AioSocketChannel, revealed by delayed shutdown,
where an inboundBufferUpdated() event is triggered on a closed Channel
with deallocated buffers.

Caveats:

Because SingleThreadEventExecutor.takeTask() does not have a notion of
timeout, confirmShutdown() adds a dummy task (WAKEUP_TASK) to wake up
takeTask() immediately and instead sleeps hard-coded 100ms.  I'll
address this issue later by modifying takeTask() times out dynamically.

Miscellaneous changes:

SingleThreadEventExecutor.wakeup() now has the default implementation.
Instead of interrupting the current thread, it simply adds a dummy task
(WAKEUP_TASK) to the task queue, which is more elegant and efficient.
NioEventLoop is the only implementation that overrides it. All other
implementations' wakeup()s were removed thanks to this change.
