### PR TITLE
Reduce the perceived time taken to retrieve initialSeedUniquifier

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -15,6 +15,8 @@
  */
 package io.netty.util.internal.logging;
 
+import io.netty.util.internal.ThreadLocalRandom;
+
 /**
  * Creates an {@link InternalLogger} or changes the default factory
  * implementation.  This factory allows you to choose what logging framework
@@ -31,8 +33,19 @@ package io.netty.util.internal.logging;
  * as possible and shouldn't be called more than once.
  */
 public abstract class InternalLoggerFactory {
+
     private static volatile InternalLoggerFactory defaultFactory =
             newDefaultFactory(InternalLoggerFactory.class.getName());
+
+    static {
+        // Initiate some time-consuming background jobs here,
+        // because this class is often initialized at the earliest time.
+        try {
+            Class.forName(ThreadLocalRandom.class.getName(), true, InternalLoggerFactory.class.getClassLoader());
+        } catch (Exception ignored) {
+            // Should not fail, but it does not harm to fail.
+        }
+    }
 
     @SuppressWarnings("UnusedCatchParameter")
     private static InternalLoggerFactory newDefaultFactory(String name) {

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -50,7 +50,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     private MessageSizeEstimator.Handle estimatorHandle;
 
     private final Channel parent;
-    private final ChannelId id = DefaultChannelId.newInstance();
+    private final ChannelId id;
     private final Unsafe unsafe;
     private final DefaultChannelPipeline pipeline;
     private final ChannelFuture succeededFuture = new SucceededChannelFuture(this, null);
@@ -75,6 +75,20 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      */
     protected AbstractChannel(Channel parent) {
         this.parent = parent;
+        id = DefaultChannelId.newInstance();
+        unsafe = newUnsafe();
+        pipeline = new DefaultChannelPipeline(this);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param parent
+     *        the parent of this channel. {@code null} if there's no parent.
+     */
+    protected AbstractChannel(Channel parent, ChannelId id) {
+        this.parent = parent;
+        this.id = id;
         unsafe = newUnsafe();
         pipeline = new DefaultChannelPipeline(this);
     }

--- a/transport/src/main/java/io/netty/channel/DefaultChannelId.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelId.java
@@ -65,26 +65,6 @@ final class DefaultChannelId implements ChannelId {
     }
 
     static {
-        byte[] machineId = null;
-        String customMachineId = SystemPropertyUtil.get("io.netty.machineId");
-        if (customMachineId != null) {
-            if (MACHINE_ID_PATTERN.matcher(customMachineId).matches()) {
-                machineId = parseMachineId(customMachineId);
-                logger.debug("-Dio.netty.machineId: {} (user-set)", customMachineId);
-            } else {
-                logger.warn("-Dio.netty.machineId: {} (malformed)", customMachineId);
-            }
-        }
-
-        if (machineId == null) {
-            machineId = defaultMachineId();
-            if (logger.isDebugEnabled()) {
-                logger.debug("-Dio.netty.machineId: {} (auto-detected)", formatAddress(machineId));
-            }
-        }
-
-        MACHINE_ID = machineId;
-
         int processId = -1;
         String customProcessId = SystemPropertyUtil.get("io.netty.processId");
         if (customProcessId != null) {
@@ -110,6 +90,26 @@ final class DefaultChannelId implements ChannelId {
         }
 
         PROCESS_ID = processId;
+
+        byte[] machineId = null;
+        String customMachineId = SystemPropertyUtil.get("io.netty.machineId");
+        if (customMachineId != null) {
+            if (MACHINE_ID_PATTERN.matcher(customMachineId).matches()) {
+                machineId = parseMachineId(customMachineId);
+                logger.debug("-Dio.netty.machineId: {} (user-set)", customMachineId);
+            } else {
+                logger.warn("-Dio.netty.machineId: {} (malformed)", customMachineId);
+            }
+        }
+
+        if (machineId == null) {
+            machineId = defaultMachineId();
+            if (logger.isDebugEnabled()) {
+                logger.debug("-Dio.netty.machineId: {} (auto-detected)", formatAddress(machineId));
+            }
+        }
+
+        MACHINE_ID = machineId;
     }
 
     @SuppressWarnings("DynamicRegexReplaceableByCompiledPattern")

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -74,7 +74,7 @@ public class EmbeddedChannel extends AbstractChannel {
      * @param handlers the @link ChannelHandler}s which will be add in the {@link ChannelPipeline}
      */
     public EmbeddedChannel(ChannelHandler... handlers) {
-        super(null);
+        super(null, EmbeddedChannelId.INSTANCE);
 
         if (handlers == null) {
             throw new NullPointerException("handlers");

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannelId.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannelId.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.embedded;
+
+import io.netty.channel.ChannelId;
+
+/**
+ * A dummy {@link ChannelId} implementation.
+ */
+final class EmbeddedChannelId implements ChannelId {
+
+    private static final long serialVersionUID = -251711922203466130L;
+
+    static final ChannelId INSTANCE = new EmbeddedChannelId();
+
+    private EmbeddedChannelId() { }
+
+    @Override
+    public String asShortText() {
+        return toString();
+    }
+
+    @Override
+    public String asLongText() {
+        return toString();
+    }
+
+    @Override
+    public int compareTo(ChannelId o) {
+        if (o == INSTANCE) {
+            return 0;
+        }
+
+        return asLongText().compareTo(o.asLongText());
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+
+    @Override
+    public String toString() {
+        return "embedded";
+    }
+}


### PR DESCRIPTION
Motivation:

When system is in short of entrophy, the initialization of
ThreadLocalRandom can take at most 3 seconds.  The initialization occurs
when ThreadLocalRandom.current() is invoked first time, which might be
much later than the moment when the application has started.  If we
start the initialization of ThreadLocalRandom as early as possible, we
can reduce the perceived time taken for the retrieval.

Modification:

Begin the initialization of ThreadLocalRandom in InternalLoggerFactory,
potentially one of the firstly initialized class in a Netty application.

Make DefaultChannelId retrieve the current process ID before retrieving
the current machine ID, because retrieval of a machine ID is more likely
to use ThreadLocalRandom.current().

Use a dummy channel ID for EmbeddedChannel, which prevents many unit
tests from creating a ThreadLocalRandom instance.

Result:

We gain extra 100ms at minimum for initialSeedUniquifier generation.  If
an application has its own initialization that takes long enough time
and generates good amount of entrophy, it is very likely that we will
gain a lot more.
