### PR TITLE
Proposal to improve Traffic Shaping Handler

### DIFF
--- a/src/main/java/org/jboss/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/src/main/java/org/jboss/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -78,7 +78,7 @@ public abstract class AbstractTrafficShapingHandler extends
     /**
      * Default minimal time to wait
      */
-    private static final long MINIMAL_WAIT = 10;
+    static final long MINIMAL_WAIT = 10;
 
     /**
      * Traffic Counter
@@ -128,12 +128,13 @@ public abstract class AbstractTrafficShapingHandler extends
 
      private void init(ObjectSizeEstimator newObjectSizeEstimator,
              Timer newTimer, long newWriteLimit, long newReadLimit,
-             long newCheckInterval) {
+             long newCheckInterval, long newMaxTime) {
          objectSizeEstimator = newObjectSizeEstimator;
          timer = newTimer;
          writeLimit = newWriteLimit;
          readLimit = newReadLimit;
          checkInterval = newCheckInterval;
+         maxTime = newMaxTime;
          //logger.warn("TSH: "+writeLimit+":"+readLimit+":"+checkInterval);
      }
 
@@ -169,7 +170,8 @@ public abstract class AbstractTrafficShapingHandler extends
      */
     protected AbstractTrafficShapingHandler(Timer timer, long writeLimit,
                                             long readLimit, long checkInterval) {
-        init(new DefaultObjectSizeEstimator(), timer, writeLimit, readLimit, checkInterval);
+        init(new DefaultObjectSizeEstimator(), timer, writeLimit, readLimit, checkInterval,
+                DEFAULT_MAX_TIME);
     }
 
     /**
@@ -191,7 +193,7 @@ public abstract class AbstractTrafficShapingHandler extends
     protected AbstractTrafficShapingHandler(
             ObjectSizeEstimator objectSizeEstimator, Timer timer,
             long writeLimit, long readLimit, long checkInterval) {
-        init(objectSizeEstimator, timer, writeLimit, readLimit, checkInterval);
+        init(objectSizeEstimator, timer, writeLimit, readLimit, checkInterval, DEFAULT_MAX_TIME);
     }
 
     /**
@@ -206,7 +208,8 @@ public abstract class AbstractTrafficShapingHandler extends
      */
     protected AbstractTrafficShapingHandler(Timer timer, long writeLimit,
                                             long readLimit) {
-        init(new DefaultObjectSizeEstimator(), timer, writeLimit, readLimit, DEFAULT_CHECK_INTERVAL);
+        init(new DefaultObjectSizeEstimator(), timer, writeLimit, readLimit,
+                DEFAULT_CHECK_INTERVAL, DEFAULT_MAX_TIME);
     }
 
     /**
@@ -225,7 +228,8 @@ public abstract class AbstractTrafficShapingHandler extends
     protected AbstractTrafficShapingHandler(
             ObjectSizeEstimator objectSizeEstimator, Timer timer,
             long writeLimit, long readLimit) {
-        init(objectSizeEstimator, timer, writeLimit, readLimit, DEFAULT_CHECK_INTERVAL);
+        init(objectSizeEstimator, timer, writeLimit, readLimit,
+                DEFAULT_CHECK_INTERVAL, DEFAULT_MAX_TIME);
     }
 
     /**
@@ -235,7 +239,8 @@ public abstract class AbstractTrafficShapingHandler extends
      *          created once for instance like HashedWheelTimer(10, TimeUnit.MILLISECONDS, 1024)
      */
     protected AbstractTrafficShapingHandler(Timer timer) {
-        init(new DefaultObjectSizeEstimator(), timer, 0, 0, DEFAULT_CHECK_INTERVAL);
+        init(new DefaultObjectSizeEstimator(), timer, 0, 0,
+                DEFAULT_CHECK_INTERVAL, DEFAULT_MAX_TIME);
     }
 
     /**
@@ -249,7 +254,8 @@ public abstract class AbstractTrafficShapingHandler extends
      */
     protected AbstractTrafficShapingHandler(
             ObjectSizeEstimator objectSizeEstimator, Timer timer) {
-        init(objectSizeEstimator, timer, 0, 0, DEFAULT_CHECK_INTERVAL);
+        init(objectSizeEstimator, timer, 0, 0,
+                DEFAULT_CHECK_INTERVAL, DEFAULT_MAX_TIME);
     }
 
     /**
@@ -262,7 +268,7 @@ public abstract class AbstractTrafficShapingHandler extends
      *            channels or 0 if no stats are to be computed
      */
     protected AbstractTrafficShapingHandler(Timer timer, long checkInterval) {
-        init(new DefaultObjectSizeEstimator(), timer, 0, 0, checkInterval);
+        init(new DefaultObjectSizeEstimator(), timer, 0, 0, checkInterval, DEFAULT_MAX_TIME);
     }
 
     /**
@@ -280,7 +286,52 @@ public abstract class AbstractTrafficShapingHandler extends
     protected AbstractTrafficShapingHandler(
             ObjectSizeEstimator objectSizeEstimator, Timer timer,
             long checkInterval) {
-        init(objectSizeEstimator, timer, 0, 0, checkInterval);
+        init(objectSizeEstimator, timer, 0, 0, checkInterval, DEFAULT_MAX_TIME);
+    }
+
+    /**
+     * Constructor using default {@link ObjectSizeEstimator}
+     *
+     * @param timer
+     *          created once for instance like HashedWheelTimer(10, TimeUnit.MILLISECONDS, 1024)
+     * @param writeLimit
+     *          0 or a limit in bytes/s
+     * @param readLimit
+     *          0 or a limit in bytes/s
+     * @param checkInterval
+     *          The delay between two computations of performances for
+     *            channels or 0 if no stats are to be computed
+     * @param maxTime
+     *          The max time to wait in case of excess of traffic (to prevent Time Out event)
+     */
+    protected AbstractTrafficShapingHandler(Timer timer, long writeLimit,
+                                            long readLimit, long checkInterval, long maxTime) {
+        init(new DefaultObjectSizeEstimator(), timer, writeLimit, readLimit, checkInterval,
+                maxTime);
+    }
+
+    /**
+     * Constructor using the specified ObjectSizeEstimator
+     *
+     * @param objectSizeEstimator
+     *            the {@link ObjectSizeEstimator} that will be used to compute
+     *            the size of the message
+     * @param timer
+     *          created once for instance like HashedWheelTimer(10, TimeUnit.MILLISECONDS, 1024)
+     * @param writeLimit
+     *          0 or a limit in bytes/s
+     * @param readLimit
+     *          0 or a limit in bytes/s
+     * @param checkInterval
+     *          The delay between two computations of performances for
+     *            channels or 0 if no stats are to be computed
+     * @param maxTime
+     *          The max time to wait in case of excess of traffic (to prevent Time Out event)
+     */
+    protected AbstractTrafficShapingHandler(
+            ObjectSizeEstimator objectSizeEstimator, Timer timer,
+            long writeLimit, long readLimit, long checkInterval, long maxTime) {
+        init(objectSizeEstimator, timer, writeLimit, readLimit, checkInterval, maxTime);
     }
 
     /**

--- a/src/main/java/org/jboss/netty/handler/traffic/ChannelTrafficShapingHandler.java
+++ b/src/main/java/org/jboss/netty/handler/traffic/ChannelTrafficShapingHandler.java
@@ -49,7 +49,9 @@ import org.jboss.netty.util.Timer;
  * it is recommended to set a positive value, even if it is high since the precision of the
  * Traffic Shaping depends on the period where the traffic is computed. The highest the interval,
  * the less precise the traffic shaping will be. It is suggested as higher value something close
- * to 5 or 10 minutes.<br>
+ * to 5 or 10 minutes.<br><br>
+ *
+ * maxTimeToWait, by default set to 15s, allows to specify an upper bound of time shaping.<br><br>
  * </li>
  * <li>When you shutdown your application, release all the external resources (except the timer internal itself)
  * by calling:<br>
@@ -62,6 +64,11 @@ public class ChannelTrafficShapingHandler extends AbstractTrafficShapingHandler 
     public ChannelTrafficShapingHandler(Timer timer, long writeLimit,
             long readLimit, long checkInterval) {
         super(timer, writeLimit, readLimit, checkInterval);
+    }
+
+    public ChannelTrafficShapingHandler(Timer timer, long writeLimit,
+            long readLimit, long checkInterval, long maxTime) {
+        super(timer, writeLimit, readLimit, checkInterval, maxTime);
     }
 
     public ChannelTrafficShapingHandler(Timer timer, long writeLimit,
@@ -82,6 +89,13 @@ public class ChannelTrafficShapingHandler extends AbstractTrafficShapingHandler 
             long writeLimit, long readLimit, long checkInterval) {
         super(objectSizeEstimator, timer, writeLimit, readLimit,
                 checkInterval);
+    }
+
+    public ChannelTrafficShapingHandler(
+            ObjectSizeEstimator objectSizeEstimator, Timer timer,
+            long writeLimit, long readLimit, long checkInterval, long maxTime) {
+        super(objectSizeEstimator, timer, writeLimit, readLimit,
+                checkInterval, maxTime);
     }
 
     public ChannelTrafficShapingHandler(

--- a/src/main/java/org/jboss/netty/handler/traffic/GlobalTrafficShapingHandler.java
+++ b/src/main/java/org/jboss/netty/handler/traffic/GlobalTrafficShapingHandler.java
@@ -45,7 +45,9 @@ import org.jboss.netty.util.Timer;
  * it is recommended to set a positive value, even if it is high since the precision of the
  * Traffic Shaping depends on the period where the traffic is computed. The highest the interval,
  * the less precise the traffic shaping will be. It is suggested as higher value something close
- * to 5 or 10 minutes.<br>
+ * to 5 or 10 minutes.<br><br>
+ *
+ * maxTimeToWait, by default set to 15s, allows to specify an upper bound of time shaping.<br><br>
  * </li>
  * <li>Add it in your pipeline, before a recommended {@link ExecutionHandler} (like
  * {@link OrderedMemoryAwareThreadPoolExecutor} or {@link MemoryAwareThreadPoolExecutor}).<br>
@@ -79,6 +81,12 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
     }
 
     public GlobalTrafficShapingHandler(Timer timer, long writeLimit,
+            long readLimit, long checkInterval, long maxTime) {
+        super(timer, writeLimit, readLimit, checkInterval, maxTime);
+        createGlobalTrafficCounter();
+    }
+
+    public GlobalTrafficShapingHandler(Timer timer, long writeLimit,
             long readLimit) {
         super(timer, writeLimit, readLimit);
         createGlobalTrafficCounter();
@@ -99,6 +107,14 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
             long checkInterval) {
         super(objectSizeEstimator, timer, writeLimit, readLimit,
                 checkInterval);
+        createGlobalTrafficCounter();
+    }
+
+    public GlobalTrafficShapingHandler(ObjectSizeEstimator objectSizeEstimator,
+            Timer timer, long writeLimit, long readLimit,
+            long checkInterval, long maxTime) {
+        super(objectSizeEstimator, timer, writeLimit, readLimit,
+                checkInterval, maxTime);
         createGlobalTrafficCounter();
     }
 

--- a/src/main/java/org/jboss/netty/handler/traffic/TrafficCounter.java
+++ b/src/main/java/org/jboss/netty/handler/traffic/TrafficCounter.java
@@ -337,16 +337,16 @@ public class TrafficCounter {
     public long getReadTimeToWait(long limitTraffic, long maxTime) {
         long interval = System.currentTimeMillis() - lastTime.get();
         long sum = currentReadBytes.get();
-        if (interval > 10 && sum > 0) {
+        if (interval > AbstractTrafficShapingHandler.MINIMAL_WAIT && sum > 0) {
             long time = (sum * 1000 / limitTraffic - interval) / 10 * 10;
-            if (time > 10) {
+            if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
                 return time > maxTime ? maxTime : time;
             }
         }
         sum += lastReadBytes;
         long time = (sum * 1000 / limitTraffic - interval - getCheckInterval())
                 / 10 * 10;
-        if (time > 10) {
+        if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
             return time > maxTime ? maxTime : time;
         }
         return 0;
@@ -360,16 +360,16 @@ public class TrafficCounter {
     public long getWriteTimeToWait(long limitTraffic, long maxTime) {
         long interval = System.currentTimeMillis() - lastTime.get();
         long sum = currentWrittenBytes.get();
-        if (interval > 10 && sum > 0) {
+        if (interval > AbstractTrafficShapingHandler.MINIMAL_WAIT && sum > 0) {
             long time = (sum * 1000 / limitTraffic - interval) / 10 * 10;
-            if (time > 10) {
+            if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
                 return time > maxTime ? maxTime : time;
             }
         }
         sum += lastWrittenBytes;
         long time = (sum * 1000 / limitTraffic - interval - getCheckInterval())
                 / 10 * 10;
-        if (time > 10) {
+        if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
             return time > maxTime ? maxTime : time;
         }
         return 0;


### PR DESCRIPTION
Motivation:
Currently Traffic Shaping is using 1 timer only and could lead to
"partial" wrong bandwidth computation when "short" time occurs between
adding used bytes and when the TrafficCounter updates itself and finally
when the traffic is computed.
Indeed, the TrafficCounter is updated every x delay and it is at the
same time saved into "lastXxxxBytes" and set to 0. Therefore, when one
request the counter, it first updates the TrafficCounter with the added
used bytes. If this value is set just before the TrafficCounter is
updated, then the bandwidth computation will use the TrafficCounter with
a "0" value (this value being reset once the delay occurs). Therefore,
the traffic shaping computation is wrong in rare cases.

Secondly the traffic shapping should avoid if possible the "Timeout"
effect by not stopping reading or writing more than a maxTime, this
maxTime being less than the TimeOut limit.

Modifications:
The TrafficCounter has 2 new methods that compute the time to wait
according to read or write) using in priority the currentXxxxBytes (as
before), but could used (if current is at 0) the lastXxxxxBytes, and
therefore having more chance to take into account the real traffic.

Moreover  the Handler could change the default "max time to wait", which
is by default set to half of "standard" Time Out (30s:2 = 15s).

Result:
The Traffic Shaping is better take into account (no 0 value when it
shouldn't) and it tries to not block traffic more than Time Out event.

This version is for V3.9 but could simply be port to V4.X and Master.
