### PR TITLE
+= won't let compile optimize String concats

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -559,13 +559,16 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
                             .size() - 2);
                     // remove past size
                     globalBodySize -= pastAttribute.size();
-                    StringBuilder replacement = new StringBuilder().append(HttpPostBodyUtil.CONTENT_DISPOSITION).append(": ").append(HttpPostBodyUtil.FORM_DATA)
-                            .append("; ").append(HttpPostBodyUtil.NAME).append("=\"").append(fileUpload.getName()).append("\"\r\n");
-                    replacement.append(HttpHeaders.Names.CONTENT_TYPE).append(": ").append(HttpPostBodyUtil.MULTIPART_MIXED).append("; ")
-                            .append(HttpHeaders.Values.BOUNDARY).append('=').append(multipartMixedBoundary).append("\r\n\r\n");
+                    StringBuilder replacement = new StringBuilder().append(HttpPostBodyUtil.CONTENT_DISPOSITION)
+                            .append(": ").append(HttpPostBodyUtil.FORM_DATA).append("; ").append(HttpPostBodyUtil.NAME)
+                            .append("=\"").append(fileUpload.getName()).append("\"\r\n");
+                    replacement.append(HttpHeaders.Names.CONTENT_TYPE).append(": ")
+                            .append(HttpPostBodyUtil.MULTIPART_MIXED).append("; ").append(HttpHeaders.Values.BOUNDARY)
+                            .append('=').append(multipartMixedBoundary).append("\r\n\r\n");
                     replacement.append("--").append(multipartMixedBoundary).append("\r\n");
-                    replacement.append(HttpPostBodyUtil.CONTENT_DISPOSITION).append(": ").append(HttpPostBodyUtil.FILE).append("; ")
-                            .append(HttpPostBodyUtil.FILENAME).append("=\"").append(fileUpload.getFilename()).append("\"\r\n");
+                    replacement.append(HttpPostBodyUtil.CONTENT_DISPOSITION).append(": ").append(HttpPostBodyUtil.FILE)
+                            .append("; ").append(HttpPostBodyUtil.FILENAME).append("=\"")
+                            .append(fileUpload.getFilename()).append("\"\r\n");
                     pastAttribute.setValue(replacement.toString(), 1);
                     // update past size
                     globalBodySize += pastAttribute.size();


### PR DESCRIPTION
I think this is sufficient and the compiler optimizes the other single line string concatenations, right? 
