### PR TITLE
Allow ThreadNameDeterminer everywhere.

### DIFF
--- a/src/main/java/org/jboss/netty/channel/socket/oio/OioClientSocketChannelFactory.java
+++ b/src/main/java/org/jboss/netty/channel/socket/oio/OioClientSocketChannelFactory.java
@@ -24,6 +24,7 @@ import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.group.ChannelGroup;
 import org.jboss.netty.channel.socket.ClientSocketChannelFactory;
 import org.jboss.netty.channel.socket.SocketChannel;
+import org.jboss.netty.util.ThreadNameDeterminer;
 import org.jboss.netty.util.internal.ExecutorUtil;
 
 /**
@@ -95,11 +96,24 @@ public class OioClientSocketChannelFactory implements ClientSocketChannelFactory
      *        the {@link Executor} which will execute the I/O worker threads
      */
     public OioClientSocketChannelFactory(Executor workerExecutor) {
+        this(workerExecutor, null);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param workerExecutor
+     *        the {@link Executor} which will execute the I/O worker threads
+     * @param determiner
+     *        the {@link ThreadNameDeterminer} to set the thread names.
+     */
+    public OioClientSocketChannelFactory(Executor workerExecutor,
+                                         ThreadNameDeterminer determiner) {
         if (workerExecutor == null) {
             throw new NullPointerException("workerExecutor");
         }
         this.workerExecutor = workerExecutor;
-        sink = new OioClientSocketPipelineSink(workerExecutor);
+        sink = new OioClientSocketPipelineSink(workerExecutor, determiner);
     }
 
     public SocketChannel newChannel(ChannelPipeline pipeline) {

--- a/src/main/java/org/jboss/netty/channel/socket/oio/OioClientSocketPipelineSink.java
+++ b/src/main/java/org/jboss/netty/channel/socket/oio/OioClientSocketPipelineSink.java
@@ -22,6 +22,7 @@ import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.ChannelState;
 import org.jboss.netty.channel.ChannelStateEvent;
 import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.util.ThreadNameDeterminer;
 import org.jboss.netty.util.ThreadRenamingRunnable;
 import org.jboss.netty.util.internal.DeadLockProofWorker;
 
@@ -35,9 +36,11 @@ import static org.jboss.netty.channel.Channels.*;
 class OioClientSocketPipelineSink extends AbstractOioChannelSink {
 
     private final Executor workerExecutor;
+    private final ThreadNameDeterminer determiner;
 
-    OioClientSocketPipelineSink(Executor workerExecutor) {
+    OioClientSocketPipelineSink(Executor workerExecutor, ThreadNameDeterminer determiner) {
         this.workerExecutor = workerExecutor;
+        this.determiner = determiner;
     }
 
     public void eventSunk(
@@ -123,7 +126,8 @@ class OioClientSocketPipelineSink extends AbstractOioChannelSink {
                     workerExecutor,
                     new ThreadRenamingRunnable(
                             new OioWorker(channel),
-                            "Old I/O client worker (" + channel + ')'));
+                            "Old I/O client worker (" + channel + ')',
+                            determiner));
             workerStarted = true;
         } catch (Throwable t) {
             if (t instanceof ConnectException) {

--- a/src/main/java/org/jboss/netty/channel/socket/oio/OioDatagramChannelFactory.java
+++ b/src/main/java/org/jboss/netty/channel/socket/oio/OioDatagramChannelFactory.java
@@ -24,6 +24,7 @@ import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.group.ChannelGroup;
 import org.jboss.netty.channel.socket.DatagramChannel;
 import org.jboss.netty.channel.socket.DatagramChannelFactory;
+import org.jboss.netty.util.ThreadNameDeterminer;
 import org.jboss.netty.util.internal.ExecutorUtil;
 
 /**
@@ -94,11 +95,24 @@ public class OioDatagramChannelFactory implements DatagramChannelFactory {
      *        the {@link Executor} which will execute the I/O worker threads
      */
     public OioDatagramChannelFactory(Executor workerExecutor) {
+        this(workerExecutor, null);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param workerExecutor
+     *        the {@link Executor} which will execute the I/O worker threads
+     * @param determiner
+     *        the {@link ThreadNameDeterminer} to set the thread names.
+     */
+    public OioDatagramChannelFactory(Executor workerExecutor,
+                                     ThreadNameDeterminer determiner) {
         if (workerExecutor == null) {
             throw new NullPointerException("workerExecutor");
         }
         this.workerExecutor = workerExecutor;
-        sink = new OioDatagramPipelineSink(workerExecutor);
+        sink = new OioDatagramPipelineSink(workerExecutor, determiner);
     }
 
     public DatagramChannel newChannel(ChannelPipeline pipeline) {

--- a/src/main/java/org/jboss/netty/channel/socket/oio/OioServerSocketChannelFactory.java
+++ b/src/main/java/org/jboss/netty/channel/socket/oio/OioServerSocketChannelFactory.java
@@ -21,6 +21,7 @@ import org.jboss.netty.channel.ChannelSink;
 import org.jboss.netty.channel.group.ChannelGroup;
 import org.jboss.netty.channel.socket.ServerSocketChannel;
 import org.jboss.netty.channel.socket.ServerSocketChannelFactory;
+import org.jboss.netty.util.ThreadNameDeterminer;
 import org.jboss.netty.util.internal.ExecutorUtil;
 
 import java.util.concurrent.Executor;
@@ -112,6 +113,21 @@ public class OioServerSocketChannelFactory implements ServerSocketChannelFactory
      */
     public OioServerSocketChannelFactory(
             Executor bossExecutor, Executor workerExecutor) {
+        this(bossExecutor, workerExecutor, null);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param bossExecutor
+     *        the {@link Executor} which will execute the boss threads
+     * @param workerExecutor
+     *        the {@link Executor} which will execute the I/O worker threads
+     * @param determiner
+     *        the {@link ThreadNameDeterminer} to set the thread names.
+     */
+    public OioServerSocketChannelFactory(Executor bossExecutor, Executor workerExecutor,
+                                         ThreadNameDeterminer determiner) {
         if (bossExecutor == null) {
             throw new NullPointerException("bossExecutor");
         }
@@ -120,7 +136,7 @@ public class OioServerSocketChannelFactory implements ServerSocketChannelFactory
         }
         this.bossExecutor = bossExecutor;
         this.workerExecutor = workerExecutor;
-        sink = new OioServerSocketPipelineSink(workerExecutor);
+        sink = new OioServerSocketPipelineSink(workerExecutor, determiner);
     }
 
     public ServerSocketChannel newChannel(ChannelPipeline pipeline) {

--- a/src/main/java/org/jboss/netty/util/HashedWheelTimer.java
+++ b/src/main/java/org/jboss/netty/util/HashedWheelTimer.java
@@ -171,6 +171,24 @@ public class HashedWheelTimer implements Timer {
     public HashedWheelTimer(
             ThreadFactory threadFactory,
             long tickDuration, TimeUnit unit, int ticksPerWheel) {
+        this(threadFactory, null, tickDuration, unit, ticksPerWheel);
+    }
+
+    /**
+     * Creates a new timer.
+     *
+     * @param threadFactory  a {@link ThreadFactory} that creates a
+     *                       background {@link Thread} which is dedicated to
+     *                       {@link TimerTask} execution.
+     * @param determiner     thread name determiner to control thread name.
+     * @param tickDuration   the duration between tick
+     * @param unit           the time unit of the {@code tickDuration}
+     * @param ticksPerWheel  the size of the wheel
+     */
+    public HashedWheelTimer(
+            ThreadFactory threadFactory,
+            ThreadNameDeterminer determiner,
+            long tickDuration, TimeUnit unit, int ticksPerWheel) {
 
         if (threadFactory == null) {
             throw new NullPointerException("threadFactory");
@@ -206,7 +224,8 @@ public class HashedWheelTimer implements Timer {
         roundDuration = tickDuration * wheel.length;
 
         workerThread = threadFactory.newThread(new ThreadRenamingRunnable(
-                        worker, "Hashed wheel timer #" + id.incrementAndGet()));
+                        worker, "Hashed wheel timer #" + id.incrementAndGet(),
+                        determiner));
 
         // Misuse check
         misuseDetector.increase();


### PR DESCRIPTION
Find a couple of places where threads are created but no
ThreadNameDeterminer can be passed in to control the name of the
threads created. Keep all existing c'tors for backwards compatibility.
