### PR TITLE
Add content length and date headers to CORS response

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
@@ -30,6 +30,8 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import java.util.Date;
+
 /**
  * Handles <a href="http://www.w3.org/TR/cors/">Cross Origin Resource Sharing</a> (CORS) requests.
  * <p>
@@ -62,6 +64,8 @@ public class CorsHandler extends ChannelHandlerAdapter {
     private void handlePreflight(final ChannelHandlerContext ctx, final HttpRequest request) {
         final HttpResponse response = new DefaultHttpResponse(request.getProtocolVersion(), OK);
         if (setOrigin(response)) {
+            HttpHeaders.setContentLength(response, 0);
+            HttpHeaders.setDate(response, new Date());
             setAllowMethods(response);
             setAllowHeaders(response);
             setAllowCredentials(response);


### PR DESCRIPTION
Load balancers such as [ELB](http://aws.amazon.com/elasticloadbalancing/) will return a `502` to a client's preflight request due to the omission of date and content-length headers in Netty.

Am not sure this is the best place to put this, but some way of appending minimal standard response headers would be nice... maybe as a flag in `HttpServerCodec`?
