### PR TITLE
Stop reading the channel when bandwidth limit if reached

### DIFF
--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -194,6 +194,7 @@ public abstract class AbstractTrafficShapingHandler extends ChannelHandlerAdapte
 
         @Override
         public void run() {
+            ctx.channel().config().setAutoRead(true);
             ctx.attr(READ_SUSPENDED).set(false);
             ctx.read();
         }
@@ -234,6 +235,7 @@ public abstract class AbstractTrafficShapingHandler extends ChannelHandlerAdapte
                 // try to limit the traffic
                 if (!isSuspended(ctx)) {
                     ctx.attr(READ_SUSPENDED).set(true);
+                    ctx.channel().config().setAutoRead(false);
 
                     // Create a Runnable to reactive the read if needed. If one was create before it will just be
                     // reused to limit object creation
@@ -249,13 +251,6 @@ public abstract class AbstractTrafficShapingHandler extends ChannelHandlerAdapte
             }
         }
         ctx.fireChannelRead(msg);
-    }
-
-    @Override
-    public void read(ChannelHandlerContext ctx) {
-        if (!isSuspended(ctx)) {
-            ctx.read();
-        }
     }
 
     private static boolean isSuspended(ChannelHandlerContext ctx) {


### PR DESCRIPTION
@fredericBregier @normanmaurer 
previous discussion on this problem: https://github.com/netty/netty/pull/2494#issuecomment-49735979

when isSuspended return false, ctx.read will make the channel readable, and otherwise the channel is not readable, following this logic, there may be something wrong: 
1. ctx.read will call AbstractNioChannel#doBeginRead, and doBeginRead will add readInterestOps to the channel, and thus the channel is readable, but
2. if you don't call ctx.read when isSuspended return true, the readInterestOps is NOT removed from the channel, the channel is still readable;

we should call ctx.channel().config().setAutoRead(false) when isSuspended return true.
