### PR TITLE
HTTP Chunk, wrong delimiter written

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
@@ -45,7 +45,7 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
     private static final byte[] ZERO_CRLF = { '0', CR, LF };
     private static final byte[] ZERO_CRLF_CRLF = { '0', CR, LF, CR, LF };
     private static final byte[] HEADER_SEPARATOR = { COLON, SP };
-    private static final ByteBuf CRLF_BUF = unreleasableBuffer(directBuffer(ZERO_CRLF.length).writeBytes(ZERO_CRLF));
+    private static final ByteBuf CRLF_BUF = unreleasableBuffer(directBuffer(CRLF.length).writeBytes(CRLF));
     private static final ByteBuf ZERO_CRLF_CRLF_BUF = unreleasableBuffer(directBuffer(ZERO_CRLF_CRLF.length)
             .writeBytes(ZERO_CRLF_CRLF));
 


### PR DESCRIPTION
CRLF_BUF is being created from ZERO_CRLF rather than CRLF.

This has the effect of appending a 0 to every chunked HTTP content. 

Below is a diff of the trace of two curl requests to a simple Netty Http Server which echoes input back to the client. The text sent is "hello". The first request is against 4.0.7-final, the second against 4.0.8-final.

In both cases the request header "Accept-Encoding: gzip" is sent. Curl barfs on 4.0.8-final request presumably because it recognises that the content isn't encoded correctly.

```
Recv data, 47 bytes (0x2f)
Recv data, 49 bytes (0x31)

42,47c42,47
< 0004: ...........H.........
< 001b: a
< 001e: .....6....
< 002a: 0
< 002d:
Info: Connection #0 to host 127.0.0.1 left intact

 > 0004: ...........H.........0
 > 001c: a
 > 001f: .....6....0
 > 002c: 0
 > 002f:
Info: Problem (3) in the Chunked-Encoded data
```
