### PR TITLE
Nio SSL server greeting unit test

### DIFF
--- a/src/test/java/org/jboss/netty/handler/ssl/AbstractSocketSslGreetingTest.java
+++ b/src/test/java/org/jboss/netty/handler/ssl/AbstractSocketSslGreetingTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.netty.handler.ssl;
+
+import org.jboss.netty.bootstrap.ClientBootstrap;
+import org.jboss.netty.bootstrap.ServerBootstrap;
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelFactory;
+import org.jboss.netty.channel.ChannelFuture;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelStateEvent;
+import org.jboss.netty.channel.ExceptionEvent;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+import org.jboss.netty.example.securechat.SecureChatSslContextFactory;
+import org.jboss.netty.handler.execution.ExecutionHandler;
+import org.jboss.netty.handler.execution.OrderedMemoryAwareThreadPoolExecutor;
+import org.jboss.netty.logging.InternalLogger;
+import org.jboss.netty.logging.InternalLoggerFactory;
+import org.jboss.netty.util.TestUtil;
+import org.junit.Test;
+
+import javax.net.ssl.SSLEngine;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Random;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.*;
+
+public abstract class AbstractSocketSslGreetingTest {
+    static final InternalLogger logger =
+        InternalLoggerFactory.getInstance(AbstractSocketSslGreetingTest.class);
+
+    static final byte[] greeting = new byte[]{'a'};
+
+    protected abstract ChannelFactory newServerSocketChannelFactory(Executor executor);
+    protected abstract ChannelFactory newClientSocketChannelFactory(Executor executor);
+
+    protected boolean isExecutorRequired() {
+        return false;
+    }
+
+    @Test
+    public void testSslEcho() throws Throwable {
+        ServerBootstrap sb = new ServerBootstrap(newServerSocketChannelFactory(Executors.newCachedThreadPool()));
+        ClientBootstrap cb = new ClientBootstrap(newClientSocketChannelFactory(Executors.newCachedThreadPool()));
+
+        EchoHandler sh = new EchoHandler(true);
+        EchoHandler ch = new EchoHandler(false);
+
+        SSLEngine sse = SecureChatSslContextFactory.getServerContext().createSSLEngine();
+        SSLEngine cse = SecureChatSslContextFactory.getClientContext().createSSLEngine();
+        sse.setUseClientMode(false);
+        cse.setUseClientMode(true);
+
+        // Workaround for blocking I/O transport write-write dead lock.
+        sb.setOption("receiveBufferSize", 1048576);
+        sb.setOption("receiveBufferSize", 1048576);
+
+        sb.getPipeline().addFirst("ssl", new SslHandler(sse));
+        sb.getPipeline().addLast("handler", sh);
+        cb.getPipeline().addFirst("ssl", new SslHandler(cse));
+        cb.getPipeline().addLast("handler", ch);
+        ExecutorService eventExecutor = null;
+        if (isExecutorRequired()) {
+            eventExecutor = new OrderedMemoryAwareThreadPoolExecutor(16, 0, 0);
+            sb.getPipeline().addFirst("executor", new ExecutionHandler(eventExecutor));
+            cb.getPipeline().addFirst("executor", new ExecutionHandler(eventExecutor));
+        }
+
+        Channel sc = sb.bind(new InetSocketAddress(0));
+        int port = ((InetSocketAddress) sc.getLocalAddress()).getPort();
+
+        ChannelFuture ccf = cb.connect(new InetSocketAddress(TestUtil.getLocalHost(), port));
+        ccf.awaitUninterruptibly();
+        if (!ccf.isSuccess()) {
+            logger.error("Connection attempt failed", ccf.getCause());
+            sc.close().awaitUninterruptibly();
+        }
+        assertTrue(ccf.isSuccess());
+
+        Channel cc = ccf.getChannel();
+        ChannelFuture hf = cc.getPipeline().get(SslHandler.class).handshake();
+        hf.awaitUninterruptibly();
+        if (!hf.isSuccess()) {
+            logger.error("Handshake failed", hf.getCause());
+            sh.channel.close().awaitUninterruptibly();
+            ch.channel.close().awaitUninterruptibly();
+            sc.close().awaitUninterruptibly();
+        }
+
+        assertTrue(hf.isSuccess());
+
+        while (ch.counter < greeting.length) {
+            if (sh.exception.get() != null) {
+                break;
+            }
+            if (ch.exception.get() != null) {
+                break;
+            }
+
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                // Ignore.
+            }
+        }
+
+//        while (sh.counter < data.length) {
+//            if (sh.exception.get() != null) {
+//                break;
+//            }
+//            if (ch.exception.get() != null) {
+//                break;
+//            }
+//
+//            try {
+//                Thread.sleep(1);
+//            } catch (InterruptedException e) {
+//                // Ignore.
+//            }
+//        }
+
+        sh.channel.close().awaitUninterruptibly();
+        ch.channel.close().awaitUninterruptibly();
+        sc.close().awaitUninterruptibly();
+        cb.shutdown();
+        sb.shutdown();
+        cb.releaseExternalResources();
+        sb.releaseExternalResources();
+
+        if (eventExecutor != null) {
+            eventExecutor.shutdown();
+        }
+        if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
+            throw sh.exception.get();
+        }
+        if (ch.exception.get() != null && !(ch.exception.get() instanceof IOException)) {
+            throw ch.exception.get();
+        }
+        if (sh.exception.get() != null) {
+            throw sh.exception.get();
+        }
+        if (ch.exception.get() != null) {
+            throw ch.exception.get();
+        }
+    }
+
+    private static class EchoHandler extends SimpleChannelUpstreamHandler {
+        volatile Channel channel;
+        final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
+        volatile int counter;
+        private final boolean server;
+
+        EchoHandler(boolean server) {
+            this.server = server;
+        }
+
+        @Override
+        public void channelOpen(ChannelHandlerContext ctx, ChannelStateEvent e)
+                throws Exception {
+            channel = e.getChannel();
+            if (server) {
+                logger.debug("send greeting");
+                channel.write(ChannelBuffers.wrappedBuffer(greeting, 0, greeting.length));
+            }
+        }
+
+        @Override
+        public void messageReceived(ChannelHandlerContext ctx, MessageEvent e)
+                throws Exception {
+            logger.debug("messageReceived");
+            ChannelBuffer m = (ChannelBuffer) e.getMessage();
+            byte[] actual = new byte[m.readableBytes()];
+            m.getBytes(0, actual);
+
+            assertEquals(greeting[0], actual[0]);
+
+            counter += actual.length;
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e)
+                throws Exception {
+            logger.warn(
+                    "Unexpected exception from the " +
+                    (server? "server" : "client") + " side", e.getCause());
+
+            exception.compareAndSet(null, e.getCause());
+            e.getChannel().close();
+        }
+    }
+}

--- a/src/test/java/org/jboss/netty/handler/ssl/NioNioSocketSslGreetingTest.java
+++ b/src/test/java/org/jboss/netty/handler/ssl/NioNioSocketSslGreetingTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.netty.handler.ssl;
+
+import java.util.concurrent.Executor;
+
+import org.jboss.netty.channel.ChannelFactory;
+import org.jboss.netty.channel.socket.nio.NioClientSocketChannelFactory;
+import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
+
+public class NioNioSocketSslGreetingTest extends AbstractSocketSslGreetingTest {
+
+    @Override
+    protected ChannelFactory newClientSocketChannelFactory(Executor executor) {
+        return new NioClientSocketChannelFactory(executor, executor);
+    }
+
+    @Override
+    protected ChannelFactory newServerSocketChannelFactory(Executor executor) {
+        return new NioServerSocketChannelFactory(executor, executor);
+    }
+
+}


### PR DESCRIPTION
SSL clients waiting for Nio ssl servers to send a greeting, don't get one. Works with 3.8.1, and is broken in 3.9.0+.
