### PR TITLE
Improve performance of encodeHeader

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/HttpMessageEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/HttpMessageEncoder.java
@@ -161,12 +161,18 @@ public abstract class HttpMessageEncoder extends OneToOneEncoder {
 
     private static void encodeHeader(ChannelBuffer buf, String header, String value)
             throws UnsupportedEncodingException {
-        buf.writeBytes(header.getBytes("ASCII"));
+        encodeAscii(header, buf);
         buf.writeByte(COLON);
         buf.writeByte(SP);
-        buf.writeBytes(value.getBytes("ASCII"));
+        encodeAscii(value, buf);
         buf.writeByte(CR);
         buf.writeByte(LF);
+    }
+
+    private static void encodeAscii(String s, ChannelBuffer buf) {
+        for (int i = 0; i < s.length(); i++) {
+            buf.writeByte(s.charAt(i));
+        }
     }
 
     protected abstract void encodeInitialLine(ChannelBuffer buf, HttpMessage message) throws Exception;


### PR DESCRIPTION
Similar to https://github.com/netty/netty/pull/1496  but for 3.6 branch. I am not sure if the next version will be 3.6.x or 3.7. Let me know if you would prefer that I submit for 3.x . Thanks for the quick turnaround on 4!
