### PR TITLE
failure future before firing exception event

### DIFF
--- a/src/main/java/org/jboss/netty/channel/local/DefaultLocalChannel.java
+++ b/src/main/java/org/jboss/netty/channel/local/DefaultLocalChannel.java
@@ -198,8 +198,8 @@ final class DefaultLocalChannel extends AbstractChannel implements LocalChannel 
                     break;
                 }
 
-                fireExceptionCaught(this, cause);
                 e.getFuture().setFailure(cause);
+                fireExceptionCaught(this, cause);
             }
         }
     }


### PR DESCRIPTION
Jeff pointed out a potential problem in my previous commit to 3.6.  We usually fail the future before firing the exception event.
