### PR TITLE
Fire INTEREST_OPS ChannelStateEvent on change in AbstractNioWorker.

### DIFF
--- a/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioWorker.java
+++ b/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioWorker.java
@@ -488,6 +488,7 @@ abstract class AbstractNioWorker extends AbstractNioSelector implements Worker {
             }
 
             if (channel.getRawInterestOps() != newInterestOps) {
+                changed = true;
                 key.interestOps(newInterestOps);
                 if (Thread.currentThread() != thread &&
                     wakenUp.compareAndSet(false, true)) {


### PR DESCRIPTION
Motivation:

We forgot to set the flag 'changed' to 'true' after updating
interestOps.

Modifications:

Add a missing 'changed = true;'

Result:

ChannelStateEvent(INTEREST_OPS) is always triggered correctly.
