### PR TITLE
codec-memcache: prefix abstract classes with Abstract.

### DIFF
--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObjectAggregator.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObjectAggregator.java
@@ -27,7 +27,7 @@ import io.netty.handler.codec.memcache.binary.BinaryMemcacheResponseEncoder;
  * and its following {@link MemcacheContent}s into a single {@link MemcacheMessage} with
  * no following {@link MemcacheContent}s.  It is useful when you don't want to take
  * care of memcache messages where the content comes along in chunks. Insert this
- * handler after a MemcacheObjectDecoder in the {@link ChannelPipeline}.
+ * handler after a AbstractMemcacheObjectDecoder in the {@link ChannelPipeline}.
  * <p/>
  * For example, here for the binary protocol:
  * <p/>
@@ -35,13 +35,14 @@ import io.netty.handler.codec.memcache.binary.BinaryMemcacheResponseEncoder;
  * {@link ChannelPipeline} p = ...;
  * ...
  * p.addLast("decoder", new {@link BinaryMemcacheRequestDecoder}());
- * p.addLast("aggregator", <b>new {@link MemcacheObjectAggregator}(1048576)</b>);
+ * p.addLast("aggregator", <b>new {@link io.netty.handler.codec.memcache.binary.BinaryMemcacheObjectAggregator}(1048576)
+ * </b>);
  * ...
  * p.addLast("encoder", new {@link BinaryMemcacheResponseEncoder}());
  * p.addLast("handler", new YourMemcacheRequestHandler());
  * </pre>
  */
