### PR TITLE
Upgrading to HTTP/2 draft 14 framing

### DIFF
--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>hpack</artifactId>
-      <version>0.8.0</version>
+      <version>0.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoder.java
@@ -16,6 +16,8 @@
 package io.netty.handler.codec.http2;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_HEADER_TABLE_SIZE;
+import static io.netty.handler.codec.http2.Http2Exception.protocolError;
+import static io.netty.handler.codec.http2.Http2Headers.PSEUDO_HEADER_PREFIX;
 import static io.netty.util.CharsetUtil.UTF_8;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
@@ -23,25 +25,36 @@ import io.netty.buffer.Unpooled;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Collections;
 import java.util.Map.Entry;
+import java.util.Set;
+import java.util.TreeSet;
 
 import com.twitter.hpack.Encoder;
 
 public class DefaultHttp2HeadersEncoder implements Http2HeadersEncoder {
     private final Encoder encoder;
     private final ByteBuf tableSizeChangeOutput = Unpooled.buffer();
+    private final Set<String> sensitiveHeaders = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
+    private int maxHeaderListSize = Integer.MAX_VALUE;
 
     public DefaultHttp2HeadersEncoder() {
-        this(DEFAULT_HEADER_TABLE_SIZE);
+        this(DEFAULT_HEADER_TABLE_SIZE, Collections.<String>emptySet());
     }
 
-    public DefaultHttp2HeadersEncoder(int maxHeaderTableSize) {
+    public DefaultHttp2HeadersEncoder(int maxHeaderTableSize, Set<String> sensitiveHeaders) {
         encoder = new Encoder(maxHeaderTableSize);
+        this.sensitiveHeaders.addAll(sensitiveHeaders);
     }
 
     @Override
     public void encodeHeaders(Http2Headers headers, ByteBuf buffer) throws Http2Exception {
         try {
+            if (headers.size() > maxHeaderListSize) {
+                throw protocolError("Number of headers (%d) exceeds maxHeaderListSize (%d)",
+                        headers.size(), maxHeaderListSize);
+            }
+
             // If there was a change in the table size, serialize the output from the encoder
             // resulting from that change.
             if (tableSizeChangeOutput.isReadable()) {
@@ -50,12 +63,19 @@ public class DefaultHttp2HeadersEncoder implements Http2HeadersEncoder {
             }
 
             OutputStream stream = new ByteBufOutputStream(buffer);
-            for (Entry<String, String> header : headers) {
-                byte[] key = header.getKey().getBytes(UTF_8);
-                byte[] value = header.getValue().getBytes(UTF_8);
-                encoder.encodeHeader(stream, key, value, false);
+            // Write pseudo headers first as required by the HTTP/2 spec.
+            for (Http2Headers.PseudoHeaderName pseudoHeader : Http2Headers.PseudoHeaderName.values()) {
+                String name = pseudoHeader.value();
+                String value = headers.get(name);
+                if (value != null) {
+                    encodeHeader(name, value, stream);
+                }
             }
-            encoder.endHeaders(stream);
+            for (Entry<String, String> header : headers) {
+                if (!header.getKey().startsWith(PSEUDO_HEADER_PREFIX)) {
+                    encodeHeader(header.getKey(), header.getValue(), stream);
+                }
+            }
         } catch (IOException e) {
             throw Http2Exception.format(Http2Error.COMPRESSION_ERROR,
                     "Failed encoding headers block: %s", e.getMessage());
@@ -77,4 +97,21 @@ public class DefaultHttp2HeadersEncoder implements Http2HeadersEncoder {
         return encoder.getMaxHeaderTableSize();
     }
 
+    @Override
+    public void maxHeaderListSize(int max) {
+        if (max < 0) {
+            throw new IllegalArgumentException("maxHeaderListSize must be positive: " + max);
+        }
+        maxHeaderListSize = max;
+    }
+
+    @Override
+    public int maxHeaderListSize() {
+        return maxHeaderListSize;
+    }
+
+    private void encodeHeader(String key, String value, OutputStream stream) throws IOException {
+        boolean sensitive = sensitiveHeaders.contains(key);
+        encoder.encodeHeader(stream, key.getBytes(UTF_8), value.getBytes(UTF_8), sensitive);
+    }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowController.java
@@ -66,7 +66,7 @@ public class DefaultHttp2InboundFlowController implements Http2InboundFlowContro
 
     @Override
     public void applyInboundFlowControl(int streamId, ByteBuf data, int padding,
-            boolean endOfStream, boolean endOfSegment, FrameWriter frameWriter)
+            boolean endOfStream, FrameWriter frameWriter)
             throws Http2Exception {
         int dataLength = data.readableBytes();
         applyConnectionFlowControl(dataLength, frameWriter);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandler.java
@@ -53,22 +53,22 @@ public class DelegatingHttp2ConnectionHandler extends AbstractHttp2ConnectionHan
 
     @Override
     public ChannelFuture writeData(ChannelHandlerContext ctx, ChannelPromise promise, int streamId,
-            ByteBuf data, int padding, boolean endStream, boolean endSegment) {
-        return super.writeData(ctx, promise, streamId, data, padding, endStream, endSegment);
+            ByteBuf data, int padding, boolean endStream) {
+        return super.writeData(ctx, promise, streamId, data, padding, endStream);
     }
 
     @Override
     public ChannelFuture writeHeaders(ChannelHandlerContext ctx, ChannelPromise promise,
-            int streamId, Http2Headers headers, int padding, boolean endStream, boolean endSegment) {
-        return super.writeHeaders(ctx, promise, streamId, headers, padding, endStream, endSegment);
+            int streamId, Http2Headers headers, int padding, boolean endStream) {
+        return super.writeHeaders(ctx, promise, streamId, headers, padding, endStream);
     }
 
     @Override
     public ChannelFuture writeHeaders(ChannelHandlerContext ctx, ChannelPromise promise,
             int streamId, Http2Headers headers, int streamDependency, short weight,
-            boolean exclusive, int padding, boolean endStream, boolean endSegment) {
+            boolean exclusive, int padding, boolean endStream) {
         return super.writeHeaders(ctx, promise, streamId, headers, streamDependency, weight,
-                exclusive, padding, endStream, endSegment);
+                exclusive, padding, endStream);
     }
 
     @Override
@@ -102,16 +102,16 @@ public class DelegatingHttp2ConnectionHandler extends AbstractHttp2ConnectionHan
 
     @Override
     public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
-            boolean endOfStream, boolean endOfSegment) throws Http2Exception {
-        observer.onDataRead(ctx, streamId, data, padding, endOfStream, endOfSegment);
+            boolean endOfStream) throws Http2Exception {
+        observer.onDataRead(ctx, streamId, data, padding, endOfStream);
     }
 
     @Override
     public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
-            int streamDependency, short weight, boolean exclusive, int padding, boolean endStream,
-            boolean endSegment) throws Http2Exception {
+            int streamDependency, short weight, boolean exclusive, int padding, boolean endStream)
+            throws Http2Exception {
         observer.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive,
-                padding, endStream, endSegment);
+                padding, endStream);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2HttpConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2HttpConnectionHandler.java
@@ -177,10 +177,10 @@ public class DelegatingHttp2HttpConnectionHandler extends DelegatingHttp2Connect
                 ChannelPromise headerPromise = ctx.newPromise();
                 ChannelPromise dataPromise = ctx.newPromise();
                 promiseAggregator.add(headerPromise, dataPromise);
-                writeHeaders(ctx, headerPromise, streamId, http2Headers.build(), 0, false, false);
-                writeData(ctx, dataPromise, streamId, httpMsg.content(), 0, true, true);
+                writeHeaders(ctx, headerPromise, streamId, http2Headers.build(), 0, false);
+                writeData(ctx, dataPromise, streamId, httpMsg.content(), 0, true);
             } else {
-                writeHeaders(ctx, promise, streamId, http2Headers.build(), 0, true, true);
+                writeHeaders(ctx, promise, streamId, http2Headers.build(), 0, true);
             }
         } else {
             ctx.write(msg, promise);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -20,6 +20,8 @@ import static io.netty.handler.codec.http2.Http2Exception.format;
 import static io.netty.util.CharsetUtil.UTF_8;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.Http2StreamRemovalPolicy.Action;
@@ -31,19 +33,19 @@ public final class Http2CodecUtil {
 
     private static final byte[] CONNECTION_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(UTF_8);
     private static final byte[] EMPTY_PING = new byte[8];
+    private static IgnoreSettingsHandler ignoreSettingsHandler = new IgnoreSettingsHandler();
 
     public static final int CONNECTION_STREAM_ID = 0;
     public static final int HTTP_UPGRADE_STREAM_ID = 1;
     public static final String HTTP_UPGRADE_SETTINGS_HEADER = "HTTP2-Settings";
-    public static final String HTTP_UPGRADE_PROTOCOL_NAME = "h2c-13";
+    public static final String HTTP_UPGRADE_PROTOCOL_NAME = "h2c-14";
+    public static final String TLS_UPGRADE_PROTOCOL_NAME = "h2-14";
 
-    public static final int MAX_FRAME_PAYLOAD_LENGTH = 16383;
     public static final int PING_FRAME_PAYLOAD_LENGTH = 8;
     public static final short MAX_UNSIGNED_BYTE = 0xFF;
     public static final int MAX_UNSIGNED_SHORT = 0xFFFF;
     public static final long MAX_UNSIGNED_INT = 0xFFFFFFFFL;
-    public static final int FRAME_HEADER_LENGTH = 8;
-    public static final int FRAME_LENGTH_MASK = 0x3FFF;
+    public static final int FRAME_HEADER_LENGTH = 9;
     public static final int SETTING_ENTRY_LENGTH = 6;
     public static final int PRIORITY_ENTRY_LENGTH = 5;
     public static final int INT_FIELD_LENGTH = 4;
@@ -54,12 +56,26 @@ public final class Http2CodecUtil {
     public static final int SETTINGS_ENABLE_PUSH = 2;
     public static final int SETTINGS_MAX_CONCURRENT_STREAMS = 3;
     public static final int SETTINGS_INITIAL_WINDOW_SIZE = 4;
+    public static final int SETTINGS_MAX_FRAME_SIZE = 5;
+    public static final int SETTINGS_MAX_HEADER_LIST_SIZE = 6;
+
+    public static final int MAX_FRAME_SIZE_LOWER_BOUND = 0x4000;
+    public static final int MAX_FRAME_SIZE_UPPER_BOUND = 0xFFFFFF;
 
     public static final int DEFAULT_WINDOW_SIZE = 65535;
     public static final boolean DEFAULT_ENABLE_PUSH = true;
     public static final short DEFAULT_PRIORITY_WEIGHT = 16;
     public static final int DEFAULT_HEADER_TABLE_SIZE = 4096;
     public static final int DEFAULT_MAX_HEADER_SIZE = 8192;
+    public static final int DEFAULT_MAX_FRAME_SIZE = MAX_FRAME_SIZE_LOWER_BOUND;
+
+    /**
+     * Indicates whether or not the given value for max frame size falls within the valid range.
+     */
+    public static boolean isMaxFrameSizeValid(int maxFrameSize) {
+        return maxFrameSize >= MAX_FRAME_SIZE_LOWER_BOUND
+                && maxFrameSize <= MAX_FRAME_SIZE_UPPER_BOUND;
+    }
 
     /**
      * Returns a buffer containing the the {@link #CONNECTION_PREFACE}.
@@ -104,6 +120,15 @@ public final class Http2CodecUtil {
                 action.removeStream(stream);
             }
         };
+    }
+
+    /**
+     * Creates a new {@link ChannelHandler} that does nothing but ignore inbound settings frames.
+     * This is a useful utility to avoid verbose logging output for pipelines that don't handle
+     * settings frames directly.
+     */
+    public static ChannelHandler ignoreSettingsHandler() {
+        return ignoreSettingsHandler;
     }
 
     /**
@@ -165,7 +190,7 @@ public final class Http2CodecUtil {
     public static void writeFrameHeader(ByteBuf out, int payloadLength, byte type,
             Http2Flags flags, int streamId) {
         out.ensureWritable(FRAME_HEADER_LENGTH + payloadLength);
-        out.writeShort(payloadLength);
+        out.writeMedium(payloadLength);
         out.writeByte(type);
         out.writeByte(flags.value());
         out.writeInt(streamId);
@@ -179,6 +204,21 @@ public final class Http2CodecUtil {
             promise.setFailure(cause);
         }
         throw cause;
+    }
+
+    /**
+     * A{@link ChannelHandler} that does nothing but ignore inbound settings frames. This is a
+     * useful utility to avoid verbose logging output for pipelines that don't handle settings
+     * frames directly.
+     */
+    @ChannelHandler.Sharable
+    private static class IgnoreSettingsHandler extends ChannelHandlerAdapter {
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            if (!(msg instanceof Http2Settings)) {
+                super.channelRead(ctx, msg);
+            }
+        }
     }
 
     private Http2CodecUtil() {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Flags.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Flags.java
@@ -20,7 +20,6 @@ package io.netty.handler.codec.http2;
  */
 public final class Http2Flags {
     public static final short END_STREAM = 0x1;
-    public static final short END_SEGMENT = 0x2;
     public static final short END_HEADERS = 0x4;
     public static final short ACK = 0x1;
     public static final short PADDED = 0x8;
@@ -48,14 +47,6 @@ public final class Http2Flags {
      */
     public boolean endOfStream() {
         return isFlagSet(END_STREAM);
-    }
-
-    /**
-     * Determines whether the {@link #END_SEGMENT} flag is set. Only applies to DATA and HEADERS
-     * frames.
-     */
-    public boolean endOfSegment() {
-        return isFlagSet(END_SEGMENT);
     }
 
     /**
@@ -111,13 +102,6 @@ public final class Http2Flags {
      */
     public Http2Flags endOfStream(boolean endOfStream) {
         return setFlag(endOfStream, END_STREAM);
-    }
-
-    /**
-     * Sets the {@link #END_SEGMENT} flag.
-     */
-    public Http2Flags endOfSegment(boolean endOfSegment) {
-        return setFlag(endOfSegment, END_SEGMENT);
     }
 
     /**
@@ -210,9 +194,6 @@ public final class Http2Flags {
         }
         if (priorityPresent()) {
             builder.append("PRIORITY_PRESENT,");
-        }
-        if (endOfSegment()) {
-            builder.append("END_OF_SEGMENT,");
         }
         if (paddingPresent()) {
             builder.append("PADDING_PRESENT,");

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameAdapter.java
@@ -24,18 +24,18 @@ public class Http2FrameAdapter implements Http2FrameObserver {
 
     @Override
     public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
-            boolean endOfStream, boolean endOfSegment) throws Http2Exception {
+            boolean endOfStream) throws Http2Exception {
     }
 
     @Override
     public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
-            int padding, boolean endStream, boolean endSegment) throws Http2Exception {
+            int padding, boolean endStream) throws Http2Exception {
     }
 
     @Override
     public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
-            int streamDependency, short weight, boolean exclusive, int padding, boolean endStream,
-            boolean endSegment) throws Http2Exception {
+            int streamDependency, short weight, boolean exclusive, int padding, boolean endStream)
+            throws Http2Exception {
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
@@ -51,25 +51,24 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
     }
 
     public void logData(Direction direction, int streamId, ByteBuf data, int padding,
-            boolean endStream, boolean endSegment) {
+            boolean endStream) {
         log(direction,
-                "DATA: streamId=%d, padding=%d, endStream=%b, endSegment=%b, length=%d, bytes=%s",
-                streamId, padding, endStream, endSegment, data.readableBytes(), ByteBufUtil.hexDump(data));
+                "DATA: streamId=%d, padding=%d, endStream=%b, length=%d, bytes=%s",
+                streamId, padding, endStream, data.readableBytes(), ByteBufUtil.hexDump(data));
     }
 
     public void logHeaders(Direction direction, int streamId, Http2Headers headers, int padding,
-            boolean endStream, boolean endSegment) {
-        log(direction, "HEADERS: streamId:%d, headers=%s, padding=%d, endStream=%b, endSegment=%b",
-                streamId, headers, padding, endStream, endSegment);
+            boolean endStream) {
+        log(direction, "HEADERS: streamId:%d, headers=%s, padding=%d, endStream=%b",
+                streamId, headers, padding, endStream);
     }
 
     public void logHeaders(Direction direction, int streamId, Http2Headers headers,
-            int streamDependency, short weight, boolean exclusive, int padding, boolean endStream,
-            boolean endSegment) {
+            int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) {
         log(direction,
                 "HEADERS: streamId:%d, headers=%s, streamDependency=%d, weight=%d, exclusive=%b, "
-                        + "padding=%d, endStream=%b, endSegment=%b", streamId, headers,
-                streamDependency, weight, exclusive, padding, endStream, endSegment);
+                        + "padding=%d, endStream=%b", streamId, headers,
+                streamDependency, weight, exclusive, padding, endStream);
     }
 
     public void logPriority(Direction direction, int streamId, int streamDependency, short weight,

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameObserver.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameObserver.java
@@ -33,10 +33,9 @@ public interface Http2FrameObserver {
      * @param padding the number of padding bytes found at the end of the frame.
      * @param endOfStream Indicates whether this is the last frame to be sent from the remote
      *            endpoint for this stream.
-     * @param endOfSegment Indicates whether this frame is the end of the current segment.
      */
     void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
-            boolean endOfStream, boolean endOfSegment) throws Http2Exception;
+            boolean endOfStream) throws Http2Exception;
 
     /**
      * Handles an inbound HEADERS frame.
@@ -47,10 +46,9 @@ public interface Http2FrameObserver {
      * @param padding the number of padding bytes found at the end of the frame.
      * @param endStream Indicates whether this is the last frame to be sent from the remote endpoint
      *            for this stream.
-     * @param endSegment Indicates whether this frame is the end of the current segment.
      */
     void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
-            boolean endStream, boolean endSegment) throws Http2Exception;
+            boolean endStream) throws Http2Exception;
 
     /**
      * Handles an inbound HEADERS frame with priority information specified.
@@ -65,11 +63,10 @@ public interface Http2FrameObserver {
      * @param padding the number of padding bytes found at the end of the frame.
      * @param endStream Indicates whether this is the last frame to be sent from the remote endpoint
      *            for this stream.
-     * @param endSegment Indicates whether this frame is the end of the current segment.
      */
     void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
-            int streamDependency, short weight, boolean exclusive, int padding, boolean endStream,
-            boolean endSegment) throws Http2Exception;
+            int streamDependency, short weight, boolean exclusive, int padding, boolean endStream)
+            throws Http2Exception;
 
     /**
      * Handles an inbound PRIORITY frame.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameReader.java
@@ -44,6 +44,26 @@ public interface Http2FrameReader extends Closeable {
     long maxHeaderTableSize();
 
     /**
+     * Sets the maximum allowed frame size. Attempts to read frames longer than this maximum will fail.
+     */
+    void maxFrameSize(int max);
+
+    /**
+     * Gets the maximum allowed frame size.
+     */
+    int maxFrameSize();
+
+    /**
+     * Sets the maximum allowed header elements.
+     */
+    void maxHeaderListSize(int max);
+
+    /**
+     * Gets the maximum allowed header elements.
+     */
+    int maxHeaderListSize();
+
+    /**
      * Closes this reader and frees any allocated resources.
      */
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
@@ -36,11 +36,10 @@ public interface Http2FrameWriter extends Closeable {
      * @param data the payload of the frame.
      * @param padding the amount of padding to be added to the end of the frame
      * @param endStream indicates if this is the last frame to be sent for the stream.
-     * @param endSegment indicates if this is the last frame in the current segment.
      * @return the future for the write.
      */
     ChannelFuture writeData(ChannelHandlerContext ctx, ChannelPromise promise, int streamId,
-            ByteBuf data, int padding, boolean endStream, boolean endSegment);
+            ByteBuf data, int padding, boolean endStream);
 
     /**
      * Writes a HEADERS frame to the remote endpoint.
@@ -51,11 +50,10 @@ public interface Http2FrameWriter extends Closeable {
      * @param headers the headers to be sent.
      * @param padding the amount of padding to be added to the end of the frame
      * @param endStream indicates if this is the last frame to be sent for the stream.
-     * @param endSegment indicates if this is the last frame in the current segment.
      * @return the future for the write.
      */
     ChannelFuture writeHeaders(ChannelHandlerContext ctx, ChannelPromise promise, int streamId,
-            Http2Headers headers, int padding, boolean endStream, boolean endSegment);
+            Http2Headers headers, int padding, boolean endStream);
 
     /**
      * Writes a HEADERS frame with priority specified to the remote endpoint.
@@ -70,12 +68,11 @@ public interface Http2FrameWriter extends Closeable {
      * @param exclusive whether this stream should be the exclusive dependant of its parent.
      * @param padding the amount of padding to be added to the end of the frame
      * @param endStream indicates if this is the last frame to be sent for the stream.
-     * @param endSegment indicates if this is the last frame in the current segment.
      * @return the future for the write.
      */
     ChannelFuture writeHeaders(ChannelHandlerContext ctx, ChannelPromise promise, int streamId,
             Http2Headers headers, int streamDependency, short weight, boolean exclusive,
-            int padding, boolean endStream, boolean endSegment);
+            int padding, boolean endStream);
 
     /**
      * Writes a PRIORITY frame to the remote endpoint.
@@ -206,4 +203,24 @@ public interface Http2FrameWriter extends Closeable {
      * Gets the maximum size of the HPACK header table used for decoding HTTP/2 headers.
      */
     long maxHeaderTableSize();
