### PR TITLE
Updated the ChannelGroup JavaDoc

### DIFF
--- a/transport/src/main/java/io/netty/channel/group/ChannelGroup.java
+++ b/transport/src/main/java/io/netty/channel/group/ChannelGroup.java
@@ -80,7 +80,6 @@ import java.util.Set;
  *
  *     // Close the serverChannel and then all accepted connections.
  *     <strong>allChannels.close().awaitUninterruptibly();</strong>
- *     b.releaseExternalResources();
  * }
  *
  * public class MyHandler extends {@link ChannelHandlerAdapter} {


### PR DESCRIPTION
As releaseExternalResources() method is removed from ServerBootstrap, we don't need to call the "b.releaseExternalResources();" to close the Netty Server.
