### PR TITLE
Correction on StringBuilder default init size

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelId.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelId.java
@@ -423,7 +423,7 @@ final class DefaultChannelId implements ChannelId {
     }
 
     private String newLongValue() {
-        StringBuilder buf = new StringBuilder(2*data.length + 5);
+        StringBuilder buf = new StringBuilder(2 * data.length + 5);
         int i = 0;
         i = appendHexDumpField(buf, i, MACHINE_ID_LEN);
         i = appendHexDumpField(buf, i, PROCESS_ID_LEN);


### PR DESCRIPTION
Motivation:
The default StringBuilder size is too small (data.length + 4) while it will be 2*data.length (byte to Hex) + 5 "-" char (since 5 peaces appended).

Modification:
Changing initial size to the correct one

Result:
Allocation of the correct final size from the beginning for this StringBuilder.
