### PR TITLE
Apply receive timeout to commPort when using RxtxChannel.

### DIFF
--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannel.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannel.java
@@ -66,7 +66,7 @@ public class RxtxChannel extends OioByteStreamChannel {
         RxtxDeviceAddress remote = (RxtxDeviceAddress) remoteAddress;
         final CommPortIdentifier cpi = CommPortIdentifier.getPortIdentifier(remote.value());
         final CommPort commPort = cpi.open(getClass().getName(), 1000);
-
+        commPort.enableReceiveTimeout(config().getOption(READ_TIMEOUT));
         deviceAddress = remote;
 
         serialPort = (SerialPort) commPort;


### PR DESCRIPTION
 Part of [#1390]
