### PR TITLE
Upgrading to HTTP/2 draft 14 HTTP/1.x message flow

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
@@ -17,13 +17,14 @@ package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.internal.StringUtil;
 
 
 /**
  * Default implementation of a {@link FullHttpResponse}.
  */
 public class DefaultFullHttpResponse extends DefaultHttpResponse implements FullHttpResponse {
-
+    private static final int HASH_CODE_PRIME = 31;
     private final ByteBuf content;
     private final HttpHeaders trailingHeaders;
     private final boolean validateHeaders;
@@ -34,6 +35,10 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
 
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status, ByteBuf content) {
         this(version, status, content, true);
+    }
+
+    public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders) {
+        this(version, status, Unpooled.buffer(0), validateHeaders);
     }
 
     public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status,
@@ -108,13 +113,39 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
         return this;
     }
 
-    @Override
-    public FullHttpResponse copy() {
+    /**
+     * Copy this object
+     *
+     * @param copyContent
+     * <ul>
+     * <li>{@code true} if this object's {@link #content()} should be used to copy.</li>
+     * <li>{@code false} if {@code newContent} should be used instead.</li>
+     * </ul>
+     * @param newContent
+     * <ul>
+     * <li>if {@code copyContent} is false then this will be used in the copy's content.</li>
+     * <li>if {@code null} then a default buffer of 0 size will be selected</li>
+     * </ul>
+     * @return A copy of this object
+     */
+    private FullHttpResponse copy(boolean copyContent, ByteBuf newContent) {
         DefaultFullHttpResponse copy = new DefaultFullHttpResponse(
-                protocolVersion(), status(), content().copy(), validateHeaders);
+                protocolVersion(), status(),
+                copyContent ? content().copy() :
+                    newContent == null ? Unpooled.buffer(0) : newContent);
         copy.headers().set(headers());
         copy.trailingHeaders().set(trailingHeaders());
         return copy;
+    }
+
+    @Override
+    public FullHttpResponse copy(ByteBuf newContent) {
+        return copy(false, newContent);
+    }
+
+    @Override
+    public FullHttpResponse copy() {
+        return copy(true, null);
     }
 
     @Override
@@ -124,5 +155,39 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
         duplicate.headers().set(headers());
         duplicate.trailingHeaders().set(trailingHeaders());
         return duplicate;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = HASH_CODE_PRIME * result + content().hashCode();
