### PR TITLE
[codec-memcache] Avoid memory leak when encoding the key

### DIFF
--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoder.java
@@ -64,7 +64,12 @@ public abstract class BinaryMemcacheEncoder<M extends BinaryMemcacheMessage<H>, 
             return;
         }
 
-        buf.writeBytes(Unpooled.copiedBuffer(key, CharsetUtil.UTF_8));
+        ByteBuf keyBuf = Unpooled.copiedBuffer(key, CharsetUtil.UTF_8);
+        try {
+            buf.writeBytes(keyBuf);
+        } finally {
+            keyBuf.release();
+        }
     }
 
     /**


### PR DESCRIPTION
fixed the other part in my code and this should fix it in the memcache codec
