### PR TITLE
clear out the hash table after resizing, and check for table modificatio...

### DIFF
--- a/src/main/java/org/jboss/netty/util/internal/ConcurrentIdentityHashMap.java
+++ b/src/main/java/org/jboss/netty/util/internal/ConcurrentIdentityHashMap.java
@@ -315,7 +315,11 @@ public final class ConcurrentIdentityHashMap<K, V> extends AbstractMap<K, V>
 
         V get(Object key, int hash) {
             if (count != 0) { // read-volatile
-                HashEntry<K, V> e = getFirst(hash);
+                HashEntry<K, V>[] tab = table;
+                HashEntry<K, V> e = tab[hash & tab.length - 1];
+                if (tab != table) {
+                    return get(key, hash);
+                }
                 while (e != null) {
                     if (e.hash == hash && keyEq(key, e.key())) {
                         V opaque = e.value();
@@ -333,7 +337,11 @@ public final class ConcurrentIdentityHashMap<K, V> extends AbstractMap<K, V>
 
         boolean containsKey(Object key, int hash) {
             if (count != 0) { // read-volatile
-                HashEntry<K, V> e = getFirst(hash);
+                HashEntry<K, V>[] tab = table;
+                HashEntry<K, V> e = tab[hash & tab.length - 1];
+                if (tab != table) {
+                    return containsKey(key, hash);
+                }
                 while (e != null) {
                     if (e.hash == hash && keyEq(key, e.key())) {
                         return true;
@@ -363,6 +371,9 @@ public final class ConcurrentIdentityHashMap<K, V> extends AbstractMap<K, V>
                             return true;
                         }
                     }
+                }
+                if (table != tab) {
+                    return containsValue(value);
                 }
             }
             return false;
@@ -507,6 +518,9 @@ public final class ConcurrentIdentityHashMap<K, V> extends AbstractMap<K, V>
                 }
             }
             table = newTable;
+            for (int i = 0; i < oldCapacity; ++i) {
+              oldTable[i] = null;
+            }
             return reduce;
         }
 


### PR DESCRIPTION
this branch clears the ConcurrentIdentityHashMap Segment's table after a resize. the motivation of this change is the following:

HashedWheelTimer uses ConcurrentIdentityHashMap, and when the table resizes, tasks in the table
will have references in the oldTable despite being removed due to cancellation or expiration. when using the CMS collector, the oldTable is likely to be tenured, which means that it won't be collected for a while, and will bring in the cancelled/expired tasks with it into the oldgen. this caused unnecessary object promotion.
