### PR TITLE
fix grouping for isActive - socket.isBound is almost always true

### DIFF
--- a/transport/src/main/java/io/netty/channel/socket/oio/OioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioDatagramChannel.java
@@ -127,7 +127,8 @@ public final class OioDatagramChannel extends AbstractOioMessageChannel implemen
     @Override
     public boolean isActive() {
         return isOpen()
-            && ((config.getOption(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION) && isRegistered()) || socket.isBound());
+            && ((config.getOption(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION) && isRegistered())
+                 || socket.isBound());
     }
 
     @Override


### PR DESCRIPTION
This change restores firing the channel's inactive event. That event is meant to fire when the channel transitions from active to not active, but from the [JDK documentation for DatagramSockets for 'isBound'](http://download.java.net/jdk7/archive/b123/docs/api/java/net/DatagramSocket.html#isBound%28%29):

> Returns the binding state of the socket.
> If the socket was bound prior to being closed, then this method will continue to return true after the socket is closed.

So, once bound, the channel is always active - even if it's been closed and/or disconnected. The `|| socket.isBound()` was overriding the first part of that expression. Added some parentheses to fix grouping in the boolean expression.
