### PR TITLE
Small performance improvements

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -1319,7 +1319,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf {
         return result + ", components=" + components.size() + ')';
     }
 
-    private final class Component {
+    private static final class Component {
         final ByteBuf buf;
         final int length;
         int offset;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseDecoder.java
@@ -110,7 +110,7 @@ public class HttpResponseDecoder extends HttpObjectDecoder {
     protected HttpMessage createMessage(String[] initialLine) {
         return new DefaultHttpResponse(
                 HttpVersion.valueOf(initialLine[0]),
-                new HttpResponseStatus(Integer.valueOf(initialLine[1]), initialLine[2]), validateHeaders);
+                new HttpResponseStatus(Integer.parseInt(initialLine[1]), initialLine[2]), validateHeaders);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskAttribute.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/DiskAttribute.java
@@ -83,13 +83,14 @@ public class DiskAttribute extends AbstractDiskHttpData implements Attribute {
 
     @Override
     public void addContent(ByteBuf buffer, boolean last) throws IOException {
-        int localsize = buffer.readableBytes();
-        checkSize(size + localsize);
-        if (definedSize > 0 && definedSize < size + localsize) {
-            definedSize = size + localsize;
+        final long newDefinedSize = size + buffer.readableBytes();
+        checkSize(newDefinedSize);
+        if (definedSize > 0 && definedSize < newDefinedSize) {
+            definedSize = newDefinedSize;
         }
         super.addContent(buffer, last);
     }
+
     @Override
     public int hashCode() {
         return getName().hashCode();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
@@ -120,7 +120,7 @@ public final class PerMessageDeflateClientExtensionHandshaker implements WebSock
             if (CLIENT_MAX_WINDOW.equalsIgnoreCase(parameter.getKey())) {
                 // allowed client_window_size_bits
                 if (allowClientWindowSize) {
-                    clientWindowSize = Integer.valueOf(parameter.getValue());
+                    clientWindowSize = Integer.parseInt(parameter.getValue());
                 } else {
                     succeed = false;
                 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
@@ -111,7 +111,7 @@ public final class PerMessageDeflateServerExtensionHandshaker implements WebSock
             } else if (SERVER_MAX_WINDOW.equalsIgnoreCase(parameter.getKey())) {
                 // use provided windowSize if it is allowed
                 if (allowServerWindowSize) {
-                    serverWindowSize = Integer.valueOf(parameter.getValue());
+                    serverWindowSize = Integer.parseInt(parameter.getValue());
                     if (serverWindowSize > MAX_WINDOW_SIZE || serverWindowSize < MIN_WINDOW_SIZE) {
                         deflateEnabled = false;
                     }

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspResponseDecoder.java
@@ -78,7 +78,7 @@ public class RtspResponseDecoder extends RtspObjectDecoder {
     protected HttpMessage createMessage(String[] initialLine) throws Exception {
         return new DefaultHttpResponse(
                 RtspVersions.valueOf(initialLine[0]),
-                new HttpResponseStatus(Integer.valueOf(initialLine[1]), initialLine[2]), validateHeaders);
+                new HttpResponseStatus(Integer.parseInt(initialLine[1]), initialLine[2]), validateHeaders);
     }
 
     @Override

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeAggregator.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeAggregator.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.stomp;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.AsciiString;
 import io.netty.handler.codec.MessageAggregator;
 import io.netty.handler.codec.TooLongFrameException;
 
@@ -70,12 +69,8 @@ public class StompSubframeAggregator
 
     @Override
     protected long contentLength(StompHeadersSubframe start) throws Exception {
-        CharSequence value = start.headers().get(StompHeaders.CONTENT_LENGTH);
-        if (value instanceof AsciiString) {
-            return ((AsciiString) value).parseLong();
-        }
-
-        return Long.parseLong(value.toString());
+        String value = start.headers().get(StompHeaders.CONTENT_LENGTH);
+        return Long.parseLong(value);
     }
 
     @Override

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.stomp;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.AsciiString;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.ReplayingDecoder;
@@ -220,14 +219,10 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
     }
 
     private static long getContentLength(StompHeaders headers, long defaultValue) {
-        CharSequence contentLength = headers.get(StompHeaders.CONTENT_LENGTH);
+        String contentLength = headers.get(StompHeaders.CONTENT_LENGTH);
         if (contentLength != null) {
             try {
-                if (contentLength instanceof AsciiString) {
-                    return ((AsciiString) contentLength).parseLong();
-                } else {
-                    return Long.parseLong(contentLength.toString());
-                }
+                return Long.parseLong(contentLength);
             } catch (NumberFormatException ignored) {
                 return defaultValue;
             }

--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -44,11 +44,7 @@ public final class NativeLibraryLoader {
         String workdir = SystemPropertyUtil.get("io.netty.native.workdir");
         if (workdir != null) {
             File f = new File(workdir);
-            if (!f.exists()) {
-                // ok to ignore as createTempFile will take care
-                //noinspection ResultOfMethodCallIgnored
-                f.mkdirs();
-            }
+            f.mkdirs();
 
             try {
                 f = f.getAbsoluteFile();
@@ -130,9 +126,7 @@ public final class NativeLibraryLoader {
         }
 
         File f = new File(path);
-        if (!f.exists()) {
-            f.mkdirs();
-        }
+        f.mkdirs();
 
         if (!f.isDirectory()) {
             return null;

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -759,9 +759,7 @@ public final class PlatformDependent {
         }
 
         File f = new File(path);
-        if (!f.exists()) {
-            f.mkdirs();
-        }
+        f.mkdirs();
 
         if (!f.isDirectory()) {
             return null;


### PR DESCRIPTION
Modifications:
- Added a static modifier for `CompositeByteBuf.Component`class.
  This class is an inner class, but does not use its embedded reference to the object which created it. This reference makes the instances of the class larger, and may keep the reference to the creator object alive longer than necessary.
- Removed unnecessary boxing/unboxing operations in `HttpResponseDecoder`, `RtspResponseDecoder`, `PerMessageDeflateClientExtensionHandshaker` and `PerMessageDeflateServerExtensionHandshaker`.
  A boxed primitive is created from a `String`, just to extract the unboxed primitive value.
- Removed unnecessary 3 times calculations in `DiskAttribute.addContent(...)`.
- Removed unnecessary checks if file exists before call `mkdirs()` in `NativeLibraryLoader` and `PlatformDependent`.
  Because the method `mkdirs()` has this check inside.
- Removed unnecessary `instanceof AsciiString` check in `StompSubframeAggregator.contentLength(StompHeadersSubframe)` and `StompSubframeDecoder.getContentLength(StompHeaders, long)`.
  Because `StompHeaders.get(CharSequence)` always returns `java.lang.String`.
