### PR TITLE
Transport: Clarifying the role of Bootstrap#bind()

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -33,6 +33,9 @@ import java.util.Map;
 /**
  * {@link AbstractBootstrap} is a helper class that makes it easy to bootstrap a {@link Channel}. It support
  * method-chaining to provide an easy way to configure the {@link AbstractBootstrap}.
+ *
+ * <p>When not used in a {@link ServerBootstrap} context, the {@link #bind()} methods are useful for connectionless
+ * transports such as datagram (UDP).</p>
  */
 abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C extends Channel> implements Cloneable {
 

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -34,6 +34,8 @@ import java.util.Map.Entry;
  * A {@link Bootstrap} that makes it easy to bootstrap a {@link Channel} to use
  * for clients.
  *
+ * <p>The {@link #bind()} methods are useful in combination with connectionless transports such as datagram (UDP).
+ * For regular TCP connections, please use the provided {@link #connect()} methods.</p>
  */
 public final class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
 


### PR DESCRIPTION
This small changeset clarifies the role of Bootstrap#bind(),
especially when not used in a ServerBoostrap context.
