### PR TITLE
[microbench] Upgrade JMH to 0.4.1 and make use of @Params.

### DIFF
--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
-      <version>0.3.2</version>
+      <version>0.4.1</version>
     </dependency>
   </dependencies>
 

--- a/microbench/src/test/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
+++ b/microbench/src/test/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
@@ -21,6 +21,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.microbench.util.AbstractMicrobenchmark;
 import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
+import org.openjdk.jmh.annotations.Param;
 
 /**
  * This class benchmarks different allocators with different allocation sizes.
@@ -32,147 +33,31 @@ public class ByteBufAllocatorBenchmark extends AbstractMicrobenchmark {
     private final ByteBufAllocator pooledHeapAllocator = new PooledByteBufAllocator(false);
     private final ByteBufAllocator pooledDirectAllocator = new PooledByteBufAllocator(true);
 
+    @Param({ "00000", "00256", "01024", "04096", "16384", "65536" })
+    public int size;
+
     @GenerateMicroBenchmark
-    public void unpooledHeapAllocAndFree_1_0() {
-        ByteBuf buffer = unpooledHeapAllocator.buffer(0);
+    public void unpooledHeapAllocAndFree() {
+        ByteBuf buffer = unpooledHeapAllocator.buffer(size);
         buffer.release();
     }
 
     @GenerateMicroBenchmark
-    public void unpooledHeapAllocAndFree_2_256() {
-        ByteBuf buffer = unpooledHeapAllocator.buffer(256);
+    public void unpooledDirectAllocAndFree() {
+        ByteBuf buffer = unpooledDirectAllocator.buffer(size);
         buffer.release();
     }
 
     @GenerateMicroBenchmark
-    public void unpooledHeapAllocAndFree_3_1024() {
-        ByteBuf buffer = unpooledHeapAllocator.buffer(1024);
+    public void pooledHeapAllocAndFree() {
+        ByteBuf buffer = pooledHeapAllocator.buffer(size);
         buffer.release();
     }
 
     @GenerateMicroBenchmark
-    public void unpooledHeapAllocAndFree_4_4096() {
-        ByteBuf buffer = unpooledHeapAllocator.buffer(4096);
+    public void pooledDirectAllocAndFree() {
+        ByteBuf buffer = pooledDirectAllocator.buffer(size);
         buffer.release();
     }
 
-    @GenerateMicroBenchmark
-    public void unpooledHeapAllocAndFree_5_16384() {
-        ByteBuf buffer = unpooledHeapAllocator.buffer(16384);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void unpooledHeapAllocAndFree_6_65536() {
-        ByteBuf buffer = unpooledHeapAllocator.buffer(65536);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void unpooledDirectAllocAndFree_1_0() {
-        ByteBuf buffer = unpooledDirectAllocator.buffer(0);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void unpooledDirectAllocAndFree_2_256() {
-        ByteBuf buffer = unpooledDirectAllocator.buffer(256);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void unpooledDirectAllocAndFree_3_1024() {
-        ByteBuf buffer = unpooledDirectAllocator.buffer(1024);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void unpooledDirectAllocAndFree_4_4096() {
-        ByteBuf buffer = unpooledDirectAllocator.buffer(4096);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void unpooledDirectAllocAndFree_5_16384() {
-        ByteBuf buffer = unpooledDirectAllocator.buffer(16384);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void unpooledDirectAllocAndFree_6_65536() {
-        ByteBuf buffer = unpooledDirectAllocator.buffer(65536);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void pooledHeapAllocAndFree_1_0() {
-        ByteBuf buffer = pooledHeapAllocator.buffer(0);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void pooledHeapAllocAndFree_2_256() {
-        ByteBuf buffer = pooledHeapAllocator.buffer(256);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void pooledHeapAllocAndFree_3_1024() {
-        ByteBuf buffer = pooledHeapAllocator.buffer(1024);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void pooledHeapAllocAndFree_4_4096() {
-        ByteBuf buffer = pooledHeapAllocator.buffer(4096);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void pooledHeapAllocAndFree_5_16384() {
-        ByteBuf buffer = pooledHeapAllocator.buffer(16384);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void pooledHeapAllocAndFree_6_65536() {
-        ByteBuf buffer = pooledHeapAllocator.buffer(65536);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void pooledDirectAllocAndFree_1_0() {
-        ByteBuf buffer = pooledDirectAllocator.buffer(0);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void pooledDirectAllocAndFree_2_256() {
-        ByteBuf buffer = pooledDirectAllocator.buffer(256);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void pooledDirectAllocAndFree_3_1024() {
-        ByteBuf buffer = pooledDirectAllocator.buffer(1024);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void pooledDirectAllocAndFree_4_4096() {
-        ByteBuf buffer = pooledDirectAllocator.buffer(4096);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void pooledDirectAllocAndFree_5_16384() {
-        ByteBuf buffer = pooledDirectAllocator.buffer(16384);
-        buffer.release();
-    }
-
-    @GenerateMicroBenchmark
-    public void pooledDirectAllocAndFree_6_65536() {
-        ByteBuf buffer = pooledDirectAllocator.buffer(65536);
-        buffer.release();
-    }
 }

--- a/microbench/src/test/java/io/netty/microbench/util/AbstractMicrobenchmark.java
+++ b/microbench/src/test/java/io/netty/microbench/util/AbstractMicrobenchmark.java
@@ -41,7 +41,7 @@ import java.io.File;
 public class AbstractMicrobenchmark {
 
     protected static final int DEFAULT_WARMUP_ITERATIONS = 10;
-    protected static final int DEFAULT_MEASURE_ITERATIONS = 1;
+    protected static final int DEFAULT_MEASURE_ITERATIONS = 10;
     protected static final int DEFAULT_FORKS = 2;
 
     protected static final String[] JVM_ARGS = new String[] {


### PR DESCRIPTION
I dont want to upgrade all the time, but we got @Params support which makes it look so much nicer :)

```
Benchmark                                                      (size)   Mode   Samples         Mean   Mean error    Units
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree      00000  thrpt         2    12306.120          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree      00256  thrpt         2    10978.065          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree      01024  thrpt         2     9669.683          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree      04096  thrpt         2     6535.983          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree      16384  thrpt         2     6732.000          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree      65536  thrpt         2     6714.374          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledHeapAllocAndFree        00000  thrpt         2    11720.884          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledHeapAllocAndFree        00256  thrpt         2    10056.961          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledHeapAllocAndFree        01024  thrpt         2     8544.572          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledHeapAllocAndFree        04096  thrpt         2     6446.857          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledHeapAllocAndFree        16384  thrpt         2     6633.493          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledHeapAllocAndFree        65536  thrpt         2     6433.788          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.unpooledDirectAllocAndFree    00000  thrpt         2     2200.349          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.unpooledDirectAllocAndFree    00256  thrpt         2     1827.377          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.unpooledDirectAllocAndFree    01024  thrpt         2     1992.389          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.unpooledDirectAllocAndFree    04096  thrpt         2     1606.827          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.unpooledDirectAllocAndFree    16384  thrpt         2      868.110          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.unpooledDirectAllocAndFree    65536  thrpt         2      284.873          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.unpooledHeapAllocAndFree      00000  thrpt         2    33790.695          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.unpooledHeapAllocAndFree      00256  thrpt         2    20015.072          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.unpooledHeapAllocAndFree      01024  thrpt         2     6268.291          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.unpooledHeapAllocAndFree      04096  thrpt         2     2836.629          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.unpooledHeapAllocAndFree      16384  thrpt         2     1072.343          NaN   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.unpooledHeapAllocAndFree      65536  thrpt         2      274.864          NaN   ops/ms
```
