### PR TITLE
Refactor HttpObjectDecoder and it's subclasses to create less GC

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpDecoderUtil.java
@@ -1,0 +1,65 @@
+/*
+* Copyright 2014 The Netty Project
+*
+* The Netty Project licenses this file to you under the Apache License,
+* version 2.0 (the "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at:
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+package io.netty.handler.codec.http;
+
+final class HttpDecoderUtil {
+    private static final String EMPTY = "";
+
+    static int startIndex(char[] chars, int startIndex, int endIndex) {
+        for (int i = startIndex; i < endIndex; i++) {
+            if (chars[i] <=  ' ') {
+                startIndex++;
+            } else {
+                break;
+            }
+        }
+        return startIndex;
+    }
+
+    static int endIndex(char[] chars, int startIndex, int endIndex) {
+        for (int i = endIndex - 1; i > startIndex; i--) {
+            if (chars[i] <= ' ') {
+                endIndex--;
+            } else {
+                break;
+            }
+        }
+        return endIndex;
+    }
+
+    static String newString(char[] chars, int startIndex, int endIndex) {
+        int size = endIndex - startIndex;
+        if (size == 0) {
+            return EMPTY;
+        }
+        return new String(chars, startIndex, size);
+    }
+
+    static int parseInt(char[] chars, int startIndex, int endIndex) {
+        int result = 0;
+        for (int i = startIndex; i < endIndex; i++) {
+            int digit = chars[i] - '0';
+            if ((digit < 0) || (digit > 9)) {
+                throw new NumberFormatException();
+            }
+            result *= 10;
+            result += digit;
+        }
+        return result;
+    }
+
+    private HttpDecoderUtil() { }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestDecoder.java
@@ -76,10 +76,12 @@ public class HttpRequestDecoder extends HttpObjectDecoder {
     }
 
     @Override
-    protected HttpMessage createMessage(String[] initialLine) throws Exception {
+    protected HttpMessage createMessage(
+            char[] initialLine, int aStart, int aEnd, int bStart, int bEnd, int cStart, int cEnd) throws Exception {
         return new DefaultHttpRequest(
-                HttpVersion.valueOf(initialLine[2]),
-                HttpMethod.valueOf(initialLine[0]), initialLine[1], validateHeaders);
+                HttpVersion.valueOf(initialLine, cStart, cEnd),
+                HttpMethod.valueOf(initialLine, aStart, aEnd), HttpDecoderUtil.newString(initialLine, bStart, bEnd),
+                validateHeaders);
     }
 
     @Override
@@ -91,4 +93,5 @@ public class HttpRequestDecoder extends HttpObjectDecoder {
     protected boolean isDecodingRequest() {
         return true;
     }
+
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
@@ -107,10 +107,13 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
     }
 
     @Override
-    protected HttpMessage createMessage(String[] initialLine) {
+    protected HttpMessage createMessage(
+            char[] initialLine, int aStart, int aEnd, int bStart, int bEnd, int cStart, int cEnd) {
+
         return new DefaultHttpResponse(
-                HttpVersion.valueOf(initialLine[0]),
-                new HttpResponseStatus(Integer.valueOf(initialLine[1]), initialLine[2]), validateHeaders);
+                HttpVersion.valueOf(initialLine, aStart, aEnd),
+                HttpResponseStatus.valueOf(HttpDecoderUtil.parseInt(initialLine, bStart, bEnd),
+                        initialLine, cStart, cEnd), validateHeaders);
     }
 
     @Override
@@ -122,4 +125,5 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
     protected boolean isDecodingRequest() {
         return false;
     }
+
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
@@ -453,15 +453,39 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
         return new HttpResponseStatus(code, reasonPhrase + " (" + code + ')');
     }
 
-    /**
-     * Parses the specified HTTP status line into a {@link HttpResponseStatus}.  The expected formats of the line are:
-     * <ul>
-     * <li>{@code statusCode} (e.g. 200)</li>
-     * <li>{@code statusCode} {@code reasonPhrase} (e.g. 404 Not Found)</li>
-     * </ul>
-     *
-     * @throws IllegalArgumentException if the specified status line is malformed
-     */
+    static HttpResponseStatus valueOf(int code, char[] chars, int startIndex, int endIndex) {
+        int size = endIndex - startIndex;
+        // We will try to servie 200 and 400 return codes via fast-path as these are the most common.
+        switch (code) {
+            // Fast-path for 200 OK
+            case 200:
+                if (size == 2 && chars[startIndex] == 'O' && chars[startIndex + 1] == 'K') {
+                    return OK;
+                }
+                break;
+            // Fast-path for 404 Not Found
+            case 404:
+                if (size == 8 && chars[startIndex] == 'N' && chars[startIndex + 1] == 'o'
+                        && chars[startIndex + 2] == 't' && chars[startIndex + 3] == ' '
+                        && chars[startIndex + 4] == 'F' && chars[startIndex + 5] == 'o'
+                        && chars[startIndex + 5] == 'u' && chars[startIndex + 6] == 'n'
+                        && chars[startIndex + 7] == 'd') {
+                    return NOT_FOUND;
+                }
+                break;
+        }
+        return new HttpResponseStatus(code, new String(chars, startIndex, endIndex - startIndex));
+    }
+
+     /**
+      * Parses the specified HTTP status line into a {@link HttpResponseStatus}.  The expected formats of the line are:
+      * <ul>
+      * <li>{@code statusCode} (e.g. 200)</li>
+      * <li>{@code statusCode} {@code reasonPhrase} (e.g. 404 Not Found)</li>
+      * </ul>
+      *
+      * @throws IllegalArgumentException if the specified status line is malformed
+      */
     public static HttpResponseStatus parseLine(CharSequence line) {
         String status = line.toString();
         try {

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspRequestDecoder.java
@@ -71,9 +71,11 @@ public class RtspRequestDecoder extends RtspObjectDecoder {
     }
 
     @Override
-    protected HttpMessage createMessage(String[] initialLine) throws Exception {
-        return new DefaultHttpRequest(RtspVersions.valueOf(initialLine[2]),
-                RtspMethods.valueOf(initialLine[0]), initialLine[1], validateHeaders);
+    protected HttpMessage createMessage(
+            char[] initialLine, int aStart, int aEnd, int bStart, int bEnd, int cStart, int cEnd) throws Exception {
+        return new DefaultHttpRequest(RtspVersions.valueOf(new String(initialLine, cStart, cEnd - cStart)),
+                RtspMethods.valueOf(new String(initialLine, aStart, aEnd - aStart)),
+                new String(initialLine, bStart, bEnd - bStart), validateHeaders);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspResponseDecoder.java
@@ -75,10 +75,12 @@ public class RtspResponseDecoder extends RtspObjectDecoder {
     }
 
     @Override
-    protected HttpMessage createMessage(String[] initialLine) throws Exception {
+    protected HttpMessage createMessage(
+            char[] initialLine, int aStart, int aEnd, int bStart, int bEnd, int cStart, int cEnd) throws Exception {
         return new DefaultHttpResponse(
-                RtspVersions.valueOf(initialLine[0]),
-                new HttpResponseStatus(Integer.valueOf(initialLine[1]), initialLine[2]), validateHeaders);
+                RtspVersions.valueOf(new String(initialLine, aStart, aEnd - aStart)),
+                new HttpResponseStatus(Integer.valueOf(new String(initialLine, bStart, bEnd - bStart)),
+                        new String(initialLine, cStart, cEnd - cStart)), validateHeaders);
     }
 
     @Override

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpMethodTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpMethodTest.java
@@ -1,0 +1,41 @@
+/*
+* Copyright 2014 The Netty Project
+*
+* The Netty Project licenses this file to you under the Apache License,
+* version 2.0 (the "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at:
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+package io.netty.handler.codec.http;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HttpMethodTest {
+
+    @Test
+    public void testWithoutWhitespace() {
+        char[] chars = "GET".toCharArray();
+        Assert.assertSame(HttpMethod.GET, HttpMethod.valueOf(chars, 0, chars.length));
+    }
+
+    @Test
+    public void testWithWhitespace() {
+        char[] chars = "  GET    ".toCharArray();
+        Assert.assertSame(HttpMethod.GET, HttpMethod.valueOf(chars, 1, chars.length - 1));
+    }
+
+    @Test
+    public void testUnknown() {
+        char[] chars = "  TEST    ".toCharArray();
+        HttpMethod method = HttpMethod.valueOf(chars, 0, chars.length);
+        Assert.assertEquals("TEST", method.name());
+    }
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpVersionTest.java
@@ -1,0 +1,34 @@
+/*
+* Copyright 2014 The Netty Project
+*
+* The Netty Project licenses this file to you under the Apache License,
+* version 2.0 (the "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at:
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+package io.netty.handler.codec.http;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HttpVersionTest {
+
+    @Test
+    public void testWithoutWhiteSpaces() {
+        char[] chars = "HTTP/1.1".toCharArray();
+        Assert.assertSame(HttpVersion.HTTP_1_1, HttpVersion.valueOf(chars, 0, chars.length));
+    }
+
+    @Test
+    public void testWithWhiteSpaces() {
+        char[] chars = "  HTTP/1.1   ".toCharArray();
+        Assert.assertSame(HttpVersion.HTTP_1_1, HttpVersion.valueOf(chars, 1, chars.length - 1));
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/AppendableCharSequence.java
+++ b/common/src/main/java/io/netty/util/internal/AppendableCharSequence.java
@@ -121,6 +121,10 @@ public final class AppendableCharSequence implements CharSequence, Appendable {
         return new String(chars, start, length);
     }
 
+    public char[] chars() {
+        return chars;
+    }
+
     private static char[] expand(char[] array, int neededSpace, int size) {
         int newCapacity = array.length;
         do {


### PR DESCRIPTION
Motivation:

HttpObjectDecoder and its subclasses did generate not needed garbage by using temporary Strings.

Modification:

- Refactor HttpObjectDecoder and its subclasses to directly act on char[] to remove the temporary String creation
- Also added fast-path for often use HttpResponseStatus

Result:

Less GC pressure