### PR TITLE
Allow to use VoidPromise for flush(...), write(...) and sendFile(...)

### DIFF
--- a/testsuite/src/test/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
+++ b/testsuite/src/test/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
@@ -64,7 +64,7 @@ public class SocketEchoTest extends AbstractSocketTest {
     }
 
     public void testSimpleEcho(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        testSimpleEcho0(sb, cb, Integer.MAX_VALUE, false);
+        testSimpleEcho0(sb, cb, Integer.MAX_VALUE, false, false);
     }
 
     @Test(timeout = 30000)
@@ -73,7 +73,7 @@ public class SocketEchoTest extends AbstractSocketTest {
     }
 
     public void testSimpleEchoWithBridge(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        testSimpleEcho0(sb, cb, Integer.MAX_VALUE, true);
+        testSimpleEcho0(sb, cb, Integer.MAX_VALUE, true, false);
     }
 
     @Test(timeout = 30000)
@@ -82,7 +82,7 @@ public class SocketEchoTest extends AbstractSocketTest {
     }
 
     public void testSimpleEchoWithBoundedBuffer(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        testSimpleEcho0(sb, cb, 32, false);
+        testSimpleEcho0(sb, cb, 32, false, false);
     }
 
     @Test(timeout = 30000)
@@ -91,11 +91,30 @@ public class SocketEchoTest extends AbstractSocketTest {
     }
 
     public void testSimpleEchoWithBridgedBoundedBuffer(ServerBootstrap sb, Bootstrap cb) throws Throwable {
-        testSimpleEcho0(sb, cb, 32, true);
+        testSimpleEcho0(sb, cb, 32, true, false);
+    }
+
+    @Test(timeout = 30000)
+    public void testSimpleEchoWithVoidPromise() throws Throwable {
+        run();
+    }
+
+    public void testSimpleEchoWithVoidPromise(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        testSimpleEcho0(sb, cb, Integer.MAX_VALUE, false, true);
+    }
+
+    @Test(timeout = 30000)
+    public void testSimpleEchoWithBridgeAndVoidPromise() throws Throwable {
+        run();
+    }
+
+    public void testSimpleEchoWithBridgeAndVoidPromise(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        testSimpleEcho0(sb, cb, Integer.MAX_VALUE, true, true);
     }
 
     private static void testSimpleEcho0(
-            ServerBootstrap sb, Bootstrap cb, int maxInboundBufferSize, boolean bridge) throws Throwable {
+            ServerBootstrap sb, Bootstrap cb, int maxInboundBufferSize, boolean bridge, boolean voidPromise)
+            throws Throwable {
 
         final EchoHandler sh = new EchoHandler(maxInboundBufferSize);
         final EchoHandler ch = new EchoHandler(maxInboundBufferSize);
@@ -123,7 +142,12 @@ public class SocketEchoTest extends AbstractSocketTest {
 
         for (int i = 0; i < data.length;) {
             int length = Math.min(random.nextInt(1024 * 64), data.length - i);
-            cc.write(Unpooled.wrappedBuffer(data, i, length));
+            ByteBuf buf = Unpooled.wrappedBuffer(data, i, length);
+            if (voidPromise) {
+                assertEquals(cc.voidPromise(), cc.write(buf, cc.voidPromise()));
+            } else {
+                assertNotEquals(cc.voidPromise(), cc.write(buf));
+            }
             i += length;
         }
 

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -173,7 +173,6 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, ChannelPr
      * following methods:
      * <ul>
      *   <li>{@link #headContext()}</li>
-     *   <li>{@link #voidFuture()}</li>
      *   <li>{@link #localAddress()}</li>
      *   <li>{@link #remoteAddress()}</li>
      *   <li>{@link #closeForcibly()}</li>
@@ -185,11 +184,6 @@ public interface Channel extends AttributeMap, ChannelOutboundInvoker, ChannelPr
          * Return the internal {@link ChannelHandlerContext} that is placed before all user handlers.
          */
         ChannelHandlerContext headContext();
-
-        /**
-         * Return a {@link VoidChannelPromise}. This method always return the same instance.
-         */
-        ChannelPromise voidFuture();
 
         /**
          * Return the {@link SocketAddress} to which is bound local or

--- a/transport/src/main/java/io/netty/channel/ChannelFuture.java
+++ b/transport/src/main/java/io/netty/channel/ChannelFuture.java
@@ -193,12 +193,4 @@ public interface ChannelFuture extends Future<Void> {
 
     @Override
     ChannelFuture awaitUninterruptibly();
-
-    /**
-     * A {@link ChannelFuture} which is not allowed to be sent to {@link ChannelPipeline} due to
-     * implementation details.
-     */
-    interface Unsafe extends ChannelFuture {
-        // Tag interface
-    }
 }

--- a/transport/src/main/java/io/netty/channel/ChannelPropertyAccess.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPropertyAccess.java
@@ -58,4 +58,19 @@ interface ChannelPropertyAccess {
      * every call of blocking methods will just return without blocking.
      */
     ChannelFuture newFailedFuture(Throwable cause);
+
+    /**
+     * Return a special ChannelPromise which can be reused for different operations. It's only supported to use
+     * it for {@link ChannelOutboundInvoker#write(Object, ChannelPromise)} ,
+     * {@link ChannelOutboundInvoker#flush(ChannelPromise)} and
+     * {@link ChannelOutboundInvoker#sendFile(FileRegion, ChannelPromise)}.
+     *
+     * Be aware that the returned {@link ChannelPromise} will not support most operations and should only be used
+     * if you want to safe object allocation for every operation. You will not be able to detect if the operation
+     * was complete, only if it failed as the implementation will call
+     * {@link ChannelPipeline#fireExceptionCaught(Throwable)} in this case.
+     *
+     * <strong>Be aware this is an expert feature and should be used with care!</strong>
+     */
+    ChannelPromise voidPromise();
 }

--- a/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
@@ -57,7 +57,7 @@ public class ThreadPerChannelEventLoop extends SingleThreadEventLoop {
             Channel ch = this.ch;
             if (isShuttingDown()) {
                 if (ch != null) {
-                    ch.unsafe().close(ch.unsafe().voidFuture());
+                    ch.unsafe().close(ch.voidPromise());
                 }
                 if (confirmShutdown()) {
                     break;

--- a/transport/src/main/java/io/netty/channel/VoidChannelPromise.java
+++ b/transport/src/main/java/io/netty/channel/VoidChannelPromise.java
@@ -21,7 +21,7 @@ import io.netty.util.concurrent.GenericFutureListener;
 
 import java.util.concurrent.TimeUnit;
 
-final class VoidChannelPromise extends AbstractFuture<Void> implements ChannelFuture.Unsafe, ChannelPromise {
+final class VoidChannelPromise extends AbstractFuture<Void> implements ChannelPromise {
 
     private final Channel channel;
 
@@ -38,31 +38,31 @@ final class VoidChannelPromise extends AbstractFuture<Void> implements ChannelFu
     }
 
     @Override
-    public ChannelPromise addListener(GenericFutureListener<? extends Future<Void>> listener) {
+    public VoidChannelPromise addListener(GenericFutureListener<? extends Future<Void>> listener) {
         fail();
         return this;
     }
 
     @Override
-    public ChannelPromise addListeners(GenericFutureListener<? extends Future<Void>>... listeners) {
+    public VoidChannelPromise addListeners(GenericFutureListener<? extends Future<Void>>... listeners) {
         fail();
         return this;
     }
 
     @Override
-    public ChannelPromise removeListener(GenericFutureListener<? extends Future<Void>> listener) {
+    public VoidChannelPromise removeListener(GenericFutureListener<? extends Future<Void>> listener) {
         // NOOP
         return this;
     }
 
     @Override
-    public ChannelPromise removeListeners(GenericFutureListener<? extends Future<Void>>... listeners) {
+    public VoidChannelPromise removeListeners(GenericFutureListener<? extends Future<Void>>... listeners) {
         // NOOP
         return this;
     }
 
     @Override
-    public ChannelPromise await() throws InterruptedException {
+    public VoidChannelPromise await() throws InterruptedException {
         if (Thread.interrupted()) {
             throw new InterruptedException();
         }
@@ -82,7 +82,7 @@ final class VoidChannelPromise extends AbstractFuture<Void> implements ChannelFu
     }
 
     @Override
-    public ChannelPromise awaitUninterruptibly() {
+    public VoidChannelPromise awaitUninterruptibly() {
         fail();
         return this;
     }
@@ -120,28 +120,30 @@ final class VoidChannelPromise extends AbstractFuture<Void> implements ChannelFu
     }
 
     @Override
-    public ChannelPromise sync() {
+    public VoidChannelPromise sync() {
         fail();
         return this;
     }
 
     @Override
-    public ChannelPromise syncUninterruptibly() {
+    public VoidChannelPromise syncUninterruptibly() {
         fail();
         return this;
     }
     @Override
-    public ChannelPromise setFailure(Throwable cause) {
+    public VoidChannelPromise setFailure(Throwable cause) {
+        channel.pipeline().fireExceptionCaught(cause);
         return this;
     }
 
     @Override
-    public ChannelPromise setSuccess() {
+    public VoidChannelPromise setSuccess() {
         return this;
     }
 
     @Override
     public boolean tryFailure(Throwable cause) {
+        channel.pipeline().fireExceptionCaught(cause);
         return false;
     }
 
@@ -155,7 +157,7 @@ final class VoidChannelPromise extends AbstractFuture<Void> implements ChannelFu
     }
 
     @Override
-    public ChannelPromise setSuccess(Void result) {
+    public VoidChannelPromise setSuccess(Void result) {
         return this;
     }
 

--- a/transport/src/main/java/io/netty/channel/aio/AbstractAioChannel.java
+++ b/transport/src/main/java/io/netty/channel/aio/AbstractAioChannel.java
@@ -117,7 +117,7 @@ public abstract class AbstractAioChannel extends AbstractChannel {
                             ConnectTimeoutException cause =
                                     new ConnectTimeoutException("connection timed out: " + remoteAddress);
                             if (connectFuture != null && connectFuture.tryFailure(cause)) {
-                                close(voidFuture());
+                                close(voidPromise());
                             }
                         }
                     }, connectTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/transport/src/main/java/io/netty/channel/aio/AioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/aio/AioEventLoop.java
@@ -97,7 +97,7 @@ final class AioEventLoop extends SingleThreadEventLoop {
         }
 
         for (Channel ch: channels) {
-            ch.unsafe().close(ch.unsafe().voidFuture());
+            ch.unsafe().close(ch.voidPromise());
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -47,7 +47,7 @@ public class LocalChannel extends AbstractChannel {
     private final Runnable shutdownHook = new Runnable() {
         @Override
         public void run() {
-            unsafe().close(unsafe().voidFuture());
+            unsafe().close(voidPromise());
         }
     };
 
@@ -198,7 +198,7 @@ public class LocalChannel extends AbstractChannel {
     protected void doClose() throws Exception {
         LocalChannel peer = this.peer;
         if (peer != null && peer.isActive()) {
-            peer.unsafe().close(peer.unsafe().voidFuture());
+            peer.unsafe().close(voidPromise());
             this.peer = null;
         }
     }
@@ -206,7 +206,7 @@ public class LocalChannel extends AbstractChannel {
     @Override
     protected Runnable doDeregister() throws Exception {
         if (isOpen()) {
-            unsafe().close(unsafe().voidFuture());
+            unsafe().close(voidPromise());
         }
         ((SingleThreadEventExecutor) eventLoop()).removeShutdownHook(shutdownHook);
         return null;
@@ -307,7 +307,7 @@ public class LocalChannel extends AbstractChannel {
                 } catch (Throwable t) {
                     promise.setFailure(t);
                     pipeline().fireExceptionCaught(t);
-                    close(voidFuture());
+                    close(voidPromise());
                     return;
                 }
             }
@@ -316,7 +316,7 @@ public class LocalChannel extends AbstractChannel {
             if (!(boundChannel instanceof LocalServerChannel)) {
                 Exception cause = new ChannelException("connection refused");
                 promise.setFailure(cause);
-                close(voidFuture());
+                close(voidPromise());
                 return;
             }
 

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -36,7 +36,7 @@ public class LocalServerChannel extends AbstractServerChannel {
     private final Runnable shutdownHook = new Runnable() {
         @Override
         public void run() {
-            unsafe().close(unsafe().voidFuture());
+            unsafe().close(voidPromise());
         }
     };
 

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -19,9 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.ChannelProgressivePromise;
-import io.netty.channel.ChannelPromise;
-import io.netty.channel.FileRegion;
 import io.netty.channel.socket.ChannelInputShutdownEvent;
 
 import java.io.IOException;
@@ -123,7 +120,7 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
                             key.interestOps(key.interestOps() & ~readInterestOp);
                             pipeline.fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
                         } else {
-                            close(voidFuture());
+                            close(voidPromise());
                         }
                     }
                 } else if (!firedChannelReadSuspended) {
@@ -149,9 +146,9 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
     }
 
     @Override
-    protected void doFlushFileRegion(final FileRegion region, final ChannelPromise promise) throws Exception {
+    protected void doFlushFileRegion(final FlushTask task) throws Exception {
         if (javaChannel() instanceof WritableByteChannel) {
-            TransferTask transferTask = new TransferTask(region, (WritableByteChannel) javaChannel(), promise);
+            TransferTask transferTask = new TransferTask(task, (WritableByteChannel) javaChannel());
             transferTask.transfer();
         } else {
             throw new UnsupportedOperationException("Underlying Channel is not of instance "
@@ -161,44 +158,39 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
 
     private final class TransferTask implements NioTask<SelectableChannel> {
         private long writtenBytes;
-        private final FileRegion region;
+        private final FlushTask task;
         private final WritableByteChannel wch;
-        private final ChannelPromise promise;
 
-        TransferTask(FileRegion region, WritableByteChannel wch, ChannelPromise promise) {
-            this.region = region;
+        TransferTask(FlushTask task, WritableByteChannel wch) {
+            this.task = task;
             this.wch = wch;
-            this.promise = promise;
         }
 
         void transfer() {
             try {
                 for (;;) {
-                    long localWrittenBytes = region.transferTo(wch, writtenBytes);
+                    long localWrittenBytes = task.region().transferTo(wch, writtenBytes);
                     if (localWrittenBytes == 0) {
                         // reschedule for write once the channel is writable again
                         eventLoop().executeWhenWritable(
                                 AbstractNioByteChannel.this, this);
                         return;
                     } else if (localWrittenBytes == -1) {
-                        checkEOF(region, writtenBytes);
-                        promise.setSuccess();
+                        checkEOF(task.region(), writtenBytes);
+                        task.setSuccess();
                         return;
                     } else {
                         writtenBytes += localWrittenBytes;
-                        if (promise instanceof ChannelProgressivePromise) {
-                            ((ChannelProgressivePromise) promise).setProgress(writtenBytes, region.count());
-                        }
-                        if (writtenBytes >= region.count()) {
-                            region.release();
-                            promise.setSuccess();
+                        task.setProgress(writtenBytes);
+
+                        if (writtenBytes >= task.region().count()) {
+                            task.setSuccess();
                             return;
                         }
                     }
                 }
             } catch (Throwable cause) {
-                region.release();
-                promise.setFailure(cause);
+                task.setFailure(cause);
             }
         }
 
@@ -210,16 +202,15 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
         @Override
         public void channelUnregistered(SelectableChannel ch, Throwable cause) throws Exception {
             if (cause != null) {
-                promise.setFailure(cause);
+                task.setFailure(cause);
                 return;
             }
 
-            if (writtenBytes < region.count()) {
-                region.release();
+            if (writtenBytes < task.region().count()) {
                 if (!isOpen()) {
-                    promise.setFailure(new ClosedChannelException());
+                    task.setFailure(new ClosedChannelException());
                 } else {
-                    promise.setFailure(new IllegalStateException(
+                    task.setFailure(new IllegalStateException(
                             "Channel was unregistered before the region could be fully written"));
                 }
             }

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -186,7 +186,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
                                 ConnectTimeoutException cause =
                                         new ConnectTimeoutException("connection timed out: " + remoteAddress);
                                 if (connectPromise != null && connectPromise.tryFailure(cause)) {
-                                    close(voidFuture());
+                                    close(voidPromise());
                                 }
                             }
                         }, connectTimeoutMillis, TimeUnit.MILLISECONDS);

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
@@ -87,7 +87,7 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
                     pipeline.fireInboundBufferUpdated();
                 }
                 if (closed && isOpen()) {
-                    close(voidFuture());
+                    close(voidPromise());
                 } else if (!firedChannelReadSuspended) {
                     pipeline.fireChannelReadSuspended();
                 }

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -243,7 +243,7 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                         logger.warn("Failed to re-register a Channel to the new Selector.", e);
                         if (a instanceof AbstractNioChannel) {
                             AbstractNioChannel ch = (AbstractNioChannel) a;
-                            ch.unsafe().close(ch.unsafe().voidFuture());
+                            ch.unsafe().close(ch.voidPromise());
                         } else {
                             @SuppressWarnings("unchecked")
                             NioTask<SelectableChannel> task = (NioTask<SelectableChannel>) a;
@@ -418,7 +418,7 @@ public final class NioEventLoop extends SingleThreadEventLoop {
         final NioUnsafe unsafe = ch.unsafe();
         if (!k.isValid()) {
             // close the channel if the key is not valid anymore
-            unsafe.close(unsafe.voidFuture());
+            unsafe.close(ch.voidPromise());
             return;
         }
 
@@ -448,7 +448,7 @@ public final class NioEventLoop extends SingleThreadEventLoop {
             if (readyOps != -1 && (readyOps & SelectionKey.OP_WRITE) != 0) {
                 unregisterWritableTasks(ch);
             }
-            unsafe.close(unsafe.voidFuture());
+            unsafe.close(ch.voidPromise());
         }
     }
 
@@ -518,7 +518,7 @@ public final class NioEventLoop extends SingleThreadEventLoop {
 
         for (AbstractNioChannel ch: channels) {
             unregisterWritableTasks(ch);
-            ch.unsafe().close(ch.unsafe().voidFuture());
+            ch.unsafe().close(ch.voidPromise());
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/oio/AbstractOioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/AbstractOioByteChannel.java
@@ -128,7 +128,7 @@ public abstract class AbstractOioByteChannel extends AbstractOioChannel {
                 firedInboundBufferSuspeneded = true;
                 pipeline.fireChannelReadSuspended();
                 pipeline.fireExceptionCaught(t);
-                unsafe().close(unsafe().voidFuture());
+                unsafe().close(voidPromise());
             }
         } finally {
             if (read) {
@@ -140,7 +140,7 @@ public abstract class AbstractOioByteChannel extends AbstractOioChannel {
                     if (Boolean.TRUE.equals(config().getOption(ChannelOption.ALLOW_HALF_CLOSURE))) {
                         pipeline.fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
                     } else {
-                        unsafe().close(unsafe().voidFuture());
+                        unsafe().close(voidPromise());
                     }
                 }
             } else if (!firedInboundBufferSuspeneded) {

--- a/transport/src/main/java/io/netty/channel/oio/AbstractOioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/AbstractOioMessageChannel.java
@@ -56,7 +56,7 @@ public abstract class AbstractOioMessageChannel extends AbstractOioChannel {
             pipeline.fireChannelReadSuspended();
             pipeline.fireExceptionCaught(t);
             if (t instanceof IOException) {
-                unsafe().close(unsafe().voidFuture());
+                unsafe().close(voidPromise());
             }
         } finally {
             if (read) {
@@ -66,7 +66,7 @@ public abstract class AbstractOioMessageChannel extends AbstractOioChannel {
                 pipeline.fireChannelReadSuspended();
             }
             if (closed && isOpen()) {
-                unsafe().close(unsafe().voidFuture());
+                unsafe().close(voidPromise());
             }
         }
     }


### PR DESCRIPTION
At the moment a new ChannelPromise is created for every flush(...), write(...) and sendFile(...) operation. This can keep the GC quite busy if you write fast enough. Often the user don't care about the returned ChannelFuture and so may would like to not create a new one and so not put so much pressure on the GC.

With this pull-req it's possible to use a VoidChannelPromise and pass it to the stated operations. This will not work for all ChannelHandlers as those which depend on for example on adding ChannelFutureListener to the promise during processing will not work anymore. This is not a problem as it will throw an IllegalStateException in this case. This is more of an advanced feature so I think we should not have to much concern here.

The VoidChannelPromise can be accessed with 

``` java
channel.unsafe().voidPromise();
```

This change produce a bit of API breakage but only for Transport implementations so I think it should not affect 99% of our users and so is ok. 

This fixes #1317
