### PR TITLE
make deregister protected in ThreadPerChannelEventLoop

### DIFF
--- a/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
@@ -76,7 +76,7 @@ public class ThreadPerChannelEventLoop extends SingleThreadEventLoop {
         }
     }
 
-    private void deregister() {
+    protected void deregister() {
         ch = null;
         parent.activeChildren.remove(this);
         parent.idleChildren.add(this);


### PR DESCRIPTION
It is more difficult to subclass and override the run loop without access to the deregister method.
