### PR TITLE
Update HttpObjectDecoder.java

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -712,6 +712,8 @@ public abstract class HttpObjectDecoder extends ReplayingDecoder<HttpObjectDecod
 
             // Abort decoding if the header part is too large.
             if (headerSize >= maxHeaderSize) {
+                // #2009
+                resetNow();
                 // TODO: Respond with Bad Request and discard the traffic
                 //    or close the connection.
                 //       No need to notify the upstream handlers - just log.


### PR DESCRIPTION
If HttpObjectDecoder#resetNow() was not called before throwing TooLongFrameException, the Handler will not be able to handle the Exception with very very large HTTP header.

Please see the issue #2009.
