### PR TITLE
noJdkZlibDecoder system variable is being negated.

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibCodecFactory.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibCodecFactory.java
@@ -29,7 +29,7 @@ public final class ZlibCodecFactory {
     private static final boolean noJdkZlibDecoder;
 
     static {
-        noJdkZlibDecoder = !SystemPropertyUtil.getBoolean("io.netty.noJdkZlibDecoder", true);
+        noJdkZlibDecoder = SystemPropertyUtil.getBoolean("io.netty.noJdkZlibDecoder", true);
         logger.debug("-Dio.netty.noJdkZlibDecoder: {}", noJdkZlibDecoder);
     }
 


### PR DESCRIPTION
This means:
1. The JdkZlibDecoder is being selected by default if you are using java 7; and,
2. -DnoJdkZlibDecoder=false will use the JZlibDecoder, expecting you to have that dependency on the classpath.
