### PR TITLE
CompositeByteBuf.deallocate memory improvement

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -1599,8 +1599,11 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf {
         }
 
         freed = true;
-        for (Component c: components) {
-            c.freeIfNecessary();
+        int size = components.size();
+        // We're not using foreach to avoid creating an iterator.
+        // see https://github.com/netty/netty/issues/2642
+        for (int i = 0; i < size; i++) {
+            components.get(i).freeIfNecessary();
         }
 
         if (leak != null) {


### PR DESCRIPTION
Motivation:

CompositeByteBuf.deallocate generates unnecessary GC pressure when using the 'foreach' loop, as a 'foreach' loop creates an iterator when looping. More info #2642

Modification:

Convert 'foreach' loop into regular 'for' loop.

Result:

Less GC pressure (and possibly more throughput) as the 'for' loop does not create an iterator
