### PR TITLE
Add lengthAdjustment option to LengthFieldPrepender

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldPrepender.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldPrepender.java
@@ -51,6 +51,7 @@ public class LengthFieldPrepender extends MessageToByteEncoder<ByteBuf> {
 
     private final int lengthFieldLength;
     private final boolean lengthIncludesLengthFieldLength;
+    private final int lengthAdjustment;
 
     /**
      * Creates a new instance.
@@ -79,6 +80,40 @@ public class LengthFieldPrepender extends MessageToByteEncoder<ByteBuf> {
      *         if {@code lengthFieldLength} is not 1, 2, 3, 4, or 8
      */
     public LengthFieldPrepender(int lengthFieldLength, boolean lengthIncludesLengthFieldLength) {
+        this(lengthFieldLength, 0, lengthIncludesLengthFieldLength);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param lengthFieldLength the length of the prepended length field.
+     *                          Only 1, 2, 3, 4, and 8 are allowed.
+     * @param lengthAdjustment  the compensation value to add to the value
+     *                          of the length field
+     *
+     * @throws IllegalArgumentException
+     *         if {@code lengthFieldLength} is not 1, 2, 3, 4, or 8
+     */
+    public LengthFieldPrepender(int lengthFieldLength, int lengthAdjustment) {
+        this(lengthFieldLength, lengthAdjustment, false);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param lengthFieldLength the length of the prepended length field.
+     *                          Only 1, 2, 3, 4, and 8 are allowed.
+     * @param lengthAdjustment  the compensation value to add to the value
+     *                          of the length field
+     * @param lengthIncludesLengthFieldLength
+     *                          if {@code true}, the length of the prepended
+     *                          length field is added to the value of the
+     *                          prepended length field.
+     *
+     * @throws IllegalArgumentException
+     *         if {@code lengthFieldLength} is not 1, 2, 3, 4, or 8
+     */
+    public LengthFieldPrepender(int lengthFieldLength, int lengthAdjustment, boolean lengthIncludesLengthFieldLength) {
         if (lengthFieldLength != 1 && lengthFieldLength != 2 &&
             lengthFieldLength != 3 && lengthFieldLength != 4 &&
             lengthFieldLength != 8) {
@@ -89,6 +124,7 @@ public class LengthFieldPrepender extends MessageToByteEncoder<ByteBuf> {
 
         this.lengthFieldLength = lengthFieldLength;
         this.lengthIncludesLengthFieldLength = lengthIncludesLengthFieldLength;
+        this.lengthAdjustment = lengthAdjustment;
     }
 
     @Override
@@ -96,8 +132,15 @@ public class LengthFieldPrepender extends MessageToByteEncoder<ByteBuf> {
             ChannelHandlerContext ctx,
             ByteBuf msg, ByteBuf out) throws Exception {
 
-        int length = lengthIncludesLengthFieldLength?
-                msg.readableBytes() + lengthFieldLength : msg.readableBytes();
+        int length = (lengthIncludesLengthFieldLength?
+                msg.readableBytes() + lengthFieldLength : msg.readableBytes()) +
+                lengthAdjustment;
+
+        if (length < 0) {
+            throw new IllegalArgumentException(
+                    "Adjusted frame length (" + length + ") is less than zero");
+        }
+
         switch (lengthFieldLength) {
         case 1:
             if (length >= 256) {


### PR DESCRIPTION
Because I want to write as follows:

``` scala
ch.pipeline()
  .addLast("framer", new LengthFieldBasedFrameDecoder(17, 0, 1, 1, 1))
  .addLast("prepender", new LengthFieldPrepender(1, -1))
  .addLast("decoder", new FooDecoder())
  .addLast("encoder", new FooEncoder())
  .addLast("handler", new FooHandler())
```

This pipeline can communicate 1 to 16 bytes data.
