### PR TITLE
fix Junit test for V3.9 and issue #2305

### DIFF
--- a/src/test/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/src/test/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -105,6 +105,7 @@ public class HttpPostRequestDecoderTest {
                 "794692081&town=794660090&town=794665227&town=794665136&town=794669931";
         DefaultHttpRequest defaultHttpRequest =
                     new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        defaultHttpRequest.setChunked(true);
 
         HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(defaultHttpRequest);
 
@@ -124,5 +125,6 @@ public class HttpPostRequestDecoderTest {
         decoder.offer(part2);
         decoder.offer(part3);
         decoder.offer(part4);
+        decoder.offer(HttpChunk.LAST_CHUNK);
     }
 }


### PR DESCRIPTION
Fix Junit test for issue #2305 for V3.9 only where setChunked was not correctly setup in the request.
Adding it and adding LAST_CHUNK correct the JUnit test.
