### PR TITLE
Fix IdleStateHandler silently crashing on voidPromise

### DIFF
--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -256,14 +256,15 @@ public class IdleStateHandler extends ChannelDuplexHandler {
 
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-        promise.addListener(new ChannelFutureListener() {
+        ChannelPromise p = promise == ctx.voidPromise() ? ctx.newPromise() : promise;
+        p.addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(ChannelFuture future) throws Exception {
                 lastWriteTime = System.nanoTime();
                 firstWriterIdleEvent = firstAllIdleEvent = true;
             }
         });
-        ctx.write(msg, promise);
+        ctx.write(msg, p);
     }
 
     private void initialize(ChannelHandlerContext ctx) {

--- a/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.timeout;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class IdleStateHandlerTest {
+    @Test
+    public void testWriteWithVoidPromise() {
+        ByteBuf buf = Unpooled.buffer();
+        EmbeddedChannel ch = new EmbeddedChannel(new IdleStateHandler(0, 0, 0));
+        ch.writeAndFlush(buf, ch.voidPromise());
+        assertEquals(buf, ch.readOutbound());
+    }
+}


### PR DESCRIPTION
Motivation:

`IdleStateHandler` may receive a `voidPromise` into its `write` method. When it adds a listener to this promise it fails with `IllegalStateException`. `AbstractChannelHandlerContext` then swallows the `ISE` in `notifyOutboundHandlerException`, silently dropping the message sent.

Modifications:

In `IdleStateHandler.write` detect `voidPromise` and replace it with `newPromise`.

Result:

`IdleStateHandler` works as expected regardless of the promise type.
