### PR TITLE
Fix life-cycle aware handlers processing in the default pipeline, add te...

### DIFF
--- a/src/main/java/org/jboss/netty/channel/DefaultChannelPipeline.java
+++ b/src/main/java/org/jboss/netty/channel/DefaultChannelPipeline.java
@@ -160,8 +160,12 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
     private DefaultChannelHandlerContext remove(DefaultChannelHandlerContext ctx) {
         if (head == tail) {
+            callBeforeRemove(ctx);
+
             head = tail = null;
             name2ctx.clear();
+
+            callAfterRemove(ctx);
         } else if (ctx == head) {
             removeFirst();
         } else if (ctx == tail) {
@@ -227,7 +231,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             name2ctx.remove(oldTail.getName());
         }
 
-        callBeforeRemove(oldTail);
+        callAfterRemove(oldTail);
 
         return oldTail.getHandler();
     }

--- a/src/test/java/org/jboss/netty/channel/DefaultChannelPipelineTest.java
+++ b/src/test/java/org/jboss/netty/channel/DefaultChannelPipelineTest.java
@@ -15,9 +15,13 @@
  */
 package org.jboss.netty.channel;
 
-import static org.junit.Assert.*;
-
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class DefaultChannelPipelineTest {
     @Test
@@ -50,5 +54,86 @@ public class DefaultChannelPipelineTest {
     public void testToString() {
         DefaultChannelPipeline pipeline = new DefaultChannelPipeline();
         assertNotNull(pipeline.toString());
+    }
+
+    @Test
+    public void testLifeCycleAware() {
+        DefaultChannelPipeline pipeline = new DefaultChannelPipeline();
+
+        List<LifeCycleAwareTestHandler> handlers = new ArrayList<LifeCycleAwareTestHandler>();
+
+        for (int i = 0; i < 20; i++) {
+            LifeCycleAwareTestHandler handler = new LifeCycleAwareTestHandler("handler-" + i);
+
+            // Add handler.
+            pipeline.addFirst(handler.name, handler);
+
+            // Validate handler life-cycle methods called.
+            handler.validate(true, true, false, false);
+
+            // Store handler into the list.
+            handlers.add(handler);
+        }
+
+        // Change the order of remove operations over all handlers in the pipeline.
+        Collections.shuffle(handlers);
+
+        for (LifeCycleAwareTestHandler handler : handlers) {
+            assertSame(handler, pipeline.remove(handler.name));
+
+            // Validate handler life-cycle methods called.
+            handler.validate(true, true, true, true);
+        }
+    }
+
+    /** Test handler to validate life-cycle aware behavior. */
+    private static final class LifeCycleAwareTestHandler extends SimpleChannelHandler
+        implements LifeCycleAwareChannelHandler {
+        private final String name;
+
+        private boolean beforeAdd;
+        private boolean afterAdd;
+        private boolean beforeRemove;
+        private boolean afterRemove;
+
+        /**
+         * Constructs life-cycle aware test handler.
+         *
+         * @param name Handler name to display in assertion messages.
+         */
+        private LifeCycleAwareTestHandler(String name) {
+            this.name = name;
+        }
+
+        public void validate(boolean beforeAdd, boolean afterAdd, boolean beforeRemove, boolean afterRemove) {
+            assertEquals(name, beforeAdd, this.beforeAdd);
+            assertEquals(name, afterAdd, this.afterAdd);
+            assertEquals(name, beforeRemove, this.beforeRemove);
+            assertEquals(name, afterRemove, this.afterRemove);
+        }
+
+        public void beforeAdd(ChannelHandlerContext ctx) {
+            validate(false, false, false, false);
+
+            beforeAdd = true;
+        }
+
+        public void afterAdd(ChannelHandlerContext ctx) {
+            validate(true, false, false, false);
+
+            afterAdd = true;
+        }
+
+        public void beforeRemove(ChannelHandlerContext ctx) {
+            validate(true, true, false, false);
+
+            beforeRemove = true;
+        }
+
+        public void afterRemove(ChannelHandlerContext ctx) {
+            validate(true, true, true, false);
+
+            afterRemove = true;
+        }
     }
 }


### PR DESCRIPTION
Netty 3.6 works incorrectly with life-cycle aware handlers. I add test for default pipeline and fix callbacks.
