### PR TITLE
Update dependency from org.jboss.logging:jboss-logging-spi:2.1.2.GA to org.jboss.logging:jboss-logging:3.1.4.GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,8 +151,8 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.logging</groupId>
-      <artifactId>jboss-logging-spi</artifactId>
-      <version>2.1.2.GA</version>
+      <artifactId>jboss-logging</artifactId>
+      <version>3.1.4.GA</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>


### PR DESCRIPTION
org.jboss.logging:jboss-logging-spi is EOL, the replacement is: org.jboss.logging:jboss-logging:3.1.4.GA, would you please change to depend on that artifact?
