### PR TITLE
Remove overridden next() method in EventLoop interface.

### DIFF
--- a/transport/src/main/java/io/netty/channel/EventLoop.java
+++ b/transport/src/main/java/io/netty/channel/EventLoop.java
@@ -29,9 +29,6 @@ public interface EventLoop extends EventExecutor, EventLoopGroup {
     @Override
     EventLoopGroup parent();
 
-    @Override
-    EventLoop next();
-
     /**
      * Creates a new default {@link ChannelHandlerInvoker} implementation that uses this {@link EventLoop} to
      * invoke event handler methods.


### PR DESCRIPTION
Motivation:
EventLoop overrides the next() method with the same signature of its
super class EventLoopGroup.

Modifications:
Remove the duplicate method declaration from the EventLoop interface.

Result:
Perhaps makes the API slightly more readable as there is one less
method.
