### PR TITLE
Various fixes for compliance with HTTP/2 spec

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PriorityTree.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2PriorityTree.java
@@ -16,8 +16,8 @@
 package io.netty.handler.codec.http2;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
-import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_UNSIGNED_BYTE;
-import io.netty.handler.codec.http2.Http2PriorityTree.Priority;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_WEIGHT;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_WEIGHT;
 
 import java.util.ArrayDeque;
 import java.util.Collections;
@@ -62,7 +62,7 @@ public class DefaultHttp2PriorityTree<T> implements Http2PriorityTree<T> {
         if (parent < 0) {
             throw new IllegalArgumentException("Parent stream ID must be >= 0");
         }
-        if (weight < 1 || weight > MAX_UNSIGNED_BYTE) {
+        if (weight < MIN_WEIGHT || weight > MAX_WEIGHT) {
             throw new IllegalArgumentException("Invalid weight: " + weight);
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -43,6 +43,8 @@ public final class Http2CodecUtil {
     public static final int SETTING_ENTRY_LENGTH = 5;
     public static final int PRIORITY_ENTRY_LENGTH = 5;
     public static final int INT_FIELD_LENGTH = 4;
+    public static final short MAX_WEIGHT = (short) 256;
+    public static final short MIN_WEIGHT = (short) 1;
 
     public static final short SETTINGS_HEADER_TABLE_SIZE = 1;
     public static final short SETTINGS_ENABLE_PUSH = 2;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -56,12 +56,18 @@ public interface Http2Connection {
         Http2Stream reservePushStream(int streamId, Http2Stream parent) throws Http2Exception;
 
         /**
+         * Indicates whether or not this endpoint is the server-side of the connection.
+         */
+        boolean isServer();
+
+        /**
          * Sets whether server push is allowed to this endpoint.
          */
         void allowPushTo(boolean allow);
 
         /**
-         * Gets whether or not server push is allowed to this endpoint.
+         * Gets whether or not server push is allowed to this endpoint. This is always false
+         * for a server endpoint.
          */
         boolean allowPushTo();
 
@@ -97,7 +103,7 @@ public interface Http2Connection {
     }
 
     /**
-     * Indicates whether or not this endpoint is the server-side of the connection.
+     * Indicates whether or not the local endpoint for this connection is the server.
      */
     boolean isServer();
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -116,17 +116,27 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void clientReservePushStreamShouldSucceed() throws Http2Exception {
-        Http2Stream stream = client.remote().createStream(2, true);
-        Http2Stream pushStream = client.local().reservePushStream(3, stream);
-        assertEquals(3, pushStream.id());
+        Http2Stream stream = server.remote().createStream(3, true);
+        Http2Stream pushStream = server.local().reservePushStream(4, stream);
+        assertEquals(4, pushStream.id());
         assertEquals(State.RESERVED_LOCAL, pushStream.state());
-        assertEquals(1, client.activeStreams().size());
-        assertEquals(3, client.local().lastStreamCreated());
+        assertEquals(1, server.activeStreams().size());
+        assertEquals(4, server.local().lastStreamCreated());
     }
 
     @Test(expected = Http2Exception.class)
-    public void createStreamWithInvalidIdShouldThrow() throws Http2Exception {
-        server.remote().createStream(1, true);
+    public void newStreamBehindExpectedShouldThrow() throws Http2Exception {
+        server.local().createStream(0, true);
+    }
+
+    @Test(expected = Http2Exception.class)
+    public void newStreamNotForServerShouldThrow() throws Http2Exception {
+        server.local().createStream(11, true);
+    }
+
+    @Test(expected = Http2Exception.class)
+    public void newStreamNotForClientShouldThrow() throws Http2Exception {
+        client.local().createStream(10, true);
     }
 
     @Test(expected = Http2Exception.class)

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameIOTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameIOTest.java
@@ -62,8 +62,8 @@ public class DefaultHttp2FrameIOTest {
 
         when(ctx.alloc()).thenReturn(alloc);
 
-        reader = new DefaultHttp2FrameReader(false);
-        writer = new DefaultHttp2FrameWriter(true);
+        reader = new DefaultHttp2FrameReader();
+        writer = new DefaultHttp2FrameWriter();
     }
 
     @Test
@@ -118,7 +118,7 @@ public class DefaultHttp2FrameIOTest {
     }
 
     @Test
-    public void settingsShouldRoundtrip() throws Exception {
+    public void settingsShouldStripShouldRoundtrip() throws Exception {
         Http2Settings settings = new Http2Settings();
         settings.pushEnabled(true);
         settings.maxHeaderTableSize(4096);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -69,7 +69,7 @@ public class Http2FrameRoundtripTest {
         MockitoAnnotations.initMocks(this);
 
         requestLatch = new CountDownLatch(1);
-        frameWriter = new DefaultHttp2FrameWriter(false);
+        frameWriter = new DefaultHttp2FrameWriter();
         dataCaptor = ArgumentCaptor.forClass(ByteBuf.class);
 
         sb = new ServerBootstrap();
@@ -259,7 +259,7 @@ public class Http2FrameRoundtripTest {
 
         FrameAdapter(Http2FrameObserver observer) {
             this.observer = observer;
-            reader = new DefaultHttp2FrameReader(observer != null);
+            reader = new DefaultHttp2FrameReader();
         }
 
         @Override

--- a/example/src/main/java/io/netty/example/http2/client/Http2ClientConnectionHandler.java
+++ b/example/src/main/java/io/netty/example/http2/client/Http2ClientConnectionHandler.java
@@ -192,10 +192,10 @@ public class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler
     }
 
     private static Http2FrameReader frameReader() {
-        return new Http2InboundFrameLogger(new DefaultHttp2FrameReader(false), logger);
+        return new Http2InboundFrameLogger(new DefaultHttp2FrameReader(), logger);
     }
 
     private static Http2FrameWriter frameWriter() {
-        return new Http2OutboundFrameLogger(new DefaultHttp2FrameWriter(false), logger);
+        return new Http2OutboundFrameLogger(new DefaultHttp2FrameWriter(), logger);
     }
 }


### PR DESCRIPTION
Motivation:

A few items were identified where the http2 codec is out of compliance
with the spec.

Modifications:
- Fixed handling of priority weight on the wire. Now adding 1 after
  reading from the wire and subtracing 1 before writing.
- Fixed handling of next stream ID. Client streamIds were starting at 3,
  but they need to start at 1 to allow the upgrade from HTTP/1.1. Also
  making next stream ID logic more flexible. Allowing the next created
  stream to be any number in the sequence following the previously created
  stream.
- Disallowing SETTINGS frames with ENABLE_PUSH specified for server
  endpoints. This means that attempts to write this frame from a server,
  or read it from a client will fail.

Result:

The http2 implementation will be more inline with the spec.
