### PR TITLE
Javadoc enhancement

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelInboundMessageHandlerAdapter.java
+++ b/transport/src/main/java/io/netty/channel/ChannelInboundMessageHandlerAdapter.java
@@ -23,6 +23,7 @@ import io.netty.util.internal.TypeParameterMatcher;
 
 /**
  * {@link ChannelHandler} which handles inbound messages of a specific type.
+ * For typical message processing, only messageReceived needs to be overridden.
  *
  * <pre>
  *     public class StringHandler extends
@@ -147,6 +148,7 @@ public abstract class ChannelInboundMessageHandlerAdapter<I>
 
     /**
      * Is called once a message was received.
+	 * Override this method to process received messages. 
      *
      * @param ctx           the {@link ChannelHandlerContext} which this {@link ChannelHandler} belongs to
      * @param msg           the message to handle


### PR DESCRIPTION
Javadoc: Imply that messageReceived is enough to override, as opposed to other methods of the class ChannelInboundMessageHandlerAdapter. My first Github pull request. Sorry for the indentation issue, can't get rid of it.
