### PR TITLE
Add ZLIB_OR_NONE support to JdkZlibDecoder [#2016]

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
@@ -35,7 +35,7 @@ public class JdkZlibDecoder extends ZlibDecoder {
     private static final int FCOMMENT = 0x10;
     private static final int FRESERVED = 0xE0;
 
-    private final Inflater inflater;
+    private Inflater inflater;
     private final byte[] dictionary;
 
     // GZIP related
@@ -57,6 +57,8 @@ public class JdkZlibDecoder extends ZlibDecoder {
     private int xlen = -1;
 
     private volatile boolean finished;
+
+    private boolean decideZlibOrNone;
 
     /**
      * Creates a new instance with the default wrapper ({@link ZlibWrapper#ZLIB}).
@@ -100,6 +102,11 @@ public class JdkZlibDecoder extends ZlibDecoder {
                 inflater = new Inflater();
                 crc = null;
                 break;
+            case ZLIB_OR_NONE:
+                // Postpone the decision until decode(...) is called.
+                decideZlibOrNone = true;
+                crc = null;
+                break;
             default:
                 throw new IllegalArgumentException("Only GZIP or ZLIB is supported, but you used " + wrapper);
         }
@@ -121,6 +128,17 @@ public class JdkZlibDecoder extends ZlibDecoder {
 
         if (!in.isReadable()) {
             return;
+        }
+
+        if (decideZlibOrNone) {
+            // First two bytes are needed to decide if it's a ZLIB stream.
+            if (in.readableBytes() < 2) {
+                return;
+            }
+
+            boolean nowrap = !looksLikeZlib(in.getShort(0));
+            inflater = new Inflater(nowrap);
+            decideZlibOrNone = false;
         }
 
         if (crc != null) {
@@ -214,7 +232,9 @@ public class JdkZlibDecoder extends ZlibDecoder {
     @Override
     protected void handlerRemoved0(ChannelHandlerContext ctx) throws Exception {
         super.handlerRemoved0(ctx);
-        inflater.end();
+        if (inflater != null) {
+            inflater.end();
+        }
     }
 
     private boolean readGZIPHeader(ByteBuf in) {
@@ -355,5 +375,17 @@ public class JdkZlibDecoder extends ZlibDecoder {
             throw new CompressionException(
                     "CRC value missmatch. Expected: " + crcValue + ", Got: " + readCrc);
         }
+    }
+
+    /*
+     * Returns true if the cmf_flg parameter (think: first two bytes of a zlib stream)
+     * indicates that this is a zlib stream.
+     * <p>
+     * You can lookup the details in the ZLIB RFC:
+     * <a href="http://tools.ietf.org/html/rfc1950#section-2.2">RFC 1950</a>.
+     */
+    private boolean looksLikeZlib(short cmf_flg) {
+        return (cmf_flg & 0x7800) == 0x7800 &&
+                cmf_flg % 31 == 0;
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibCodecFactory.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibCodecFactory.java
@@ -98,15 +98,10 @@ public final class ZlibCodecFactory {
     }
 
     public static ZlibDecoder newZlibDecoder(ZlibWrapper wrapper) {
-        switch (wrapper) {
-            case ZLIB_OR_NONE:
-                return new JZlibDecoder(wrapper);
-            default:
-                if (PlatformDependent.javaVersion() < 7 || noJdkZlibDecoder) {
-                    return new JZlibDecoder(wrapper);
-                } else {
-                    return new JdkZlibDecoder(wrapper);
-                }
+        if (PlatformDependent.javaVersion() < 7 || noJdkZlibDecoder) {
+            return new JZlibDecoder(wrapper);
+        } else {
+            return new JdkZlibDecoder(wrapper);
         }
     }
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
@@ -30,21 +30,8 @@ public class JdkZlibTest extends ZlibTest {
         return new JdkZlibDecoder(wrapper);
     }
 
-    @Override
-    @Test(expected = IllegalArgumentException.class)
-    public void testZLIB_OR_NONE() throws Exception {
-        new JdkZlibDecoder(ZlibWrapper.ZLIB_OR_NONE);
-    }
-
-    @Override
-    @Test(expected = IllegalArgumentException.class)
-    public void testZLIB_OR_NONE2() throws Exception {
-        new JdkZlibDecoder(ZlibWrapper.ZLIB_OR_NONE);
-    }
-
-    @Override
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = DecompressionException.class)
     public void testZLIB_OR_NONE3() throws Exception {
-        new JdkZlibDecoder(ZlibWrapper.ZLIB_OR_NONE);
+        super.testZLIB_OR_NONE3();
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest2.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest2.java
@@ -29,21 +29,8 @@ public class ZlibCrossTest2 extends ZlibTest {
         return new JdkZlibDecoder(wrapper);
     }
 
-    @Override
-    @Test(expected = IllegalArgumentException.class)
-    public void testZLIB_OR_NONE() throws Exception {
-        new JdkZlibDecoder(ZlibWrapper.ZLIB_OR_NONE);
-    }
-
-    @Override
-    @Test(expected = IllegalArgumentException.class)
-    public void testZLIB_OR_NONE2() throws Exception {
-        new JdkZlibDecoder(ZlibWrapper.ZLIB_OR_NONE);
-    }
-
-    @Override
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = DecompressionException.class)
     public void testZLIB_OR_NONE3() throws Exception {
-        new JdkZlibDecoder(ZlibWrapper.ZLIB_OR_NONE);
+        super.testZLIB_OR_NONE3();
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
@@ -179,7 +179,7 @@ public abstract class ZlibTest {
     public void testZLIB_OR_NONE2() throws Exception {
         testCompressNone(ZlibWrapper.ZLIB, ZlibWrapper.ZLIB_OR_NONE);
         testCompressSmall(ZlibWrapper.ZLIB, ZlibWrapper.ZLIB_OR_NONE);
-        testCompressLarge(ZlibWrapper.GZIP, ZlibWrapper.ZLIB_OR_NONE);
+        testCompressLarge(ZlibWrapper.ZLIB, ZlibWrapper.ZLIB_OR_NONE);
     }
 
     @Test


### PR DESCRIPTION
This is my take on #2016.

I am detecting if a stream is a zlib stream by looking at its first two bytes. Obviously this heuristic is not perfect as such a 'valid' byte combination may also appear in a normal DEFLATE stream ... this is however quite unlikely.

According to the spec (http://tools.ietf.org/html/rfc1950#section-2.2), the first byte of a ZLIB stream is 0x78 (7 means that the sliding window size is 32KB and 8 stands for the DEFLATE algorithm). The second byte contains some more information which I am not running any checks on, however I use it to ensure that "... when viewed as a 16-bit unsigned integer stored in MSB order (CMF*256 + FLG) is a multiple of 31." There shouldn't be any trouble with signed short overflow as the theoretically biggest possible short value 0x78FF (of the first two bytes) is still in the range of a 16-bit signed integer.
