### PR TITLE
Allow to disable ensureAccess() on every method call for performance rea...

### DIFF
--- a/common/src/main/java/io/netty/util/ReferenceCountUtil.java
+++ b/common/src/main/java/io/netty/util/ReferenceCountUtil.java
@@ -94,6 +94,18 @@ public final class ReferenceCountUtil {
     }
 
     /**
+     * Will throw a {@link IllegalReferenceCountException} if the specified object is of type
+     * {@link ReferenceCounted} and {@link ReferenceCounted#refCnt()} is {@code 0}.
+     */
+    public static void ensureAccessible(Object msg) {
+        if (msg instanceof ReferenceCounted) {
+            if (((ReferenceCounted) msg).refCnt() == 0) {
+                throw new IllegalReferenceCountException(0);
+            }
+        }
+    }
+
+    /**
      * Releases the objects when the thread that called {@link #releaseLater(Object)} has been terminated.
      */
     private static final class ReleasingTask implements Runnable {

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -330,6 +330,9 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
 
     private void invokeChannelRead(Object msg) {
         try {
+            // Make sure the object was not released before
+            ReferenceCountUtil.ensureAccessible(msg);
+
             ((ChannelInboundHandler) handler()).channelRead(this, msg);
         } catch (Throwable t) {
             notifyHandlerException(t);
@@ -655,6 +658,9 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
 
     private void invokeWrite(Object msg, ChannelPromise promise) {
         try {
+            // Make sure the object was not released before
+            ReferenceCountUtil.ensureAccessible(msg);
+
             ((ChannelOutboundHandler) handler()).write(this, msg, promise);
         } catch (Throwable t) {
             notifyOutboundHandlerException(t, promise);


### PR DESCRIPTION
...sons.

Motiviation:

At the moment we use AbstractByteBuf.ensureAccess() on every operation which is quite heavy in terms of performance hit. Especially as it is "only" a safety check and nothing more. We should allow to limit the usage of it.

Modification:
- Add System property io.netty.buffer.ensureAccess which allows to disable it
- Check for ensureAccess() in DefaultChannelHandlerContext all the time to not completily disable safety.

Result:

Give a nice performance boost in benchmarks.