+
+    /**
+     * Sets the maximum allowed frame size. Attempts to write frames longer than this maximum will fail.
+     */
+    void maxFrameSize(int max);
+
+    /**
+     * Gets the maximum allowed frame size.
+     */
+    int maxFrameSize();
+
+    /**
+     * Sets the maximum allowed header elements.
+     */
+    void maxHeaderListSize(int max);
+
+    /**
+     * Gets the maximum allowed header elements.
+     */
+    int maxHeaderListSize();
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -57,6 +57,11 @@ public abstract class Http2Headers implements Iterable<Entry<String, String>> {
         }
 
         @Override
+        public int size() {
+            return 0;
+        }
+
+        @Override
         public Set<String> names() {
             return Collections.emptySet();
         }
@@ -68,42 +73,67 @@ public abstract class Http2Headers implements Iterable<Entry<String, String>> {
     };
 
     /**
-     * HTTP2 header names.
+     * The prefix used to denote an HTTP/2 psuedo-header.
      */
-    public enum HttpName {
+    public static String PSEUDO_HEADER_PREFIX = ":";
+
+    /**
+     * HTTP/2 pseudo-headers names.
+     */
+    public enum PseudoHeaderName {
         /**
          * {@code :method}.
          */
-        METHOD(":method"),
+        METHOD(PSEUDO_HEADER_PREFIX + "method"),
 
         /**
          * {@code :scheme}.
          */
-        SCHEME(":scheme"),
+        SCHEME(PSEUDO_HEADER_PREFIX + "scheme"),
 
         /**
          * {@code :authority}.
          */
-        AUTHORITY(":authority"),
+        AUTHORITY(PSEUDO_HEADER_PREFIX + "authority"),
 
         /**
          * {@code :path}.
          */
-        PATH(":path"),
+        PATH(PSEUDO_HEADER_PREFIX + "path"),
 
         /**
          * {@code :status}.
          */
-        STATUS(":status");
+        STATUS(PSEUDO_HEADER_PREFIX + "status");
 
         private final String value;
 
-        HttpName(String value) {
+        PseudoHeaderName(String value) {
             this.value = value;
         }
 
         public String value() {
             return value;
+        }
+
+        /**
+         * Indicates whether the given header name is a valid HTTP/2 pseudo header.
+         */
+        public static boolean isPseudoHeader(String header) {
+            if (header == null || !header.startsWith(Http2Headers.PSEUDO_HEADER_PREFIX)) {
+                // Not a pseudo-header.
+                return false;
+            }
+
+            // Check the header name against the set of valid pseudo-headers.
+            for (PseudoHeaderName pseudoHeader : PseudoHeaderName.values()) {
+                String pseudoHeaderName = pseudoHeader.value();
+                if (pseudoHeaderName.equals(header)) {
+                    // It's a valid pseudo-header.
+                    return true;
+                }
+            }
+            return false;
         }
     }
 
@@ -146,38 +176,43 @@ public abstract class Http2Headers implements Iterable<Entry<String, String>> {
     public abstract boolean isEmpty();
 
     /**
-     * Gets the {@link HttpName#METHOD} header or {@code null} if there is no such header
+     * Gets the number of headers contained in this object.
+     */
+    public abstract int size();
+
+    /**
+     * Gets the {@link PseudoHeaderName#METHOD} header or {@code null} if there is no such header
      */
     public final String method() {
-        return get(HttpName.METHOD.value());
+        return get(PseudoHeaderName.METHOD.value());
     }
 
     /**
-     * Gets the {@link HttpName#SCHEME} header or {@code null} if there is no such header
+     * Gets the {@link PseudoHeaderName#SCHEME} header or {@code null} if there is no such header
      */
     public final String scheme() {
-        return get(HttpName.SCHEME.value());
+        return get(PseudoHeaderName.SCHEME.value());
     }
 
     /**
-     * Gets the {@link HttpName#AUTHORITY} header or {@code null} if there is no such header
+     * Gets the {@link PseudoHeaderName#AUTHORITY} header or {@code null} if there is no such header
      */
     public final String authority() {
-        return get(HttpName.AUTHORITY.value());
+        return get(PseudoHeaderName.AUTHORITY.value());
     }
 
     /**
-     * Gets the {@link HttpName#PATH} header or {@code null} if there is no such header
+     * Gets the {@link PseudoHeaderName#PATH} header or {@code null} if there is no such header
      */
     public final String path() {
-        return get(HttpName.PATH.value());
+        return get(PseudoHeaderName.PATH.value());
     }
 
     /**
-     * Gets the {@link HttpName#STATUS} header or {@code null} if there is no such header
+     * Gets the {@link PseudoHeaderName#STATUS} header or {@code null} if there is no such header
      */
     public final String status() {
-        return get(HttpName.STATUS.value());
+        return get(PseudoHeaderName.STATUS.value());
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersDecoder.java
@@ -36,4 +36,14 @@ public interface Http2HeadersDecoder {
      * Gets the maximum header table size for this decoder.
      */
     int maxHeaderTableSize();
+
+    /**
+     * Sets the maximum allowed header elements.
+     */
+    void maxHeaderListSize(int max);
+
+    /**
+     * Gets the maximum allowed header elements.
+     */
+    int maxHeaderListSize();
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersEncoder.java
@@ -39,4 +39,14 @@ public interface Http2HeadersEncoder {
      * Gets the current maximum value for the header table size.
      */
     int maxHeaderTableSize();
+
+    /**
+     * Sets the maximum allowed header elements.
+     */
+    void maxHeaderListSize(int max);
+
+    /**
+     * Gets the maximum allowed header elements.
+     */
+    int maxHeaderListSize();
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFlowController.java
@@ -54,10 +54,9 @@ public interface Http2InboundFlowController {
      * @param data the data portion of the data frame. Does not contain padding.
      * @param padding the amount of padding received in the original frame.
      * @param endOfStream indicates whether this is the last frame for the stream.
-     * @param endOfSegment indicates whether this is the last frame for the current segment.
      * @param frameWriter allows this flow controller to send window updates to the remote endpoint.
      * @throws Http2Exception thrown if any protocol-related error occurred.
      */
     void applyInboundFlowControl(int streamId, ByteBuf data, int padding, boolean endOfStream,
-            boolean endOfSegment, FrameWriter frameWriter) throws Http2Exception;
+            FrameWriter frameWriter) throws Http2Exception;
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
@@ -46,28 +46,28 @@ public class Http2InboundFrameLogger implements Http2FrameReader {
 
             @Override
             public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data,
-                    int padding, boolean endOfStream, boolean endOfSegment)
+                    int padding, boolean endOfStream)
                     throws Http2Exception {
-                logger.logData(INBOUND, streamId, data, padding, endOfStream, endOfSegment);
-                observer.onDataRead(ctx, streamId, data, padding, endOfStream, endOfSegment);
+                logger.logData(INBOUND, streamId, data, padding, endOfStream);
+                observer.onDataRead(ctx, streamId, data, padding, endOfStream);
             }
 
             @Override
             public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
-                    Http2Headers headers, int padding, boolean endStream, boolean endSegment)
+                    Http2Headers headers, int padding, boolean endStream)
                     throws Http2Exception {
-                logger.logHeaders(INBOUND, streamId, headers, padding, endStream, endSegment);
-                observer.onHeadersRead(ctx, streamId, headers, padding, endStream, endSegment);
+                logger.logHeaders(INBOUND, streamId, headers, padding, endStream);
+                observer.onHeadersRead(ctx, streamId, headers, padding, endStream);
             }
 
             @Override
             public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
                     Http2Headers headers, int streamDependency, short weight, boolean exclusive,
-                    int padding, boolean endStream, boolean endSegment) throws Http2Exception {
+                    int padding, boolean endStream) throws Http2Exception {
                 logger.logHeaders(INBOUND, streamId, headers, streamDependency, weight, exclusive,
-                        padding, endStream, endSegment);
+                        padding, endStream);
                 observer.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive,
-                        padding, endStream, endSegment);
+                        padding, endStream);
             }
 
             @Override
