### PR TITLE
Proposal to fix for #1753

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoder.java
@@ -40,7 +40,7 @@ import java.util.TreeMap;
 import static io.netty.buffer.Unpooled.*;
 
 /**
- * This decoder will decode Body and can handle POST BODY.
+ * This decoder will decode Body and can handle POST BODY (or for PUT, PATCH or OPTIONS).
  *
  * You <strong>MUST</strong> call {@link #destroy()} after completion to release all resources.
  *
@@ -172,6 +172,49 @@ public class HttpPostRequestDecoder {
 
     /**
      *
+     * @param request
+     *            the request to decode
+     * @param unlimitedMethod
+     *            True to unlimit method, False will limit to POST, PUT, PATCH and OPTIONS
+     * @throws NullPointerException
+     *             for request
+     * @throws IncompatibleDataDecoderException
+     *             if the request has no body to decode
+     * @throws ErrorDataDecoderException
+     *             if the default charset was wrong when decoding or other
+     *             errors
+     */
+    public HttpPostRequestDecoder(HttpRequest request, boolean unlimitedMethod)
+           throws ErrorDataDecoderException,
+           IncompatibleDataDecoderException {
+        this(new DefaultHttpDataFactory(DefaultHttpDataFactory.MINSIZE), request,
+               HttpConstants.DEFAULT_CHARSET, unlimitedMethod);
+    }
+
+    /**
+     *
+     * @param factory
+     *            the factory used to create InterfaceHttpData
+     * @param request
+     *            the request to decode
+     * @param unlimitedMethod
+     *            True to unlimit method, False will limit to POST, PUT, PATCH and OPTIONS
+     * @throws NullPointerException
+     *             for request or factory
+     * @throws IncompatibleDataDecoderException
+     *             if the request has no body to decode
+     * @throws ErrorDataDecoderException
+     *             if the default charset was wrong when decoding or other
+     *             errors
+     */
+    public HttpPostRequestDecoder(HttpDataFactory factory, HttpRequest request, boolean unlimitedMethod)
+           throws ErrorDataDecoderException,
+           IncompatibleDataDecoderException {
+        this(factory, request, HttpConstants.DEFAULT_CHARSET, unlimitedMethod);
+    }
+
+    /**
+     *
      * @param factory
      *            the factory used to create InterfaceHttpData
      * @param request
@@ -188,6 +231,30 @@ public class HttpPostRequestDecoder {
      */
     public HttpPostRequestDecoder(HttpDataFactory factory, HttpRequest request, Charset charset)
             throws ErrorDataDecoderException, IncompatibleDataDecoderException {
+        this(factory, request, charset, false);
+    }
+
+    /**
+     *
+     * @param factory
+     *            the factory used to create InterfaceHttpData
+     * @param request
+     *            the request to decode
+     * @param charset
+     *            the charset to use as default
+     * @param unlimitedMethod
+     *            True to unlimit method, False will limit to POST, PUT, PATCH and OPTIONS
+     * @throws NullPointerException
+     *             for request or charset or factory
+     * @throws IncompatibleDataDecoderException
+     *             if the request has no body to decode
+     * @throws ErrorDataDecoderException
+     *             if the default charset was wrong when decoding or other
+     *             errors
+     */
+    public HttpPostRequestDecoder(HttpDataFactory factory, HttpRequest request, Charset charset,
+            boolean unlimitedMethod)
+            throws ErrorDataDecoderException, IncompatibleDataDecoderException {
         if (factory == null) {
             throw new NullPointerException("factory");
         }
@@ -198,9 +265,14 @@ public class HttpPostRequestDecoder {
             throw new NullPointerException("charset");
         }
         this.request = request;
-        HttpMethod method = request.getMethod();
-        if (method.equals(HttpMethod.POST) || method.equals(HttpMethod.PUT) || method.equals(HttpMethod.PATCH)) {
+        if (unlimitedMethod) {
             bodyToDecode = true;
+        } else {
+            HttpMethod method = request.getMethod();
+            if (method.equals(HttpMethod.POST) || method.equals(HttpMethod.PUT)
+                    || method.equals(HttpMethod.PATCH) || method.equals(HttpMethod.OPTIONS)) {
+                bodyToDecode = true;
+            }
         }
         this.charset = charset;
         this.factory = factory;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -45,7 +45,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
- * This encoder will help to encode Request for a FORM as POST.
+ * This encoder will help to encode Request for a FORM as POST, PUT, PATCH or OPTIONS.
  */
 public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
 
@@ -132,7 +132,7 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
      * @throws NullPointerException
      *             for request
      * @throws ErrorDataEncoderException
-     *             if the request is not a POST
+     *             if the request is not a POST, PUT, PATCH or OPTIONS
      */
     public HttpPostRequestEncoder(HttpRequest request, boolean multipart) throws ErrorDataEncoderException {
         this(new DefaultHttpDataFactory(DefaultHttpDataFactory.MINSIZE), request, multipart,
@@ -150,7 +150,7 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
      * @throws NullPointerException
      *             for request and factory
      * @throws ErrorDataEncoderException
-     *             if the request is not a POST
+     *             if the request is not a POST, PUT, PATCH or OPTIONS
      */
     public HttpPostRequestEncoder(HttpDataFactory factory, HttpRequest request, boolean multipart)
             throws ErrorDataEncoderException {
@@ -172,11 +172,78 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
      * @throws NullPointerException
      *             for request or charset or factory
      * @throws ErrorDataEncoderException
-     *             if the request is not a POST
+     *             if the request is not a POST, PUT, PATCH or OPTIONS
      */
     public HttpPostRequestEncoder(
             HttpDataFactory factory, HttpRequest request, boolean multipart, Charset charset,
             EncoderMode encoderMode)
+            throws ErrorDataEncoderException {
+        this(factory, request, multipart, charset, encoderMode, false);
+    }
+
+    /**
+     *
+     * @param request
+     *            the request to encode
+     * @param multipart
+     *            True if the FORM is a ENCTYPE="multipart/form-data"
+     * @param unlimitedMethod
+     *            True to unlimit method, False will limit to POST, PUT, PATCH and OPTIONS
+     * @throws NullPointerException
+     *             for request
+     * @throws ErrorDataEncoderException
+     *             if the request is not a POST, PUT, PATCH or OPTIONS
+     */
+    public HttpPostRequestEncoder(HttpRequest request, boolean multipart, boolean unlimitedMethod)
+            throws ErrorDataEncoderException {
+        this(new DefaultHttpDataFactory(DefaultHttpDataFactory.MINSIZE), request, multipart,
+                HttpConstants.DEFAULT_CHARSET, EncoderMode.RFC1738, unlimitedMethod);
+    }
+
+    /**
+     *
+     * @param factory
+     *            the factory used to create InterfaceHttpData
+     * @param request
+     *            the request to encode
+     * @param multipart
+     *            True if the FORM is a ENCTYPE="multipart/form-data"
+     * @param unlimitedMethod
+     *            True to unlimit method, False will limit to POST, PUT, PATCH and OPTIONS
+     * @throws NullPointerException
+     *             for request and factory
+     * @throws ErrorDataEncoderException
+     *             if the request is not a POST, PUT, PATCH or OPTIONS
+     */
+    public HttpPostRequestEncoder(HttpDataFactory factory, HttpRequest request, boolean multipart,
+            boolean unlimitedMethod)
+            throws ErrorDataEncoderException {
+        this(factory, request, multipart, HttpConstants.DEFAULT_CHARSET, EncoderMode.RFC1738,
+                unlimitedMethod);
+    }
+
+    /**
+     *
+     * @param factory
+     *            the factory used to create InterfaceHttpData
+     * @param request
+     *            the request to encode
+     * @param multipart
+     *            True if the FORM is a ENCTYPE="multipart/form-data"
+     * @param charset
+     *            the charset to use as default
+     * @param encoderMode
+     *            the mode for the encoder to use. See {@link EncoderMode} for the details.
+     * @param unlimitedMethod
+     *            True to unlimit method, False will limit to POST, PUT, PATCH and OPTIONS
+     * @throws NullPointerException
+     *             for request or charset or factory
+     * @throws ErrorDataEncoderException
+     *             if the request is not a POST, PUT, PATCH or OPTIONS
+     */
+    public HttpPostRequestEncoder(
+            HttpDataFactory factory, HttpRequest request, boolean multipart, Charset charset,
+            EncoderMode encoderMode, boolean unlimitedMethod)
             throws ErrorDataEncoderException {
         if (factory == null) {
             throw new NullPointerException("factory");
@@ -187,7 +254,9 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
         if (charset == null) {
             throw new NullPointerException("charset");
         }
-        if (request.getMethod() != HttpMethod.POST) {
+        if (!unlimitedMethod && request.getMethod() != HttpMethod.POST
+                && request.getMethod() != HttpMethod.PUT && request.getMethod() != HttpMethod.PATCH
+                && request.getMethod() != HttpMethod.OPTIONS) {
             throw new ErrorDataEncoderException("Cannot create a Encoder if not a POST");
         }
         this.request = request;


### PR DESCRIPTION
Proposal to fix for #1753

Create constructors for Multipart CODEC with extra argument unlimitedMethod to allow to bypass test of method used.

By default (false), only PUT, POST, PATCH and OPTIONS are allowed.
If true, all methods are allowed.

This fix tends to allow body in request as it seems allowed in RFC 2616 (or not forbidden), but not implemented.
This will allow Netty to support this if needed, for instance for REST implementation where GET could use a Body as request part.

Note also that both Encoder and Decoder now support by default the same subset of methods:
- POST, PUT, PATCH and OPTIONS
  While before:
- Encoder was supporting only POST
- Decoder was supporting only POST, PUT and PATCH
