### PR TITLE
Fix nioBuffer implementation for CompositeByteBuf

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -1122,7 +1122,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf {
 
         //noinspection ForLoopReplaceableByForEach
         for (int i = 0; i < buffers.length; i++) {
-            merged.put(buffers[0]);
+            merged.put(buffers[i]);
         }
 
         merged.flip();

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -177,6 +177,27 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
     }
 
     @Test
+    public void testCompositeToSingleBuffer() {
+        CompositeByteBuf buf = compositeBuffer(3);
+
+        buf.addComponent(wrappedBuffer(new byte[] {1, 2, 3}));
+        assertEquals(1, buf.numComponents());
+
+        buf.addComponent(wrappedBuffer(new byte[] {4}));
+        assertEquals(2, buf.numComponents());
+
+        buf.addComponent(wrappedBuffer(new byte[] {5, 6}));
+        assertEquals(3, buf.numComponents());
+
+        // NOTE: hard-coding 6 here, since it seems like addComponent doesn't bump the writer index.
+        // I'm unsure as to whether or not this is correct behavior
+        ByteBuffer nioBuffer = buf.nioBuffer(0, 6);
+        byte[] bytes = nioBuffer.array();
+        assertEquals(6, bytes.length);
+        assertArrayEquals(new byte[] {1, 2, 3, 4, 5, 6}, bytes);
+    }
+
+    @Test
     public void testFullConsolidation() {
         CompositeByteBuf buf = freeLater(compositeBuffer(Integer.MAX_VALUE));
         buf.addComponent(wrappedBuffer(new byte[] { 1 }));


### PR DESCRIPTION
The method for copying all of a CompositeByteBuf's constituent buffers into a single nio buffer had a bug. I've fixed the bug and included a test that previously failed. 

I was unsure (and left a note to that effect) of what the behavior of CompositeByteBuf#addComponent should be. It does not appear to bump the writer index, resulting in 0 readable bytes after components have been added. Is it the intention that the code adding the components be responsible for updating the writer index?
