### PR TITLE
Refactor Bzip2 tests

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
@@ -27,16 +27,24 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
 
 import static io.netty.handler.codec.compression.Bzip2Constants.*;
 import static org.junit.Assert.*;
 
 public class Bzip2DecoderTest {
 
+    private static final byte[] DATA = { 0x42, 0x5A, 0x68, 0x37, 0x31, 0x41, 0x59, 0x26, 0x53,
+                                         0x59, 0x77, 0x7B, (byte) 0xCA, (byte) 0xC0, 0x00, 0x00,
+                                         0x00, 0x05, (byte) 0x80, 0x00, 0x01, 0x02, 0x00, 0x04,
+                                         0x20, 0x20, 0x00, 0x30, (byte) 0xCD, 0x34, 0x19, (byte) 0xA6,
+                                         (byte) 0x89, (byte) 0x99, (byte) 0xC5, (byte) 0xDC, (byte) 0x91,
+                                         0x4E, 0x14, 0x24, 0x1D, (byte) 0xDE, (byte) 0xF2, (byte) 0xB0, 0x00 };
+
     private static final ThreadLocalRandom rand;
 
     private static final byte[] BYTES_SMALL = new byte[256];
-    private static final byte[] BYTES_LARGE = new byte[MAX_BLOCK_SIZE * BASE_BLOCK_SIZE * 2];
+    private static final byte[] BYTES_LARGE = new byte[MAX_BLOCK_SIZE * BASE_BLOCK_SIZE + 256];
 
     static {
         rand = ThreadLocalRandom.current();
@@ -112,12 +120,8 @@ public class Bzip2DecoderTest {
         expected.expect(DecompressionException.class);
         expected.expectMessage("stream CRC error");
 
-        final byte[] data = { 0x42, 0x5A, 0x68, 0x37, 0x31, 0x41, 0x59, 0x26, 0x53,
-                              0x59, 0x77, 0x7B, (byte) 0xCA, (byte) 0xC0, 0x00, 0x00,
-                              0x00, 0x05, (byte) 0x80, 0x00, 0x01, 0x02, 0x00, 0x04,
-                              0x20, 0x20, 0x00, 0x30, (byte) 0xCD, 0x34, 0x19, (byte) 0xA6,
-                              (byte) 0x89, (byte) 0x99, (byte) 0xC5, (byte) 0xDC, (byte) 0x91,
-                              0x4E, 0x14, 0x24, 0x1D, (byte) 0xDD, (byte) 0xF2, (byte) 0xB0, 0x00 };
+        final byte[] data = Arrays.copyOf(DATA, DATA.length);
+        data[41] = (byte) 0xDD;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
         try {
@@ -139,12 +143,8 @@ public class Bzip2DecoderTest {
         expected.expect(DecompressionException.class);
         expected.expectMessage("incorrect huffman groups number");
 
-        final byte[] data = { 0x42, 0x5A, 0x68, 0x37, 0x31, 0x41, 0x59, 0x26, 0x53,
-                              0x59, 0x77, 0x7B, (byte) 0xCA, (byte) 0xC0, 0x00, 0x00,
-                              0x00, 0x05, (byte) 0x80, 0x00, 0x01, 0x02, 0x00, 0x04,
-                              0x20, 0x70, 0x00, 0x30, (byte) 0xCD, 0x34, 0x19, (byte) 0xA6,
-                              (byte) 0x89, (byte) 0x99, (byte) 0xC5, (byte) 0xDC, (byte) 0x91,
-                              0x4E, 0x14, 0x24, 0x1D, (byte) 0xDE, (byte) 0xF2, (byte) 0xB0, 0x00 };
+        final byte[] data = Arrays.copyOf(DATA, DATA.length);
+        data[25] = 0x70;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
         channel.writeInbound(in);
@@ -155,12 +155,8 @@ public class Bzip2DecoderTest {
         expected.expect(DecompressionException.class);
         expected.expectMessage("incorrect selectors number");
 
-        final byte[] data = { 0x42, 0x5A, 0x68, 0x37, 0x31, 0x41, 0x59, 0x26, 0x53,
-                              0x59, 0x77, 0x7B, (byte) 0xCA, (byte) 0xC0, 0x00, 0x00,
-                              0x00, 0x05, (byte) 0x80, 0x00, 0x01, 0x02, 0x00, 0x04,
-                              0x20, 0x2F, (byte) 0xFF, 0x30, (byte) 0xCD, 0x34, 0x19, (byte) 0xA6,
-                              (byte) 0x89, (byte) 0x99, (byte) 0xC5, (byte) 0xDC, (byte) 0x91,
-                              0x4E, 0x14, 0x24, 0x1D, (byte) 0xDE, (byte) 0xF2, (byte) 0xB0, 0x00 };
+        final byte[] data = Arrays.copyOf(DATA, DATA.length);
+        data[25] = 0x2F;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
         channel.writeInbound(in);
@@ -171,12 +167,8 @@ public class Bzip2DecoderTest {
         expected.expect(DecompressionException.class);
         expected.expectMessage("block CRC error");
 
-        final byte[] data = { 0x42, 0x5A, 0x68, 0x37, 0x31, 0x41, 0x59, 0x26, 0x53,
-                              0x59, 0x77, 0x77, (byte) 0xCA, (byte) 0xC0, 0x00, 0x00,
-                              0x00, 0x05, (byte) 0x80, 0x00, 0x01, 0x02, 0x00, 0x04,
-                              0x20, 0x20, 0x00, 0x30, (byte) 0xCD, 0x34, 0x19, (byte) 0xA6,
-                              (byte) 0x89, (byte) 0x99, (byte) 0xC5, (byte) 0xDC, (byte) 0x91,
-                              0x4E, 0x14, 0x24, 0x1D, (byte) 0xDE, (byte) 0xF2, (byte) 0xB0, 0x00 };
+        final byte[] data = Arrays.copyOf(DATA, DATA.length);
+        data[11] = 0x77;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
         channel.writeInbound(in);
@@ -187,20 +179,14 @@ public class Bzip2DecoderTest {
         expected.expect(DecompressionException.class);
         expected.expectMessage("start pointer invalid");
 
-        final byte[] data = { 0x42, 0x5A, 0x68, 0x37, 0x31, 0x41, 0x59, 0x26, 0x53,
-                              0x59, 0x77, 0x7B, (byte) 0xCA, (byte) 0xC0, (byte) 0xFF, 0x00,
-                              0x00, 0x05, (byte) 0x80, 0x00, 0x01, 0x02, 0x00, 0x04,
-                              0x20, 0x20, 0x00, 0x30, (byte) 0xCD, 0x34, 0x19, (byte) 0xA6,
-                              (byte) 0x89, (byte) 0x99, (byte) 0xC5, (byte) 0xDC, (byte) 0x91,
-                              0x4E, 0x14, 0x24, 0x1D, (byte) 0xDE, (byte) 0xF2, (byte) 0xB0, 0x00 };
+        final byte[] data = Arrays.copyOf(DATA, DATA.length);
+        data[14] = (byte) 0xFF;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
         channel.writeInbound(in);
     }
 
-    private static void testDecompression(final byte[] data) throws Exception {
-        final EmbeddedChannel channel = new EmbeddedChannel(new Bzip2Decoder());
-
+    private static void testDecompression(final EmbeddedChannel channel, final byte[] data) throws Exception {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         BZip2CompressorOutputStream bZip2Os = new BZip2CompressorOutputStream(os, randomBlockSize());
         bZip2Os.write(data);
@@ -220,12 +206,12 @@ public class Bzip2DecoderTest {
 
     @Test
     public void testDecompressionOfSmallChunkOfData() throws Exception {
-        testDecompression(BYTES_SMALL);
+        testDecompression(channel, BYTES_SMALL);
     }
 
     @Test
     public void testDecompressionOfLargeChunkOfData() throws Exception {
-        testDecompression(BYTES_LARGE);
+        testDecompression(channel, BYTES_LARGE);
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/compression/Bzip2EncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Bzip2EncoderTest.java
@@ -21,6 +21,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.internal.ThreadLocalRandom;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -33,7 +34,7 @@ public class Bzip2EncoderTest {
     private static final ThreadLocalRandom rand;
 
     private static final byte[] BYTES_SMALL = new byte[256];
-    private static final byte[] BYTES_LARGE = new byte[MAX_BLOCK_SIZE * BASE_BLOCK_SIZE * 2];
+    private static final byte[] BYTES_LARGE = new byte[MAX_BLOCK_SIZE * BASE_BLOCK_SIZE + 256];
 
     static {
         rand = ThreadLocalRandom.current();
@@ -41,28 +42,14 @@ public class Bzip2EncoderTest {
         rand.nextBytes(BYTES_LARGE);
     }
 
-    @Test
-    public void testStreamInitialization() throws Exception {
-        final EmbeddedChannel channel = new EmbeddedChannel(new Bzip2Encoder());
+    private EmbeddedChannel channel;
 
-        ByteBuf in = Unpooled.wrappedBuffer("test".getBytes());
-        channel.writeOutbound(in);
-
-        ByteBuf out = channel.readOutbound();
-
-        assertEquals(MAGIC_NUMBER, out.readMedium());
-        assertEquals(9 + '0', out.readByte());
-
-        out.release();
-        assertTrue(channel.finish());
-        out = channel.readOutbound();
-        out.release();
-        assertNull(channel.readOutbound());
+    @Before
+    public void initChannel() {
+        channel = new EmbeddedChannel(new Bzip2Encoder(randomBlockSize()));
     }
 
-    private static void testCompression(final byte[] data) throws Exception {
-        final EmbeddedChannel channel = new EmbeddedChannel(new Bzip2Encoder(randomBlockSize()));
-
+    private static void testCompression(final EmbeddedChannel channel, final byte[] data) throws Exception {
         ByteBuf in = Unpooled.wrappedBuffer(data);
         channel.writeOutbound(in);
         channel.finish();
@@ -74,32 +61,32 @@ public class Bzip2EncoderTest {
 
     @Test
     public void testCompressionOfSmallChunkOfData() throws Exception {
-        testCompression(BYTES_SMALL);
+        testCompression(channel, BYTES_SMALL);
     }
 
     @Test
     public void testCompressionOfLargeChunkOfData() throws Exception {
-        testCompression(BYTES_LARGE);
+        testCompression(channel, BYTES_LARGE);
     }
 
     @Test
     public void testCompressionOfBatchedFlowOfData() throws Exception {
-        final EmbeddedChannel channel = new EmbeddedChannel(new Bzip2Encoder(randomBlockSize()));
+        final byte[] data = BYTES_LARGE;
 
         int written = 0, length = rand.nextInt(100);
-        while (written + length < BYTES_LARGE.length) {
-            ByteBuf in = Unpooled.wrappedBuffer(BYTES_LARGE, written, length);
+        while (written + length < data.length) {
+            ByteBuf in = Unpooled.wrappedBuffer(data, written, length);
             channel.writeOutbound(in);
             written += length;
             length = rand.nextInt(100);
         }
-        ByteBuf in = Unpooled.wrappedBuffer(BYTES_LARGE, written, BYTES_LARGE.length - written);
+        ByteBuf in = Unpooled.wrappedBuffer(data, written, data.length - written);
         channel.writeOutbound(in);
         channel.finish();
 
-        byte[] uncompressed = uncompress(channel, BYTES_LARGE.length);
+        byte[] uncompressed = uncompress(channel, data.length);
 
-        assertArrayEquals(BYTES_LARGE, uncompressed);
+        assertArrayEquals(data, uncompressed);
     }
 
     private static byte[] uncompress(EmbeddedChannel channel, int length) throws Exception {


### PR DESCRIPTION
Motivation:

Complicated code of Bzip2 tests with some unnecessary actions.

Modifications:
- Reduce size of `BYTES_LARGE` array of random test data for Bzip2  tests.
- Removed unnecessary creations of `EmbeddedChannel` instances in Bzip2 tests.
- Simplified tests in `Bzip2DecoderTest` which expect exception.
- Removed unnecessary `testStreamInitialization()` from `Bzip2EncoderTest`.

Result:

Reduced time to test the 'codec' package by 7 percent, simplified code of Bzip2 tests.
