### PR TITLE
Refactoring in preparation to unify I/O logic for all branches

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -16,6 +16,9 @@
 package io.netty.buffer;
 
 import io.netty.util.CharsetUtil;
+import io.netty.util.Recycler;
+import io.netty.util.Recycler.Handle;
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -41,6 +44,8 @@ public final class ByteBufUtil {
 
     static final ByteBufAllocator DEFAULT_ALLOCATOR;
 
+    private static final int THREAD_LOCAL_BUFFER_SIZE;
+
     static {
         final char[] DIGITS = "0123456789abcdef".toCharArray();
         for (int i = 0; i < 256; i ++) {
@@ -62,6 +67,9 @@ public final class ByteBufUtil {
         }
 
         DEFAULT_ALLOCATOR = alloc;
+
+        THREAD_LOCAL_BUFFER_SIZE = SystemPropertyUtil.getInt("io.netty.threadLocalDirectBufferSize", 64 * 1024);
+        logger.debug("-Dio.netty.threadLocalDirectBufferSize: {}", THREAD_LOCAL_BUFFER_SIZE);
     }
 
     /**
@@ -376,6 +384,90 @@ public final class ByteBufUtil {
             throw new IllegalStateException(x);
         }
         return dst.flip().toString();
+    }
+
+    /**
+     * Returns a cached thread-local direct buffer, if available.
+     *
+     * @return a cached thread-local direct buffer, if available.  {@code null} otherwise.
+     */
+    public static ByteBuf threadLocalDirectBuffer() {
+        if (THREAD_LOCAL_BUFFER_SIZE <= 0) {
+            return null;
+        }
+
+        if (PlatformDependent.hasUnsafe()) {
+            return ThreadLocalUnsafeDirectByteBuf.newInstance();
+        } else {
+            return ThreadLocalDirectByteBuf.newInstance();
+        }
+    }
+
+    static final class ThreadLocalUnsafeDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
+
+        private static final Recycler<ThreadLocalUnsafeDirectByteBuf> RECYCLER =
+                new Recycler<ThreadLocalUnsafeDirectByteBuf>() {
+                    @Override
+                    protected ThreadLocalUnsafeDirectByteBuf newObject(Handle handle) {
+                        return new ThreadLocalUnsafeDirectByteBuf(handle);
+                    }
+                };
+
+        static ThreadLocalUnsafeDirectByteBuf newInstance() {
+            ThreadLocalUnsafeDirectByteBuf buf = RECYCLER.get();
+            buf.setRefCnt(1);
+            return buf;
+        }
+
+        private final Handle handle;
+
+        private ThreadLocalUnsafeDirectByteBuf(Handle handle) {
+            super(UnpooledByteBufAllocator.DEFAULT, 256, Integer.MAX_VALUE);
+            this.handle = handle;
+        }
+
+        @Override
+        protected void deallocate() {
+            if (capacity() > THREAD_LOCAL_BUFFER_SIZE) {
+                super.deallocate();
+            } else {
+                clear();
+                RECYCLER.recycle(this, handle);
+            }
+        }
+    }
+
+    static final class ThreadLocalDirectByteBuf extends UnpooledDirectByteBuf {
+
+        private static final Recycler<ThreadLocalDirectByteBuf> RECYCLER = new Recycler<ThreadLocalDirectByteBuf>() {
+            @Override
+            protected ThreadLocalDirectByteBuf newObject(Handle handle) {
+                return new ThreadLocalDirectByteBuf(handle);
+            }
+        };
+
+        static ThreadLocalDirectByteBuf newInstance() {
+            ThreadLocalDirectByteBuf buf = RECYCLER.get();
+            buf.setRefCnt(1);
+            return buf;
+        }
+
+        private final Handle handle;
+
+        private ThreadLocalDirectByteBuf(Handle handle) {
+            super(UnpooledByteBufAllocator.DEFAULT, 256, Integer.MAX_VALUE);
+            this.handle = handle;
+        }
+
+        @Override
+        protected void deallocate() {
+            if (capacity() > THREAD_LOCAL_BUFFER_SIZE) {
+                super.deallocate();
+            } else {
+                clear();
+                RECYCLER.recycle(this, handle);
+            }
+        }
     }
 
     private ByteBufUtil() { }

--- a/common/src/main/java/io/netty/util/ReferenceCountUtil.java
+++ b/common/src/main/java/io/netty/util/ReferenceCountUtil.java
@@ -62,7 +62,7 @@ public final class ReferenceCountUtil {
     }
 
     /**
-     * Try to call {@link ReferenceCounted#release()} if the specified message implements {@link ReferenceCounted}.
+     * Try to call {@link ReferenceCounted#release(int)} if the specified message implements {@link ReferenceCounted}.
      * If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
      */
     public static boolean release(Object msg, int decrement) {
@@ -70,6 +70,38 @@ public final class ReferenceCountUtil {
             return ((ReferenceCounted) msg).release(decrement);
         }
         return false;
+    }
+
+    /**
+     * Try to call {@link ReferenceCounted#release()} if the specified message implements {@link ReferenceCounted}.
+     * If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
+     * Unlike {@link #release(Object)} this method catches an exception raised by {@link ReferenceCounted#release()}
+     * and logs it, rather than rethrowing it to the caller.  It is usually recommended to use {@link #release(Object)}
+     * instead, unless you absolutely need to swallow an exception.
+     */
+    public static void safeRelease(Object msg) {
+        try {
+            release(msg);
+        } catch (Throwable t) {
+            logger.warn("Failed to release a message: {}", msg, t);
+        }
+    }
+
+    /**
+     * Try to call {@link ReferenceCounted#release(int)} if the specified message implements {@link ReferenceCounted}.
+     * If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
+     * Unlike {@link #release(Object)} this method catches an exception raised by {@link ReferenceCounted#release(int)}
+     * and logs it, rather than rethrowing it to the caller.  It is usually recommended to use
+     * {@link #release(Object, int)} instead, unless you absolutely need to swallow an exception.
+     */
+    public static void safeRelease(Object msg, int decrement) {
+        try {
+            release(msg, decrement);
+        } catch (Throwable t) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("Failed to release a message: {} (decrement: {})", msg, decrement, t);
+            }
+        }
     }
 
     /**

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -15,10 +15,15 @@
  */
 package io.netty.channel.epoll;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.EventLoop;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.OneTimeTask;
 
 import java.net.InetSocketAddress;
