### PR TITLE
fix example missing break statement in ReplayingDecoder

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
@@ -190,6 +190,7 @@ import java.util.List;
  *       ByteBuf frame = buf.readBytes(length);
  *       <strong>checkpoint(MyDecoderState.READ_LENGTH);</strong>
  *       out.add(frame);
+ *       break;
  *     default:
  *       throw new Error("Shouldn't reach here.");
  *     }


### PR DESCRIPTION
The example in ReplayingDecoder seems lack of one break statement
