### PR TITLE
Wrong byte order on little endian platforms without unaligned memory access

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * The {@link PlatformDependent} operations which requires access to {@code sun.misc.*}.
@@ -32,6 +33,8 @@ final class PlatformDependent0 {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(PlatformDependent0.class);
     private static final Unsafe UNSAFE;
+    private static final boolean BIG_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
+
     private static final long CLEANER_FIELD_OFFSET;
     private static final long ADDRESS_FIELD_OFFSET;
 
@@ -184,26 +187,33 @@ final class PlatformDependent0 {
     static short getShort(long address) {
         if (UNALIGNED) {
             return UNSAFE.getShort(address);
-        } else {
+        } else if (BIG_ENDIAN) {
             return (short) (getByte(address) << 8 | getByte(address + 1) & 0xff);
+        } else {
+            return (short) (getByte(address + 1) << 8 | getByte(address) & 0xff);
         }
     }
 
     static int getInt(long address) {
         if (UNALIGNED) {
             return UNSAFE.getInt(address);
-        } else {
+        } else if (BIG_ENDIAN) {
             return getByte(address) << 24 |
                   (getByte(address + 1) & 0xff) << 16 |
                   (getByte(address + 2) & 0xff) <<  8 |
                    getByte(address + 3) & 0xff;
+        } else {
+            return getByte(address + 3) << 24 |
+                  (getByte(address + 2) & 0xff) << 16 |
+                  (getByte(address + 1) & 0xff) <<  8 |
+                   getByte(address) & 0xff;
         }
     }
 
     static long getLong(long address) {
         if (UNALIGNED) {
             return UNSAFE.getLong(address);
-        } else {
+        } else if (BIG_ENDIAN) {
             return (long) getByte(address) << 56 |
                   ((long) getByte(address + 1) & 0xff) << 48 |
                   ((long) getByte(address + 2) & 0xff) << 40 |
@@ -212,6 +222,15 @@ final class PlatformDependent0 {
                   ((long) getByte(address + 5) & 0xff) << 16 |
                   ((long) getByte(address + 6) & 0xff) <<  8 |
                    (long) getByte(address + 7) & 0xff;
+        } else {
+            return (long) getByte(address + 7) << 56 |
+                  ((long) getByte(address + 6) & 0xff) << 48 |
+                  ((long) getByte(address + 5) & 0xff) << 40 |
+                  ((long) getByte(address + 4) & 0xff) << 32 |
+                  ((long) getByte(address + 3) & 0xff) << 24 |
+                  ((long) getByte(address + 2) & 0xff) << 16 |
+                  ((long) getByte(address + 1) & 0xff) <<  8 |
+                   (long) getByte(address) & 0xff;
         }
     }
 
@@ -222,27 +241,35 @@ final class PlatformDependent0 {
     static void putShort(long address, short value) {
         if (UNALIGNED) {
             UNSAFE.putShort(address, value);
-        } else {
+        } else if (BIG_ENDIAN) {
             putByte(address, (byte) (value >>> 8));
             putByte(address + 1, (byte) value);
+        } else {
+            putByte(address + 1, (byte) (value >>> 8));
+            putByte(address, (byte) value);
         }
     }
 
     static void putInt(long address, int value) {
         if (UNALIGNED) {
             UNSAFE.putInt(address, value);
-        } else {
+        } else if (BIG_ENDIAN) {
             putByte(address, (byte) (value >>> 24));
             putByte(address + 1, (byte) (value >>> 16));
             putByte(address + 2, (byte) (value >>> 8));
             putByte(address + 3, (byte) value);
+        } else {
+            putByte(address + 3, (byte) (value >>> 24));
+            putByte(address + 2, (byte) (value >>> 16));
+            putByte(address + 1, (byte) (value >>> 8));
+            putByte(address, (byte) value);
         }
     }
 
     static void putLong(long address, long value) {
         if (UNALIGNED) {
             UNSAFE.putLong(address, value);
-        } else {
+        } else if (BIG_ENDIAN) {
             putByte(address, (byte) (value >>> 56));
             putByte(address + 1, (byte) (value >>> 48));
             putByte(address + 2, (byte) (value >>> 40));
@@ -251,6 +278,15 @@ final class PlatformDependent0 {
             putByte(address + 5, (byte) (value >>> 16));
             putByte(address + 6, (byte) (value >>> 8));
             putByte(address + 7, (byte) value);
+        } else {
+            putByte(address + 7, (byte) (value >>> 56));
+            putByte(address + 6, (byte) (value >>> 48));
+            putByte(address + 5, (byte) (value >>> 40));
+            putByte(address + 4, (byte) (value >>> 32));
+            putByte(address + 3, (byte) (value >>> 24));
+            putByte(address + 2, (byte) (value >>> 16));
+            putByte(address + 1, (byte) (value >>> 8));
+            putByte(address, (byte) value);
         }
     }
 


### PR DESCRIPTION
I found a byte order problem when using direct buffers on a platform that supports Unsafe but not unaligned memory access. The existing fallback implementation in PlatformDependent0.java only works on big endian platforms and does not work in my test system (Raspberry Pi, Raspbian, JDK 8 Preview). 