@@ -98,6 +103,9 @@ abstract class AbstractEpollChannel extends AbstractChannel {
 
     @Override
     protected void doBeginRead() throws Exception {
+        // Channel.read() or ChannelHandlerContext.read() was called
+        ((AbstractEpollUnsafe) unsafe()).readPending = true;
+
         if ((flags & readFlag) == 0) {
             flags |= readFlag;
             modifyEvents();
@@ -159,6 +167,47 @@ abstract class AbstractEpollChannel extends AbstractChannel {
     @Override
     protected abstract AbstractEpollUnsafe newUnsafe();
 
+    /**
+     * Returns an off-heap copy of the specified {@link ByteBuf}, and releases the original one.
+     */
+    protected final ByteBuf newDirectBuffer(ByteBuf buf) {
+        return newDirectBuffer(buf, buf);
+    }
+
+    /**
+     * Returns an off-heap copy of the specified {@link ByteBuf}, and releases the specified holder.
+     * The caller must ensure that the holder releases the original {@link ByteBuf} when the holder is released by
+     * this method.
+     */
+    protected final ByteBuf newDirectBuffer(Object holder, ByteBuf buf) {
+        final int readableBytes = buf.readableBytes();
+        if (readableBytes == 0) {
+            ReferenceCountUtil.safeRelease(holder);
+            return Unpooled.EMPTY_BUFFER;
+        }
+
+        final ByteBufAllocator alloc = alloc();
+        if (alloc.isDirectBufferPooled()) {
+            return newDirectBuffer0(holder, buf, alloc, readableBytes);
+        }
+
+        final ByteBuf directBuf = ByteBufUtil.threadLocalDirectBuffer();
+        if (directBuf == null) {
+            return newDirectBuffer0(holder, buf, alloc, readableBytes);
+        }
+
+        directBuf.writeBytes(buf, buf.readerIndex(), readableBytes);
+        ReferenceCountUtil.safeRelease(holder);
+        return directBuf;
+    }
+
+    private static ByteBuf newDirectBuffer0(Object holder, ByteBuf buf, ByteBufAllocator alloc, int capacity) {
+        final ByteBuf directBuf = alloc.directBuffer(capacity);
+        directBuf.writeBytes(buf, buf.readerIndex(), capacity);
+        ReferenceCountUtil.safeRelease(holder);
+        return directBuf;
+    }
+
     protected static void checkResolvable(InetSocketAddress addr) {
         if (addr.isUnresolved()) {
             throw new UnresolvedAddressException();
@@ -178,13 +227,6 @@ abstract class AbstractEpollChannel extends AbstractChannel {
          */
         void epollRdHupReady() {
             // NOOP
-        }
-
-        @Override
-        public void beginRead() {
-            // Channel.read() or ChannelHandlerContext.read() was called
-            readPending = true;
-            super.beginRead();
         }
 
         @Override

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -16,13 +16,14 @@
 package io.netty.channel.epoll;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufHolder;
+import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultAddressedEnvelope;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramChannelConfig;
@@ -44,6 +45,12 @@ import java.nio.channels.NotYetConnectedException;
  */
 public final class EpollDatagramChannel extends AbstractEpollChannel implements DatagramChannel {
     private static final ChannelMetadata METADATA = new ChannelMetadata(true);
+    private static final String EXPECTED_TYPES =
+            " (expected: " + StringUtil.simpleClassName(DatagramPacket.class) + ", " +
+            StringUtil.simpleClassName(AddressedEnvelope.class) + '<' +
+            StringUtil.simpleClassName(ByteBuf.class) + ", " +
+            StringUtil.simpleClassName(InetSocketAddress.class) + ">, " +
+            StringUtil.simpleClassName(ByteBuf.class) + ')';
 
     private volatile InetSocketAddress local;
     private volatile InetSocketAddress remote;
@@ -282,27 +289,20 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
     }
 
     private boolean doWriteMessage(Object msg) throws IOException {
-        final Object m;
+        final ByteBuf data;
         InetSocketAddress remoteAddress;
-        ByteBuf data;
-        if (msg instanceof DatagramPacket) {
-            DatagramPacket packet = (DatagramPacket) msg;
-            remoteAddress = packet.recipient();
-            m = packet.content();
+        if (msg instanceof AddressedEnvelope) {
+            @SuppressWarnings("unchecked")
+            AddressedEnvelope<ByteBuf, InetSocketAddress> envelope =
+                    (AddressedEnvelope<ByteBuf, InetSocketAddress>) msg;
+            data = envelope.content();
+            remoteAddress = envelope.recipient();
         } else {
-            m = msg;
+            data = (ByteBuf) msg;
             remoteAddress = null;
         }
 
-        if (m instanceof ByteBufHolder) {
-            data = ((ByteBufHolder) m).content();
-        } else if (m instanceof ByteBuf) {
-            data = (ByteBuf) m;
-        } else {
-            throw new UnsupportedOperationException("unsupported message type: " + StringUtil.simpleClassName(msg));
-        }
-
-        int dataLen = data.readableBytes();
+        final int dataLen = data.readableBytes();
         if (dataLen == 0) {
             return true;
         }
@@ -324,7 +324,55 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             writtenBytes = Native.sendTo(fd, nioData, nioData.position(), nioData.limit(),
                     remoteAddress.getAddress(), remoteAddress.getPort());
         }
+
         return writtenBytes > 0;
+    }
+
+    @Override
+    protected Object filterOutboundMessage(Object msg) {
+        if (msg instanceof DatagramPacket) {
+            DatagramPacket packet = (DatagramPacket) msg;
+            ByteBuf content = packet.content();
+            if (content.hasMemoryAddress()) {
+                return msg;
+            }
+
+            // We can only handle direct buffers so we need to copy if a non direct is
+            // passed to write.
+            return new DatagramPacket(newDirectBuffer(packet, content), packet.recipient());
+        }
+
+        if (msg instanceof ByteBuf) {
+            ByteBuf buf = (ByteBuf) msg;
+            if (buf.hasMemoryAddress()) {
+                return msg;
+            }
+
+            // We can only handle direct buffers so we need to copy if a non direct is
+            // passed to write.
+            return newDirectBuffer(buf);
+        }
+
+        if (msg instanceof AddressedEnvelope) {
+            @SuppressWarnings("unchecked")
+            AddressedEnvelope<Object, SocketAddress> e = (AddressedEnvelope<Object, SocketAddress>) msg;
+            if (e.content() instanceof ByteBuf &&
+                (e.recipient() == null || e.recipient() instanceof InetSocketAddress)) {
+
+                ByteBuf content = (ByteBuf) e.content();
+                if (content.hasMemoryAddress()) {
+                    return e;
+                }
+
+                // We can only handle direct buffers so we need to copy if a non direct is
+                // passed to write.
+                return new DefaultAddressedEnvelope<ByteBuf, InetSocketAddress>(
+                        newDirectBuffer(e, content), (InetSocketAddress) e.recipient());
+            }
+        }
+
+        throw new UnsupportedOperationException(
+                "unsupported message type: " + StringUtil.simpleClassName(msg) + EXPECTED_TYPES);
     }
 
     @Override
@@ -427,42 +475,6 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                     clearEpollIn();
                 }
             }
-        }
-
-        @Override
-        public void write(Object msg, ChannelPromise promise) {
-            if (msg instanceof DatagramPacket) {
-                DatagramPacket packet = (DatagramPacket) msg;
-                ByteBuf content = packet.content();
-                if (isCopyNeeded(content)) {
-                    // We can only handle direct buffers so we need to copy if a non direct is
-                    // passed to write.
-                    int readable = content.readableBytes();
-                    ByteBuf dst = alloc().directBuffer(readable);
-                    dst.writeBytes(content, content.readerIndex(), readable);
-
-                    content.release();
-                    msg = new DatagramPacket(dst, packet.recipient(), packet.sender());
-                }
-            } else if (msg instanceof ByteBuf) {
-                ByteBuf buf = (ByteBuf) msg;
-                if (isCopyNeeded(buf)) {
-                    // We can only handle direct buffers so we need to copy if a non direct is
-                    // passed to write.
-                    int readable = buf.readableBytes();
-                    ByteBuf dst = alloc().directBuffer(readable);
-                    dst.writeBytes(buf, buf.readerIndex(), readable);
-
-                    buf.release();
-                    msg = dst;
-                }
-            }
-
-            super.write(msg, promise);
-        }
-
-        private boolean isCopyNeeded(ByteBuf content) {
-            return !content.hasMemoryAddress() || content.nioBufferCount() != 1;
         }
     }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -74,7 +74,12 @@ public final class EpollServerSocketChannel extends AbstractEpollChannel impleme
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) {
+    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Object filterOutboundMessage(Object msg) throws Exception {
         throw new UnsupportedOperationException();
     }
 

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -35,6 +35,7 @@ import io.netty.channel.sctp.SctpMessage;
 import io.netty.channel.sctp.SctpNotificationHandler;
 import io.netty.channel.sctp.SctpServerChannel;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -320,22 +321,25 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
         mi.payloadProtocolID(packet.protocolIdentifier());
         mi.streamNumber(packet.streamIdentifier());
 
-        boolean done = false;
-        try {
-            final int writtenBytes = javaChannel().send(nioData, mi);
-            done = writtenBytes > 0;
-            return done;
-        } finally {
-            // Handle this in the finally block to make sure we release the old buffer in all cases
-            // See https://github.com/netty/netty/issues/2644
-            if (needsCopy) {
-                if (!done) {
-                    in.current(new SctpMessage(mi, data));
-                } else {
-                    in.current(data);
-                }
+        final int writtenBytes = javaChannel().send(nioData, mi);
+        return writtenBytes > 0;
+    }
+
+    @Override
+    protected final Object filterOutboundMessage(Object msg) throws Exception {
+        if (msg instanceof SctpMessage) {
+            SctpMessage m = (SctpMessage) msg;
+            ByteBuf buf = m.content();
+            if (buf.isDirect() && buf.nioBufferCount() == 1) {
+                return m;
             }
+
+            return new SctpMessage(m.protocolIdentifier(), m.streamIdentifier(), newDirectBuffer(m, buf));
         }
+
+        throw new UnsupportedOperationException(
+                "unsupported message type: " + StringUtil.simpleClassName(msg) +
+                " (expected: " + StringUtil.simpleClassName(SctpMessage.class));
     }
 
     @Override

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
@@ -221,6 +221,11 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    protected Object filterOutboundMessage(Object msg) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
     private final class NioSctpServerChannelConfig extends DefaultSctpServerChannelConfig {
         private NioSctpServerChannelConfig(NioSctpServerChannel channel, SctpServerChannel javaChannel) {
             super(channel, javaChannel);

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpChannel.java
@@ -34,6 +34,7 @@ import io.netty.channel.sctp.SctpMessage;
 import io.netty.channel.sctp.SctpNotificationHandler;
 import io.netty.channel.sctp.SctpServerChannel;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -64,6 +65,7 @@ public class OioSctpChannel extends AbstractOioMessageChannel
             InternalLoggerFactory.getInstance(OioSctpChannel.class);
 
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
+    private static final String EXPECTED_TYPE = " (expected: " + StringUtil.simpleClassName(SctpMessage.class) + ')';
 
     private final SctpChannel ch;
     private final SctpChannelConfig config;
@@ -271,6 +273,16 @@ public class OioSctpChannel extends AbstractOioMessageChannel
                 }
             }
         }
+    }
+
+    @Override
+    protected Object filterOutboundMessage(Object msg) throws Exception {
+        if (msg instanceof SctpMessage) {
+            return msg;
+        }
+
+        throw new UnsupportedOperationException(
+                "unsupported message type: " + StringUtil.simpleClassName(msg) + EXPECTED_TYPE);
     }
 
     @Override

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
@@ -290,6 +290,11 @@ public class OioSctpServerChannel extends AbstractOioMessageChannel
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    protected Object filterOutboundMessage(Object msg) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
     private final class OioSctpServerChannelConfig extends DefaultSctpServerChannelConfig {
         private OioSctpServerChannelConfig(OioSctpServerChannel channel, SctpServerChannel javaChannel) {
             super(channel, javaChannel);

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtAcceptorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtAcceptorChannel.java
@@ -99,6 +99,11 @@ public abstract class NioUdtAcceptorChannel extends AbstractNioMessageChannel im
     }
 
     @Override
+    protected final Object filterOutboundMessage(Object msg) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean isActive() {
         return javaChannel().socket().isBound();
     }

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel.java
@@ -27,6 +27,7 @@ import io.netty.channel.udt.DefaultUdtChannelConfig;
 import io.netty.channel.udt.UdtChannel;
 import io.netty.channel.udt.UdtChannelConfig;
 import io.netty.channel.udt.UdtMessage;
+import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -47,6 +48,7 @@ public class NioUdtMessageConnectorChannel extends AbstractNioMessageChannel imp
             InternalLoggerFactory.getInstance(NioUdtMessageConnectorChannel.class);
 
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
+    private static final String EXPECTED_TYPE = " (expected: " + StringUtil.simpleClassName(UdtMessage.class) + ')';
 
     private final UdtChannelConfig config;
 
@@ -194,6 +196,16 @@ public class NioUdtMessageConnectorChannel extends AbstractNioMessageChannel imp
         }
 
         return true;
+    }
+
+    @Override
+    protected final Object filterOutboundMessage(Object msg) throws Exception {
+        if (msg instanceof UdtMessage) {
+            return msg;
+        }
+
+        throw new UnsupportedOperationException(
+                "unsupported message type: " + StringUtil.simpleClassName(msg) + EXPECTED_TYPE);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -25,7 +25,6 @@ import io.netty.util.internal.ThreadLocalRandom;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -374,7 +373,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      */
     protected abstract class AbstractUnsafe implements Unsafe {
 
-        private ChannelOutboundBuffer outboundBuffer =  new ChannelOutboundBuffer(AbstractChannel.this);
+        private ChannelOutboundBuffer outboundBuffer = new ChannelOutboundBuffer(AbstractChannel.this);
         private boolean inFlush0;
 
         @Override
@@ -618,7 +617,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public void beginRead() {
+        public final void beginRead() {
             if (!isActive()) {
                 return;
             }
@@ -637,7 +636,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public void write(Object msg, ChannelPromise promise) {
+        public final void write(Object msg, ChannelPromise promise) {
             ChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
             if (outboundBuffer == null) {
                 // If the outboundBuffer is null we know the channel was closed and so
@@ -649,15 +648,25 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 ReferenceCountUtil.release(msg);
                 return;
             }
-            int size = estimatorHandle().size(msg);
-            if (size < 0) {
-                size = 0;
+
+            int size;
+            try {
+                msg = filterOutboundMessage(msg);
+                size = estimatorHandle().size(msg);
+                if (size < 0) {
+                    size = 0;
+                }
+            } catch (Throwable t) {
+                safeSetFailure(promise, t);
+                ReferenceCountUtil.release(msg);
+                return;
             }
+
             outboundBuffer.addMessage(msg, size, promise);
         }
 
         @Override
-        public void flush() {
+        public final void flush() {
             ChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
             if (outboundBuffer == null) {
                 return;
@@ -707,7 +716,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         }
 
         @Override
-        public ChannelPromise voidPromise() {
+        public final ChannelPromise voidPromise() {
             return unsafeVoidPromise;
         }
 
@@ -823,12 +832,12 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      */
     protected abstract void doWrite(ChannelOutboundBuffer in) throws Exception;
 
-    protected static void checkEOF(FileRegion region) throws IOException {
-        if (region.transfered() < region.count()) {
-            throw new EOFException("Expected to be able to write "
-                    + region.count() + " bytes, but only wrote "
-                    + region.transfered());
-        }
+    /**
+     * Invoked when a new message is added to a {@link ChannelOutboundBuffer} of this {@link AbstractChannel}, so that
+     * the {@link Channel} implementation converts the message to another. (e.g. heap buffer -> direct buffer)
+     */
+    protected Object filterOutboundMessage(Object msg) throws Exception {
+        return msg;
     }
 
     static final class CloseFuture extends DefaultChannelPromise {

--- a/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
@@ -15,7 +15,7 @@
  */
 package io.netty.channel;
 
-import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.EmptyArrays;
 
 import java.net.SocketAddress;
 
@@ -71,24 +71,14 @@ public abstract class AbstractServerChannel extends AbstractChannel implements S
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    protected final Object filterOutboundMessage(Object msg) {
+        throw new UnsupportedOperationException();
+    }
+
     private final class DefaultServerUnsafe extends AbstractUnsafe {
         @Override
-        public void write(Object msg, ChannelPromise promise) {
-            ReferenceCountUtil.release(msg);
-            reject(promise);
-        }
-
-        @Override
-        public void flush() {
-            // ignore
-        }
-
-        @Override
         public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
-            reject(promise);
-        }
-
-        private void reject(ChannelPromise promise) {
             safeSetFailure(promise, new UnsupportedOperationException());
         }
     }

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -35,6 +35,11 @@ import java.nio.channels.SelectionKey;
  * {@link AbstractNioChannel} base class for {@link Channel}s that operate on bytes.
  */
 public abstract class AbstractNioByteChannel extends AbstractNioChannel {
+
+    private static final String EXPECTED_TYPES =
+            " (expected: " + StringUtil.simpleClassName(ByteBuf.class) + ", " +
+            StringUtil.simpleClassName(FileRegion.class) + ')';
+
     private Runnable flushTask;
 
     /**
@@ -188,17 +193,6 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
                     continue;
                 }
 
-                if (!buf.isDirect()) {
-                    ByteBufAllocator alloc = alloc();
-                    if (alloc.isDirectBufferPooled()) {
-                        // Non-direct buffers are copied into JDK's own internal direct buffer on every I/O.
-                        // We can do a better job by using our pooled allocator. If the current allocator does not
-                        // pool a direct buffer, we rely on JDK's direct buffer pool.
-                        buf = alloc.directBuffer(readableBytes).writeBytes(buf);
-                        in.current(buf);
-                    }
-                }
-
                 boolean setOpWrite = false;
                 boolean done = false;
                 long flushedAmount = 0;
@@ -258,9 +252,29 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
                     break;
                 }
             } else {
-                throw new UnsupportedOperationException("unsupported message type: " + StringUtil.simpleClassName(msg));
+                // Should not reach here.
+                throw new Error();
             }
         }
+    }
+
+    @Override
+    protected final Object filterOutboundMessage(Object msg) {
+        if (msg instanceof ByteBuf) {
+            ByteBuf buf = (ByteBuf) msg;
+            if (buf.isDirect()) {
+                return msg;
+            }
+
+            return newDirectBuffer(buf);
+        }
+
+        if (msg instanceof FileRegion) {
+            return msg;
+        }
+
+        throw new UnsupportedOperationException(
+                "unsupported message type: " + StringUtil.simpleClassName(msg) + EXPECTED_TYPES);
     }
 
     protected final void incompleteWrite(boolean setOpWrite) {

--- a/transport/src/main/java/io/netty/channel/oio/AbstractOioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/AbstractOioByteChannel.java
@@ -33,10 +33,14 @@ import java.io.IOException;
  * Abstract base class for OIO which reads and writes bytes from/to a Socket
  */
 public abstract class AbstractOioByteChannel extends AbstractOioChannel {
-    private RecvByteBufAllocator.Handle allocHandle;
 
-    private volatile boolean inputShutdown;
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
+    private static final String EXPECTED_TYPES =
+            " (expected: " + StringUtil.simpleClassName(ByteBuf.class) + ", " +
+            StringUtil.simpleClassName(FileRegion.class) + ')';
+
+    private RecvByteBufAllocator.Handle allocHandle;
+    private volatile boolean inputShutdown;
 
     /**
      * @see AbstractOioByteChannel#AbstractOioByteChannel(Channel)
@@ -212,6 +216,16 @@ public abstract class AbstractOioByteChannel extends AbstractOioChannel {
                         "unsupported message type: " + StringUtil.simpleClassName(msg)));
             }
         }
+    }
+
+    @Override
+    protected final Object filterOutboundMessage(Object msg) throws Exception {
+        if (msg instanceof ByteBuf || msg instanceof FileRegion) {
+            return msg;
+        }
+
+        throw new UnsupportedOperationException(
+                "unsupported message type: " + StringUtil.simpleClassName(msg) + EXPECTED_TYPES);
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.FileRegion;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -137,6 +138,13 @@ public abstract class OioByteStreamChannel extends AbstractOioByteChannel {
             if (written >= region.count()) {
                 return;
             }
+        }
+    }
+
+    private static void checkEOF(FileRegion region) throws IOException {
+        if (region.transfered() < region.count()) {
+            throw new EOFException("Expected to be able to write " + region.count() + " bytes, " +
+                                   "but only wrote " + region.transfered());
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
@@ -179,6 +179,11 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    protected final Object filterOutboundMessage(Object msg) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
     private final class NioServerSocketChannelConfig  extends DefaultServerSocketChannelConfig {
         private NioServerSocketChannelConfig(NioServerSocketChannel channel, ServerSocket javaSocket) {
             super(channel, javaSocket);

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
@@ -175,6 +175,11 @@ public class OioServerSocketChannel extends AbstractOioMessageChannel
     }
 
     @Override
+    protected Object filterOutboundMessage(Object msg) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected void doConnect(
             SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
Motivation:

While trying to merge our ChannelOutboundBuffer changes we've made last week, I realized that we have quite a bit of conflicting changes at 4.1 and master.  It was primarily because we added ChannelOutboundBuffer.beforeAdd() and moved some logic there, such as direct buffer conversion.

However, this is not possible with the changes we've made for 4.0.  We made ChannelOutboundBuffer final for example.

Maintaining multiple branch is already getting painful and having different core will make it even worse, so I think we should keep the differences between 4.0 and other branches minimal (maybe master is fine until we merge the FJP patch.)

So, I modified the 4.0 API and added all the necessary extension points such as filterOutboundMessage() (and plus some minor cleanup as usual.)
- Move ChannelOutboundBuffer.safeRelease() to ReferenceCountUtil
- Backport ThreadLocalPooledDirectByteBuf
  - TODO: Move and polish it - netty-buffers?
- Make most public methods in AbstractUnsafe final
  - Add AbstractChannel.filterOutboundMessage() so that a transport can convert a message to another (e.g. heap -> off-heap), and also reject unsupported messages
  - Move all direct buffer conversions to filterOutboundMessage()
  - Move all message type checks to filterOutboundMessage()
- Move AbstractChannel.checkEOF() to OioByteStreamChannel, because it's the only place it is used at all

Strictly speaking, it's not a fully backward compatible change, but ChannelOutboundBuffer was never extensible practically and the added methods are either static or they are transport-implementor only with the default implementation, so I think it doesn't really matter.

Once this is merged to 4.0, I'll continue merging 4.0 to 4.1 and master.
