### PR TITLE
Addings helper methods to HTTP/2 handler

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandler.java
@@ -174,10 +174,6 @@ public abstract class AbstractHttp2ConnectionHandler extends ByteToMessageDecode
         freeResources();
     }
 
-    protected final ChannelHandlerContext ctx() {
-        return ctx;
-    }
-
     @Override
     public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
         // Avoid NotYetConnectedException
@@ -228,9 +224,128 @@ public abstract class AbstractHttp2ConnectionHandler extends ByteToMessageDecode
     }
 
     /**
+     * Default implementation. Does nothing.
+     */
+    @Override
+    public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
+            boolean endOfStream, boolean endOfSegment, boolean compressed) throws Http2Exception {
+    }
+
+    /**
+     * This will never actually be called, so marked as final. All received headers frames will be
+     * handled by
+     * {@link #onHeadersRead(ChannelHandlerContext, int, Http2Headers, int, short, boolean, int, boolean, boolean)}.
+     */
+    @Override
+    public final void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+            int padding, boolean endStream, boolean endSegment) throws Http2Exception {
+    }
+
+    /**
+     * Default implementation. Does nothing.
+     */
+    @Override
+    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+            int streamDependency, short weight, boolean exclusive, int padding, boolean endStream,
+            boolean endSegment) throws Http2Exception {
+    }
+
+    /**
+     * Default implementation. Does nothing.
+     */
+    @Override
+    public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency,
+            short weight, boolean exclusive) throws Http2Exception {
+    }
+
+    /**
+     * Default implementation. Does nothing.
+     */
+    @Override
+    public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
+            throws Http2Exception {
+    }
+
+    /**
+     * Default implementation. Does nothing.
+     */
+    @Override
+    public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
+    }
+
+    /**
+     * Default implementation. Does nothing.
+     */
+    @Override
+    public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings)
+            throws Http2Exception {
+    }
+
+    /**
+     * Default implementation. Does nothing.
+     */
+    @Override
+    public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
+    }
+
+    /**
+     * Default implementation. Does nothing.
+     */
+    @Override
+    public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
+    }
+
+    /**
+     * Default implementation. Does nothing.
+     */
+    @Override
+    public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
+            Http2Headers headers, int padding) throws Http2Exception {
+    }
+
+    /**
+     * Default implementation. Does nothing.
+     */
+    @Override
+    public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
+            ByteBuf debugData) throws Http2Exception {
+    }
+
+    /**
+     * Default implementation. Does nothing.
+     */
+    @Override
+    public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
+            throws Http2Exception {
+    }
+
+    /**
+     * Default implementation. Does nothing.
+     */
+    @Override
+    public void onAltSvcRead(ChannelHandlerContext ctx, int streamId, long maxAge, int port,
+            ByteBuf protocolId, String host, String origin) throws Http2Exception {
+    }
+
+    /**
+     * Default implementation. Does nothing.
+     */
+    @Override
+    public void onBlockedRead(ChannelHandlerContext ctx, int streamId) throws Http2Exception {
+    }
+
+    protected final ChannelHandlerContext ctx() {
+        return ctx;
+    }
+
+    protected final Http2Connection connection() {
+        return connection;
+    }
+
+    /**
      * Gets the next stream ID that can be created by the local endpoint.
      */