+        result = HASH_CODE_PRIME * result + trailingHeaders().hashCode();
+        result = HASH_CODE_PRIME * result + super.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof DefaultFullHttpResponse)) {
+            return false;
+        }
+
+        DefaultFullHttpResponse other = (DefaultFullHttpResponse) o;
+
+        return super.equals(other) &&
+               content().equals(other.content()) &&
+               trailingHeaders().equals(other.trailingHeaders());
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder buf = new StringBuilder();
+        appendAll(buf);
+        buf.append(StringUtil.NEWLINE);
+        appendHeaders(buf, trailingHeaders());
+
+        // Remove the last newline.
+        buf.setLength(buf.length() - StringUtil.NEWLINE.length());
+        return buf.toString();
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
@@ -104,6 +104,10 @@ public abstract class DefaultHttpMessage extends DefaultHttpObject implements Ht
     }
 
     void appendHeaders(StringBuilder buf) {
+        appendHeaders(buf, headers());
+    }
+
+    void appendHeaders(StringBuilder buf, HttpHeaders headers) {
         for (Map.Entry<String, String> e: headers()) {
             buf.append(e.getKey());
             buf.append(": ");

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
@@ -21,7 +21,7 @@ import io.netty.util.internal.StringUtil;
  * The default {@link HttpRequest} implementation.
  */
 public class DefaultHttpRequest extends DefaultHttpMessage implements HttpRequest {
-
+    private static final int HASH_CODE_PRIME = 31;
     private HttpMethod method;
     private String uri;
 
@@ -91,8 +91,38 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
     }
 
     @Override
+    public int hashCode() {
+        int result = 1;
+        result = HASH_CODE_PRIME * result + method.hashCode();
+        result = HASH_CODE_PRIME * result + uri.hashCode();
+        result = HASH_CODE_PRIME * result + super.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof DefaultHttpRequest)) {
+            return false;
+        }
+
+        DefaultHttpRequest other = (DefaultHttpRequest) o;
+
+        return method().equals(other.method()) &&
+               uri().equalsIgnoreCase(other.uri()) &&
+               super.equals(o);
+    }
+
+    @Override
     public String toString() {
         StringBuilder buf = new StringBuilder();
+        appendAll(buf);
+
+        // Remove the last newline.
+        buf.setLength(buf.length() - StringUtil.NEWLINE.length());
+        return buf.toString();
+    }
+
+    void appendAll(StringBuilder buf) {
         buf.append(StringUtil.simpleClassName(this));
         buf.append("(decodeResult: ");
         buf.append(decoderResult());
@@ -105,9 +135,5 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
         buf.append(protocolVersion().text());
         buf.append(StringUtil.NEWLINE);
         appendHeaders(buf);
-
-        // Remove the last newline.
-        buf.setLength(buf.length() - StringUtil.NEWLINE.length());
-        return buf.toString();
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
@@ -21,7 +21,7 @@ import io.netty.util.internal.StringUtil;
  * The default {@link HttpResponse} implementation.
  */
 public class DefaultHttpResponse extends DefaultHttpMessage implements HttpResponse {
-
+    private static final int HASH_CODE_PRIME = 31;
     private HttpResponseStatus status;
 
     /**
@@ -71,10 +71,9 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
 
     @Override
     public int hashCode() {
-        final int prime = 31;
         int result = 1;
-        result = prime * result + status.hashCode();
-        result = prime * result + super.hashCode();
+        result = HASH_CODE_PRIME * result + status.hashCode();
+        result = HASH_CODE_PRIME * result + super.hashCode();
         return result;
     }
 
@@ -92,6 +91,14 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
     @Override
     public String toString() {
         StringBuilder buf = new StringBuilder();
+        appendAll(buf);
+
+        // Remove the last newline.
+        buf.setLength(buf.length() - StringUtil.NEWLINE.length());
+        return buf.toString();
+    }
+
+    void appendAll(StringBuilder buf) {
         buf.append(StringUtil.simpleClassName(this));
         buf.append("(decodeResult: ");
         buf.append(decoderResult());
@@ -102,9 +109,5 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
         buf.append(status());
         buf.append(StringUtil.NEWLINE);
         appendHeaders(buf);
-
-        // Remove the last newline.
-        buf.setLength(buf.length() - StringUtil.NEWLINE.length());
-        return buf.toString();
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpMessage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpMessage.java
@@ -15,11 +15,23 @@
  */
 package io.netty.handler.codec.http;
 
+import io.netty.buffer.ByteBuf;
+
 /**
  * Combines {@link HttpMessage} and {@link LastHttpContent} into one
  * message. So it represent a <i>complete</i> http message.
  */
 public interface FullHttpMessage extends HttpMessage, LastHttpContent {
+    /**
+     * Create a copy of this {@link FullHttpMessage} with alternative content.
+     *
+     * @param newContent The buffer to use instead of this {@link FullHttpMessage}'s content in the copy operation.
+     * <p>
+     * NOTE: retain will NOT be called on this buffer. {@code null} results in an empty default choice buffer.
+     * @return The result of the copy operation
+     */
+    FullHttpMessage copy(ByteBuf newContent);
+
     @Override
     FullHttpMessage copy();
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpRequest.java
@@ -15,11 +15,15 @@
  */
 package io.netty.handler.codec.http;
 
+import io.netty.buffer.ByteBuf;
+
 /**
- * Combinate the {@link HttpRequest} and {@link FullHttpMessage}, so the request is a <i>complete</i> HTTP
- * request.
+ * Combinate the {@link HttpRequest} and {@link FullHttpMessage}, so the request is a <i>complete</i> HTTP request.
  */
 public interface FullHttpRequest extends HttpRequest, FullHttpMessage {
+    @Override
+    FullHttpRequest copy(ByteBuf newContent);
+
     @Override
     FullHttpRequest copy();
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpResponse.java
@@ -15,11 +15,15 @@
  */
 package io.netty.handler.codec.http;
 
+import io.netty.buffer.ByteBuf;
+
 /**
- * Combination of a {@link HttpResponse} and {@link FullHttpMessage}.
- * So it represent a <i>complete</i> http response.
+ * Combination of a {@link HttpResponse} and {@link FullHttpMessage}. So it represent a <i>complete</i> http response.
  */
 public interface FullHttpResponse extends HttpResponse, FullHttpMessage {
+    @Override
+    FullHttpResponse copy(ByteBuf newContent);
+
     @Override
     FullHttpResponse copy();
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -263,13 +263,39 @@ public class HttpObjectAggregator
             super(request, content, trailingHeaders);
         }
 
-        @Override
-        public FullHttpRequest copy() {
+        /**
+         * Copy this object
+         *
+         * @param copyContent
+         * <ul>
+         * <li>{@code true} if this object's {@link #content()} should be used to copy.</li>
+         * <li>{@code false} if {@code newContent} should be used instead.</li>
+         * </ul>
+         * @param newContent
+         * <ul>
+         * <li>if {@code copyContent} is false then this will be used in the copy's content.</li>
+         * <li>if {@code null} then a default buffer of 0 size will be selected</li>
+         * </ul>
+         * @return A copy of this object
+         */
+        private FullHttpRequest copy(boolean copyContent, ByteBuf newContent) {
             DefaultFullHttpRequest copy = new DefaultFullHttpRequest(
-                    protocolVersion(), method(), uri(), content().copy());
+                    protocolVersion(), method(), uri(),
+                    copyContent ? content().copy() :
+                        newContent == null ? Unpooled.buffer(0) : newContent);
             copy.headers().set(headers());
             copy.trailingHeaders().set(trailingHeaders());
             return copy;
+        }
+
+        @Override
+        public FullHttpRequest copy(ByteBuf newContent) {
+            return copy(false, newContent);
+        }
+
+        @Override
+        public FullHttpRequest copy() {
+            return copy(true, null);
         }
 
         @Override
@@ -340,13 +366,39 @@ public class HttpObjectAggregator
             super(message, content, trailingHeaders);
         }
 
-        @Override
-        public FullHttpResponse copy() {
+        /**
+         * Copy this object
+         *
+         * @param copyContent
+         * <ul>
+         * <li>{@code true} if this object's {@link #content()} should be used to copy.</li>
+         * <li>{@code false} if {@code newContent} should be used instead.</li>
+         * </ul>
+         * @param newContent
+         * <ul>
+         * <li>if {@code copyContent} is false then this will be used in the copy's content.</li>
+         * <li>if {@code null} then a default buffer of 0 size will be selected</li>
+         * </ul>
+         * @return A copy of this object
+         */
+        private FullHttpResponse copy(boolean copyContent, ByteBuf newContent) {
             DefaultFullHttpResponse copy = new DefaultFullHttpResponse(
-                    protocolVersion(), status(), content().copy());
+                    protocolVersion(), status(),
+                    copyContent ? content().copy() :
+                        newContent == null ? Unpooled.buffer(0) : newContent);
             copy.headers().set(headers());
             copy.trailingHeaders().set(trailingHeaders());
             return copy;
+        }
+
+        @Override
+        public FullHttpResponse copy(ByteBuf newContent) {
+            return copy(false, newContent);
+        }
+
+        @Override
+        public FullHttpResponse copy() {
+            return copy(true, null);
         }
 
         @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
@@ -540,6 +540,13 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
         return reasonPhrase;
     }
 
+    /**
+     * Determine if the status code is of the informational class (1xx)
+     */
+    public boolean isInformational() {
+        return code >= 100 && code < 200;
+    }
+
     @Override
     public int hashCode() {
         return code();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http.multipart;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.AsciiString;
 import io.netty.handler.codec.DecoderResult;
@@ -1203,13 +1204,39 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
             return this;
         }
 
-        @Override
-        public FullHttpRequest copy() {
+        /**
+         * Copy this object
+         *
+         * @param copyContent
+         * <ul>
+         * <li>{@code true} if this object's {@link #content()} should be used to copy.</li>
+         * <li>{@code false} if {@code newContent} should be used instead.</li>
+         * </ul>
+         * @param newContent
+         * <ul>
+         * <li>if {@code copyContent} is false then this will be used in the copy's content.</li>
+         * <li>if {@code null} then a default buffer of 0 size will be selected</li>
+         * </ul>
+         * @return A copy of this object
+         */
+        private FullHttpRequest copy(boolean copyContent, ByteBuf newContent) {
             DefaultFullHttpRequest copy = new DefaultFullHttpRequest(
-                    protocolVersion(), method(), uri(), content().copy());
+                    protocolVersion(), method(), uri(),
+                    copyContent ? content().copy() :
+                        newContent == null ? Unpooled.buffer(0) : newContent);
             copy.headers().set(headers());
             copy.trailingHeaders().set(trailingHeaders());
             return copy;
+        }
+
+        @Override
+        public FullHttpRequest copy(ByteBuf newContent) {
+            return copy(false, newContent);
+        }
+
+        @Override
+        public FullHttpRequest copy() {
+            return copy(true, null);
         }
 
         @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -128,6 +128,24 @@ public final class DefaultHttp2Headers extends Http2Headers {
         return new HeaderIterator();
     }
 
+    @Override
+    public String forEach(HeaderVisitor visitor) {
+        if (isEmpty()) {
+            return null;
+        }
+
+        HeaderEntry e = head.after;
+        do {
+            if (visitor.visit(e)) {
+                e = e.after;
+            } else {
+                return e.getKey();
+            }
+        } while (e != head);
+
+        return null;
+    }
+
     /**
      * Short cut for {@code new DefaultHttp2Headers.Builder()}.
      */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2HttpConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2HttpConnectionHandler.java
@@ -68,17 +68,17 @@ public class DelegatingHttp2HttpConnectionHandler extends DelegatingHttp2Connect
         }
 
         // Consume the Authority extension header if present
-        value = httpHeaders.get(Http2HttpHeaders.Names.AUTHORITY);
+        value = httpHeaders.get(Http2ToHttpHeaders.Names.AUTHORITY);
         if (value != null) {
             http2Headers.authority(value);
-            httpHeaders.remove(Http2HttpHeaders.Names.AUTHORITY);
+            httpHeaders.remove(Http2ToHttpHeaders.Names.AUTHORITY);
         }
 
         // Consume the Scheme extension header if present
-        value = httpHeaders.get(Http2HttpHeaders.Names.SCHEME);
+        value = httpHeaders.get(Http2ToHttpHeaders.Names.SCHEME);
         if (value != null) {
             http2Headers.scheme(value);
-            httpHeaders.remove(Http2HttpHeaders.Names.SCHEME);
+            httpHeaders.remove(Http2ToHttpHeaders.Names.SCHEME);
         }
     }
 
@@ -114,7 +114,7 @@ public class DelegatingHttp2HttpConnectionHandler extends DelegatingHttp2Connect
      */
     private int getStreamId(HttpHeaders httpHeaders) throws Http2Exception {
         int streamId = 0;
-        String value = httpHeaders.get(Http2HttpHeaders.Names.STREAM_ID);
+        String value = httpHeaders.get(Http2ToHttpHeaders.Names.STREAM_ID);
         if (value == null) {
             streamId = nextStreamId();
         } else {
@@ -124,7 +124,7 @@ public class DelegatingHttp2HttpConnectionHandler extends DelegatingHttp2Connect
                 throw Http2Exception.format(Http2Error.INTERNAL_ERROR,
                                     "Invalid user-specified stream id value '%s'", value);
             }
-            httpHeaders.remove(Http2HttpHeaders.Names.STREAM_ID);
+            httpHeaders.remove(Http2ToHttpHeaders.Names.STREAM_ID);
         }
 
         return streamId;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameObserver.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameObserver.java
