### PR TITLE
Fixing bug in HTTP/2 ping handling.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandler.java
@@ -968,7 +968,8 @@ public abstract class AbstractHttp2ConnectionHandler extends ByteToMessageDecode
             verifyPrefaceReceived();
 
             // Send an ack back to the remote client.
-            frameWriter.writePing(ctx, ctx.newPromise(), true, data);
+            // Need to retain the buffer here since it will be released after the write completes.
+            frameWriter.writePing(ctx, ctx.newPromise(), true, data.retain());
 
             AbstractHttp2ConnectionHandler.this.onPingRead(ctx, data);
         }


### PR DESCRIPTION
Motivation:

The current HTTP/2 ping handling replies with an ack using the same
buffer as the received ping. It doesn't call retain(), however, which
causes a ReferenceCountException since the buffer ends up getting
released twice (once by the write and once by the decoder).

Modifications:

Modified AbstractHttp2ConnectionHandler to retain() the buffer. Added a
ping to Http2ConnectionRoundtripTest.stressTest() to verify the problem
and that this fixes it.

Result:

Ping should no longer cause an exception.
