### PR TITLE
Fix inconsistent code in the doc

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
@@ -40,21 +40,21 @@ import java.util.List;
  *
  *   {@code @Override}
  *   protected void decode({@link ChannelHandlerContext} ctx,
- *                           {@link ByteBuf} in, List&lt;Object&gt; out) throws Exception {
+ *                           {@link ByteBuf} buf, List&lt;Object&gt; out) throws Exception {
  *
- *     if (in.readableBytes() &lt; 4) {
+ *     if (buf.readableBytes() &lt; 4) {
  *        return;
  *     }
  *
- *     in.markReaderIndex();
- *     int length = in.readInt();
+ *     buf.markReaderIndex();
+ *     int length = buf.readInt();
  *
- *     if (in.readableBytes() &lt; length) {
- *        in.resetReaderIndex();
+ *     if (buf.readableBytes() &lt; length) {
+ *        buf.resetReaderIndex();
  *        return;
  *     }
  *
- *     out.add(in.readBytes(length));
+ *     out.add(buf.readBytes(length));
  *   }
  * }
  * </pre>
@@ -108,11 +108,11 @@ import java.util.List;
  *   private final Queue&lt;Integer&gt; values = new LinkedList&lt;Integer&gt;();
  *
  *   {@code @Override}
- *   public void decode(.., {@link ByteBuf} in, List&lt;Object&gt; out) throws Exception {
+ *   public void decode(.., {@link ByteBuf} buf, List&lt;Object&gt; out) throws Exception {
  *
  *     // A message contains 2 integers.
- *     values.offer(buffer.readInt());
- *     values.offer(buffer.readInt());
+ *     values.offer(buf.readInt());
+ *     values.offer(buf.readInt());
  *
  *     // This assertion will fail intermittently since values.offer()
  *     // can be called more than two times!
@@ -128,15 +128,15 @@ import java.util.List;
  *   private final Queue&lt;Integer&gt; values = new LinkedList&lt;Integer&gt;();
  *
  *   {@code @Override}
- *   public void decode(.., {@link ByteBuf} buffer, List&lt;Object&gt; out) throws Exception {
+ *   public void decode(.., {@link ByteBuf} buf, List&lt;Object&gt; out) throws Exception {
  *
  *     // Revert the state of the variable that might have been changed
  *     // since the last partial decode.
  *     values.clear();
  *
  *     // A message contains 2 integers.
- *     values.offer(buffer.readInt());
- *     values.offer(buffer.readInt());
+ *     values.offer(buf.readInt());
+ *     values.offer(buf.readInt());
  *
  *     // Now we know this assertion will never fail.
  *     assert values.size() == 2;
@@ -181,7 +181,7 @@ import java.util.List;
  *
  *   {@code @Override}
  *   protected void decode({@link ChannelHandlerContext} ctx,
- *                           {@link ByteBuf} in, List&lt;Object&gt; out) throws Exception {
+ *                           {@link ByteBuf} buf, List&lt;Object&gt; out) throws Exception {
  *     switch (state()) {
  *     case READ_LENGTH:
  *       length = buf.readInt();
@@ -209,7 +209,7 @@ import java.util.List;
  *
  *   {@code @Override}
  *   protected void decode({@link ChannelHandlerContext} ctx,
- *                           {@link ByteBuf} in, List&lt;Object&gt; out) throws Exception {
+ *                           {@link ByteBuf} buf, List&lt;Object&gt; out) throws Exception {
  *     if (!readLength) {
  *       length = buf.readInt();
  *       <strong>readLength = true;</strong>
@@ -240,7 +240,7 @@ import java.util.List;
  *
  *     {@code @Override}
  *     protected Object decode({@link ChannelHandlerContext} ctx,
- *                             {@link ByteBuf} in, List&lt;Object&gt; out) {
+ *                             {@link ByteBuf} buf, List&lt;Object&gt; out) {
  *         ...
  *         // Decode the first message
  *         Object firstMessage = ...;


### PR DESCRIPTION
Fix inconsistent code in the class doc of ReplayingDecoder.
Affected branches: master, 4.0, 4.1, haven't check other branches.
