### PR TITLE
Fixing issue #2312

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -299,7 +299,7 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuffer nioBuffer(int index, int length) {
-        return (ByteBuffer) buffer.duplicate().position(index).limit(length);
+        return (ByteBuffer) buffer.duplicate().position(index).limit(index + length);
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -194,4 +194,17 @@ public class ReadOnlyDirectByteBufferBufTest {
         ByteBuf slice = buf.slice();
         Assert.assertEquals(buf, slice);
     }
+
+    @Test
+    public void testWrapBufferRoundTrip() {
+        ByteBuf buf = buffer(((ByteBuffer) allocate(16).putInt(1).putInt(2).flip()).asReadOnlyBuffer());
+        buffers.add(buf);
+
+        Assert.assertEquals(1, buf.readInt());
+
+        ByteBuffer nioBuffer = buf.nioBuffer();
+
+        // Ensure this can be accessed without throwing a BufferUnderflowException
+        Assert.assertEquals(2, nioBuffer.getInt());
+    }
 }


### PR DESCRIPTION
Fix limit computation of NIO ByteBuffers obtained via ReadOnlyByteBufferBuf.nioBuffer

Motivation:

When starting with a read-only NIO buffer, wrapping it in a ByteBuf,
and then later retrieving a re-wrapped NIO buffer the limit was getting
too short.

Modifications:

Changed ReadOnlyByteBufferBuf.nioBuffer(int,int) to compute the
limit in the same manner as the internalNioBuffer method.

Result:

Round-trip conversion from NIO to ByteBuf to NIO will work reliably.
