### PR TITLE
ChunkedInput to support HTTP chunked transfer encoding - Take #2

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpChunkedInput.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpChunkedInput.java
@@ -33,13 +33,13 @@ import io.netty.handler.stream.ChunkedInput;
  *     response.headers().set(TRANSFER_ENCODING, CHUNKED);
  *     ctx.write(response);
  *
- *     HttpContentChunkedInput httpChunkWriter = new HttpContentChunkedInput(
+ *     HttpContentChunkedInput httpChunkWriter = new HttpChunkedInput(
  *         new ChunkedFile(&quot;/tmp/myfile.txt&quot;));
  *     ChannelFuture sendFileFuture = ctx.write(httpChunkWriter);
  * }
  * </pre>
  */
-public class HttpContentChunkedInput implements ChunkedInput<HttpContent> {
+public class HttpChunkedInput implements ChunkedInput<HttpContent> {
 
     private ChunkedInput<ByteBuf> input;
     private boolean sentLastChunk;
@@ -49,7 +49,7 @@ public class HttpContentChunkedInput implements ChunkedInput<HttpContent> {
      * Creates a new instance using the specified input.
      * @param input {@link ChunkedInput} containing data to write
      */
-    public HttpContentChunkedInput(ChunkedInput<ByteBuf> input) {
+    public HttpChunkedInput(ChunkedInput<ByteBuf> input) {
         this.input = input;
         this.lastHttpContent = LastHttpContent.EMPTY_LAST_CONTENT;
     }
@@ -61,7 +61,7 @@ public class HttpContentChunkedInput implements ChunkedInput<HttpContent> {
      * @param lastHttpContent {@link LastHttpContent} that will be written as the terminating chunk. Use this for
      *            training headers.
      */
-    public HttpContentChunkedInput(ChunkedInput<ByteBuf> input, LastHttpContent lastHttpContent) {
+    public HttpChunkedInput(ChunkedInput<ByteBuf> input, LastHttpContent lastHttpContent) {
         this.input = input;
         this.lastHttpContent = lastHttpContent;
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpChunkedInputTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpChunkedInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2014 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -34,7 +34,7 @@ import java.nio.channels.Channels;
 
 import org.junit.Test;
 
-public class HttpContentChunkedInputTest {
+public class HttpChunkedInputTest {
     private static final byte[] BYTES = new byte[1024 * 64];
     private static final File TMP;
 
@@ -65,22 +65,22 @@ public class HttpContentChunkedInputTest {
 
     @Test
     public void testChunkedStream() {
-        check(new HttpContentChunkedInput(new ChunkedStream(new ByteArrayInputStream(BYTES))));
+        check(new HttpChunkedInput(new ChunkedStream(new ByteArrayInputStream(BYTES))));
     }
 
     @Test
     public void testChunkedNioStream() {
-        check(new HttpContentChunkedInput(new ChunkedNioStream(Channels.newChannel(new ByteArrayInputStream(BYTES)))));
+        check(new HttpChunkedInput(new ChunkedNioStream(Channels.newChannel(new ByteArrayInputStream(BYTES)))));
     }
 
     @Test
     public void testChunkedFile() throws IOException {
-        check(new HttpContentChunkedInput(new ChunkedFile(TMP)));
+        check(new HttpChunkedInput(new ChunkedFile(TMP)));
     }
 
     @Test
     public void testChunkedNioFile() throws IOException {
-        check(new HttpContentChunkedInput(new ChunkedNioFile(TMP)));
+        check(new HttpChunkedInput(new ChunkedNioFile(TMP)));
     }
 
     private static void check(ChunkedInput<?>... inputs) {
@@ -101,7 +101,7 @@ public class HttpContentChunkedInputTest {
                 break;
             } else {
                 if (lastHttpContent != null) {
-                    assertTrue("Last chunk must be DefaultHttpContent", lastHttpContent instanceof DefaultHttpContent);
+                    assertTrue("Chunk must be DefaultHttpContent", lastHttpContent instanceof DefaultHttpContent);
                 }
             }
 
@@ -120,6 +120,6 @@ public class HttpContentChunkedInputTest {
         }
 
         assertEquals(BYTES.length * inputs.length, read);
-        assertTrue("Last chunk must be DefaultLastHttpContent", lastHttpContent instanceof DefaultLastHttpContent);
+        assertTrue("Last chunk must be DefaultLastHttpContent", lastHttpContent == LastHttpContent.EMPTY_LAST_CONTENT);
     }
 }


### PR DESCRIPTION
io.netty.handler.stream.ChunkedFile writes raw binary data and does not support HTTP chunked transfer encoding (see http://en.wikipedia.org/wiki/Chunked_transfer_encoding).

Implemented as proposed by @normanmaurer: HttpContentChunkInput(ChunkedInput<ByteBuf> input)
