### PR TITLE
[#1844] HttpRequestEncoder should append '/' to absolute path requests

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestEncoder.java
@@ -41,13 +41,19 @@ public class HttpRequestEncoder extends HttpObjectEncoder<HttpRequest> {
         // Add / as absolute path if no is present.
         // See http://tools.ietf.org/html/rfc2616#section-5.1.2
         String uri = request.getUri();
-        int start = uri.indexOf("://");
-        if (start != -1) {
-            int startIndex = start + 3;
-            if (uri.lastIndexOf(SLASH) <= startIndex) {
-                uri += SLASH;
+
+        if (uri.length() == 0) {
+            uri += SLASH;
+        } else {
+            int start = uri.indexOf("://");
+            if (start != -1 && uri.charAt(0) != SLASH) {
+                int startIndex = start + 3;
+                if (uri.lastIndexOf(SLASH) <= startIndex) {
+                    uri += SLASH;
+                }
             }
         }
+
         buf.writeBytes(uri.getBytes(CharsetUtil.UTF_8));
 
         buf.writeByte(SP);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestEncoderTest.java
@@ -46,4 +46,34 @@ public class HttpRequestEncoderTest {
         String req = buffer.toString(Charset.forName("US-ASCII"));
         assertEquals("GET http://localhost/ HTTP/1.1\r\n", req);
     }
+
+    @Test
+    public void testAbsPath() throws Exception {
+        HttpRequestEncoder encoder = new HttpRequestEncoder();
+        ByteBuf buffer = Unpooled.buffer(64);
+        encoder.encodeInitialLine(buffer, new DefaultHttpRequest(HttpVersion.HTTP_1_1,
+                HttpMethod.GET, "/"));
+        String req = buffer.toString(Charset.forName("US-ASCII"));
+        assertEquals("GET / HTTP/1.1\r\n", req);
+    }
+
+    @Test
+    public void testEmptyAbsPath() throws Exception {
+        HttpRequestEncoder encoder = new HttpRequestEncoder();
+        ByteBuf buffer = Unpooled.buffer(64);
+        encoder.encodeInitialLine(buffer, new DefaultHttpRequest(HttpVersion.HTTP_1_1,
+                HttpMethod.GET, ""));
+        String req = buffer.toString(Charset.forName("US-ASCII"));
+        assertEquals("GET / HTTP/1.1\r\n", req);
+    }
+
+    @Test
+    public void testQueryStringPath() throws Exception {
+        HttpRequestEncoder encoder = new HttpRequestEncoder();
+        ByteBuf buffer = Unpooled.buffer(64);
+        encoder.encodeInitialLine(buffer, new DefaultHttpRequest(HttpVersion.HTTP_1_1,
+                HttpMethod.GET, "/?url=http://example.com"));
+        String req = buffer.toString(Charset.forName("US-ASCII"));
+        assertEquals("GET /?url=http://example.com HTTP/1.1\r\n", req);
+    }
 }


### PR DESCRIPTION
This addresses https://github.com/netty/netty/issues/1844. Requests constructed with an empty URI get the root path ("/") in the request string.
