### PR TITLE
Fixed NPE in WebSocketFrameDecoder if end couldn't be found in buffer

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket00FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket00FrameDecoder.java
@@ -60,12 +60,17 @@ public class WebSocket00FrameDecoder extends ReplayingDecoder<Void> implements W
 
         // Decode a frame otherwise.
         byte type = in.readByte();
+        WebSocketFrame frame;
         if ((type & 0x80) == 0x80) {
             // If the MSB on type is set, decode the frame length
-            out.add(decodeBinaryFrame(ctx, type, in));
+            frame = decodeBinaryFrame(ctx, type, in);
         } else {
             // Decode a 0xff terminated UTF-8 string
-            out.add(decodeTextFrame(ctx, in));
+            frame = decodeTextFrame(ctx, in);
+        }
+
+        if (frame != null) {
+            out.add(frame);
         }
     }
 


### PR DESCRIPTION
I got this exception very often since i upgraded to netty 4.0.21 and used the new openssl implementation (before i have used 4.0.19 and my own openssl implementation).

```
 io.netty.handler.codec.DecoderException: java.lang.NullPointerException: element
       at io.netty.handler.codec.ReplayingDecoder.callDecode(ReplayingDecoder.java:418)
       at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:149)
       at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:333)
       at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:319)
       at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:990)
       at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:873)
       at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:241)
       at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:149)
       at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:333)
       at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:319)
       at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:787)
       at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:125)
       at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:511)
       at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:468)
       at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:382)
       at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:354)
       at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:116)
       at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:137)
       at java.lang.Thread.run(Thread.java:744)
 Caused by: java.lang.NullPointerException: element
       at io.netty.util.internal.RecyclableArrayList.add(RecyclableArrayList.java:104)
       at io.netty.handler.codec.http.websocketx.WebSocket00FrameDecoder.decode(WebSocket00FrameDecoder.java:68)
       at io.netty.handler.codec.ReplayingDecoder.callDecode(ReplayingDecoder.java:363)
       ... 18 more
```
