### PR TITLE
Cleaning up HTTP/2 integration tests and examples

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.channel.Channel;
+
+/**
+ * Utilities for the integration tests.
+ */
+final class Http2TestUtil {
+    /**
+     * Interface that allows for running a operation that throws a {@link Http2Exception}.
+     */
+    interface Http2Runnable {
+        void run() throws Http2Exception;
+    }
+
+    /**
+     * Runs the given operation within the event loop thread of the given {@link Channel}.
+     */
+    static void runInChannel(Channel channel, final Http2Runnable runnable) {
+        channel.eventLoop().execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    runnable.run();
+                } catch (Http2Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+    }
+
+    private Http2TestUtil() {
+    }
+}

--- a/example/src/main/java/io/netty/example/http2/client/Http2ClientConnectionHandler.java
+++ b/example/src/main/java/io/netty/example/http2/client/Http2ClientConnectionHandler.java
@@ -67,16 +67,16 @@ public class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler
         initialized = ctx.newPromise();
     }
 
-    public ChannelFuture writeData(int streamId, ByteBuf data, int padding, boolean endStream,
-            boolean endSegment, boolean compressed) throws Http2Exception {
-        return super.writeData(ctx(), ctx().newPromise(), streamId, data, padding, endStream,
-                endSegment, compressed);
+    public ChannelFuture writeData(ChannelPromise promise, int streamId, ByteBuf data, int padding,
+            boolean endStream, boolean endSegment, boolean compressed) throws Http2Exception {
+        return super.writeData(ctx(), promise, streamId, data, padding, endStream, endSegment,
+                compressed);
     }
 
-    public ChannelFuture writeHeaders(int streamId, Http2Headers headers, int padding,
-            boolean endStream, boolean endSegment) throws Http2Exception {
-        return super.writeHeaders(ctx(), ctx().newPromise(), streamId, headers, padding, endStream,
-                endSegment);
+    public ChannelFuture writeHeaders(ChannelPromise promise, int streamId, Http2Headers headers,
+            int padding, boolean endStream, boolean endSegment) throws Http2Exception {
+        return super
+                .writeHeaders(ctx(), promise, streamId, headers, padding, endStream, endSegment);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Some tests and the example code were still sending requests from the
test thread rather than from the event loop.

Modifications:
- Modified the roundtrip tests to use a new utility Http2TestUtil to
  perform the write operations in the event loop thread.
- Modified the Http2Client under examples to write all requests in the
  event loop thread.

Result:

Tests and examples now send requests in the correct thread context.
