### PR TITLE
Close ObjectInputStream in ObjectDecoder.decode(...)

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/serialization/ObjectDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ObjectDecoder.java
@@ -20,6 +20,7 @@ import io.netty.buffer.ByteBufInputStream;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 
+import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.StreamCorruptedException;
 
@@ -70,8 +71,10 @@ public class ObjectDecoder extends LengthFieldBasedFrameDecoder {
             return null;
         }
 
-        return new CompactObjectInputStream(
-                new ByteBufInputStream(frame), classResolver).readObject();
+        ObjectInputStream is = new CompactObjectInputStream(new ByteBufInputStream(frame), classResolver);
+        Object result = is.readObject();
+        is.close();
+        return result;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

We create a new `CompactObjectInputStream` with `ByteBufInputStream` in `ObjectDecoder.decode(...)` method and don't close this InputStreams before return statement.

Modifications:

Save link to the ObjectInputStream and close it before return statement.

Result:

Close InputStreams and clean up unused resources. It will be better for GC.
