### PR TITLE
reduce memory usage in ProtobufVarint32LengthFieldPrepender.java for issue [#2339] 

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrepender.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrepender.java
@@ -47,7 +47,7 @@ public class ProtobufVarint32LengthFieldPrepender extends MessageToByteEncoder<B
         out.ensureWritable(headerLen + bodyLen);
 
         CodedOutputStream headerOut =
-                CodedOutputStream.newInstance(new ByteBufOutputStream(out));
+                CodedOutputStream.newInstance(new ByteBufOutputStream(out), headerLen);
         headerOut.writeRawVarint32(bodyLen);
         headerOut.flush();
 


### PR DESCRIPTION
Patch for 4.0 because we use this version in production, but it also may be apply for 4.1 and master without changes
