### PR TITLE
data curruption by ChannelTrafficShapingHandler

### DIFF
--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -245,17 +245,6 @@ public abstract class AbstractTrafficShapingHandler extends ChannelHandlerAdapte
                     }
                     ctx.executor().schedule(reopenTask, wait,
                             TimeUnit.MILLISECONDS);
-                } else {
-                    // Create a Runnable to update the next handler in the chain. If one was create before it will
-                    // just be reused to limit object creation
-                    Runnable bufferUpdateTask = new Runnable() {
-                        @Override
-                        public void run() {
-                            ctx.fireChannelRead(msg);
-                        }
-                    };
-                    ctx.executor().schedule(bufferUpdateTask, wait, TimeUnit.MILLISECONDS);
-                    return;
                 }
             }
         }


### PR DESCRIPTION
ChannelTrafficShapingHandler may corrupt inbound data stream by
scheduling the fireChannelRead event. There is no need for delaying the handler from processing inbound data.
