### PR TITLE
RXTX: provide a wait option after opening the serial port

### DIFF
--- a/example/src/main/java/io/netty/example/rxtx/RxtxClient.java
+++ b/example/src/main/java/io/netty/example/rxtx/RxtxClient.java
@@ -18,6 +18,7 @@ package io.netty.example.rxtx;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.rxtx.RxtxChannelOption;
 import io.netty.channel.socket.oio.OioEventLoopGroup;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.codec.string.StringDecoder;
@@ -35,7 +36,9 @@ public final class RxtxClient {
         try {
             b.group(new OioEventLoopGroup())
              .channel(RxtxChannel.class)
-             .remoteAddress(new RxtxDeviceAddress("/dev/ttyUSB0"))
+             .remoteAddress(new RxtxDeviceAddress("/dev/tty.usbmodem641"))
+             .option(RxtxChannelOption.BAUD_RATE, 57600)
+             .option(RxtxChannelOption.WAIT_AFTER_CONNECT, 1500)
              .handler(new ChannelInitializer<RxtxChannel>() {
                  @Override
                  public void initChannel(RxtxChannel ch) throws Exception {

--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannel.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannel.java
@@ -21,6 +21,7 @@ import gnu.io.SerialPort;
 import io.netty.buffer.BufType;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelMetadata;
+import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.socket.oio.AbstractOioByteChannel;
 
 import java.io.IOException;
@@ -104,7 +105,12 @@ public class RxtxChannel extends AbstractOioByteChannel {
     protected void doConnect(SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
         RxtxDeviceAddress remote = (RxtxDeviceAddress) remoteAddress;
         final CommPortIdentifier cpi = CommPortIdentifier.getPortIdentifier(remote.value());
-        final CommPort commPort = cpi.open(getClass().getName(), 1000);
+        final CommPort commPort = cpi.open(getClass().getName(), config().getOption(CONNECT_TIMEOUT_MILLIS));
+
+        Integer waitAfterConnect = config().getOption(WAIT_AFTER_CONNECT);
+        if (waitAfterConnect != 0) {
+            Thread.sleep(waitAfterConnect);
+        }
 
         deviceAddress = remote;
 

--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannelConfig.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannelConfig.java
@@ -150,6 +150,7 @@ public class RxtxChannelConfig extends DefaultChannelConfig {
     private volatile Stopbits stopbits = Stopbits.STOPBITS_1;
     private volatile Databits databits = Databits.DATABITS_8;
     private volatile Paritybit paritybit = Paritybit.NONE;
+    private volatile int waitAfterConnect;
 
     public RxtxChannelConfig(RxtxChannel channel) {
         super(channel);
@@ -157,7 +158,8 @@ public class RxtxChannelConfig extends DefaultChannelConfig {
 
     @Override
     public Map<ChannelOption<?>, Object> getOptions() {
-        return getOptions(super.getOptions(), BAUD_RATE, DTR, RTS, STOP_BITS, DATA_BITS, PARITY_BIT);
+        return getOptions(super.getOptions(), BAUD_RATE, DTR, RTS, STOP_BITS, DATA_BITS, PARITY_BIT,
+                WAIT_AFTER_CONNECT);
     }
 
     @SuppressWarnings("unchecked")
@@ -181,6 +183,9 @@ public class RxtxChannelConfig extends DefaultChannelConfig {
         if (option == PARITY_BIT) {
             return (T) getParitybit();
         }
+        if (option == WAIT_AFTER_CONNECT) {
+            return (T) Integer.valueOf(waitAfterConnect);
+        }
         return super.getOption(option);
     }
 
@@ -200,6 +205,8 @@ public class RxtxChannelConfig extends DefaultChannelConfig {
             setDatabits((Databits) value);
         } else if (option == PARITY_BIT) {
             setParitybit((Paritybit) value);
+        } else if (option == WAIT_AFTER_CONNECT) {
+            setWaitAfterConnect((Integer) value);
         } else {
             return super.setOption(option, value);
         }
@@ -244,6 +251,16 @@ public class RxtxChannelConfig extends DefaultChannelConfig {
      */
     public void setParitybit(final Paritybit paritybit) {
         this.paritybit = paritybit;
+    }
+
+    /**
+     * Sets the time to wait (in milliseconds) after the serial port has been opened.
+     * This might be needed depending on the kind of serial device you use.
+     *
+     * @param waitAfterConnect how long to wait after the serial port has been opened (in milliseconds)
+     */
+    public void setWaitAfterConnect(int waitAfterConnect) {
+        this.waitAfterConnect = waitAfterConnect;
     }
 
     /**
@@ -307,4 +324,5 @@ public class RxtxChannelConfig extends DefaultChannelConfig {
     public void setRts(final boolean rts) {
         this.rts = rts;
     }
+
 }

--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannelOption.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannelOption.java
@@ -42,6 +42,9 @@ public final class RxtxChannelOption<T> extends ChannelOption<T> {
     public static final RxtxChannelOption<Paritybit> PARITY_BIT =
             new RxtxChannelOption<Paritybit>("PARITY_BIT");
 
+    public static final RxtxChannelOption<Integer> WAIT_AFTER_CONNECT =
+            new RxtxChannelOption<Integer>("WAIT_AFTER_CONNECT");
+
     private RxtxChannelOption(String name) {
         super(name);
     }


### PR DESCRIPTION
I'm not sure why this pause might be needed for some devices, but this is at least something which works with the devices I had trouble with.
One of the "known" device is an Arduino on Mac OS X (Lion). Perhaps the virtual serial device is too slow compared to "native" ones.
