### PR TITLE
Simplify Bzip2 tests

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
@@ -199,25 +199,23 @@ public class Bzip2DecoderTest {
     }
 
     private static void testDecompression(final byte[] data) throws Exception {
-        for (int blockSize = MIN_BLOCK_SIZE; blockSize <= MAX_BLOCK_SIZE; blockSize++) {
-            final EmbeddedChannel channel = new EmbeddedChannel(new Bzip2Decoder());
+        final EmbeddedChannel channel = new EmbeddedChannel(new Bzip2Decoder());
 
-            ByteArrayOutputStream os = new ByteArrayOutputStream();
-            BZip2CompressorOutputStream bZip2Os = new BZip2CompressorOutputStream(os, blockSize);
-            bZip2Os.write(data);
-            bZip2Os.close();
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        BZip2CompressorOutputStream bZip2Os = new BZip2CompressorOutputStream(os, randomBlockSize());
+        bZip2Os.write(data);
+        bZip2Os.close();
 
-            ByteBuf compressed = Unpooled.wrappedBuffer(os.toByteArray());
-            channel.writeInbound(compressed);
+        ByteBuf compressed = Unpooled.wrappedBuffer(os.toByteArray());
+        channel.writeInbound(compressed);
 
-            ByteBuf uncompressed = readUncompressed(channel);
-            ByteBuf dataBuf = Unpooled.wrappedBuffer(data);
+        ByteBuf uncompressed = readUncompressed(channel);
+        ByteBuf dataBuf = Unpooled.wrappedBuffer(data);
 
-            assertEquals(dataBuf, uncompressed);
+        assertEquals(dataBuf, uncompressed);
 
-            uncompressed.release();
-            dataBuf.release();
-        }
+        uncompressed.release();
+        dataBuf.release();
     }
 
     @Test
@@ -235,8 +233,7 @@ public class Bzip2DecoderTest {
         final byte[] data = BYTES_LARGE;
 
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        BZip2CompressorOutputStream bZip2Os = new BZip2CompressorOutputStream(os,
-                                                    rand.nextInt(MIN_BLOCK_SIZE, MAX_BLOCK_SIZE + 1));
+        BZip2CompressorOutputStream bZip2Os = new BZip2CompressorOutputStream(os, randomBlockSize());
         bZip2Os.write(data);
         bZip2Os.close();
 
@@ -269,5 +266,9 @@ public class Bzip2DecoderTest {
         }
 
         return uncompressed;
+    }
+
+    private static int randomBlockSize() {
+        return rand.nextInt(MIN_BLOCK_SIZE, MAX_BLOCK_SIZE + 1);
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/Bzip2EncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Bzip2EncoderTest.java
@@ -61,17 +61,15 @@ public class Bzip2EncoderTest {
     }
 
     private static void testCompression(final byte[] data) throws Exception {
-        for (int blockSize = MIN_BLOCK_SIZE; blockSize <= MAX_BLOCK_SIZE; blockSize++) {
-            final EmbeddedChannel channel = new EmbeddedChannel(new Bzip2Encoder(blockSize));
+        final EmbeddedChannel channel = new EmbeddedChannel(new Bzip2Encoder(randomBlockSize()));
 
-            ByteBuf in = Unpooled.wrappedBuffer(data);
-            channel.writeOutbound(in);
-            channel.finish();
+        ByteBuf in = Unpooled.wrappedBuffer(data);
+        channel.writeOutbound(in);
+        channel.finish();
 
-            byte[] uncompressed = uncompress(channel, data.length);
+        byte[] uncompressed = uncompress(channel, data.length);
 
-            assertArrayEquals(data, uncompressed);
-        }
+        assertArrayEquals(data, uncompressed);
     }
 
     @Test
@@ -86,8 +84,7 @@ public class Bzip2EncoderTest {
 
     @Test
     public void testCompressionOfBatchedFlowOfData() throws Exception {
-        final EmbeddedChannel channel = new EmbeddedChannel(new Bzip2Encoder(
-                                rand.nextInt(MIN_BLOCK_SIZE, MAX_BLOCK_SIZE + 1)));
+        final EmbeddedChannel channel = new EmbeddedChannel(new Bzip2Encoder(randomBlockSize()));
 
         int written = 0, length = rand.nextInt(100);
         while (written + length < BYTES_LARGE.length) {
@@ -133,5 +130,9 @@ public class Bzip2EncoderTest {
         assertEquals(-1, bZip2Is.read());
 
         return uncompressed;
+    }
+
+    private static int randomBlockSize() {
+        return rand.nextInt(MIN_BLOCK_SIZE, MAX_BLOCK_SIZE + 1);
     }
 }


### PR DESCRIPTION
Motivation:

Sometimes we have a 'build time out' error because tests for bzip2 codec take a long time.

Modifications:

Removed cycles from Bzip2EncoderTest.testCompression(byte[]) and Bzip2DecoderTest.testDecompression(byte[]).

Result:

Reduced time to test the 'codec' package by 30 percent.
