### PR TITLE
IOExceptions caught during a doWrite() should fire in the pipeline

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -639,6 +639,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             } catch (Throwable t) {
                 outboundBuffer.failFlushed(t);
                 if (t instanceof IOException) {
+                    pipeline().fireExceptionCaught(t);
                     close(voidPromise());
                 }
             } finally {


### PR DESCRIPTION
Silently calling close() on the channel here makes debugging a nightmare
