### PR TITLE
Exposing ChannelOutboundBuffer.totalPendingSize 

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -594,9 +594,9 @@ public final class ChannelOutboundBuffer {
 
         RECYCLER.recycle(this, handle);
     }
-    
-    public long totalPendingWriteSize() {
-    	return this.totalPendingSize;
+
+    public long totalPendingWriteBytes() {
+        return this.totalPendingSize;
     }
 
     private static final class Entry {


### PR DESCRIPTION
Channel.isWritable sometimes gives too few information about current channel (write) state,  
total pending write size is more descriptive and may use to create batch (write) heuristic. 
