### PR TITLE
Chrome requires the :version: header in SPDY_SESSION_PUSHED_SYN_STREAM

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/spdy/SpdyHttpEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/spdy/SpdyHttpEncoder.java
@@ -293,6 +293,7 @@ public class SpdyHttpEncoder implements ChannelDownstreamHandler {
             HttpResponse httpResponse = (HttpResponse) httpMessage;
             SpdyHeaders.setStatus(spdyVersion, spdySynStreamFrame, httpResponse.getStatus());
             SpdyHeaders.setUrl(spdyVersion, spdySynStreamFrame, URL);
+            SpdyHeaders.setVersion(spdyVersion, spdySynStreamFrame, httpMessage.getProtocolVersion());
             spdySynStreamFrame.setUnidirectional(true);
         }
 


### PR DESCRIPTION
Otherwise it issues a HTTP_TRANSACTION_SPDY_SEND_REQUEST_HEADERS and a SPDY_STREAM_ERROR saying "HEADERS incomplete headers, but pending data frames."
