### PR TITLE
Demonstrate HTTP2 client is racy.

### DIFF
--- a/example/src/main/java/io/netty/example/http2/client/Http2ClientInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/client/Http2ClientInitializer.java
@@ -38,7 +38,7 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
         ChannelPipeline pipeline = ch.pipeline();
 
         pipeline.addLast("http2FrameCodec", new Http2FrameCodec());
-        pipeline.addLast("spdyFrameLogger", new Http2FrameLogger(INFO));
+        pipeline.addLast("http2FrameLogger", new Http2FrameLogger(INFO));
         pipeline.addLast("http2ConnectionHandler", new Http2ConnectionHandler(false));
         pipeline.addLast("httpHandler", httpResponseHandler);
     }

--- a/example/src/main/java/io/netty/example/http2/client/Http2FrameLogger.java
+++ b/example/src/main/java/io/netty/example/http2/client/Http2FrameLogger.java
@@ -19,6 +19,7 @@ import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.draft10.frame.Http2Frame;
+import io.netty.handler.codec.http2.draft10.frame.Http2SettingsFrame;
 import io.netty.util.internal.logging.InternalLogLevel;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -55,6 +56,9 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
         if (acceptMessage(msg)) {
+            if (msg instanceof Http2SettingsFrame) {
+              Thread.sleep(100);
+            }
             log((Http2Frame) msg, Direction.OUTBOUND);
         }
         super.write(ctx, msg, promise);

--- a/example/src/main/java/io/netty/example/http2/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/server/Http2ServerInitializer.java
@@ -16,9 +16,11 @@
 
 package io.netty.example.http2.server;
 
+import static io.netty.util.internal.logging.InternalLogLevel.INFO;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.example.http2.client.Http2FrameLogger;
 import io.netty.handler.codec.http2.draft10.connection.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.draft10.frame.Http2FrameCodec;
 
@@ -31,6 +33,7 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
         ChannelPipeline p = ch.pipeline();
 
         p.addLast("http2FrameCodec", new Http2FrameCodec());
+        p.addLast("http2FrameLogger", new Http2FrameLogger(INFO));
         p.addLast("http2ConnectionHandler", new Http2ConnectionHandler(true));
         p.addLast("helloWorldHandler", new HelloWorldHandler());
     }


### PR DESCRIPTION
Don't merge.  Demonstrates that HTTP2 client is racey.  The client needs something to block on / wait for before attempting to send its first query.  It has no way of knowing whether or not the server has sent settings yet.

Repro: run Http2Server.  Repeatedly run Http2Client.  It fails every time.  Without the Thread.sleep() it only fails the first time for me locally.
