### PR TITLE
Change `#writeBytes` for `String` to use `#getBytes` from String.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
@@ -88,10 +88,7 @@ public class ByteBufOutputStream extends OutputStream implements DataOutput {
 
     @Override
     public void writeBytes(String s) throws IOException {
-        int len = s.length();
-        for (int i = 0; i < len; i ++) {
-            write((byte) s.charAt(i));
-        }
+        write(s.getBytes());
     }
 
     @Override


### PR DESCRIPTION
This may potentially even yield a better performance, especially on direct buffers, since memory region will
be copied. On an on-heap buffers this will be slightly faster, since `arraycpy` is used to copy the array.
