### PR TITLE
A selectNow event loop and some hacks to make it fit in.

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -108,6 +108,12 @@
       <artifactId>netty-transport-rxtx</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>${project.version}</version>
+      <classifier>${os.detected.classifier} </classifier>
+    </dependency>
   </dependencies>
 
   <build>
@@ -130,6 +136,13 @@
         </configuration>
       </plugin>
     </plugins>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.2.3.Final</version>
+      </extension>
+    </extensions>
   </build>
 </project>
 

--- a/example/src/main/java/io/netty/example/echo/EchoEpollServer.java
+++ b/example/src/main/java/io/netty/example/echo/EchoEpollServer.java
@@ -16,6 +16,7 @@
 package io.netty.example.echo;
 
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
@@ -53,6 +54,7 @@ public final class EchoEpollServer {
         try {
             ServerBootstrap b = new ServerBootstrap();
             b.group(bossGroup, workerGroup)
+             .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
              .channel(EpollServerSocketChannel.class)
              .option(ChannelOption.SO_BACKLOG, 100)
              .handler(new LoggingHandler(LogLevel.INFO))

--- a/example/src/main/java/io/netty/example/echo/EchoEpollServer.java
+++ b/example/src/main/java/io/netty/example/echo/EchoEpollServer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.echo;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+
+/**
+ * Echoes back any received data from a client.
+ */
+public final class EchoEpollServer {
+
+    static final boolean SSL = System.getProperty("ssl") != null;
+    static final int PORT = Integer.parseInt(System.getProperty("port", "8007"));
+
+    public static void main(String[] args) throws Exception {
+        // Configure SSL.
+        final SslContext sslCtx;
+        if (SSL) {
+            SelfSignedCertificate ssc = new SelfSignedCertificate();
+            sslCtx = SslContext.newServerContext(ssc.certificate(), ssc.privateKey());
+        } else {
+            sslCtx = null;
+        }
+
+        // Configure the server.
+        EventLoopGroup bossGroup = new EpollEventLoopGroup(1);
+        EventLoopGroup workerGroup = new EpollEventLoopGroup();
+        try {
+            ServerBootstrap b = new ServerBootstrap();
+            b.group(bossGroup, workerGroup)
+             .channel(NioServerSocketChannel.class)
+             .option(ChannelOption.SO_BACKLOG, 100)
+             .handler(new LoggingHandler(LogLevel.INFO))
+             .childHandler(new ChannelInitializer<SocketChannel>() {
+                 @Override
+                 public void initChannel(SocketChannel ch) throws Exception {
+                     ChannelPipeline p = ch.pipeline();
+                     if (sslCtx != null) {
+                         p.addLast(sslCtx.newHandler(ch.alloc()));
+                     }
+                     //p.addLast(new LoggingHandler(LogLevel.INFO));
+                     p.addLast(new EchoServerHandler());
+                 }
+             });
+
+            // Start the server.
+            ChannelFuture f = b.bind(PORT).sync();
+
+            // Wait until the server socket is closed.
+            f.channel().closeFuture().sync();
+        } finally {
+            // Shut down all event loops to terminate all threads.
+            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully();
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/echo/EchoEpollServer.java
+++ b/example/src/main/java/io/netty/example/echo/EchoEpollServer.java
@@ -22,8 +22,8 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslContext;
@@ -53,7 +53,7 @@ public final class EchoEpollServer {
         try {
             ServerBootstrap b = new ServerBootstrap();
             b.group(bossGroup, workerGroup)
-             .channel(NioServerSocketChannel.class)
+             .channel(EpollServerSocketChannel.class)
              .option(ChannelOption.SO_BACKLOG, 100)
              .handler(new LoggingHandler(LogLevel.INFO))
              .childHandler(new ChannelInitializer<SocketChannel>() {

--- a/example/src/main/java/io/netty/example/echo/EchoSelectNowServer.java
+++ b/example/src/main/java/io/netty/example/echo/EchoSelectNowServer.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.echo;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.nio.NioSelectNowEventLoop;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+
+import java.nio.channels.spi.SelectorProvider;
+import java.util.concurrent.Executor;
+
+/**
+ * Echoes back any received data from a client.
+ */
+public final class EchoSelectNowServer {
+
+    static final boolean SSL = System.getProperty("ssl") != null;
+    static final int PORT = Integer.parseInt(System.getProperty("port", "8007"));
+
+    public static void main(String[] args) throws Exception {
+        // Configure SSL.
+        final SslContext sslCtx;
+        if (SSL) {
+            SelfSignedCertificate ssc = new SelfSignedCertificate();
+            sslCtx = SslContext.newServerContext(ssc.certificate(), ssc.privateKey());
+        } else {
+            sslCtx = null;
+        }
+
+        // Configure the server.
+        EventLoopGroup bossGroup = new NioEventLoopGroup(1) {
+        	@Override
+        	protected EventLoop newChild(Executor executor, Object... args)
+        			throws Exception {
+        		return new NioSelectNowEventLoop(this, executor, (SelectorProvider) args[0]);
+        	}
+        };
+        EventLoopGroup workerGroup = new NioEventLoopGroup() {
+        	@Override
+        	protected EventLoop newChild(Executor executor, Object... args)
+        			throws Exception {
+        		return new NioSelectNowEventLoop(this, executor, (SelectorProvider) args[0]);
+        	}
+        };
+        try {
+            ServerBootstrap b = new ServerBootstrap();
+            b.group(bossGroup, workerGroup)
+             .channel(NioServerSocketChannel.class)
+             .option(ChannelOption.SO_BACKLOG, 100)
+             .handler(new LoggingHandler(LogLevel.INFO))
+             .childHandler(new ChannelInitializer<SocketChannel>() {
+                 @Override
+                 public void initChannel(SocketChannel ch) throws Exception {
+                     ChannelPipeline p = ch.pipeline();
+                     if (sslCtx != null) {
+                         p.addLast(sslCtx.newHandler(ch.alloc()));
+                     }
+                     //p.addLast(new LoggingHandler(LogLevel.INFO));
+                     p.addLast(new EchoServerHandler());
+                 }
+             });
+
+            // Start the server.
+            ChannelFuture f = b.bind(PORT).sync();
+
+            // Wait until the server socket is closed.
+            f.channel().closeFuture().sync();
+        } finally {
+            // Shut down all event loops to terminate all threads.
+            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully();
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/echo/EchoSelectNowServer.java
+++ b/example/src/main/java/io/netty/example/echo/EchoSelectNowServer.java
@@ -16,6 +16,7 @@
 package io.netty.example.echo;
 
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
@@ -70,6 +71,7 @@ public final class EchoSelectNowServer {
         try {
             ServerBootstrap b = new ServerBootstrap();
             b.group(bossGroup, workerGroup)
+             .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
              .channel(NioServerSocketChannel.class)
              .option(ChannelOption.SO_BACKLOG, 100)
              .handler(new LoggingHandler(LogLevel.INFO))

--- a/example/src/main/java/io/netty/example/echo/EchoServer.java
+++ b/example/src/main/java/io/netty/example/echo/EchoServer.java
@@ -16,6 +16,7 @@
 package io.netty.example.echo;
 
 import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
@@ -53,6 +54,7 @@ public final class EchoServer {
         try {
             ServerBootstrap b = new ServerBootstrap();
             b.group(bossGroup, workerGroup)
+             .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
              .channel(NioServerSocketChannel.class)
              .option(ChannelOption.SO_BACKLOG, 100)
              .handler(new LoggingHandler(LogLevel.INFO))

--- a/example/src/main/java/io/netty/example/echo/EchoServerHandler.java
+++ b/example/src/main/java/io/netty/example/echo/EchoServerHandler.java
@@ -27,7 +27,7 @@ public class EchoServerHandler extends ChannelHandlerAdapter {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
-        ctx.write(msg);
+        ctx.write(msg, ctx.voidPromise());
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -100,8 +100,8 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     }
 
     @Override
-    public NioEventLoop eventLoop() {
-        return (NioEventLoop) super.eventLoop();
+    public INioEventLoop eventLoop() {
+        return (INioEventLoop) super.eventLoop();
     }
 
     /**
@@ -329,7 +329,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
 
     @Override
     protected boolean isCompatible(EventLoop loop) {
-        return loop instanceof NioEventLoop;
+        return loop instanceof INioEventLoop;
     }
 
     @Override
@@ -337,7 +337,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         boolean selected = false;
         for (;;) {
             try {
-                selectionKey = javaChannel().register(eventLoop().selector, 0, this);
+                selectionKey = javaChannel().register(eventLoop().selector(), 0, this);
                 return;
             } catch (CancelledKeyException e) {
                 if (!selected) {

--- a/transport/src/main/java/io/netty/channel/nio/INioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/INioEventLoop.java
@@ -1,0 +1,17 @@
+package io.netty.channel.nio;
+
+import java.io.IOException;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+
+import io.netty.channel.EventLoop;
+
+public interface INioEventLoop extends EventLoop {
+
+	Selector selector();
+
+	int selectNow() throws IOException;
+
+	void cancel(SelectionKey selectionKey);
+
+}

--- a/transport/src/main/java/io/netty/channel/nio/NioSelectNowEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioSelectNowEventLoop.java
@@ -225,16 +225,18 @@ public final class NioSelectNowEventLoop extends SingleThreadEventLoop implement
      * @return
      */
     private static int backoff(final int backoffCounter) {
-    	if(backoffCounter > 1000) {
-    		LockSupport.parkNanos(1);
-    	} 
+    	
+    	if (backoffCounter > 3000) {
+    		LockSupport.parkNanos(5000);
+    	}
     	else if(backoffCounter > 2000) {
     		Thread.yield();
     	}
-    	else if(backoffCounter > 3000) {
-    		LockSupport.parkNanos(5000);
-    	}
-		return backoffCounter + 1;
+    	else if(backoffCounter > 1000) {
+    		LockSupport.parkNanos(1);
+    	} 
+    	
+    	return backoffCounter + 1;
 	}
 
 	private void processSelectedKeys() {


### PR DESCRIPTION
- new sample to run it: EchoSelectNowServer.
- added interface for both new loop and old loop to implement so you can
switch between them.

This is a sucky PR, more of a proof of concept really. If you want the build to pass you'll need to disable checkstyle in the parent pom.
I have verified the code works and compared performance on relevant hardware for the EchoServer sample. I used the https://github.com/nitsanw/java-ping spinning client to measure the performance before and after and from what I can see the results are as follows(figures in ns):
                 Min,     50%,       90%,      99%,   99.9%,  99.99%
NettyS     7464,   11215,   11557,   12949,   14319,    17278
NettySN  7456,    7968,     8199,     9877,    10971,    14326
JavaPS   6812,    9671,   10218,   11441,    12496,    16286
JavaPSN 6401,   6837,     6946,     8507,     10081,    12955

Where NettyS is current implementation, NettySN is using the selectNow event loop running the EchoServer. JavaPS is the java-ping project TCP select server, and JavaPSN is the selectNow server.
The difference is a consistent 3us between select/selectNow on the median and above.
This does not account for coordinated ommision and does not target an environment where selector interaction is in a different pattern. In particular the spin/backoff strategy could prove less responsive if the backoff cold state took longer than the select() blocking wakeup under similar conditions.
Also note this approach is far more CPU intensive and routine wakeups are harmful when there are more threads than core etc... YMMV ;-) 