@@ -154,4 +154,23 @@ public class Http2InboundFrameLogger implements Http2FrameReader {
         return reader.maxHeaderTableSize();
     }
 
+    @Override
+    public void maxFrameSize(int max) {
+        reader.maxFrameSize(max);
+    }
+
+    @Override
+    public int maxFrameSize() {
+        return reader.maxFrameSize();
+    }
+
+    @Override
+    public void maxHeaderListSize(int max) {
+        reader.maxHeaderListSize(max);
+    }
+
+    @Override
+    public int maxHeaderListSize() {
+        return reader.maxHeaderListSize();
+    }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OrHttpChooser.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OrHttpChooser.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.http2;
 
+import static io.netty.handler.codec.http2.Http2CodecUtil.TLS_UPGRADE_PROTOCOL_NAME;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -40,7 +41,7 @@ public abstract class Http2OrHttpChooser extends ByteToMessageDecoder {
 
     public enum SelectedProtocol {
         /** Must be updated to match the HTTP/2 draft number. */
-        HTTP_2("h2-13"),
+        HTTP_2(TLS_UPGRADE_PROTOCOL_NAME),
         HTTP_1_1("http/1.1"),
         HTTP_1_0("http/1.0"),
         UNKNOWN("Unknown");

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFlowController.java
@@ -30,14 +30,18 @@ public interface Http2OutboundFlowController {
         /**
          * Writes a single data frame to the remote endpoint.
          */
-        void writeFrame(int streamId, ByteBuf data, int padding, boolean endStream,
-                boolean endSegment);
+        void writeFrame(int streamId, ByteBuf data, int padding, boolean endStream);
 
         /**
          * Called if an error occurred before the write could take place. Sets the failure on the
          * channel promise.
          */
         void setFailure(Throwable cause);
+
+        /**
+         * Gets the maximum allowed frame size.
+         */
+        int maxFrameSize();
     }
 
     /**
@@ -79,10 +83,9 @@ public interface Http2OutboundFlowController {
      * @param data the data be be sent to the remote endpoint.
      * @param padding the number of bytes of padding to be added to the frame.
      * @param endStream indicates whether this frames is to be the last sent on this stream.
-     * @param endSegment indicates whether this is to be the last frame in the segment.
      * @param frameWriter peforms to the write of the frame to the remote endpoint.
      * @throws Http2Exception thrown if a protocol-related error occurred.
      */
     void sendFlowControlled(int streamId, ByteBuf data, int padding, boolean endStream,
-            boolean endSegment, FrameWriter frameWriter) throws Http2Exception;
+            FrameWriter frameWriter) throws Http2Exception;
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
@@ -43,26 +43,26 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
 
     @Override
     public ChannelFuture writeData(ChannelHandlerContext ctx, ChannelPromise promise, int streamId,
-            ByteBuf data, int padding, boolean endStream, boolean endSegment) {
-        logger.logData(OUTBOUND, streamId, data, padding, endStream, endSegment);
-        return writer.writeData(ctx, promise, streamId, data, padding, endStream, endSegment);
+            ByteBuf data, int padding, boolean endStream) {
+        logger.logData(OUTBOUND, streamId, data, padding, endStream);
+        return writer.writeData(ctx, promise, streamId, data, padding, endStream);
     }
 
     @Override
     public ChannelFuture writeHeaders(ChannelHandlerContext ctx, ChannelPromise promise,
-            int streamId, Http2Headers headers, int padding, boolean endStream, boolean endSegment) {
-        logger.logHeaders(OUTBOUND, streamId, headers, padding, endStream, endSegment);
-        return writer.writeHeaders(ctx, promise, streamId, headers, padding, endStream, endSegment);
+            int streamId, Http2Headers headers, int padding, boolean endStream) {
+        logger.logHeaders(OUTBOUND, streamId, headers, padding, endStream);
+        return writer.writeHeaders(ctx, promise, streamId, headers, padding, endStream);
     }
 
     @Override
     public ChannelFuture writeHeaders(ChannelHandlerContext ctx, ChannelPromise promise,
             int streamId, Http2Headers headers, int streamDependency, short weight,
-            boolean exclusive, int padding, boolean endStream, boolean endSegment) {
+            boolean exclusive, int padding, boolean endStream) {
         logger.logHeaders(OUTBOUND, streamId, headers, streamDependency, weight, exclusive,
-                padding, endStream, endSegment);
+                padding, endStream);
         return writer.writeHeaders(ctx, promise, streamId, headers, streamDependency, weight,
-                exclusive, padding, endStream, endSegment);
+                exclusive, padding, endStream);
     }
 
     @Override
