### PR TITLE
#751 - Added support for legacy websocket v7 in order to pass SocksJS tests

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket07FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket07FrameDecoder.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+// (BSD License: http://www.opensource.org/licenses/bsd-license)
+//
+// Copyright (c) 2011, Joe Walnes and contributors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or
+// without modification, are permitted provided that the
+// following conditions are met:
+//
+// * Redistributions of source code must retain the above
+// copyright notice, this list of conditions and the
+// following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+//
+// * Neither the name of the Webbit nor the names of
+// its contributors may be used to endorse or promote products
+// derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+// CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+// GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+// OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package io.netty.handler.codec.http.websocketx;
+
+/**
+ * Decodes a web socket frame from wire protocol version 7 format. V7 is essentially the same as V8.
+ */
+public class WebSocket07FrameDecoder extends WebSocket08FrameDecoder {
+
+    /**
+     * Constructor
+     *
+     * @param maskedPayload
+     *            Web socket servers must set this to true processed incoming masked payload. Client implementations
+     *            must set this to false.
+     * @param allowExtensions
+     *            Flag to allow reserved extension bits to be used or not
+     * @param maxFramePayloadLength
+     *            Maximum length of a frame's payload. Setting this to an appropriate value for you application
+     *            helps check for denial of services attacks.
+     */
+    public WebSocket07FrameDecoder(boolean maskedPayload, boolean allowExtensions, int maxFramePayloadLength) {
+        super(maskedPayload, allowExtensions, maxFramePayloadLength);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket07FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket07FrameEncoder.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+// (BSD License: http://www.opensource.org/licenses/bsd-license)
+//
+// Copyright (c) 2011, Joe Walnes and contributors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or
+// without modification, are permitted provided that the
+// following conditions are met:
+//
+// * Redistributions of source code must retain the above
+// copyright notice, this list of conditions and the
+// following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+//
+// * Neither the name of the Webbit nor the names of
+// its contributors may be used to endorse or promote products
+// derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+// CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+// GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+// BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+// OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package io.netty.handler.codec.http.websocketx;
+
+/**
+ * <p>
+ * Encodes a web socket frame into wire protocol version 7 format. V7 is essentially the same as V8.
+ * </p>
+ */
+public class WebSocket07FrameEncoder extends WebSocket08FrameEncoder {
+
+    /**
+     * Constructor
+     *
+     * @param maskPayload
+     *            Web socket clients must set this to true to mask payload. Server implementations must set this to
+     *            false.
+     */
+    public WebSocket07FrameEncoder(boolean maskPayload) {
+        super(maskPayload);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker07.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker07.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.websocketx;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaders.Values;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpRequestEncoder;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseDecoder;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.logging.InternalLogger;
+import io.netty.logging.InternalLoggerFactory;
+import io.netty.util.CharsetUtil;
+
+import java.net.URI;
+import java.util.Map;
+
+/**
+ * <p>
+ * Performs client side opening and closing handshakes for web socket specification version <a
+ * href="http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-07" >draft-ietf-hybi-thewebsocketprotocol-
+ * 10</a>
+ * </p>
+ */
+public class WebSocketClientHandshaker07 extends WebSocketClientHandshaker {
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(WebSocketClientHandshaker07.class);
+
+    public static final String MAGIC_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+    private String expectedChallengeResponseString;
+
+    private final boolean allowExtensions;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param webSocketURL
+     *            URL for web socket communications. e.g "ws://myhost.com/mypath". Subsequent web socket frames will be
+     *            sent to this URL.
+     * @param version
+     *            Version of web socket specification to use to connect to the server
+     * @param subprotocol
+     *            Sub protocol request sent to the server.
+     * @param allowExtensions
+     *            Allow extensions to be used in the reserved bits of the web socket frame
+     * @param customHeaders
+     *            Map of custom headers to add to the client request
+     * @param maxFramePayloadLength
+     *            Maximum length of a frame's payload
+     */
+    public WebSocketClientHandshaker07(URI webSocketURL, WebSocketVersion version, String subprotocol,
+            boolean allowExtensions, Map<String, String> customHeaders, int maxFramePayloadLength) {
+        super(webSocketURL, version, subprotocol, customHeaders, maxFramePayloadLength);
+        this.allowExtensions = allowExtensions;
+    }
+
+    /**
+     * /**
+     * <p>
+     * Sends the opening request to the server:
+     * </p>
+     *
+     * <pre>
+     * GET /chat HTTP/1.1
+     * Host: server.example.com
+     * Upgrade: websocket
+     * Connection: Upgrade
+     * Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
+     * Sec-WebSocket-Origin: http://example.com
+     * Sec-WebSocket-Protocol: chat, superchat
+     * Sec-WebSocket-Version: 7
+     * </pre>
+     *
+     * @param channel
+     *            Channel into which we can write our request
+     */
+    @Override
+    public ChannelFuture handshake(Channel channel, final ChannelFuture handshakeFuture) {
+        // Get path
+        URI wsURL = getWebSocketUrl();
+        String path = wsURL.getPath();
+        if (wsURL.getQuery() != null && !wsURL.getQuery().isEmpty()) {
+            path = wsURL.getPath() + '?' + wsURL.getQuery();
+        }
+
+        if (path == null || path.isEmpty()) {
+            path = "/";
+        }
+
+        // Get 16 bit nonce and base 64 encode it
+        byte[] nonce = WebSocketUtil.randomBytes(16);
+        String key = WebSocketUtil.base64(nonce);
+
+        String acceptSeed = key + MAGIC_GUID;
+        byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII));
+        expectedChallengeResponseString = WebSocketUtil.base64(sha1);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug(String.format("WS Version 07 Client Handshake key: %s. Expected response: %s.", key,
+                    expectedChallengeResponseString));
+        }
+
+        // Format request
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, path);
+        request.addHeader(Names.UPGRADE, Values.WEBSOCKET.toLowerCase());
+        request.addHeader(Names.CONNECTION, Values.UPGRADE);
+        request.addHeader(Names.SEC_WEBSOCKET_KEY, key);
+        request.addHeader(Names.HOST, wsURL.getHost());
+
+        int wsPort = wsURL.getPort();
+        String originValue = "http://" + wsURL.getHost();
+        if (wsPort != 80 && wsPort != 443) {
+            // if the port is not standard (80/443) its needed to add the port to the header.
+            // See http://tools.ietf.org/html/rfc6454#section-6.2
+            originValue = originValue + ':' + wsPort;
+        }
+        request.addHeader(Names.SEC_WEBSOCKET_ORIGIN, originValue);
+
+        String expectedSubprotocol = getExpectedSubprotocol();
+        if (expectedSubprotocol != null && !expectedSubprotocol.isEmpty()) {
+            request.addHeader(Names.SEC_WEBSOCKET_PROTOCOL, expectedSubprotocol);
+        }
+
+        request.addHeader(Names.SEC_WEBSOCKET_VERSION, "7");
+
+        if (customHeaders != null) {
+            for (Map.Entry<String, String> e : customHeaders.entrySet()) {
+                request.addHeader(e.getKey(), e.getValue());
+            }
+        }
+
+        ChannelFuture future = channel.write(request);
+        future.addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) {
+                ChannelPipeline p = future.channel().pipeline();
+                p.addAfter(
+                        p.context(HttpRequestEncoder.class).name(),
+                        "ws-encoder", new WebSocket07FrameEncoder(true));
+
+                if (future.isSuccess()) {
+                    handshakeFuture.setSuccess();
+                } else {
+                    handshakeFuture.setFailure(future.cause());
+                }
+            }
+        });
+
+        return handshakeFuture;
+    }
+
+    /**
+     * <p>
+     * Process server response:
+     * </p>
+     *
+     * <pre>
+     * HTTP/1.1 101 Switching Protocols
+     * Upgrade: websocket
+     * Connection: Upgrade
+     * Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
+     * Sec-WebSocket-Protocol: chat
+     * </pre>
+     *
+     * @param channel
+     *            Channel
+     * @param response
+     *            HTTP response returned from the server for the request sent by beginOpeningHandshake00().
+     * @throws WebSocketHandshakeException
+     */
+    @Override
+    public void finishHandshake(Channel channel, HttpResponse response) {
+        final HttpResponseStatus status = HttpResponseStatus.SWITCHING_PROTOCOLS;
+
+        if (!response.getStatus().equals(status)) {
+            throw new WebSocketHandshakeException("Invalid handshake response status: " + response.getStatus());
+        }
+
+        String upgrade = response.getHeader(Names.UPGRADE);
+        if (!Values.WEBSOCKET.equalsIgnoreCase(upgrade)) {
+            throw new WebSocketHandshakeException("Invalid handshake response upgrade: "
+                    + response.getHeader(Names.UPGRADE));
+        }
+
+        String connection = response.getHeader(Names.CONNECTION);
+        if (!Values.UPGRADE.equalsIgnoreCase(connection)) {
+            throw new WebSocketHandshakeException("Invalid handshake response connection: "
+                    + response.getHeader(Names.CONNECTION));
+        }
+
+        String accept = response.getHeader(Names.SEC_WEBSOCKET_ACCEPT);
+        if (accept == null || !accept.equals(expectedChallengeResponseString)) {
+            throw new WebSocketHandshakeException(String.format("Invalid challenge. Actual: %s. Expected: %s", accept,
+                    expectedChallengeResponseString));
+        }
+
+        String subprotocol = response.getHeader(Names.SEC_WEBSOCKET_PROTOCOL);
+        setActualSubprotocol(subprotocol);
+
+        setHandshakeComplete();
+
+        ChannelPipeline p = channel.pipeline();
+        p.remove(HttpRequestEncoder.class);
+        p.get(HttpResponseDecoder.class).replace(
+                "ws-decoder",
+                new WebSocket07FrameDecoder(false, allowExtensions, getMaxFramePayloadLength()));
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerFactory.java
@@ -81,6 +81,10 @@ public final class WebSocketClientHandshakerFactory {
             return new WebSocketClientHandshaker08(
                     webSocketURL, V08, subprotocol, allowExtensions, customHeaders, maxFramePayloadLength);
         }
+        if (version == V07) {
+            return new WebSocketClientHandshaker07(
+                    webSocketURL, V07, subprotocol, allowExtensions, customHeaders, maxFramePayloadLength);
+        }
         if (version == V00) {
             return new WebSocketClientHandshaker00(
                     webSocketURL, V00, subprotocol, customHeaders, maxFramePayloadLength);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker07.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker07.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http.websocketx;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpChunkAggregator;
+import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.logging.InternalLogger;
+import io.netty.logging.InternalLoggerFactory;
+import io.netty.util.CharsetUtil;
+
+import static io.netty.handler.codec.http.HttpHeaders.Values.*;
+import static io.netty.handler.codec.http.HttpVersion.*;
+
+/**
+ * <p>
+ * Performs server side opening and closing handshakes for web socket specification version <a
+ * href="http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-10" >draft-ietf-hybi-thewebsocketprotocol-
+ * 10</a>
+ * </p>
+ */
+public class WebSocketServerHandshaker07 extends WebSocketServerHandshaker {
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(WebSocketServerHandshaker07.class);
+
+    public static final String WEBSOCKET_07_ACCEPT_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+    private final boolean allowExtensions;
+
+    /**
+     * Constructor specifying the destination web socket location
+     *
+     * @param webSocketURL
+     *            URL for web socket communications. e.g "ws://myhost.com/mypath".
+     *            Subsequent web socket frames will be sent to this URL.
+     * @param subprotocols
+     *            CSV of supported protocols
+     * @param allowExtensions
+     *            Allow extensions to be used in the reserved bits of the web socket frame
+     * @param maxFramePayloadLength
+     *            Maximum allowable frame payload length. Setting this value to your application's
+     *            requirement may reduce denial of service attacks using long data frames.
+     */
+    public WebSocketServerHandshaker07(
+            String webSocketURL, String subprotocols, boolean allowExtensions, int maxFramePayloadLength) {
+        super(WebSocketVersion.V07, webSocketURL, subprotocols, maxFramePayloadLength);
+        this.allowExtensions = allowExtensions;
+    }
+
+    /**
+     * <p>
+     * Handle the web socket handshake for the web socket specification <a href=
+     * "http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-07">HyBi version 7</a>.
+     * </p>
+     *
+     * <p>
+     * Browser request to the server:
+     * </p>
+     *
+     * <pre>
+     * GET /chat HTTP/1.1
+     * Host: server.example.com
+     * Upgrade: websocket
+     * Connection: Upgrade
+     * Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
+     * Sec-WebSocket-Origin: http://example.com
+     * Sec-WebSocket-Protocol: chat, superchat
+     * Sec-WebSocket-Version: 7
+     * </pre>
+     *
+     * <p>
+     * Server response:
+     * </p>
+     *
+     * <pre>
+     * HTTP/1.1 101 Switching Protocols
+     * Upgrade: websocket
+     * Connection: Upgrade
+     * Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
+     * Sec-WebSocket-Protocol: chat
+     * </pre>
+     *
+     * @param channel
+     *            Channel
+     * @param req
+     *            HTTP request
+     */
+    @Override
+    public ChannelFuture handshake(Channel channel, HttpRequest req, ChannelFuture future) {
+
+        if (logger.isDebugEnabled()) {
+            logger.debug(String.format("Channel %s WS Version 7 server handshake", channel.id()));
+        }
+
+        HttpResponse res = new DefaultHttpResponse(HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS);
+
+        String key = req.getHeader(Names.SEC_WEBSOCKET_KEY);
+        if (key == null) {
+            throw new WebSocketHandshakeException("not a WebSocket request: missing key");
+        }
+        String acceptSeed = key + WEBSOCKET_07_ACCEPT_GUID;
+        byte[] sha1 = WebSocketUtil.sha1(acceptSeed.getBytes(CharsetUtil.US_ASCII));
+        String accept = WebSocketUtil.base64(sha1);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug(String.format("WS Version 7 Server Handshake key: %s. Response: %s.", key, accept));
+        }
+
+        res.setStatus(HttpResponseStatus.SWITCHING_PROTOCOLS);
+        res.addHeader(Names.UPGRADE, WEBSOCKET.toLowerCase());
+        res.addHeader(Names.CONNECTION, Names.UPGRADE);
+        res.addHeader(Names.SEC_WEBSOCKET_ACCEPT, accept);
+        String subprotocols = req.getHeader(Names.SEC_WEBSOCKET_PROTOCOL);
+        if (subprotocols != null) {
+            String selectedSubprotocol = selectSubprotocol(subprotocols);
+            if (selectedSubprotocol == null) {
+                throw new WebSocketHandshakeException("Requested subprotocol(s) not supported: " + subprotocols);
+            } else {
+                res.addHeader(Names.SEC_WEBSOCKET_PROTOCOL, selectedSubprotocol);
+                setSelectedSubprotocol(selectedSubprotocol);
+            }
+        }
+
+        channel.write(res, future);
+
+        // Upgrade the connection and send the handshake response.
+        future.addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) {
+                ChannelPipeline p = future.channel().pipeline();
+                if (p.get(HttpChunkAggregator.class) != null) {
+                    p.remove(HttpChunkAggregator.class);
+                }
+
+                p.get(HttpRequestDecoder.class).replace("wsdecoder",
+                        new WebSocket07FrameDecoder(true, allowExtensions, getMaxFramePayloadLength()));
+                p.replace(HttpResponseEncoder.class, "wsencoder", new WebSocket07FrameEncoder(false));
+            }
+        });
+
+        return future;
+    }
+
+    /**
+     * Echo back the closing frame and close the connection
+     *
+     * @param channel
+     *            Channel
+     * @param frame
+     *            Web Socket frame that was received
+     */
+    @Override
+    public ChannelFuture close(Channel channel, CloseWebSocketFrame frame, ChannelFuture future) {
+        future.addListener(ChannelFutureListener.CLOSE);
+        return channel.write(frame, future);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
@@ -93,6 +93,10 @@ public class WebSocketServerHandshakerFactory {
                 // Version 8 of the wire protocol - version 10 of the draft hybi specification.
                 return new WebSocketServerHandshaker08(
                         webSocketURL, subprotocols, allowExtensions, maxFramePayloadLength);
+            } else if (version.equals(WebSocketVersion.V07.toHttpHeaderValue())) {
+                // Version 8 of the wire protocol - version 07 of the draft hybi specification.
+                return new WebSocketServerHandshaker07(
+                        webSocketURL, subprotocols, allowExtensions, maxFramePayloadLength);
             } else {
                 return null;
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketVersion.java
@@ -34,6 +34,12 @@ public enum WebSocketVersion {
     V00,
 
     /**
+     * <a href= "http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-07"
+     * >draft-ietf-hybi-thewebsocketprotocol- 07</a>
+     */
+    V07,
+
+    /**
      * <a href= "http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-10"
      * >draft-ietf-hybi-thewebsocketprotocol- 10</a>
      */
@@ -52,6 +58,9 @@ public enum WebSocketVersion {
     public String toHttpHeaderValue() {
         if (this == V00) {
             return "0";
+        }
+        if (this == V07) {
+            return "7";
         }
         if (this == V08) {
             return "8";


### PR DESCRIPTION
I did not have too much time to test (could not dig up FF6) so it would be good if someone help test this.  I did test netty client to netty server in V7.

I think the only significant binary difference in the protocol is the version number in the handshake so that is the only change I made.

Here's the diff between the specs: http://tools.ietf.org/rfcdiff?url2=draft-ietf-hybi-thewebsocketprotocol-08.txt

Please let me know if this passes the SocksJS tests.
