### PR TITLE
JDKZlibEncoder hangs (fails to flush) on large messages

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -212,8 +212,11 @@ public class JdkZlibEncoder extends ZlibEncoder {
 
         deflater.setInput(inAry);
         while (!deflater.needsInput()) {
-            int numBytes = deflater.deflate(encodeBuf, 0, encodeBuf.length, Deflater.SYNC_FLUSH);
-            out.writeBytes(encodeBuf, 0, numBytes);
+            int numBytes = encodeBuf.length;
+            while (numBytes == encodeBuf.length) {
+                numBytes = deflater.deflate(encodeBuf, 0, encodeBuf.length, Deflater.SYNC_FLUSH);
+                out.writeBytes(encodeBuf, 0, numBytes);
+            }
         }
     }
 


### PR DESCRIPTION
If the message is great than 8k the message is not flushed.
