### PR TITLE
Eliminate unnecessary extra synchronization in DefaultChannelPipeline

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -326,7 +326,7 @@ final class DefaultChannelPipeline implements ChannelPipeline {
         // Lazily initialize the data structure that maps an EventExecutorGroup to a ChannelHandlerInvoker.
         Map<EventExecutorGroup, ChannelHandlerInvoker> childInvokers = this.childInvokers;
         if (childInvokers == null) {
-            childInvokers = this.childInvokers = new IdentityHashMap<EventExecutorGroup, ChannelHandlerInvoker>();
+            childInvokers = this.childInvokers = new IdentityHashMap<EventExecutorGroup, ChannelHandlerInvoker>(4);
         }
 
         // Pick one of the child executors and remember its invoker


### PR DESCRIPTION
Motivation:
At the moment whenever we add/remove a ChannelHandler with an EventExecutorGroup we have two synchronization points in the execution path. One to find the childInvoker and one for add/remove itself. We can eliminate the former by call findIInvoker in the synchronization block, as we need to synchronize anyway.

Modification:
Remove the usage of AtomicFieldUpdater and the extra synchronization in findInvoker by moving the call of the method in the synchronized(this) block.

Result:
Less synchronization points and volatile reads/writes
