### PR TITLE
Make channelRead final in SimpleChannelInboundHandler.

### DIFF
--- a/transport/src/main/java/io/netty/channel/SimpleChannelInboundHandler.java
+++ b/transport/src/main/java/io/netty/channel/SimpleChannelInboundHandler.java
@@ -96,7 +96,7 @@ public abstract class SimpleChannelInboundHandler<I> extends ChannelHandlerAdapt
     }
 
     @Override
-    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+    public final void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         boolean release = true;
         try {
             if (acceptInboundMessage(msg)) {


### PR DESCRIPTION
Motivation:

Users might override channelRead by accident.
See http://stackoverflow.com/questions/25110538/netty-ping-pong-with-a-pojo

Modifications:

Make channelRead final.

Result:

Can't override channelRead.
