### PR TITLE
Slip in DefaultOioSocketChannelConfig (setAllowHalfClosure used to ignor...

### DIFF
--- a/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioSocketChannelConfig.java
@@ -134,7 +134,7 @@ public class DefaultOioSocketChannelConfig extends DefaultSocketChannelConfig im
 
     @Override
     public OioSocketChannelConfig setAllowHalfClosure(boolean allowHalfClosure) {
-        super.setAllowHalfClosure(true);
+        super.setAllowHalfClosure(allowHalfClosure);
         return this;
     }
 


### PR DESCRIPTION
...e argument)
