### PR TITLE
small modification to LocalAddress

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalAddress.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalAddress.java
@@ -18,6 +18,7 @@ package io.netty.channel.local;
 import io.netty.channel.Channel;
 
 import java.net.SocketAddress;
+import java.util.UUID;
 
 /**
  * An endpoint in the local transport.  Each endpoint is identified by a unique


### PR DESCRIPTION
changing the creation the id of the local address to use UUID to avoid potential collision when multiple clients are used with Local transport, see https://github.com/netty/netty/issues/1765