@@ -139,5 +139,25 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
     @Override
     public long maxHeaderTableSize() {
         return writer.maxHeaderTableSize();
+    }
+
+    @Override
+    public void maxFrameSize(int max) {
+        writer.maxFrameSize(max);
+    }
+
+    @Override
+    public int maxFrameSize() {
+        return writer.maxFrameSize();
+    }
+
+    @Override
+    public void maxHeaderListSize(int max) {
+        writer.maxHeaderListSize(max);
+    }
+
+    @Override
+    public int maxHeaderListSize() {
+        return writer.maxHeaderListSize();
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
@@ -20,6 +20,9 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_ENABLE_PUSH;
 import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_HEADER_TABLE_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_INITIAL_WINDOW_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_MAX_CONCURRENT_STREAMS;
+import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_MAX_FRAME_SIZE;
+import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_MAX_HEADER_LIST_SIZE;
+import static io.netty.handler.codec.http2.Http2CodecUtil.isMaxFrameSizeValid;
 import io.netty.util.collection.IntObjectHashMap;
 
 /**
@@ -30,6 +33,7 @@ import io.netty.util.collection.IntObjectHashMap;
 public final class Http2Settings extends IntObjectHashMap<Long> {
 
     public Http2Settings() {
+        this(6 /* number of standard settings */);
     }
 
     public Http2Settings(int initialCapacity, float loadFactor) {
@@ -40,21 +44,37 @@ public final class Http2Settings extends IntObjectHashMap<Long> {
         super(initialCapacity);
     }
 
+    /**
+     * Overrides the superclass method to perform verification of standard HTTP/2 settings.
+     *
+     * @throws IllegalArgumentException if verification of the setting fails.
+     */
     @Override
     public Long put(int key, Long value) {
         verifyStandardSetting(key, value);
         return super.put(key, value);
     }
 
+    /**
+     * Gets the {@code SETTINGS_HEADER_TABLE_SIZE} value. If unavailable, returns {@code null}.
+     */
     public Long headerTableSize() {
         return get(SETTINGS_HEADER_TABLE_SIZE);
     }
 
+    /**
+     * Sets the {@code SETTINGS_HEADER_TABLE_SIZE} value.
+     *
+     * @throws IllegalArgumentException if verification of the setting fails.
+     */
     public Http2Settings headerTableSize(long value) {
         put(SETTINGS_HEADER_TABLE_SIZE, value);
         return this;
     }
 
+    /**
+     * Gets the {@code SETTINGS_ENABLE_PUSH} value. If unavailable, returns {@code null}.
+     */
     public Boolean pushEnabled() {
         Long value = get(SETTINGS_ENABLE_PUSH);
         if (value == null) {
@@ -63,37 +83,97 @@ public final class Http2Settings extends IntObjectHashMap<Long> {
         return value != 0L;
     }
 
+    /**
+     * Sets the {@code SETTINGS_ENABLE_PUSH} value.
+     */
     public Http2Settings pushEnabled(boolean enabled) {
-        put(SETTINGS_ENABLE_PUSH, enabled? 1L : 0L);
+        put(SETTINGS_ENABLE_PUSH, enabled ? 1L : 0L);
         return this;
     }
 
+    /**
+     * Gets the {@code SETTINGS_MAX_CONCURRENT_STREAMS} value. If unavailable, returns {@code null}.
+     */
     public Long maxConcurrentStreams() {
         return get(SETTINGS_MAX_CONCURRENT_STREAMS);
     }
 
+    /**
+     * Sets the {@code SETTINGS_MAX_CONCURRENT_STREAMS} value.
+     *
+     * @throws IllegalArgumentException if verification of the setting fails.
+     */
     public Http2Settings maxConcurrentStreams(long value) {
         put(SETTINGS_MAX_CONCURRENT_STREAMS, value);
         return this;
     }
 
+    /**
+     * Gets the {@code SETTINGS_INITIAL_WINDOW_SIZE} value. If unavailable, returns {@code null}.
+     */
     public Integer initialWindowSize() {
-        Long value = get(SETTINGS_INITIAL_WINDOW_SIZE);
-        if (value == null) {
-            return null;
-        }
-        return value.intValue();
+        return getIntValue(SETTINGS_INITIAL_WINDOW_SIZE);
     }
 
+    /**
+     * Sets the {@code SETTINGS_INITIAL_WINDOW_SIZE} value.
+     *
+     * @throws IllegalArgumentException if verification of the setting fails.
+     */
     public Http2Settings initialWindowSize(int value) {
         put(SETTINGS_INITIAL_WINDOW_SIZE, (long) value);
         return this;
     }
 
+    /**
+     * Gets the {@code SETTINGS_MAX_FRAME_SIZE} value. If unavailable, returns {@code null}.
+     */
+    public Integer maxFrameSize() {
+        return getIntValue(SETTINGS_MAX_FRAME_SIZE);
+    }
+
+    /**
+     * Sets the {@code SETTINGS_MAX_FRAME_SIZE} value.
+     *
+     * @throws IllegalArgumentException if verification of the setting fails.
+     */
+    public Http2Settings maxFrameSize(int value) {
+        put(SETTINGS_MAX_FRAME_SIZE, (long) value);
+        return this;
+    }
+
+    /**
+     * Gets the {@code SETTINGS_MAX_HEADER_LIST_SIZE} value. If unavailable, returns {@code null}.
+     */
+    public Integer maxHeaderListSize() {
+        return getIntValue(SETTINGS_MAX_HEADER_LIST_SIZE);
+    }
+
+    /**
+     * Sets the {@code SETTINGS_MAX_HEADER_LIST_SIZE} value.
+     *
+     * @throws IllegalArgumentException if verification of the setting fails.
+     */
+    public Http2Settings maxHeaderListSize(int value) {
+        put(SETTINGS_MAX_HEADER_LIST_SIZE, (long) value);
+        return this;
+    }
+
+    /**
+     * Clears and then copies the given settings into this object.
+     */
     public Http2Settings copyFrom(Http2Settings settings) {
         clear();
         putAll(settings);
         return this;
+    }
+
+    Integer getIntValue(int key) {
+        Long value = get(key);
+        if (value == null) {
+            return null;
+        }
+        return value.intValue();
     }
 
     private void verifyStandardSetting(int key, Long value) {
@@ -103,7 +183,8 @@ public final class Http2Settings extends IntObjectHashMap<Long> {
         switch (key) {
             case SETTINGS_HEADER_TABLE_SIZE:
                 if (value < 0L || value > MAX_UNSIGNED_INT) {
-                    throw new IllegalArgumentException("Setting HEADER_TABLE_SIZE is invalid: " + value);
+                    throw new IllegalArgumentException("Setting HEADER_TABLE_SIZE is invalid: "
+                            + value);
                 }
                 break;
             case SETTINGS_ENABLE_PUSH:
@@ -113,12 +194,26 @@ public final class Http2Settings extends IntObjectHashMap<Long> {
                 break;
             case SETTINGS_MAX_CONCURRENT_STREAMS:
                 if (value < 0L || value > MAX_UNSIGNED_INT) {
-                    throw new IllegalArgumentException("Setting MAX_CONCURRENT_STREAMS is invalid: " + value);
+                    throw new IllegalArgumentException(
+                            "Setting MAX_CONCURRENT_STREAMS is invalid: " + value);
                 }
                 break;
             case SETTINGS_INITIAL_WINDOW_SIZE:
                 if (value < 0L || value > Integer.MAX_VALUE) {
-                    throw new IllegalArgumentException("Setting INITIAL_WINDOW_SIZE is invalid: " + value);
+                    throw new IllegalArgumentException("Setting INITIAL_WINDOW_SIZE is invalid: "
+                            + value);
+                }
+                break;
+            case SETTINGS_MAX_FRAME_SIZE:
+                if (!isMaxFrameSizeValid(value.intValue())) {
+                    throw new IllegalArgumentException("Setting MAX_FRAME_SIZE is invalid: "
+                            + value);
+                }
+                break;
+            case SETTINGS_MAX_HEADER_LIST_SIZE:
+                if (value < 0) {
+                    throw new IllegalArgumentException("Setting MAX_HEADER_LIST_SIZE is invalid: "
+                            + value);
                 }
                 break;
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameIOTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameIOTest.java
@@ -67,33 +67,33 @@ public class DefaultHttp2FrameIOTest {
     @Test
     public void emptyDataShouldRoundtrip() throws Exception {
         ByteBuf data = Unpooled.EMPTY_BUFFER;
-        writer.writeData(ctx, promise, 1000, data, 0, false, false);
+        writer.writeData(ctx, promise, 1000, data, 0, false);
 
         ByteBuf frame = captureWrite();
         reader.readFrame(ctx, frame, observer);
-        verify(observer).onDataRead(eq(ctx), eq(1000), eq(data), eq(0), eq(false), eq(false));
+        verify(observer).onDataRead(eq(ctx), eq(1000), eq(data), eq(0), eq(false));
         frame.release();
     }
 
     @Test
     public void dataShouldRoundtrip() throws Exception {
         ByteBuf data = dummyData();
-        writer.writeData(ctx, promise, 1000, data.retain().duplicate(), 0, false, false);
+        writer.writeData(ctx, promise, 1000, data.retain().duplicate(), 0, false);
 
         ByteBuf frame = captureWrite();
         reader.readFrame(ctx, frame, observer);
-        verify(observer).onDataRead(eq(ctx), eq(1000), eq(data), eq(0), eq(false), eq(false));
+        verify(observer).onDataRead(eq(ctx), eq(1000), eq(data), eq(0), eq(false));
         frame.release();
     }
 
     @Test
     public void dataWithPaddingShouldRoundtrip() throws Exception {
         ByteBuf data = dummyData();
-        writer.writeData(ctx, promise, 1, data.retain().duplicate(), 0xFF, true, true);
+        writer.writeData(ctx, promise, 1, data.retain().duplicate(), 0xFF, true);
 
         ByteBuf frame = captureWrite();
         reader.readFrame(ctx, frame, observer);
-        verify(observer).onDataRead(eq(ctx), eq(1), eq(data), eq(0xFF), eq(true), eq(true));
+        verify(observer).onDataRead(eq(ctx), eq(1), eq(data), eq(0xFF), eq(true));
         frame.release();
     }
 
@@ -197,84 +197,84 @@ public class DefaultHttp2FrameIOTest {
     @Test
     public void emptyHeadersShouldRoundtrip() throws Exception {
         Http2Headers headers = Http2Headers.EMPTY_HEADERS;
-        writer.writeHeaders(ctx, promise, 1, headers, 0, true, true);
+        writer.writeHeaders(ctx, promise, 1, headers, 0, true);
         ByteBuf frame = captureWrite();
         reader.readFrame(ctx, frame, observer);
-        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0), eq(true), eq(true));
+        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0), eq(true));
         frame.release();
     }
 
     @Test
     public void emptyHeadersWithPaddingShouldRoundtrip() throws Exception {
         Http2Headers headers = Http2Headers.EMPTY_HEADERS;
-        writer.writeHeaders(ctx, promise, 1, headers, 0xFF, true, true);
+        writer.writeHeaders(ctx, promise, 1, headers, 0xFF, true);
         ByteBuf frame = captureWrite();
         reader.readFrame(ctx, frame, observer);
-        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0xFF), eq(true), eq(true));
+        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0xFF), eq(true));
         frame.release();
     }
 
     @Test
     public void headersWithoutPriorityShouldRoundtrip() throws Exception {
         Http2Headers headers = dummyHeaders();
-        writer.writeHeaders(ctx, promise, 1, headers, 0, true, true);
+        writer.writeHeaders(ctx, promise, 1, headers, 0, true);
         ByteBuf frame = captureWrite();
         reader.readFrame(ctx, frame, observer);
-        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0), eq(true), eq(true));
+        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0), eq(true));
         frame.release();
     }
 
     @Test
     public void headersWithPaddingWithoutPriorityShouldRoundtrip() throws Exception {
         Http2Headers headers = dummyHeaders();
-        writer.writeHeaders(ctx, promise, 1, headers, 0xFF, true, true);
+        writer.writeHeaders(ctx, promise, 1, headers, 0xFF, true);
         ByteBuf frame = captureWrite();
         reader.readFrame(ctx, frame, observer);
-        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0xFF), eq(true), eq(true));
+        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0xFF), eq(true));
         frame.release();
     }
 
     @Test
     public void headersWithPriorityShouldRoundtrip() throws Exception {
         Http2Headers headers = dummyHeaders();
-        writer.writeHeaders(ctx, promise, 1, headers, 2, (short) 3, true, 0, true, true);
+        writer.writeHeaders(ctx, promise, 1, headers, 2, (short) 3, true, 0, true);
         ByteBuf frame = captureWrite();
         reader.readFrame(ctx, frame, observer);
         verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0),
