### PR TITLE
Fixing 2 typos in codec documentation.

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToByteCodec.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToByteCodec.java
@@ -25,7 +25,7 @@ import io.netty.channel.ChannelPromise;
 /**
  * A Codec for on-the-fly encoding/decoding of bytes.
  *
- * This can be though of an combination of {@link ByteToByteDecoder} and {@link ByteToByteEncoder}.
+ * This can be thought of as a combination of {@link ByteToByteDecoder} and {@link ByteToByteEncoder}.
  *
  * Here is an example of a {@link ByteToByteCodec} which just square {@link Integer} read from a {@link ByteBuf}.
  * <pre>

--- a/codec/src/main/java/io/netty/handler/codec/MessageToMessageCodec.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageToMessageCodec.java
@@ -26,7 +26,7 @@ import io.netty.util.internal.TypeParameterMatcher;
 /**
  * A Codec for on-the-fly encoding/decoding of message.
  *
- * This can be though of an combination of {@link MessageToMessageDecoder} and {@link MessageToMessageEncoder}.
+ * This can be thought of as a combination of {@link MessageToMessageDecoder} and {@link MessageToMessageEncoder}.
  *
  * Here is an example of a {@link MessageToMessageCodec} which just decode from {@link Integer} to {@link Long}
  * and encode from {@link Long} to {@link Integer}.


### PR DESCRIPTION
This is just a small PR which fixes two typos in the codec javadoc blocks.
