### PR TITLE
Adding context to Http2FrameObserver

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandler.java
@@ -121,81 +121,83 @@ public class DelegatingHttp2ConnectionHandler extends AbstractHttp2ConnectionHan
     }
 
     @Override
-    public void onDataRead(int streamId, ByteBuf data, int padding, boolean endOfStream,
-            boolean endOfSegment, boolean compressed) throws Http2Exception {
-        observer.onDataRead(streamId, data, padding, endOfStream, endOfSegment, compressed);
+    public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
+            boolean endOfStream, boolean endOfSegment, boolean compressed) throws Http2Exception {
+        observer.onDataRead(ctx, streamId, data, padding, endOfStream, endOfSegment, compressed);
     }
 
     @Override
-    public void onHeadersRead(int streamId, Http2Headers headers, int padding, boolean endStream,
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+            int padding, boolean endStream, boolean endSegment) throws Http2Exception {
+        observer.onHeadersRead(ctx, streamId, headers, padding, endStream, endSegment);
+    }
+
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+            int streamDependency, short weight, boolean exclusive, int padding, boolean endStream,
             boolean endSegment) throws Http2Exception {
-        observer.onHeadersRead(streamId, headers, padding, endStream, endSegment);
+        observer.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive,
+                padding, endStream, endSegment);
     }
 
     @Override
-    public void onHeadersRead(int streamId, Http2Headers headers, int streamDependency,
-            short weight, boolean exclusive, int padding, boolean endStream, boolean endSegment)
+    public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency,
+            short weight, boolean exclusive) throws Http2Exception {
+        observer.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
+    }
+
+    @Override
+    public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
             throws Http2Exception {
-        observer.onHeadersRead(streamId, headers, streamDependency, weight, exclusive, padding,
-                endStream, endSegment);
+        observer.onRstStreamRead(ctx, streamId, errorCode);
     }
 
     @Override
-    public void onPriorityRead(int streamId, int streamDependency, short weight, boolean exclusive)
+    public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
+        observer.onSettingsAckRead(ctx);
+    }
+
+    @Override
+    public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception {
+        observer.onSettingsRead(ctx, settings);
+    }
+
+    @Override
+    public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
+        observer.onPingRead(ctx, data);
+    }
+
+    @Override
+    public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
+        observer.onPingAckRead(ctx, data);
+    }
+
+    @Override
+    public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
+            Http2Headers headers, int padding) throws Http2Exception {
+        observer.onPushPromiseRead(ctx, streamId, promisedStreamId, headers, padding);
+    }
+
+    @Override
+    public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData)
             throws Http2Exception {
-        observer.onPriorityRead(streamId, streamDependency, weight, exclusive);
+        observer.onGoAwayRead(ctx, lastStreamId, errorCode, debugData);
     }
 
     @Override
-    public void onRstStreamRead(int streamId, long errorCode) throws Http2Exception {
-        observer.onRstStreamRead(streamId, errorCode);
-    }
-
-    @Override
-    public void onSettingsAckRead() throws Http2Exception {
-        observer.onSettingsAckRead();
-    }
-
-    @Override
-    public void onSettingsRead(Http2Settings settings) throws Http2Exception {
-        observer.onSettingsRead(settings);
-    }
-
-    @Override
-    public void onPingRead(ByteBuf data) throws Http2Exception {
-        observer.onPingRead(data);
-    }
-
-    @Override
-    public void onPingAckRead(ByteBuf data) throws Http2Exception {
-        observer.onPingAckRead(data);
-    }
-
-    @Override
-    public void onPushPromiseRead(int streamId, int promisedStreamId, Http2Headers headers,
-            int padding) throws Http2Exception {
-        observer.onPushPromiseRead(streamId, promisedStreamId, headers, padding);
-    }
-
-    @Override
-    public void onGoAwayRead(int lastStreamId, long errorCode, ByteBuf debugData)
+    public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
             throws Http2Exception {
-        observer.onGoAwayRead(lastStreamId, errorCode, debugData);
+        observer.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
     }
 
     @Override
