### PR TITLE
Replaced depreciated 'sendUnsupportedWebSocketVersionResponse()'

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -60,7 +60,7 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelHandlerAdapter {
                 getWebSocketLocation(ctx.pipeline(), req, websocketPath), subprotocols, allowExtensions);
         final WebSocketServerHandshaker handshaker = wsFactory.newHandshaker(req);
         if (handshaker == null) {
-            WebSocketServerHandshakerFactory.sendUnsupportedWebSocketVersionResponse(ctx.channel());
+            WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ctx.channel());
         } else {
             final ChannelFuture handshakeFuture = handshaker.handshake(ctx.channel(), req);
             handshakeFuture.addListener(new ChannelFutureListener() {

--- a/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/server/WebSocketServerHandler.java
@@ -101,7 +101,7 @@ public class WebSocketServerHandler extends SimpleChannelInboundHandler<Object> 
                 getWebSocketLocation(req), null, false);
         handshaker = wsFactory.newHandshaker(req);
         if (handshaker == null) {
-            WebSocketServerHandshakerFactory.sendUnsupportedWebSocketVersionResponse(ctx.channel());
+            WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ctx.channel());
         } else {
             handshaker.handshake(ctx.channel(), req);
         }

--- a/example/src/main/java/io/netty/example/http/websocketx/sslserver/WebSocketSslServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/sslserver/WebSocketSslServerHandler.java
@@ -98,7 +98,7 @@ public class WebSocketSslServerHandler extends SimpleChannelInboundHandler<Objec
                 getWebSocketLocation(req), null, false);
         handshaker = wsFactory.newHandshaker(req);
         if (handshaker == null) {
-            WebSocketServerHandshakerFactory.sendUnsupportedWebSocketVersionResponse(ctx.channel());
+            WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ctx.channel());
         } else {
             handshaker.handshake(ctx.channel(), req);
         }

--- a/testsuite/src/test/java/io/netty/testsuite/websockets/autobahn/AutobahnServerHandler.java
+++ b/testsuite/src/test/java/io/netty/testsuite/websockets/autobahn/AutobahnServerHandler.java
@@ -87,7 +87,7 @@ public class AutobahnServerHandler extends ChannelHandlerAdapter {
                 getWebSocketLocation(req), null, false, Integer.MAX_VALUE);
         handshaker = wsFactory.newHandshaker(req);
         if (handshaker == null) {
-            WebSocketServerHandshakerFactory.sendUnsupportedWebSocketVersionResponse(ctx.channel());
+            WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ctx.channel());
         } else {
             handshaker.handshake(ctx.channel(), req);
         }


### PR DESCRIPTION
Replaced depreciated 'sendUnsupportedWebSocketVersionResponse()' with 'sendUnsupportedVersionResponse()'
