### PR TITLE
Small fixes and improvements

### DIFF
--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -186,7 +186,7 @@ public final class NetUtil {
             somaxconn = Integer.parseInt(in.readLine());
             logger.debug("/proc/sys/net/core/somaxconn: {}", somaxconn);
         } catch (Exception e) {
-            // Failed to get SOMAXCONN
+            logger.debug("Failed to get SOMAXCONN", e);
         } finally {
             if (in != null) {
                 try {

--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -236,7 +236,7 @@ public abstract class Recycler<T> {
             }
             to.size = size;
 
-            if (end == LINK_CAPACITY & head.next != null) {
+            if (end == LINK_CAPACITY && head.next != null) {
                 this.head = head.next;
             }
 

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -163,7 +163,7 @@ public class EmbeddedChannel extends AbstractChannel {
      *
      * @param msgs the messages to be written
      *
-     * @return {@code true} if the write operation did add something to the the inbound buffer
+     * @return {@code true} if the write operation did add something to the inbound buffer
      */
     public boolean writeInbound(Object... msgs) {
         ensureOpen();
@@ -185,7 +185,7 @@ public class EmbeddedChannel extends AbstractChannel {
      * Write messages to the outbound of this {@link Channel}.
      *
      * @param msgs              the messages to be written
-     * @return bufferReadable   returns {@code true} if the write operation did add something to the the outbound buffer
+     * @return bufferReadable   returns {@code true} if the write operation did add something to the outbound buffer
      */
     public boolean writeOutbound(Object... msgs) {
         ensureOpen();


### PR DESCRIPTION
Motivation:

Fix some typos in Netty.

Modifications:
- Fix potentially dangerous use of non-short-circuit logic in `Recycler.transfer(Stack<?>)`.
- Removed double 'the the' in javadoc of EmbeddedChannel.
- Write to log an exception message if we can not get SOMAXCONN in the NetUtil's static block.
