### PR TITLE
Same fix for Netty 3.9 than from #2081

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -436,7 +436,7 @@ public class HttpPostRequestEncoder implements ChunkedInput {
          *              currentFileUpload = data
          *              duringMixedMode = false;
          *      else
-         *          if (currentFileUpload.name == data.name && not HTML5 mode)
+         *          if (currentFileUpload.name == data.name && !EncoderMode.HTML5)
          *              change multipart body header of previous file into multipart list to
          *                      mixedmultipart start, mixedmultipart body header
          *              add mixedmultipart delimiter, mixedmultipart body header and Data to multipart list


### PR DESCRIPTION
 Allow an HTML5 encoder mode for HttpPostRequestEncoder #2081

Was simpler in Netty 3.9 since ATTACHMENT was already there.
Note: IMHO, I believe we should keep in Decoder the FILE or ATTACHMENT decoding capability, since there is no issue to allow both, but could be for some to only allow one (even if FILE is not "standard").
