### PR TITLE
Consider writerIndex when LzfDecoder writes into a new heap buffer

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/LzfDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/LzfDecoder.java
@@ -147,7 +147,7 @@ public class LzfDecoder extends ByteToMessageDecoder {
 
                         ByteBuf uncompressed = ctx.alloc().heapBuffer(originalLength, originalLength);
                         final byte[] outputArray = uncompressed.array();
-                        final int outPos = uncompressed.arrayOffset();
+                        final int outPos = uncompressed.arrayOffset() + uncompressed.writerIndex();
 
                         boolean success = false;
                         try {


### PR DESCRIPTION
Motivation:

LzfDecoder do not consider writerIndex when it writes into array of a new heap buffer (when it decodes a compressed chuck of data)
