### PR TITLE
Added asserts to make sure ChannelHandlers are removed from the pipeline

### DIFF
--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -149,8 +149,11 @@ public class DefaultChannelPipelineTest {
         assertSame(pipeline.get("handler3"), handler3);
 
         pipeline.remove(handler1);
+        assertNull(pipeline.get("handler1"));
         pipeline.remove(handler2);
+        assertNull(pipeline.get("handler2"));
         pipeline.remove(handler3);
+        assertNull(pipeline.get("handler3"));
     }
 
     @Test


### PR DESCRIPTION
I noticed this while reading through the source code. I believe these assert statements are missing to make sure the ChannelHandlers were actually removed from the pipeline.

Spoiler alert ... they are :).
