### PR TITLE
maintain decoder result in HttpObjectAggregator

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -260,10 +260,12 @@ public class HttpObjectAggregator extends MessageToMessageDecoder<HttpObject> {
             HttpRequest req = (HttpRequest) msg;
             fullMsg = new DefaultFullHttpRequest(
                     req.getProtocolVersion(), req.getMethod(), req.getUri(), Unpooled.EMPTY_BUFFER, false);
+            fullMsg.setDecoderResult(req.getDecoderResult());
         } else if (msg instanceof HttpResponse) {
             HttpResponse res = (HttpResponse) msg;
             fullMsg = new DefaultFullHttpResponse(
                     res.getProtocolVersion(), res.getStatus(), Unpooled.EMPTY_BUFFER, false);
+            fullMsg.setDecoderResult(res.getDecoderResult());
         } else {
             throw new IllegalStateException();
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
@@ -192,7 +192,9 @@ public class HttpObjectAggregatorTest {
     public void testBadRequest() {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpRequestDecoder(), new HttpObjectAggregator(1024 * 1024));
         ch.writeInbound(Unpooled.copiedBuffer("GET / HTTP/1.0 with extra\r\n", CharsetUtil.UTF_8));
-        assertThat(ch.readInbound(), is(instanceOf(FullHttpRequest.class)));
+        Object inbound = ch.readInbound();
+        assertThat(inbound, is(instanceOf(FullHttpRequest.class)));
+        assertTrue(((FullHttpRequest) inbound).getDecoderResult().isFailure());
         assertNull(ch.readInbound());
         ch.finish();
     }
@@ -201,7 +203,9 @@ public class HttpObjectAggregatorTest {
     public void testBadResponse() throws Exception {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder(), new HttpObjectAggregator(1024 * 1024));
         ch.writeInbound(Unpooled.copiedBuffer("HTTP/1.0 BAD_CODE Bad Server\r\n", CharsetUtil.UTF_8));
-        assertThat(ch.readInbound(), is(instanceOf(FullHttpResponse.class)));
+        Object inbound = ch.readInbound();
+        assertThat(inbound, is(instanceOf(FullHttpResponse.class)));
+        assertTrue(((FullHttpResponse) inbound).getDecoderResult().isFailure());
         assertNull(ch.readInbound());
         ch.finish();
     }


### PR DESCRIPTION
I noticed the HttpObjectAggregator was dropping the DecoderResult from the HttpRequestDecoder so I made this fix for you.

I'm can make pull requests for 4.1 and master as well.  Not sure what else you might be maintaining.
