### PR TITLE
Buffered encoder 4.0

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
@@ -98,12 +98,12 @@ public final class HttpClientCodec
 
         @Override
         protected void encode(
-                ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
+                ChannelHandlerContext ctx, Object msg, ByteBuf buf) throws Exception {
             if (msg instanceof HttpRequest && !done) {
                 queue.offer(((HttpRequest) msg).getMethod());
             }
 
-            super.encode(ctx, msg, out);
+            super.encode(ctx, msg, buf);
 
             if (failOnMissingResponse) {
                 // check if the request is chunked if so do not increment

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpRequestEncoder.java
@@ -29,6 +29,12 @@ public class HttpRequestEncoder extends HttpObjectEncoder<HttpRequest> {
     private static final char QUESTION_MARK = '?';
     private static final byte[] CRLF = { CR, LF };
 
+    public HttpRequestEncoder() { }
+
+    public HttpRequestEncoder(int initialBufferCapacity, int flushThreshold) {
+        super(initialBufferCapacity, flushThreshold);
+    }
+
     @Override
     public boolean acceptOutboundMessage(Object msg) throws Exception {
         return super.acceptOutboundMessage(msg) && !(msg instanceof HttpResponse);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseEncoder.java
@@ -26,6 +26,12 @@ import static io.netty.handler.codec.http.HttpConstants.*;
 public class HttpResponseEncoder extends HttpObjectEncoder<HttpResponse> {
     private static final byte[] CRLF = { CR, LF };
 
+    public HttpResponseEncoder() { }
+
+    public HttpResponseEncoder(int initialBufferCapacity, int flushThreshold) {
+        super(initialBufferCapacity, flushThreshold);
+    }
+
     @Override
     public boolean acceptOutboundMessage(Object msg) throws Exception {
         return super.acceptOutboundMessage(msg) && !(msg instanceof HttpRequest);

--- a/codec/src/main/java/io/netty/handler/codec/MessageToByteEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageToByteEncoder.java
@@ -17,12 +17,16 @@ package io.netty.handler.codec;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFlushPromiseNotifier;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.TypeParameterMatcher;
 
 
@@ -42,11 +46,22 @@ import io.netty.util.internal.TypeParameterMatcher;
  *         }
  *     }
  * </pre>
+ *
+ * By default each encoded message is written directly after {@link #encode(ChannelHandlerContext, Object, ByteBuf)}
+ * returns. You can change this by specify a {@code flushTreshold} via the {@link #MessageToByteEncoder(boolean, int)}
+ * or {@link #MessageToByteEncoder(Class, boolean, int)} constructor to only write once the treshold was reached.
+ * Be aware that if you use a {@code flushTreshold} &gt 0 it is <strong>not possible</strong> marking your sub-class as
+ * {@link Sharable}.
  */
 public abstract class MessageToByteEncoder<I> extends ChannelOutboundHandlerAdapter {
 
     private final TypeParameterMatcher matcher;
     private final boolean preferDirect;
+    private final int flushTreshold;
+
+    // Will be used if flushTreshold > 0
+    private final ChannelFlushPromiseNotifier notifier;
+    private ByteBuf buffer;
 
     /**
      * @see {@link #MessageToByteEncoder(boolean)} with {@code true} as boolean parameter.
@@ -70,21 +85,66 @@ public abstract class MessageToByteEncoder<I> extends ChannelOutboundHandlerAdap
      *                              {@link ByteBuf}, which is backed by an byte array.
      */
     protected MessageToByteEncoder(boolean preferDirect) {
+        this(preferDirect, 0);
+    }
+
+    /**
+     * Create a new instance which will try to detect the types to match out of the type parameter of the class.
+     *
+     * @param preferDirect          {@code true} if a direct {@link ByteBuf} should be tried to be used as target for
+     *                              the encoded messages. If {@code false} is used it will allocate a heap
+     *                              {@link ByteBuf}, which is backed by an byte array.
+     * @param flushTreshold         the maximum size of the buffer before it is written or {@code 0} if it should be
+     *                              written after each {@link #encode(ChannelHandlerContext, Object, ByteBuf)} call
+     */
+    protected MessageToByteEncoder(boolean preferDirect, int flushTreshold) {
+        notifier = verifyAndInit(flushTreshold);
         matcher = TypeParameterMatcher.find(this, MessageToByteEncoder.class, "I");
         this.preferDirect = preferDirect;
+        this.flushTreshold = flushTreshold;
     }
 
     /**
      * Create a new instance
      *
-     * @param outboundMessageType   The tpye of messages to match
+     * @param outboundMessageType   the type of messages to match
      * @param preferDirect          {@code true} if a direct {@link ByteBuf} should be tried to be used as target for
      *                              the encoded messages. If {@code false} is used it will allocate a heap
      *                              {@link ByteBuf}, which is backed by an byte array.
      */
     protected MessageToByteEncoder(Class<? extends I> outboundMessageType, boolean preferDirect) {
+       this(outboundMessageType, preferDirect, 0);
+    }
+
+    /**
+     * Create a new instance
+     *
+     * @param outboundMessageType   the type of messages to match
+     * @param preferDirect          {@code true} if a direct {@link ByteBuf} should be tried to be used as target for
+     *                              the encoded messages. If {@code false} is used it will allocate a heap
+     *                              {@link ByteBuf}, which is backed by an byte array.
+     @param flushTreshold           the maximum size of the buffer before it is written or {@code 0} if it should be
+                                    written after each {@link #encode(ChannelHandlerContext, Object, ByteBuf)} call
+     */
+    protected MessageToByteEncoder(Class<? extends I> outboundMessageType, boolean preferDirect, int flushTreshold) {
+        notifier = verifyAndInit(flushTreshold);
         matcher = TypeParameterMatcher.get(outboundMessageType);
         this.preferDirect = preferDirect;
+        this.flushTreshold = flushTreshold;
+    }
+
+    private ChannelFlushPromiseNotifier verifyAndInit(int flushTreshold) {
+        if (flushTreshold == 0) {
+            return null;
+        }
+        if (flushTreshold > 0) {
+            CodecUtil.ensureNotSharable(this);
+            return new ChannelFlushPromiseNotifier(true);
+        }
+        if (flushTreshold < 0) {
+            throw new IllegalArgumentException("flushTreshold: " + flushTreshold + " (expected: >= 0)");
+        }
+        return null;
     }
 
     /**
@@ -97,37 +157,171 @@ public abstract class MessageToByteEncoder<I> extends ChannelOutboundHandlerAdap
 
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-        ByteBuf buf = null;
         try {
             if (acceptOutboundMessage(msg)) {
+                ByteBuf out = buffer;
+                int writerIndex = 0;
                 @SuppressWarnings("unchecked")
                 I cast = (I) msg;
-                buf = allocateBuffer(ctx, cast, preferDirect);
                 try {
-                    encode(ctx, cast, buf);
+                    if (out == null) {
+                        // Allocate new buffer
+                        out = allocateBuffer(ctx, cast, preferDirect);
+                    }
+                    writerIndex = out.writerIndex();
+                    encode(ctx, cast, out);
+
+                    int readable = out.readableBytes();
+                    if (flushTreshold > 0) {
+                        int wIndex = out.writerIndex();
+                        if (wIndex < writerIndex) {
+                            throw new EncoderException(
+                                    StringUtil.simpleClassName(getClass()) +
+                                            ".encode() did decrease writerIndex of out while flushTreshold > 0");
+                        }
+                        if (flushTreshold < out.readableBytes()) {
+                            if (buffer == null) {
+                                // we have nothing buffered so we can just directly write it.
+                                ctx.write(out, promise);
+                            } else {
+                                // null out buffer
+                                buffer = null;
+
+                                // flush all bytes now
+                                writeBufferedBytes0(ctx, out, promise);
+                            }
+                        } else {
+                            buffer = out;
+
+                            long delta = wIndex - writerIndex;
+                            ctx.channel().unsafe().outboundBuffer().incrementPendingOutboundBytes(delta);
+                            // add to notifier so the promise will be notified later once we wrote everything
+                            notifier.add(promise, delta);
+                        }
+                    } else {
+                        assert buffer == null;
+                        if (readable > 0) {
+                            ctx.write(out, promise);
+                        } else {
+                            out.release();
+                            out = null;
+                            ctx.write(Unpooled.EMPTY_BUFFER, promise);
+                        }
+                    }
+                    // Set to null to prevent release of it.
+                    out = null;
+                } catch (Throwable cause) {
+                    resetWriterIndexAndRethrow(cause, writerIndex);
                 } finally {
                     ReferenceCountUtil.release(cast);
+                    if (out != null) {
+                        out.release();
+                    }
                 }
-
-                if (buf.isReadable()) {
-                    ctx.write(buf, promise);
-                } else {
-                    buf.release();
-                    ctx.write(Unpooled.EMPTY_BUFFER, promise);
-                }
-                buf = null;
             } else {
+                if (flushTreshold > 0) {
+                    writeBufferedBytes(ctx);
+                }
                 ctx.write(msg, promise);
             }
         } catch (EncoderException e) {
             throw e;
-        } catch (Throwable e) {
-            throw new EncoderException(e);
-        } finally {
-            if (buf != null) {
-                buf.release();
-            }
+        } catch (Throwable t) {
+            throw new EncoderException(t);
         }
+    }
+
+    private void resetWriterIndexAndRethrow(Throwable e, int writerIndex) {
+        ByteBuf buffer = this.buffer;
+        if (buffer != null) {
+            buffer.writerIndex(writerIndex);
+        }
+        if (e instanceof EncoderException) {
+            throw (EncoderException) e;
+        }
+        throw new EncoderException(e);
+    }
+
+    @Override
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        if (flushTreshold > 0) {
+            writeBufferedBytes(ctx);
+        }
+        super.close(ctx, promise);
+    }
+
+    @Override
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        if (flushTreshold > 0) {
+            writeBufferedBytes(ctx);
+        }
+        super.disconnect(ctx, promise);
+    }
+
+    @Override
+    public void flush(ChannelHandlerContext ctx) throws Exception {
+        if (flushTreshold > 0) {
+            writeBufferedBytes(ctx);
+        }
+        super.flush(ctx);
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        if (flushTreshold > 0) {
+            writeBufferedBytes(ctx);
+        }
+        super.handlerRemoved(ctx);
+    }
+
+    /**
+     * Manually flush the buffered data.
+     */
+    protected final ChannelFuture writeBufferedBytes(ChannelHandlerContext ctx) throws Exception {
+        ByteBuf buffer = this.buffer;
+        if (buffer == null) {
+            // Nothing buffered yet so just return here.
+            return ctx.newSucceededFuture();
+        }
+        this.buffer = null;
+        return writeBufferedBytes0(ctx, buffer, ctx.newPromise());
+    }
+
+    private ChannelFuture writeBufferedBytes0(ChannelHandlerContext ctx, ByteBuf buffer, ChannelPromise promise)
+            throws Exception {
+        assert notifier != null;
+
+        final int size = buffer.readableBytes();
+        // Decrement now as we will now trigger the actual write
+        ctx.channel().unsafe().outboundBuffer().decrementPendingOutboundBytes(size);
+
+        ChannelFuture future = ctx.write(buffer, promise).addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) throws Exception {
+                notifier.increaseWriteCounter(size);
+                if (future.isSuccess()) {
+                    notifier.notifyPromises();
+                } else {
+                    notifier.notifyPromises(future.cause());
+                }
+            }
+        });
+        bufferedBytesWritten(ctx, size);
+        return future;
+    }
+
+    /**
+     * Callback which is executed once {@link #writeBufferedBytes(ChannelHandlerContext)} was executed and something
+     * was written through the {@link ChannelPipeline}.
+     *
+     * Do nothing by default, sub-classes may override this method.
+     *
+     * @param ctx       the {@link ChannelHandlerContext} to use
+     * @param amount    the number of bytes that were written
+     */
+    protected void bufferedBytesWritten(@SuppressWarnings("unused") ChannelHandlerContext ctx,
+                                        @SuppressWarnings("unused") int amount) {
+        // NOOP
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -155,7 +155,7 @@ public final class ChannelOutboundBuffer {
      * Increment the pending bytes which will be written at some point.
      * This method is thread-safe!
      */
-    void incrementPendingOutboundBytes(long size) {
+    public void incrementPendingOutboundBytes(long size) {
         if (size == 0) {
             return;
         }
@@ -172,7 +172,7 @@ public final class ChannelOutboundBuffer {
      * Decrement the pending bytes which will be written at some point.
      * This method is thread-safe!
      */
-    void decrementPendingOutboundBytes(long size) {
+    public void decrementPendingOutboundBytes(long size) {
         if (size == 0) {
             return;
         }


### PR DESCRIPTION
Introduce a new abstract codec called MessageToBufferedByteEncoder which allows to buffer written data into one buffer.

Using the sub-class in protocols that allows for pipelining or for cases where the messages are made out of multiple parts can improve performance a lot. To show this HTTP was moved over to use the MessageToBufferedByteEncoder which shows a large performance improvement