### PR TITLE
SPDY: allow MAX_CONCURRENT_STREAMS to be set to 0

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/spdy/SpdySessionHandler.java
+++ b/src/main/java/org/jboss/netty/handler/codec/spdy/SpdySessionHandler.java
@@ -44,12 +44,13 @@ public class SpdySessionHandler extends SimpleChannelUpstreamHandler
     private final SpdySession spdySession = new SpdySession();
     private volatile int lastGoodStreamID;
 
-    private volatile int remoteConcurrentStreams;
-    private volatile int localConcurrentStreams;
-    private volatile int maxConcurrentStreams;
+    private static final int DEFAULT_MAX_CONCURRENT_STREAMS = Integer.MAX_VALUE;
+    private volatile int remoteConcurrentStreams = DEFAULT_MAX_CONCURRENT_STREAMS;
+    private volatile int localConcurrentStreams  = DEFAULT_MAX_CONCURRENT_STREAMS;
+    private volatile int maxConcurrentStreams    = DEFAULT_MAX_CONCURRENT_STREAMS;
 
     private static final int DEFAULT_WINDOW_SIZE = 64 * 1024; // 64 KB default initial window size
-    private volatile int initialSendWindowSize = DEFAULT_WINDOW_SIZE;
+    private volatile int initialSendWindowSize    = DEFAULT_WINDOW_SIZE;
     private volatile int initialReceiveWindowSize = DEFAULT_WINDOW_SIZE;
 
     private final Object flowControlLock = new Object();
@@ -687,23 +688,7 @@ public class SpdySessionHandler extends SimpleChannelUpstreamHandler
         } else {
             localConcurrentStreams = newConcurrentStreams;
         }
-        if (localConcurrentStreams == remoteConcurrentStreams) {
-            maxConcurrentStreams = localConcurrentStreams;
-            return;
-        }
-        if (localConcurrentStreams == 0) {
-            maxConcurrentStreams = remoteConcurrentStreams;
-            return;
-        }
-        if (remoteConcurrentStreams == 0) {
-            maxConcurrentStreams = localConcurrentStreams;
-            return;
-        }
-        if (localConcurrentStreams > remoteConcurrentStreams) {
-            maxConcurrentStreams = remoteConcurrentStreams;
-        } else {
-            maxConcurrentStreams = localConcurrentStreams;
-        }
+        maxConcurrentStreams = Math.min(localConcurrentStreams, remoteConcurrentStreams);
     }
 
     // need to synchronize to prevent new streams from being created while updating active streams
@@ -731,8 +716,7 @@ public class SpdySessionHandler extends SimpleChannelUpstreamHandler
         }
 
         int maxConcurrentStreams = this.maxConcurrentStreams; // read volatile once
-        if (maxConcurrentStreams != 0 &&
-           spdySession.numActiveStreams() >= maxConcurrentStreams) {
+        if (spdySession.numActiveStreams() >= maxConcurrentStreams) {
             return false;
         }
         spdySession.acceptStream(


### PR DESCRIPTION
Previously, 0 was treated as a sentinel value that indicated unlimited concurrent streams are allowed. This pull request allows 0 to instead be a legal value for max concurrent streams, providing a mechanism for either servers or clients to signal that no new streams may be opened on the session.