-                eq(true), eq(true));
+                eq(true));
         frame.release();
     }
 
     @Test
     public void headersWithPaddingWithPriorityShouldRoundtrip() throws Exception {
         Http2Headers headers = dummyHeaders();
-        writer.writeHeaders(ctx, promise, 1, headers, 2, (short) 3, true, 0xFF, true, true);
+        writer.writeHeaders(ctx, promise, 1, headers, 2, (short) 3, true, 0xFF, true);
         ByteBuf frame = captureWrite();
         reader.readFrame(ctx, frame, observer);
         verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0xFF),
-                eq(true), eq(true));
+                eq(true));
         frame.release();
     }
 
     @Test
     public void continuedHeadersShouldRoundtrip() throws Exception {
         Http2Headers headers = largeHeaders();
-        writer.writeHeaders(ctx, promise, 1, headers, 2, (short) 3, true, 0, true, true);
+        writer.writeHeaders(ctx, promise, 1, headers, 2, (short) 3, true, 0, true);
         ByteBuf frame = captureWrite();
         reader.readFrame(ctx, frame, observer);
         verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0),
-                eq(true), eq(true));
+                eq(true));
         frame.release();
     }
 
     @Test
     public void continuedHeadersWithPaddingShouldRoundtrip() throws Exception {
         Http2Headers headers = largeHeaders();
-        writer.writeHeaders(ctx, promise, 1, headers, 2, (short) 3, true, 0xFF, true, true);
+        writer.writeHeaders(ctx, promise, 1, headers, 2, (short) 3, true, 0xFF, true);
         ByteBuf frame = captureWrite();
         reader.readFrame(ctx, frame, observer);
         verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0xFF),
