### PR TITLE
Remove code-duplication from unsafe ByteBuf implementations.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1187,4 +1187,12 @@ public abstract class AbstractByteBuf extends ByteBuf {
             throw new IllegalReferenceCountException(0);
         }
     }
+
+    ByteBuffer internalNioBuffer() {
+        throw new UnsupportedOperationException();
+    }
+
+    int idx(int index) {
+        return index;
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/DirectByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/DirectByteBufUtil.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.ScatteringByteChannel;
+
+/**
+ * Helper methods for direct {@link ByteBuf} implementations.
+ */
+final class DirectByteBufUtil {
+
+    static int _getUnsignedMedium(AbstractByteBuf byteBuf, int index) {
+        return (byteBuf._getByte(index) & 0xff) << 16 | (byteBuf._getByte(index + 1) & 0xff) << 8
+                | byteBuf._getByte(index + 2) & 0xff;
+    }
+
+    static void _setMedium(AbstractByteBuf byteBuf, int index, int value) {
+        byteBuf._setByte(index, (byte) (value >>> 16));
+        byteBuf._setByte(index + 1, (byte) (value >>> 8));
+        byteBuf._setByte(index + 2, (byte) value);
+    }
+
+    static ByteBuffer nioBuffer(AbstractByteBuf byteBuf, ByteBuffer buffer, int index, int length) {
+        byteBuf.checkIndex(index, length);
+        int pos = byteBuf.idx(index);
+        return ((ByteBuffer) buffer.duplicate().position(pos).limit(pos + length)).slice();
+    }
+
+    static void getBytes(AbstractByteBuf byteBuf, ByteBuffer buffer, int index, ByteBuffer dst) {
+        getBytes(byteBuf, buffer, index, dst, false);
+    }
+
+    private static void getBytes(AbstractByteBuf byteBuf, ByteBuffer buffer, int index,
+                                 ByteBuffer dst, boolean internal) {
+        byteBuf.checkIndex(index);
+        if (dst == null) {
+            throw new NullPointerException("dst");
+        }
+
+        int bytesToCopy = Math.min(byteBuf.capacity() - index, dst.remaining());
+        ByteBuffer tmpBuf;
+        if (internal) {
+            tmpBuf = byteBuf.internalNioBuffer();
+        } else {
+            tmpBuf = buffer.duplicate();
+        }
+        int pos = byteBuf.idx(index);
+        tmpBuf.clear().position(pos).limit(pos + bytesToCopy);
+        dst.put(tmpBuf);
+    }
+
+    static void readBytes(AbstractByteBuf byteBuf, ByteBuffer buffer, ByteBuffer dst) {
+        int length = dst.remaining();
+        byteBuf.checkReadableBytes(length);
+        getBytes(byteBuf, buffer, byteBuf.readerIndex, dst, true);
+        byteBuf.readerIndex += length;
+    }
+
+    static int getBytes(AbstractByteBuf byteBuf, ByteBuffer buffer, int index, GatheringByteChannel out, int length)
+            throws IOException {
+        return getBytes(byteBuf, buffer, index, out, length, false);
+    }
+
+    static int readBytes(AbstractByteBuf byteBuf, ByteBuffer buffer, GatheringByteChannel out, int length)
+            throws IOException {
+        byteBuf.checkReadableBytes(length);
+        int readBytes = getBytes(byteBuf, buffer, byteBuf.readerIndex, out, length, true);
+        byteBuf.readerIndex += readBytes;
+        return readBytes;
+    }
+
+    private static int getBytes(AbstractByteBuf byteBuf, ByteBuffer buffer, int index,
+                                GatheringByteChannel out, int length, boolean internal) throws IOException {
+        byteBuf.ensureAccessible();
+        if (length == 0) {
+            return 0;
+        }
+
+        ByteBuffer tmpBuf;
+        if (internal) {
+            tmpBuf = byteBuf.internalNioBuffer();
+        } else {
+            tmpBuf = buffer.duplicate();
+        }
+        int pos = byteBuf.idx(index);
+        tmpBuf.clear().position(pos).limit(pos + length);
+        return out.write(tmpBuf);
+    }
+
+    static void getBytes(AbstractByteBuf byteBuf, ByteBuffer buffer, int index, byte[] dst, int dstIndex, int length) {
+        getBytes(byteBuf, buffer, index, dst, dstIndex, length, false);
+    }
+
+    private static void getBytes(AbstractByteBuf byteBuf, ByteBuffer buffer,
+                                 int index, byte[] dst, int dstIndex, int length, boolean internal) {
+        byteBuf.checkDstIndex(index, length, dstIndex, dst.length);
+
+        if (dstIndex < 0 || dstIndex > dst.length - length) {
+            throw new IndexOutOfBoundsException(String.format(
+                    "dstIndex: %d, length: %d (expected: range(0, %d))", dstIndex, length, dst.length));
+        }
+
+        ByteBuffer tmpBuf;
+        if (internal) {
+            tmpBuf = byteBuf.internalNioBuffer();
+        } else {
+            tmpBuf = buffer.duplicate();
+        }
+        tmpBuf.clear().position(index).limit(index + length);
+        tmpBuf.get(dst, dstIndex, length);
+    }
+
+    static void readBytes(AbstractByteBuf byteBuf, ByteBuffer buffer, byte[] dst, int dstIndex, int length) {
+        byteBuf.checkReadableBytes(length);
+        getBytes(byteBuf, buffer, byteBuf.readerIndex, dst, dstIndex, length, true);
+        byteBuf.readerIndex += length;
+    }
+
+    static void getBytes(AbstractByteBuf byteBuf, int index, ByteBuf dst, int dstIndex, int length) {
+        byteBuf.checkDstIndex(index, length, dstIndex, dst.capacity());
+        if (dst.hasArray()) {
+            byteBuf.getBytes(index, dst.array(), dst.arrayOffset() + dstIndex, length);
+        } else if (dst.nioBufferCount() > 0) {
+            for (ByteBuffer bb: dst.nioBuffers(dstIndex, length)) {
+                int bbLen = bb.remaining();
+                byteBuf.getBytes(index, bb);
+                index += bbLen;
+            }
+        } else {
+            dst.setBytes(dstIndex, byteBuf, index, length);
+        }
+    }
+
+    static void getBytes(AbstractByteBuf byteBuf, ByteBuffer buffer, int index, OutputStream out, int length)
+            throws IOException {
+        getBytes(byteBuf, buffer, index, out, length, false);
+    }
+
+    private static void getBytes(AbstractByteBuf byteBuf, ByteBuffer buffer, int index,
+                          OutputStream out, int length, boolean internal) throws IOException {
+        byteBuf.ensureAccessible();
+        if (length == 0) {
+            return;
+        }
+        byte[] tmp = new byte[length];
+        ByteBuffer tmpBuf;
+        if (internal) {
+            tmpBuf = byteBuf.internalNioBuffer();
+        } else {
+            tmpBuf = buffer.duplicate();
+        }
+        tmpBuf.clear().position(index);
+        tmpBuf.get(tmp);
+        out.write(tmp);
+    }
+
+    static void readBytes(
+            AbstractByteBuf byteBuf, ByteBuffer buffer, OutputStream out, int length) throws IOException {
+        byteBuf.checkReadableBytes(length);
+        getBytes(byteBuf, buffer, byteBuf.readerIndex, out, length, true);
+        byteBuf.readerIndex += length;
+    }
+
+    static void setBytes(AbstractByteBuf byteBuf, int index, ByteBuffer src) {
+        byteBuf.ensureAccessible();
+        ByteBuffer tmpBuf = byteBuf.internalNioBuffer();
+        if (src == tmpBuf) {
+            src = src.duplicate();
+        }
+        int pos = byteBuf.idx(index);
+        tmpBuf.clear().position(pos).limit(pos + src.remaining());
+        tmpBuf.put(src);
+    }
+
+    static int setBytes(AbstractByteBuf byteBuf, int index, ScatteringByteChannel in, int length) throws IOException {
+        byteBuf.ensureAccessible();
+        ByteBuffer tmpBuf = byteBuf.internalNioBuffer();
+        int pos = byteBuf.idx(index);
+        tmpBuf.clear().position(pos).limit(pos + length);
+        try {
+            return in.read(tmpBuf);
+        } catch (ClosedChannelException ignored) {
+            return -1;
+        }
+    }
+
+    static int setBytes(AbstractByteBuf byteBuf, int index, InputStream in, int length) throws IOException {
+        byteBuf.ensureAccessible();
+        byte[] tmp = new byte[length];
+        int readBytes = in.read(tmp);
+        if (readBytes <= 0) {
+            return readBytes;
+        }
+        ByteBuffer tmpBuf = byteBuf.internalNioBuffer();
+        tmpBuf.clear().position(index);
+        tmpBuf.put(tmp, 0, readBytes);
+        return readBytes;
+    }
+
+    static void setBytes(AbstractByteBuf byteBuf, int index, ByteBuf src, int srcIndex, int length) {
+        byteBuf.checkSrcIndex(index, length, srcIndex, src.capacity());
+        if (src.nioBufferCount() > 0) {
+            for (ByteBuffer bb: src.nioBuffers(srcIndex, length)) {
+                int bbLen = bb.remaining();
+                byteBuf.setBytes(index, bb);
+                index += bbLen;
+            }
+        } else {
+            src.getBytes(srcIndex, byteBuf, index, length);
+        }
+    }
+
+    static void setBytes(AbstractByteBuf byteBuf, int index, byte[] src, int srcIndex, int length) {
+        byteBuf.checkSrcIndex(index, length, srcIndex, src.length);
+        ByteBuffer tmpBuf = byteBuf.internalNioBuffer();
+        int pos = byteBuf.idx(index);
+        tmpBuf.clear().position(pos).limit(pos + length);
+        tmpBuf.put(src, srcIndex, length);
+    }
+
+    static ByteBuf copy(AbstractByteBuf byteBuf, int index, int length) {
+        byteBuf.checkIndex(index, length);
+        ByteBuf copy = byteBuf.alloc().directBuffer(length, byteBuf.maxCapacity());
+        copy.writeBytes(byteBuf, index, length);
+        return copy;
+    }
+
+    static ByteBuffer internalNioBuffer(AbstractByteBuf byteBuf, int index, int length) {
+        byteBuf.checkIndex(index, length);
+        int pos = byteBuf.idx(index);
+        return (ByteBuffer) byteBuf.internalNioBuffer().clear().position(pos).limit(pos + length);
+    }
+
+    private DirectByteBufUtil() { }
+}

--- a/buffer/src/main/java/io/netty/buffer/HeapByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/HeapByteBufUtil.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.internal.PlatformDependent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.ScatteringByteChannel;
+
+/**
+ * Helper methods for heap {@link ByteBuf} implementations.
+ */
+final class HeapByteBufUtil {
+
+    static void getBytes(AbstractByteBuf byteBuf, int index, ByteBuf dst, int dstIndex, int length) {
+        byteBuf.checkDstIndex(index, length, dstIndex, dst.capacity());
+        if (dst.hasMemoryAddress()) {
+            PlatformDependent.copyMemory(byteBuf.array(), byteBuf.idx(index), dst.memoryAddress() + dstIndex, length);
+        } else if (dst.hasArray()) {
+            byteBuf.getBytes(index, dst.array(), dst.arrayOffset() + dstIndex, length);
+        } else {
+            dst.setBytes(dstIndex, byteBuf.array(), byteBuf.idx(index), length);
+        }
+    }
+
+    static void getBytes(AbstractByteBuf byteBuf, int index, byte[] dst, int dstIndex, int length) {
+        byteBuf.checkDstIndex(index, length, dstIndex, dst.length);
+        System.arraycopy(byteBuf.array(), byteBuf.idx(index), dst, dstIndex, length);
+    }
+
+    static void getBytes(AbstractByteBuf byteBuf, int index, ByteBuffer dst) {
+        byteBuf.checkIndex(index);
+        dst.put(byteBuf.array(), byteBuf.idx(index), Math.min(byteBuf.capacity() - index, dst.remaining()));
+    }
+
+    static void getBytes(AbstractByteBuf byteBuf, int index, OutputStream out, int length) throws IOException {
+        byteBuf.ensureAccessible();
+        out.write(byteBuf.array(), byteBuf.idx(index), length);
+    }
+
+    static int getBytes(AbstractByteBuf byteBuf, int index, GatheringByteChannel out, int length) throws IOException {
+        return getBytes(byteBuf, index, out, length, false);
+    }
+
+    private static int getBytes(AbstractByteBuf byteBuf, int index, GatheringByteChannel out,
+                                int length, boolean internal) throws IOException {
+        byteBuf.ensureAccessible();
+        ByteBuffer tmpBuf;
+        if (internal) {
+            tmpBuf = byteBuf.internalNioBuffer();
+        } else {
+            tmpBuf = ByteBuffer.wrap(byteBuf.array());
+        }
+        int pos = byteBuf.idx(index);
+        return out.write((ByteBuffer) tmpBuf.clear().position(pos).limit(pos + length));
+    }
+
+    static int readBytes(AbstractByteBuf byteBuf, GatheringByteChannel out, int length) throws IOException {
+        byteBuf.checkReadableBytes(length);
+        int readBytes = getBytes(byteBuf, byteBuf.readerIndex, out, length, true);
+        byteBuf.readerIndex += readBytes;
+        return readBytes;
+    }
+
+    static void setBytes(AbstractByteBuf byteBuf, int index, ByteBuf src, int srcIndex, int length) {
+        byteBuf.checkSrcIndex(index, length, srcIndex, src.capacity());
+        if (src.hasMemoryAddress()) {
+            PlatformDependent.copyMemory(src.memoryAddress() + srcIndex, byteBuf.array(), byteBuf.idx(index), length);
+        } else  if (src.hasArray()) {
+            byteBuf.setBytes(index, src.array(), src.arrayOffset() + srcIndex, length);
+        } else {
+            src.getBytes(srcIndex, byteBuf.array(), byteBuf.idx(index), length);
+        }
+    }
+
+    static void setBytes(AbstractByteBuf byteBuf, int index, byte[] src, int srcIndex, int length) {
+        byteBuf.checkSrcIndex(index, length, srcIndex, src.length);
+        System.arraycopy(src, srcIndex, byteBuf.array(), byteBuf.idx(index), length);
+    }
+
+    static void setBytes(AbstractByteBuf byteBuf, int index, ByteBuffer src) {
+        byteBuf.ensureAccessible();
+        src.get(byteBuf.array(), byteBuf.idx(index), src.remaining());
+    }
+
+    static int setBytes(AbstractByteBuf byteBuf, int index, InputStream in, int length) throws IOException {
+        byteBuf.ensureAccessible();
+        return in.read(byteBuf.array(), byteBuf.idx(index), length);
+    }
+
+    static int setBytes(AbstractByteBuf byteBuf, int index, ScatteringByteChannel in, int length) throws IOException {
+        byteBuf.ensureAccessible();
+        try {
+            int pos = byteBuf.idx(index);
+            return in.read((ByteBuffer) byteBuf.internalNioBuffer().clear().position(pos).limit(pos + length));
+        } catch (ClosedChannelException ignored) {
+            return -1;
+        }
+    }
+
+    static ByteBuffer nioBuffer(AbstractByteBuf byteBuf, int index, int length) {
+        byteBuf.ensureAccessible();
+        int pos = byteBuf.idx(index);
+        return ByteBuffer.wrap(byteBuf.array(), pos, length).slice();
+    }
+
+    static ByteBuffer internalNioBuffer(AbstractByteBuf byteBuf, int index, int length) {
+        byteBuf.checkIndex(index, length);
+        int pos = byteBuf.idx(index);
+        return (ByteBuffer) byteBuf.internalNioBuffer().clear().position(pos).limit(pos + length);
+    }
+
+    static byte _getByte(byte[] array, int idx) {
+        return array[idx];
+    }
+
+    static short _getShort(byte[] array, int idx) {
+        return (short) (array[idx] << 8 | array[idx + 1] & 0xFF);
+    }
+
+    static int _getUnsignedMedium(byte[] array, int idx) {
+        return  (array[idx]     & 0xff) << 16 |
+                (array[idx + 1] & 0xff) <<  8 |
+                array[idx + 2] & 0xff;
+    }
+
+    static int _getInt(byte[] array, int idx) {
+        return  (array[idx]     & 0xff) << 24 |
+                (array[idx + 1] & 0xff) << 16 |
+                (array[idx + 2] & 0xff) <<  8 |
+                array[idx + 3] & 0xff;
+    }
+
+    static long _getLong(byte[] array, int idx) {
+        return  ((long) array[idx]     & 0xff) << 56 |
+                ((long) array[idx + 1] & 0xff) << 48 |
+                ((long) array[idx + 2] & 0xff) << 40 |
+                ((long) array[idx + 3] & 0xff) << 32 |
+                ((long) array[idx + 4] & 0xff) << 24 |
+                ((long) array[idx + 5] & 0xff) << 16 |
+                ((long) array[idx + 6] & 0xff) <<  8 |
+                (long) array[idx + 7] & 0xff;
+    }
+
+    static void _setByte(byte[] array, int idx, int value) {
+        array[idx] = (byte) value;
+    }
+
+    static void _setShort(byte[] array, int idx, int value) {
+        array[idx]     = (byte) (value >>> 8);
+        array[idx + 1] = (byte) value;
+    }
+
+    static void _setMedium(byte[] array, int idx, int value) {
+        array[idx]     = (byte) (value >>> 16);
+        array[idx + 1] = (byte) (value >>> 8);
+        array[idx + 2] = (byte) value;
+    }
+
+    static void _setInt(byte[] array, int idx, int value) {
+        array[idx]     = (byte) (value >>> 24);
+        array[idx + 1] = (byte) (value >>> 16);
+        array[idx + 2] = (byte) (value >>> 8);
+        array[idx + 3] = (byte) value;
+    }
+
+    static void _setLong(byte[] array, int idx, long value) {
+        array[idx]     = (byte) (value >>> 56);
+        array[idx + 1] = (byte) (value >>> 48);
+        array[idx + 2] = (byte) (value >>> 40);
+        array[idx + 3] = (byte) (value >>> 32);
+        array[idx + 4] = (byte) (value >>> 24);
+        array[idx + 5] = (byte) (value >>> 16);
+        array[idx + 6] = (byte) (value >>> 8);
+        array[idx + 7] = (byte) value;
+    }
+
+    static ByteBuf copy(AbstractByteBuf byteBuf, int index, int length) {
+        byteBuf.checkIndex(index, length);
+        ByteBuf buffer = byteBuf.alloc().heapBuffer(length);
+        byteBuf.getBytes(index, buffer, length);
+        return buffer;
+    }
+
+    private HeapByteBufUtil() { }
+}

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -124,6 +124,7 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
         return null;
     }
 