-    public void onWindowUpdateRead(int streamId, int windowSizeIncrement) throws Http2Exception {
-        observer.onWindowUpdateRead(streamId, windowSizeIncrement);
+    public void onAltSvcRead(ChannelHandlerContext ctx, int streamId, long maxAge, int port,
+            ByteBuf protocolId, String host, String origin) throws Http2Exception {
+        observer.onAltSvcRead(ctx, streamId, maxAge, port, protocolId, host, origin);
     }
 
     @Override
-    public void onAltSvcRead(int streamId, long maxAge, int port, ByteBuf protocolId, String host,
-            String origin) throws Http2Exception {
-        observer.onAltSvcRead(streamId, maxAge, port, protocolId, host, origin);
-    }
-
-    @Override
-    public void onBlockedRead(int streamId) throws Http2Exception {
-        observer.onBlockedRead(streamId);
+    public void onBlockedRead(ChannelHandlerContext ctx, int streamId) throws Http2Exception {
+        observer.onBlockedRead(ctx, streamId);
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameObserver.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameObserver.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
 
 /**
  * An observer of HTTP/2 frames.
@@ -25,20 +26,23 @@ public interface Http2FrameObserver {
     /**
      * Handles an inbound DATA frame.
      *
+     * @param ctx the context from the handler where the frame was read.
      * @param streamId the subject stream for the frame.
-     * @param data the payload of the frame.
+     * @param data payload buffer for the frame. If this buffer needs to be retained by the observer
+     *            they must make a copy.
      * @param padding the number of padding bytes found at the end of the frame.
      * @param endOfStream Indicates whether this is the last frame to be sent from the remote
      *            endpoint for this stream.
      * @param endOfSegment Indicates whether this frame is the end of the current segment.
      * @param compressed Indicates whether or not the payload is compressed with gzip encoding.
      */
-    void onDataRead(int streamId, ByteBuf data, int padding, boolean endOfStream,
-            boolean endOfSegment, boolean compressed) throws Http2Exception;
+    void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
+            boolean endOfStream, boolean endOfSegment, boolean compressed) throws Http2Exception;
 
     /**
      * Handles an inbound HEADERS frame.
      *
+     * @param ctx the context from the handler where the frame was read.
      * @param streamId the subject stream for the frame.
      * @param headers the received headers.
      * @param padding the number of padding bytes found at the end of the frame.
@@ -46,12 +50,13 @@ public interface Http2FrameObserver {
      *            for this stream.
      * @param endSegment Indicates whether this frame is the end of the current segment.
      */
-    void onHeadersRead(int streamId, Http2Headers headers, int padding, boolean endStream,
-            boolean endSegment) throws Http2Exception;
+    void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
+            boolean endStream, boolean endSegment) throws Http2Exception;
 
     /**
      * Handles an inbound HEADERS frame with priority information specified.
      *
+     * @param ctx the context from the handler where the frame was read.
      * @param streamId the subject stream for the frame.
      * @param headers the received headers.
      * @param streamDependency the stream on which this stream depends, or 0 if dependent on the
@@ -63,103 +68,120 @@ public interface Http2FrameObserver {
      *            for this stream.
      * @param endSegment Indicates whether this frame is the end of the current segment.
      */
-    void onHeadersRead(int streamId, Http2Headers headers, int streamDependency, short weight,
-            boolean exclusive, int padding, boolean endStream, boolean endSegment)
-            throws Http2Exception;
+    void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+            int streamDependency, short weight, boolean exclusive, int padding, boolean endStream,
+            boolean endSegment) throws Http2Exception;
 
     /**
      * Handles an inbound PRIORITY frame.
      *
+     * @param ctx the context from the handler where the frame was read.
      * @param streamId the subject stream for the frame.
      * @param streamDependency the stream on which this stream depends, or 0 if dependent on the
      *            connection.
      * @param weight the new weight for the stream.
      * @param exclusive whether or not the stream should be the exclusive dependent of its parent.
      */
-    void onPriorityRead(int streamId, int streamDependency, short weight, boolean exclusive)
-            throws Http2Exception;
+    void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency,
+            short weight, boolean exclusive) throws Http2Exception;
 
     /**
      * Handles an inbound RST_STREAM frame.
      *
+     * @param ctx the context from the handler where the frame was read.
      * @param streamId the stream that is terminating.
      * @param errorCode the error code identifying the type of failure.
      */
-    void onRstStreamRead(int streamId, long errorCode) throws Http2Exception;
+    void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception;
 
     /**
      * Handles an inbound SETTINGS acknowledgment frame.
+     * @param ctx the context from the handler where the frame was read.
      */
-    void onSettingsAckRead() throws Http2Exception;
+    void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception;
 
     /**
      * Handles an inbound SETTINGS frame.
      *
+     * @param ctx the context from the handler where the frame was read.
      * @param settings the settings received from the remote endpoint.
      */
-    void onSettingsRead(Http2Settings settings) throws Http2Exception;
+    void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception;
 
     /**
      * Handles an inbound PING frame.
      *
-     * @param data the payload of the frame.
+     * @param ctx the context from the handler where the frame was read.
+     * @param data the payload of the frame. If this buffer needs to be retained by the observer
+     *            they must make a copy.
      */
-    void onPingRead(ByteBuf data) throws Http2Exception;
+    void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception;
 
     /**
      * Handles an inbound PING acknowledgment.
      *
-     * @param data the payload of the frame.
+     * @param ctx the context from the handler where the frame was read.
+     * @param data the payload of the frame. If this buffer needs to be retained by the observer
+     *            they must make a copy.
      */
-    void onPingAckRead(ByteBuf data) throws Http2Exception;
+    void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception;
 
     /**
      * Handles an inbound PUSH_PROMISE frame.
      *
+     * @param ctx the context from the handler where the frame was read.
      * @param streamId the stream the frame was sent on.
      * @param promisedStreamId the ID of the promised stream.
      * @param headers the received headers.
      * @param paddingthe number of padding bytes found at the end of the frame.
      */
-    void onPushPromiseRead(int streamId, int promisedStreamId, Http2Headers headers, int padding)
-            throws Http2Exception;
+    void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
+            Http2Headers headers, int padding) throws Http2Exception;
 
     /**
      * Handles an inbound GO_AWAY frame.
      *
+     * @param ctx the context from the handler where the frame was read.
      * @param lastStreamId the last known stream of the remote endpoint.
      * @param errorCode the error code, if abnormal closure.
-     * @param debugData application-defined debug data.
+     * @param debugData application-defined debug data. If this buffer needs to be retained by the
+     *            observer they must make a copy.
      */
-    void onGoAwayRead(int lastStreamId, long errorCode, ByteBuf debugData) throws Http2Exception;
+    void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData)
+            throws Http2Exception;
 
     /**
      * Handles an inbound WINDOW_UPDATE frame.
      *
+     * @param ctx the context from the handler where the frame was read.
      * @param streamId the stream the frame was sent on.
      * @param windowSizeIncrement the increased number of bytes of the remote endpoint's flow
      *            control window.
      */
