### PR TITLE
Regression in SslHandler which may cause to not have wrap() called

### DIFF
--- a/src/main/java/org/jboss/netty/handler/ssl/SslHandler.java
+++ b/src/main/java/org/jboss/netty/handler/ssl/SslHandler.java
@@ -1244,21 +1244,20 @@ public class SslHandler extends FrameDecoder
                                 "Unknown handshake status: " + handshakeStatus);
                     }
                 }
-
-                if (needsWrap) {
-                    // wrap() acquires pendingUnencryptedWrites first and then
-                    // handshakeLock.  If handshakeLock is already hold by the
-                    // current thread, calling wrap() will lead to a dead lock
-                    // i.e. pendingUnencryptedWrites -> handshakeLock vs.
-                    //      handshakeLock -> pendingUnencryptedLock -> handshakeLock
-                    //
-                    // There is also a same issue between pendingEncryptedWrites
-                    // and pendingUnencryptedWrites.
-                    if (!Thread.holdsLock(handshakeLock) &&
-                        !pendingEncryptedWritesLock.isHeldByCurrentThread()) {
-                        wrap(ctx, channel);
-                    }
-                }
+            }
+            if (needsWrap) {
+                 // wrap() acquires pendingUnencryptedWrites first and then
+                 // handshakeLock.  If handshakeLock is already hold by the
+                 // current thread, calling wrap() will lead to a dead lock
+                 // i.e. pendingUnencryptedWrites -> handshakeLock vs.
+                 //      handshakeLock -> pendingUnencryptedLock -> handshakeLock
+                 //
+                 // There is also a same issue between pendingEncryptedWrites
+                 // and pendingUnencryptedWrites.
+                 if (!Thread.holdsLock(handshakeLock) &&
+                     pendingEncryptedWritesLock.isHeldByCurrentThread()) {
+                     wrap(ctx, channel);
+                 }
             }
             outAppBuf.flip();
 


### PR DESCRIPTION
Bugfix in SslHandler.java,
commit e784a773f7dbfc4bba49e4ce88ddde82ec3c4e52 introduced a bug when adding synchronization accidentally changed the body of a for-loop.

3.6.0 broke our server using netty 3.x.
Comparing 3.5.11 and 3.6.0 it is clear that adding the sync statement in commit e784a773f7dbfc4bba49e4ce88ddde82ec3c4e52  a mistake was made by putting the if(needsWrap) statement into the for-loop beginning at line 1197.

With this fix our server runs fine again.