+    @Override
     protected final ByteBuffer internalNioBuffer() {
         ByteBuffer tmpNioBuf = this.tmpNioBuf;
         if (tmpNioBuf == null) {
@@ -154,6 +155,7 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
 
     protected abstract Recycler<?> recycler();
 
+    @Override
     protected final int idx(int index) {
         return offset + index;
     }

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -262,6 +262,7 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
         throw new ReadOnlyBufferException();
     }
 
+    @Override
     protected final ByteBuffer internalNioBuffer() {
         ByteBuffer tmpNioBuf = this.tmpNioBuf;
         if (tmpNioBuf == null) {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
@@ -22,7 +22,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.channels.ClosedChannelException;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 
@@ -32,9 +31,6 @@ import java.nio.channels.ScatteringByteChannel;
  * constructor explicitly.
  */
 public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf {
-
-    private static final boolean NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
-
     private final ByteBufAllocator alloc;
 
     private long memoryAddress;
@@ -216,237 +212,120 @@ public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf
 
     @Override
     protected byte _getByte(int index) {
-        return PlatformDependent.getByte(addr(index));
+        return UnsafeDirectByteBufUtil._getByte(this, index);
     }
 
     @Override
     protected short _getShort(int index) {
-        short v = PlatformDependent.getShort(addr(index));
-        return NATIVE_ORDER? v : Short.reverseBytes(v);
+        return UnsafeDirectByteBufUtil._getShort(this, index);
     }
 
     @Override
     protected int _getUnsignedMedium(int index) {
-        long addr = addr(index);
-        return (PlatformDependent.getByte(addr) & 0xff) << 16 |
-                (PlatformDependent.getByte(addr + 1) & 0xff) << 8 |
-                PlatformDependent.getByte(addr + 2) & 0xff;
+        return UnsafeDirectByteBufUtil._getUnsignedMedium(this, index);
     }
 
     @Override
     protected int _getInt(int index) {
-        int v = PlatformDependent.getInt(addr(index));
-        return NATIVE_ORDER? v : Integer.reverseBytes(v);
+        return UnsafeDirectByteBufUtil._getInt(this, index);
     }
 
     @Override
     protected long _getLong(int index) {
-        long v = PlatformDependent.getLong(addr(index));
-        return NATIVE_ORDER? v : Long.reverseBytes(v);
+        return UnsafeDirectByteBufUtil._getLong(this, index);
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
-        checkIndex(index, length);
-        if (dst == null) {
-            throw new NullPointerException("dst");
-        }
-        if (dstIndex < 0 || dstIndex > dst.capacity() - length) {
-            throw new IndexOutOfBoundsException("dstIndex: " + dstIndex);
-        }
-
-        if (dst.hasMemoryAddress()) {
-            PlatformDependent.copyMemory(addr(index), dst.memoryAddress() + dstIndex, length);
-        } else if (dst.hasArray()) {
-            PlatformDependent.copyMemory(addr(index), dst.array(), dst.arrayOffset() + dstIndex, length);
-        } else {
-            dst.setBytes(dstIndex, this, index, length);
-        }
+        UnsafeDirectByteBufUtil.getBytes(this, index, dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
-        checkIndex(index, length);
-        if (dst == null) {
-            throw new NullPointerException("dst");
-        }
-        if (dstIndex < 0 || dstIndex > dst.length - length) {
-            throw new IndexOutOfBoundsException(String.format(
-                    "dstIndex: %d, length: %d (expected: range(0, %d))", dstIndex, length, dst.length));
-        }
-
-        if (length != 0) {
-            PlatformDependent.copyMemory(addr(index), dst, dstIndex, length);
-        }
+        UnsafeDirectByteBufUtil.getBytes(this, index, dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuffer dst) {
-        getBytes(index, dst, false);
+        DirectByteBufUtil.getBytes(this, buffer, index, dst);
         return this;
-    }
-
-    private void getBytes(int index, ByteBuffer dst, boolean internal) {
-        checkIndex(index);
-        if (dst == null) {
-            throw new NullPointerException("dst");
-        }
-
-        int bytesToCopy = Math.min(capacity() - index, dst.remaining());
-        ByteBuffer tmpBuf;
-        if (internal) {
-            tmpBuf = internalNioBuffer();
-        } else {
-            tmpBuf = buffer.duplicate();
-        }
-        tmpBuf.clear().position(index).limit(index + bytesToCopy);
-        dst.put(tmpBuf);
     }
 
     @Override
     public ByteBuf readBytes(ByteBuffer dst) {
-        int length = dst.remaining();
-        checkReadableBytes(length);
-        getBytes(readerIndex, dst, true);
-        readerIndex += length;
+        DirectByteBufUtil.readBytes(this, buffer, dst);
         return this;
     }
 
     @Override
     protected void _setByte(int index, int value) {
-        PlatformDependent.putByte(addr(index), (byte) value);
+        UnsafeDirectByteBufUtil._setByte(this, index, value);
     }
 
     @Override
     protected void _setShort(int index, int value) {
-        PlatformDependent.putShort(addr(index), NATIVE_ORDER ? (short) value : Short.reverseBytes((short) value));
+        UnsafeDirectByteBufUtil._setShort(this, index, value);
     }
 
     @Override
     protected void _setMedium(int index, int value) {
-        long addr = addr(index);
-        PlatformDependent.putByte(addr, (byte) (value >>> 16));
-        PlatformDependent.putByte(addr + 1, (byte) (value >>> 8));
-        PlatformDependent.putByte(addr + 2, (byte) value);
+        UnsafeDirectByteBufUtil._setMedium(this, index, value);
     }
 
     @Override
     protected void _setInt(int index, int value) {
-        PlatformDependent.putInt(addr(index), NATIVE_ORDER ? value : Integer.reverseBytes(value));
+        UnsafeDirectByteBufUtil._setInt(this, index, value);
     }
 
     @Override
     protected void _setLong(int index, long value) {
-        PlatformDependent.putLong(addr(index), NATIVE_ORDER ? value : Long.reverseBytes(value));
+        UnsafeDirectByteBufUtil._setLong(this, index, value);
     }
 
     @Override
     public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
-        checkIndex(index, length);
-        if (src == null) {
-            throw new NullPointerException("src");
-        }
-        if (srcIndex < 0 || srcIndex > src.capacity() - length) {
-            throw new IndexOutOfBoundsException("srcIndex: " + srcIndex);
-        }
-
-        if (length != 0) {
-            if (src.hasMemoryAddress()) {
-                PlatformDependent.copyMemory(src.memoryAddress() + srcIndex, addr(index), length);
-            } else if (src.hasArray()) {
-                PlatformDependent.copyMemory(src.array(), src.arrayOffset() + srcIndex, addr(index), length);
-            } else {
-                src.getBytes(srcIndex, this, index, length);
-            }
-        }
+        UnsafeDirectByteBufUtil.setBytes(this, index, src, srcIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
-        checkIndex(index, length);
-        if (length != 0) {
-            PlatformDependent.copyMemory(src, srcIndex, addr(index), length);
-        }
+        UnsafeDirectByteBufUtil.setBytes(this, index, src, srcIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf setBytes(int index, ByteBuffer src) {
-        ensureAccessible();
-        ByteBuffer tmpBuf = internalNioBuffer();
-        if (src == tmpBuf) {
-            src = src.duplicate();
-        }
-
-        tmpBuf.clear().position(index).limit(index + src.remaining());
-        tmpBuf.put(src);
+        DirectByteBufUtil.setBytes(this, index, src);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, OutputStream out, int length) throws IOException {
-        ensureAccessible();
-        if (length != 0) {
-            byte[] tmp = new byte[length];
-            PlatformDependent.copyMemory(addr(index), tmp, 0, length);
-            out.write(tmp);
-        }
+        UnsafeDirectByteBufUtil.getBytes(this, index, out, length);
         return this;
     }
 
     @Override
     public int getBytes(int index, GatheringByteChannel out, int length) throws IOException {
-        return getBytes(index, out, length, false);
-    }
-
-    private int getBytes(int index, GatheringByteChannel out, int length, boolean internal) throws IOException {
-        ensureAccessible();
-        if (length == 0) {
-            return 0;
-        }
-
-        ByteBuffer tmpBuf;
-        if (internal) {
-            tmpBuf = internalNioBuffer();
-        } else {
-            tmpBuf = buffer.duplicate();
-        }
-        tmpBuf.clear().position(index).limit(index + length);
-        return out.write(tmpBuf);
+        return DirectByteBufUtil.getBytes(this, buffer, index, out, length);
     }
 
     @Override
     public int readBytes(GatheringByteChannel out, int length) throws IOException {
-        checkReadableBytes(length);
-        int readBytes = getBytes(readerIndex, out, length, true);
-        readerIndex += readBytes;
-        return readBytes;
+        return DirectByteBufUtil.readBytes(this, buffer, out, length);
     }
 
     @Override
     public int setBytes(int index, InputStream in, int length) throws IOException {
-        checkIndex(index, length);
-        byte[] tmp = new byte[length];
-        int readBytes = in.read(tmp);
-        if (readBytes > 0) {
-            PlatformDependent.copyMemory(tmp, 0, addr(index), readBytes);
-        }
-        return readBytes;
+        return UnsafeDirectByteBufUtil.setBytes(this, index, in, length);
     }
 
     @Override
     public int setBytes(int index, ScatteringByteChannel in, int length) throws IOException {
-        ensureAccessible();
-        ByteBuffer tmpBuf = internalNioBuffer();
-        tmpBuf.clear().position(index).limit(index + length);
-        try {
-            return in.read(tmpBuf);
-        } catch (ClosedChannelException ignored) {
-            return -1;
-        }
+        return DirectByteBufUtil.setBytes(this, index, in, length);
     }
 
     @Override
@@ -461,26 +340,16 @@ public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf
 
     @Override
     public ByteBuf copy(int index, int length) {
-        checkIndex(index, length);
-        ByteBuf copy = alloc().directBuffer(length, maxCapacity());
-        if (length != 0) {
-            if (copy.hasMemoryAddress()) {
-                PlatformDependent.copyMemory(addr(index), copy.memoryAddress(), length);
-                copy.setIndex(0, length);
-            } else {
-                copy.writeBytes(this, index, length);
-            }
-        }
-        return copy;
+        return UnsafeDirectByteBufUtil.copy(this, index, length);
     }
 
     @Override
     public ByteBuffer internalNioBuffer(int index, int length) {
-        checkIndex(index, length);
-        return (ByteBuffer) internalNioBuffer().clear().position(index).limit(index + length);
+        return DirectByteBufUtil.internalNioBuffer(this, index, length);
     }
 
-    private ByteBuffer internalNioBuffer() {
+    @Override
+    ByteBuffer internalNioBuffer() {
         ByteBuffer tmpNioBuf = this.tmpNioBuf;
         if (tmpNioBuf == null) {
             this.tmpNioBuf = tmpNioBuf = buffer.duplicate();
@@ -490,8 +359,7 @@ public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf
 
     @Override
     public ByteBuffer nioBuffer(int index, int length) {
-        checkIndex(index, length);
-        return ((ByteBuffer) buffer.duplicate().position(index).limit(index + length)).slice();
+        return DirectByteBufUtil.nioBuffer(this, buffer, index, length);
     }
 
     @Override
@@ -511,10 +379,6 @@ public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf
     @Override
     public ByteBuf unwrap() {
         return null;
-    }
-
-    long addr(int index) {
-        return memoryAddress + index;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnsafeDirectByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeDirectByteBufUtil.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.internal.PlatformDependent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteOrder;
+
+/**
+ * Helper methods for direct {@link ByteBuf} implementations that use {@link sun.misc.Unsafe}
+ */
+final class UnsafeDirectByteBufUtil {
+    private static final boolean NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
+
+    static byte _getByte(ByteBuf byteBuf, int index) {
+        return PlatformDependent.getByte(addr(byteBuf, index));
+    }
+
+    static short _getShort(ByteBuf byteBuf, int index) {
+        return _getShort(byteBuf, index, NATIVE_ORDER);
+    }
+
+    static short _getShort(ByteBuf byteBuf, int index, boolean nativeByteOrder) {
+        short v = PlatformDependent.getShort(addr(byteBuf, index));
+        return nativeByteOrder? v : Short.reverseBytes(v);
+    }
+
+    static int _getUnsignedMedium(ByteBuf byteBuf, int index) {
+        long addr = addr(byteBuf, index);
+        return (PlatformDependent.getByte(addr) & 0xff) << 16 |
+                (PlatformDependent.getByte(addr + 1) & 0xff) << 8 |
+                PlatformDependent.getByte(addr + 2) & 0xff;
+    }
+
+    static int _getInt(ByteBuf byteBuf, int index) {
+        return _getInt(byteBuf, index, NATIVE_ORDER);
+    }
+
+    static int _getInt(ByteBuf byteBuf, int index, boolean nativeByteOrder) {
+        int v = PlatformDependent.getInt(addr(byteBuf, index));
+        return nativeByteOrder? v : Integer.reverseBytes(v);
+    }
+
+    static long _getLong(ByteBuf byteBuf, int index) {
+        return _getLong(byteBuf, index, NATIVE_ORDER);
+    }
+
+    static long _getLong(ByteBuf byteBuf, int index, boolean nativeByteOrder) {
+        long v = PlatformDependent.getLong(addr(byteBuf, index));
+        return nativeByteOrder? v : Long.reverseBytes(v);
+    }
+
+    static void getBytes(AbstractByteBuf byteBuf, int index, ByteBuf dst, int dstIndex, int length) {
+        byteBuf.checkIndex(index, length);
+        if (dst == null) {
+            throw new NullPointerException("dst");
+        }
+        if (dstIndex < 0 || dstIndex > dst.capacity() - length) {
+            throw new IndexOutOfBoundsException("dstIndex: " + dstIndex);
+        }
+
+        if (dst.hasMemoryAddress()) {
+            PlatformDependent.copyMemory(addr(byteBuf, index), dst.memoryAddress() + dstIndex, length);
+        } else if (dst.hasArray()) {
+            PlatformDependent.copyMemory(addr(byteBuf, index), dst.array(), dst.arrayOffset() + dstIndex, length);
+        } else {
+            dst.setBytes(dstIndex, byteBuf, index, length);
+        }
+    }
+
+    static void getBytes(AbstractByteBuf byteBuf, int index, byte[] dst, int dstIndex, int length) {
+        byteBuf.checkIndex(index, length);
+        if (dst == null) {
+            throw new NullPointerException("dst");
+        }
+        if (dstIndex < 0 || dstIndex > dst.length - length) {
+            throw new IndexOutOfBoundsException(String.format(
+                    "dstIndex: %d, length: %d (expected: range(0, %d))", dstIndex, length, dst.length));
+        }
+
+        if (length != 0) {
+            PlatformDependent.copyMemory(addr(byteBuf, index), dst, dstIndex, length);
+        }
+    }
+
+    static ByteBuf copy(AbstractByteBuf byteBuf, int index, int length) {
+        byteBuf.checkIndex(index, length);
+        ByteBuf copy = byteBuf.alloc().directBuffer(length, byteBuf.maxCapacity());
+        if (length != 0) {
+            if (copy.hasMemoryAddress()) {
+                PlatformDependent.copyMemory(addr(byteBuf, index), copy.memoryAddress(), length);
+                copy.setIndex(0, length);
+            } else {
+                copy.writeBytes(byteBuf, index, length);
+            }
+        }
+        return copy;
+    }
+
+    static int setBytes(AbstractByteBuf byteBuf, int index, InputStream in, int length) throws IOException {
+        byteBuf.checkIndex(index, length);
+        byte[] tmp = new byte[length];
+        int readBytes = in.read(tmp);
+        if (readBytes > 0) {
+            PlatformDependent.copyMemory(tmp, 0, addr(byteBuf, index), readBytes);
+        }
+        return readBytes;
+    }
+
+    static void _setByte(ByteBuf byteBuf, int index, int value) {
+        PlatformDependent.putByte(addr(byteBuf, index), (byte) value);
+    }
+
+    static void _setShort(ByteBuf byteBuf, int index, int value) {
+        _setShort(byteBuf, index, value, NATIVE_ORDER);
+    }
+
+    static void _setShort(ByteBuf byteBuf, int index, int value, boolean nativeByteOrder) {
+        PlatformDependent.putShort(addr(byteBuf, index),
+                nativeByteOrder ? (short) value : Short.reverseBytes((short) value));
+    }
+
+    static void _setMedium(ByteBuf byteBuf, int index, int value) {
+        long addr = addr(byteBuf, index);
+        PlatformDependent.putByte(addr, (byte) (value >>> 16));
+        PlatformDependent.putByte(addr + 1, (byte) (value >>> 8));
+        PlatformDependent.putByte(addr + 2, (byte) value);
+    }
+
+    static void _setInt(ByteBuf byteBuf, int index, int value) {
+        _setInt(byteBuf, index, value, NATIVE_ORDER);
+    }
+
+    static void _setInt(ByteBuf byteBuf, int index, int value, boolean nativeByteOrder) {
+        PlatformDependent.putInt(addr(byteBuf, index), nativeByteOrder ? value : Integer.reverseBytes(value));
+    }
+
+    static void _setLong(ByteBuf byteBuf, int index, long value) {
+        _setLong(byteBuf, index, value, NATIVE_ORDER);
+    }
+
+    static void _setLong(ByteBuf byteBuf, int index, long value, boolean nativeByteOrder) {
+        PlatformDependent.putLong(addr(byteBuf, index), nativeByteOrder ? value : Long.reverseBytes(value));
+    }
+
+    static void setBytes(AbstractByteBuf byteBuf, int index, ByteBuf src, int srcIndex, int length) {
+        byteBuf.checkIndex(index, length);
+        if (src == null) {
+            throw new NullPointerException("src");
+        }
+        if (srcIndex < 0 || srcIndex > src.capacity() - length) {
+            throw new IndexOutOfBoundsException("srcIndex: " + srcIndex);
+        }
+
+        if (length != 0) {
+            if (src.hasMemoryAddress()) {
+                PlatformDependent.copyMemory(src.memoryAddress() + srcIndex, addr(byteBuf, index), length);
+            } else if (src.hasArray()) {
+                PlatformDependent.copyMemory(src.array(), src.arrayOffset() + srcIndex, addr(byteBuf, index), length);
+            } else {
+                src.getBytes(srcIndex, byteBuf, index, length);
+            }
+        }
+    }
+
+    static void setBytes(AbstractByteBuf byteBuf, int index, byte[] src, int srcIndex, int length) {
+        byteBuf.checkIndex(index, length);
+        if (length != 0) {
+            PlatformDependent.copyMemory(src, srcIndex, addr(byteBuf, index), length);
+        }
+    }
+
+    static void getBytes(AbstractByteBuf byteBuf, int index, OutputStream out, int length) throws IOException {
+        byteBuf.ensureAccessible();
+        if (length != 0) {
+            byte[] tmp = new byte[length];
+            PlatformDependent.copyMemory(addr(byteBuf, index), tmp, 0, length);
+            out.write(tmp);
+        }
+    }
+
+    static long addr(ByteBuf buf, int index) {
+        return buf.memoryAddress() + index;
+    }
+
+    private UnsafeDirectByteBufUtil() { }
+}

--- a/buffer/src/main/java/io/netty/buffer/UnsafeDirectSwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeDirectSwappedByteBuf.java
@@ -16,8 +16,6 @@
 
 package io.netty.buffer;
 
-import io.netty.util.internal.PlatformDependent;
-
 import java.nio.ByteOrder;
 
 /**
@@ -34,19 +32,10 @@ final class UnsafeDirectSwappedByteBuf extends SwappedByteBuf {
         nativeByteOrder = NATIVE_ORDER == (order() == ByteOrder.BIG_ENDIAN);
     }
 
-    private long addr(int index) {
-        // We need to call wrapped.memoryAddress() everytime and NOT cache it as it may change if the buffer expand.
-        // See:
-        // - https://github.com/netty/netty/issues/2587
-        // - https://github.com/netty/netty/issues/2580
-        return wrapped.memoryAddress() + index;
-    }
-
     @Override
     public long getLong(int index) {
         wrapped.checkIndex(index, 8);
-        long v = PlatformDependent.getLong(addr(index));
-        return nativeByteOrder? v : Long.reverseBytes(v);
+        return UnsafeDirectByteBufUtil._getLong(wrapped, index, nativeByteOrder);
     }
 
     @Override
@@ -72,8 +61,7 @@ final class UnsafeDirectSwappedByteBuf extends SwappedByteBuf {
     @Override
     public int getInt(int index) {
         wrapped.checkIndex(index, 4);
-        int v = PlatformDependent.getInt(addr(index));
-        return nativeByteOrder? v : Integer.reverseBytes(v);
+        return UnsafeDirectByteBufUtil._getInt(wrapped, index, nativeByteOrder);
     }
 
     @Override
@@ -84,28 +72,27 @@ final class UnsafeDirectSwappedByteBuf extends SwappedByteBuf {
     @Override
     public short getShort(int index) {
         wrapped.checkIndex(index, 2);
-        short v = PlatformDependent.getShort(addr(index));
-        return nativeByteOrder? v : Short.reverseBytes(v);
+        return UnsafeDirectByteBufUtil._getShort(wrapped, index, nativeByteOrder);
     }
 
     @Override
     public ByteBuf setShort(int index, int value) {
         wrapped.checkIndex(index, 2);
-        _setShort(index, value);
+        UnsafeDirectByteBufUtil._setShort(wrapped, index, value, nativeByteOrder);
         return this;
     }
 
     @Override
     public ByteBuf setInt(int index, int value) {
         wrapped.checkIndex(index, 4);
-        _setInt(index, value);
+        UnsafeDirectByteBufUtil._setInt(wrapped, index, value, nativeByteOrder);
         return this;
     }
 
     @Override
     public ByteBuf setLong(int index, long value) {
         wrapped.checkIndex(index, 8);
-        _setLong(index, value);
+        UnsafeDirectByteBufUtil._setLong(wrapped, index, value, nativeByteOrder);
         return this;
     }
 
@@ -131,7 +118,7 @@ final class UnsafeDirectSwappedByteBuf extends SwappedByteBuf {
     public ByteBuf writeShort(int value) {
         wrapped.ensureAccessible();
         wrapped.ensureWritable(2);
-        _setShort(wrapped.writerIndex, value);
+        UnsafeDirectByteBufUtil._setShort(wrapped, wrapped.writerIndex, value, nativeByteOrder);
         wrapped.writerIndex += 2;
         return this;
     }
@@ -140,7 +127,7 @@ final class UnsafeDirectSwappedByteBuf extends SwappedByteBuf {
     public ByteBuf writeInt(int value) {
         wrapped.ensureAccessible();
         wrapped.ensureWritable(4);
-        _setInt(wrapped.writerIndex, value);
+        UnsafeDirectByteBufUtil._setInt(wrapped, wrapped.writerIndex, value, nativeByteOrder);
         wrapped.writerIndex += 4;
         return this;
     }
@@ -149,7 +136,7 @@ final class UnsafeDirectSwappedByteBuf extends SwappedByteBuf {
     public ByteBuf writeLong(long value) {
         wrapped.ensureAccessible();
         wrapped.ensureWritable(8);
-        _setLong(wrapped.writerIndex, value);
+        UnsafeDirectByteBufUtil._setLong(wrapped, wrapped.writerIndex, value, nativeByteOrder);
         wrapped.writerIndex += 8;
         return this;
     }
@@ -170,17 +157,5 @@ final class UnsafeDirectSwappedByteBuf extends SwappedByteBuf {
     public ByteBuf writeDouble(double value) {
         writeLong(Double.doubleToRawLongBits(value));
         return this;
-    }
-
-    private void _setShort(int index, int value) {
-        PlatformDependent.putShort(addr(index), nativeByteOrder ? (short) value : Short.reverseBytes((short) value));
-    }
-
-    private void _setInt(int index, int value) {
-        PlatformDependent.putInt(addr(index), nativeByteOrder ? value : Integer.reverseBytes(value));
-    }
-
-    private void _setLong(int index, long value) {
-        PlatformDependent.putLong(addr(index), nativeByteOrder ? value : Long.reverseBytes(value));
     }
 }


### PR DESCRIPTION
Motivation:

We had a lot of code-duplication in our unsafe ByteBuf implementations which make it really hard to maintain in the long term.

Modifications:

- Introduce UnsafeDirectByteBufUtil which contains all the logic to use Unsafe on
- Make use of UnsafeDirectByteBufUtil in all our unsafe ByteBuf implementations

Result:

Share a lot of code and remove duplications. This will lead to easier maintance in the long term