-    void onWindowUpdateRead(int streamId, int windowSizeIncrement) throws Http2Exception;
+    void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
+            throws Http2Exception;
 
     /**
      * Handles an inbound ALT_SVC frame.
      *
+     * @param ctx the context from the handler where the frame was read.
      * @param streamId the stream.
      * @param maxAge the freshness lifetime of the alternative service association.
      * @param port the port that the alternative service is available upon.
-     * @param protocolId the ALPN protocol identifier of the alternative service.
+     * @param protocolId the ALPN protocol identifier of the alternative service. If this buffer
+     *            needs to be retained by the observer they must make a copy.
      * @param host the host that the alternative service is available upon.
      * @param origin an optional origin that the alternative service is available upon. May be
      *            {@code null}.
      */
-    void onAltSvcRead(int streamId, long maxAge, int port, ByteBuf protocolId, String host,
-            String origin) throws Http2Exception;
+    void onAltSvcRead(ChannelHandlerContext ctx, int streamId, long maxAge, int port,
+            ByteBuf protocolId, String host, String origin) throws Http2Exception;
 
     /**
      * Handles an inbound BLOCKED frame.
      *
+     * @param ctx the context from the handler where the frame was read.
      * @param streamId the stream that is blocked or 0 if the entire connection is blocked.
      */
-    void onBlockedRead(int streamId) throws Http2Exception;
+    void onBlockedRead(ChannelHandlerContext ctx, int streamId) throws Http2Exception;
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameReader.java
@@ -16,7 +16,7 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
 
 import java.io.Closeable;
 
