### PR TITLE
Bug fix: HTTP/1.0 compliant (keep-alive disabled)

### DIFF
--- a/example/src/main/java/io/netty/example/http/snoop/HttpSnoopServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/snoop/HttpSnoopServerHandler.java
@@ -179,6 +179,11 @@ public class HttpSnoopServerHandler extends SimpleChannelInboundHandler<Object> 
 
         // Write the response.
         ctx.write(response);
+        
+        // Bug fix: HTTP/1.0 compliant (keep-alive disabled)
+        if (keepAlive == false) {
+            ctx.close();
+        }
 
         return keepAlive;
     }


### PR DESCRIPTION
FIXED BUG: Can cause error on Apache Bench 2.3 (ab), 
because HTTP/1.0 protocol automatically close the connection by default, unless the client ask to make the connection "keep-alive" in http request in the first place.
