### PR TITLE
Changed Http2ClientConnectionHandler to not update reader index.

### DIFF
--- a/example/src/main/java/io/netty/example/http2/client/Http2ClientConnectionHandler.java
+++ b/example/src/main/java/io/netty/example/http2/client/Http2ClientConnectionHandler.java
@@ -125,7 +125,7 @@ public class Http2ClientConnectionHandler extends AbstractHttp2ConnectionHandler
         int available = data.readableBytes();
         if (collectedData == null) {
             collectedData = ctx().alloc().buffer(available);
-            collectedData.writeBytes(data);
+            collectedData.writeBytes(data, data.readerIndex(), data.readableBytes());
         } else {
             // Expand the buffer
             ByteBuf newBuffer = ctx().alloc().buffer(collectedData.readableBytes() + available);


### PR DESCRIPTION
Motivation:
When running the Http2Client the data returned from the server, the
"Hello World" string, is supposed to be printed but instead the following
is displayed:
Received message:

The reason is that the following line increases the ByteBuf's readerIndex:
collectedData.writeBytes(data);

Modifications:
Changing the above mentioned method to use a writeBytes call that does
not increase the readerIndex:
collectedData.writeBytes(data, data.readerIndex(), data.readableBytes());

Result:
The example now logs the correct data sent from the server:
Received message: Hello World
