### PR TITLE
Correct ConcurrentHashMapV8 bitwise arithmetic

### DIFF
--- a/common/src/main/java/io/netty/util/internal/chmv8/ConcurrentHashMapV8.java
+++ b/common/src/main/java/io/netty/util/internal/chmv8/ConcurrentHashMapV8.java
@@ -2672,7 +2672,7 @@ public class ConcurrentHashMapV8<K,V>
                         return;
                     }
                 }
-                else if ((s | WAITER) == 0) {
+                else if ((s & WAITER) == 0) {
                     if (U.compareAndSwapInt(this, LOCKSTATE, s, s | WAITER)) {
                         waiting = true;
                         waiter = Thread.currentThread();


### PR DESCRIPTION
Previously ConcurrentHashMapV8 evaulated ((x | 1) == 0), an expression
that always returned false.  This commit brings Netty closer to the
Java 8 implementation.
