### PR TITLE
 netty-1597: Rewrite ByteBufInputStream.readLine() to avoid IndexOutOfBoundsException and to behave more correctly for lines ending in '\r'

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
@@ -204,7 +204,7 @@ public class ByteBufInputStream extends InputStream implements DataInput {
                     break loop;
 
                 default:
-                    lineBuf.append((char)c);
+                    lineBuf.append((char) c);
             }
         }
 

--- a/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufStreamTest.java
@@ -134,6 +134,7 @@ public class ByteBufStreamTest {
 
         assertEquals("Hello, World!", in.readUTF());
         assertEquals("The first line", in.readLine());
+        assertEquals("", in.readLine());
 
         assertEquals(4, in.read(tmp));
         assertEquals(1, tmp[0]);


### PR DESCRIPTION
Fixes '\r' handling in ByteBufInputStream.readLine().
