### PR TITLE
added maven version 3.1.1 to requireMavenVersion in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
                   <version>[1.7.0,)</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
-                  <version>[3.0.5,3.1)</version>
+                  <version>[3.0.5,3.1.1]</version>
                 </requireMavenVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
Is there a reason why 3.1.1 is not supported? The tests seem to pass.
