### PR TITLE
Optimize encode of known HTTP Method/Status/Version

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -355,5 +355,11 @@ public final class ByteBufUtil {
         return dst.flip().toString();
     }
 
+    public static void writeAscii(ByteBuf buf, CharSequence s) {
+        for (int i = 0; i < s.length(); i++) {
+            buf.writeByte(s.charAt(i));
+        }
+    }
+
     private ByteBufUtil() { }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
@@ -15,6 +15,10 @@
  */
 package io.netty.handler.codec.http;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.util.CharsetUtil;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,7 +35,7 @@ public class HttpMethod implements Comparable<HttpMethod> {
      * capabilities of a server, without implying a resource action or initiating a resource
      * retrieval.
      */
-    public static final HttpMethod OPTIONS = new HttpMethod("OPTIONS");
+    public static final HttpMethod OPTIONS = new HttpMethod("OPTIONS", true);
 
     /**
      * The GET getMethod means retrieve whatever information (in the form of an entity) is identified
@@ -39,49 +43,49 @@ public class HttpMethod implements Comparable<HttpMethod> {
      * produced data which shall be returned as the entity in the response and not the source text
      * of the process, unless that text happens to be the output of the process.
      */
-    public static final HttpMethod GET = new HttpMethod("GET");
+    public static final HttpMethod GET = new HttpMethod("GET", true);
 
     /**
      * The HEAD getMethod is identical to GET except that the server MUST NOT return a message-body
      * in the response.
      */
-    public static final HttpMethod HEAD = new HttpMethod("HEAD");
+    public static final HttpMethod HEAD = new HttpMethod("HEAD", true);
 
     /**
      * The POST getMethod is used to request that the origin server accept the entity enclosed in the
      * request as a new subordinate of the resource identified by the Request-URI in the
      * Request-Line.
      */
-    public static final HttpMethod POST = new HttpMethod("POST");
+    public static final HttpMethod POST = new HttpMethod("POST", true);
 
     /**
      * The PUT getMethod requests that the enclosed entity be stored under the supplied Request-URI.
      */
-    public static final HttpMethod PUT = new HttpMethod("PUT");
+    public static final HttpMethod PUT = new HttpMethod("PUT", true);
 
     /**
      * The PATCH getMethod requests that a set of changes described in the
      * request entity be applied to the resource identified by the Request-URI.
      */
-    public static final HttpMethod PATCH = new HttpMethod("PATCH");
+    public static final HttpMethod PATCH = new HttpMethod("PATCH", true);
 
     /**
      * The DELETE getMethod requests that the origin server delete the resource identified by the
      * Request-URI.
      */
-    public static final HttpMethod DELETE = new HttpMethod("DELETE");
+    public static final HttpMethod DELETE = new HttpMethod("DELETE", true);
 
     /**
      * The TRACE getMethod is used to invoke a remote, application-layer loop- back of the request
      * message.
      */
-    public static final HttpMethod TRACE = new HttpMethod("TRACE");
+    public static final HttpMethod TRACE = new HttpMethod("TRACE", true);
 
     /**
      * This specification reserves the getMethod name CONNECT for use with a proxy that can dynamically
      * switch to being a tunnel
      */
-    public static final HttpMethod CONNECT = new HttpMethod("CONNECT");
+    public static final HttpMethod CONNECT = new HttpMethod("CONNECT", true);
 
     private static final Map<String, HttpMethod> methodMap =
             new HashMap<String, HttpMethod>();
@@ -122,6 +126,7 @@ public class HttpMethod implements Comparable<HttpMethod> {
     }
 
     private final String name;
+    private final byte[] encoded;
 
     /**
      * Creates a new HTTP getMethod with the specified name.  You will not need to
@@ -131,6 +136,10 @@ public class HttpMethod implements Comparable<HttpMethod> {
      * <a href="http://en.wikipedia.org/wiki/Internet_Content_Adaptation_Protocol">ICAP</a>
      */
     public HttpMethod(String name) {
+        this(name, false);
+    }
+
+    private HttpMethod(String name, boolean encode) {
         if (name == null) {
             throw new NullPointerException("name");
         }
@@ -142,14 +151,18 @@ public class HttpMethod implements Comparable<HttpMethod> {
 
         for (int i = 0; i < name.length(); i ++) {
             if (Character.isISOControl(name.charAt(i)) ||
-                Character.isWhitespace(name.charAt(i))) {
+                    Character.isWhitespace(name.charAt(i))) {
                 throw new IllegalArgumentException("invalid character in name");
             }
         }
 
         this.name = name;
+        if (encode) {
+            encoded = name.getBytes(CharsetUtil.US_ASCII);
+        } else {
+            encoded = null;
+        }
     }
-
     /**
      * Returns the name of this getMethod.
      */
@@ -180,5 +193,13 @@ public class HttpMethod implements Comparable<HttpMethod> {
     @Override
     public int compareTo(HttpMethod o) {
         return name().compareTo(o.name());
+    }
+
+    void encode(ByteBuf buf) {
+        if (encoded != null) {
+            buf.writeBytes(encoded);
+        } else {
+            ByteBufUtil.writeAscii(buf, name);
+        }
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.FileRegion;
 import io.netty.handler.codec.MessageToMessageEncoder;
@@ -178,9 +179,7 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
     }
 
     protected static void encodeAscii(String s, ByteBuf buf) {
-        for (int i = 0; i < s.length(); i++) {
-            buf.writeByte(s.charAt(i));
-        }
+        ByteBufUtil.writeAscii(buf, s);
     }
 
     protected abstract void encodeInitialLine(ByteBuf buf, H message) throws Exception;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestEncoder.java
@@ -35,7 +35,7 @@ public class HttpRequestEncoder extends HttpObjectEncoder<HttpRequest> {
 
     @Override
     protected void encodeInitialLine(ByteBuf buf, HttpRequest request) throws Exception {
-        encodeAscii(request.getMethod().toString(), buf);
+        request.getMethod().encode(buf);
         buf.writeByte(SP);
 
         // Add / as absolute path if no is present.
@@ -57,7 +57,7 @@ public class HttpRequestEncoder extends HttpObjectEncoder<HttpRequest> {
         buf.writeBytes(uri.getBytes(CharsetUtil.UTF_8));
 
         buf.writeByte(SP);
-        encodeAscii(request.getProtocolVersion().toString(), buf);
+        request.getProtocolVersion().encode(buf);
         buf.writeBytes(CRLF);
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseEncoder.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.CharsetUtil;
 
 import static io.netty.handler.codec.http.HttpConstants.*;
 
@@ -34,11 +33,9 @@ public class HttpResponseEncoder extends HttpObjectEncoder<HttpResponse> {
 
     @Override
     protected void encodeInitialLine(ByteBuf buf, HttpResponse response) throws Exception {
-        encodeAscii(response.getProtocolVersion().toString(), buf);
+        response.getProtocolVersion().encode(buf);
         buf.writeByte(SP);
-        encodeAscii(String.valueOf(response.getStatus().code()), buf);
-        buf.writeByte(SP);
-        encodeAscii(String.valueOf(response.getStatus().reasonPhrase()), buf);
+        response.getStatus().encode(buf);
         buf.writeBytes(CRLF);
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
@@ -15,6 +15,12 @@
  */
 package io.netty.handler.codec.http;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.util.CharsetUtil;
+
+import static io.netty.handler.codec.http.HttpConstants.SP;
+
 /**
  * The response code and its description of HTTP or its derived protocols, such as
  * <a href="http://en.wikipedia.org/wiki/Real_Time_Streaming_Protocol">RTSP</a> and
@@ -25,282 +31,293 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
     /**
      * 100 Continue
      */
-    public static final HttpResponseStatus CONTINUE = new HttpResponseStatus(100, "Continue");
+    public static final HttpResponseStatus CONTINUE = new HttpResponseStatus(100, "Continue", true);
 
     /**
      * 101 Switching Protocols
      */
-    public static final HttpResponseStatus SWITCHING_PROTOCOLS = new HttpResponseStatus(101, "Switching Protocols");
+    public static final HttpResponseStatus SWITCHING_PROTOCOLS =
+            new HttpResponseStatus(101, "Switching Protocols", true);
 
     /**
      * 102 Processing (WebDAV, RFC2518)
      */
-    public static final HttpResponseStatus PROCESSING = new HttpResponseStatus(102, "Processing");
+    public static final HttpResponseStatus PROCESSING = new HttpResponseStatus(102, "Processing", true);
 
     /**
      * 200 OK
      */
-    public static final HttpResponseStatus OK = new HttpResponseStatus(200, "OK");
+    public static final HttpResponseStatus OK = new HttpResponseStatus(200, "OK", true);
 
     /**
      * 201 Created
      */
-    public static final HttpResponseStatus CREATED = new HttpResponseStatus(201, "Created");
+    public static final HttpResponseStatus CREATED = new HttpResponseStatus(201, "Created", true);
 
     /**
      * 202 Accepted
      */
-    public static final HttpResponseStatus ACCEPTED = new HttpResponseStatus(202, "Accepted");
+    public static final HttpResponseStatus ACCEPTED = new HttpResponseStatus(202, "Accepted", true);
 
     /**
      * 203 Non-Authoritative Information (since HTTP/1.1)
      */
     public static final HttpResponseStatus NON_AUTHORITATIVE_INFORMATION =
-            new HttpResponseStatus(203, "Non-Authoritative Information");
+            new HttpResponseStatus(203, "Non-Authoritative Information", true);
 
     /**
      * 204 No Content
      */
-    public static final HttpResponseStatus NO_CONTENT = new HttpResponseStatus(204, "No Content");
+    public static final HttpResponseStatus NO_CONTENT = new HttpResponseStatus(204, "No Content", true);
 
     /**
      * 205 Reset Content
      */
-    public static final HttpResponseStatus RESET_CONTENT = new HttpResponseStatus(205, "Reset Content");
+    public static final HttpResponseStatus RESET_CONTENT = new HttpResponseStatus(205, "Reset Content", true);
 
     /**
      * 206 Partial Content
      */
-    public static final HttpResponseStatus PARTIAL_CONTENT = new HttpResponseStatus(206, "Partial Content");
+    public static final HttpResponseStatus PARTIAL_CONTENT = new HttpResponseStatus(206, "Partial Content", true);
 
     /**
      * 207 Multi-Status (WebDAV, RFC2518)
      */
-    public static final HttpResponseStatus MULTI_STATUS = new HttpResponseStatus(207, "Multi-Status");
+    public static final HttpResponseStatus MULTI_STATUS = new HttpResponseStatus(207, "Multi-Status", true);
 
     /**
      * 300 Multiple Choices
      */
-    public static final HttpResponseStatus MULTIPLE_CHOICES = new HttpResponseStatus(300, "Multiple Choices");
+    public static final HttpResponseStatus MULTIPLE_CHOICES = new HttpResponseStatus(300, "Multiple Choices", true);
 
     /**
      * 301 Moved Permanently
      */
-    public static final HttpResponseStatus MOVED_PERMANENTLY = new HttpResponseStatus(301, "Moved Permanently");
+    public static final HttpResponseStatus MOVED_PERMANENTLY = new HttpResponseStatus(301, "Moved Permanently", true);
 
     /**
      * 302 Found
      */
-    public static final HttpResponseStatus FOUND = new HttpResponseStatus(302, "Found");
+    public static final HttpResponseStatus FOUND = new HttpResponseStatus(302, "Found", true);
 
     /**
      * 303 See Other (since HTTP/1.1)
      */
-    public static final HttpResponseStatus SEE_OTHER = new HttpResponseStatus(303, "See Other");
+    public static final HttpResponseStatus SEE_OTHER = new HttpResponseStatus(303, "See Other", true);
 
     /**
      * 304 Not Modified
      */
-    public static final HttpResponseStatus NOT_MODIFIED = new HttpResponseStatus(304, "Not Modified");
+    public static final HttpResponseStatus NOT_MODIFIED = new HttpResponseStatus(304, "Not Modified", true);
 
     /**
      * 305 Use Proxy (since HTTP/1.1)
      */
-    public static final HttpResponseStatus USE_PROXY = new HttpResponseStatus(305, "Use Proxy");
+    public static final HttpResponseStatus USE_PROXY = new HttpResponseStatus(305, "Use Proxy", true);
 
     /**
      * 307 Temporary Redirect (since HTTP/1.1)
      */
-    public static final HttpResponseStatus TEMPORARY_REDIRECT = new HttpResponseStatus(307, "Temporary Redirect");
+    public static final HttpResponseStatus TEMPORARY_REDIRECT = new HttpResponseStatus(307, "Temporary Redirect", true);
 
     /**
      * 400 Bad Request
      */
-    public static final HttpResponseStatus BAD_REQUEST = new HttpResponseStatus(400, "Bad Request");
+    public static final HttpResponseStatus BAD_REQUEST = new HttpResponseStatus(400, "Bad Request", true);
 
     /**
      * 401 Unauthorized
      */
-    public static final HttpResponseStatus UNAUTHORIZED = new HttpResponseStatus(401, "Unauthorized");
+    public static final HttpResponseStatus UNAUTHORIZED = new HttpResponseStatus(401, "Unauthorized", true);
 
     /**
      * 402 Payment Required
      */
-    public static final HttpResponseStatus PAYMENT_REQUIRED = new HttpResponseStatus(402, "Payment Required");
+    public static final HttpResponseStatus PAYMENT_REQUIRED = new HttpResponseStatus(402, "Payment Required", true);
 
     /**
      * 403 Forbidden
      */
-    public static final HttpResponseStatus FORBIDDEN = new HttpResponseStatus(403, "Forbidden");
+    public static final HttpResponseStatus FORBIDDEN = new HttpResponseStatus(403, "Forbidden", true);
 
     /**
      * 404 Not Found
      */
-    public static final HttpResponseStatus NOT_FOUND = new HttpResponseStatus(404, "Not Found");
+    public static final HttpResponseStatus NOT_FOUND = new HttpResponseStatus(404, "Not Found", true);
 
     /**
      * 405 Method Not Allowed
      */
-    public static final HttpResponseStatus METHOD_NOT_ALLOWED = new HttpResponseStatus(405, "Method Not Allowed");
+    public static final HttpResponseStatus METHOD_NOT_ALLOWED =
+            new HttpResponseStatus(405, "Method Not Allowed", true);
 
     /**
      * 406 Not Acceptable
      */
-    public static final HttpResponseStatus NOT_ACCEPTABLE = new HttpResponseStatus(406, "Not Acceptable");
+    public static final HttpResponseStatus NOT_ACCEPTABLE = new HttpResponseStatus(406, "Not Acceptable", true);
 
     /**
      * 407 Proxy Authentication Required
      */
     public static final HttpResponseStatus PROXY_AUTHENTICATION_REQUIRED =
-            new HttpResponseStatus(407, "Proxy Authentication Required");
+            new HttpResponseStatus(407, "Proxy Authentication Required", true);
 
     /**
      * 408 Request Timeout
      */
-    public static final HttpResponseStatus REQUEST_TIMEOUT = new HttpResponseStatus(408, "Request Timeout");
+    public static final HttpResponseStatus REQUEST_TIMEOUT = new HttpResponseStatus(408, "Request Timeout", true);
 
     /**
      * 409 Conflict
      */
-    public static final HttpResponseStatus CONFLICT = new HttpResponseStatus(409, "Conflict");
+    public static final HttpResponseStatus CONFLICT = new HttpResponseStatus(409, "Conflict", true);
 
     /**
      * 410 Gone
      */
-    public static final HttpResponseStatus GONE = new HttpResponseStatus(410, "Gone");
+    public static final HttpResponseStatus GONE = new HttpResponseStatus(410, "Gone", true);
 
     /**
      * 411 Length Required
      */
-    public static final HttpResponseStatus LENGTH_REQUIRED = new HttpResponseStatus(411, "Length Required");
+    public static final HttpResponseStatus LENGTH_REQUIRED = new HttpResponseStatus(411, "Length Required", true);
 
     /**
      * 412 Precondition Failed
      */
-    public static final HttpResponseStatus PRECONDITION_FAILED = new HttpResponseStatus(412, "Precondition Failed");
+    public static final HttpResponseStatus PRECONDITION_FAILED =
+            new HttpResponseStatus(412, "Precondition Failed", true);
 
     /**
      * 413 Request Entity Too Large
      */
     public static final HttpResponseStatus REQUEST_ENTITY_TOO_LARGE =
-            new HttpResponseStatus(413, "Request Entity Too Large");
+            new HttpResponseStatus(413, "Request Entity Too Large", true);
 
     /**
      * 414 Request-URI Too Long
      */
-    public static final HttpResponseStatus REQUEST_URI_TOO_LONG = new HttpResponseStatus(414, "Request-URI Too Long");
+    public static final HttpResponseStatus REQUEST_URI_TOO_LONG =
+            new HttpResponseStatus(414, "Request-URI Too Long", true);
 
     /**
      * 415 Unsupported Media Type
      */
     public static final HttpResponseStatus UNSUPPORTED_MEDIA_TYPE =
-            new HttpResponseStatus(415, "Unsupported Media Type");
+            new HttpResponseStatus(415, "Unsupported Media Type", true);
 
     /**
      * 416 Requested Range Not Satisfiable
      */
     public static final HttpResponseStatus REQUESTED_RANGE_NOT_SATISFIABLE =
-            new HttpResponseStatus(416, "Requested Range Not Satisfiable");
+            new HttpResponseStatus(416, "Requested Range Not Satisfiable", true);
 
     /**
      * 417 Expectation Failed
      */
-    public static final HttpResponseStatus EXPECTATION_FAILED = new HttpResponseStatus(417, "Expectation Failed");
+    public static final HttpResponseStatus EXPECTATION_FAILED =
+            new HttpResponseStatus(417, "Expectation Failed", true);
 
     /**
      * 422 Unprocessable Entity (WebDAV, RFC4918)
      */
-    public static final HttpResponseStatus UNPROCESSABLE_ENTITY = new HttpResponseStatus(422, "Unprocessable Entity");
+    public static final HttpResponseStatus UNPROCESSABLE_ENTITY =
+            new HttpResponseStatus(422, "Unprocessable Entity", true);
 
     /**
      * 423 Locked (WebDAV, RFC4918)
      */
-    public static final HttpResponseStatus LOCKED = new HttpResponseStatus(423, "Locked");
+    public static final HttpResponseStatus LOCKED = new HttpResponseStatus(423, "Locked", true);
 
     /**
      * 424 Failed Dependency (WebDAV, RFC4918)
      */
-    public static final HttpResponseStatus FAILED_DEPENDENCY = new HttpResponseStatus(424, "Failed Dependency");
+    public static final HttpResponseStatus FAILED_DEPENDENCY =
+            new HttpResponseStatus(424, "Failed Dependency", true);
 
     /**
      * 425 Unordered Collection (WebDAV, RFC3648)
      */
-    public static final HttpResponseStatus UNORDERED_COLLECTION = new HttpResponseStatus(425, "Unordered Collection");
+    public static final HttpResponseStatus UNORDERED_COLLECTION =
+            new HttpResponseStatus(425, "Unordered Collection", true);
 
     /**
      * 426 Upgrade Required (RFC2817)
      */
-    public static final HttpResponseStatus UPGRADE_REQUIRED = new HttpResponseStatus(426, "Upgrade Required");
+    public static final HttpResponseStatus UPGRADE_REQUIRED = new HttpResponseStatus(426, "Upgrade Required", true);
 
     /**
      * 428 Precondition Required (RFC6585)
      */
-    public static final HttpResponseStatus PRECONDITION_REQUIRED = new HttpResponseStatus(428, "Precondition Required");
+    public static final HttpResponseStatus PRECONDITION_REQUIRED =
+            new HttpResponseStatus(428, "Precondition Required", true);
 
     /**
      * 429 Too Many Requests (RFC6585)
      */
-    public static final HttpResponseStatus TOO_MANY_REQUESTS = new HttpResponseStatus(429, "Too Many Requests");
+    public static final HttpResponseStatus TOO_MANY_REQUESTS = new HttpResponseStatus(429, "Too Many Requests", true);
 
     /**
      * 431 Request Header Fields Too Large (RFC6585)
      */
     public static final HttpResponseStatus REQUEST_HEADER_FIELDS_TOO_LARGE =
-            new HttpResponseStatus(431, "Request Header Fields Too Large");
+            new HttpResponseStatus(431, "Request Header Fields Too Large", true);
 
     /**
      * 500 Internal Server Error
      */
     public static final HttpResponseStatus INTERNAL_SERVER_ERROR =
-            new HttpResponseStatus(500, "Internal Server Error");
+            new HttpResponseStatus(500, "Internal Server Error", true);
 
     /**
      * 501 Not Implemented
      */
-    public static final HttpResponseStatus NOT_IMPLEMENTED = new HttpResponseStatus(501, "Not Implemented");
+    public static final HttpResponseStatus NOT_IMPLEMENTED = new HttpResponseStatus(501, "Not Implemented", true);
 
     /**
      * 502 Bad Gateway
      */
-    public static final HttpResponseStatus BAD_GATEWAY = new HttpResponseStatus(502, "Bad Gateway");
+    public static final HttpResponseStatus BAD_GATEWAY = new HttpResponseStatus(502, "Bad Gateway", true);
 
     /**
      * 503 Service Unavailable
      */
-    public static final HttpResponseStatus SERVICE_UNAVAILABLE = new HttpResponseStatus(503, "Service Unavailable");
+    public static final HttpResponseStatus SERVICE_UNAVAILABLE =
+            new HttpResponseStatus(503, "Service Unavailable", true);
 
     /**
      * 504 Gateway Timeout
      */
-    public static final HttpResponseStatus GATEWAY_TIMEOUT = new HttpResponseStatus(504, "Gateway Timeout");
+    public static final HttpResponseStatus GATEWAY_TIMEOUT = new HttpResponseStatus(504, "Gateway Timeout", true);
 
     /**
      * 505 HTTP Version Not Supported
      */
     public static final HttpResponseStatus HTTP_VERSION_NOT_SUPPORTED =
-            new HttpResponseStatus(505, "HTTP Version Not Supported");
+            new HttpResponseStatus(505, "HTTP Version Not Supported", true);
 
     /**
      * 506 Variant Also Negotiates (RFC2295)
      */
     public static final HttpResponseStatus VARIANT_ALSO_NEGOTIATES =
-            new HttpResponseStatus(506, "Variant Also Negotiates");
+            new HttpResponseStatus(506, "Variant Also Negotiates", true);
 
     /**
      * 507 Insufficient Storage (WebDAV, RFC4918)
      */
-    public static final HttpResponseStatus INSUFFICIENT_STORAGE = new HttpResponseStatus(507, "Insufficient Storage");
+    public static final HttpResponseStatus INSUFFICIENT_STORAGE =
+            new HttpResponseStatus(507, "Insufficient Storage", true);
 
     /**
      * 510 Not Extended (RFC2774)
      */
-    public static final HttpResponseStatus NOT_EXTENDED = new HttpResponseStatus(510, "Not Extended");
+    public static final HttpResponseStatus NOT_EXTENDED = new HttpResponseStatus(510, "Not Extended", true);
 
     /**
      * 511 Network Authentication Required (RFC6585)
      */
     public static final HttpResponseStatus NETWORK_AUTHENTICATION_REQUIRED =
-            new HttpResponseStatus(511, "Network Authentication Required");
+            new HttpResponseStatus(511, "Network Authentication Required", true);
 
     /**
      * Returns the {@link HttpResponseStatus} represented by the specified code.
@@ -441,14 +458,18 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
     }
 
     private final int code;
-
     private final String reasonPhrase;
+    private final byte[] encoded;
 
     /**
      * Creates a new instance with the specified {@code code} and its
      * {@code reasonPhrase}.
      */
     public HttpResponseStatus(int code, String reasonPhrase) {
+        this(code, reasonPhrase, false);
+    }
+
+    private HttpResponseStatus(int code, String reasonPhrase, boolean encode) {
         if (code < 0) {
             throw new IllegalArgumentException(
                     "code: " + code + " (expected: 0+)");
@@ -471,6 +492,11 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
 
         this.code = code;
         this.reasonPhrase = reasonPhrase;
+        if (encode) {
+            encoded = (code + " " + reasonPhrase).getBytes(CharsetUtil.US_ASCII);
+        } else {
+            encoded = null;
+        }
     }
 
     /**
@@ -513,5 +539,15 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
         buf.append(' ');
         buf.append(reasonPhrase);
         return buf.toString();
+    }
+
+    void encode(ByteBuf buf) {
+        if (encoded != null) {
+            buf.writeBytes(encoded);
+        } else {
+            ByteBufUtil.writeAscii(buf, String.valueOf(code));
+            buf.writeByte(SP);
+            ByteBufUtil.writeAscii(buf, String.valueOf(reasonPhrase));
+        }
     }
 }


### PR DESCRIPTION
This commit use a pre-encoded byte[] of known HTTP Method/Status/Version as there is not need to do it over and over again. 

@trustin @jpinner @wgallagher please review
