### PR TITLE
Grab-bag of minor changes to HTTP/2

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -30,14 +30,14 @@ import static io.netty.handler.codec.http2.Http2Stream.State.OPEN;
 import static io.netty.handler.codec.http2.Http2Stream.State.RESERVED_LOCAL;
 import static io.netty.handler.codec.http2.Http2Stream.State.RESERVED_REMOTE;
 import io.netty.handler.codec.http2.Http2StreamRemovalPolicy.Action;
+import io.netty.util.collection.Collections;
+import io.netty.util.collection.IntObjectHashMap;
+import io.netty.util.collection.IntObjectMap;
 
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -46,14 +46,12 @@ import java.util.Set;
 public class DefaultHttp2Connection implements Http2Connection {
 
     private final Set<Listener> listeners = new HashSet<Listener>(4);
-    private final Map<Integer, Http2Stream> streamMap = new HashMap<Integer, Http2Stream>();
+    private final IntObjectMap<Http2Stream> streamMap = new IntObjectHashMap<Http2Stream>();
     private final ConnectionStream connectionStream = new ConnectionStream();
     private final Set<Http2Stream> activeStreams = new LinkedHashSet<Http2Stream>();
     private final DefaultEndpoint localEndpoint;
     private final DefaultEndpoint remoteEndpoint;
     private final Http2StreamRemovalPolicy removalPolicy;
-    private boolean goAwaySent;
-    private boolean goAwayReceived;
 
     /**
      * Creates a connection with compression disabled and an immediate stream removal policy.
@@ -143,7 +141,7 @@ public class DefaultHttp2Connection implements Http2Connection {
 
     @Override
     public Set<Http2Stream> activeStreams() {
-        return Collections.unmodifiableSet(activeStreams);
+        return java.util.Collections.unmodifiableSet(activeStreams);
     }
 
     @Override
@@ -157,28 +155,8 @@ public class DefaultHttp2Connection implements Http2Connection {
     }
 
     @Override
-    public void goAwaySent() {
-        goAwaySent = true;
-    }
-
-    @Override
-    public void goAwayReceived() {
-        goAwayReceived = true;
-    }
-
-    @Override
-    public boolean isGoAwaySent() {
-        return goAwaySent;
-    }
-
-    @Override
-    public boolean isGoAwayReceived() {
-        return goAwayReceived;
-    }
-
-    @Override
     public boolean isGoAway() {
-        return isGoAwaySent() || isGoAwayReceived();
+        return localEndpoint.isGoAwayReceived() || remoteEndpoint.isGoAwayReceived();
     }
 
     private void addStream(DefaultStream stream) {
@@ -203,17 +181,33 @@ public class DefaultHttp2Connection implements Http2Connection {
         ((DefaultStream) stream.parent()).removeChild(stream);
     }
 
-    private void activate(Http2Stream stream) {
+    private void activate(DefaultStream stream) {
         activeStreams.add(stream);
+
+        // Update the number of active streams initiated by the endpoint.
+        stream.createdBy().numActiveStreams++;
+
+        // Notify the listeners.
         for (Listener listener : listeners) {
             listener.streamActive(stream);
         }
     }
 
-    private void deactivate(Http2Stream stream) {
+    private void deactivate(DefaultStream stream) {
         activeStreams.remove(stream);
+
+        // Update the number of active streams initiated by the endpoint.
+        stream.createdBy().numActiveStreams--;
+
+        // Notify the listeners.
         for (Listener listener : listeners) {
             listener.streamInactive(stream);
+        }
+    }
+
+    private void notifyGoingAway() {
+        for (Listener listener : listeners) {
+            listener.goingAway();
         }
     }
 
@@ -243,10 +237,13 @@ public class DefaultHttp2Connection implements Http2Connection {
         private State state = IDLE;
         private short weight = DEFAULT_PRIORITY_WEIGHT;
         private DefaultStream parent;
-        private Map<Integer, DefaultStream> children = newChildMap();
+        private IntObjectMap<DefaultStream> children = newChildMap();
         private int totalChildWeights;
+        private boolean terminateSent;
+        private boolean terminateReceived;
         private FlowState inboundFlow;
         private FlowState outboundFlow;
+        private Object data;
 
         DefaultStream(int id) {
             this.id = id;
@@ -260,6 +257,42 @@ public class DefaultHttp2Connection implements Http2Connection {
         @Override
         public final State state() {
             return state;
+        }
+
+        @Override
+        public boolean isTerminateReceived() {
+            return terminateReceived;
+        }
+
+        @Override
+        public void terminateReceived() {
+            terminateReceived = true;
+        }
+
+        @Override
+        public boolean isTerminateSent() {
+            return terminateSent;
+        }
+
+        @Override
+        public void terminateSent() {
+            terminateSent = true;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return terminateSent || terminateReceived;
+        }
+
+        @Override
+        public void data(Object data) {
+            this.data = data;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> T data() {
+            return (T) data;
         }
 
         @Override
@@ -326,7 +359,8 @@ public class DefaultHttp2Connection implements Http2Connection {
 
         @Override
         public final Collection<? extends Http2Stream> children() {
-            return Collections.unmodifiableCollection(children.values());
+            DefaultStream[] childrenArray = children.values(DefaultStream.class);
+            return Arrays.asList(childrenArray);
         }
 
         @Override
@@ -471,6 +505,10 @@ public class DefaultHttp2Connection implements Http2Connection {
             return state == HALF_CLOSED_REMOTE || state == OPEN || state == RESERVED_LOCAL;
         }
 
+        final DefaultEndpoint createdBy() {
+            return localEndpoint.createdStreamId(id)? localEndpoint : remoteEndpoint;
+        }
+
         final void weight(short weight) {
             if (parent != null && weight != this.weight) {
                 int delta = weight - this.weight;
@@ -479,13 +517,13 @@ public class DefaultHttp2Connection implements Http2Connection {
             this.weight = weight;
         }
 
-        final Map<Integer, DefaultStream> removeAllChildren() {
+        final IntObjectMap<DefaultStream> removeAllChildren() {
             if (children.isEmpty()) {
-                return Collections.emptyMap();
+                return Collections.emptyIntObjectMap();
             }
 
             totalChildWeights = 0;
-            Map<Integer, DefaultStream> prevChildren = children;
+            IntObjectMap<DefaultStream> prevChildren = children;
             children = newChildMap();
             return prevChildren;
         }
@@ -499,7 +537,7 @@ public class DefaultHttp2Connection implements Http2Connection {
                 // If it was requested that this child be the exclusive dependency of this node,
                 // move any previous children to the child node, becoming grand children
                 // of this node.
-                for (DefaultStream grandchild : removeAllChildren().values()) {
+                for (DefaultStream grandchild : removeAllChildren().values(DefaultStream.class)) {
                     child.addChild(grandchild, false);
                 }
             }
@@ -520,7 +558,7 @@ public class DefaultHttp2Connection implements Http2Connection {
                 totalChildWeights -= child.weight();
 
                 // Move up any grand children to be directly dependent on this node.
-                for (DefaultStream grandchild : child.children.values()) {
+                for (DefaultStream grandchild : child.children.values(DefaultStream.class)) {
                     addChild(grandchild, false);
                 }
             }
@@ -537,8 +575,8 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
     }
 
-    private static <T> Map<Integer, DefaultStream> newChildMap() {
-        return new LinkedHashMap<Integer, DefaultStream>(4);
+    private static <T> IntObjectMap<DefaultStream> newChildMap() {
+        return new IntObjectHashMap<DefaultStream>(4);
     }
 
     /**
@@ -589,9 +627,19 @@ public class DefaultHttp2Connection implements Http2Connection {
         private final boolean server;
         private int nextStreamId;
         private int lastStreamCreated;
-        private int maxStreams;
+        private int lastKnownStream = -1;
         private boolean pushToAllowed;
         private boolean allowCompressedData;
+
+        /**
+         * The maximum number of active streams allowed to be created by this endpoint.
+         */
+        private int maxStreams;
+
+        /**
+         * The current number of active streams created by this endpoint.
+         */
+        private int numActiveStreams;
 
         DefaultEndpoint(boolean server, boolean allowCompressedData) {
             this.allowCompressedData = allowCompressedData;
@@ -613,6 +661,17 @@ public class DefaultHttp2Connection implements Http2Connection {
             // For manually created client-side streams, 1 is reserved for HTTP upgrade, so
             // start at 3.
             return nextStreamId > 1? nextStreamId : nextStreamId + 2;
+        }
+
+        @Override
+        public boolean createdStreamId(int streamId) {
+            boolean even = (streamId & 1) == 0;
+            return server == even;
+        }
+
+        @Override
+        public boolean acceptingNewStreams() {
+            return nextStreamId() > 0 && numActiveStreams + 1 <= maxStreams;
         }
 
         @Override
@@ -682,6 +741,11 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         @Override
+        public int numActiveStreams() {
+            return numActiveStreams;
+        }
+
+        @Override
         public int maxStreams() {
             return maxStreams;
         }
@@ -707,6 +771,25 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         @Override
+        public int lastKnownStream() {
+            return isGoAwayReceived()? lastKnownStream : lastStreamCreated;
+        }
+
+        @Override
+        public boolean isGoAwayReceived() {
+            return lastKnownStream >= 0;
+        }
+
+        @Override
+        public void goAwayReceived(int lastKnownStream) {
+            boolean alreadyNotified = isGoAway();
+            this.lastKnownStream = lastKnownStream;
+            if (!alreadyNotified) {
+                notifyGoingAway();
+            }
+        }
+
+        @Override
         public Endpoint opposite() {
             return isLocal() ? remoteEndpoint : localEndpoint;
         }
@@ -716,7 +799,7 @@ public class DefaultHttp2Connection implements Http2Connection {
                 throw protocolError("Cannot create a stream since the connection is going away");
             }
             verifyStreamId(streamId);
-            if (streamMap.size() + 1 > maxStreams) {
+            if (!acceptingNewStreams()) {
                 throw protocolError("Maximum streams exceeded for this endpoint.");
             }
         }
@@ -729,8 +812,7 @@ public class DefaultHttp2Connection implements Http2Connection {
                 throw protocolError("Request stream %d is behind the next expected stream %d",
                         streamId, nextStreamId);
             }
-            boolean even = (streamId & 1) == 0;
-            if (server != even) {
+            if (!createdStreamId(streamId)) {
                 throw protocolError("Request stream %d is not correct for %s connection", streamId,
                         server ? "server" : "client");
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionAdapter.java
@@ -46,4 +46,8 @@ public class Http2ConnectionAdapter implements Http2Connection.Listener {
     @Override
     public void streamPrioritySubtreeChanged(Http2Stream stream, Http2Stream subtreeRoot) {
     }
+
+    @Override
+    public void goingAway() {
+    }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -73,6 +73,34 @@ public interface Http2Stream {
     Http2Stream closeRemoteSide();
 
     /**
+     * Indicates whether a RST_STREAM frame has been received from the remote endpoint for this stream.
+     */
+    boolean isTerminateReceived();
+
+    /**
+     * Sets the flag indicating that a RST_STREAM frame has been received from the remote endpoint
+     * for this stream. This does not affect the stream state.
+     */
+    void terminateReceived();
+
+    /**
+     * Indicates whether a RST_STREAM frame has been sent from the local endpoint for this stream.
+     */
+    boolean isTerminateSent();
+
+    /**
+     * Sets the flag indicating that a RST_STREAM frame has been sent from the local endpoint
+     * for this stream. This does not affect the stream state.
+     */
+    void terminateSent();
+
+    /**
+     * Indicates whether or not this stream has been terminated. This is a short form for
+     * {@link #isTerminateSent()} || {@link #isTerminateReceived()}.
+     */
+    boolean isTerminated();
+
+    /**
      * Indicates whether the remote side of this stream is open (i.e. the state is either
      * {@link State#OPEN} or {@link State#HALF_CLOSED_LOCAL}).
      */
@@ -83,6 +111,16 @@ public interface Http2Stream {
      * {@link State#OPEN} or {@link State#HALF_CLOSED_REMOTE}).
      */
     boolean localSideOpen();
+
+    /**
+     * Associates the application-defined data with this stream.
+     */
+    void data(Object data);
+
+    /**
+     * Returns application-defined data if any was associated with this stream.
+     */
+    <T> T data();
 
     /**
      * Gets the in-bound flow control state for this stream.

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -156,7 +156,7 @@ public class DefaultHttp2ConnectionTest {
 
     @Test(expected = Http2Exception.class)
     public void goAwayReceivedShouldDisallowCreation() throws Http2Exception {
-        server.goAwayReceived();
+        server.local().goAwayReceived(0);
         server.remote().createStream(3, true);
     }
 

--- a/common/src/main/java/io/netty/util/collection/Collections.java
+++ b/common/src/main/java/io/netty/util/collection/Collections.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.util.collection;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Utility methods for collections.
+ */
+public final class Collections {
+    private static final IntObjectMap<Object> EMPTY_INT_OBJECT_MAP = new EmptyIntObjectMap();
+
+    private Collections() {
+    }
+
+    /**
+     * Returns an unmodifiable empty {@link IntObjectMap}.
+     */
+    @SuppressWarnings("unchecked")
+    public static <V> IntObjectMap<V> emptyIntObjectMap() {
+        return (IntObjectMap<V>) EMPTY_INT_OBJECT_MAP;
+    }
+
+    /**
+     * Creates an unmodifiable wrapper around the given map.
+     */
+    public static <V> IntObjectMap<V> unmodifiable(final IntObjectMap<V> map) {
+        return new UnmodifiableIntObjectMap<V>(map);
+    }
+
+    /**
+     * An empty map. All operations that attempt to modify the map are unsupported.
+     *
+     * @param <V> the value type for the map.
+     */
+    private static final class EmptyIntObjectMap implements IntObjectMap<Object> {
+
+        @Override
+        public Object get(int key) {
+            return null;
+        }
+
+        @Override
+        public Object put(int key, Object value) {
+            throw new UnsupportedOperationException("put");
+        }
+
+        @Override
+        public void putAll(IntObjectMap<Object> sourceMap) {
+            throw new UnsupportedOperationException("putAll");
+        }
+
+        @Override
+        public Object remove(int key) {
+            throw new UnsupportedOperationException("remove");
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
+
+        @Override
+        public void clear() {
+            // Do nothing.
+        }
+
+        @Override
+        public boolean containsKey(int key) {
+            return false;
+        }
+
+        @Override
+        public boolean containsValue(Object value) {
+            return false;
+        }
+
+        @Override
+        public Iterable<Entry<Object>> entries() {
+            return java.util.Collections.emptySet();
+        }
+
+        @Override
+        public int[] keys() {
+            return new int[0];
+        }
+
+        @Override
+        public Object[] values(Class<Object> clazz) {
+            return new Object[0];
+        }
+    }
+
+    /**
+     * An unmodifiable wrapper around a {@link IntObjectMap}.
+     *
+     * @param <V> the value type stored in the map.
+     */
+    private static final class UnmodifiableIntObjectMap<V> implements IntObjectMap<V>,
+            Iterable<IntObjectMap.Entry<V>> {
+        final IntObjectMap<V> map;
+
+        UnmodifiableIntObjectMap(IntObjectMap<V> map) {
+            this.map = map;
+        }
+
+        @Override
+        public V get(int key) {
+            return map.get(key);
+        }
+
+        @Override
+        public V put(int key, V value) {
+            throw new UnsupportedOperationException("put");
+        }
+
+        @Override
+        public void putAll(IntObjectMap<V> sourceMap) {
+            throw new UnsupportedOperationException("putAll");
+        }
+
+        @Override
+        public V remove(int key) {
+            throw new UnsupportedOperationException("remove");
+        }
+
+        @Override
+        public int size() {
+            return map.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return map.isEmpty();
+        }
+
+        @Override
+        public void clear() {
+            throw new UnsupportedOperationException("clear");
+        }
+
+        @Override
+        public boolean containsKey(int key) {
+            return map.containsKey(key);
+        }
+
+        @Override
+        public boolean containsValue(V value) {
+            return map.containsValue(value);
+        }
+
+        @Override
+        public Iterable<Entry<V>> entries() {
+            return this;
+        }
+
+        @Override
+        public Iterator<Entry<V>> iterator() {
+            return new IteratorImpl(map.entries().iterator());
+        }
+
+        @Override
+        public int[] keys() {
+            return map.keys();
+        }
+
+        @Override
+        public V[] values(Class<V> clazz) {
+            return map.values(clazz);
+        }
+
+        /**
+         * Unmodifiable wrapper for an iterator.
+         */
+        private class IteratorImpl implements Iterator<Entry<V>> {
+            final Iterator<Entry<V>> iter;
+
+            IteratorImpl(Iterator<Entry<V>> iter) {
+                this.iter = iter;
+            }
+
+            @Override
+            public boolean hasNext() {
+                return iter.hasNext();
+            }
+
+            @Override
+            public Entry<V> next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                return new EntryImpl(iter.next());
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("remove");
+            }
+        }
+
+        /**
+         * Unmodifiable wrapper for an entry.
+         */
+        private class EntryImpl implements Entry<V> {
+            final Entry<V> entry;
+
+            EntryImpl(Entry<V> entry) {
+                this.entry = entry;
+            }
+
+            @Override
+            public int key() {
+                return entry.key();
+            }
+
+            @Override
+            public V value() {
+                return entry.value();
+            }
+
+            @Override
+            public void setValue(V value) {
+                throw new UnsupportedOperationException("setValue");
+            }
+        }
+    };
+}

--- a/common/src/main/java/io/netty/util/collection/IntObjectHashMap.java
+++ b/common/src/main/java/io/netty/util/collection/IntObjectHashMap.java
@@ -74,6 +74,9 @@ public class IntObjectHashMap<V> implements IntObjectMap<V>, Iterable<IntObjectM
 
         this.loadFactor = loadFactor;
 
+        // Adjust the initial capacity if necessary.
+        initialCapacity = adjustCapacity(initialCapacity);
+
         // Allocate the arrays.
         states = new byte[initialCapacity];
         keys = new int[initialCapacity];
@@ -336,13 +339,20 @@ public class IntObjectHashMap<V> implements IntObjectMap<V>, Iterable<IntObjectM
 
         if (size > maxSize) {
             // Need to grow the arrays.
-            // TODO: consider using the next prime greater than capacity * 2.
-            rehash(capacity() * 2);
+            rehash(adjustCapacity(capacity() * 2));
         } else if (available == 0) {
             // Open addressing requires that we have at least 1 slot available. Need to refresh
             // the arrays to clear any removed elements.
             rehash(capacity());
         }
+    }
+
+    /**
+     * Adjusts the given capacity value to ensure that it's odd. Even capacities can break probing.
+     * TODO: would be better to ensure it's prime as well.
+     */
+    private int adjustCapacity(int capacity) {
+        return capacity |= 1;
     }
 
     /**


### PR DESCRIPTION
Motivation:

Various small fixes/improvements to the interface to the HTTP/2 classes,
as well as some minor performance improvements.

Modifications:
- Added fix for IntObjectHashMap to ensure that capacity is always odd.
  Even capacity can cause probing to fail.
- Cleaned the access to GOAWAY information in Http2Connection interface.
  Endpoints now manage their own state for GOAWAY. Also added a goingAway
  event handler.
- Added Endpoint methods for checking MAX_CONCURRENT_STREAMS or if the
  number of streams for the endpoint have been exhausted. See
  Endpoint.nextStreamId()/acceptingNewStreams().
- Changed DefaultHttp2Connection to use IntObjectHashMap. This should be
  a slight memory improvement.
- Fixed check for MAX_CONCURRENT_STREAMS to correctly use the number of
  active streams for the endpoint (not total active). See
  DefaultHttp2Connection.checkNewStreamAllowed.
- Exposing a few methods to subclasses of AbstractHttp2ConnectionHandler
  (e.g. exception handling).
- Cleaning up GOAWAY and RST_STREAM handling in
  AbstractHttp2ConnectionHandler.

Result:

HTTP/2 code should provide more information to subclasses and will have
a reduced memory footprint.