@@ -30,7 +30,7 @@ public interface Http2FrameReader extends Closeable {
      * Attempts to read the next frame from the input buffer. If enough data is available to fully
      * read the frame, notifies the observer of the read frame.
      */
-    void readFrame(ByteBufAllocator alloc, ByteBuf input, Http2FrameObserver observer)
+    void readFrame(ChannelHandlerContext ctx, ByteBuf input, Http2FrameObserver observer)
             throws Http2Exception;
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
@@ -17,7 +17,7 @@ package io.netty.handler.codec.http2;
 
 import static io.netty.handler.codec.http2.Http2FrameLogger.Direction.INBOUND;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
 
 /**
  * Decorator around a {@link Http2FrameReader} that logs all inbound frames before calling
@@ -40,104 +40,108 @@ public class Http2InboundFrameLogger implements Http2FrameReader {
     }
 
     @Override
-    public void readFrame(ByteBufAllocator alloc, ByteBuf input, final Http2FrameObserver observer)
+    public void readFrame(ChannelHandlerContext ctx, ByteBuf input, final Http2FrameObserver observer)
             throws Http2Exception {
-        reader.readFrame(alloc, input, new Http2FrameObserver() {
+        reader.readFrame(ctx, input, new Http2FrameObserver() {
 
             @Override
-            public void onDataRead(int streamId, ByteBuf data, int padding, boolean endOfStream,
-                    boolean endOfSegment, boolean compressed) throws Http2Exception {
+            public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data,
+                    int padding, boolean endOfStream, boolean endOfSegment, boolean compressed)
+                    throws Http2Exception {
                 logger.logData(INBOUND, streamId, data, padding, endOfStream, endOfSegment,
                         compressed);
-                observer.onDataRead(streamId, data, padding, endOfStream, endOfSegment, compressed);
+                observer.onDataRead(ctx, streamId, data, padding, endOfStream, endOfSegment, compressed);
             }
 
             @Override
-            public void onHeadersRead(int streamId, Http2Headers headers, int padding,
-                    boolean endStream, boolean endSegment) throws Http2Exception {
+            public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
+                    Http2Headers headers, int padding, boolean endStream, boolean endSegment)
+                    throws Http2Exception {
                 logger.logHeaders(INBOUND, streamId, headers, padding, endStream, endSegment);
-                observer.onHeadersRead(streamId, headers, padding, endStream, endSegment);
+                observer.onHeadersRead(ctx, streamId, headers, padding, endStream, endSegment);
             }
 
             @Override
-            public void onHeadersRead(int streamId, Http2Headers headers, int streamDependency,
-                    short weight, boolean exclusive, int padding, boolean endStream,
-                    boolean endSegment) throws Http2Exception {
+            public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
+                    Http2Headers headers, int streamDependency, short weight, boolean exclusive,
+                    int padding, boolean endStream, boolean endSegment) throws Http2Exception {
                 logger.logHeaders(INBOUND, streamId, headers, streamDependency, weight, exclusive,
                         padding, endStream, endSegment);
-                observer.onHeadersRead(streamId, headers, streamDependency, weight, exclusive,
+                observer.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive,
                         padding, endStream, endSegment);
             }
 
             @Override
-            public void onPriorityRead(int streamId, int streamDependency, short weight,
-                    boolean exclusive) throws Http2Exception {
+            public void onPriorityRead(ChannelHandlerContext ctx, int streamId,
+                    int streamDependency, short weight, boolean exclusive) throws Http2Exception {
                 logger.logPriority(INBOUND, streamId, streamDependency, weight, exclusive);
-                observer.onPriorityRead(streamId, streamDependency, weight, exclusive);
+                observer.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
             }
 
             @Override
-            public void onRstStreamRead(int streamId, long errorCode) throws Http2Exception {
-                logger.logRstStream(INBOUND, streamId, errorCode);
-                observer.onRstStreamRead(streamId, errorCode);
-            }
-
-            @Override
-            public void onSettingsAckRead() throws Http2Exception {
-                logger.logSettingsAck(INBOUND);
-                observer.onSettingsAckRead();
-            }
-
-            @Override
-            public void onSettingsRead(Http2Settings settings) throws Http2Exception {
-                logger.logSettings(INBOUND, settings);
-                observer.onSettingsRead(settings);
-            }
-
-            @Override
-            public void onPingRead(ByteBuf data) throws Http2Exception {
-                logger.logPing(INBOUND, data);
-                observer.onPingRead(data);
-            }
-
-            @Override
-            public void onPingAckRead(ByteBuf data) throws Http2Exception {
-                logger.logPingAck(INBOUND, data);
-                observer.onPingAckRead(data);
-            }
-
-            @Override
-            public void onPushPromiseRead(int streamId, int promisedStreamId, Http2Headers headers,
-                    int padding) throws Http2Exception {
-                logger.logPushPromise(INBOUND, streamId, promisedStreamId, headers, padding);
-                observer.onPushPromiseRead(streamId, promisedStreamId, headers, padding);
-            }
-
-            @Override
-            public void onGoAwayRead(int lastStreamId, long errorCode, ByteBuf debugData)
+            public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
                     throws Http2Exception {
-                logger.logGoAway(INBOUND, lastStreamId, errorCode, debugData);
-                observer.onGoAwayRead(lastStreamId, errorCode, debugData);
+                logger.logRstStream(INBOUND, streamId, errorCode);
+                observer.onRstStreamRead(ctx, streamId, errorCode);
             }
 
             @Override
-            public void onWindowUpdateRead(int streamId, int windowSizeIncrement)
+            public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
+                logger.logSettingsAck(INBOUND);
+                observer.onSettingsAckRead(ctx);
+            }
+
+            @Override
+            public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings)
+                    throws Http2Exception {
+                logger.logSettings(INBOUND, settings);
+                observer.onSettingsRead(ctx, settings);
+            }
+
+            @Override
+            public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
+                logger.logPing(INBOUND, data);
+                observer.onPingRead(ctx, data);
+            }
+
+            @Override
+            public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
+                logger.logPingAck(INBOUND, data);
+                observer.onPingAckRead(ctx, data);
+            }
+
+            @Override
+            public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId,
+                    int promisedStreamId, Http2Headers headers, int padding) throws Http2Exception {
+                logger.logPushPromise(INBOUND, streamId, promisedStreamId, headers, padding);
+                observer.onPushPromiseRead(ctx, streamId, promisedStreamId, headers, padding);
+            }
+
+            @Override
+            public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
+                    ByteBuf debugData) throws Http2Exception {
+                logger.logGoAway(INBOUND, lastStreamId, errorCode, debugData);
+                observer.onGoAwayRead(ctx, lastStreamId, errorCode, debugData);
+            }
+
+            @Override
+            public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
                     throws Http2Exception {
                 logger.logWindowsUpdate(INBOUND, streamId, windowSizeIncrement);
-                observer.onWindowUpdateRead(streamId, windowSizeIncrement);
+                observer.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
             }
 
             @Override
-            public void onAltSvcRead(int streamId, long maxAge, int port, ByteBuf protocolId,
-                    String host, String origin) throws Http2Exception {
+            public void onAltSvcRead(ChannelHandlerContext ctx, int streamId, long maxAge,
+                    int port, ByteBuf protocolId, String host, String origin) throws Http2Exception {
                 logger.logAltSvc(INBOUND, streamId, maxAge, port, protocolId, host, origin);
-                observer.onAltSvcRead(streamId, maxAge, port, protocolId, host, origin);
+                observer.onAltSvcRead(ctx, streamId, maxAge, port, protocolId, host, origin);
             }
 
             @Override
-            public void onBlockedRead(int streamId) throws Http2Exception {
+            public void onBlockedRead(ChannelHandlerContext ctx, int streamId) throws Http2Exception {
                 logger.logBlocked(INBOUND, streamId);
-                observer.onBlockedRead(streamId);
+                observer.onBlockedRead(ctx, streamId);
             }
         });
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameIOTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameIOTest.java
@@ -71,8 +71,8 @@ public class DefaultHttp2FrameIOTest {
         ByteBuf data = Unpooled.EMPTY_BUFFER;
         writer.writeData(ctx, promise, 1000, data, 0, false, false, false);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onDataRead(eq(1000), eq(data), eq(0), eq(false), eq(false), eq(false));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onDataRead(eq(ctx), eq(1000), eq(data), eq(0), eq(false), eq(false), eq(false));
     }
 
     @Test
@@ -80,8 +80,8 @@ public class DefaultHttp2FrameIOTest {
         ByteBuf data = dummyData();
         writer.writeData(ctx, promise, 1000, data.retain().duplicate(), 0, false, false, false);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onDataRead(eq(1000), eq(data), eq(0), eq(false), eq(false), eq(false));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onDataRead(eq(ctx), eq(1000), eq(data), eq(0), eq(false), eq(false), eq(false));
     }
 
     @Test
@@ -89,32 +89,32 @@ public class DefaultHttp2FrameIOTest {
         ByteBuf data = dummyData();
         writer.writeData(ctx, promise, 1, data.retain().duplicate(), 256, true, true, true);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onDataRead(eq(1), eq(data), eq(256), eq(true), eq(true), eq(true));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onDataRead(eq(ctx), eq(1), eq(data), eq(256), eq(true), eq(true), eq(true));
     }
 
     @Test
     public void priorityShouldRoundtrip() throws Exception {
         writer.writePriority(ctx, promise, 1, 2, (short) 255, true);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onPriorityRead(eq(1), eq(2), eq((short) 255), eq(true));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onPriorityRead(eq(ctx), eq(1), eq(2), eq((short) 255), eq(true));
     }
 
     @Test
     public void rstStreamShouldRoundtrip() throws Exception {
         writer.writeRstStream(ctx, promise, 1, MAX_UNSIGNED_INT);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onRstStreamRead(eq(1), eq(MAX_UNSIGNED_INT));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onRstStreamRead(eq(ctx), eq(1), eq(MAX_UNSIGNED_INT));
     }
 
     @Test
     public void emptySettingsShouldRoundtrip() throws Exception {
         writer.writeSettings(ctx, promise, new Http2Settings());
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onSettingsRead(eq(new Http2Settings()));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onSettingsRead(eq(ctx), eq(new Http2Settings()));
     }
 
     @Test
@@ -128,16 +128,16 @@ public class DefaultHttp2FrameIOTest {
 
         writer.writeSettings(ctx, promise, settings);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onSettingsRead(eq(settings));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onSettingsRead(eq(ctx), eq(settings));
     }
 
     @Test
     public void settingsAckShouldRoundtrip() throws Exception {
         writer.writeSettingsAck(ctx, promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onSettingsAckRead();
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onSettingsAckRead(eq(ctx));
     }
 
     @Test
@@ -145,8 +145,8 @@ public class DefaultHttp2FrameIOTest {
         ByteBuf data = dummyData();
         writer.writePing(ctx, promise, false, data.retain().duplicate());
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onPingRead(eq(data));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onPingRead(eq(ctx), eq(data));
     }
 
     @Test
@@ -154,8 +154,8 @@ public class DefaultHttp2FrameIOTest {
         ByteBuf data = dummyData();
         writer.writePing(ctx, promise, true, data.retain().duplicate());
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onPingAckRead(eq(data));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onPingAckRead(eq(ctx), eq(data));
     }
 
     @Test
@@ -163,16 +163,16 @@ public class DefaultHttp2FrameIOTest {
         ByteBuf data = dummyData();
         writer.writeGoAway(ctx, promise, 1, MAX_UNSIGNED_INT, data.retain().duplicate());
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onGoAwayRead(eq(1), eq(MAX_UNSIGNED_INT), eq(data));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onGoAwayRead(eq(ctx), eq(1), eq(MAX_UNSIGNED_INT), eq(data));
     }
 
     @Test
     public void windowUpdateShouldRoundtrip() throws Exception {
         writer.writeWindowUpdate(ctx, promise, 1, Integer.MAX_VALUE);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onWindowUpdateRead(eq(1), eq(Integer.MAX_VALUE));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onWindowUpdateRead(eq(ctx), eq(1), eq(Integer.MAX_VALUE));
     }
 
     @Test
@@ -180,8 +180,8 @@ public class DefaultHttp2FrameIOTest {
         writer.writeAltSvc(ctx, promise, 1, MAX_UNSIGNED_INT, MAX_UNSIGNED_SHORT, dummyData(), "host",
                 "origin");
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onAltSvcRead(eq(1), eq(MAX_UNSIGNED_INT), eq(MAX_UNSIGNED_SHORT),
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onAltSvcRead(eq(ctx), eq(1), eq(MAX_UNSIGNED_INT), eq(MAX_UNSIGNED_SHORT),
                 eq(dummyData()), eq("host"), eq("origin"));
     }
 
@@ -189,8 +189,8 @@ public class DefaultHttp2FrameIOTest {
     public void altSvcWithoutOriginShouldRoundtrip() throws Exception {
         writer.writeAltSvc(ctx, promise, 1, MAX_UNSIGNED_INT, MAX_UNSIGNED_SHORT, dummyData(), "host", null);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onAltSvcRead(eq(1), eq(MAX_UNSIGNED_INT), eq(MAX_UNSIGNED_SHORT),
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onAltSvcRead(eq(ctx), eq(1), eq(MAX_UNSIGNED_INT), eq(MAX_UNSIGNED_SHORT),
                 eq(dummyData()), eq("host"), isNull(String.class));
     }
 
@@ -198,8 +198,8 @@ public class DefaultHttp2FrameIOTest {
     public void blockedShouldRoundtrip() throws Exception {
         writer.writeBlocked(ctx, promise, 1);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onBlockedRead(eq(1));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onBlockedRead(eq(ctx), eq(1));
     }
 
     @Test
@@ -207,8 +207,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = Http2Headers.EMPTY_HEADERS;
         writer.writeHeaders(ctx, promise, 1, headers, 0, true, true);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onHeadersRead(eq(1), eq(headers), eq(0), eq(true), eq(true));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0), eq(true), eq(true));
     }
 
     @Test
@@ -216,8 +216,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = Http2Headers.EMPTY_HEADERS;
         writer.writeHeaders(ctx, promise, 1, headers, 256, true, true);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onHeadersRead(eq(1), eq(headers), eq(256), eq(true), eq(true));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(256), eq(true), eq(true));
     }
 
     @Test
@@ -225,8 +225,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = dummyHeaders();
         writer.writeHeaders(ctx, promise, 1, headers, 0, true, true);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onHeadersRead(eq(1), eq(headers), eq(0), eq(true), eq(true));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0), eq(true), eq(true));
     }
 
     @Test
@@ -234,8 +234,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = dummyHeaders();
         writer.writeHeaders(ctx, promise, 1, headers, 256, true, true);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onHeadersRead(eq(1), eq(headers), eq(256), eq(true), eq(true));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(256), eq(true), eq(true));
     }
 
     @Test
@@ -243,8 +243,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = dummyHeaders();
         writer.writeHeaders(ctx, promise, 1, headers, 2, (short) 3, true, 0, true, true);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onHeadersRead(eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0),
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0),
                 eq(true), eq(true));
     }
 
@@ -253,8 +253,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = dummyHeaders();
         writer.writeHeaders(ctx, promise, 1, headers, 2, (short) 3, true, 256, true, true);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onHeadersRead(eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(256),
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(256),
                 eq(true), eq(true));
     }
 
@@ -263,8 +263,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = largeHeaders();
         writer.writeHeaders(ctx, promise, 1, headers, 2, (short) 3, true, 0, true, true);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onHeadersRead(eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0),
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0),
                 eq(true), eq(true));
     }
 
@@ -273,8 +273,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = largeHeaders();
         writer.writeHeaders(ctx, promise, 1, headers, 2, (short) 3, true, 256, true, true);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onHeadersRead(eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(256),
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(256),
                 eq(true), eq(true));
     }
 
@@ -283,8 +283,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = Http2Headers.EMPTY_HEADERS;
         writer.writePushPromise(ctx, promise, 1, 2, headers, 0);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onPushPromiseRead(eq(1), eq(2), eq(headers), eq(0));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0));
     }
 
     @Test
@@ -292,8 +292,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = dummyHeaders();
         writer.writePushPromise(ctx, promise, 1, 2, headers, 0);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onPushPromiseRead(eq(1), eq(2), eq(headers), eq(0));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0));
     }
 
     @Test
@@ -301,8 +301,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = dummyHeaders();
         writer.writePushPromise(ctx, promise, 1, 2, headers, 256);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onPushPromiseRead(eq(1), eq(2), eq(headers), eq(256));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(256));
     }
 
     @Test
@@ -310,8 +310,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = largeHeaders();
         writer.writePushPromise(ctx, promise, 1, 2, headers, 0);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onPushPromiseRead(eq(1), eq(2), eq(headers), eq(0));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0));
     }
 
     @Test
@@ -319,8 +319,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = largeHeaders();
         writer.writePushPromise(ctx, promise, 1, 2, headers, 256);
         ByteBuf frame = captureWrite();
-        reader.readFrame(alloc, frame, observer);
-        verify(observer).onPushPromiseRead(eq(1), eq(2), eq(headers), eq(256));
+        reader.readFrame(ctx, frame, observer);
+        verify(observer).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(256));
     }
 
     private ByteBuf captureWrite() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http2;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
@@ -128,10 +129,11 @@ public class Http2ConnectionRoundtripTest {
 
         // Wait for all frames to be received.
         awaitRequests();
-        verify(serverObserver, times(numStreams)).onHeadersRead(anyInt(), eq(headers), eq(0),
-                eq((short) 16), eq(false), eq(0), eq(false), eq(false));
-        verify(serverObserver, times(numStreams)).onDataRead(anyInt(),
-                eq(Unpooled.copiedBuffer(text.getBytes())), eq(0), eq(true), eq(true), eq(false));
+        verify(serverObserver, times(numStreams)).onHeadersRead(any(ChannelHandlerContext.class),
+                anyInt(), eq(headers), eq(0), eq((short) 16), eq(false), eq(0), eq(false),
+                eq(false));
+        verify(serverObserver, times(numStreams)).onDataRead(any(ChannelHandlerContext.class),
+                anyInt(), eq(Unpooled.copiedBuffer(text.getBytes())), eq(0), eq(true), eq(true), eq(false));
     }
 
     private void awaitRequests() throws Exception {
@@ -157,97 +159,100 @@ public class Http2ConnectionRoundtripTest {
     private final class FrameCountDown implements Http2FrameObserver {
 
         @Override
-        public void onDataRead(int streamId, ByteBuf data, int padding, boolean endOfStream,
-                boolean endOfSegment, boolean compressed) throws Http2Exception {
-            serverObserver.onDataRead(streamId, copy(data), padding, endOfStream, endOfSegment,
-                    compressed);
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onHeadersRead(int streamId, Http2Headers headers, int padding,
-                boolean endStream, boolean endSegment) throws Http2Exception {
-            serverObserver.onHeadersRead(streamId, headers, padding, endStream, endSegment);
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void
-                onHeadersRead(int streamId, Http2Headers headers, int streamDependency,
-                        short weight, boolean exclusive, int padding, boolean endStream,
-                        boolean endSegment) throws Http2Exception {
-            serverObserver.onHeadersRead(streamId, headers, streamDependency, weight, exclusive,
-                    padding, endStream, endSegment);
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onPriorityRead(int streamId, int streamDependency, short weight,
-                boolean exclusive) throws Http2Exception {
-            serverObserver.onPriorityRead(streamId, streamDependency, weight, exclusive);
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onRstStreamRead(int streamId, long errorCode) throws Http2Exception {
-            serverObserver.onRstStreamRead(streamId, errorCode);
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onSettingsAckRead() throws Http2Exception {
-            serverObserver.onSettingsAckRead();
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onSettingsRead(Http2Settings settings) throws Http2Exception {
-            serverObserver.onSettingsRead(settings);
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onPingRead(ByteBuf data) throws Http2Exception {
-            serverObserver.onPingRead(copy(data));
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onPingAckRead(ByteBuf data) throws Http2Exception {
-            serverObserver.onPingAckRead(copy(data));
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onPushPromiseRead(int streamId, int promisedStreamId, Http2Headers headers,
-                int padding) throws Http2Exception {
-            serverObserver.onPushPromiseRead(streamId, promisedStreamId, headers, padding);
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onGoAwayRead(int lastStreamId, long errorCode, ByteBuf debugData)
+        public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
+                boolean endOfStream, boolean endOfSegment, boolean compressed)
                 throws Http2Exception {
-            serverObserver.onGoAwayRead(lastStreamId, errorCode, copy(debugData));
+            serverObserver.onDataRead(ctx, streamId, copy(data), padding, endOfStream,
+                    endOfSegment, compressed);
             requestLatch.countDown();
         }
 
         @Override
-        public void onWindowUpdateRead(int streamId, int windowSizeIncrement) throws Http2Exception {
-            serverObserver.onWindowUpdateRead(streamId, windowSizeIncrement);
+        public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+                int padding, boolean endStream, boolean endSegment) throws Http2Exception {
+            serverObserver.onHeadersRead(ctx, streamId, headers, padding, endStream, endSegment);
             requestLatch.countDown();
         }
 
         @Override
-        public void onAltSvcRead(int streamId, long maxAge, int port, ByteBuf protocolId,
-                String host, String origin) throws Http2Exception {
-            serverObserver.onAltSvcRead(streamId, maxAge, port, copy(protocolId), host, origin);
+        public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+                int streamDependency, short weight, boolean exclusive, int padding,
+                boolean endStream, boolean endSegment) throws Http2Exception {
+            serverObserver.onHeadersRead(ctx, streamId, headers, streamDependency, weight,
+                    exclusive, padding, endStream, endSegment);
             requestLatch.countDown();
         }
 
         @Override
-        public void onBlockedRead(int streamId) throws Http2Exception {
-            serverObserver.onBlockedRead(streamId);
+        public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency,
+                short weight, boolean exclusive) throws Http2Exception {
+            serverObserver.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
+            requestLatch.countDown();
+        }
+
+        @Override
+        public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
+                throws Http2Exception {
+            serverObserver.onRstStreamRead(ctx, streamId, errorCode);
+            requestLatch.countDown();
+        }
+
+        @Override
+        public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
+            serverObserver.onSettingsAckRead(ctx);
+            requestLatch.countDown();
+        }
+
+        @Override
+        public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception {
+            serverObserver.onSettingsRead(ctx, settings);
+            requestLatch.countDown();
+        }
+
+        @Override
+        public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
+            serverObserver.onPingRead(ctx, copy(data));
+            requestLatch.countDown();
+        }
+
+        @Override
+        public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
+            serverObserver.onPingAckRead(ctx, copy(data));
+            requestLatch.countDown();
+        }
+
+        @Override
+        public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId,
+                int promisedStreamId, Http2Headers headers, int padding) throws Http2Exception {
+            serverObserver.onPushPromiseRead(ctx, streamId, promisedStreamId, headers, padding);
+            requestLatch.countDown();
+        }
+
+        @Override
+        public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData)
+                throws Http2Exception {
+            serverObserver.onGoAwayRead(ctx, lastStreamId, errorCode, copy(debugData));
+            requestLatch.countDown();
+        }
+
+        @Override
+        public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId,
+                int windowSizeIncrement) throws Http2Exception {
+            serverObserver.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
+            requestLatch.countDown();
+        }
+
+        @Override
+        public void onAltSvcRead(ChannelHandlerContext ctx, int streamId, long maxAge, int port,
+                ByteBuf protocolId, String host, String origin) throws Http2Exception {
+            serverObserver
+                    .onAltSvcRead(ctx, streamId, maxAge, port, copy(protocolId), host, origin);
+            requestLatch.countDown();
+        }
+
+        @Override
+        public void onBlockedRead(ChannelHandlerContext ctx, int streamId) throws Http2Exception {
+            serverObserver.onBlockedRead(ctx, streamId);
             requestLatch.countDown();
         }
 

--- a/example/src/main/java/io/netty/example/http2/client/Http2ClientConnectionHandler.java
+++ b/example/src/main/java/io/netty/example/http2/client/Http2ClientConnectionHandler.java
@@ -80,8 +80,8 @@ public class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler
     }
 
     @Override
-    public void onDataRead(int streamId, ByteBuf data, int padding, boolean endOfStream,
-            boolean endOfSegment, boolean compressed) throws Http2Exception {
+    public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
+            boolean endOfStream, boolean endOfSegment, boolean compressed) throws Http2Exception {
 
         // Copy the data into the buffer.
         int available = data.readableBytes();
@@ -112,65 +112,68 @@ public class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler
     }
 
     @Override
-    public void onHeadersRead(int streamId, Http2Headers headers, int padding, boolean endStream,
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+            int padding, boolean endStream, boolean endSegment) throws Http2Exception {
+    }
+
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+            int streamDependency, short weight, boolean exclusive, int padding, boolean endStream,
             boolean endSegment) throws Http2Exception {
     }
 
     @Override
-    public void onHeadersRead(int streamId, Http2Headers headers, int streamDependency,
-            short weight, boolean exclusive, int padding, boolean endStream, boolean endSegment)
+    public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency,
+            short weight, boolean exclusive) throws Http2Exception {
+    }
+
+    @Override
+    public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
             throws Http2Exception {
     }
 
     @Override
-    public void onPriorityRead(int streamId, int streamDependency, short weight, boolean exclusive)
+    public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
+    }
+
+    @Override
+    public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings)
             throws Http2Exception {
-    }
-
-    @Override
-    public void onRstStreamRead(int streamId, long errorCode) throws Http2Exception {
-    }
-
-    @Override
-    public void onSettingsAckRead() throws Http2Exception {
-    }
-
-    @Override
-    public void onSettingsRead(Http2Settings settings) throws Http2Exception {
         if (!initialized.isDone()) {
             initialized.setSuccess();
         }
     }
 
     @Override
-    public void onPingRead(ByteBuf data) throws Http2Exception {
+    public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
     }
 
     @Override
-    public void onPingAckRead(ByteBuf data) throws Http2Exception {
+    public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
     }
 
     @Override
-    public void onPushPromiseRead(int streamId, int promisedStreamId, Http2Headers headers,
-            int padding) throws Http2Exception {
+    public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
+            Http2Headers headers, int padding) throws Http2Exception {
     }
 
     @Override
-    public void onGoAwayRead(int lastStreamId, long errorCode, ByteBuf debugData)
+    public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
+            ByteBuf debugData) throws Http2Exception {
+    }
+
+    @Override
+    public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
             throws Http2Exception {
     }
 
     @Override
-    public void onWindowUpdateRead(int streamId, int windowSizeIncrement) throws Http2Exception {
+    public void onAltSvcRead(ChannelHandlerContext ctx, int streamId, long maxAge, int port,
+            ByteBuf protocolId, String host, String origin) throws Http2Exception {
     }
 
     @Override
-    public void onAltSvcRead(int streamId, long maxAge, int port, ByteBuf protocolId, String host,
-            String origin) throws Http2Exception {
-    }
-
-    @Override
-    public void onBlockedRead(int streamId) throws Http2Exception {
+    public void onBlockedRead(ChannelHandlerContext ctx, int streamId) throws Http2Exception {
     }
 
     @Override

--- a/example/src/main/java/io/netty/example/http2/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/server/HelloWorldHttp2Handler.java
@@ -36,26 +36,26 @@ public class HelloWorldHttp2Handler extends AbstractHttp2ConnectionHandler {
     }
 
     @Override
-    public void onDataRead(int streamId, ByteBuf data, int padding, boolean endOfStream,
-            boolean endOfSegment, boolean compressed) throws Http2Exception {
+    public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
+            boolean endOfStream, boolean endOfSegment, boolean compressed) throws Http2Exception {
         if (endOfStream) {
             sendResponse(ctx(), streamId);
         }
     }
 
     @Override
-    public void onHeadersRead(int streamId,
-            io.netty.handler.codec.http2.Http2Headers headers, int padding,
-            boolean endStream, boolean endSegment) throws Http2Exception {
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
+            io.netty.handler.codec.http2.Http2Headers headers, int padding, boolean endStream,
+            boolean endSegment) throws Http2Exception {
         if (endStream) {
             sendResponse(ctx(), streamId);
         }
     }
 
     @Override
-    public void onHeadersRead(int streamId,
-            io.netty.handler.codec.http2.Http2Headers headers, int streamDependency,
-            short weight, boolean exclusive, int padding, boolean endStream, boolean endSegment)
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
+            io.netty.handler.codec.http2.Http2Headers headers, int streamDependency, short weight,
+            boolean exclusive, int padding, boolean endStream, boolean endSegment)
             throws Http2Exception {
         if (endStream) {
             sendResponse(ctx(), streamId);
@@ -63,52 +63,53 @@ public class HelloWorldHttp2Handler extends AbstractHttp2ConnectionHandler {
     }
 
     @Override
-    public void onPriorityRead(int streamId, int streamDependency, short weight, boolean exclusive)
+    public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency,
+            short weight, boolean exclusive) throws Http2Exception {
+    }
+
+    @Override
+    public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
             throws Http2Exception {
     }
 
     @Override
-    public void onRstStreamRead(int streamId, long errorCode) throws Http2Exception {
+    public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
     }
 
     @Override
-    public void onSettingsAckRead() throws Http2Exception {
+    public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception {
     }
 
     @Override
-    public void onSettingsRead(Http2Settings settings) throws Http2Exception {
+    public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
     }
 
     @Override
-    public void onPingRead(ByteBuf data) throws Http2Exception {
+    public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
     }
 
     @Override
-    public void onPingAckRead(ByteBuf data) throws Http2Exception {
+    public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
+            io.netty.handler.codec.http2.Http2Headers headers, int padding) throws Http2Exception {
     }
 
     @Override
-    public void onPushPromiseRead(int streamId, int promisedStreamId,
-            io.netty.handler.codec.http2.Http2Headers headers, int padding)
+    public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
+            ByteBuf debugData) throws Http2Exception {
+    }
+
+    @Override
+    public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
             throws Http2Exception {
     }
 
     @Override
-    public void onGoAwayRead(int lastStreamId, long errorCode, ByteBuf debugData)
-            throws Http2Exception {
+    public void onAltSvcRead(ChannelHandlerContext ctx, int streamId, long maxAge, int port,
+            ByteBuf protocolId, String host, String origin) throws Http2Exception {
     }
 
     @Override
-    public void onWindowUpdateRead(int streamId, int windowSizeIncrement) throws Http2Exception {
-    }
-
-    @Override
-    public void onAltSvcRead(int streamId, long maxAge, int port, ByteBuf protocolId, String host,
-            String origin) throws Http2Exception {
-    }
-
-    @Override
-    public void onBlockedRead(int streamId) throws Http2Exception {
+    public void onBlockedRead(ChannelHandlerContext ctx, int streamId) throws Http2Exception {
     }
 
     @Override


### PR DESCRIPTION
Motivation:

The Http2FrameObserver isn't provided the ChannelHandlerContext when
it's called back. This will force observers to find an alternative means
of obtaining the context if they need to do things like copying buffers.

Modifications:

Changed the Http2FrameReader and Http2FrameObserver to include the
context. Updated all other uses of these interfaces.

Result:

Frame observers will now have the channel context.
