### PR TITLE
Fix for first issue from #1652 on computation of time to wait in Abstrac...

### DIFF
--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -205,7 +205,7 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
             // Time is too short, so just lets continue
             return 0;
         }
-        return (bytes * 1000 / limit - interval / 10) * 10;
+        return (bytes * 1000 / limit - interval) / 10 * 10;
     }
 
     @Override


### PR DESCRIPTION
Fix for first issue from #1652 on computation of time to wait in AbstractTrafficShapingHandler for Netty 4, using the same formula than in Netty 3 (wrong place for parenthese).
Was:

```
(bytes * 1000 / limit - interval / 10) * 10;
```

Becomes:

```
(bytes * 1000 / limit - interval) / 10 * 10;
```