-    protected int nextStreamId() {
+    protected final int nextStreamId() {
         return connection.local().nextStreamId();
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandler.java
@@ -121,12 +121,6 @@ public class DelegatingHttp2ConnectionHandler extends AbstractHttp2ConnectionHan
 
     @Override
     public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
-            int padding, boolean endStream, boolean endSegment) throws Http2Exception {
-        observer.onHeadersRead(ctx, streamId, headers, padding, endStream, endSegment);
-    }
-
-    @Override
-    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
             int streamDependency, short weight, boolean exclusive, int padding, boolean endStream,
             boolean endSegment) throws Http2Exception {
         observer.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive,

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameObserver.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameObserver.java
@@ -29,7 +29,8 @@ public interface Http2FrameObserver {
      * @param ctx the context from the handler where the frame was read.
      * @param streamId the subject stream for the frame.
      * @param data payload buffer for the frame. If this buffer needs to be retained by the observer
-     *            they must make a copy.
+     *            they must make a copy. This buffer does not need to be released
+     *            by the observer.
      * @param padding the number of padding bytes found at the end of the frame.
      * @param endOfStream Indicates whether this is the last frame to be sent from the remote
      *            endpoint for this stream.
@@ -113,7 +114,8 @@ public interface Http2FrameObserver {
      *
      * @param ctx the context from the handler where the frame was read.
      * @param data the payload of the frame. If this buffer needs to be retained by the observer
-     *            they must make a copy.
+     *            they must make a copy. This buffer does not need to be released
+     *            by the observer.
      */
     void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception;
 
@@ -122,7 +124,8 @@ public interface Http2FrameObserver {
      *
      * @param ctx the context from the handler where the frame was read.
      * @param data the payload of the frame. If this buffer needs to be retained by the observer
-     *            they must make a copy.
+     *            they must make a copy. This buffer does not need to be released
+     *            by the observer.
      */
     void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception;
 
@@ -145,7 +148,8 @@ public interface Http2FrameObserver {
      * @param lastStreamId the last known stream of the remote endpoint.
      * @param errorCode the error code, if abnormal closure.
      * @param debugData application-defined debug data. If this buffer needs to be retained by the
-     *            observer they must make a copy.
+     *            observer they must make a copy. This buffer does not need to be released
+     *            by the observer.
      */
     void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData)
             throws Http2Exception;
@@ -169,7 +173,8 @@ public interface Http2FrameObserver {
      * @param maxAge the freshness lifetime of the alternative service association.
      * @param port the port that the alternative service is available upon.
      * @param protocolId the ALPN protocol identifier of the alternative service. If this buffer
-     *            needs to be retained by the observer they must make a copy.
+     *            needs to be retained by the observer they must make a copy. This buffer does not
+     *            need to be released by the observer.
      * @param host the host that the alternative service is available upon.
      * @param origin an optional origin that the alternative service is available upon. May be
      *            {@code null}.

--- a/example/src/main/java/io/netty/example/http2/client/Http2ClientConnectionHandler.java
+++ b/example/src/main/java/io/netty/example/http2/client/Http2ClientConnectionHandler.java
@@ -151,11 +151,6 @@ public class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler
 
     @Override
     public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
-            int padding, boolean endStream, boolean endSegment) throws Http2Exception {
-    }
-
-    @Override
-    public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
             int streamDependency, short weight, boolean exclusive, int padding, boolean endStream,
             boolean endSegment) throws Http2Exception {
         if (headers.contains(UPGRADE_RESPONSE_HEADER)) {
@@ -164,56 +159,10 @@ public class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler
     }
 
     @Override
-    public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency,
-            short weight, boolean exclusive) throws Http2Exception {
-    }
-
-    @Override
-    public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
-            throws Http2Exception {
-    }
-
-    @Override
-    public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
-    }
-
-    @Override
     public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception {
         if (!initPromise.isDone()) {
             initPromise.setSuccess();
         }
-    }
-
-    @Override
-    public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
-    }
-
-    @Override
-    public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
-    }
-
-    @Override
-    public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
-            Http2Headers headers, int padding) throws Http2Exception {
-    }
-
-    @Override
-    public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
-            ByteBuf debugData) throws Http2Exception {
-    }
-
-    @Override
-    public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
-            throws Http2Exception {
-    }
-
-    @Override
-    public void onAltSvcRead(ChannelHandlerContext ctx, int streamId, long maxAge, int port,
-            ByteBuf protocolId, String host, String origin) throws Http2Exception {
-    }
-
-    @Override
-    public void onBlockedRead(ChannelHandlerContext ctx, int streamId) throws Http2Exception {
     }
 
     @Override

--- a/example/src/main/java/io/netty/example/http2/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/server/HelloWorldHttp2Handler.java
@@ -15,6 +15,8 @@
 
 package io.netty.example.http2.server;
 
+import static io.netty.example.http2.Http2ExampleUtil.UPGRADE_RESPONSE_HEADER;
+import static io.netty.util.internal.logging.InternalLogLevel.INFO;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.example.http2.client.Http2ClientConnectionHandler;
@@ -32,11 +34,8 @@ import io.netty.handler.codec.http2.Http2FrameLogger;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2InboundFrameLogger;
 import io.netty.handler.codec.http2.Http2OutboundFrameLogger;
