### PR TITLE
Support IPv4 default route in ipfilter.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -110,7 +110,17 @@ public final class IpSubnetFilterRule implements IpFilterRule {
         }
 
         private static int prefixToSubnetMask(int cidrPrefix) {
-            return -1 << 32 - cidrPrefix;
+            /**
+             * Perform the shift on a long and downcast it to int afterwards.
+             * This is necessary to handle a cidrPrefix of zero correctly.
+             * The left shift operator on an int only uses the five least
+             * significant bits of the right-hand operand. Thus -1 << 32 evaluates
+             * to -1 instead of 0. The left shift operator applied on a long
+             * uses the six least significant bits.
+             *
+             * Also see https://github.com/netty/netty/issues/2767
+             */
+            return (int) ((-1L << 32 - cidrPrefix) & 0xffffffff);
         }
     }
 

--- a/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
@@ -30,6 +30,14 @@ import java.net.SocketAddress;
 public class IpSubnetFilterTest {
 
     @Test
+    public void testIpv4DefaultRoute() {
+        IpSubnetFilterRule rule = new IpSubnetFilterRule("0.0.0.0", 0, IpFilterRuleType.ACCEPT);
+        Assert.assertTrue(rule.matches(newSockAddress("91.114.240.43")));
+        Assert.assertTrue(rule.matches(newSockAddress("10.0.0.3")));
+        Assert.assertTrue(rule.matches(newSockAddress("192.168.93.2")));
+    }
+
+    @Test
     public void testIp4SubnetFilterRule() throws Exception {
         IpSubnetFilterRule rule = new IpSubnetFilterRule("192.168.56.1", 24, IpFilterRuleType.ACCEPT);
         for (int i = 0; i <= 255; i++) {


### PR DESCRIPTION
Motivation:

In GitHub issue #2767 a bug was reported that the IPv4
default route leads to the ipfilter package denying
instead of accepting all addresses.

While the issue was reported for Netty 3.9, this bug
also applies to Netty 4 and higher.

Modifications:

When computing the subnet address from the CIDR prefix,
correctly handle the case where the prefix is set to zero.

Result:

Ipfilter accepts all addresses when passed the
IPv4 default route.
