### PR TITLE
Fix for #1313 & #1332

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestDecoder.java
@@ -783,8 +783,8 @@ public class HttpPostRequestDecoder {
                 .get(HttpPostBodyUtil.NAME);
             if (currentAttribute == null) {
                 try {
-                    currentAttribute = factory.createAttribute(request, nameAttribute
-                            .getValue());
+                    currentAttribute = factory.createAttribute(request,
+                            decodeAttribute(cleanString(nameAttribute.getValue()), charset));
                 } catch (NullPointerException e) {
                     throw new ErrorDataDecoderException(e);
                 } catch (IllegalArgumentException e) {
@@ -959,7 +959,8 @@ public class HttpPostRequestDecoder {
                         String[] values = StringUtil.split(contents[i], '=');
                         Attribute attribute;
                         try {
-                            attribute = factory.createAttribute(request, values[0].trim(),
+                            attribute = factory.createAttribute(request,
+                                    decodeAttribute(cleanString(values[0].trim()), charset),
                                     decodeAttribute(cleanString(values[1]), charset));
                         } catch (NullPointerException e) {
                             throw new ErrorDataDecoderException(e);
@@ -1031,7 +1032,7 @@ public class HttpPostRequestDecoder {
                             Attribute attribute;
                             try {
                                 attribute = factory.createAttribute(request,
-                                        contents[0].trim(),
+                                        decodeAttribute(cleanString(contents[0].trim()), charset),
                                         decodeAttribute(cleanString(contents[i]), charset));
                             } catch (NullPointerException e) {
                                 throw new ErrorDataDecoderException(e);
@@ -1146,7 +1147,8 @@ public class HttpPostRequestDecoder {
             try {
                 currentFileUpload = factory.createFileUpload(
                         request,
-                        nameAttribute.getValue(), filenameAttribute.getValue(),
+                        decodeAttribute(cleanString(nameAttribute.getValue()), charset),
+                        decodeAttribute(cleanString(filenameAttribute.getValue()), charset),
                         contentTypeAttribute.getValue(), mechanism.value(),
                         localCharset, size);
             } catch (NullPointerException e) {

--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -463,6 +463,7 @@ public class HttpPostRequestEncoder implements ChunkedInput {
             if (localcharset != null) {
                 // Content-Type: charset=charset
                 internal.addValue(HttpHeaders.Names.CONTENT_TYPE + ": " +
+                        HttpPostBodyUtil.DEFAULT_TEXT_CONTENT_TYPE + "; " +
                         HttpHeaders.Values.CHARSET + '=' + localcharset + "\r\n");
             }
             // CRLF between body header and data


### PR DESCRIPTION
For issue #1313, partial fix: enhance coding/deconding to missing part.
Now filename is correctly undecoded. 
Name and Value must be encoded to allow parsing and respect to HTTP RFC since all value and name must be URI encoded (and then decoded). Some items were not correctly decoded, so the reason of the issue.

For issue #1332, add text/plain to content-type as default type if not specified.
