### PR TITLE
ReadOnlyByteBuffer.isWritable() should return false

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
@@ -45,6 +45,16 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    public boolean isWritable() {
+        return false;
+    }
+
+    @Override
+    public boolean isWritable(int numBytes) {
+        return false;
+    }
+
+    @Override
     public ByteBuf unwrap() {
         return buffer;
     }

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
@@ -174,4 +174,12 @@ public class ReadOnlyByteBufTest {
     public void shouldRejectSetBytes5() {
         unmodifiableBuffer(EMPTY_BUFFER).setBytes(0, (ByteBuffer) null);
     }
+
+    public void shouldIndicateNotWriteable() {
+        assertFalse(unmodifiableBuffer(buffer(1)).isWritable());
+    }
+
+    public void shouldIndicteNotWritableAnyNumber() {
+        assertFalse(unmodifiableBuffer(buffer(1)).isWritable(1));
+    }
 }


### PR DESCRIPTION
Both .isWritable() and isWritable(int) can return true at the moment, which seems incorrect.
