### PR TITLE
Corrected inconsistencies in the Javadoc.

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandler.java
@@ -43,7 +43,7 @@ import java.net.SocketAddress;
  * {@link ChannelPipeline} it belongs to via a context object.  Using the
  * context object, the {@link ChannelHandler} can pass events upstream or
  * downstream, modify the pipeline dynamically, or store the information
- * (attachment) which is specific to the handler.
+ * (using {@link AttributeKey}s) which is specific to the handler.
  *
  * <h3>State management</h3>
  *
@@ -59,7 +59,7 @@ import java.net.SocketAddress;
  *     <b>private boolean loggedIn;</b>
  *
  *     {@code @Override}
- *     public void channelRead({@link ChannelHandlerContext} ctx, Message message) {
+ *     protected void messageReceived({@link ChannelHandlerContext} ctx, Message message) {
  *         {@link Channel} ch = e.getChannel();
  *         if (message instanceof LoginMessage) {
  *             authenticate((LoginMessage) message);
@@ -91,11 +91,11 @@ import java.net.SocketAddress;
  *
  * </pre>
  *
- * <h4>Using an attachment</h4>
+ * <h4>Using {@link AttributeKey}s</h4>
  *
  * Although it's recommended to use member variables to store the state of a
  * handler, for some reason you might not want to create many handler instances.
- * In such a case, you can use an <em>attachment</em> which is provided by
+ * In such a case, you can use {@link AttributeKey}s which are attached to the
  * {@link ChannelHandlerContext}:
  * <pre>
  * public interface Message {
@@ -104,18 +104,14 @@ import java.net.SocketAddress;
  *
  * {@code @Sharable}
  * public class DataServerHandler extends {@link SimpleChannelInboundHandler}&lt;Message&gt; {
- *   private final {@link AttributeKey}&lt{@link Boolean}&gt auth =
+ *     private final {@link AttributeKey}&lt{@link Boolean}&gt auth =
  *           {@link AttributeKey#valueOf(String) AttributeKey.valueOf("auth")};
  *
- *   // This handler will receive a sequence of increasing integers starting
- *   // from 1.
- *   {@code @Override}
- *   public void channelRead({@link ChannelHandlerContext} ctx, {@link Integer} integer) {
- *     {@link Attribute}&lt{@link Boolean}&gt attr = ctx.attr(auth);
- *
  *     {@code @Override}
- *     public void channelRead({@link ChannelHandlerContext} ctx, Message message) {
+ *     protected void messageReceived({@link ChannelHandlerContext} ctx, Message message) {
+ *         {@link Attribute}&lt{@link Boolean}&gt attr = ctx.attr(auth);
  *         {@link Channel} ch = ctx.channel();
+ *
  *         if (message instanceof LoginMessage) {
  *             authenticate((LoginMessage) o);
  *             <b>attr.set(true)</b>;
@@ -130,7 +126,7 @@ import java.net.SocketAddress;
  *     ...
  * }
  * </pre>
- * Now that the state of the handler is stored as an attachment, you can add the
+ * Now that the state of the handler is attached to the {@link ChannelHandlerContext}, you can add the
  * same handler instance to different pipelines:
  * <pre>
  * public class DataServerInitializer extends {@link ChannelInitializer}&lt{@link Channel}&gt {
@@ -147,7 +143,7 @@ import java.net.SocketAddress;
  *
  * <h4>The {@code @Sharable} annotation</h4>
  * <p>
- * In the examples above which used an attachment,
+ * In the example above which used an {@link AttributeKey},
  * you might have noticed the {@code @Sharable} annotation.
  * <p>
  * If a {@link ChannelHandler} is annotated with the {@code @Sharable}

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
@@ -30,24 +30,21 @@ import java.nio.channels.Channels;
 
 /**
  * Enables a {@link ChannelHandler} to interact with its {@link ChannelPipeline}
- * and other handlers.  A handler can notify the next {@link ChannelHandler} in the {@link ChannelPipeline},
- * modify the {@link ChannelPipeline} it belongs to dynamically.
+ * and other handlers. Among other things a handler can notify the next {@link ChannelHandler} in the
+ * {@link ChannelPipeline} as well as modify the {@link ChannelPipeline} it belongs to dynamically.
  *
  * <h3>Notify</h3>
  *
-<<<<<<< HEAD
- * You can notify the closest handler in the same {@link ChannelPipeline} by calling one of the various method.
-=======
  * You can notify the closest handler in the
  * same {@link ChannelPipeline} by calling one of the various methods provided here.
->>>>>>> 7ec70d0... Merge package private interfaces into public ones. Related to [#1989] and [#1991]
+ *
  * Please refer to {@link ChannelPipeline} to understand how an event flows.
  *
  * <h3>Modifying a pipeline</h3>
  *
  * You can get the {@link ChannelPipeline} your handler belongs to by calling
  * {@link #pipeline()}.  A non-trivial application could insert, remove, or
- * replace handlers in the pipeline dynamically in runtime.
+ * replace handlers in the pipeline dynamically at runtime.
  *
  * <h3>Retrieving for later use</h3>
  *
@@ -85,7 +82,7 @@ import java.nio.channels.Channels;
  * {@link ChannelHandlerContext}s if it is added to one or more
  * {@link ChannelPipeline}s more than once.
  * <p>
- * For example, the following handler will have as many independent attachments
+ * For example, the following handler will have as many independent {@link AttributeKey}s
  * as how many times it is added to pipelines, regardless if it is added to the
  * same pipeline multiple times or added to different pipelines multiple times:
  * <pre>
@@ -110,7 +107,7 @@ import java.nio.channels.Channels;
  *
  * // Different context objects are given to "f1", "f2", "f3", and "f4" even if
  * // they refer to the same handler instance.  Because the FactorialHandler
- * // stores its state in a context object (as an attachment), the factorial is
+ * // stores its state in a context object (using an {@link AttributeKey}), the factorial is
  * // calculated correctly 4 times once the two pipelines (p1 and p2) are active.
  * FactorialHandler fh = new FactorialHandler();
  *

--- a/transport/src/main/java/io/netty/channel/SimpleChannelInboundHandler.java
+++ b/transport/src/main/java/io/netty/channel/SimpleChannelInboundHandler.java
@@ -40,7 +40,7 @@ import io.netty.util.internal.TypeParameterMatcher;
  * <h3>Backward compatibility consideration</h3>
  * <p>
  * Since 5.0, {@code channelRead0(ChannelHandlerContext, I)} has been renamed to
- * {@link #messageReceived(ChannelHandlerContext, Object)}.
+ * {@link #messageReceived(ChannelHandlerContext, I)}.
  * </p>
  */
 public abstract class SimpleChannelInboundHandler<I> extends ChannelHandlerAdapter {


### PR DESCRIPTION
While reading through the code I found some minor errors/inconsistencies in the Javadoc of ChannelHandler and ChannelHandlerContext. The comments were still talking about attachements and not the new AttributeKeys. Let me know what you think and if I used the correct wording. Thanks.

PS: The Javadoc in HTML: https://dl.dropboxusercontent.com/u/48211751/doc_fixes/index.html