-public abstract class MemcacheObjectAggregator extends MessageToMessageDecoder<MemcacheObject> {
+public abstract class AbstractMemcacheObjectAggregator extends MessageToMessageDecoder<MemcacheObject> {
 
     /**
      * Contains the current message that gets aggregated.
@@ -59,7 +60,7 @@ public abstract class MemcacheObjectAggregator extends MessageToMessageDecoder<M
 
     private final int maxContentLength;
 
-    protected MemcacheObjectAggregator(int maxContentLength) {
+    protected AbstractMemcacheObjectAggregator(int maxContentLength) {
         if (maxContentLength <= 0) {
             throw new IllegalArgumentException("maxContentLength must be a positive integer: " + maxContentLength);
         }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObjectDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObjectDecoder.java
@@ -23,5 +23,5 @@ import io.netty.handler.codec.ByteToMessageDecoder;
  * Currently it just acts as a common denominator, but will certainly include methods once the ascii protocol
  * is implemented.
  */
-public abstract class MemcacheObjectDecoder extends ByteToMessageDecoder {
+public abstract class AbstractMemcacheObjectDecoder extends ByteToMessageDecoder {
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObjectEncoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObjectEncoder.java
@@ -25,13 +25,13 @@ import io.netty.util.internal.StringUtil;
 import java.util.List;
 
 /**
- * A general purpose {@link MemcacheObjectEncoder} that encodes {@link MemcacheMessage}s.
+ * A general purpose {@link AbstractMemcacheObjectEncoder} that encodes {@link MemcacheMessage}s.
  * <p/>
  * <p>Note that this class is designed to be extended, especially because both the binary and ascii protocol
  * require different treatment of their messages. Since the content chunk writing is the same for both, the encoder
  * abstracts this right away.</p>
  */
-public abstract class MemcacheObjectEncoder<M extends MemcacheMessage> extends MessageToMessageEncoder<Object> {
+public abstract class AbstractMemcacheObjectEncoder<M extends MemcacheMessage> extends MessageToMessageEncoder<Object> {
 
     private boolean expectingMoreContent;
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheContent.java
@@ -21,10 +21,10 @@ import io.netty.channel.ChannelPipeline;
 /**
  * An Memcache content chunk.
  * <p/>
- * A MemcacheObjectDecoder generates {@link MemcacheContent} after
- * {@link MemcacheMessage} when the content is large. If you prefer not to
- * receive {@link MemcacheContent} in your handler, place a aggregator
- * after MemcacheObjectDecoder in the {@link ChannelPipeline}.
+ * A implementation of a {@link AbstractMemcacheObjectDecoder} generates {@link MemcacheContent} after
+ * {@link MemcacheMessage} when the content is large. If you prefer not to receive {@link MemcacheContent}
+ * in your handler, place a aggregator after an implementation of the {@link AbstractMemcacheObjectDecoder}
+ * in the {@link ChannelPipeline}.
  */
 public interface MemcacheContent extends MemcacheObject, ByteBufHolder {
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder.java
@@ -17,11 +17,11 @@ package io.netty.handler.codec.memcache.binary;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.memcache.AbstractMemcacheObjectDecoder;
 import io.netty.handler.codec.memcache.DefaultLastMemcacheContent;
 import io.netty.handler.codec.memcache.DefaultMemcacheContent;
 import io.netty.handler.codec.memcache.LastMemcacheContent;
 import io.netty.handler.codec.memcache.MemcacheContent;
-import io.netty.handler.codec.memcache.MemcacheObjectDecoder;
 import io.netty.util.CharsetUtil;
 
 import java.util.List;
@@ -33,8 +33,9 @@ import static io.netty.buffer.ByteBufUtil.*;
  * <p/>
  * The difference in the protocols (header) is implemented by the subclasses.
  */
-public abstract class BinaryMemcacheDecoder<M extends BinaryMemcacheMessage<H>, H extends BinaryMemcacheMessageHeader>
-    extends MemcacheObjectDecoder {
+public abstract class AbstractBinaryMemcacheDecoder
+        <M extends BinaryMemcacheMessage<H>, H extends BinaryMemcacheMessageHeader>
+    extends AbstractMemcacheObjectDecoder {
 
     public static final int DEFAULT_MAX_CHUNK_SIZE = 8192;
 
@@ -48,18 +49,18 @@ public abstract class BinaryMemcacheDecoder<M extends BinaryMemcacheMessage<H>, 
     private State state = State.READ_HEADER;
 
     /**
-     * Create a new {@link BinaryMemcacheDecoder} with default settings.
+     * Create a new {@link AbstractBinaryMemcacheDecoder} with default settings.
      */
-    protected BinaryMemcacheDecoder() {
+    protected AbstractBinaryMemcacheDecoder() {
         this(DEFAULT_MAX_CHUNK_SIZE);
     }
 
     /**
-     * Create a new {@link BinaryMemcacheDecoder} with custom settings.
+     * Create a new {@link AbstractBinaryMemcacheDecoder} with custom settings.
      *
      * @param chunkSize the maximum chunk size of the payload.
      */
-    protected BinaryMemcacheDecoder(int chunkSize) {
+    protected AbstractBinaryMemcacheDecoder(int chunkSize) {
         if (chunkSize < 0) {
             throw new IllegalArgumentException("chunkSize must be a positive integer: " + chunkSize);
         }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheEncoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheEncoder.java
@@ -18,14 +18,15 @@ package io.netty.handler.codec.memcache.binary;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
-import io.netty.handler.codec.memcache.MemcacheObjectEncoder;
+import io.netty.handler.codec.memcache.AbstractMemcacheObjectEncoder;
 import io.netty.util.CharsetUtil;
 
 /**
  * A {@link MessageToByteEncoder} that encodes binary memache messages into bytes.
  */
-public abstract class BinaryMemcacheEncoder<M extends BinaryMemcacheMessage<H>, H extends BinaryMemcacheMessageHeader>
-    extends MemcacheObjectEncoder<M> {
+public abstract class AbstractBinaryMemcacheEncoder
+        <M extends BinaryMemcacheMessage<H>, H extends BinaryMemcacheMessageHeader>
+    extends AbstractMemcacheObjectEncoder<M> {
 
     /**
      * Every binary memcache message has at least a 24 bytes header.

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheMessageHeader.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheMessageHeader.java
@@ -18,7 +18,7 @@ package io.netty.handler.codec.memcache.binary;
 /**
  * The default implementation of a {@link BinaryMemcacheMessageHeader}.
  */
-public abstract class DefaultBinaryMemcacheMessageHeader implements BinaryMemcacheMessageHeader {
+public abstract class AbstractBinaryMemcacheMessageHeader implements BinaryMemcacheMessageHeader {
 
     private byte magic;
     private byte opcode;

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheClientCodec.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheClientCodec.java
@@ -45,7 +45,7 @@ public final class BinaryMemcacheClientCodec
      * Create a new {@link BinaryMemcacheClientCodec} with the default settings applied.
      */
     public BinaryMemcacheClientCodec() {
-        this(BinaryMemcacheDecoder.DEFAULT_MAX_CHUNK_SIZE);
+        this(AbstractBinaryMemcacheDecoder.DEFAULT_MAX_CHUNK_SIZE);
     }
 
     /**

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregator.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregator.java
@@ -20,20 +20,20 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.TooLongFrameException;
+import io.netty.handler.codec.memcache.AbstractMemcacheObjectAggregator;
 import io.netty.handler.codec.memcache.FullMemcacheMessage;
 import io.netty.handler.codec.memcache.LastMemcacheContent;
 import io.netty.handler.codec.memcache.MemcacheContent;
 import io.netty.handler.codec.memcache.MemcacheMessage;
 import io.netty.handler.codec.memcache.MemcacheObject;
-import io.netty.handler.codec.memcache.MemcacheObjectAggregator;
 import io.netty.util.ReferenceCountUtil;
 
 import java.util.List;
 
 /**
- * A {@link MemcacheObjectAggregator} for the binary protocol.
+ * A memcache object aggregator for the binary protocol.
  */
-public class BinaryMemcacheObjectAggregator extends MemcacheObjectAggregator {
+public class BinaryMemcacheObjectAggregator extends AbstractMemcacheObjectAggregator {
 
     private boolean tooLongFrameFound;
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequestDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequestDecoder.java
@@ -21,7 +21,7 @@ import io.netty.buffer.ByteBuf;
  * The decoder part which takes care of decoding the request-specific headers.
  */
 public class BinaryMemcacheRequestDecoder
-    extends BinaryMemcacheDecoder<BinaryMemcacheRequest, BinaryMemcacheRequestHeader> {
+    extends AbstractBinaryMemcacheDecoder<BinaryMemcacheRequest, BinaryMemcacheRequestHeader> {
 
     public BinaryMemcacheRequestDecoder() {
         this(DEFAULT_MAX_CHUNK_SIZE);

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequestEncoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequestEncoder.java
@@ -21,7 +21,7 @@ import io.netty.buffer.ByteBuf;
  * The encoder part which takes care of encoding the request headers.
  */
 public class BinaryMemcacheRequestEncoder
-    extends BinaryMemcacheEncoder<BinaryMemcacheRequest, BinaryMemcacheRequestHeader> {
+    extends AbstractBinaryMemcacheEncoder<BinaryMemcacheRequest, BinaryMemcacheRequestHeader> {
 
     @Override
     protected void encodeHeader(ByteBuf buf, BinaryMemcacheRequestHeader header) {

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponseDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponseDecoder.java
@@ -21,7 +21,7 @@ import io.netty.buffer.ByteBuf;
  * The decoder which takes care of decoding the response headers.
  */
 public class BinaryMemcacheResponseDecoder
-    extends BinaryMemcacheDecoder<BinaryMemcacheResponse, BinaryMemcacheResponseHeader> {
+    extends AbstractBinaryMemcacheDecoder<BinaryMemcacheResponse, BinaryMemcacheResponseHeader> {
 
     public BinaryMemcacheResponseDecoder() {
         this(DEFAULT_MAX_CHUNK_SIZE);

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponseEncoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponseEncoder.java
@@ -21,7 +21,7 @@ import io.netty.buffer.ByteBuf;
  * The encoder which takes care of encoding the response headers.
  */
 public class BinaryMemcacheResponseEncoder
-    extends BinaryMemcacheEncoder<BinaryMemcacheResponse, BinaryMemcacheResponseHeader> {
+    extends AbstractBinaryMemcacheEncoder<BinaryMemcacheResponse, BinaryMemcacheResponseHeader> {
 
     @Override
     protected void encodeHeader(ByteBuf buf, BinaryMemcacheResponseHeader header) {

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheServerCodec.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheServerCodec.java
@@ -27,7 +27,7 @@ import io.netty.channel.ChannelHandlerAppender;
 public class BinaryMemcacheServerCodec extends ChannelHandlerAppender {
 
     public BinaryMemcacheServerCodec() {
-        this(BinaryMemcacheDecoder.DEFAULT_MAX_CHUNK_SIZE);
+        this(AbstractBinaryMemcacheDecoder.DEFAULT_MAX_CHUNK_SIZE);
     }
 
     public BinaryMemcacheServerCodec(int decodeChunkSize) {

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheRequestHeader.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheRequestHeader.java
@@ -18,7 +18,7 @@ package io.netty.handler.codec.memcache.binary;
 /**
  * The default implementation of a {@link BinaryMemcacheRequestHeader}.
  */
-public class DefaultBinaryMemcacheRequestHeader extends DefaultBinaryMemcacheMessageHeader
+public class DefaultBinaryMemcacheRequestHeader extends AbstractBinaryMemcacheMessageHeader
     implements BinaryMemcacheRequestHeader {
 
     /**

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheResponseHeader.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheResponseHeader.java
@@ -18,7 +18,7 @@ package io.netty.handler.codec.memcache.binary;
 /**
  * The default implementation of a {@link BinaryMemcacheResponseHeader}.
  */
-public class DefaultBinaryMemcacheResponseHeader extends DefaultBinaryMemcacheMessageHeader
+public class DefaultBinaryMemcacheResponseHeader extends AbstractBinaryMemcacheMessageHeader
     implements BinaryMemcacheResponseHeader {
 
     /**

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheDecoderTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheDecoderTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
 /**
- * Verifies the correct functionality of the {@link BinaryMemcacheDecoder}.
+ * Verifies the correct functionality of the {@link AbstractBinaryMemcacheDecoder}.
  * <p/>
  * While technically there are both a {@link BinaryMemcacheRequestDecoder} and a {@link BinaryMemcacheResponseDecoder}
  * they implement the same basics and just differ in the type of headers returned.

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.*;
 
 /**
- * Verifies the correct functionality of the {@link BinaryMemcacheEncoder}.
+ * Verifies the correct functionality of the {@link AbstractBinaryMemcacheEncoder}.
  */
 public class BinaryMemcacheEncoderTest {
 


### PR DESCRIPTION
I found that some classes were not properly prefixed with abstract, following along with the style.
