### PR TITLE
Fix fileChannel not closed, preventing delete to occur correctly (see #2142) Netty V4.0

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -225,6 +225,14 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
 
     @Override
     public void delete() {
+        if (fileChannel != null) {
+            try {
+                fileChannel.force(false);
+                fileChannel.close();
+            } catch (IOException e) { //ignore
+            }
+            fileChannel = null;
+        }
         if (! isRenamed) {
             if (file != null && file.exists()) {
                 file.delete();


### PR DESCRIPTION
Related to issue #2142
