### PR TITLE
WebSocket's MD methods will fail when input is backed by non-zero offset array

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketUtil.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketUtil.java
@@ -52,7 +52,9 @@ final class WebSocketUtil {
         try {
             MessageDigest md = MessageDigest.getInstance("MD5");
             if (buffer.hasArray()) {
-                md.update(buffer.array(), buffer.readerIndex(), buffer.readableBytes());
+                int offset = buffer.arrayOffset() + buffer.readerIndex();
+                int length = buffer.readableBytes();
+                md.update(buffer.array(), offset, length);
             } else {
                 md.update(buffer.toByteBuffer());
             }
@@ -86,7 +88,9 @@ final class WebSocketUtil {
         try {
             MessageDigest md = MessageDigest.getInstance("SHA1");
             if (buffer.hasArray()) {
-                md.update(buffer.array(), buffer.readerIndex(), buffer.readableBytes());
+                int offset = buffer.arrayOffset() + buffer.readerIndex();
+                int length = buffer.readableBytes();
+                md.update(buffer.array(), offset, length);
             } else {
                 md.update(buffer.toByteBuffer());
             }

--- a/src/test/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketUtilTest.java
+++ b/src/test/java/org/jboss/netty/handler/codec/http/websocketx/WebSocketUtilTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013 The Netty Project
+ * 
+ * The Netty Project licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.jboss.netty.handler.codec.http.websocketx;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
+
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+
+import static org.junit.Assert.*;
+
+public class WebSocketUtilTest {
+
+    private final static Charset UTF_8 = Charset.forName("UTF-8");
+
+    @Test
+    public void testMd5() {
+        byte[] bytes1 = "hello, world".getBytes(UTF_8);
+        ChannelBuffer buf1 = ChannelBuffers.wrappedBuffer(bytes1, 0, bytes1.length);
+        byte[] bytes2 = "   hello, world".getBytes(UTF_8);
+        ChannelBuffer buf2 = ChannelBuffers.wrappedBuffer(bytes2, 3, bytes2.length - 3);
+
+        assertEquals(buf1, buf2);
+
+        ChannelBuffer digest1 = WebSocketUtil.md5(buf1);
+        ChannelBuffer digest2 = WebSocketUtil.md5(buf2);
+
+        assertEquals(digest1, digest2);
+    }
+    
+    @Test
+    public void testSha1() {
+        byte[] bytes1 = "hello, world".getBytes(UTF_8);
+        ChannelBuffer buf1 = ChannelBuffers.wrappedBuffer(bytes1, 0, bytes1.length);
+        byte[] bytes2 = "   hello, world".getBytes(UTF_8);
+        ChannelBuffer buf2 = ChannelBuffers.wrappedBuffer(bytes2, 3, bytes2.length - 3);
+
+        assertEquals(buf1, buf2);
+
+        ChannelBuffer digest1 = WebSocketUtil.sha1(buf1);
+        ChannelBuffer digest2 = WebSocketUtil.sha1(buf2);
+
+        assertEquals(digest1, digest2);
+    }
+
+}


### PR DESCRIPTION
The message digest methods of `WebSocketUtil` will fail when the specified input buffer is backed by array that have non-zero offset. Attached test can produce the following failure:

```
-------------------------------------------------------------------------------
Test set: org.jboss.netty.handler.codec.http.websocketx.WebSocketUtilTest
-------------------------------------------------------------------------------
Tests run: 2, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.082 sec <<< FAILURE!
testSha1(org.jboss.netty.handler.codec.http.websocketx.WebSocketUtilTest)  Time elapsed: 0.018 sec  <<< FAILURE!
java.lang.AssertionError: expected: org.jboss.netty.buffer.BigEndianHeapChannelBuffer<BigEndianHeapChannelBuffer(ridx=0, widx=20, cap=20)>
but was: org.jboss.netty.buffer.BigEndianHeapChannelBuffer<BigEndianHeapChannelBuffer(ridx=0, widx=20, cap=20)>
    at org.junit.Assert.fail(Assert.java:93)
    at org.junit.Assert.failNotEquals(Assert.java:647)
    at org.junit.Assert.assertEquals(Assert.java:128)
    at org.junit.Assert.assertEquals(Assert.java:147)
    at org.jboss.netty.handler.codec.http.websocketx.WebSocketUtilTest.testSha1(WebSocketUtilTest.java:58)
    ...
testMd5(org.jboss.netty.handler.codec.http.websocketx.WebSocketUtilTest)  Time elapsed: 0 sec  <<< FAILURE!
java.lang.AssertionError: expected: org.jboss.netty.buffer.BigEndianHeapChannelBuffer<BigEndianHeapChannelBuffer(ridx=0, widx=16, cap=16)>
but was: org.jboss.netty.buffer.BigEndianHeapChannelBuffer<BigEndianHeapChannelBuffer(ridx=0, widx=16, cap=16)>
    at org.junit.Assert.fail(Assert.java:93)
    at org.junit.Assert.failNotEquals(Assert.java:647)
    at org.junit.Assert.assertEquals(Assert.java:128)
    at org.junit.Assert.assertEquals(Assert.java:147)
    at org.jboss.netty.handler.codec.http.websocketx.WebSocketUtilTest.testMd5(WebSocketUtilTest.java:43)
    ...
```
