### PR TITLE
Fix for issue #2765 relative to unstable trafficshaping test procedure

### DIFF
--- a/testsuite/src/test/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/test/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -109,7 +109,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         }
         return minimalWaitBetween;
     }
-    
+
     private static long[] computeWaitAutoRead(int []autoRead) {
         long [] minimalWaitBetween = new long[autoRead.length + 1];
         minimalWaitBetween[0] = 0;
@@ -279,7 +279,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
             final boolean limitRead, final boolean limitWrite, final boolean globalLimit, int[] autoRead,
             long[] minimalWaitBetween, int[] multipleMessage) throws Throwable {
         TESTRUN ++;
-        logger.info("TEST: " + TESTNAME + " RUN: "+ TESTRUN +
+        logger.info("TEST: " + TESTNAME + " RUN: " + TESTRUN +
                 " Exec: " + additionalExecutor + " Read: " + limitRead + " Write: " + limitWrite + " Global: "
                 + globalLimit);
         final ServerHandler sh = new ServerHandler(autoRead, multipleMessage);
@@ -342,7 +342,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         assertTrue("Error during exceution of TrafficShapping: " + promise.cause(), promise.isSuccess());
 
         float average = (totalNb * messageSize) / (float) (stop - start);
-        logger.info("TEST: " + TESTNAME + " RUN: "+ TESTRUN +
+        logger.info("TEST: " + TESTNAME + " RUN: " + TESTRUN +
                 " Average of traffic: " + average + " compare to " + bandwidthFactor);
         sh.channel.close().sync();
         ch.channel.close().sync();


### PR DESCRIPTION
Motivation:
The test procedure is unstable due to not enough precise timestamping
during the check.

Modifications:
Reducing the test cases and cibling "stable" test ("timestamp-able")
bring more stability to the tests.

Result:
Tests for TrafficShapingHandler seem more stable (whatever using JVM 6,
7 or 8).

Will be ported to 4.1, 3.9 and master
