### PR TITLE
Not throw a Http2Exception when a ChannelFuture is returned

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -22,7 +22,6 @@ import static io.netty.handler.codec.http2.Http2Stream.State.HALF_CLOSED_REMOTE;
 import static io.netty.handler.codec.http2.Http2Stream.State.OPEN;
 import static io.netty.handler.codec.http2.Http2Stream.State.RESERVED_LOCAL;
 import static io.netty.handler.codec.http2.Http2Stream.State.RESERVED_REMOTE;
-import io.netty.handler.codec.http2.Http2Stream.State;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -146,10 +145,10 @@ public class DefaultHttp2Connection implements Http2Connection {
         public Http2Stream openForPush() throws Http2Exception {
             switch (state) {
                 case RESERVED_LOCAL:
-                    state = State.HALF_CLOSED_REMOTE;
+                    state = HALF_CLOSED_REMOTE;
                     break;
                 case RESERVED_REMOTE:
-                    state = State.HALF_CLOSED_LOCAL;
+                    state = HALF_CLOSED_LOCAL;
                     break;
                 default:
                     throw protocolError("Attempting to open non-reserved stream for push");
@@ -173,7 +172,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         public Http2Stream closeLocalSide() {
             switch (state) {
                 case OPEN:
-                    state = State.HALF_CLOSED_LOCAL;
+                    state = HALF_CLOSED_LOCAL;
                     break;
                 case HALF_CLOSED_LOCAL:
                     break;
@@ -188,7 +187,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         public Http2Stream closeRemoteSide() {
             switch (state) {
                 case OPEN:
-                    state = State.HALF_CLOSED_REMOTE;
+                    state = HALF_CLOSED_REMOTE;
                     break;
                 case HALF_CLOSED_REMOTE:
                     break;
@@ -243,9 +242,9 @@ public class DefaultHttp2Connection implements Http2Connection {
             // Create and initialize the stream.
             DefaultStream stream = new DefaultStream(streamId);
             if (halfClosed) {
-                stream.state = isLocal() ? State.HALF_CLOSED_LOCAL : State.HALF_CLOSED_REMOTE;
+                stream.state = isLocal() ? HALF_CLOSED_LOCAL : HALF_CLOSED_REMOTE;
             } else {
-                stream.state = State.OPEN;
+                stream.state = OPEN;
             }
 
             // Update the next and last stream IDs.
@@ -278,7 +277,7 @@ public class DefaultHttp2Connection implements Http2Connection {
 
             // Create and initialize the stream.
             DefaultStream stream = new DefaultStream(streamId);
-            stream.state = isLocal() ? State.RESERVED_LOCAL : State.RESERVED_REMOTE;
+            stream.state = isLocal() ? RESERVED_LOCAL : RESERVED_REMOTE;
 
             // Update the next and last stream IDs.
             nextStreamId = streamId + 2;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -575,7 +575,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader {
         }
     }
 
-    private void readGoAwayFrame(ChannelHandlerContext ctx, ByteBuf payload,
+    private static void readGoAwayFrame(ChannelHandlerContext ctx, ByteBuf payload,
             Http2FrameObserver observer) throws Http2Exception {
         int lastStreamId = readUnsignedInt(payload);
         long errorCode = payload.readUnsignedInt();
@@ -620,7 +620,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader {
     /**
      * Base class for processing of HEADERS and PUSH_PROMISE header blocks that potentially span
      * multiple frames. The implementation of this interface will perform the final callback to the
-     * {@linkHttp2FrameObserver} once the end of headers is reached.
+     * {@link Http2FrameObserver} once the end of headers is reached.
      */
     private abstract class HeadersContinuation {
         private final HeadersBuilder builder = new HeadersBuilder();
@@ -635,7 +635,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader {
          *
          * @param endOfHeaders whether the fragment is the last in the header block.
          * @param fragment the fragment of the header block to be added.
-         * @param padding the amount of padding to be supplied to the {@linkHttp2FrameObserver}
+         * @param padding the amount of padding to be supplied to the {@link Http2FrameObserver}
          *            callback.
          * @param observer the observer to be notified if the header block is completed.
          */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2OutboundFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2OutboundFlowController.java
@@ -38,6 +38,11 @@ import java.util.concurrent.TimeUnit;
  */
 public class DefaultHttp2OutboundFlowController implements Http2OutboundFlowController {
     /**
+     * The interval (in ns) at which the removed priority garbage collector runs.
+     */
+    private static final long GARBAGE_COLLECTION_INTERVAL = TimeUnit.SECONDS.toNanos(2);
+
+    /**
      * A comparators that sorts priority nodes in ascending order by the amount
      * of priority data available for its subtree.
      */
@@ -577,7 +582,7 @@ public class DefaultHttp2OutboundFlowController implements Http2OutboundFlowCont
          */
         private void incrementPendingBytes(int numBytes) {
             int previouslyStreamable = streamableBytes();
-            this.pendingBytes += numBytes;
+            pendingBytes += numBytes;
             incrementPriorityBytes(streamableBytes() - previouslyStreamable);
         }
 
@@ -688,10 +693,6 @@ public class DefaultHttp2OutboundFlowController implements Http2OutboundFlowCont
      * Controls garbage collection for priorities that have been marked for removal.
      */
     private final class GarbageCollector implements Runnable {
-        /**
-         * The interval (in ns) at which the removed priority garbage collector runs.
-         */
-        private final long GARBAGE_COLLECTION_INTERVAL = TimeUnit.SECONDS.toNanos(2);
 
         private final Queue<Priority<FlowState>> garbage;
         private long lastGarbageCollection;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandler.java
@@ -59,32 +59,28 @@ public class DelegatingHttp2ConnectionHandler extends AbstractHttp2ConnectionHan
 
     @Override
     public ChannelFuture writeData(ChannelHandlerContext ctx, ChannelPromise promise, int streamId,
-            ByteBuf data, int padding, boolean endStream, boolean endSegment, boolean compressed)
-            throws Http2Exception {
+            ByteBuf data, int padding, boolean endStream, boolean endSegment, boolean compressed) {
         return super.writeData(ctx, promise, streamId, data, padding, endStream, endSegment,
                 compressed);
     }
 
     @Override
     public ChannelFuture writeHeaders(ChannelHandlerContext ctx, ChannelPromise promise,
-            int streamId, Http2Headers headers, int padding, boolean endStream, boolean endSegment)
-            throws Http2Exception {
+            int streamId, Http2Headers headers, int padding, boolean endStream, boolean endSegment) {
         return super.writeHeaders(ctx, promise, streamId, headers, padding, endStream, endSegment);
     }
 
     @Override
     public ChannelFuture writeHeaders(ChannelHandlerContext ctx, ChannelPromise promise,
             int streamId, Http2Headers headers, int streamDependency, short weight,
-            boolean exclusive, int padding, boolean endStream, boolean endSegment)
-            throws Http2Exception {
+            boolean exclusive, int padding, boolean endStream, boolean endSegment) {
         return super.writeHeaders(ctx, promise, streamId, headers, streamDependency, weight,
                 exclusive, padding, endStream, endSegment);
     }
 
     @Override
     public ChannelFuture writePriority(ChannelHandlerContext ctx, ChannelPromise promise,
-            int streamId, int streamDependency, short weight, boolean exclusive)
-            throws Http2Exception {
+            int streamId, int streamDependency, short weight, boolean exclusive) {
         return super.writePriority(ctx, promise, streamId, streamDependency, weight, exclusive);
     }
 
@@ -96,27 +92,24 @@ public class DelegatingHttp2ConnectionHandler extends AbstractHttp2ConnectionHan
 
     @Override
     public ChannelFuture writeSettings(ChannelHandlerContext ctx, ChannelPromise promise,
-            Http2Settings settings) throws Http2Exception {
+            Http2Settings settings) {
         return super.writeSettings(ctx, promise, settings);
     }
 
     @Override
-    public ChannelFuture writePing(ChannelHandlerContext ctx, ChannelPromise promise, ByteBuf data)
-            throws Http2Exception {
+    public ChannelFuture writePing(ChannelHandlerContext ctx, ChannelPromise promise, ByteBuf data) {
         return super.writePing(ctx, promise, data);
     }
 
     @Override
     public ChannelFuture writePushPromise(ChannelHandlerContext ctx, ChannelPromise promise,
-            int streamId, int promisedStreamId, Http2Headers headers, int padding)
-            throws Http2Exception {
+            int streamId, int promisedStreamId, Http2Headers headers, int padding) {
         return super.writePushPromise(ctx, promise, streamId, promisedStreamId, headers, padding);
     }
 
     @Override
     public ChannelFuture writeAltSvc(ChannelHandlerContext ctx, ChannelPromise promise,
-            int streamId, long maxAge, int port, ByteBuf protocolId, String host, String origin)
-            throws Http2Exception {
+            int streamId, long maxAge, int port, ByteBuf protocolId, String host, String origin) {
         return super.writeAltSvc(ctx, promise, streamId, maxAge, port, protocolId, host, origin);
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameObserver.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameObserver.java
@@ -133,7 +133,7 @@ public interface Http2FrameObserver {
      * @param streamId the stream the frame was sent on.
      * @param promisedStreamId the ID of the promised stream.
      * @param headers the received headers.
-     * @param paddingthe number of padding bytes found at the end of the frame.
+     * @param padding the number of padding bytes found at the end of the frame.
      */
     void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
             Http2Headers headers, int padding) throws Http2Exception;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameType.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameType.java
@@ -49,7 +49,7 @@ public enum Http2FrameType {
 
     private final short code;
 
-    private Http2FrameType(short code) {
+    Http2FrameType(short code) {
         this.code = code;
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
@@ -41,8 +41,7 @@ public interface Http2FrameWriter extends Closeable {
      * @return the future for the write.
      */
     ChannelFuture writeData(ChannelHandlerContext ctx, ChannelPromise promise, int streamId,
-            ByteBuf data, int padding, boolean endStream, boolean endSegment, boolean compressed)
-            throws Http2Exception;
+            ByteBuf data, int padding, boolean endStream, boolean endSegment, boolean compressed);
 
     /**
      * Writes a HEADERS frame to the remote endpoint.
@@ -57,8 +56,7 @@ public interface Http2FrameWriter extends Closeable {
      * @return the future for the write.
      */
     ChannelFuture writeHeaders(ChannelHandlerContext ctx, ChannelPromise promise, int streamId,
-            Http2Headers headers, int padding, boolean endStream, boolean endSegment)
-            throws Http2Exception;
+            Http2Headers headers, int padding, boolean endStream, boolean endSegment);
 
     /**
      * Writes a HEADERS frame with priority specified to the remote endpoint.
@@ -78,7 +76,7 @@ public interface Http2FrameWriter extends Closeable {
      */
     ChannelFuture writeHeaders(ChannelHandlerContext ctx, ChannelPromise promise, int streamId,
             Http2Headers headers, int streamDependency, short weight, boolean exclusive,
-            int padding, boolean endStream, boolean endSegment) throws Http2Exception;
+            int padding, boolean endStream, boolean endSegment);
 
     /**
      * Writes a PRIORITY frame to the remote endpoint.
@@ -93,7 +91,7 @@ public interface Http2FrameWriter extends Closeable {
      * @return the future for the write.
      */
     ChannelFuture writePriority(ChannelHandlerContext ctx, ChannelPromise promise, int streamId,
-            int streamDependency, short weight, boolean exclusive) throws Http2Exception;
+            int streamDependency, short weight, boolean exclusive);
 
     /**
      * Writes a RST_STREAM frame to the remote endpoint.
@@ -116,7 +114,7 @@ public interface Http2FrameWriter extends Closeable {
      * @return the future for the write.
      */
     ChannelFuture writeSettings(ChannelHandlerContext ctx, ChannelPromise promise,
-            Http2Settings settings) throws Http2Exception;
+            Http2Settings settings);
 
     /**
      * Writes a SETTINGS acknowledgment to the remote endpoint.
@@ -125,8 +123,7 @@ public interface Http2FrameWriter extends Closeable {
      * @param promise the promise for the write.
      * @return the future for the write.
      */
-    ChannelFuture writeSettingsAck(ChannelHandlerContext ctx, ChannelPromise promise)
-            throws Http2Exception;
+    ChannelFuture writeSettingsAck(ChannelHandlerContext ctx, ChannelPromise promise);
 
     /**
      * Writes a PING frame to the remote endpoint.
@@ -139,7 +136,7 @@ public interface Http2FrameWriter extends Closeable {
      * @return the future for the write.
      */
     ChannelFuture writePing(ChannelHandlerContext ctx, ChannelPromise promise, boolean ack,
-            ByteBuf data) throws Http2Exception;
+            ByteBuf data);
 
     /**
      * Writes a PUSH_PROMISE frame to the remote endpoint.
@@ -153,7 +150,7 @@ public interface Http2FrameWriter extends Closeable {
      * @return the future for the write.
      */
     ChannelFuture writePushPromise(ChannelHandlerContext ctx, ChannelPromise promise, int streamId,
-            int promisedStreamId, Http2Headers headers, int padding) throws Http2Exception;
+            int promisedStreamId, Http2Headers headers, int padding);
 
     /**
      * Writes a GO_AWAY frame to the remote endpoint.
@@ -179,7 +176,7 @@ public interface Http2FrameWriter extends Closeable {
      * @return the future for the write.
      */
     ChannelFuture writeWindowUpdate(ChannelHandlerContext ctx, ChannelPromise promise,
-            int streamId, int windowSizeIncrement) throws Http2Exception;
+            int streamId, int windowSizeIncrement);
 
     /**
      * Writes a ALT_SVC frame to the remote endpoint.
@@ -196,8 +193,7 @@ public interface Http2FrameWriter extends Closeable {
      * @return the future for the write.
      */
     ChannelFuture writeAltSvc(ChannelHandlerContext ctx, ChannelPromise promise, int streamId,
-            long maxAge, int port, ByteBuf protocolId, String host, String origin)
-            throws Http2Exception;
+            long maxAge, int port, ByteBuf protocolId, String host, String origin);
 
     /**
      * Writes a BLOCKED frame to the remote endpoint.
@@ -207,8 +203,7 @@ public interface Http2FrameWriter extends Closeable {
      * @param streamId the stream that is blocked or 0 if the entire connection is blocked.
      * @return the future for the write.
      */
-    ChannelFuture writeBlocked(ChannelHandlerContext ctx, ChannelPromise promise, int streamId)
-            throws Http2Exception;
+    ChannelFuture writeBlocked(ChannelHandlerContext ctx, ChannelPromise promise, int streamId);
 
     /**
      * Closes this writer and frees any allocated resources.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFlowController.java
@@ -23,7 +23,7 @@ import io.netty.buffer.ByteBuf;
 public interface Http2OutboundFlowController {
 
     /**
-     * Interface that abstracts the writing of {@link Http2Frame} objects to the remote endpoint.
+     * Interface that abstracts the writing of frames to the remote endpoint.
      */
     interface FrameWriter {
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
@@ -43,8 +43,7 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
 
     @Override
     public ChannelFuture writeData(ChannelHandlerContext ctx, ChannelPromise promise, int streamId,
-            ByteBuf data, int padding, boolean endStream, boolean endSegment, boolean compressed)
-            throws Http2Exception {
+            ByteBuf data, int padding, boolean endStream, boolean endSegment, boolean compressed) {
         logger.logData(OUTBOUND, streamId, data, padding, endStream, endSegment, compressed);
         return writer.writeData(ctx, promise, streamId, data, padding, endStream, endSegment,
                 compressed);
@@ -52,8 +51,7 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
 
     @Override
     public ChannelFuture writeHeaders(ChannelHandlerContext ctx, ChannelPromise promise,
-            int streamId, Http2Headers headers, int padding, boolean endStream, boolean endSegment)
-            throws Http2Exception {
+            int streamId, Http2Headers headers, int padding, boolean endStream, boolean endSegment) {
         logger.logHeaders(OUTBOUND, streamId, headers, padding, endStream, endSegment);
         return writer.writeHeaders(ctx, promise, streamId, headers, padding, endStream, endSegment);
     }
@@ -61,8 +59,7 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
     @Override
     public ChannelFuture writeHeaders(ChannelHandlerContext ctx, ChannelPromise promise,
             int streamId, Http2Headers headers, int streamDependency, short weight,
-            boolean exclusive, int padding, boolean endStream, boolean endSegment)
-            throws Http2Exception {
+            boolean exclusive, int padding, boolean endStream, boolean endSegment) {
         logger.logHeaders(OUTBOUND, streamId, headers, streamDependency, weight, exclusive,
                 padding, endStream, endSegment);
         return writer.writeHeaders(ctx, promise, streamId, headers, streamDependency, weight,
@@ -71,8 +68,7 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
 
     @Override
     public ChannelFuture writePriority(ChannelHandlerContext ctx, ChannelPromise promise,
-            int streamId, int streamDependency, short weight, boolean exclusive)
-            throws Http2Exception {
+            int streamId, int streamDependency, short weight, boolean exclusive) {
         logger.logPriority(OUTBOUND, streamId, streamDependency, weight, exclusive);
         return writer.writePriority(ctx, promise, streamId, streamDependency, weight, exclusive);
     }
@@ -85,29 +81,27 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
 
     @Override
     public ChannelFuture writeSettings(ChannelHandlerContext ctx, ChannelPromise promise,
-            Http2Settings settings) throws Http2Exception {
+            Http2Settings settings) {
         logger.logSettings(OUTBOUND, settings);
         return writer.writeSettings(ctx, promise, settings);
     }
 
     @Override
-    public ChannelFuture writeSettingsAck(ChannelHandlerContext ctx, ChannelPromise promise)
-            throws Http2Exception {
+    public ChannelFuture writeSettingsAck(ChannelHandlerContext ctx, ChannelPromise promise) {
         logger.logSettingsAck(OUTBOUND);
         return writer.writeSettingsAck(ctx, promise);
     }
 
     @Override
     public ChannelFuture writePing(ChannelHandlerContext ctx, ChannelPromise promise, boolean ack,
-            ByteBuf data) throws Http2Exception {
+            ByteBuf data) {
         logger.logPing(OUTBOUND, data);
         return writer.writePing(ctx, promise, ack, data);
     }
 
     @Override
     public ChannelFuture writePushPromise(ChannelHandlerContext ctx, ChannelPromise promise,
-            int streamId, int promisedStreamId, Http2Headers headers, int padding)
-            throws Http2Exception {
+            int streamId, int promisedStreamId, Http2Headers headers, int padding) {
         logger.logPushPromise(OUTBOUND, streamId, promisedStreamId, headers, padding);
         return writer.writePushPromise(ctx, promise, streamId, promisedStreamId, headers, padding);
     }
@@ -121,22 +115,21 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
 
     @Override
     public ChannelFuture writeWindowUpdate(ChannelHandlerContext ctx, ChannelPromise promise,
-            int streamId, int windowSizeIncrement) throws Http2Exception {
+            int streamId, int windowSizeIncrement) {
         logger.logWindowsUpdate(OUTBOUND, streamId, windowSizeIncrement);
         return writer.writeWindowUpdate(ctx, promise, streamId, windowSizeIncrement);
     }
 
     @Override
     public ChannelFuture writeAltSvc(ChannelHandlerContext ctx, ChannelPromise promise,
-            int streamId, long maxAge, int port, ByteBuf protocolId, String host, String origin)
-            throws Http2Exception {
+            int streamId, long maxAge, int port, ByteBuf protocolId, String host, String origin) {
         logger.logAltSvc(OUTBOUND, streamId, maxAge, port, protocolId, host, origin);
         return writer.writeAltSvc(ctx, promise, streamId, maxAge, port, protocolId, host, origin);
     }
 
     @Override
     public ChannelFuture writeBlocked(ChannelHandlerContext ctx, ChannelPromise promise,
-            int streamId) throws Http2Exception {
+            int streamId) {
         logger.logBlocked(OUTBOUND, streamId);
         return writer.writeBlocked(ctx, promise, streamId);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2PriorityTree.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2PriorityTree.java
@@ -101,7 +101,6 @@ public interface Http2PriorityTree<T> extends Iterable<Http2PriorityTree.Priorit
      * priority values.
      *
      * @param streamId the stream to be prioritized
-     * @param data optional user-defined data to associate to the stream
      * @return the priority for the stream.
      */
     Priority<T> prioritizeUsingDefaults(int streamId);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
@@ -62,7 +62,7 @@ public class Http2Settings {
         }
 
         enable(MAX_HEADER_TABLE_SIZE_MASK);
-        this.maxHeaderTableSize = headerTableSize;
+        maxHeaderTableSize = headerTableSize;
         return this;
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -120,14 +120,10 @@ public class Http2ConnectionRoundtripTest {
             clientChannel.eventLoop().execute(new Runnable() {
                 @Override
                 public void run() {
-                    try {
-                        http2Client.writeHeaders(ctx(), newPromise(), streamId, headers, 0,
-                                (short) 16, false, 0, false, false);
-                        http2Client.writeData(ctx(), newPromise(), streamId,
-                                Unpooled.copiedBuffer(text.getBytes()), 0, true, true, false);
-                    } catch (Http2Exception e) {
-                        throw new RuntimeException(e);
-                    }
+                    http2Client.writeHeaders(ctx(), newPromise(), streamId, headers, 0,
+                            (short) 16, false, 0, false, false);
+                    http2Client.writeData(ctx(), newPromise(), streamId,
+                            Unpooled.copiedBuffer(text.getBytes()), 0, true, true, false);
                 }
             });
         }


### PR DESCRIPTION
Motivation:
At the moment we have some methods that return a ChannelFuture but still throw a Http2Exception too. This is confusing in terms of semantic. A method which returns a ChannelFuture should not throw an Http2Exception but just fail the ChannelFuture.

Modifications:
- Make sure we fail the returned ChannelFuture in cases of Http2Exception and remove the throws Http2Exception from the method signature.
- Also some cleanup

Result:
Make the API usage more clear.
