### PR TITLE
Pluggable algorithm to choose next EventLoop

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/DefaultEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultEventExecutorGroup.java
@@ -15,6 +15,7 @@
  */
 package io.netty.util.concurrent;
 
+import io.netty.util.metrics.MetricsCollector;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 
@@ -22,7 +23,7 @@ import java.util.concurrent.ThreadFactory;
  * Default implementation of {@link MultithreadEventExecutorGroup} which will use {@link DefaultEventExecutor} instances
  * to handle the tasks.
  */
-public class DefaultEventExecutorGroup extends MultithreadEventExecutorGroup {
+public class DefaultEventExecutorGroup extends MultithreadEventExecutorGroup<EventExecutor> {
 
     /**
      * @see {@link #DefaultEventExecutorGroup(int, ThreadFactory)}
@@ -38,11 +39,11 @@ public class DefaultEventExecutorGroup extends MultithreadEventExecutorGroup {
      * @param threadFactory     the ThreadFactory to use, or {@code null} if the default should be used.
      */
     public DefaultEventExecutorGroup(int nThreads, ThreadFactory threadFactory) {
-        super(nThreads, threadFactory);
+        super(nThreads, threadFactory, null);
     }
 
     @Override
-    protected EventExecutor newChild(Executor executor, Object... args) throws Exception {
+    protected EventExecutor newChild(Executor executor, MetricsCollector metrics, Object... args) throws Exception {
         return new DefaultEventExecutor(this, executor);
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -15,8 +15,15 @@
  */
 package io.netty.util.concurrent;
 
+import io.netty.util.metrics.EventExecutorChooser;
+import io.netty.util.metrics.MetricsCollector;
+import io.netty.util.metrics.NoMetricsCollector;
+
+import java.net.SocketAddress;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
@@ -27,34 +34,34 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Abstract base class for {@link EventExecutorGroup} implementations that handles their tasks with multiple threads at
  * the same time.
  */
-public abstract class MultithreadEventExecutorGroup extends AbstractEventExecutorGroup {
+public abstract class MultithreadEventExecutorGroup<T extends EventExecutor> extends AbstractEventExecutorGroup {
 
-    private final EventExecutor[] children;
     private final Set<EventExecutor> readonlyChildren;
-    private final AtomicInteger childIndex = new AtomicInteger();
     private final AtomicInteger terminatedChildren = new AtomicInteger();
     private final Promise<?> terminationFuture = new DefaultPromise(GlobalEventExecutor.INSTANCE);
-    private final EventExecutorChooser chooser;
+    private final EventExecutorChooser<T> chooser;
 
     /**
      * Create a new instance.
      *
-     * @param nThreads          the number of threads that will be used by this instance.
-     * @param threadFactory     the ThreadFactory to use, or {@code null} if the default should be used.
-     * @param args              arguments which will passed to each {@link #newChild(Executor, Object...)} call
+     * @param nThreads  the number of threads that will be used by this instance.
+     * @param threadFactory the ThreadFactory to use, or {@code null} if the default should be used.
+     * @param args  arguments which will passed to each {@link #newChild(Executor, MetricsCollector, Object...)} call
      */
-    protected MultithreadEventExecutorGroup(int nThreads, ThreadFactory threadFactory, Object... args) {
-        this(nThreads, threadFactory == null ? null : new ThreadPerTaskExecutor(threadFactory), args);
+    protected MultithreadEventExecutorGroup(
+            int nThreads, ThreadFactory threadFactory, EventExecutorChooser<T> chooser, Object... args) {
+        this(nThreads, threadFactory == null ? null : new ThreadPerTaskExecutor(threadFactory), chooser, args);
     }
 
     /**
      * Create a new instance.
      *
-     * @param nThreads          the number of threads that will be used by this instance.
-     * @param executor          the Executor to use, or {@code null} if the default should be used.
-     * @param args              arguments which will passed to each {@link #newChild(Executor, Object...)} call
+     * @param nThreads  the number of threads that will be used by this instance.
+     * @param executor  the Executor to use, or {@code null} if the default should be used.
+     * @param args  arguments which will passed to each {@link #newChild(Executor, MetricsCollector, Object...)} call
      */
-    protected MultithreadEventExecutorGroup(int nThreads, Executor executor, Object... args) {
+    protected MultithreadEventExecutorGroup(
+            final int nThreads, Executor executor, EventExecutorChooser<T> chooser, Object... args) {
         if (nThreads <= 0) {
             throw new IllegalArgumentException(String.format("nThreads: %d (expected: > 0)", nThreads));
         }
@@ -63,29 +70,31 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
             executor = new ThreadPerTaskExecutor(newDefaultThreadFactory());
         }
 
-        children = new EventExecutor[nThreads];
-        if (isPowerOfTwo(children.length)) {
-            chooser = new PowerOfTwoEventExecutorChooser();
-        } else {
-            chooser = new GenericEventExecutorChooser();
-        }
+        this.chooser = chooser != null
+                        ? chooser
+                        : isPowerOfTwo(nThreads)
+                            ? new PowerOfTwoRoundRobinChooser(nThreads)
+                            : new RoundRobinChooser(nThreads);
 
         for (int i = 0; i < nThreads; i ++) {
             boolean success = false;
             try {
-                children[i] = newChild(executor, args);
+                MetricsCollector metrics = this.chooser.newMetricsCollector();
+                T child = newChild(executor, metrics, args);
+                metrics.init(child);
+                this.chooser.addChild(child, metrics);
+
                 success = true;
             } catch (Exception e) {
                 // TODO: Think about if this is a good exception type
                 throw new IllegalStateException("failed to create a child event loop", e);
             } finally {
                 if (!success) {
-                    for (int j = 0; j < i; j ++) {
-                        children[j].shutdownGracefully();
+                    for (EventExecutor e : this.chooser.children()) {
+                        e.shutdownGracefully();
                     }
 
-                    for (int j = 0; j < i; j ++) {
-                        EventExecutor e = children[j];
+                    for (EventExecutor e : this.chooser.children()) {
                         try {
                             while (!e.isTerminated()) {
                                 e.awaitTermination(Integer.MAX_VALUE, TimeUnit.SECONDS);
@@ -103,18 +112,18 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
         final FutureListener<Object> terminationListener = new FutureListener<Object>() {
             @Override
             public void operationComplete(Future<Object> future) throws Exception {
-                if (terminatedChildren.incrementAndGet() == children.length) {
+                if (terminatedChildren.incrementAndGet() == nThreads) {
                     terminationFuture.setSuccess(null);
                 }
             }
         };
 
-        for (EventExecutor e: children) {
+        for (EventExecutor e : this.chooser.children()) {
             e.terminationFuture().addListener(terminationListener);
         }
 
-        Set<EventExecutor> childrenSet = new LinkedHashSet<EventExecutor>(children.length);
-        Collections.addAll(childrenSet, children);
+        Set<EventExecutor> childrenSet = new LinkedHashSet<EventExecutor>(this.chooser.children().size());
+        childrenSet.addAll(this.chooser.children());
         readonlyChildren = Collections.unmodifiableSet(childrenSet);
     }
 
@@ -123,8 +132,12 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
     }
 
     @Override
-    public EventExecutor next() {
-        return chooser.next();
+    public T next() {
+        return chooser.next(null);
+    }
+
+    public T next(SocketAddress remoteAddress) {
+        return chooser.next(remoteAddress);
     }
 
     /**
@@ -132,7 +145,7 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
      * 1:1 to the threads it use.
      */
     public final int executorCount() {
-        return children.length;
+        return chooser.children().size();
     }
 
     @Override
@@ -146,11 +159,11 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
      * called for each thread that will serve this {@link MultithreadEventExecutorGroup}.
      *
      */
-    protected abstract EventExecutor newChild(Executor executor, Object... args) throws Exception;
+    protected abstract T newChild(Executor executor, MetricsCollector metrics, Object... args) throws Exception;
 
     @Override
     public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
-        for (EventExecutor l: children) {
+        for (EventExecutor l: chooser.children()) {
             l.shutdownGracefully(quietPeriod, timeout, unit);
         }
         return terminationFuture();
@@ -164,14 +177,14 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
     @Override
     @Deprecated
     public void shutdown() {
-        for (EventExecutor l: children) {
+        for (EventExecutor l: chooser.children()) {
             l.shutdown();
         }
     }
 
     @Override
     public boolean isShuttingDown() {
-        for (EventExecutor l: children) {
+        for (EventExecutor l: chooser.children()) {
             if (!l.isShuttingDown()) {
                 return false;
             }
@@ -181,7 +194,7 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
 
     @Override
     public boolean isShutdown() {
-        for (EventExecutor l: children) {
+        for (EventExecutor l: chooser.children()) {
             if (!l.isShutdown()) {
                 return false;
             }
@@ -191,7 +204,7 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
 
     @Override
     public boolean isTerminated() {
-        for (EventExecutor l: children) {
+        for (EventExecutor l: chooser.children()) {
             if (!l.isTerminated()) {
                 return false;
             }
@@ -203,7 +216,7 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
     public boolean awaitTermination(long timeout, TimeUnit unit)
             throws InterruptedException {
         long deadline = System.nanoTime() + unit.toNanos(timeout);
-        loop: for (EventExecutor l: children) {
+        loop: for (EventExecutor l: chooser.children()) {
             for (;;) {
                 long timeLeft = deadline - System.nanoTime();
                 if (timeLeft <= 0) {
@@ -221,21 +234,75 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
         return (val & -val) == val;
     }
 
-    private interface EventExecutorChooser {
-        EventExecutor next();
-    }
+    private final class RoundRobinChooser implements EventExecutorChooser<T> {
 
-    private final class PowerOfTwoEventExecutorChooser implements EventExecutorChooser {
+        private final EventExecutor[] children;
+        private final AtomicInteger index = new AtomicInteger();
+        private int i;
+
+        RoundRobinChooser(int nChildren) {
+            children = new EventExecutor[nChildren];
+        }
+
         @Override
-        public EventExecutor next() {
-            return children[childIndex.getAndIncrement() & children.length - 1];
+        @SuppressWarnings("unchecked")
+        public T next(SocketAddress remoteAddress) {
+            // This cast is correct because children is only modified by addChild
+            return (T) children[index.getAndIncrement() % children.length];
+        }
+
+        @Override
+        public void addChild(T executor, MetricsCollector metrics) {
+            children[i++] = executor;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public List<T> children() {
+            // This cast is correct because children only contains objects of type T
+            // as is ensured by the addChild method
+            return Arrays.asList((T[]) children);
+        }
+
+        @Override
+        public MetricsCollector newMetricsCollector() {
+            return NoMetricsCollector.INSTANCE;
         }
     }
 
-    private final class GenericEventExecutorChooser implements EventExecutorChooser {
+    private final class PowerOfTwoRoundRobinChooser implements EventExecutorChooser<T> {
+
+        private final EventExecutor[] children;
+        private final AtomicInteger index = new AtomicInteger();
+        private int i;
+
+        PowerOfTwoRoundRobinChooser(int nChildren) {
+            children = new EventExecutor[nChildren];
+        }
+
         @Override
-        public EventExecutor next() {
-            return children[Math.abs(childIndex.getAndIncrement() % children.length)];
+        @SuppressWarnings("unchecked")
+        public T next(SocketAddress remoteAddress) {
+            // This cast is correct because children is only modified by addChild
+            return (T) children[index.getAndIncrement() & children.length - 1];
+        }
+
+        @Override
+        public void addChild(T executor, MetricsCollector metrics) {
+            children[i++] = executor;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public List<T> children() {
+            // This cast is correct because children only contains objects of type T
+            // as is ensured by the addChild method
+            return Arrays.asList((T[]) children);
+        }
+
+        @Override
+        public MetricsCollector newMetricsCollector() {
+            return NoMetricsCollector.INSTANCE;
         }
     }
 }

--- a/common/src/main/java/io/netty/util/metrics/CumulativeHistory.java
+++ b/common/src/main/java/io/netty/util/metrics/CumulativeHistory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.util.metrics;
+
+/**
+ * Maintains the sum of the last N ticks.
+ */
+public class CumulativeHistory {
+    private long tickValue;
+    private volatile long totalValue;
+    private long[] pastValues;
+    private int idx;
+
+    /**
+     * @param pastTicks     number of ticks to keep track of
+     */
+    public CumulativeHistory(int pastTicks) {
+        if (pastTicks < 1) {
+            throw new IllegalArgumentException("pastTicks must not be smaller than one.");
+        }
+
+        pastValues = new long[pastTicks];
+    }
+
+    public void update(long by) {
+        tickValue += by;
+    }
+
+    public void tick() {
+        totalValue -= pastValues[idx];
+        totalValue += tickValue;
+        pastValues[idx] = tickValue;
+        tickValue = 0;
+
+        idx = ++idx < pastValues.length ? idx : 0;
+    }
+
+    public long value() {
+        return totalValue;
+    }
+}

--- a/common/src/main/java/io/netty/util/metrics/DefaultMetricsCollector.java
+++ b/common/src/main/java/io/netty/util/metrics/DefaultMetricsCollector.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.util.metrics;
+
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+public class DefaultMetricsCollector implements MetricsCollector {
+    private boolean initialized;
+    private int curTick;
+
+    private int registeredChannels;
+    private final CumulativeHistory bytesRead;
+    private final CumulativeHistory bytesWritten;
+
+    public DefaultMetricsCollector() {
+        this.bytesRead = new CumulativeHistory(10);
+        this.bytesWritten = new CumulativeHistory(10);
+    }
+
+    public <T extends EventExecutor> void init(T eventExecutor) {
+        if (initialized) {
+            throw new RuntimeException("init must not be called twice.");
+        } else {
+            initialized = true;
+        }
+
+        eventExecutor.scheduleAtFixedRate(new Runnable() {
+            @Override
+            public void run() {
+                bytesRead.tick();
+                bytesWritten.tick();
+            }
+        }, 0, 1, TimeUnit.SECONDS);
+    }
+
+    public void registerChannel() {
+        ++registeredChannels;
+    }
+
+    public void unregisterChannel() {
+        assert registeredChannels > 0;
+        --registeredChannels;
+    }
+
+    public void readBytes(long bytes) {
+        bytesRead.update(bytes);
+    }
+
+    public void writeBytes(long bytes) {
+        bytesWritten.update(bytes);
+    }
+
+    public int registeredChannels() {
+        return registeredChannels;
+    }
+
+    public long bytesRead() {
+        return bytesRead.value();
+    }
+
+    public long bytesWritten() {
+        return bytesWritten.value();
+    }
+}

--- a/common/src/main/java/io/netty/util/metrics/EventExecutorChooser.java
+++ b/common/src/main/java/io/netty/util/metrics/EventExecutorChooser.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.util.metrics;
+
+import io.netty.util.concurrent.EventExecutor;
+import java.net.SocketAddress;
+import java.util.List;
+
+/**
+ * @param <T>   A subclass of {@link EventExecutor}. The main reason to introduce this parameter was to be able to
+ *               hide the internal Event*Executor naming convention from the public API which uses Event*Loop instead.
+ */
+public interface EventExecutorChooser<T extends EventExecutor> {
+    T next(SocketAddress remoteAddress);
+
+    void addChild(T executor, MetricsCollector metrics);
+
+    List<T> children();
+
+    MetricsCollector newMetricsCollector();
+}

--- a/common/src/main/java/io/netty/util/metrics/ExpMovingAverage.java
+++ b/common/src/main/java/io/netty/util/metrics/ExpMovingAverage.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.util.metrics;
+
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import static java.lang.Math.exp;
+
+/*
+ * Exponentially Weighted Moving Average.
+ *
+ * For more details have a look at the
+ * <a href="http://en.wikipedia.org/wiki/Exponential_smoothing#The_exponential_moving_average">Wikipedia article</a>
+ * and Neil J. Gunther's <a href="http://www.teamquest.com/pdfs/whitepaper/ldavg1.pdf">discussion</a> of the
+ * UNIX load average.
+ */
+public class ExpMovingAverage {
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(ExpMovingAverage.class);
+
+    private volatile double value;
+    private long uncounted;
+
+    private double alpha;
+    private int interval;
+
+    private long lastTickTime;
+    private boolean initialized;
+
+    /**
+     * @param alpha factor at which to devalue the average per tick
+     * @param interval  interval in seconds at which {@link #tick()} will be called.
+     */
+    public ExpMovingAverage(double alpha, int interval) {
+        if (alpha < 0 || alpha > 1) {
+            throw new IllegalArgumentException("alpha must be between 0 and 1");
+        }
+
+        if (interval < 1) {
+            throw new IllegalArgumentException("interval must be bigger than 1");
+        }
+
+        this.alpha = alpha;
+        this.interval = interval;
+    }
+
+    public static ExpMovingAverage loadAverageOneMinute() {
+        return new ExpMovingAverage(exp(-5.0 / 60), 5);
+    }
+
+    public static ExpMovingAverage loadAverageFiveMinutes() {
+        return new ExpMovingAverage(exp(-5.0 / 60 / 5), 5);
+    }
+
+    public static ExpMovingAverage loadAverageFifteenMinutes() {
+        return new ExpMovingAverage(exp(-5.0 / 60 / 15), 5);
+    }
+
+    /**
+     * Adds the value to the previous values passed to {@link #update(int)}. This will only
+     * be represented in the exponential moving average after {@link #tick()} was called.
+     */
+    public void update(int by) {
+        uncounted += by;
+    }
+
+    /**
+     * This method should be called every {@link #interval} seconds to update
+     * the exponential moving average {@link #value}. This method will reset {@link #value}
+     * to zero.
+     */
+    public void tick() {
+        final double newValue = normalizeAndResetUncounted();
+        if (initialized) {
+            value = value * (1 - alpha) + newValue * alpha;
+        } else {
+            value = newValue;
+            initialized = true;
+        }
+    }
+
+    /**
+     * @return  The exponential moving average of all data points collected before
+     *          the last call to {@link #tick()}.
+     */
+    public double value() {
+        return value;
+    }
+
+    private double normalizeAndResetUncounted() {
+        double newValue;
+        final long now = System.nanoTime();
+        if (initialized) {
+            final double deltaSeconds = (now - lastTickTime) / 1000.0 / 1000 / 1000;
+            final double inaccRatio = deltaSeconds / interval;
+            if (inaccRatio > 0.1 && inaccRatio < 1.1) {
+                newValue = uncounted;
+            } else {
+                newValue = uncounted * (interval / deltaSeconds);
+
+                if (logger.isDebugEnabled()) {
+                    logger.debug("The actual tick value interval was " + deltaSeconds + " seconds. " +
+                                 "Should have been " + interval + " seconds.");
+                }
+            }
+        } else {
+            newValue = uncounted;
+        }
+
+        lastTickTime = now;
+        uncounted = 0;
+
+        return newValue;
+    }
+}

--- a/common/src/main/java/io/netty/util/metrics/MetricsCollector.java
+++ b/common/src/main/java/io/netty/util/metrics/MetricsCollector.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.util.metrics;
+
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.MultithreadEventExecutorGroup;
+
+/**
+ * Derive from this interface to implement your own {@link MetricsCollector} to be used in an
+ * {@link EventExecutorChooser} implementation.
+ *
+ * Take a look at the {@link DefaultMetricsCollector} class for more details.
+ */
+public interface MetricsCollector {
+    /**
+     * If used with a {@link MultithreadEventExecutorGroup} implementation, this method is called
+     * immediately after the current instance is passed to an eventExecutor and can be used for any additional
+     * initialization work that requires access to the eventExecutor. With the exception of the object's constructor,
+     * this method is called before any other method. This method is called exactly once.
+     *
+     * @param eventExecutor     the {@link EventExecutor} to which the object is attached to.
+     */
+    <T extends EventExecutor> void init(T eventExecutor);
+}

--- a/common/src/main/java/io/netty/util/metrics/NoMetricsCollector.java
+++ b/common/src/main/java/io/netty/util/metrics/NoMetricsCollector.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.util.metrics;
+
+import io.netty.util.concurrent.EventExecutor;
+
+/**
+ * A metrics collector that doesn't collect any metrics. It's for example used by the default
+ * {@link EventExecutorChooser} implementation the
+ * {@link io.netty.util.concurrent.MultithreadEventExecutorGroup.RoundRobinChooser}.
+ */
+public final class NoMetricsCollector implements MetricsCollector {
+
+    public static final NoMetricsCollector INSTANCE = new NoMetricsCollector();
+
+    private NoMetricsCollector() { }
+
+    @Override
+    public <T extends EventExecutor> void init(T eventExecutor) {
+        // NOOP
+    }
+}

--- a/common/src/main/java/io/netty/util/metrics/package-info.java
+++ b/common/src/main/java/io/netty/util/metrics/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Metric collections classes.
+ */
+package io.netty.util.metrics;

--- a/common/src/test/java/io/netty/util/metrics/CumulativeHistoryTest.java
+++ b/common/src/test/java/io/netty/util/metrics/CumulativeHistoryTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.util.metrics;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class CumulativeHistoryTest {
+    @Test
+    public void testRemember0() {
+        CumulativeHistory history = new CumulativeHistory(1);
+
+        history.update(100);
+        history.update(100);
+        history.update(200);
+        history.update(400);
+        assertEquals(0, history.value());
+        history.tick();
+        assertEquals(800, history.value());
+        history.update(200);
+        history.update(300);
+        history.tick();
+        assertEquals(500, history.value());
+        history.tick();
+        assertEquals(0, history.value());
+    }
+
+    @Test
+    public void testRemember5() {
+        CumulativeHistory history = new CumulativeHistory(5);
+
+        history.update(100);
+        history.update(100);
+        assertEquals(0, history.value());
+        history.tick();
+        history.update(200);
+        history.tick();
+        assertEquals(400, history.value());
+        history.update(100);
+        assertEquals(400, history.value());
+        history.update(100);
+        history.tick();
+        assertEquals(600, history.value());
+        history.tick();
+        assertEquals(600, history.value());
+        history.tick();
+        assertEquals(600, history.value());
+
+        history.tick();
+        assertEquals(400, history.value());
+        history.tick();
+        assertEquals(200, history.value());
+        history.tick();
+        assertEquals(0, history.value());
+        history.tick();
+        assertEquals(0, history.value());
+        history.tick();
+        assertEquals(0, history.value());
+    }
+
+    @Test
+    public void testMissingUpdates() {
+        CumulativeHistory history = new CumulativeHistory(10);
+        for (int i = 0; i < 30; i++) {
+            history.tick();
+            assertEquals(0, history.value());
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIllegalSize() {
+        CumulativeHistory history = new CumulativeHistory(0);
+    }
+}

--- a/common/src/test/java/io/netty/util/metrics/ExpMovingAverageTest.java
+++ b/common/src/test/java/io/netty/util/metrics/ExpMovingAverageTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.util.metrics;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class ExpMovingAverageTest {
+    @Test
+    @Ignore
+    public void test1() throws Exception {
+        final ExpMovingAverage avg = new ExpMovingAverage(0.3, 5);
+
+        final ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(1);
+        executor.scheduleAtFixedRate(new Runnable() {
+            private int state;
+
+            @Override
+            public void run() {
+                switch (state) {
+                    case 0:
+                        avg.update(1000);
+                        break;
+                    case 1:
+                        avg.update(1050);
+                        break;
+                    case 2:
+                        avg.update(950);
+                        break;
+                    case 3:
+                        avg.update(1000);
+                        break;
+                    case 4:
+                        avg.update(1100);
+                        break;
+                    case 5:
+                        avg.update(3000);
+                        break;
+                    case 6:
+                        avg.update(10000);
+                        break;
+                    case 7:
+                        avg.update(15000);
+                        break;
+                    case 8:
+                        avg.update(25000);
+                        break;
+                    case 9:
+                        avg.update(45000);
+                        break;
+                    case 10:
+                        avg.update(1000);
+                        break;
+                    case 11:
+                        avg.update(1100);
+                        break;
+                    case 12:
+                        avg.update(1200);
+                        break;
+                    case 13:
+                        executor.shutdown();
+                        break;
+                }
+
+                System.out.println("state " + state + ": " + avg.value());
+
+                state++;
+                avg.tick();
+            }
+        }, 0, 5, TimeUnit.SECONDS).get();
+    }
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -24,6 +24,7 @@ import io.netty.util.collection.IntObjectMap;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import io.netty.util.metrics.MetricsCollector;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -60,8 +61,8 @@ final class EpollEventLoop extends SingleThreadEventLoop {
     private volatile int wakenUp;
     private volatile int ioRatio = 50;
 
-    EpollEventLoop(EventLoopGroup parent, Executor executor, int maxEvents) {
-        super(parent, executor, false);
+    EpollEventLoop(EventLoopGroup parent, Executor executor, MetricsCollector metrics, int maxEvents) {
+        super(parent, executor, metrics, false);
         events = new long[maxEvents];
         boolean success = false;
         int epollFd = -1;

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -16,9 +16,11 @@
 package io.netty.channel.epoll;
 
 import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopChooser;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.metrics.MetricsCollector;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
@@ -40,7 +42,7 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
      * Create a new instance using the specified number of threads and the default {@link ThreadFactory}.
      */
     public EpollEventLoopGroup(int nThreads) {
-        this(nThreads, null);
+        this(nThreads, (ThreadFactory) null);
     }
 
     /**
@@ -55,7 +57,37 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
      * maximal amount of epoll events to handle per epollWait(...).
      */
     public EpollEventLoopGroup(int nThreads, ThreadFactory threadFactory, int maxEventsAtOnce) {
-        super(nThreads, threadFactory, maxEventsAtOnce);
+        this(nThreads, threadFactory, null, maxEventsAtOnce);
+    }
+
+    /**
+     * Create a new instance using the default number of threads and the default {@link ThreadFactory}.
+     */
+    public EpollEventLoopGroup(EventLoopChooser chooser) {
+        this(0, chooser);
+    }
+
+    /**
+     * Create a new instance using the specified number of threads and the default {@link ThreadFactory}.
+     */
+    public EpollEventLoopGroup(int nThreads, EventLoopChooser chooser) {
+        this(nThreads, null, chooser);
+    }
+
+    /**
+     * Create a new instance using the specified number of threads and the given {@link ThreadFactory}.
+     */
+    public EpollEventLoopGroup(int nThreads, ThreadFactory threadFactory, EventLoopChooser chooser) {
+        this(nThreads, threadFactory, chooser, 128);
+    }
+
+    /**
+     * Create a new instance using the specified number of threads, the given {@link ThreadFactory} and the given
+     * maximal amount of epoll events to handle per epollWait(...).
+     */
+    public EpollEventLoopGroup(
+            int nThreads, ThreadFactory threadFactory, EventLoopChooser chooser, int maxEventsAtOnce) {
+        super(nThreads, threadFactory, chooser, maxEventsAtOnce);
     }
 
     /**
@@ -69,7 +101,7 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
     }
 
     @Override
-    protected EventLoop newChild(Executor executor, Object... args) throws Exception {
-        return new EpollEventLoop(this, executor, (Integer) args[0]);
+    protected EventLoop newChild(Executor executor, MetricsCollector metrics, Object... args) throws Exception {
+        return new EpollEventLoop(this, executor, metrics, (Integer) args[0]);
     }
 }

--- a/transport/src/main/java/io/netty/channel/DefaultEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/DefaultEventLoop.java
@@ -16,6 +16,7 @@
 package io.netty.channel;
 
 import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.metrics.NoMetricsCollector;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
@@ -39,11 +40,11 @@ public class DefaultEventLoop extends SingleThreadEventLoop {
     }
 
     public DefaultEventLoop(EventLoopGroup parent, ThreadFactory threadFactory) {
-        super(parent, threadFactory, true);
+        super(parent, threadFactory, NoMetricsCollector.INSTANCE, true);
     }
 
     public DefaultEventLoop(EventLoopGroup parent, Executor executor) {
-        super(parent, executor, true);
+        super(parent, executor, NoMetricsCollector.INSTANCE, true);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/DefaultEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/DefaultEventLoopGroup.java
@@ -15,6 +15,8 @@
  */
 package io.netty.channel;
 
+import io.netty.util.metrics.MetricsCollector;
+
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 
@@ -46,11 +48,11 @@ public class DefaultEventLoopGroup extends MultithreadEventLoopGroup {
      * @param threadFactory     the {@link ThreadFactory} or {@code null} to use the default
      */
     public DefaultEventLoopGroup(int nThreads, ThreadFactory threadFactory) {
-        super(nThreads, threadFactory);
+        super(nThreads, threadFactory, null);
     }
 
     @Override
-    protected EventLoop newChild(Executor executor, Object... args) throws Exception {
+    protected EventLoop newChild(Executor executor, MetricsCollector metrics, Object... args) throws Exception {
         return new DefaultEventLoop(this, executor);
     }
 }

--- a/transport/src/main/java/io/netty/channel/DefaultMetricsCollectorChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/DefaultMetricsCollectorChannelHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.metrics.DefaultMetricsCollector;
+
+public class DefaultMetricsCollectorChannelHandler extends ChannelHandlerAdapter {
+    @Override
+    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+        DefaultMetricsCollector metrics = (DefaultMetricsCollector) ctx.channel().eventLoop().metrics();
+        metrics.registerChannel();
+
+        ctx.fireChannelRegistered();
+    }
+
+    @Override
+    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+        DefaultMetricsCollector metrics = (DefaultMetricsCollector) ctx.channel().eventLoop().metrics();
+        metrics.unregisterChannel();
+
+        ctx.fireChannelUnregistered();
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        DefaultMetricsCollector metrics = (DefaultMetricsCollector) ctx.channel().eventLoop().metrics();
+        metrics.readBytes(((ByteBuf) msg).readableBytes());
+
+        ctx.fireChannelRead(msg);
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        DefaultMetricsCollector metrics = (DefaultMetricsCollector) ctx.channel().eventLoop().metrics();
+        metrics.writeBytes(((ByteBuf) msg).readableBytes());
+
+        ctx.write(msg, promise);
+    }
+}

--- a/transport/src/main/java/io/netty/channel/EventLoop.java
+++ b/transport/src/main/java/io/netty/channel/EventLoop.java
@@ -17,6 +17,7 @@
 package io.netty.channel;
 
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.metrics.MetricsCollector;
 
 /**
  * Will handle all the I/O-Operations for a {@link Channel} once it was registered.
@@ -34,4 +35,6 @@ public interface EventLoop extends EventExecutor, EventLoopGroup {
      * invoke event handler methods.
      */
     ChannelHandlerInvoker asInvoker();
+
+    MetricsCollector metrics();
 }

--- a/transport/src/main/java/io/netty/channel/EventLoopChooser.java
+++ b/transport/src/main/java/io/netty/channel/EventLoopChooser.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel;
+
+import io.netty.util.metrics.EventExecutorChooser;
+import io.netty.util.metrics.MetricsCollector;
+import java.net.SocketAddress;
+import java.nio.channels.SocketChannel;
+import io.netty.util.concurrent.MultithreadEventExecutorGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import java.util.List;
+
+/**
+ * Implement this interface to create your own mapping of {@link SocketChannel}s to {@link EventLoops}s.
+ * For a reference implementation have a look at
+ * {@link io.netty.util.concurrent.MultithreadEventExecutorGroup.RoundRobinChooser}.
+ */
+public interface EventLoopChooser extends EventExecutorChooser<EventLoop> {
+    /**
+     * This method is called whenever a newly accepted {@link SocketChannel} is to be mapped to an
+     * {@link EventLoop} in which case remoteAddress contains its {@link SocketAddress}.
+     * Furthermore, this method is also called to assign tasks (scheduled by Netty or by the user) to
+     * {@link EventLoop}s in which case remoteAddress will be null. A developer must ensure that this
+     * method works in both cases!
+     *
+     * @param remoteAddress the address of the {@link SocketChannel} or null.
+     * @return  This method MUST NOT return null.
+     */
+    @Override
+    EventLoop next(SocketAddress remoteAddress);
+
+    /**
+     * Add a new {@link EventLoop} and its corresponding {@link MetricsCollector}.
+     * <p/>
+     * If the {@link io.netty.util.metrics.EventExecutorChooser} is passed to the constructor of a
+     * {@link MultithreadEventExecutorGroup} implementation (e.g. {@link NioEventLoopGroup}), then {@link #addChild}
+     * is called once for each of its {@link EventLoop}s and the {@link MetricsCollector} objects attached to them.
+     * Furthermore, it is guaranteed that {@link #addChild} will only ever be called with {@link MetricsCollector}
+     * objects created by {@link #newMetricsCollector()}.
+     */
+    @Override
+    void addChild(EventLoop executor, MetricsCollector metrics);
+
+    /**
+     * Returns an unmodifiable list of {@link EventLoop}s that are possible candidates to be returned by
+     * a call to {@link #next(SocketAddress)}.
+     */
+    @Override
+    List<EventLoop> children();
+
+    /**
+     * Factory method to create a new instance of a {@link MetricsCollector}.
+     * <p/>
+     * The main use case of this method is to create a new {@link MetricsCollector} object that is subsequently passed
+     * to {@link #addChild(EventLoop, MetricsCollector)} and attached to the {@link EventLoop}.
+     */
+    @Override
+    MetricsCollector newMetricsCollector();
+}

--- a/transport/src/main/java/io/netty/channel/EventLoopChooserAdapter.java
+++ b/transport/src/main/java/io/netty/channel/EventLoopChooserAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel;
+
+import io.netty.util.metrics.DefaultMetricsCollector;
+import io.netty.util.metrics.MetricsCollector;
+
+import java.net.SocketAddress;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public abstract class EventLoopChooserAdapter implements EventLoopChooser {
+
+    protected final List<EventLoop> eventLoops = new CopyOnWriteArrayList<EventLoop>();
+    protected final List<DefaultMetricsCollector> metrics = new CopyOnWriteArrayList<DefaultMetricsCollector>();
+
+    @Override
+    public void addChild(EventLoop eventLoop, MetricsCollector collector) {
+        eventLoops.add(eventLoop);
+        metrics.add((DefaultMetricsCollector) collector);
+    }
+
+    @Override
+    public List<EventLoop> children() {
+        return Collections.unmodifiableList(eventLoops);
+    }
+
+    @Override
+    public MetricsCollector newMetricsCollector() {
+        return new DefaultMetricsCollector();
+    }
+
+    @Override
+    public abstract EventLoop next(SocketAddress remoteAddress);
+}

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -16,6 +16,7 @@
 package io.netty.channel;
 
 import io.netty.util.concurrent.SingleThreadEventExecutor;
+import io.netty.util.metrics.MetricsCollector;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
@@ -27,13 +28,18 @@ import java.util.concurrent.ThreadFactory;
 public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor implements EventLoop {
 
     private final ChannelHandlerInvoker invoker = new DefaultChannelHandlerInvoker(this);
+    private final MetricsCollector metrics;
 
-    protected SingleThreadEventLoop(EventLoopGroup parent, ThreadFactory threadFactory, boolean addTaskWakesUp) {
+    protected SingleThreadEventLoop(
+            EventLoopGroup parent, ThreadFactory threadFactory, MetricsCollector metrics, boolean addTaskWakesUp) {
         super(parent, threadFactory, addTaskWakesUp);
+        this.metrics = metrics;
     }
 
-    protected SingleThreadEventLoop(EventLoopGroup parent, Executor executor, boolean addTaskWakesUp) {
+    protected SingleThreadEventLoop(
+            EventLoopGroup parent, Executor executor, MetricsCollector metrics, boolean addTaskWakesUp) {
         super(parent, executor, addTaskWakesUp);
+        this.metrics = metrics;
     }
 
     @Override
@@ -67,6 +73,11 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
 
         channel.unsafe().register(this, promise);
         return promise;
+    }
+
+    @Override
+    public MetricsCollector metrics() {
+        return metrics;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
@@ -15,6 +15,8 @@
  */
 package io.netty.channel;
 
+import io.netty.util.metrics.NoMetricsCollector;
+
 /**
  * {@link SingleThreadEventLoop} which is used to handle OIO {@link Channel}'s. So in general there will be
  * one {@link ThreadPerChannelEventLoop} per {@link Channel}.
@@ -26,7 +28,7 @@ public class ThreadPerChannelEventLoop extends SingleThreadEventLoop {
     private Channel ch;
 
     public ThreadPerChannelEventLoop(ThreadPerChannelEventLoopGroup parent) {
-        super(parent, parent.executor, true);
+        super(parent, parent.executor, NoMetricsCollector.INSTANCE, true);
         this.parent = parent;
     }
 

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
@@ -24,6 +24,8 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
+import io.netty.util.metrics.MetricsCollector;
+import io.netty.util.metrics.NoMetricsCollector;
 
 import java.net.SocketAddress;
 import java.util.ArrayDeque;
@@ -115,6 +117,11 @@ final class EmbeddedEventLoop extends AbstractEventLoop implements ChannelHandle
     @Override
     public ChannelHandlerInvoker asInvoker() {
         return this;
+    }
+
+    @Override
+    public MetricsCollector metrics() {
+        return NoMetricsCollector.INSTANCE;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -24,6 +24,7 @@ import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import io.netty.util.metrics.MetricsCollector;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -110,8 +111,9 @@ public final class NioEventLoop extends SingleThreadEventLoop {
     private int cancelledKeys;
     private boolean needsToSelectAgain;
 
-    NioEventLoop(NioEventLoopGroup parent, Executor executor, SelectorProvider selectorProvider) {
-        super(parent, executor, false);
+    NioEventLoop(
+            NioEventLoopGroup parent, Executor executor, MetricsCollector metrics, SelectorProvider selectorProvider) {
+        super(parent, executor, metrics, false);
         if (selectorProvider == null) {
             throw new NullPointerException("selectorProvider");
         }

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
@@ -17,8 +17,10 @@ package io.netty.channel.nio;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopChooser;
 import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.metrics.MetricsCollector;
 
 import java.nio.channels.Selector;
 import java.nio.channels.spi.SelectorProvider;
@@ -43,7 +45,7 @@ public class NioEventLoopGroup extends MultithreadEventLoopGroup {
      * {@link SelectorProvider} which is returned by {@link SelectorProvider#provider()}.
      */
     public NioEventLoopGroup(int nThreads) {
-        this(nThreads, (Executor) null);
+        this(nThreads, (Executor) null, (EventLoopChooser) null);
     }
 
     /**
@@ -64,12 +66,37 @@ public class NioEventLoopGroup extends MultithreadEventLoopGroup {
      */
     public NioEventLoopGroup(
             int nThreads, ThreadFactory threadFactory, final SelectorProvider selectorProvider) {
-        super(nThreads, threadFactory, selectorProvider);
+        this(nThreads, threadFactory, null, selectorProvider);
+    }
+
+    public NioEventLoopGroup(int nThreads, Executor executor, final SelectorProvider selectorProvider) {
+        this(nThreads, executor, null, selectorProvider);
+    }
+
+    public NioEventLoopGroup(EventLoopChooser chooser) {
+        this(0, chooser);
+    }
+
+    public NioEventLoopGroup(int nThreads, EventLoopChooser chooser) {
+        this(nThreads, (Executor) null, chooser);
+    }
+
+    public NioEventLoopGroup(int nThreads, ThreadFactory threadFactory, EventLoopChooser chooser) {
+        this(nThreads, threadFactory, chooser, SelectorProvider.provider());
+    }
+
+    public NioEventLoopGroup(int nThreads, Executor executor, EventLoopChooser chooser) {
+        this(nThreads, executor, chooser, SelectorProvider.provider());
+    }
+
+    public NioEventLoopGroup(int nThreads, ThreadFactory threadFactory, EventLoopChooser chooser,
+                              final SelectorProvider selectorProvider) {
+        super(nThreads, threadFactory, chooser, selectorProvider);
     }
 
     public NioEventLoopGroup(
-            int nThreads, Executor executor, final SelectorProvider selectorProvider) {
-        super(nThreads, executor, selectorProvider);
+            int nThreads, Executor executor, EventLoopChooser chooser, final SelectorProvider selectorProvider) {
+        super(nThreads, executor, chooser, selectorProvider);
     }
 
     /**
@@ -93,7 +120,7 @@ public class NioEventLoopGroup extends MultithreadEventLoopGroup {
     }
 
     @Override
-    protected EventLoop newChild(Executor executor, Object... args) throws Exception {
-        return new NioEventLoop(this, executor, (SelectorProvider) args[0]);
+    protected EventLoop newChild(Executor executor, MetricsCollector metrics, Object... args) throws Exception {
+        return new NioEventLoop(this, executor, metrics, (SelectorProvider) args[0]);
     }
 }

--- a/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
@@ -20,6 +20,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import io.netty.channel.local.LocalChannel;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.metrics.NoMetricsCollector;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -440,7 +441,7 @@ public class SingleThreadEventLoopTest {
         final AtomicInteger cleanedUp = new AtomicInteger();
 
         SingleThreadEventLoopA() {
-            super(null, Executors.defaultThreadFactory(), true);
+            super(null, Executors.defaultThreadFactory(), NoMetricsCollector.INSTANCE, true);
         }
 
         @Override
@@ -467,7 +468,7 @@ public class SingleThreadEventLoopTest {
     private static class SingleThreadEventLoopB extends SingleThreadEventLoop {
 
         SingleThreadEventLoopB() {
-            super(null, Executors.defaultThreadFactory(), false);
+            super(null, Executors.defaultThreadFactory(), NoMetricsCollector.INSTANCE, false);
         }
 
         @Override

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -28,8 +28,10 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.SingleThreadEventLoop;
+import io.netty.util.metrics.MetricsCollector;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import io.netty.util.metrics.NoMetricsCollector;
 import org.junit.Test;
 
 import java.nio.channels.ClosedChannelException;
@@ -190,9 +192,9 @@ public class LocalChannelTest {
         final EventLoopGroup serverGroup = new DefaultEventLoopGroup(1);
         final EventLoopGroup clientGroup = new DefaultEventLoopGroup(1) {
             @Override
-            protected EventLoop newChild(Executor threadFactory, Object... args)
-                    throws Exception {
-                return new SingleThreadEventLoop(this, threadFactory, true) {
+            protected EventLoop newChild(Executor threadFactory, MetricsCollector collector, Object... args)
+            throws Exception {
+                return new SingleThreadEventLoop(this, threadFactory, NoMetricsCollector.INSTANCE, true) {
                     @Override
                     protected void run() {
                         for (;;) {


### PR DESCRIPTION
Hello,

here is a first draft of what I think how #1230 should be implemented.

`EpollEventLoopGroup` and `NioEventLoopGroup` get additional constructors to accept an `EventLoopChooser` object. At its heart the `EventLoopChooser` has a method `EventLoop next(SocketAddress remoteAddress)`, which is called on each accepted channel and maps each channel to an `EventLoop`. The `remoteAddress` parameter is the IP address of the accepted channel. That's useful in cases where a developer wants to map channels to event loops based on IP address or subnet. However, it might also be null, in cases where e.g. a task is assigned an event loop. So developers have to ensure that their code works in both cases. Most developers will simply want to ignore the parameter and assign channels to event loops based on some other criteria, e.g. provided by a `MetricsProvider`.

So what's a `MetricsProvider`? A `MetricsProvider` is mostly (85,7% to be precise) a `MetricsCollector` and the latter one has lots of methods that are called in the different `Channel` implementations to collect data about their inside. Like the number of registered channels, transferred bytes, etc. Each event loop gets its own `MetricsCollector`, that way a developer can implement a `MetricsCollector` to provide metrics on a per event loop basis and use this information in the `EventLoopChooser#next(SocketAddress remoteAddress)` method to decide which channel is mapped to which event loop.

In order to make metrics computation easier, some basic data structures for (what I believe to be) common use cases are provided. One such data structure is what I call the `TickValueHistory`.

A `TickValueHistory` object simply provides the sum of the last n ticks (think n seconds) through a call to `TickValueHistory#value()`. It can be used to answer queries like "how many bytes were transferred in the last n seconds?". It's usage is illustrated in the `DefaultMetricsProvider` class. Basically, a timer increments an integer `currentTick` every second and whenever bytes are read from a channel `TickValueHistory#update(currentTick, bytesRead)` is called. The main advantage of this design is that it avoids lots of calls to `System.nanoTime()` and reduces the "hot path" to two simple integer additions. Furthermore, I am aware that on the accuracy of Netty's scheduled task times can't be counted on (1 second, might really be 2 seconds if the event loop is real busy). I am not sure how much of a problem this will be in practice and so I plan to do some experiments to see it for myself. If times turn out to be really inaccurate, an easy fix would be to simply call System.nanoTime() every tick (think "netty second") and normalize the sum to a real second (that is, divide the sum by the actual time passed).
Also I did not use Fenwick Trees (as opposed to what I wrote in my proposal). The reason being that I think that the generality they provide is simply not needed. Basically, with a Fenwick Tree one could get the sum for arbitrary periods of time (at a greater cost), while the current implementation only allows to look back a specific period of time. In other words, with Fenwick trees the `numPastTicks` parameter would not be in the constructor but in the `value` method.

What's still missing besides tests and comments?
- Add another data structure to provide a moving average. That's useful to answer questions like "What was the average pipeline traversal time in the last m seconds?"
- Add more metric collection methods. I would like to have some more discussions about what's really useful tough, in order to not add metric hooks prematurely.
- Add metric hooks to all transports.
- Benchmarks and lots of testing
- Some `EventLoopChooser` implementations to demonstrate the usefulness of all of this.
- Address @normanmaurer's and @trustin's concerns :)