-import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import static io.netty.example.http2.Http2ExampleUtil.*;
-import static io.netty.util.internal.logging.InternalLogLevel.*;
 
 /**
  * A simple handler that responds with the message "Hello World!".
@@ -89,75 +88,12 @@ public class HelloWorldHttp2Handler extends AbstractHttp2ConnectionHandler {
      */
     @Override
     public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
-            Http2Headers headers, int padding, boolean endStream,
-            boolean endSegment) throws Http2Exception {
-        if (endStream) {
-            sendResponse(ctx(), streamId);
-        }
-    }
-
-    /**
-     * If receive a frame with end-of-stream set, send a pre-canned response.
-     */
-    @Override
-    public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
             Http2Headers headers, int streamDependency, short weight,
             boolean exclusive, int padding, boolean endStream, boolean endSegment)
             throws Http2Exception {
         if (endStream) {
             sendResponse(ctx(), streamId);
         }
-    }
-
-    @Override
-    public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency,
-            short weight, boolean exclusive) throws Http2Exception {
-    }
-
-    @Override
-    public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
-            throws Http2Exception {
-    }
-
-    @Override
-    public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
-    }
-
-    @Override
-    public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings)
-            throws Http2Exception {
-    }
-
-    @Override
-    public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
-    }
-
-    @Override
-    public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
-    }
-
-    @Override
-    public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
-            Http2Headers headers, int padding) throws Http2Exception {
-    }
-
-    @Override
-    public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
-            ByteBuf debugData) throws Http2Exception {
-    }
-
-    @Override
-    public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
-                    throws Http2Exception {
-    }
-
-    @Override
-    public void onAltSvcRead(ChannelHandlerContext ctx, int streamId, long maxAge, int port,
-            ByteBuf protocolId, String host, String origin) throws Http2Exception {
-    }
-
-    @Override
-    public void onBlockedRead(ChannelHandlerContext ctx, int streamId) throws Http2Exception {
     }
 
     @Override

--- a/example/src/main/java/io/netty/example/http2/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/server/Http2ServerInitializer.java
@@ -17,13 +17,10 @@
 package io.netty.example.http2.server;
 
 import io.netty.channel.ChannelHandlerAdapter;
-import io.netty.channel.ChannelHandlerAppender;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.handler.codec.http.HttpObjectAggregator;
-import io.netty.handler.codec.http.HttpRequestDecoder;
-import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
 import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
 import io.netty.handler.ssl.SslContext;
@@ -61,7 +58,7 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
      * Configure the pipeline for a cleartext upgrade from HTTP to HTTP/2.
      */
     private static void configureClearText(SocketChannel ch) {
-        HttpCodec sourceCodec = new HttpCodec();
+        HttpServerCodec sourceCodec = new HttpServerCodec();
         HttpServerUpgradeHandler.UpgradeCodec upgradeCodec =
                 new Http2ServerUpgradeCodec(new HelloWorldHttp2Handler());
         HttpServerUpgradeHandler upgradeHandler =
@@ -70,26 +67,6 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
         ch.pipeline().addLast(sourceCodec);
         ch.pipeline().addLast(upgradeHandler);
         ch.pipeline().addLast(new UserEventLogger());
-    }
-
-    /**
-     * Source codec for HTTP cleartext upgrade.
-     */
-    private static final class HttpCodec
-            extends ChannelHandlerAppender implements HttpServerUpgradeHandler.SourceCodec {
-        HttpCodec() {
-            add("httpRequestDecoder", new HttpRequestDecoder());
-            add("httpResponseEncoder", new HttpResponseEncoder());
-            add("httpRequestAggregator", new HttpObjectAggregator(65536));
-        }
-
-        @Override
-        public void upgradeFrom(ChannelHandlerContext ctx) {
-            System.out.println("removing HTTP handlers");
-            ctx.pipeline().remove("httpRequestAggregator");
-            ctx.pipeline().remove("httpResponseEncoder");
-            ctx.pipeline().remove("httpRequestDecoder");
-        }
     }
 
     /**


### PR DESCRIPTION
Motivation:

Subclasses of AbstractHttp2ConnectionHandler have to implement all frame
handler methods, many of which can be ignored in many cases.  Also there
is no easy way to access the connection object.

Modifications:

Added default implementations for frame handler methods to
AbstractHttp2ConnectionHandler, and added an accessor for the
connection.

Also fixed example test for HTTP/2 with cleartext upgrade. It must have
been broken by recent commits.

Result:

AbstractHttp2ConnectionHandler is more subclass-friendly.
