### PR TITLE
Use ByteBuf.readSlice(...).retain() to minimize memory copies.

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoder.java
@@ -268,13 +268,13 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoder {
             }
 
             if (stripDelimiter) {
-                frame = buffer.readBytes(minFrameLength);
+                frame = buffer.readSlice(minFrameLength);
                 buffer.skipBytes(minDelimLength);
             } else {
-                frame = buffer.readBytes(minFrameLength + minDelimLength);
+                frame = buffer.readSlice(minFrameLength + minDelimLength);
             }
 
-            return frame;
+            return frame.retain();
         } else {
             if (!discardingTooLongFrame) {
                 if (buffer.readableBytes() > maxFrameLength) {

--- a/codec/src/main/java/io/netty/handler/codec/FixedLengthFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/FixedLengthFrameDecoder.java
@@ -74,7 +74,7 @@ public class FixedLengthFrameDecoder extends ByteToMessageDecoder {
         if (in.readableBytes() < frameLength) {
             return null;
         } else {
-            return in.readBytes(frameLength);
+            return in.readSlice(frameLength).retain();
         }
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/LineBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LineBasedFrameDecoder.java
@@ -100,13 +100,13 @@ public class LineBasedFrameDecoder extends ByteToMessageDecoder {
                 }
 
                 if (stripDelimiter) {
-                    frame = buffer.readBytes(length);
+                    frame = buffer.readSlice(length);
                     buffer.skipBytes(delimLength);
                 } else {
-                    frame = buffer.readBytes(length + delimLength);
+                    frame = buffer.readSlice(length + delimLength);
                 }
 
-                return frame;
+                return frame.retain();
             } else {
                 final int length = buffer.readableBytes();
                 if (length > maxLength) {


### PR DESCRIPTION
Motivation:
At the moment we call ByteBuf.readBytes(...) in these handlers but with optimizations done as part of 25e0d9d we can just use readSlice(...).retain() and eliminate the memory copy.

Modifications:
Replace ByteBuf.readBytes(...) usage with readSlice(...).retain().

Result:
Less memory copies.
