### PR TITLE
Remove compressed flag from HTTP/2

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandler.java
@@ -338,7 +338,7 @@ public abstract class AbstractHttp2ConnectionHandler extends ByteToMessageDecode
 
     protected ChannelFuture writeData(final ChannelHandlerContext ctx,
             final ChannelPromise promise, int streamId, final ByteBuf data, int padding,
-            boolean endStream, boolean endSegment, boolean compressed) {
+            boolean endStream, boolean endSegment) {
         try {
             if (connection.isGoAway()) {
                 throw protocolError("Sending data after connection going away.");
@@ -349,7 +349,7 @@ public abstract class AbstractHttp2ConnectionHandler extends ByteToMessageDecode
 
             // Hand control of the frame to the flow controller.
             outboundFlow.sendFlowControlled(streamId, data, padding, endStream, endSegment,
-                    compressed, new FlowControlWriter(ctx, data, promise));
+                    new FlowControlWriter(ctx, data, promise));
 
             return promise;
         } catch (Http2Exception e) {
@@ -1094,7 +1094,7 @@ public abstract class AbstractHttp2ConnectionHandler extends ByteToMessageDecode
 
         @Override
         public void writeFrame(int streamId, ByteBuf data, int padding,
-                boolean endStream, boolean endSegment, boolean compressed) {
+                boolean endStream, boolean endSegment) {
             if (promise.isDone()) {
                 // Most likely the write already failed. Just release the
                 // buffer.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandler.java
@@ -53,9 +53,8 @@ public class DelegatingHttp2ConnectionHandler extends AbstractHttp2ConnectionHan
 
     @Override
     public ChannelFuture writeData(ChannelHandlerContext ctx, ChannelPromise promise, int streamId,
-            ByteBuf data, int padding, boolean endStream, boolean endSegment, boolean compressed) {
-        return super.writeData(ctx, promise, streamId, data, padding, endStream, endSegment,
-                compressed);
+            ByteBuf data, int padding, boolean endStream, boolean endSegment) {
+        return super.writeData(ctx, promise, streamId, data, padding, endStream, endSegment);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFlowController.java
@@ -31,7 +31,7 @@ public interface Http2OutboundFlowController {
          * Writes a single data frame to the remote endpoint.
          */
         void writeFrame(int streamId, ByteBuf data, int padding, boolean endStream,
-                boolean endSegment, boolean compressed);
+                boolean endSegment);
 
         /**
          * Called if an error occurred before the write could take place. Sets the failure on the
@@ -80,10 +80,9 @@ public interface Http2OutboundFlowController {
      * @param padding the number of bytes of padding to be added to the frame.
      * @param endStream indicates whether this frames is to be the last sent on this stream.
      * @param endSegment indicates whether this is to be the last frame in the segment.
-     * @param compressed whether the data is compressed using gzip compression.
      * @param frameWriter peforms to the write of the frame to the remote endpoint.
      * @throws Http2Exception thrown if a protocol-related error occurred.
      */
     void sendFlowControlled(int streamId, ByteBuf data, int padding, boolean endStream,
-            boolean endSegment, boolean compressed, FrameWriter frameWriter) throws Http2Exception;
+            boolean endSegment, FrameWriter frameWriter) throws Http2Exception;
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2OutboundFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2OutboundFlowControllerTest.java
@@ -542,22 +542,21 @@ public class DefaultHttp2OutboundFlowControllerTest {
     }
 
     private void send(int streamId, ByteBuf data) throws Http2Exception {
-        controller.sendFlowControlled(streamId, data, 0, false, false, false, frameWriter);
+        controller.sendFlowControlled(streamId, data, 0, false, false, frameWriter);
     }
 
     private void verifyWrite(int streamId, ByteBuf data) {
-        verify(frameWriter).writeFrame(eq(streamId), eq(data), eq(0), eq(false), eq(false),
-                eq(false));
+        verify(frameWriter).writeFrame(eq(streamId), eq(data), eq(0), eq(false), eq(false));
     }
 
     private void verifyNoWrite(int streamId) {
         verify(frameWriter, never()).writeFrame(eq(streamId), any(ByteBuf.class), anyInt(),
-                anyBoolean(), anyBoolean(), anyBoolean());
+                anyBoolean(), anyBoolean());
     }
 
     private void captureWrite(int streamId, ArgumentCaptor<ByteBuf> captor, boolean endStream) {
         verify(frameWriter).writeFrame(eq(streamId), captor.capture(), eq(0), eq(endStream),
-                eq(false), eq(false));
+                eq(false));
     }
 
     private void setPriority(int stream, int parent, int weight, boolean exclusive)

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandlerTest.java
@@ -442,15 +442,15 @@ public class DelegatingHttp2ConnectionHandlerTest {
     @Test
     public void dataWriteAfterGoAwayShouldFail() throws Exception {
         when(connection.isGoAway()).thenReturn(true);
-        ChannelFuture future = handler.writeData(ctx, promise, STREAM_ID, dummyData(), 0, false, false, false);
+        ChannelFuture future = handler.writeData(ctx, promise, STREAM_ID, dummyData(), 0, false, false);
         assertTrue(future.awaitUninterruptibly().cause() instanceof Http2Exception);
     }
 
     @Test
     public void dataWriteShouldSucceed() throws Exception {
-        handler.writeData(ctx, promise, STREAM_ID, dummyData(), 0, false, false, false);
+        handler.writeData(ctx, promise, STREAM_ID, dummyData(), 0, false, false);
         verify(outboundFlow).sendFlowControlled(eq(STREAM_ID), eq(dummyData()), eq(0), eq(false),
-                eq(false), eq(false), any(Http2OutboundFlowController.FrameWriter.class));
+                eq(false), any(Http2OutboundFlowController.FrameWriter.class));
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -121,7 +121,7 @@ public class Http2ConnectionRoundtripTest {
                     http2Client.writePing(ctx(), newPromise(), Unpooled.copiedBuffer(pingMsg.getBytes()));
                     http2Client.writeData(
                             ctx(), newPromise(), nextStream,
-                            Unpooled.copiedBuffer(text.getBytes()), 0, true, true, false);
+                            Unpooled.copiedBuffer(text.getBytes()), 0, true, true);
                 }
             }
         });

--- a/example/src/main/java/io/netty/example/http2/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/server/HelloWorldHttp2Handler.java
@@ -112,6 +112,6 @@ public class HelloWorldHttp2Handler extends AbstractHttp2ConnectionHandler {
         Http2Headers headers = DefaultHttp2Headers.newBuilder().status("200").build();
         writeHeaders(ctx(), ctx().newPromise(), streamId, headers, 0, false, false);
 
-        writeData(ctx(), ctx().newPromise(), streamId, payload, 0, true, true, false);
+        writeData(ctx(), ctx().newPromise(), streamId, payload, 0, true, true);
     }
 }


### PR DESCRIPTION
Motivation:

There are still a few places in the HTTP/2 code that have the compressed
flag (from pre-draft 13). Need to remove this flag since it's no longer
used.

Modifications:

Various changes to remove the flag from the writing path.

Result:

No references to the compressed flag.