@@ -39,6 +39,17 @@ public interface Http2FrameObserver {
 
     /**
      * Handles an inbound HEADERS frame.
+     * <p>
+     * Only one of the following methods will be called for each HEADERS frame sequence.
+     * One will be called when the END_HEADERS flag has been received.
+     * <ul>
+     * <li>{@link #onHeadersRead(ChannelHandlerContext, int, Http2Headers, int, boolean)}</li>
+     * <li>{@link #onHeadersRead(ChannelHandlerContext, int, Http2Headers, int, short, boolean, int, boolean)}</li>
+     * <li>{@link #onPushPromiseRead(ChannelHandlerContext, int, int, Http2Headers, int)}</li>
+     * </ul>
+     * <p>
+     * To say it another way; the {@link Http2Headers} will contain all of the headers
+     * for the current message exchange step (additional queuing is not necessary).
      *
      * @param ctx the context from the handler where the frame was read.
      * @param streamId the subject stream for the frame.
@@ -51,7 +62,19 @@ public interface Http2FrameObserver {
             boolean endStream) throws Http2Exception;
 
     /**
-     * Handles an inbound HEADERS frame with priority information specified.
+     * Handles an inbound HEADERS frame with priority information specified. Only called if END_HEADERS encountered.
+     *
+     * <p>
+     * Only one of the following methods will be called for each HEADERS frame sequence.
+     * One will be called when the END_HEADERS flag has been received.
+     * <ul>
+     * <li>{@link #onHeadersRead(ChannelHandlerContext, int, Http2Headers, int, boolean)}</li>
+     * <li>{@link #onHeadersRead(ChannelHandlerContext, int, Http2Headers, int, short, boolean, int, boolean)}</li>
+     * <li>{@link #onPushPromiseRead(ChannelHandlerContext, int, int, Http2Headers, int)}</li>
+     * </ul>
+     * <p>
+     * To say it another way; the {@link Http2Headers} will contain all of the headers
+     * for the current message exchange step (additional queuing is not necessary).
      *
      * @param ctx the context from the handler where the frame was read.
      * @param streamId the subject stream for the frame.
@@ -123,7 +146,19 @@ public interface Http2FrameObserver {
     void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception;
 
     /**
-     * Handles an inbound PUSH_PROMISE frame.
+     * Handles an inbound PUSH_PROMISE frame. Only called if END_HEADERS encountered.
+     *
+     * <p>
+     * Only one of the following methods will be called for each HEADERS frame sequence.
+     * One will be called when the END_HEADERS flag has been received.
+     * <ul>
+     * <li>{@link #onHeadersRead(ChannelHandlerContext, int, Http2Headers, int, boolean)}</li>
+     * <li>{@link #onHeadersRead(ChannelHandlerContext, int, Http2Headers, int, short, boolean, int, boolean)}</li>
+     * <li>{@link #onPushPromiseRead(ChannelHandlerContext, int, int, Http2Headers, int)}</li>
+     * </ul>
+     * <p>
+     * To say it another way; the {@link Http2Headers} will contain all of the headers
+     * for the current message exchange step (additional queuing is not necessary).
      *
      * @param ctx the context from the handler where the frame was read.
      * @param streamId the stream the frame was sent on.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -70,6 +70,11 @@ public abstract class Http2Headers implements Iterable<Entry<String, String>> {
         public Iterator<Entry<String, String>> iterator() {
             return entries().iterator();
         }
+
+        @Override
+        public String forEach(HeaderVisitor visitor) {
+            return null;
+        }
     };
 
     /**
@@ -179,6 +184,27 @@ public abstract class Http2Headers implements Iterable<Entry<String, String>> {
      * Gets the number of headers contained in this object.
      */
     public abstract int size();
+
+    /**
+     * Allows a means to reduce GC pressure while iterating over a collection
+     */
+    public interface HeaderVisitor {
+        /**
+         * @return
+         * <ul>
+         * <li>{@code true} if the processor wants to continue the loop and handle the entry.</li>
+         * <li>{@code false} if the processor wants to stop handling headers and abort the loop.</li>
+         * </ul>
+         */
+        boolean visit(Map.Entry<String, String> entry);
+    }
+
+    /**
+     * Iterates over the entries contained within this header object in no guaranteed order
+     * @return {@code null} if the visitor iterated to or beyond the end of the headers.
+     *  The last-visited header name If the {@link HeaderVisitor#visit(Entry)} returned {@code false}.
+     */
+    public abstract String forEach(HeaderVisitor visitor);
 
     /**
      * Gets the {@link PseudoHeaderName#METHOD} header or {@code null} if there is no such header

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DelegatingHttp2HttpConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DelegatingHttp2HttpConnectionHandlerTest.java
@@ -124,10 +124,10 @@ public class DelegatingHttp2HttpConnectionHandlerTest {
     public void testJustHeadersRequest() throws Exception {
         final HttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, "/example");
         final HttpHeaders httpHeaders = request.headers();
-        httpHeaders.set(Http2HttpHeaders.Names.STREAM_ID, 5);
+        httpHeaders.set(Http2ToHttpHeaders.Names.STREAM_ID, 5);
         httpHeaders.set(HttpHeaders.Names.HOST, "http://my-user_name@www.example.org:5555/example");
-        httpHeaders.set(Http2HttpHeaders.Names.AUTHORITY, "www.example.org:5555");
-        httpHeaders.set(Http2HttpHeaders.Names.SCHEME, "http");
+        httpHeaders.set(Http2ToHttpHeaders.Names.AUTHORITY, "www.example.org:5555");
+        httpHeaders.set(Http2ToHttpHeaders.Names.SCHEME, "http");
         httpHeaders.add("foo", "goo");
         httpHeaders.add("foo", "goo2");
         httpHeaders.add("foo2", "goo2");

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.reset;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
@@ -36,16 +37,17 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.ByteToMessageDecoder;
-import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.DefaultLastHttpContent;
-import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.FullHttpMessage;
+import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
-import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http2.Http2TestUtil.Http2Runnable;
 import io.netty.util.NetUtil;
 
@@ -66,25 +68,33 @@ import org.mockito.MockitoAnnotations;
 public class InboundHttp2ToHttpAdapterTest {
 
     @Mock
-    private HttpResponseListener messageObserver;
+    private HttpResponseListener serverObserver;
 
     @Mock
-    private Http2FrameObserver clientObserver;
+    private HttpResponseListener clientObserver;
 
     private Http2FrameWriter frameWriter;
     private ServerBootstrap sb;
     private Bootstrap cb;
     private Channel serverChannel;
+    private Channel serverConnectedChannel;
     private Channel clientChannel;
     private CountDownLatch serverLatch;
-    private long maxContentLength;
+    private CountDownLatch clientLatch;
+    private int maxContentLength;
+    private HttpResponseDelegator serverDelegator;
+    private HttpResponseDelegator clientDelegator;
 
     @Before
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        maxContentLength = 1 << 16;
-        serverLatch = new CountDownLatch(1);
+        clientDelegator = null;
+        serverDelegator = null;
+        serverConnectedChannel = null;
+        maxContentLength = 1024;
+        setServerLatch(1);
+        setClientLatch(1);
         frameWriter = new DefaultHttp2FrameWriter();
 
         sb = new ServerBootstrap();
@@ -97,10 +107,12 @@ public class InboundHttp2ToHttpAdapterTest {
             protected void initChannel(Channel ch) throws Exception {
                 ChannelPipeline p = ch.pipeline();
                 Http2Connection connection = new DefaultHttp2Connection(true);
-                p.addLast("reader", new FrameAdapter(InboundHttp2ToHttpAdapter.newInstance(
-                    connection, maxContentLength),
-                    new CountDownLatch(10)));
-                p.addLast(new HttpResponseDelegator(messageObserver));
+                p.addLast("reader",
+                                new FrameAdapter(InboundHttp2ToHttpAdapter.newInstance(connection, maxContentLength),
+                                                new CountDownLatch(10)));
+                serverDelegator = new HttpResponseDelegator(serverObserver, serverLatch);
+                p.addLast(serverDelegator);
+                serverConnectedChannel = ch;
             }
         });
 
@@ -110,7 +122,12 @@ public class InboundHttp2ToHttpAdapterTest {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 ChannelPipeline p = ch.pipeline();
-                p.addLast("reader", new FrameAdapter(clientObserver, new CountDownLatch(10)));
+                Http2Connection connection = new DefaultHttp2Connection(false);
+                p.addLast("reader",
+                                new FrameAdapter(InboundHttp2ToHttpAdapter.newInstance(connection, maxContentLength),
+                                                new CountDownLatch(10)));
+                clientDelegator = new HttpResponseDelegator(clientObserver, clientLatch);
+                p.addLast(clientDelegator);
             }
         });
 
@@ -127,315 +144,393 @@ public class InboundHttp2ToHttpAdapterTest {
         serverChannel.close().sync();
         sb.group().shutdownGracefully();
         cb.group().shutdownGracefully();
+        clientDelegator = null;
+        serverDelegator = null;
+        clientChannel = null;
+        serverChannel = null;
+        serverConnectedChannel = null;
     }
 
     @Test
     public void clientRequestSingleHeaderNoDataFrames() throws Exception {
-        serverLatch = new CountDownLatch(2);
-        final HttpMessage request = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                        HttpMethod.GET, "/some/path/resource2", true);
+        final HttpMessage request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                        "/some/path/resource2", true);
         HttpHeaders httpHeaders = request.headers();
-        httpHeaders.set(Http2HttpHeaders.Names.SCHEME, "https");
-        httpHeaders.set(Http2HttpHeaders.Names.AUTHORITY, "example.org");
-        httpHeaders.set(Http2HttpHeaders.Names.STREAM_ID, 3);
+        httpHeaders.set(Http2ToHttpHeaders.Names.SCHEME, "https");
+        httpHeaders.set(Http2ToHttpHeaders.Names.AUTHORITY, "example.org");
+        httpHeaders.set(Http2ToHttpHeaders.Names.STREAM_ID, 3);
         httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, 0);
-        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder()
-            .method("GET").scheme("https").authority("example.org")
-            .path("/some/path/resource2").build();
+        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder().method("GET").scheme("https")
+                        .authority("example.org").path("/some/path/resource2").build();
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
             public void run() {
-                frameWriter.writeHeaders(ctx(), 3, http2Headers, 0, true, newPromise());
-                ctx().flush();
+                frameWriter.writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
+                ctxClient().flush();
             }
         });
         awaitRequests();
-        verify(messageObserver).messageReceived(eq(request));
-        verify(messageObserver).messageReceived(eq(LastHttpContent.EMPTY_LAST_CONTENT));
+        verify(serverObserver).messageReceived(eq(request));
     }
 
     @Test
     public void clientRequestOneDataFrame() throws Exception {
-        serverLatch = new CountDownLatch(2);
-        final HttpMessage request = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                        HttpMethod.GET, "/some/path/resource2", true);
-        HttpHeaders httpHeaders = request.headers();
-        httpHeaders.set(Http2HttpHeaders.Names.STREAM_ID, 3);
-        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder()
-            .method("GET").path("/some/path/resource2").build();
         final String text = "hello world";
-        final HttpContent content = new DefaultLastHttpContent(Unpooled.copiedBuffer(text.getBytes()),
-                                                               true);
+        final ByteBuf content = Unpooled.copiedBuffer(text.getBytes());
+        final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                        "/some/path/resource2", content, true);
+        HttpHeaders httpHeaders = request.headers();
+        httpHeaders.set(Http2ToHttpHeaders.Names.STREAM_ID, 3);
+        httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, text.length());
+        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder().method("GET").path("/some/path/resource2")
+                        .build();
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
             public void run() {
-                frameWriter.writeHeaders(ctx(), 3, http2Headers, 0, false, newPromise());
-                frameWriter.writeData(ctx(), 3,
-                    Unpooled.copiedBuffer(text.getBytes()), 0, true, newPromise());
-                ctx().flush();
+                frameWriter.writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                frameWriter.writeData(ctxClient(), 3, Unpooled.copiedBuffer(text.getBytes()), 0, true,
+                                newPromiseClient());
+                ctxClient().flush();
             }
         });
         awaitRequests();
-        ArgumentCaptor<HttpObject> httpObjectCaptor = ArgumentCaptor.forClass(HttpObject.class);
-        verify(messageObserver, times(2)).messageReceived(httpObjectCaptor.capture());
-
-        List<HttpObject> capturedHttpObjects = httpObjectCaptor.getAllValues();
-        assertEquals(request, capturedHttpObjects.get(0));
-        assertEquals(content, capturedHttpObjects.get(1));
+        verify(serverObserver).messageReceived(eq(request));
+        request.release();
     }
 
     @Test
     public void clientRequestMultipleDataFrames() throws Exception {
-        serverLatch = new CountDownLatch(3);
-        final HttpMessage request = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                        HttpMethod.GET, "/some/path/resource2", true);
+        final String text = "hello world big time data!";
+        final ByteBuf content = Unpooled.copiedBuffer(text.getBytes());
+        final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                        "/some/path/resource2", content, true);
         HttpHeaders httpHeaders = request.headers();
-        httpHeaders.set(Http2HttpHeaders.Names.STREAM_ID, 3);
-        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder()
-            .method("GET").path("/some/path/resource2").build();
-        final String text = "hello world";
-        final String text2 = "hello world2";
-        final HttpContent content = new DefaultHttpContent(Unpooled.copiedBuffer(text.getBytes()));
-        final HttpContent content2 = new DefaultLastHttpContent(Unpooled.copiedBuffer(text2.getBytes()),
-                                                                true);
+        httpHeaders.set(Http2ToHttpHeaders.Names.STREAM_ID, 3);
+        httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, text.length());
+        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder().method("GET").path("/some/path/resource2")
+                        .build();
+        final int midPoint = text.length() / 2;
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
             public void run() {
-                frameWriter.writeHeaders(ctx(), 3, http2Headers, 0, false, newPromise());
-                frameWriter.writeData(ctx(), 3,
-                    Unpooled.copiedBuffer(text.getBytes()), 0, false, newPromise());
-                frameWriter.writeData(ctx(), 3,
-                    Unpooled.copiedBuffer(text2.getBytes()), 0, true, newPromise());
-                ctx().flush();
+                frameWriter.writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                frameWriter.writeData(ctxClient(), 3, content.slice(0, midPoint).retain(), 0,
+                                false, newPromiseClient());
+                frameWriter.writeData(ctxClient(), 3, content.slice(midPoint, text.length() - midPoint).retain(), 0,
+                                true, newPromiseClient());
+                ctxClient().flush();
             }
         });
         awaitRequests();
-        ArgumentCaptor<HttpObject> httpObjectCaptor = ArgumentCaptor.forClass(HttpObject.class);
-        verify(messageObserver, times(3)).messageReceived(httpObjectCaptor.capture());
-
-        List<HttpObject> capturedHttpObjects = httpObjectCaptor.getAllValues();
-        assertEquals(request, capturedHttpObjects.get(0));
-        assertEquals(content, capturedHttpObjects.get(1));
-        assertEquals(content2, capturedHttpObjects.get(2));
+        verify(serverObserver).messageReceived(eq(request));
+        request.release();
     }
 
     @Test
     public void clientRequestMultipleEmptyDataFrames() throws Exception {
-        serverLatch = new CountDownLatch(4);
-        final HttpMessage request = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                        HttpMethod.GET, "/some/path/resource2", true);
-        HttpHeaders httpHeaders = request.headers();
-        httpHeaders.set(Http2HttpHeaders.Names.STREAM_ID, 3);
-        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder()
-            .method("GET").path("/some/path/resource2").build();
         final String text = "";
-        final HttpContent content = new DefaultHttpContent(Unpooled.copiedBuffer(text.getBytes()));
-        final HttpContent content2 = new DefaultLastHttpContent(Unpooled.copiedBuffer(text.getBytes()),
-                                                                true);
+        final ByteBuf content = Unpooled.copiedBuffer(text.getBytes());
+        final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                        "/some/path/resource2", content, true);
+        HttpHeaders httpHeaders = request.headers();
+        httpHeaders.set(Http2ToHttpHeaders.Names.STREAM_ID, 3);
+        httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, text.length());
+        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder().method("GET").path("/some/path/resource2")
+                        .build();
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
             public void run() {
-                frameWriter.writeHeaders(ctx(), 3, http2Headers, 0, false, newPromise());
-                frameWriter.writeData(ctx(), 3, Unpooled.copiedBuffer(text.getBytes()), 0, false,
-                        newPromise());
-                frameWriter.writeData(ctx(), 3, Unpooled.copiedBuffer(text.getBytes()), 0, false,
-                        newPromise());
-                frameWriter.writeData(ctx(), 3, Unpooled.copiedBuffer(text.getBytes()), 0, true, newPromise());
-                ctx().flush();
+                frameWriter.writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                frameWriter.writeData(ctxClient(), 3, content.retain(), 0, false, newPromiseClient());
+                frameWriter.writeData(ctxClient(), 3, content.retain(), 0, false, newPromiseClient());
+                frameWriter.writeData(ctxClient(), 3, content.retain(), 0, true, newPromiseClient());
+                ctxClient().flush();
             }
         });
         awaitRequests();
-        ArgumentCaptor<HttpObject> httpObjectCaptor = ArgumentCaptor.forClass(HttpObject.class);
-        verify(messageObserver, times(4)).messageReceived(httpObjectCaptor.capture());
-
-        List<HttpObject> capturedHttpObjects = httpObjectCaptor.getAllValues();
-        assertEquals(request, capturedHttpObjects.get(0));
-        assertEquals(content, capturedHttpObjects.get(1));
-        assertEquals(content, capturedHttpObjects.get(2));
-        assertEquals(content2, capturedHttpObjects.get(3));
+        verify(serverObserver).messageReceived(eq(request));
+        request.release();
     }
 
     @Test
-    public void clientRequestHeaderContinuation() throws Exception {
-        serverLatch = new CountDownLatch(2);
-        final HttpMessage request = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                        HttpMethod.GET, "/some/path/resource2", true);
-        HttpHeaders httpHeaders = request.headers();
-        httpHeaders.set(Http2HttpHeaders.Names.STREAM_ID, 3);
-        httpHeaders.set("foo", "goo");
-        httpHeaders.set("foo2", "goo2");
-        httpHeaders.add("foo2", "goo3");
-        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder()
-            .method("GET").path("/some/path/resource2").build();
-        final Http2Headers http2Headers2 = new DefaultHttp2Headers.Builder().set("foo", "goo")
-            .set("foo2", "goo2").add("foo2", "goo3").build();
+    public void clientRequestMultipleHeaders() throws Exception {
+        // writeHeaders will implicitly add an END_HEADERS tag each time and so this test does not follow the HTTP
+        // message flow. We currently accept this message flow and just add the second headers to the trailing headers.
         final String text = "";
-        final HttpContent content = new DefaultLastHttpContent(Unpooled.copiedBuffer(text.getBytes()),
-                                                               true);
+        final ByteBuf content = Unpooled.copiedBuffer(text.getBytes());
+        final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                        "/some/path/resource2", content, true);
+        HttpHeaders httpHeaders = request.headers();
+        httpHeaders.set(Http2ToHttpHeaders.Names.STREAM_ID, 3);
+        httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, text.length());
+        HttpHeaders trailingHeaders = request.trailingHeaders();
+        trailingHeaders.set("FoO", "goo");
+        trailingHeaders.set("foO2", "goo2");
+        trailingHeaders.add("fOo2", "goo3");
+        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder().method("GET").path("/some/path/resource2")
+                        .build();
+        final Http2Headers http2Headers2 = new DefaultHttp2Headers.Builder().set("foo", "goo").set("foo2", "goo2")
+                        .add("foo2", "goo3").build();
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
             public void run() {
-                frameWriter.writeHeaders(ctx(), 3, http2Headers, 0, false, newPromise());
-                frameWriter.writeHeaders(ctx(), 3, http2Headers2, 0, false, newPromise());
-                frameWriter.writeData(ctx(), 3,
-                    Unpooled.copiedBuffer(text.getBytes()), 0, true, newPromise());
-                ctx().flush();
+                frameWriter.writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                frameWriter.writeHeaders(ctxClient(), 3, http2Headers2, 0, false, newPromiseClient());
+                frameWriter.writeData(ctxClient(), 3, Unpooled.copiedBuffer(text.getBytes()), 0, true,
+                                newPromiseClient());
+                ctxClient().flush();
             }
         });
         awaitRequests();
-        ArgumentCaptor<HttpObject> httpObjectCaptor = ArgumentCaptor.forClass(HttpObject.class);
-        verify(messageObserver, times(2)).messageReceived(httpObjectCaptor.capture());
-
-        List<HttpObject> capturedHttpObjects = httpObjectCaptor.getAllValues();
-        assertEquals(request, capturedHttpObjects.get(0));
-        assertEquals(content, capturedHttpObjects.get(1));
+        verify(serverObserver).messageReceived(eq(request));
+        request.release();
     }
 
     @Test
     public void clientRequestTrailingHeaders() throws Exception {
-        serverLatch = new CountDownLatch(3);
-        final HttpMessage request = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                        HttpMethod.GET, "/some/path/resource2", true);
+        final String text = "some data";
+        final ByteBuf content = Unpooled.copiedBuffer(text.getBytes());
+        final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                        "/some/path/resource2", content, true);
         HttpHeaders httpHeaders = request.headers();
-        httpHeaders.set(Http2HttpHeaders.Names.STREAM_ID, 3);
-        final LastHttpContent trailer = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, true);
-        HttpHeaders trailingHeaders = trailer.trailingHeaders();
-        trailingHeaders.set("foo", "goo");
-        trailingHeaders.set("foo2", "goo2");
-        trailingHeaders.add("foo2", "goo3");
-        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder()
-            .method("GET").path("/some/path/resource2").build();
-        final Http2Headers http2Headers2 = new DefaultHttp2Headers.Builder().set("foo", "goo")
-            .set("foo2", "goo2").add("foo2", "goo3").build();
-        final String text = "not empty!";
-        final HttpContent content = new DefaultLastHttpContent(Unpooled.copiedBuffer(text.getBytes()),
-                                                               true);
+        httpHeaders.set(Http2ToHttpHeaders.Names.STREAM_ID, 3);
+        httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, text.length());
+        HttpHeaders trailingHeaders = request.trailingHeaders();
+        trailingHeaders.set("Foo", "goo");
+        trailingHeaders.set("fOo2", "goo2");
+        trailingHeaders.add("foO2", "goo3");
+        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder().method("GET").path("/some/path/resource2")
+                        .build();
+        final Http2Headers http2Headers2 = new DefaultHttp2Headers.Builder().set("foo", "goo").set("foo2", "goo2")
+                        .add("foo2", "goo3").build();
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
             public void run() {
-                frameWriter.writeHeaders(ctx(), 3, http2Headers, 0, false, newPromise());
-                frameWriter.writeData(ctx(), 3,
-                    Unpooled.copiedBuffer(text.getBytes()), 0, false, newPromise());
-                frameWriter.writeHeaders(ctx(), 3, http2Headers2, 0, true, newPromise());
-                ctx().flush();
+                frameWriter.writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                frameWriter.writeData(ctxClient(), 3, content.retain(), 0, false, newPromiseClient());
+                frameWriter.writeHeaders(ctxClient(), 3, http2Headers2, 0, true, newPromiseClient());
+                ctxClient().flush();
             }
         });
         awaitRequests();
-        ArgumentCaptor<HttpObject> httpObjectCaptor = ArgumentCaptor.forClass(HttpObject.class);
-        verify(messageObserver, times(3)).messageReceived(httpObjectCaptor.capture());
-
-        List<HttpObject> capturedHttpObjects = httpObjectCaptor.getAllValues();
-        assertEquals(request, capturedHttpObjects.get(0));
-        assertEquals(content, capturedHttpObjects.get(1));
-        assertEquals(trailer, capturedHttpObjects.get(2));
-    }
-
-    @Test
-    public void clientRequestPushPromise() throws Exception {
-        serverLatch = new CountDownLatch(4);
-        final HttpMessage request = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                        HttpMethod.GET, "/some/path/resource", true);
-        HttpHeaders httpHeaders = request.headers();
-        httpHeaders.set(Http2HttpHeaders.Names.STREAM_ID, 3);
-        final HttpMessage request2 = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                        HttpMethod.GET, "/some/path/resource2", true);
-        HttpHeaders httpHeaders2 = request2.headers();
-        httpHeaders2.set(Http2HttpHeaders.Names.SCHEME, "https");
-        httpHeaders2.set(Http2HttpHeaders.Names.AUTHORITY, "example.org");
-        httpHeaders2.set(Http2HttpHeaders.Names.STREAM_ID, 5);
-        httpHeaders2.set(Http2HttpHeaders.Names.STREAM_PROMISE_ID, 3);
-        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder()
-            .method("GET").path("/some/path/resource").build();
-        final Http2Headers http2Headers2 = new DefaultHttp2Headers.Builder()
-            .method("GET").path("/some/path/resource2").scheme("https")
-            .authority("example.org").build();
-        final String text = "hello 1!**";
-        final HttpContent content = new DefaultLastHttpContent(Unpooled.copiedBuffer(text.getBytes()),
-                                                               true);
-        final String text2 = "hello 2!><";
-        final HttpContent content2 = new DefaultLastHttpContent(Unpooled.copiedBuffer(text2.getBytes()),
-                                                                true);
-        runInChannel(clientChannel, new Http2Runnable() {
-            @Override
-            public void run() {
-                frameWriter.writeHeaders(ctx(), 3, http2Headers, 0, false, newPromise());
-                frameWriter.writePushPromise(ctx(), 3, 5, http2Headers2, 0, newPromise());
-                frameWriter.writeData(ctx(), 3,
-                    Unpooled.copiedBuffer(text.getBytes()), 0, true, newPromise());
-                frameWriter.writeData(ctx(), 5,
-                    Unpooled.copiedBuffer(text2.getBytes()), 0, true, newPromise());
-                ctx().flush();
-            }
-        });
-        awaitRequests();
-        ArgumentCaptor<HttpObject> httpObjectCaptor = ArgumentCaptor.forClass(HttpObject.class);
-        verify(messageObserver, times(4)).messageReceived(httpObjectCaptor.capture());
-
-        List<HttpObject> capturedHttpObjects = httpObjectCaptor.getAllValues();
-        assertEquals(request, capturedHttpObjects.get(0));
-        assertEquals(content, capturedHttpObjects.get(1));
-        assertEquals(request2, capturedHttpObjects.get(2));
-        assertEquals(content2, capturedHttpObjects.get(3));
+        verify(serverObserver).messageReceived(eq(request));
+        request.release();
     }
 
     @Test
     public void clientRequestStreamDependency() throws Exception {
-        serverLatch = new CountDownLatch(4);
-        final HttpMessage request = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                        HttpMethod.GET, "/some/path/resource", true);
+        setServerLatch(2);
+        final String text = "hello world big time data!";
+        final ByteBuf content = Unpooled.copiedBuffer(text.getBytes());
+        final String text2 = "hello world big time data...number 2!!";
+        final ByteBuf content2 = Unpooled.copiedBuffer(text2.getBytes());
+        final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT,
+                        "/some/path/resource", content, true);
+
         HttpHeaders httpHeaders = request.headers();
-        httpHeaders.set(Http2HttpHeaders.Names.STREAM_ID, 3);
-        final HttpMessage request2  = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
-                        HttpMethod.GET, "/some/path/resource2", true);
+        httpHeaders.set(Http2ToHttpHeaders.Names.STREAM_ID, 3);
+        httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, text.length());
+        final FullHttpMessage request2 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT,
+                        "/some/path/resource2", content2, true);
         HttpHeaders httpHeaders2 = request2.headers();
-        httpHeaders2.set(Http2HttpHeaders.Names.STREAM_ID, 5);
-        httpHeaders2.set(Http2HttpHeaders.Names.STREAM_DEPENDENCY_ID, 3);
-        httpHeaders2.set(Http2HttpHeaders.Names.STREAM_EXCLUSIVE, true);
-        httpHeaders2.set(Http2HttpHeaders.Names.STREAM_WEIGHT, 256);
-        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder()
-            .method("GET").path("/some/path/resource").build();
-        final Http2Headers http2Headers2 = new DefaultHttp2Headers.Builder()
-            .method("GET").path("/some/path/resource2").build();
-        final String text = "hello 1!**";
-        final HttpContent content = new DefaultLastHttpContent(Unpooled.copiedBuffer(text.getBytes()),
-                                                               true);
-        final String text2 = "hello 2!><";
-        final HttpContent content2 = new DefaultLastHttpContent(Unpooled.copiedBuffer(text2.getBytes()),
-                                                                true);
+        httpHeaders2.set(Http2ToHttpHeaders.Names.STREAM_ID, 5);
+        httpHeaders2.set(Http2ToHttpHeaders.Names.STREAM_DEPENDENCY_ID, 3);
+        httpHeaders2.set(Http2ToHttpHeaders.Names.STREAM_EXCLUSIVE, true);
+        httpHeaders2.set(Http2ToHttpHeaders.Names.STREAM_WEIGHT, 256);
+        httpHeaders2.set(HttpHeaders.Names.CONTENT_LENGTH, text2.length());
+        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder().method("PUT").path("/some/path/resource")
+                        .build();
+        final Http2Headers http2Headers2 = new DefaultHttp2Headers.Builder().method("PUT").path("/some/path/resource2")
+                        .build();
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
             public void run() {
-                frameWriter.writeHeaders(ctx(), 3, http2Headers, 0, false, newPromise());
-                frameWriter.writeHeaders(ctx(), 5, http2Headers2, 0, false, newPromise());
-                frameWriter.writePriority(ctx(), 5, 3, (short) 256, true, newPromise());
-                frameWriter.writeData(ctx(), 3,
-                    Unpooled.copiedBuffer(text.getBytes()), 0, true, newPromise());
-                frameWriter.writeData(ctx(), 5,
-                    Unpooled.copiedBuffer(text2.getBytes()), 0, true, newPromise());
-                ctx().flush();
+                frameWriter.writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                frameWriter.writeHeaders(ctxClient(), 5, http2Headers2, 0, false, newPromiseClient());
+                frameWriter.writePriority(ctxClient(), 5, 3, (short) 256, true, newPromiseClient());
+                frameWriter.writeData(ctxClient(), 3, content.retain(), 0, true, newPromiseClient());
+                frameWriter.writeData(ctxClient(), 5, content2.retain(), 0, true, newPromiseClient());
+                ctxClient().flush();
             }
         });
         awaitRequests();
         ArgumentCaptor<HttpObject> httpObjectCaptor = ArgumentCaptor.forClass(HttpObject.class);
-        verify(messageObserver, times(4)).messageReceived(httpObjectCaptor.capture());
-
+        verify(serverObserver, times(2)).messageReceived(httpObjectCaptor.capture());
         List<HttpObject> capturedHttpObjects = httpObjectCaptor.getAllValues();
         assertEquals(request, capturedHttpObjects.get(0));
-        assertEquals(content, capturedHttpObjects.get(1));
-        assertEquals(request2, capturedHttpObjects.get(2));
-        assertEquals(content2, capturedHttpObjects.get(3));
+        assertEquals(request2, capturedHttpObjects.get(1));
+        request.release();
+        request2.release();
+    }
+
+    @Test
+    public void serverRequestPushPromise() throws Exception {
+        setClientLatch(2);
+        final String text = "hello world big time data!";
+        final ByteBuf content = Unpooled.copiedBuffer(text.getBytes());
+        final String text2 = "hello world smaller data?";
+        final ByteBuf content2 = Unpooled.copiedBuffer(text2.getBytes());
+        final FullHttpMessage response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                        content, true);
+        HttpHeaders httpHeaders = response.headers();
+        httpHeaders.set(Http2ToHttpHeaders.Names.STREAM_ID, 3);
+        httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, text.length());
+        final FullHttpMessage response2 = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.CREATED,
+                        content2, true);
+        HttpHeaders httpHeaders2 = response2.headers();
+        httpHeaders2.set(Http2ToHttpHeaders.Names.SCHEME, "https");
+        httpHeaders2.set(Http2ToHttpHeaders.Names.AUTHORITY, "example.org");
+        httpHeaders2.set(Http2ToHttpHeaders.Names.STREAM_ID, 5);
+        httpHeaders2.set(Http2ToHttpHeaders.Names.STREAM_PROMISE_ID, 3);
+        httpHeaders2.set(HttpHeaders.Names.CONTENT_LENGTH, text2.length());
+
+        final HttpMessage request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/push/test", true);
+        httpHeaders = request.headers();
+        httpHeaders.set(Http2ToHttpHeaders.Names.STREAM_ID, 3);
+        httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, 0);
+        final Http2Headers http2Headers3 = new DefaultHttp2Headers.Builder().method("GET").path("/push/test").build();
+        runInChannel(clientChannel, new Http2Runnable() {
+            @Override
+            public void run() {
+                frameWriter.writeHeaders(ctxClient(), 3, http2Headers3, 0, true, newPromiseClient());
+                ctxClient().flush();
+            }
+        });
+        awaitRequests();
+        verify(serverObserver).messageReceived(eq(request));
+
+        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder().status("200").build();
+        final Http2Headers http2Headers2 = new DefaultHttp2Headers.Builder().status("201").scheme("https")
+                        .authority("example.org").build();
+        runInChannel(serverConnectedChannel, new Http2Runnable() {
+            @Override
+            public void run() {
+                frameWriter.writeHeaders(ctxServer(), 3, http2Headers, 0, false, newPromiseServer());
+                frameWriter.writePushPromise(ctxServer(), 3, 5, http2Headers2, 0, newPromiseServer());
+                frameWriter.writeData(ctxServer(), 3, content.retain(), 0, true, newPromiseServer());
+                frameWriter.writeData(ctxServer(), 5, content2.retain(), 0, true, newPromiseServer());
+                ctxServer().flush();
+            }
+        });
+        awaitResponses();
+        ArgumentCaptor<HttpObject> httpObjectCaptor = ArgumentCaptor.forClass(HttpObject.class);
+        verify(clientObserver, times(2)).messageReceived(httpObjectCaptor.capture());
+        List<HttpObject> capturedHttpObjects = httpObjectCaptor.getAllValues();
+        assertEquals(response, capturedHttpObjects.get(0));
+        assertEquals(response2, capturedHttpObjects.get(1));
+        response.release();
+        response2.release();
+    }
+
+    @Test
+    public void serverResponseHeaderInformational() throws Exception {
+        final FullHttpMessage request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT, "/info/test",
+                        true);
+        HttpHeaders httpHeaders = request.headers();
+        httpHeaders.set(Http2ToHttpHeaders.Names.STREAM_ID, 3);
+        httpHeaders.set(HttpHeaders.Names.EXPECT, HttpHeaders.Values.CONTINUE);
+        httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, 0);
+        final Http2Headers http2Headers = new DefaultHttp2Headers.Builder().method("PUT").path("/info/test")
+                        .set(HttpHeaders.Names.EXPECT.toString(), HttpHeaders.Values.CONTINUE).build();
+        runInChannel(clientChannel, new Http2Runnable() {
+            @Override
+            public void run() {
+                frameWriter.writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
+                ctxClient().flush();
+            }
+        });
+        awaitRequests();
+        verify(serverObserver).messageReceived(eq(request));
+        reset(serverObserver);
+
+        final FullHttpMessage response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE);
+        httpHeaders = response.headers();
+        httpHeaders.set(Http2ToHttpHeaders.Names.STREAM_ID, 3);
+        httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, 0);
+        final Http2Headers http2HeadersResponse = new DefaultHttp2Headers.Builder().status("100").build();
+        runInChannel(serverConnectedChannel, new Http2Runnable() {
+            @Override
+            public void run() {
+                frameWriter.writeHeaders(ctxServer(), 3, http2HeadersResponse, 0, false, newPromiseServer());
+                ctxServer().flush();
+            }
+        });
+        awaitResponses();
+        verify(clientObserver).messageReceived(eq(response));
+        reset(clientObserver);
+
+        setServerLatch(1);
+        final String text = "a big payload";
+        final ByteBuf payload = Unpooled.copiedBuffer(text.getBytes());
+        final FullHttpMessage request2 = request.copy(payload);
+        httpHeaders = request2.headers();
+        httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, text.length());
+        httpHeaders.remove(HttpHeaders.Names.EXPECT);
+        request.release();
+        runInChannel(clientChannel, new Http2Runnable() {
+            @Override
+            public void run() {
+                frameWriter.writeData(ctxClient(), 3, payload.retain(), 0, true, newPromiseClient());
+                ctxClient().flush();
+            }
+        });
+        awaitRequests();
+        verify(serverObserver).messageReceived(eq(request2));
+        request2.release();
+
+        setClientLatch(1);
+        final FullHttpMessage response2 = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        httpHeaders = response2.headers();
+        httpHeaders.set(Http2ToHttpHeaders.Names.STREAM_ID, 3);
+        httpHeaders.set(HttpHeaders.Names.CONTENT_LENGTH, 0);
+        final Http2Headers http2HeadersResponse2 = new DefaultHttp2Headers.Builder().status("200").build();
+        runInChannel(serverConnectedChannel, new Http2Runnable() {
+            @Override
+            public void run() {
+                frameWriter.writeHeaders(ctxServer(), 3, http2HeadersResponse2, 0, true, newPromiseServer());
+                ctxServer().flush();
+            }
+        });
+        awaitResponses();
+        verify(clientObserver).messageReceived(eq(response2));
+    }
+
+    private void setServerLatch(int count) {
+        serverLatch = new CountDownLatch(count);
+        if (serverDelegator != null) {
+            serverDelegator.latch(serverLatch);
+        }
+    }
+
+    private void setClientLatch(int count) {
+        clientLatch = new CountDownLatch(count);
+        if (clientDelegator != null) {
+            clientDelegator.latch(clientLatch);
+        }
     }
 
     private void awaitRequests() throws Exception {
-        serverLatch.await(2, SECONDS);
+        serverLatch.await(200, SECONDS);
     }
 
-    private ChannelHandlerContext ctx() {
+    private void awaitResponses() throws Exception {
+        clientLatch.await(200, SECONDS);
+    }
+
+    private ChannelHandlerContext ctxClient() {
         return clientChannel.pipeline().firstContext();
     }
 
-    private ChannelPromise newPromise() {
-        return ctx().newPromise();
+    private ChannelPromise newPromiseClient() {
+        return ctxClient().newPromise();
+    }
+
+    private ChannelHandlerContext ctxServer() {
+        return serverConnectedChannel.pipeline().firstContext();
+    }
+
+    private ChannelPromise newPromiseServer() {
+        return ctxServer().newPromise();
     }
 
     private interface HttpResponseListener {
@@ -444,130 +539,127 @@ public class InboundHttp2ToHttpAdapterTest {
 
     private final class HttpResponseDelegator extends SimpleChannelInboundHandler<HttpObject> {
         private final HttpResponseListener listener;
+        private CountDownLatch latch;
 
-        public HttpResponseDelegator(HttpResponseListener listener) {
+        public HttpResponseDelegator(HttpResponseListener listener, CountDownLatch latch) {
+            super(false);
             this.listener = listener;
+            this.latch = latch;
         }
 
         @Override
         protected void messageReceived(ChannelHandlerContext ctx, HttpObject msg) throws Exception {
             this.listener.messageReceived(msg);
-            serverLatch.countDown();
+            this.latch.countDown();
+        }
+
+        public void latch(CountDownLatch latch) {
+            this.latch = latch;
         }
     }
 
     private final class FrameAdapter extends ByteToMessageDecoder {
-
         private final Http2FrameObserver observer;
         private final DefaultHttp2FrameReader reader;
-        private final CountDownLatch requestLatch;
+        private final CountDownLatch latch;
 
-        FrameAdapter(Http2FrameObserver observer, CountDownLatch requestLatch) {
+        FrameAdapter(Http2FrameObserver observer, CountDownLatch latch) {
             this.observer = observer;
             reader = new DefaultHttp2FrameReader();
-            this.requestLatch = requestLatch;
+            this.latch = latch;
         }
 
         @Override
-        protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out)
-                throws Exception {
+        protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
             reader.readFrame(ctx, in, new Http2FrameObserver() {
 
                 @Override
-                public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data,
-                                       int padding, boolean endOfStream)
-                        throws Http2Exception {
+                public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
+                                boolean endOfStream) throws Http2Exception {
                     observer.onDataRead(ctx, streamId, copy(data), padding, endOfStream);
-                    requestLatch.countDown();
+                    latch.countDown();
                 }
 
                 @Override
-                public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
-                                          Http2Headers headers, int padding, boolean endStream)
-                        throws Http2Exception {
+                public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
+                                boolean endStream) throws Http2Exception {
                     observer.onHeadersRead(ctx, streamId, headers, padding, endStream);
-                    requestLatch.countDown();
+                    latch.countDown();
                 }
 
                 @Override
-                public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
-                                          Http2Headers headers, int streamDependency, short weight,
-                                          boolean exclusive, int padding, boolean endStream)
-                        throws Http2Exception {
-                    observer.onHeadersRead(ctx, streamId, headers, streamDependency, weight,
-                            exclusive, padding, endStream);
-                    requestLatch.countDown();
+                public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+                                int streamDependency, short weight, boolean exclusive, int padding, boolean endStream)
+                                throws Http2Exception {
+                    observer.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive, padding,
+                                    endStream);
+                    latch.countDown();
                 }
 
                 @Override
-                public void onPriorityRead(ChannelHandlerContext ctx, int streamId,
-                                           int streamDependency, short weight, boolean exclusive)
-                        throws Http2Exception {
+                public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency, short weight,
+                                boolean exclusive) throws Http2Exception {
                     observer.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
-                    requestLatch.countDown();
+                    latch.countDown();
                 }
 
                 @Override
                 public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
-                        throws Http2Exception {
+                                throws Http2Exception {
                     observer.onRstStreamRead(ctx, streamId, errorCode);
-                    requestLatch.countDown();
+                    latch.countDown();
                 }
 
                 @Override
                 public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
                     observer.onSettingsAckRead(ctx);
-                    requestLatch.countDown();
+                    latch.countDown();
                 }
 
                 @Override
-                public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings)
-                        throws Http2Exception {
+                public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception {
                     observer.onSettingsRead(ctx, settings);
-                    requestLatch.countDown();
+                    latch.countDown();
                 }
 
                 @Override
-                public void onPingRead(ChannelHandlerContext ctx, ByteBuf data)
-                        throws Http2Exception {
+                public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
                     observer.onPingRead(ctx, copy(data));
-                    requestLatch.countDown();
+                    latch.countDown();
                 }
 
                 @Override
-                public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data)
-                        throws Http2Exception {
+                public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
                     observer.onPingAckRead(ctx, copy(data));
-                    requestLatch.countDown();
+                    latch.countDown();
                 }
 
                 @Override
-                public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId,
-                                              int promisedStreamId, Http2Headers headers, int padding)
-                        throws Http2Exception {
+                public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
+                                Http2Headers headers, int padding) throws Http2Exception {
                     observer.onPushPromiseRead(ctx, streamId, promisedStreamId, headers, padding);
-                    requestLatch.countDown();
+                    latch.countDown();
                 }
 
                 @Override
-                public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId,
-                                         long errorCode, ByteBuf debugData) throws Http2Exception {
+                public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData)
+                                throws Http2Exception {
                     observer.onGoAwayRead(ctx, lastStreamId, errorCode, copy(debugData));
-                    requestLatch.countDown();
+                    latch.countDown();
                 }
 
                 @Override
-                public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId,
-                                               int windowSizeIncrement) throws Http2Exception {
+                public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
+                                throws Http2Exception {
                     observer.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
-                    requestLatch.countDown();
+                    latch.countDown();
                 }
 
                 @Override
-                public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
-                        Http2Flags flags, ByteBuf payload) {
+                public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
+                                ByteBuf payload) {
                     observer.onUnknownFrame(ctx, frameType, streamId, flags, payload);
-                    requestLatch.countDown();
+                    latch.countDown();
                 }
             });
         }

--- a/codec/src/main/java/io/netty/handler/codec/DefaultTextHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultTextHeaders.java
@@ -40,7 +40,7 @@ import java.util.HashSet;
 import java.util.TimeZone;
 
 public class DefaultTextHeaders implements TextHeaders {
-
+    private static final int HASH_CODE_PRIME = 31;
     private static final int BUCKET_SIZE = 17;
 
     private static int index(int hash) {
@@ -853,7 +853,17 @@ public class DefaultTextHeaders implements TextHeaders {
 
     @Override
     public Set<String> names() {
-        Set<String> names = new LinkedHashSet<String>(size());
+        return names(false);
+    }
+
+    /**
+     * Get the set of names for all text headers
+     * @param caseInsensitive {@code true} if names should be added in a case insensitive
+     * @return The set of names for all text headers
+     */
+    public Set<String> names(boolean caseInsensitive) {
+        Set<String> names = caseInsensitive ? new TreeSet<String>(String.CASE_INSENSITIVE_ORDER)
+                                            : new LinkedHashSet<String>(size());
         HeaderEntry e = head.after;
         while (e != head) {
             names.add(e.getKey().toString());
@@ -880,13 +890,12 @@ public class DefaultTextHeaders implements TextHeaders {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
         int result = 1;
-        for (String name : names()) {
-            result = prime * result + name.hashCode();
+        for (String name : names(true)) {
+            result = HASH_CODE_PRIME * result + name.hashCode();
             Set<String> values = new TreeSet<String>(getAll(name));
             for (String value : values) {
-                result = prime * result + value.hashCode();
+                result = HASH_CODE_PRIME * result + value.hashCode();
             }
         }
         return result;
@@ -901,8 +910,8 @@ public class DefaultTextHeaders implements TextHeaders {
         DefaultTextHeaders other = (DefaultTextHeaders) o;
 
         // First, check that the set of names match.
-        Set<String> names = names();
-        if (!names.equals(other.names())) {
+        Set<String> names = names(true);
+        if (!names.equals(other.names(true))) {
             return false;
         }
 

--- a/codec/src/test/java/io/netty/handler/codec/DefaultTextHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DefaultTextHeadersTest.java
@@ -15,23 +15,22 @@
  */
 package io.netty.handler.codec;
 
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.embedded.EmbeddedChannel;
-import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 public class DefaultTextHeadersTest {
 
     @Test
     public void testEqualsMultipleHeaders() {
         DefaultTextHeaders h1 = new DefaultTextHeaders();
-        h1.set("foo", "goo");
+        h1.set("Foo", "goo");
         h1.set("foo2", "goo2");
 
         DefaultTextHeaders h2 = new DefaultTextHeaders();
-        h2.set("foo", "goo");
-        h2.set("foo2", "goo2");
+        h2.set("FoO", "goo");
+        h2.set("fOO2", "goo2");
 
         assertTrue(h1.equals(h2));
         assertTrue(h2.equals(h1));
@@ -42,16 +41,16 @@ public class DefaultTextHeadersTest {
     @Test
     public void testEqualsDuplicateMultipleHeaders() {
         DefaultTextHeaders h1 = new DefaultTextHeaders();
-        h1.set("foo", "goo");
-        h1.set("foo2", "goo2");
-        h1.add("foo2", "goo3");
+        h1.set("FOO", "goo");
+        h1.set("Foo2", "goo2");
+        h1.add("fOo2", "goo3");
         h1.add("foo", "goo4");
 
         DefaultTextHeaders h2 = new DefaultTextHeaders();
         h2.set("foo", "goo");
         h2.set("foo2", "goo2");
         h2.add("foo", "goo4");
-        h2.add("foo2", "goo3");
+        h2.add("foO2", "goo3");
 
         assertTrue(h1.equals(h2));
         assertTrue(h2.equals(h1));
@@ -62,7 +61,7 @@ public class DefaultTextHeadersTest {
     @Test
     public void testNotEqualsDuplicateMultipleHeaders() {
         DefaultTextHeaders h1 = new DefaultTextHeaders();
-        h1.set("foo", "goo");
+        h1.set("FOO", "goo");
         h1.set("foo2", "goo2");
         h1.add("foo2", "goo3");
         h1.add("foo", "goo4");

--- a/example/src/main/java/io/netty/example/http2/client/Http2ClientInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/client/Http2ClientInitializer.java
@@ -54,12 +54,12 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
                     new Http2FrameLogger(INFO, InternalLoggerFactory.getInstance(Http2ClientInitializer.class));
 
     private final SslContext sslCtx;
-    private final long maxContentLength;
+    private final int maxContentLength;
     private DelegatingHttp2ConnectionHandler connectionHandler;
     private HttpResponseHandler responseHandler;
     private Http2SettingsHandler settingsHandler;
 
-    public Http2ClientInitializer(SslContext sslCtx, long maxContentLength) {
+    public Http2ClientInitializer(SslContext sslCtx, int maxContentLength) {
         this.sslCtx = sslCtx;
         this.maxContentLength = maxContentLength;
     }
@@ -91,8 +91,6 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
 
     protected void configureEndOfPipeline(ChannelPipeline pipeline) {
         pipeline.addLast("Http2SettingsHandler", settingsHandler);
-        pipeline.addLast("Decompressor", new HttpContentDecompressor());
-        pipeline.addLast("Aggregator", new HttpObjectAggregator((int) maxContentLength));
         pipeline.addLast("HttpResponseHandler", responseHandler);
     }
 

--- a/example/src/main/java/io/netty/example/http2/client/HttpResponseHandler.java
+++ b/example/src/main/java/io/netty/example/http2/client/HttpResponseHandler.java
@@ -19,7 +19,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http2.Http2HttpHeaders;
+import io.netty.handler.codec.http2.Http2ToHttpHeaders;
 import io.netty.util.CharsetUtil;
 
 import java.util.Iterator;
@@ -76,7 +76,7 @@ public class HttpResponseHandler extends SimpleChannelInboundHandler<FullHttpRes
 
     @Override
     protected void messageReceived(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {
-        int streamId = Integer.parseInt(msg.headers().get(Http2HttpHeaders.Names.STREAM_ID));
+        int streamId = Integer.parseInt(msg.headers().get(Http2ToHttpHeaders.Names.STREAM_ID));
         ChannelPromise promise = streamidPromiseMap.get(streamId);
         if (promise == null) {
             System.err.println("Message received for unknown stream id " + streamId);


### PR DESCRIPTION
Motivation:

HTTP/2 draft 14 came out a couple of weeks ago and we need to keep up
with the spec.

Modifications:

-Allow informational type messages to be sent up the pipeline immediatley.
-Corrections to HttpObject comparitors to support test cases
-New test cases to support sending headers immediatley
-Bug fixes cleaned up to ensure the message flow is terminated properly

Result:
Netty HTTP/2 to HTTP/1.x translation layer will support the HTTP/2 draft message flow.
