### PR TITLE
Do not flush cancelled writes.

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -385,6 +385,12 @@ public final class ChannelOutboundBuffer {
             }
 
             Entry entry = buffer[i];
+            // skip cancelled entries
+            if (entry.promise.isCancelled()) {
+                remove();
+                continue;
+            }
+
             ByteBuf buf = (ByteBuf) m;
             final int readerIndex = buf.readerIndex();
             final int readableBytes = buf.writerIndex() - readerIndex;


### PR DESCRIPTION
My experience with Netty is pretty limited, so I'm not sure if this is an issue or not. The fact is that the following lines will result in an actual channel write when I expected none:

```
        ChannelHandlerContext ctx = ...
        ByteBuf out = ...
        ctx.write(out).cancel(false);
        ctx.flush();
```

A thorough example can be found [here](https://gist.github.com/xfrag/8859329#file-nettywritecanceltest-java). Were there any plans to support such use cases in Netty? Looks like my changes don't break anything, the project compiles with all tests passed.

Thanks
