### PR TITLE
[microbench] Update JMH to 0.3.2

### DIFF
--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
-      <version>0.2.1</version>
+      <version>0.3.2</version>
     </dependency>
   </dependencies>
 

--- a/microbench/src/test/java/io/netty/microbench/util/AbstractMicrobenchmark.java
+++ b/microbench/src/test/java/io/netty/microbench/util/AbstractMicrobenchmark.java
@@ -27,6 +27,7 @@ import org.openjdk.jmh.output.results.ResultFormatType;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
 
 import java.io.File;
 
@@ -43,10 +44,12 @@ public class AbstractMicrobenchmark {
     protected static final int DEFAULT_MEASURE_ITERATIONS = 1;
     protected static final int DEFAULT_FORKS = 2;
 
-    protected static final String JVM_ARGS = "-server -dsa -da -ea:io.netty... -Xms768m" +
-        " -Xmx768m -XX:MaxDirectMemorySize=768m -XX:+AggressiveOpts -XX:+UseBiasedLocking" +
-        " -XX:+UseFastAccessorMethods -XX:+UseStringCache -XX:+OptimizeStringConcat" +
-        " -XX:+HeapDumpOnOutOfMemoryError -Dio.netty.noResourceLeakDetection";
+    protected static final String[] JVM_ARGS = new String[] {
+        "-server", "-dsa", "-da", "-ea:io.netty...", "-Xms768m", "-Xmx768m",
+        "-XX:MaxDirectMemorySize=768m", "-XX:+AggressiveOpts", "-XX:+UseBiasedLocking",
+        "-XX:+UseFastAccessorMethods", "-XX:+UseStringCache", "-XX:+OptimizeStringConcat",
+        "-XX:+HeapDumpOnOutOfMemoryError", "-Dio.netty.noResourceLeakDetection"
+    };
 
     static {
         ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.DISABLED);


### PR DESCRIPTION
This PR updates JMH and also fixes the list of JVM args that are now expected as an array.