-                eq(true), eq(true));
+                eq(true));
         frame.release();
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.netty.handler.codec.http2;
+
+import static io.netty.util.CharsetUtil.UTF_8;
+import static org.junit.Assert.assertEquals;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import java.io.ByteArrayOutputStream;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.twitter.hpack.Encoder;
+
+
+/**
+ * Tests for {@link DefaultHttp2HeadersDecoder}.
+ */
+public class DefaultHttp2HeadersDecoderTest {
+
+    private DefaultHttp2HeadersDecoder decoder;
+
+    @Before
+    public void setup() {
+        decoder = new DefaultHttp2HeadersDecoder();
+    }
+
+    @Test
+    public void decodeShouldSucceed() throws Exception {
+        ByteBuf buf = encode(":method", "GET", "akey", "avalue");
+        Http2Headers headers = decoder.decodeHeaders(buf);
+        assertEquals(2, headers.size());
+        assertEquals("GET", headers.method());
+        assertEquals("avalue", headers.get("akey"));
+    }
+
+    @Test(expected = Http2Exception.class)
+    public void decodeWithInvalidPseudoHeaderShouldFail() throws Exception {
+        ByteBuf buf = encode(":invalid", "GET", "akey", "avalue");
+        decoder.decodeHeaders(buf);
+    }
+
+    private ByteBuf encode(String... entries) throws Exception {
+        Encoder encoder = new Encoder();
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        for (int ix = 0; ix < entries.length;) {
+            String key = entries[ix++];
+            String value = entries[ix++];
+            encoder.encodeHeader(stream, key.getBytes(UTF_8), value.getBytes(UTF_8), false);
+        }
+        return Unpooled.wrappedBuffer(stream.toByteArray());
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoderTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.netty.handler.codec.http2;
+
+import static org.junit.Assert.assertTrue;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ * Tests for {@link DefaultHttp2HeadersEncoder}.
+ */
+public class DefaultHttp2HeadersEncoderTest {
+
+    private DefaultHttp2HeadersEncoder encoder;
+
+    @Before
+    public void setup() {
+        encoder = new DefaultHttp2HeadersEncoder();
+    }
+
+    @Test
+    public void encodeShouldSucceed() throws Http2Exception {
+        DefaultHttp2Headers headers =
+                DefaultHttp2Headers.newBuilder().method("GET").add("a", "1").add("a", "2").build();
+        ByteBuf buf = Unpooled.buffer();
+        encoder.encodeHeaders(headers, buf);
+        assertTrue(buf.writerIndex() > 0);
+    }
+
+    @Test(expected = Http2Exception.class)
+    public void headersExceedMaxSetSizeShouldFail() throws Http2Exception {
+        DefaultHttp2Headers headers =
+                DefaultHttp2Headers.newBuilder().method("GET").add("a", "1").add("a", "2").build();
+
+        encoder.maxHeaderListSize(2);
+        encoder.encodeHeaders(headers, Unpooled.buffer());
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http2;
 
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -39,9 +40,31 @@ public class DefaultHttp2HeadersTest {
                         .add("a", "3").build();
         List<String> aValues = headers.getAll("a");
         assertEquals(3, aValues.size());
+        assertEquals(3, headers.size());
         assertEquals("1", aValues.get(0));
         assertEquals("2", aValues.get(1));
         assertEquals("3", aValues.get(2));
+    }
+
+    @Test
+    public void setHeaderShouldReplacePrevious() {
+        DefaultHttp2Headers headers =
+                DefaultHttp2Headers.newBuilder().add("a", "1").add("a", "2")
+                        .add("a", "3").set("a", "4").build();
+        assertEquals(1, headers.size());
+        assertEquals("4", headers.get("a"));
+    }
+
+    @Test
+    public void setHeadersShouldReplacePrevious() {
+        DefaultHttp2Headers headers =
+                DefaultHttp2Headers.newBuilder().add("a", "1").add("a", "2")
+                        .add("a", "3").set("a", Arrays.asList("4", "5")).build();
+        assertEquals(2, headers.size());
+        List<String> list = headers.getAll("a");
+        assertEquals(2, list.size());
+        assertEquals("4", list.get(0));
+        assertEquals("5", list.get(1));
     }
 
     @Test(expected = NoSuchElementException.class)
@@ -76,5 +99,15 @@ public class DefaultHttp2HeadersTest {
 
         // Make sure we removed them all.
         assertTrue(headers.isEmpty());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void addInvalidPseudoHeaderShouldFail() {
+        DefaultHttp2Headers.newBuilder().add(":a", "1");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setInvalidPseudoHeaderShouldFail() {
+        DefaultHttp2Headers.newBuilder().set(":a", "1");
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowControllerTest.java
@@ -118,7 +118,7 @@ public class DefaultHttp2InboundFlowControllerTest {
 
     private void applyFlowControl(int dataSize, boolean endOfStream) throws Http2Exception {
         ByteBuf buf = dummyData(dataSize);
-        controller.applyInboundFlowControl(STREAM_ID, buf, 0, endOfStream, false, frameWriter);
+        controller.applyInboundFlowControl(STREAM_ID, buf, 0, endOfStream, frameWriter);
         buf.release();
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SettingsTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SettingsTest.java
@@ -15,6 +15,7 @@
 
 package io.netty.handler.codec.http2;
 
+import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_FRAME_SIZE_UPPER_BOUND;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -41,6 +42,8 @@ public class Http2SettingsTest {
         assertNull(settings.initialWindowSize());
         assertNull(settings.maxConcurrentStreams());
         assertNull(settings.pushEnabled());
+        assertNull(settings.maxFrameSize());
+        assertNull(settings.maxHeaderListSize());
     }
 
     @Test
@@ -49,9 +52,13 @@ public class Http2SettingsTest {
         settings.maxConcurrentStreams(2);
         settings.pushEnabled(true);
         settings.headerTableSize(3);
+        settings.maxFrameSize(MAX_FRAME_SIZE_UPPER_BOUND);
+        settings.maxHeaderListSize(4);
         assertEquals(1, (int) settings.initialWindowSize());
         assertEquals(2L, (long) settings.maxConcurrentStreams());
         assertTrue(settings.pushEnabled());
         assertEquals(3L, (long) settings.headerTableSize());
+        assertEquals(MAX_FRAME_SIZE_UPPER_BOUND, (int) settings.maxFrameSize());
+        assertEquals(4L, (long) settings.maxHeaderListSize());
     }
 }

--- a/example/src/main/java/io/netty/example/http2/client/Http2Client.java
+++ b/example/src/main/java/io/netty/example/http2/client/Http2Client.java
@@ -14,10 +14,12 @@
  */
 package io.netty.example.http2.client;
 
+import static io.netty.handler.codec.http.HttpMethod.GET;
+import static io.netty.handler.codec.http.HttpMethod.POST;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
@@ -33,9 +35,6 @@ import io.netty.util.CharsetUtil;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
-
-import static io.netty.handler.codec.http.HttpMethod.*;
-import static io.netty.handler.codec.http.HttpVersion.*;
 
 /**
  * An HTTP2 client that allows you to send HTTP2 frames to a server. Inbound and outbound frames are

--- a/example/src/main/java/io/netty/example/http2/client/HttpResponseHandler.java
+++ b/example/src/main/java/io/netty/example/http2/client/HttpResponseHandler.java
@@ -22,15 +22,11 @@ import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http2.Http2HttpHeaders;
 import io.netty.util.CharsetUtil;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Process {@link FullHttpResponse} translated from HTTP/2 frames

--- a/example/src/main/java/io/netty/example/http2/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/server/HelloWorldHttp2Handler.java
@@ -69,7 +69,7 @@ public class HelloWorldHttp2Handler extends AbstractHttp2ConnectionHandler {
             Http2Headers headers =
                     DefaultHttp2Headers.newBuilder().status("200")
                     .set(UPGRADE_RESPONSE_HEADER, "true").build();
-            writeHeaders(ctx, ctx.newPromise(), 1, headers, 0, true, true);
+            writeHeaders(ctx, ctx.newPromise(), 1, headers, 0, true);
         }
         super.userEventTriggered(ctx, evt);
     }
@@ -79,7 +79,7 @@ public class HelloWorldHttp2Handler extends AbstractHttp2ConnectionHandler {
      */
     @Override
     public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
-            boolean endOfStream, boolean endOfSegment) throws Http2Exception {
+            boolean endOfStream) throws Http2Exception {
         if (endOfStream) {
             sendResponse(ctx(), streamId, data.retain());
         }
@@ -91,8 +91,7 @@ public class HelloWorldHttp2Handler extends AbstractHttp2ConnectionHandler {
     @Override
     public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
             Http2Headers headers, int streamDependency, short weight,
-            boolean exclusive, int padding, boolean endStream, boolean endSegment)
-            throws Http2Exception {
+            boolean exclusive, int padding, boolean endStream) throws Http2Exception {
         if (endStream) {
             sendResponse(ctx(), streamId, RESPONSE_BYTES.duplicate());
         }
@@ -110,8 +109,8 @@ public class HelloWorldHttp2Handler extends AbstractHttp2ConnectionHandler {
     private void sendResponse(ChannelHandlerContext ctx, int streamId, ByteBuf payload) {
         // Send a frame for the response status
         Http2Headers headers = DefaultHttp2Headers.newBuilder().status("200").build();
-        writeHeaders(ctx(), ctx().newPromise(), streamId, headers, 0, false, false);
+        writeHeaders(ctx(), ctx().newPromise(), streamId, headers, 0, false);
 
-        writeData(ctx(), ctx().newPromise(), streamId, payload, 0, true, true);
+        writeData(ctx(), ctx().newPromise(), streamId, payload, 0, true);
     }
 }


### PR DESCRIPTION
Motivation:

HTTP/2 draft 14 came out a couple of weeks ago and we need to keep up
with the spec.

Modifications:
- Removed use of segment throughout.
- Added new setting for MAX_FRAME_SIZE. Used by the frame reader/writer
  rather than a constant.
- Added new setting for MAX_HEADER_LIST_SIZE. This is currently unused.
- Expanded the header size to 9 bytes. The frame length field is now 3
  bytes and added logic for checking that it falls within the valid range.

Result:

Netty will support HTTP/2 draft 14 framing. There will still be some
work to do to be compliant with the HTTP adaptation layer.
