### PR TITLE
Refactor integration tests of compression codecs

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/compression/Bzip2IntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Bzip2IntegrationTest.java
@@ -15,45 +15,19 @@
  */
 package io.netty.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.CompositeByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.ThreadLocalRandom;
 import org.junit.Test;
 
-import java.util.Arrays;
+public class Bzip2IntegrationTest extends IntegrationTest {
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-
-public class Bzip2IntegrationTest {
-
-    private static final ThreadLocalRandom rand = ThreadLocalRandom.current();
-
-    public static final byte[] EMPTY = new byte[0];
-
-    @Test
-    public void testEmpty() throws Exception {
-        testIdentity(EMPTY);
+    @Override
+    protected EmbeddedChannel createEncoderEmbeddedChannel() {
+        return new EmbeddedChannel(new Bzip2Encoder());
     }
 
-    @Test
-    public void testOneByte() throws Exception {
-        testIdentity(new byte[] { 'A' });
-    }
-
-    @Test
-    public void testTwoBytes() throws Exception {
-        testIdentity(new byte[] { 'B', 'A' });
-    }
-
-    @Test
-    public void testRegular() throws Exception {
-        byte[] data = ("Netty is a NIO client server framework which enables quick and easy development " +
-                                "of network applications such as protocol servers and clients.").getBytes();
-        testIdentity(data);
+    @Override
+    protected EmbeddedChannel createDecoderEmbeddedChannel() {
+        return new EmbeddedChannel(new Bzip2Decoder());
     }
 
     @Test
@@ -75,104 +49,5 @@ public class Bzip2IntegrationTest {
         byte[] data = new byte[2300];
         rand.nextBytes(data);
         testIdentity(data);
-    }
-
-    @Test
-    public void testLargeRandom() throws Exception {
-        byte[] data = new byte[1048576];
-        rand.nextBytes(data);
-        testIdentity(data);
-    }
-
-    @Test
-    public void testPartRandom() throws Exception {
-        byte[] data = new byte[12345];
-        rand.nextBytes(data);
-        for (int i = 0; i < 1024; i++) {
-            data[i] = 123;
-        }
-        testIdentity(data);
-    }
-
-    @Test
-    public void testCompressible() throws Exception {
-        byte[] data = new byte[10000];
-        for (int i = 0; i < data.length; i++) {
-            data[i] = i % 4 != 0 ? 0 : (byte) rand.nextInt();
-        }
-        testIdentity(data);
-    }
-
-    @Test
-    public void testLongBlank() throws Exception {
-        byte[] data = new byte[100000];
-        testIdentity(data);
-    }
-
-    @Test
-    public void testLongSame() throws Exception {
-        byte[] data = new byte[100000];
-        Arrays.fill(data, (byte) 123);
-        testIdentity(data);
-    }
-
-    @Test
-    public void testSequential() throws Exception {
-        byte[] data = new byte[49];
-        for (int i = 0; i < data.length; i++) {
-            data[i] = (byte) i;
-        }
-        testIdentity(data);
-    }
-
-    private static void testIdentity(byte[] data) {
-        ByteBuf in = Unpooled.wrappedBuffer(data);
-        EmbeddedChannel encoder = new EmbeddedChannel(new Bzip2Encoder());
-        EmbeddedChannel decoder = new EmbeddedChannel(new Bzip2Decoder());
-        try {
-            ByteBuf msg;
-
-            encoder.writeOutbound(in.copy());
-            encoder.finish();
-            CompositeByteBuf compressed = Unpooled.compositeBuffer();
-            while ((msg = encoder.readOutbound()) != null) {
-                compressed.addComponent(msg);
-                compressed.writerIndex(compressed.writerIndex() + msg.readableBytes());
-            }
-            assertThat(compressed, is(notNullValue()));
-            assertThat(compressed, is(not(in)));
-
-            decoder.writeInbound(compressed.retain());
-            assertFalse(compressed.isReadable());
-            CompositeByteBuf decompressed = Unpooled.compositeBuffer();
-            while ((msg = decoder.readInbound()) != null) {
-                decompressed.addComponent(msg);
-                decompressed.writerIndex(decompressed.writerIndex() + msg.readableBytes());
-            }
-            assertEquals(in, decompressed);
-
-            compressed.release();
-            decompressed.release();
-            in.release();
-        } finally {
-            encoder.close();
-            decoder.close();
-
-            for (;;) {
-                Object msg = encoder.readOutbound();
-                if (msg == null) {
-                    break;
-                }
-                ReferenceCountUtil.release(msg);
-            }
-
-            for (;;) {
-                Object msg = decoder.readInbound();
-                if (msg == null) {
-                    break;
-                }
-                ReferenceCountUtil.release(msg);
-            }
-        }
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/IntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/IntegrationTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ThreadLocalRandom;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+public abstract class IntegrationTest {
+
+    protected static final ThreadLocalRandom rand = ThreadLocalRandom.current();
+
+    protected abstract EmbeddedChannel createEncoderEmbeddedChannel();
+    protected abstract EmbeddedChannel createDecoderEmbeddedChannel();
+
+    @Test
+    public void testEmpty() throws Exception {
+        testIdentity(EmptyArrays.EMPTY_BYTES);
+    }
+
+    @Test
+    public void testOneByte() throws Exception {
+        final byte[] data = { 'A' };
+        testIdentity(data);
+    }
+
+    @Test
+    public void testTwoBytes() throws Exception {
+        final byte[] data = { 'B', 'A' };
+        testIdentity(data);
+    }
+
+    @Test
+    public void testRegular() throws Exception {
+        final byte[] data = ("Netty is a NIO client server framework which enables " +
+                "quick and easy development of network applications such as protocol " +
+                "servers and clients.").getBytes(CharsetUtil.UTF_8);
+        testIdentity(data);
+    }
+
+    @Test
+    public void testLargeRandom() throws Exception {
+        final byte[] data = new byte[1024 * 1024];
+        rand.nextBytes(data);
+        testIdentity(data);
+    }
+
+    @Test
+    public void testPartRandom() throws Exception {
+        final byte[] data = new byte[10240];
+        rand.nextBytes(data);
+        for (int i = 0; i < 1024; i++) {
+            data[i] = 2;
+        }
+        testIdentity(data);
+    }
+
+    @Test
+    public void testCompressible() throws Exception {
+        final byte[] data = new byte[10240];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = i % 4 != 0 ? 0 : (byte) rand.nextInt();
+        }
+        testIdentity(data);
+    }
+
+    @Test
+    public void testLongBlank() throws Exception {
+        final byte[] data = new byte[102400];
+        testIdentity(data);
+    }
+
+    @Test
+    public void testLongSame() throws Exception {
+        final byte[] data = new byte[102400];
+        Arrays.fill(data, (byte) 123);
+        testIdentity(data);
+    }
+
+    @Test
+    public void testSequential() throws Exception {
+        final byte[] data = new byte[1024];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) i;
+        }
+        testIdentity(data);
+    }
+
+    protected void testIdentity(final byte[] data) {
+        final ByteBuf in = Unpooled.wrappedBuffer(data);
+        final EmbeddedChannel encoder = createEncoderEmbeddedChannel();
+        final EmbeddedChannel decoder = createDecoderEmbeddedChannel();
+        try {
+            ByteBuf msg;
+
+            encoder.writeOutbound(in.copy());
+            encoder.finish();
+            final CompositeByteBuf compressed = Unpooled.compositeBuffer();
+            while ((msg = encoder.readOutbound()) != null) {
+                compressed.addComponent(msg);
+                compressed.writerIndex(compressed.writerIndex() + msg.readableBytes());
+            }
+            assertThat(compressed, is(notNullValue()));
+
+            decoder.writeInbound(compressed.retain());
+            assertFalse(compressed.isReadable());
+            final CompositeByteBuf decompressed = Unpooled.compositeBuffer();
+            while ((msg = decoder.readInbound()) != null) {
+                decompressed.addComponent(msg);
+                decompressed.writerIndex(decompressed.writerIndex() + msg.readableBytes());
+            }
+            assertEquals(in, decompressed);
+
+            compressed.release();
+            decompressed.release();
+            in.release();
+        } finally {
+            encoder.close();
+            decoder.close();
+
+            for (;;) {
+                Object msg = encoder.readOutbound();
+                if (msg == null) {
+                    break;
+                }
+                ReferenceCountUtil.release(msg);
+            }
+
+            for (;;) {
+                Object msg = decoder.readInbound();
+                if (msg == null) {
+                    break;
+                }
+                ReferenceCountUtil.release(msg);
+            }
+        }
+    }
+}

--- a/codec/src/test/java/io/netty/handler/codec/compression/LzfIntegrationTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/LzfIntegrationTest.java
@@ -15,142 +15,17 @@
  */
 package io.netty.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.CompositeByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.ThreadLocalRandom;
-import org.junit.Test;
 
-import java.util.Arrays;
+public class LzfIntegrationTest extends IntegrationTest {
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-
-public class LzfIntegrationTest {
-
-    private static final ThreadLocalRandom rand = ThreadLocalRandom.current();
-
-    public static final byte[] EMPTY = new byte[0];
-
-    @Test
-    public void testEmpty() throws Exception {
-        testIdentity(EMPTY);
+    @Override
+    protected EmbeddedChannel createEncoderEmbeddedChannel() {
+        return new EmbeddedChannel(new LzfEncoder());
     }
 
-    @Test
-    public void testOneByte() throws Exception {
-        testIdentity(new byte[] { 'A' });
-    }
-
-    @Test
-    public void testTwoBytes() throws Exception {
-        testIdentity(new byte[] { 'B', 'A' });
-    }
-
-    @Test
-    public void testRegular() throws Exception {
-        byte[] data = ("Netty is a NIO client server framework which enables quick and easy development " +
-                "of network applications such as protocol servers and clients.").getBytes();
-        testIdentity(data);
-    }
-
-    @Test
-    public void testLargeRandom() throws Exception {
-        byte[] data = new byte[1048576];
-        rand.nextBytes(data);
-        testIdentity(data);
-    }
-
-    @Test
-    public void testPartRandom() throws Exception {
-        byte[] data = new byte[12345];
-        rand.nextBytes(data);
-        for (int i = 0; i < 1024; i++) {
-            data[i] = 123;
-        }
-        testIdentity(data);
-    }
-
-    @Test
-    public void testCompressible() throws Exception {
-        byte[] data = new byte[10000];
-        for (int i = 0; i < data.length; i++) {
-            data[i] = i % 4 != 0 ? 0 : (byte) rand.nextInt();
-        }
-        testIdentity(data);
-    }
-
-    @Test
-    public void testLongBlank() throws Exception {
-        byte[] data = new byte[100000];
-        testIdentity(data);
-    }
-
-    @Test
-    public void testLongSame() throws Exception {
-        byte[] data = new byte[100000];
-        Arrays.fill(data, (byte) 123);
-        testIdentity(data);
-    }
-
-    @Test
-    public void testSequential() throws Exception {
-        byte[] data = new byte[49];
-        for (int i = 0; i < data.length; i++) {
-            data[i] = (byte) i;
-        }
-        testIdentity(data);
-    }
-
-    private static void testIdentity(byte[] data) {
-        ByteBuf in = Unpooled.wrappedBuffer(data);
-        EmbeddedChannel encoder = new EmbeddedChannel(new LzfEncoder());
-        EmbeddedChannel decoder = new EmbeddedChannel(new LzfDecoder());
-        try {
-            ByteBuf msg;
-
-            encoder.writeOutbound(in.copy());
-            encoder.finish();
-            CompositeByteBuf compressed = Unpooled.compositeBuffer();
-            while ((msg = encoder.readOutbound()) != null) {
-                compressed.addComponent(msg);
-                compressed.writerIndex(compressed.writerIndex() + msg.readableBytes());
-            }
-            assertThat(compressed, is(notNullValue()));
-
-            decoder.writeInbound(compressed.retain());
-            assertFalse(compressed.isReadable());
-            CompositeByteBuf decompressed = Unpooled.compositeBuffer();
-            while ((msg = decoder.readInbound()) != null) {
-                decompressed.addComponent(msg);
-                decompressed.writerIndex(decompressed.writerIndex() + msg.readableBytes());
-            }
-            assertEquals(in, decompressed);
-
-            compressed.release();
-            decompressed.release();
-            in.release();
-        } finally {
-            encoder.close();
-            decoder.close();
-
-            for (;;) {
-                Object msg = encoder.readOutbound();
-                if (msg == null) {
-                    break;
-                }
-                ReferenceCountUtil.release(msg);
-            }
-
-            for (;;) {
-                Object msg = decoder.readInbound();
-                if (msg == null) {
-                    break;
-                }
-                ReferenceCountUtil.release(msg);
-            }
-        }
+    @Override
+    protected EmbeddedChannel createDecoderEmbeddedChannel() {
+        return new EmbeddedChannel(new LzfDecoder());
     }
 }


### PR DESCRIPTION
Motivation:

Duplicated code of integration tests for different compression codecs.

Modifications:
- Added abstract class `IntegrationTest` which contains common tests for any compression codec.
- Removed common tests from `Bzip2IntegrationTest` and `LzfIntegrationTest`.
- Implemented abstract methods of `IntegrationTest` in `Bzip2IntegrationTest`, `LzfIntegrationTest` and `SnappyIntegrationTest`.

Result:

Removed duplicated code of integration tests for compression codecs and simplified an addition of integration tests for new compression codecs.
