### PR TITLE
simple example for a memcache client

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -51,6 +51,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-memcache</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-socks</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/example/src/main/java/io/netty/example/memcache/MemcacheClient.java
+++ b/example/src/main/java/io/netty/example/memcache/MemcacheClient.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.memcache;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.memcache.binary.BinaryMemcacheClientCodec;
+import io.netty.handler.codec.memcache.binary.BinaryMemcacheObjectAggregator;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+/**
+ * Simple memcache client that demonstrates get and set commands against a memcache server.
+ */
+public class MemcacheClient {
+
+    private final String host;
+    private final int port;
+
+    public MemcacheClient(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public void run() throws Exception {
+        EventLoopGroup group = new NioEventLoopGroup();
+        try {
+            Bootstrap b = new Bootstrap();
+            b.group(group)
+                    .channel(NioSocketChannel.class)
+                    .handler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        protected void initChannel(SocketChannel ch) throws Exception {
+                            ChannelPipeline p = ch.pipeline();
+                            p.addLast(new BinaryMemcacheClientCodec());
+                            p.addLast(new BinaryMemcacheObjectAggregator(5000));
+                            p.addLast(new MemcacheClientHandler());
+                        }
+                    });
+
+            // Start the connection attempt.
+            Channel ch = b.connect(host, port).sync().channel();
+
+            // Read commands from the stdin.
+            System.out.println("Enter commands (quit to end)");
+            System.out.println("get <key>");
+            System.out.println("set <key> <value>");
+            ChannelFuture lastWriteFuture = null;
+            BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+            for (;;) {
+                String line = in.readLine();
+                if (line == null) {
+                    break;
+                }
+                if ("quit".equals(line.toLowerCase())) {
+                    ch.close();
+                    ch.closeFuture().sync();
+                    break;
+                }
+                // Sends the received line to the server.
+                lastWriteFuture = ch.writeAndFlush(line);
+            }
+
+            // Wait until all messages are flushed before closing the channel.
+            if (lastWriteFuture != null) {
+                lastWriteFuture.sync();
+            }
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        // Print usage if no argument is specified.
+        if (args.length != 2) {
+            System.err.println(
+                    "Usage: " + MemcacheClient.class.getSimpleName() +
+                            " <host> <port>");
+            return;
+        }
+
+        // Parse options.
+        String host = args[0];
+        int port = Integer.parseInt(args[1]);
+
+        new MemcacheClient(host, port).run();
+    }
+}

--- a/example/src/main/java/io/netty/example/memcache/MemcacheClientHandler.java
+++ b/example/src/main/java/io/netty/example/memcache/MemcacheClientHandler.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.memcache;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.memcache.binary.BinaryMemcacheRequestHeader;
+import io.netty.handler.codec.memcache.binary.DefaultBinaryMemcacheRequestHeader;
+import io.netty.handler.codec.memcache.binary.DefaultFullBinaryMemcacheRequest;
+import io.netty.handler.codec.memcache.binary.FullBinaryMemcacheRequest;
+import io.netty.handler.codec.memcache.binary.FullBinaryMemcacheResponse;
+
+import java.nio.charset.Charset;
+
+public class MemcacheClientHandler extends ChannelHandlerAdapter {
+
+    /**
+     * Transforms basic string requests to binary memcache requests
+     */
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        String command = (String) msg;
+        if (command.startsWith("get ")) {
+            String key = command.substring("get ".length());
+            BinaryMemcacheRequestHeader header = new DefaultBinaryMemcacheRequestHeader();
+            header.setKeyLength((short) key.length());
+            header.setTotalBodyLength(key.length());
+
+            FullBinaryMemcacheRequest req = new DefaultFullBinaryMemcacheRequest(header, key, null);
+            super.write(ctx, req, promise);
+        } else if (command.startsWith("set ")) {
+            String[] parts = command.split(" ", 3);
+            String key = parts[1];
+            String value = parts[2];
+
+            BinaryMemcacheRequestHeader header = new DefaultBinaryMemcacheRequestHeader();
+
+            header.setOpcode((byte) 1);
+            header.setKeyLength((short) key.length());
+            header.setExtrasLength((byte) 8);
+            header.setTotalBodyLength(key.length() + 8 + value.length());
+
+            ByteBuf content = Unpooled.wrappedBuffer(value.getBytes());
+            ByteBuf extras = Unpooled.buffer(8, 8);
+            extras.writeInt(0);
+            extras.writeInt(0);
+            FullBinaryMemcacheRequest req = new DefaultFullBinaryMemcacheRequest(header, key, extras, content);
+            super.write(ctx, req, promise);
+        } else {
+            throw new IllegalStateException("unknown msg");
+        }
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        FullBinaryMemcacheResponse res = (FullBinaryMemcacheResponse) msg;
+        System.out.println(res.content().toString(Charset.defaultCharset()));
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        cause.printStackTrace();
+        ctx.close();
+    }
+}


### PR DESCRIPTION
This is a simple example of a memcache client that utilizes the binary memcache codec
