### PR TITLE
Fix fileChannel not closed, preventing delete to occur correctly (see #2142) Netty V3.9

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -210,6 +210,14 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
     }
 
     public void delete() {
+        if (fileChannel != null) {
+            try {
+                fileChannel.force(false);
+                fileChannel.close();
+            } catch (IOException e) { //ignore
+            }
+            fileChannel = null;
+        }
         if (! isRenamed) {
             if (file != null && file.exists()) {
                 file.delete();


### PR DESCRIPTION
Related to issue #2142
