### PR TITLE
[codec-memcache] Release extras and double check before release on decode

### DIFF
--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder.java
@@ -24,12 +24,11 @@ import io.netty.handler.codec.memcache.DefaultLastMemcacheContent;
 import io.netty.handler.codec.memcache.DefaultMemcacheContent;
 import io.netty.handler.codec.memcache.LastMemcacheContent;
 import io.netty.handler.codec.memcache.MemcacheContent;
-import io.netty.handler.codec.memcache.MemcacheMessage;
 import io.netty.util.CharsetUtil;
 
 import java.util.List;
 
-import static io.netty.buffer.ByteBufUtil.*;
+import static io.netty.buffer.ByteBufUtil.readBytes;
 
 /**
  * Decoder for both {@link BinaryMemcacheRequest} and {@link BinaryMemcacheResponse}.
@@ -202,7 +201,9 @@ public abstract class AbstractBinaryMemcacheDecoder<M extends BinaryMemcacheMess
         super.channelInactive(ctx);
 
         if (currentMessage != null && currentMessage.getExtras() != null) {
-            currentMessage.getExtras().release();
+            if (currentMessage.getExtras().refCnt() > 0) {
+                currentMessage.getExtras().release();
+            }
         }
 
         resetDecoder();

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheEncoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheEncoder.java
@@ -55,6 +55,7 @@ public abstract class AbstractBinaryMemcacheEncoder<M extends BinaryMemcacheMess
         }
 
         buf.writeBytes(extras);
+        extras.release();
     }
 
     /**


### PR DESCRIPTION
## Motivation

Extras need to be freed so that they do not hang around longer than needed. Also,
make sure that they are only freed if something is holding onto them.
## Modifications

Free it properly on encode and make sure it can be freed on decode.
## Result

Not leaking on requests and not running into exceptions on decode.
