### PR TITLE
[#1002] More Snappy fixes

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/SnappyFramedDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/SnappyFramedDecoder.java
@@ -170,11 +170,11 @@ public class SnappyFramedDecoder extends ByteToByteDecoder {
                     if (validateChecksums) {
                         // TODO: Optimize me.
                         ByteBuf uncompressed = ctx.alloc().buffer();
-                        snappy.decode(in.readSlice(chunkLength - 4), uncompressed, chunkLength);
+                        snappy.decode(in.readSlice(chunkLength - 4), uncompressed);
                         validateChecksum(uncompressed, checksum);
                         out.writeBytes(uncompressed);
                     } else {
-                        snappy.decode(in.readSlice(chunkLength - 4), out, chunkLength);
+                        snappy.decode(in.readSlice(chunkLength - 4), out);
                     }
                     snappy.reset();
                     break;

--- a/codec/src/main/java/io/netty/handler/codec/compression/SnappyFramedEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/SnappyFramedEncoder.java
@@ -61,12 +61,12 @@ public class SnappyFramedEncoder extends ByteToByteEncoder {
             for (;;) {
                 final int lengthIdx = out.writerIndex() + 1;
                 out.writeInt(0);
-                if (dataLength > 65536) {
-                    ByteBuf slice = in.readSlice(65536);
+                if (dataLength > 32768) {
+                    ByteBuf slice = in.readSlice(32768);
                     calculateAndWriteChecksum(slice, out);
-                    snappy.encode(slice, out, 65536);
+                    snappy.encode(slice, out, 32768);
                     setChunkLength(out, lengthIdx);
-                    dataLength -= 65536;
+                    dataLength -= 32768;
                 } else {
                     ByteBuf slice = in.readSlice(dataLength);
                     calculateAndWriteChecksum(slice, out);

--- a/codec/src/test/java/io/netty/handler/codec/compression/SnappyIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/SnappyIntegrationTest.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.compression;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedByteChannel;
 import io.netty.util.CharsetUtil;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Random;
@@ -37,7 +36,6 @@ public class SnappyIntegrationTest {
     }
 
     @Test
-    @Ignore // FIXME: Make it pass.
     public void test1002() throws Exception {
         // Data from https://github.com/netty/netty/issues/1002
         testIdentity(wrappedBuffer(new byte[] {
@@ -63,7 +61,6 @@ public class SnappyIntegrationTest {
     }
 
     @Test
-    @Ignore // FIXME: Make it pass.
     public void testRandom() throws Exception {
         byte[] data = new byte[16 * 1048576];
         new Random().nextBytes(data);

--- a/codec/src/test/java/io/netty/handler/codec/compression/SnappyTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/SnappyTest.java
@@ -38,7 +38,7 @@ public class SnappyTest {
             0x6e, 0x65, 0x74, 0x74, 0x79 // "netty"
         });
         ByteBuf out = Unpooled.buffer(5);
-        snappy.decode(in, out, 7);
+        snappy.decode(in, out);
 
         // "netty"
         ByteBuf expected = Unpooled.wrappedBuffer(new byte[] {
@@ -57,7 +57,7 @@ public class SnappyTest {
             0x05 // offset
         });
         ByteBuf out = Unpooled.buffer(10);
-        snappy.decode(in, out, 10);
+        snappy.decode(in, out);
 
         // "nettynetty" - we saved a whole byte :)
         ByteBuf expected = Unpooled.wrappedBuffer(new byte[] {
@@ -69,14 +69,14 @@ public class SnappyTest {
     @Test(expected = CompressionException.class)
     public void testDecodeCopyWithTinyOffset() throws Exception {
         ByteBuf in = Unpooled.wrappedBuffer(new byte[] {
-            0x0a, // preamble length
+            0x0b, // preamble length
             0x04 << 2, // literal tag + length
             0x6e, 0x65, 0x74, 0x74, 0x79, // "netty"
             0x05 << 2 | 0x01, // copy with 1-byte offset + length
-            0x03 // INVALID offset (< 4)
+            0x00 // INVALID offset (< 1)
         });
         ByteBuf out = Unpooled.buffer(10);
-        snappy.decode(in, out, 9);
+        snappy.decode(in, out);
     }
 
     @Test(expected = CompressionException.class)
@@ -89,7 +89,7 @@ public class SnappyTest {
             0x0b // INVALID offset (greater than chunk size)
         });
         ByteBuf out = Unpooled.buffer(10);
-        snappy.decode(in, out, 9);
+        snappy.decode(in, out);
     }
 
     @Test(expected = CompressionException.class)
@@ -100,7 +100,7 @@ public class SnappyTest {
             0x6e, 0x65, 0x74, 0x74, 0x79, // "netty"
         });
         ByteBuf out = Unpooled.buffer(10);
-        snappy.decode(in, out, 9);
+        snappy.decode(in, out);
     }
 
     @Test


### PR DESCRIPTION
- Make Snappy.decode stateful instead of relying on the uncompressed length being equal to the compressed length
- Correctly handle copies where offset < length
- Take copies from the output buffer in decoding
- Make the maximum encoded chunk size 32kB for compressed data
