### PR TITLE
Bug fix: HTTP/1.0 compliant (keep-alive disabled)

### DIFF
--- a/example/src/main/java/io/netty/example/http/snoop/HttpSnoopServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/snoop/HttpSnoopServerHandler.java
@@ -182,8 +182,8 @@ public class HttpSnoopServerHandler extends SimpleChannelInboundHandler<Object> 
 
         /* FIXED BUG on 'ab' Apache Bench, because HTTP/1.0 automatically close the connection by default */
         if (keepAlive == false) {
-			ctx.close();
-		}
+            ctx.close();
+        }
 
         return keepAlive;
     }


### PR DESCRIPTION
... connection by default

FIXED BUG on 'ab' Apache Bench 2.3, because HTTP/1.0 protocol automatically close the connection by default, unless the client ask to make the connection "keep-alive".
