### PR TITLE
Fix broken CompositeMatcher

### DIFF
--- a/transport/src/main/java/io/netty/channel/group/ChannelMatchers.java
+++ b/transport/src/main/java/io/netty/channel/group/ChannelMatchers.java
@@ -121,10 +121,10 @@ public final class ChannelMatchers {
         public boolean matches(Channel channel) {
             for (int i = 0; i < matchers.length; i++) {
                 if (!matchers[i].matches(channel)) {
-                    return true;
+                    return false;
                 }
             }
-            return false;
+            return true;
         }
     }
 


### PR DESCRIPTION
Motivation:

ChannelMatchers#CompositeMatcher inverts matches result.

Modifications:

Switched return values.

Result:

ChannelMatchers#CompositeMatcher will return correct results.
