### PR TITLE
4.0.19 ftl

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
@@ -17,6 +17,7 @@
 package io.netty.buffer;
 
 import io.netty.util.Recycler;
+import io.netty.util.concurrent.FastThreadLocal;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,7 +29,8 @@ import java.nio.channels.ScatteringByteChannel;
 
 final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
 
-    private static final Recycler<PooledDirectByteBuf> RECYCLER = new Recycler<PooledDirectByteBuf>() {
+    private static final Recycler<PooledDirectByteBuf> RECYCLER
+    = new Recycler<PooledDirectByteBuf>(FastThreadLocal.Type.PooledDirectByteBuf_Recycler) {
         @Override
         protected PooledDirectByteBuf newObject(Handle handle) {
             return new PooledDirectByteBuf(handle, 0);

--- a/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
@@ -15,6 +15,7 @@
 package io.netty.buffer;
 
 import io.netty.util.Recycler;
+import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.PlatformDependent;
 
 import java.io.IOException;
@@ -27,7 +28,8 @@ import java.nio.channels.ScatteringByteChannel;
 
 final class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
 
-    private static final Recycler<PooledHeapByteBuf> RECYCLER = new Recycler<PooledHeapByteBuf>() {
+    private static final Recycler<PooledHeapByteBuf> RECYCLER
+    = new Recycler<PooledHeapByteBuf>(FastThreadLocal.Type.PooledHeapByteBuf_Recycler) {
         @Override
         protected PooledHeapByteBuf newObject(Handle handle) {
             return new PooledHeapByteBuf(handle, 0);

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
@@ -17,6 +17,7 @@
 package io.netty.buffer;
 
 import io.netty.util.Recycler;
+import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.PlatformDependent;
 
 import java.io.IOException;
@@ -32,7 +33,8 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
 
     private static final boolean NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
 
-    private static final Recycler<PooledUnsafeDirectByteBuf> RECYCLER = new Recycler<PooledUnsafeDirectByteBuf>() {
+    private static final Recycler<PooledUnsafeDirectByteBuf> RECYCLER
+    = new Recycler<PooledUnsafeDirectByteBuf>(FastThreadLocal.Type.PooledUnsafeDirectByteBuf_Recycler) {
         @Override
         protected PooledUnsafeDirectByteBuf newObject(Handle handle) {
             return new PooledUnsafeDirectByteBuf(handle, 0);

--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -35,7 +35,8 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
             InternalLoggerFactory.getInstance(DefaultPromise.class.getName() + ".rejectedExecution");
 
     private static final int MAX_LISTENER_STACK_DEPTH = 8;
-    private static final ThreadLocal<Integer> LISTENER_STACK_DEPTH = new ThreadLocal<Integer>() {
+    private static final FastThreadLocal<Integer> LISTENER_STACK_DEPTH
+    = new FastThreadLocal<Integer>(FastThreadLocal.Type.DefaultPromise_ListenerStackDepth) {
         @Override
         protected Integer initialValue() {
             return 0;

--- a/common/src/main/java/io/netty/util/concurrent/DefaultThreadFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultThreadFactory.java
@@ -98,7 +98,7 @@ public class DefaultThreadFactory implements ThreadFactory {
 
     @Override
     public Thread newThread(Runnable r) {
-        Thread t = new Thread(r, prefix + nextId.incrementAndGet());
+        Thread t = new FastThreadLocal.FastThreadLocalThread(r, prefix + nextId.incrementAndGet());
         try {
             if (t.isDaemon()) {
                 if (!daemon) {

--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import java.util.EnumMap;
+
+/**
+ * A simple class providing equivalent functionality to java.lang,ThreadLocal, but operating
+ * over a predefined hash range, so that we can hash perfectly. This permits less indirection
+ * and offers a slight performance improvement, so is useful when invoked frequently.
+ *
+ * The fast path is only possible on threads that extend FastThreadLocalThread, as this class
+ * stores the necessary state. Access by any other kind of thread falls back to a regular ThreadLocal
+ *
+ * @param <V>
+ */
+public class FastThreadLocal<V> {
+
+    public static enum Type {
+        LocalChannel_ReaderStackDepth,
+        PooledDirectByteBuf_Recycler,
+        PooledHeapByteBuf_Recycler,
+        PooledUnsafeDirectByteBuf_Recycler,
+        ChannelOutboundBuffer_Recycler,
+        ChannelOutboundBuffer_PooledByteBuf_Recycler,
+        DefaultChannelHandlerContext_WriteAndFlushTask_Recycler,
+        DefaultChannelHandlerContext_WriteTask_Recycler,
+        PendingWrite_Recycler,
+        RecyclableArrayList_Recycler,
+        DefaultPromise_ListenerStackDepth,
+        PooledByteBufAllocator_DefaultAllocator
+    }
+
+    // the set of already defined FastThreadLocals
+    private static final EnumMap<Type, Boolean> SET = new EnumMap<Type, Boolean>(Type.class);
+    // the type values, for cheap iteration
+    private static final Type[] TYPES = Type.values();
+    // a marker to indicate a value has not yet been initialised
+    private static final Object EMPTY = new Object();
+
+    /**
+     * To utilise the FastThreadLocal fast-path, all threads accessing a FastThreadLocal must extend this class
+     */
+    public static class FastThreadLocalThread extends Thread {
+
+        private final EnumMap<Type, Object> lookup = initialMap();
+
+        static EnumMap<Type, Object> initialMap() {
+            EnumMap<Type, Object> r = new EnumMap<Type, Object>(Type.class);
+            for (Type type : TYPES) {
+                r.put(type, EMPTY);
+            }
+            return r;
+        }
+
+        public FastThreadLocalThread() {
+            super();
+        }
+
+        public FastThreadLocalThread(Runnable target) {
+            super(target);
+        }
+
+        public FastThreadLocalThread(ThreadGroup group, Runnable target) {
+            super(group, target);
+        }
+
+        public FastThreadLocalThread(String name) {
+            super(name);
+        }
+
+        public FastThreadLocalThread(ThreadGroup group, String name) {
+            super(group, name);
+        }
+
+        public FastThreadLocalThread(Runnable target, String name) {
+            super(target, name);
+        }
+
+        public FastThreadLocalThread(ThreadGroup group, Runnable target, String name) {
+            super(group, target, name);
+        }
+
+        public FastThreadLocalThread(ThreadGroup group, Runnable target, String name, long stackSize) {
+            super(group, target, name, stackSize);
+        }
+    }
+
+    final Type type;
+    final ThreadLocal<V> fallback = new ThreadLocal<V>() {
+        protected V initialValue() {
+            return FastThreadLocal.this.initialValue();
+        }
+    };
+
+    /**
+     * @param type the predefined type this FastThreadLocal represents; each type may be used only once
+     *             globally in a single VM
+     */
+    public FastThreadLocal(Type type) {
+        if (type != null) {
+            synchronized (SET) {
+                if (SET.put(type, Boolean.TRUE) != null) {
+                    throw new IllegalStateException(type + " has been assigned multiple times");
+                }
+            }
+        }
+        this.type = type;
+    }
+
+    /**
+     * Override this method to define the default value to assign
+     * when a thread first calls get() without a preceding set()
+     *
+     * @return the initial value
+     */
+    protected V initialValue() {
+        return null;
+    }
+
+    /**
+     * Set the value for the current thread
+     * @param value
+     */
+    public void set(V value) {
+        Thread thread = Thread.currentThread();
+        if (type == null || !(thread instanceof FastThreadLocalThread)) {
+            fallback.set(value);
+            return;
+        }
+        EnumMap<Type, Object> lookup = ((FastThreadLocalThread) thread).lookup;
+        lookup.put(type, value);
+    }
+
+    /**
+     * Sets the value to uninitialized; a proceeding call to get() will trigger a call to initialValue()
+     */
+    public void remove() {
+        Thread thread = Thread.currentThread();
+        if (type == null || !(thread instanceof FastThreadLocalThread)) {
+            fallback.remove();
+            return;
+        }
+        EnumMap<Type, Object> lookup = ((FastThreadLocalThread) thread).lookup;
+        lookup.put(type, EMPTY);
+    }
+
+    /**
+     * @return the current value for the current thread
+     */
+    public final V get() {
+        Thread thread = Thread.currentThread();
+        if (type == null || !(thread instanceof FastThreadLocalThread)) {
+            return fallback.get();
+        }
+        EnumMap<Type, Object> lookup = ((FastThreadLocalThread) thread).lookup;
+        Object v = lookup.get(type);
+        if (v == EMPTY) {
+            lookup.put(type, v = initialValue());
+        }
+        return (V) v;
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/PendingWrite.java
+++ b/common/src/main/java/io/netty/util/internal/PendingWrite.java
@@ -17,13 +17,17 @@ package io.netty.util.internal;
 
 import io.netty.util.Recycler;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.Promise;
+
+import static io.netty.util.concurrent.FastThreadLocal.Type.PendingWrite_Recycler;
 
 /**
  * Some pending write which should be picked up later.
  */
 public final class PendingWrite {
-    private static final Recycler<PendingWrite> RECYCLER = new Recycler<PendingWrite>() {
+    private static final Recycler<PendingWrite> RECYCLER
+    = new Recycler<PendingWrite>(PendingWrite_Recycler) {
         @Override
         protected PendingWrite newObject(Handle handle) {
             return new PendingWrite(handle);

--- a/common/src/main/java/io/netty/util/internal/RecyclableArrayList.java
+++ b/common/src/main/java/io/netty/util/internal/RecyclableArrayList.java
@@ -18,6 +18,7 @@ package io.netty.util.internal;
 
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
+import io.netty.util.concurrent.FastThreadLocal;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,7 +34,8 @@ public final class RecyclableArrayList extends ArrayList<Object> {
 
     private static final int DEFAULT_INITIAL_CAPACITY = 8;
 
-    private static final Recycler<RecyclableArrayList> RECYCLER = new Recycler<RecyclableArrayList>() {
+    private static final Recycler<RecyclableArrayList> RECYCLER
+    = new Recycler<RecyclableArrayList>(FastThreadLocal.Type.RecyclableArrayList_Recycler) {
         @Override
         protected RecyclableArrayList newObject(Handle handle) {
             return new RecyclableArrayList(handle);

--- a/microbench/src/test/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
+++ b/microbench/src/test/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
@@ -60,4 +60,16 @@ public class ByteBufAllocatorBenchmark extends AbstractMicrobenchmark {
         buffer.release();
     }
 
+    @GenerateMicroBenchmark
+    public void defaultPooledHeapAllocAndFree() {
+        ByteBuf buffer = PooledByteBufAllocator.DEFAULT.heapBuffer(size);
+        buffer.release();
+    }
+
+    @GenerateMicroBenchmark
+    public void defaultPooledDirectAllocAndFree() {
+        ByteBuf buffer = PooledByteBufAllocator.DEFAULT.directBuffer(size);
+        buffer.release();
+    }
+
 }

--- a/microbench/src/test/java/io/netty/microbench/internal/RecyclableArrayListBenchmark.java
+++ b/microbench/src/test/java/io/netty/microbench/internal/RecyclableArrayListBenchmark.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.internal;
+
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.internal.RecyclableArrayList;
+import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Threads;
+
+/**
+ * This class benchmarks different allocators with different allocation sizes.
+ */
+@Threads(4)
+@Measurement(iterations = 10, batchSize = 100)
+public class RecyclableArrayListBenchmark extends AbstractMicrobenchmark {
+
+    @Param({ "00000", "00256", "01024", "04096", "16384", "65536" })
+    public int size;
+
+    @GenerateMicroBenchmark
+    public void recycleSameThread() {
+        RecyclableArrayList list = RecyclableArrayList.newInstance(size);
+        list.recycle();
+    }
+}

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -29,6 +29,7 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -57,7 +58,8 @@ public final class ChannelOutboundBuffer {
         logger.debug("-Dio.netty.threadLocalDirectBufferSize: {}", threadLocalDirectBufferSize);
     }
 
-    private static final Recycler<ChannelOutboundBuffer> RECYCLER = new Recycler<ChannelOutboundBuffer>() {
+    private static final Recycler<ChannelOutboundBuffer> RECYCLER
+    = new Recycler<ChannelOutboundBuffer>(FastThreadLocal.Type.ChannelOutboundBuffer_Recycler) {
         @Override
         protected ChannelOutboundBuffer newObject(Handle handle) {
             return new ChannelOutboundBuffer(handle);
@@ -693,7 +695,8 @@ public final class ChannelOutboundBuffer {
     static final class ThreadLocalPooledByteBuf extends UnpooledDirectByteBuf {
         private final Recycler.Handle handle;
 
-        private static final Recycler<ThreadLocalPooledByteBuf> RECYCLER = new Recycler<ThreadLocalPooledByteBuf>() {
+        private static final Recycler<ThreadLocalPooledByteBuf> RECYCLER
+        = new Recycler<ThreadLocalPooledByteBuf>(FastThreadLocal.Type.ChannelOutboundBuffer_PooledByteBuf_Recycler) {
             @Override
             protected ThreadLocalPooledByteBuf newObject(Handle handle) {
                 return new ThreadLocalPooledByteBuf(handle);

--- a/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
@@ -16,6 +16,9 @@
 package io.netty.channel;
 
 import static io.netty.channel.DefaultChannelPipeline.logger;
+import static io.netty.util.concurrent.FastThreadLocal.Type.DefaultChannelHandlerContext_WriteAndFlushTask_Recycler;
+import static io.netty.util.concurrent.FastThreadLocal.Type.DefaultChannelHandlerContext_WriteTask_Recycler;
+
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.DefaultAttributeMap;
 import io.netty.util.Recycler;
@@ -950,7 +953,8 @@ final class DefaultChannelHandlerContext extends DefaultAttributeMap implements 
 
     static final class WriteTask extends AbstractWriteTask implements SingleThreadEventLoop.NonWakeupRunnable {
 
-        private static final Recycler<WriteTask> RECYCLER = new Recycler<WriteTask>() {
+        private static final Recycler<WriteTask> RECYCLER
+        = new Recycler<WriteTask>(DefaultChannelHandlerContext_WriteTask_Recycler) {
             @Override
             protected WriteTask newObject(Handle handle) {
                 return new WriteTask(handle);
@@ -976,7 +980,8 @@ final class DefaultChannelHandlerContext extends DefaultAttributeMap implements 
 
     static final class WriteAndFlushTask extends AbstractWriteTask {
 
-        private static final Recycler<WriteAndFlushTask> RECYCLER = new Recycler<WriteAndFlushTask>() {
+        private static final Recycler<WriteAndFlushTask> RECYCLER
+        = new Recycler<WriteAndFlushTask>(DefaultChannelHandlerContext_WriteAndFlushTask_Recycler) {
             @Override
             protected WriteAndFlushTask newObject(Handle handle) {
                 return new WriteAndFlushTask(handle);

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -27,6 +27,7 @@ import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
 import io.netty.channel.SingleThreadEventLoop;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
 
 import java.net.SocketAddress;
@@ -46,7 +47,8 @@ public class LocalChannel extends AbstractChannel {
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
 
     private static final int MAX_READER_STACK_DEPTH = 8;
-    private static final ThreadLocal<Integer> READER_STACK_DEPTH = new ThreadLocal<Integer>() {
+    private static final FastThreadLocal<Integer> READER_STACK_DEPTH
+    = new FastThreadLocal<Integer>(FastThreadLocal.Type.LocalChannel_ReaderStackDepth) {
         @Override
         protected Integer initialValue() {
             return 0;


### PR DESCRIPTION
As discussed, this is a separate pull request for the FastThreadLocal changes. I've made some minor tweaks, which are open to some discussion: I simplified the default bytebuf allocator changes so that they are cleaner, but the result is a very slight penalty to non-default bytebuf allocators, however the default allocator sees an ~30% increase in throughput in the microbenchmark, so it might be worth figuring out a way to deliver these benefits to user instantiated bytebuf allocators.

Some numbers for bytebufs...

4.0.19:
Benchmark                                                    (size)   Mode   Samples         Mean   Mean error    Units
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    00000  thrpt        20     9021.907      111.818   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    00256  thrpt        20     9186.624      100.175   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    01024  thrpt        20     9115.938      145.644   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    04096  thrpt        20    10207.567       61.943   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    16384  thrpt        20     8902.079      105.597   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    65536  thrpt        20     9655.586       80.938   ops/ms

4.0.19-ftl:
Benchmark                                                    (size)   Mode   Samples         Mean   Mean error    Units
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    00000  thrpt        20     8900.469      285.116   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    00256  thrpt        20     8668.458      156.805   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    01024  thrpt        20     9420.245      121.068   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    04096  thrpt        20     9542.702       66.353   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    16384  thrpt        20     9386.504       72.600   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.pooledDirectAllocAndFree    65536  thrpt        20     9164.332      106.697   ops/ms

Benchmark                                                           (size)   Mode   Samples         Mean   Mean error    Units
i.n.m.b.ByteBufAllocatorBenchmark.defaultPooledDirectAllocAndFree    00000  thrpt        20    12681.382       89.749   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.defaultPooledDirectAllocAndFree    00256  thrpt        20    12552.560       65.338   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.defaultPooledDirectAllocAndFree    01024  thrpt        20    12226.540      414.590   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.defaultPooledDirectAllocAndFree    04096  thrpt        20    12073.092      415.919   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.defaultPooledDirectAllocAndFree    16384  thrpt        20    13053.144      107.050   ops/ms
i.n.m.b.ByteBufAllocatorBenchmark.defaultPooledDirectAllocAndFree    65536  thrpt        20    12507.613      133.407   ops/ms

And some numbers of recyclable array list....

4.0.19:
Benchmark                                                (size)   Mode   Samples         Mean   Mean error    Units
i.n.m.i.RecyclableArrayListBenchmark.recycleSameThread    00000  thrpt        20    96493.439      363.794   ops/ms
i.n.m.i.RecyclableArrayListBenchmark.recycleSameThread    00256  thrpt        20    95397.559     1131.113   ops/ms
i.n.m.i.RecyclableArrayListBenchmark.recycleSameThread    01024  thrpt        20    94684.792     1868.593   ops/ms
i.n.m.i.RecyclableArrayListBenchmark.recycleSameThread    04096  thrpt        20    95421.467     1140.417   ops/ms
i.n.m.i.RecyclableArrayListBenchmark.recycleSameThread    16384  thrpt        20    93655.506     1401.171   ops/ms
i.n.m.i.RecyclableArrayListBenchmark.recycleSameThread    65536  thrpt        20    94552.290      974.530   ops/ms

4.0.19-ftl:
Benchmark                                                (size)   Mode   Samples         Mean   Mean error    Units
i.n.m.i.RecyclableArrayListBenchmark.recycleSameThread    00000  thrpt        20   110474.911     2336.413   ops/ms
i.n.m.i.RecyclableArrayListBenchmark.recycleSameThread    00256  thrpt        20   104353.207      867.748   ops/ms
i.n.m.i.RecyclableArrayListBenchmark.recycleSameThread    01024  thrpt        20   106233.236     2464.719   ops/ms
i.n.m.i.RecyclableArrayListBenchmark.recycleSameThread    04096  thrpt        20   101373.628     3747.072   ops/ms
i.n.m.i.RecyclableArrayListBenchmark.recycleSameThread    16384  thrpt        20    97362.769     2540.927   ops/ms
i.n.m.i.RecyclableArrayListBenchmark.recycleSameThread    65536  thrpt        20   106652.754     1570.151   ops/ms
