### PR TITLE
Http resp encoder perf

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
@@ -130,7 +130,7 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
         buf.writeBytes(CRLF);
     }
 
-    private static void encodeAscii(String s, ByteBuf buf) {
+    protected static void encodeAscii(String s, ByteBuf buf) {
         for (int i = 0; i < s.length(); i++) {
             buf.writeByte(s.charAt(i));
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseEncoder.java
@@ -34,11 +34,11 @@ public class HttpResponseEncoder extends HttpObjectEncoder<HttpResponse> {
 
     @Override
     protected void encodeInitialLine(ByteBuf buf, HttpResponse response) throws Exception {
-        buf.writeBytes(response.getProtocolVersion().toString().getBytes(CharsetUtil.US_ASCII));
+        encodeAscii(response.getProtocolVersion().toString(), buf);
         buf.writeByte(SP);
-        buf.writeBytes(String.valueOf(response.getStatus().code()).getBytes(CharsetUtil.US_ASCII));
+        encodeAscii(String.valueOf(response.getStatus().code()), buf);
         buf.writeByte(SP);
-        buf.writeBytes(String.valueOf(response.getStatus().reasonPhrase()).getBytes(CharsetUtil.US_ASCII));
+        encodeAscii(String.valueOf(response.getStatus().reasonPhrase()), buf);
         buf.writeBytes(CRLF);
     }
 }


### PR DESCRIPTION
This is a related perf improvement for encodeInitialLine . I am not sure if I am doing the pull request properly. Let me know if I should submit it in a different way.
