### PR TITLE
Protobuf 2.5 update

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
@@ -84,19 +84,19 @@ public class ProtobufDecoder extends MessageToMessageDecoder<ByteBuf> {
         if (msg.hasArray()) {
             final int offset = msg.readerIndex();
             if (extensionRegistry == null) {
-                return prototype.newBuilderForType().mergeFrom(
-                        msg.array(), msg.arrayOffset() + offset, msg.readableBytes()).build();
+                return prototype.getParserForType().parseFrom(
+                        msg.array(), msg.arrayOffset() + offset, msg.readableBytes());
             } else {
-                return prototype.newBuilderForType().mergeFrom(
-                        msg.array(), msg.arrayOffset() + offset, msg.readableBytes(), extensionRegistry).build();
+                return prototype.getParserForType().parseFrom(
+                        msg.array(), msg.arrayOffset() + offset, msg.readableBytes(), extensionRegistry);
             }
         } else {
             if (extensionRegistry == null) {
-                return prototype.newBuilderForType().mergeFrom(
-                        new ByteBufInputStream(msg)).build();
+                return prototype.getParserForType().parseFrom(
+                        new ByteBufInputStream(msg));
             } else {
-                return prototype.newBuilderForType().mergeFrom(
-                        new ByteBufInputStream(msg), extensionRegistry).build();
+                return prototype.getParserForType().parseFrom(
+                        new ByteBufInputStream(msg), extensionRegistry);
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0</version>
       </dependency>
       <dependency>
         <groupId>com.jcraft</groupId>


### PR DESCRIPTION
Change ProtobufDecoder to use a Parser instead of builder (supposed to be up to 25 percent faster according to gwt readme)
