### PR TITLE
[codec-memcache] Always upstream full memcache messages.

### DIFF
--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequestDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequestDecoder.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.memcache.binary;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 /**
  * The decoder part which takes care of decoding the request-specific headers.
@@ -51,4 +52,12 @@ public class BinaryMemcacheRequestDecoder
         return new DefaultBinaryMemcacheRequest(header, key, extras);
     }
 
+    @Override
+    protected BinaryMemcacheRequest buildInvalidMessage() {
+        return new DefaultBinaryMemcacheRequest(
+            new DefaultBinaryMemcacheRequestHeader(),
+            "",
+            Unpooled.EMPTY_BUFFER
+        );
+    }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponseDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponseDecoder.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.memcache.binary;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 /**
  * The decoder which takes care of decoding the response headers.
@@ -51,4 +52,12 @@ public class BinaryMemcacheResponseDecoder
         return new DefaultBinaryMemcacheResponse(header, key, extras);
     }
 
+    @Override
+    protected BinaryMemcacheResponse buildInvalidMessage() {
+        return new DefaultBinaryMemcacheResponse(
+            new DefaultBinaryMemcacheResponseHeader(),
+            "",
+            Unpooled.EMPTY_BUFFER
+        );
+    }
 }


### PR DESCRIPTION
This changeset is related to #2182, which exposes the failure in
the http codec, but the memcache codec works very similar. In addition,
better failure handling in the decoder has been added.
