### PR TITLE
Fixes for compression codecs

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2HuffmanAllocator.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2HuffmanAllocator.java
@@ -42,7 +42,7 @@ final class Bzip2HuffmanAllocator {
         i = Math.max(nodesToMove - 1, i);
 
         while (k > i + 1) {
-            int temp = i + k >> 1;
+            int temp = i + k >>> 1;
             if (array[temp] % length > limit) {
                 k = temp;
             } else {

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
@@ -31,7 +31,7 @@ public class JZlibDecoder extends ZlibDecoder {
     /**
      * Creates a new instance with the default wrapper ({@link ZlibWrapper#ZLIB}).
      *
-     * @throws CompressionException if failed to initialize zlib
+     * @throws DecompressionException if failed to initialize zlib
      */
     public JZlibDecoder() {
         this(ZlibWrapper.ZLIB);
@@ -40,7 +40,7 @@ public class JZlibDecoder extends ZlibDecoder {
     /**
      * Creates a new instance with the specified wrapper.
      *
-     * @throws CompressionException if failed to initialize zlib
+     * @throws DecompressionException if failed to initialize zlib
      */
     public JZlibDecoder(ZlibWrapper wrapper) {
         if (wrapper == null) {
@@ -58,7 +58,7 @@ public class JZlibDecoder extends ZlibDecoder {
      * is always {@link ZlibWrapper#ZLIB} because it is the only format that
      * supports the preset dictionary.
      *
-     * @throws CompressionException if failed to initialize zlib
+     * @throws DecompressionException if failed to initialize zlib
      */
     public JZlibDecoder(byte[] dictionary) {
         if (dictionary == null) {

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
@@ -29,7 +29,6 @@ import io.netty.util.internal.EmptyArrays;
 
 import java.util.concurrent.TimeUnit;
 
-
 /**
  * Compresses a {@link ByteBuf} using the deflate algorithm.
  */

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
@@ -24,7 +24,6 @@ import java.util.zip.DataFormatException;
 import java.util.zip.Deflater;
 import java.util.zip.Inflater;
 
-
 /**
  * Decompress a {@link ByteBuf} using the inflate algorithm.
  */
@@ -249,14 +248,14 @@ public class JdkZlibDecoder extends ZlibDecoder {
                 int magic1 = in.readByte();
 
                 if (magic0 != 31) {
-                    throw new CompressionException("Input is not in the GZIP format");
+                    throw new DecompressionException("Input is not in the GZIP format");
                 }
                 crc.update(magic0);
                 crc.update(magic1);
 
                 int method = in.readUnsignedByte();
                 if (method != Deflater.DEFLATED) {
-                    throw new CompressionException("Unsupported compression method "
+                    throw new DecompressionException("Unsupported compression method "
                             + method + " in the GZIP header");
                 }
                 crc.update(method);
@@ -265,7 +264,7 @@ public class JdkZlibDecoder extends ZlibDecoder {
                 crc.update(flags);
 
                 if ((flags & FRESERVED) != 0) {
-                    throw new CompressionException(
+                    throw new DecompressionException(
                             "Reserved flags are set in the GZIP header");
                 }
 
@@ -360,7 +359,7 @@ public class JdkZlibDecoder extends ZlibDecoder {
         }
         int readLength = inflater.getTotalOut();
         if (dataLength != readLength) {
-            throw new CompressionException(
+            throw new DecompressionException(
                     "Number of bytes mismatch. Expected: " + dataLength + ", Got: " + readLength);
         }
         return true;
@@ -373,7 +372,7 @@ public class JdkZlibDecoder extends ZlibDecoder {
         }
         long readCrc = crc.getValue();
         if (crcValue != readCrc) {
-            throw new CompressionException(
+            throw new DecompressionException(
                     "CRC value missmatch. Expected: " + crcValue + ", Got: " + readCrc);
         }
     }

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.zip.CRC32;
 import java.util.zip.Deflater;
 
-
 /**
  * Compresses a {@link ByteBuf} using the deflate algorithm.
  */

--- a/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
@@ -24,7 +24,7 @@ import io.netty.buffer.ByteBufUtil;
  *
  * See http://code.google.com/p/snappy/source/browse/trunk/format_description.txt
  */
-public class Snappy {
+class Snappy {
 
     private static final int MAX_HT_SIZE = 1 << 14;
     private static final int MIN_COMPRESSIBLE_BYTES = 15;

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibUtil.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibUtil.java
@@ -32,8 +32,8 @@ final class ZlibUtil {
         throw deflaterException(z, message, resultCode);
     }
 
-    static CompressionException inflaterException(Inflater z, String message, int resultCode) {
-        return new CompressionException(message + " (" + resultCode + ')' + (z.msg != null? ": " + z.msg : ""));
+    static DecompressionException inflaterException(Inflater z, String message, int resultCode) {
+        return new DecompressionException(message + " (" + resultCode + ')' + (z.msg != null? ": " + z.msg : ""));
     }
 
     static CompressionException deflaterException(Deflater z, String message, int resultCode) {


### PR DESCRIPTION
Motivation:

Fixed founded mistakes in compression codecs.

Modifications:
- Changed return type of `ZlibUtil.inflaterException()` from `CompressionException` to `DecompressionException`
- Updated throws tags in javadoc of `JZlibDecoder` to throw `DecompressionException` instead of `CompressionException`
- Fixed `JdkZlibDecoder` to throw `DecompressionException` instead of `CompressionException`
- Removed unnecessary empty lines in `JdkZlibEncoder` and `JZlibEncoder`
- Removed public modifier from `Snappy` class
- Added `MAX_UNCOMPRESSED_DATA_SIZE` constant in `SnappyFramedDecoder`
- Used `in.readableBytes()` instead of `in.writerIndex() - in.readerIndex()` in `SnappyFramedDecoder`
- Added private modifier for `enum ChunkType` in `SnappyFramedDecoder`
- Fixed potential bug (computation of average could overflow) in `Bzip2HuffmanAllocator.first(...)`.
  The code computes the average of two integers using either division or signed right shift, and then uses the result as the index of an array. If the values being averaged are very large, this can overflow (resulting in the computation of a negative average). For more info, see http://googleresearch.blogspot.ru/2006/06/extra-extra-read-all-about-it-nearly.html

Result:

Fixed sum overflow in `Bzip2HuffmanAllocator`, improved exceptions in `ZlibDecoder` implementations, hid `Snappy` class
