### PR TITLE
Upload multipart-encoded streams with CR (0x13) symbol at the end leads to the corrupted data.

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestDecoder.java
@@ -1517,6 +1517,12 @@ public class HttpPostRequestDecoder {
                                 newLine = true;
                                 index = 0;
                                 lastPosition = undecodedChunk.readerIndex() - 2;
+                            } else {
+                                // save last valid position
+                                lastPosition = undecodedChunk.readerIndex() - 1;
+
+                                // Unread next byte.
+                                undecodedChunk.readerIndex(lastPosition);
                             }
                         }
                     } else if (nextByte == HttpConstants.LF) {
@@ -1537,6 +1543,12 @@ public class HttpPostRequestDecoder {
                             newLine = true;
                             index = 0;
                             lastPosition = undecodedChunk.readerIndex() - 2;
+                        } else {
+                            // save last valid position
+                            lastPosition = undecodedChunk.readerIndex() - 1;
+
+                            // Unread next byte.
+                            undecodedChunk.readerIndex(lastPosition);
                         }
                     }
                 } else if (nextByte == HttpConstants.LF) {
@@ -1619,6 +1631,12 @@ public class HttpPostRequestDecoder {
                                 newLine = true;
                                 index = 0;
                                 lastrealpos = sao.pos - 2;
+                            } else {
+                                // unread next byte
+                                sao.pos--;
+
+                                // save last valid position
+                                lastrealpos = sao.pos;
                             }
                         }
                     } else if (nextByte == HttpConstants.LF) {
@@ -1639,6 +1657,12 @@ public class HttpPostRequestDecoder {
                             newLine = true;
                             index = 0;
                             lastrealpos = sao.pos - 2;
+                        } else {
+                            // unread next byte
+                            sao.pos--;
+
+                            // save last valid position
+                            lastrealpos = sao.pos;
                         }
                     }
                 } else if (nextByte == HttpConstants.LF) {


### PR DESCRIPTION
In my application I caught the problem with HttpPostRequestDecoder.

When users upload multipart/form-data encoded binary data with apache HttpClient - there is superfluous CR (0x13) symbol at the end of the uploaded stream (if original stream ends with CR symbol).

E.g. input stream: the only symbol 0x13
Data line in the encoded form: 0x13 0x13 0x10

Decoder passes the first 2 CR symbols and stops on the ending LF: 
- [binary data] + CR - interpret as binary data.
- LF - interpret as end of line.
