### PR TITLE
Fix for issue #1426 Spring instantiation of NioEventLoopGroup with 0 number of threads is now complicated

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
@@ -58,7 +58,7 @@ public class NioEventLoopGroup extends MultithreadEventLoopGroup {
      */
     public NioEventLoopGroup(
             int nThreads, ThreadFactory threadFactory, final SelectorProvider selectorProvider) {
-        super(nThreads= (nThreads == 0 ? DEFAULT_EVENT_LOOP_THREADS : nThreads), threadFactory, selectorProvider);
+        super((nThreads == 0 ? DEFAULT_EVENT_LOOP_THREADS : nThreads), threadFactory, selectorProvider);
     }
 
     /**


### PR DESCRIPTION
Its only a one line change in the constructor. With this user can pass in 0 as number of threads to get default number of threads. Helps in easier instantiation from spring.
