### PR TITLE
Update HttpHeaderDateFormat.java

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderDateFormat.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderDateFormat.java
@@ -66,7 +66,7 @@ final class HttpHeaderDateFormat extends SimpleDateFormat {
         private static final long serialVersionUID = -3178072504225114298L;
 
         HttpHeaderDateFormatObsolete1() {
-            super("E, dd-MMM-y HH:mm:ss z", Locale.ENGLISH);
+            super("E, dd-MMM-yy HH:mm:ss z", Locale.ENGLISH);
             setTimeZone(TimeZone.getTimeZone("GMT"));
         }
     }


### PR DESCRIPTION
Output for "E, dd-MMM-y HH:mm:ss z"
on java 1.6 I get: Wed, 22-May-13 09:11:41 GM
on java 1.7 I get: Wed, 22-May-2013 09:11:14 GMT

To be uniform on both jdks.. modified it to 
"E, dd-MMM-yy HH:mm:ss z"

learnt from - http://stackoverflow.com/questions/16687298/simpledateformat-different-behaviour-depending-on-java-version
