### PR TITLE
NioServerBossPool : init() must be called after super(...) otherwise thr...

### DIFF
--- a/src/main/java/org/jboss/netty/channel/socket/nio/NioServerBossPool.java
+++ b/src/main/java/org/jboss/netty/channel/socket/nio/NioServerBossPool.java
@@ -35,8 +35,9 @@ public class NioServerBossPool extends AbstractNioBossPool<NioServerBoss> {
      *                      if you not want to set one explicit.
      */
     public NioServerBossPool(Executor bossExecutor, int bossCount, ThreadNameDeterminer determiner) {
-        super(bossExecutor, bossCount);
+        super(bossExecutor, bossCount, false);
         this.determiner = determiner;
+        init();
     }
 
     /**

--- a/src/test/java/org/jboss/netty/channel/socket/nio/NioServerBossPoolTest.java
+++ b/src/test/java/org/jboss/netty/channel/socket/nio/NioServerBossPoolTest.java
@@ -1,0 +1,58 @@
+package org.jboss.netty.channel.socket.nio;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.jboss.netty.util.ThreadNameDeterminer;
+import org.jboss.netty.util.internal.ExecutorUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class NioServerBossPoolTest {
+
+    private static ExecutorService executor;
+
+    @BeforeClass
+    public static void init() {
+        executor = Executors.newCachedThreadPool();
+    }
+
+    @AfterClass
+    public static void destroy() {
+        ExecutorUtil.terminate(executor);
+    }
+
+    private static final String MY_CUSTOM_THREAD_NAME = "FOO";
+
+    private final ThreadNameDeterminer determiner = new ThreadNameDeterminer() {
+
+        public String determineThreadName(String currentThreadName,
+                String proposedThreadName) throws Exception {
+            return MY_CUSTOM_THREAD_NAME;
+        }
+
+    };
+
+    @Test
+    public void testNioServerBossPoolExecutorIntThreadNameDeterminer()
+            throws Exception {
+        NioServerBossPool bossPool = null;
+        try {
+            bossPool = new NioServerBossPool(executor, 1, determiner);
+            NioServerBoss nextBoss = bossPool.nextBoss();
+            assertNotNull(nextBoss);
+            // Wait for ThreadRenamingRunnable to be run by the executor
+            Thread.sleep(1000);
+            // Ok, now there should be thread
+            assertNotNull(nextBoss.thread);
+            assertEquals(MY_CUSTOM_THREAD_NAME, nextBoss.thread.getName());
+        } finally {
+            if (bossPool != null) {
+                bossPool.shutdown();
+            }
+        }
+    }
+}


### PR DESCRIPTION
...ead name determiner is not used

Hi all,

While i was trying to customize threads name i realized that the ThreadNameDeterminer in NioServerBossPool is not used.
This is because the thread is started by the parent class before `this.determiner = determiner;` is called.

This pull request provides a JUnit test that show the issue and respects the rules on the page https://netty.io/Documentation/Developer+Guide

Thanks for your great work.
