### PR TITLE
Improve Bzip2BitReader/Writer

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2BitReader.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2BitReader.java
@@ -19,14 +19,24 @@ import io.netty.buffer.ByteBuf;
 
 /**
  * An bit reader that allows the reading of single bit booleans, bit strings of
- * arbitrary length (up to 24 bits), and bit aligned 32-bit integers. A single byte
+ * arbitrary length (up to 32 bits), and bit aligned 32-bit integers. A single byte
  * at a time is read from the {@link ByteBuf} when more bits are required.
  */
 class Bzip2BitReader {
     /**
+     * Maximum count of possible readable bytes to check.
+     */
+    private static final int MAX_COUNT_OF_READABLE_BYTES = Integer.MAX_VALUE >>> 3;
+
+    /**
+     * The {@link ByteBuf} from which to read data.
+     */
+    private ByteBuf in;
+
+    /**
      * A buffer of bits read from the input stream that have not yet been returned.
      */
-    private int bitBuffer;
+    private long bitBuffer;
 
     /**
      * The number of bits currently buffered in {@link #bitBuffer}.
@@ -34,53 +44,114 @@ class Bzip2BitReader {
     private int bitCount;
 
     /**
-     * Reads up to 24 bits from the {@link ByteBuf}.
-     * @param count The number of bits to read (maximum {@code 24}, because the {@link #bitBuffer}
-     *              is {@code int} and it can store up to {@code 8} bits before calling)
+     * Set the {@link ByteBuf} from which to read data.
+     */
+    void setByteBuf(ByteBuf in) {
+        this.in = in;
+    }
+
+    /**
+     * Reads up to 32 bits from the {@link ByteBuf}.
+     * @param count The number of bits to read (maximum {@code 32} as a size of {@code int})
      * @return The bits requested, right-aligned within the integer
      */
-    int readBits(ByteBuf in, final int count) {
-        if (count < 0 || count > 24) {
-            throw new IllegalArgumentException("count: " + count + " (expected: 0-24)");
+    int readBits(final int count) {
+        if (count < 0 || count > 32) {
+            throw new IllegalArgumentException("count: " + count + " (expected: 0-32 )");
         }
         int bitCount = this.bitCount;
-        int bitBuffer = this.bitBuffer;
+        long bitBuffer = this.bitBuffer;
 
         if (bitCount < count) {
-            do {
-                int uByte = in.readUnsignedByte();
-                bitBuffer = bitBuffer << 8 | uByte;
-                bitCount += 8;
-            } while (bitCount < count);
+            long readData;
+            int offset;
+            switch (in.readableBytes()) {
+                case 1: {
+                    readData = in.readUnsignedByte();
+                    offset = 8;
+                    break;
+                }
+                case 2: {
+                    readData = in.readUnsignedShort();
+                    offset = 16;
+                    break;
+                }
+                case 3: {
+                    readData = in.readUnsignedMedium();
+                    offset = 24;
+                    break;
+                }
+                default: {
+                    readData = in.readUnsignedInt();
+                    offset = 32;
+                    break;
+                }
+            }
 
+            bitBuffer = bitBuffer << offset | readData;
+            bitCount += offset;
             this.bitBuffer = bitBuffer;
         }
 
         this.bitCount = bitCount -= count;
-        return (bitBuffer >>> bitCount) & ((1 << count) - 1);
+        return (int) (bitBuffer >>> bitCount & (count != 32 ? (1 << count) - 1 : 0xFFFFFFFFL));
     }
 
     /**
      * Reads a single bit from the {@link ByteBuf}.
      * @return {@code true} if the bit read was {@code 1}, otherwise {@code false}
      */
-    boolean readBoolean(ByteBuf in) {
-        return readBits(in, 1) != 0;
+    boolean readBoolean() {
+        return readBits(1) != 0;
     }
 
     /**
      * Reads 32 bits of input as an integer.
      * @return The integer read
      */
-    int readInt(ByteBuf in) {
-        return readBits(in, 16) << 16 | readBits(in, 16);
+    int readInt() {
+        return readBits(32);
+    }
+
+    /**
+     * Refill the {@link ByteBuf} by one byte.
+     */
+    void refill() {
+        int readData = in.readUnsignedByte();
+        bitBuffer = bitBuffer << 8 | readData;
+        bitCount += 8;
     }
 
     /**
      * Checks that at least one bit is available for reading.
      * @return {@code true} if one bit is available for reading, otherwise {@code false}
      */
-    boolean hasBit(ByteBuf in) {
+    boolean isReadable() {
         return bitCount > 0 || in.isReadable();
+    }
+
+    /**
+     * Checks that the specified number of bits available for reading.
+     * @param count The number of bits to check
+     * @return {@code true} if {@code count} bits are available for reading, otherwise {@code false}
+     */
+    boolean hasReadableBits(int count) {
+        if (count < 0) {
+            throw new IllegalArgumentException("count: " + count + " (expected value greater than 0)");
+        }
+        return bitCount >= count || (in.readableBytes() << 3 & Integer.MAX_VALUE) >= count - bitCount;
+    }
+
+    /**
+     * Checks that the specified number of bytes available for reading.
+     * @param count The number of bytes to check
+     * @return {@code true} if {@code count} bytes are available for reading, otherwise {@code false}
+     */
+    boolean hasReadableBytes(int count) {
+        if (count < 0 || count > MAX_COUNT_OF_READABLE_BYTES) {
+            throw new IllegalArgumentException("count: " + count
+                    + " (expected: 0-" + MAX_COUNT_OF_READABLE_BYTES + ')');
+        }
+        return hasReadableBits(count << 3);
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2BlockCompressor.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2BlockCompressor.java
@@ -102,7 +102,7 @@ final class Bzip2BlockCompressor {
         final boolean[] condensedInUse = new boolean[16];
 
         for (int i = 0; i < condensedInUse.length; i++) {
-            for (int j = 0, k = i << 4; j < 16; j++, k++) {
+            for (int j = 0, k = i << 4; j < HUFFMAN_SYMBOL_RANGE_SIZE; j++, k++) {
                 if (blockValuesPresent[k]) {
                     condensedInUse[i] = true;
                 }
@@ -115,7 +115,7 @@ final class Bzip2BlockCompressor {
 
         for (int i = 0; i < condensedInUse.length; i++) {
             if (condensedInUse[i]) {
-                for (int j = 0, k = i << 4; j < 16; j++, k++) {
+                for (int j = 0, k = i << 4; j < HUFFMAN_SYMBOL_RANGE_SIZE; j++, k++) {
                     writer.writeBoolean(out, blockValuesPresent[k]);
                 }
             }

--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Constants.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Constants.java
@@ -71,6 +71,16 @@ final class Bzip2Constants {
     static final int HUFFMAN_SYMBOL_RUNB = 1;
 
     /**
+     * Huffman symbols range size for Huffman used map.
+     */
+    static final int HUFFMAN_SYMBOL_RANGE_SIZE = 16;
+
+    /**
+     * Maximum length of zero-terminated bit runs of MTF'ed Huffman table.
+     */
+    static final int HUFFMAN_SELECTOR_LIST_MAX_LENGTH = 6;
+
+    /**
      * Number of symbols decoded after which a new Huffman table is selected.
      */
     static final int HUFFMAN_GROUP_RUN_LENGTH = 50;

--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
@@ -42,8 +42,7 @@ public class Bzip2Encoder extends MessageToByteEncoder<ByteBuf> {
         INIT,
         INIT_BLOCK,
         WRITE_DATA,
-        CLOSE_BLOCK,
-        EOF
+        CLOSE_BLOCK
     }
 
     private State currentState = State.INIT;

--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2HuffmanStageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2HuffmanStageDecoder.java
@@ -15,8 +15,6 @@
  */
 package io.netty.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
-
 import static io.netty.handler.codec.compression.Bzip2Constants.*;
 
 /**
@@ -170,7 +168,7 @@ final class Bzip2HuffmanStageDecoder {
      * Decodes and returns the next symbol.
      * @return The decoded symbol
      */
-    int nextSymbol(ByteBuf in) {
+    int nextSymbol() {
         // Move to next group selector if required
         if (++groupPosition % HUFFMAN_GROUP_RUN_LENGTH == 0) {
             groupIndex++;
@@ -189,13 +187,13 @@ final class Bzip2HuffmanStageDecoder {
 
         // Starting with the minimum bit length for the table, read additional bits one at a time
         // until a complete code is recognised
-        int codeBits = reader.readBits(in, codeLength);
+        int codeBits = reader.readBits(codeLength);
         for (; codeLength <= HUFFMAN_DECODE_MAX_CODE_LENGTH; codeLength++) {
             if (codeBits <= tableLimits[codeLength]) {
                 // Convert the code to a symbol index and return
                 return tableSymbols[codeBits - tableBases[codeLength]];
             }
-            codeBits = codeBits << 1 | reader.readBits(in, 1);
+            codeBits = codeBits << 1 | reader.readBits(1);
         }
 
         throw new DecompressionException("a valid code was not recognised");


### PR DESCRIPTION
Motivation:

Before this changes `Bzip2BitReader` and `Bzip2BitWriter` accessed to a `ByteBuf` byte by byte. So tests for Bzip2 compression codec takes a lot of time if we ran them with paranoid level of resource leak detection. For more information see comments to #2681 and #2689.

Modifications:
- Increased size of bit buffers from 8 to 64 bits.
- Improved read and write operations.
- Save link to the incoming `ByteBuf` inside `Bzip2BitReader`.
- Added methods to check possible readable bits and bytes in `Bzip2BitReader`.
- Updated Bzip2 classes to use new API of `Bzip2BitReader`.
- Added new constants to `Bzip2Constants`.

Result:

Increased size of bit buffers and improved performance of Bzip2 compression codec (for general work by 13% and for tests with paranoid level of resource leak detection by 55%).

Results of benchmark to encode and decode an array of 900256 bytes (like in Bzip2 tests):

|  | normal mode | leakDetectionLevel=paranoid |
| :-- | :-: | :-: |
| before | 208 ms | 50 s |
| after | 182 ms | 22 s |
