### PR TITLE
Fix DefaultChannelPipeline.first()

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -751,7 +751,7 @@ final class DefaultChannelPipeline implements ChannelPipeline {
     @Override
     public ChannelHandler first() {
         DefaultChannelHandlerContext first = head.next;
-        if (first == null) {
+        if (first == head) {
             return null;
         }
         return first.handler();


### PR DESCRIPTION
DefaultChannelPipeline.first() will expose the tail handler if there are no user handlers, while DefaultChannelPipeline.last() returns null in this same case.
