### PR TITLE
Fix HttpContentDecoder (broken in 4.0.0.Final)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecoder.java
@@ -214,7 +214,7 @@ public abstract class HttpContentDecoder extends MessageToMessageDecoder<HttpObj
 
     private void decode(ByteBuf in, List<Object> out) {
         // call retain here as it will call release after its written to the channel
-        decoder.writeOutbound(in.retain());
+        decoder.writeInbound(in.retain());
         fetchDecoderOutput(out);
     }
 
@@ -228,7 +228,7 @@ public abstract class HttpContentDecoder extends MessageToMessageDecoder<HttpObj
 
     private void fetchDecoderOutput(List<Object> out) {
         for (;;) {
-            ByteBuf buf = (ByteBuf) decoder.readOutbound();
+            ByteBuf buf = (ByteBuf) decoder.readInbound();
             if (buf == null) {
                 break;
             }


### PR DESCRIPTION
Modify HttpContentDecoder to writeInbound and readInbound from it's internal decoder. The EmbeddedChannel contains a decoder, which works on inbound data.
