### PR TITLE
Fix example for Http Upload

### DIFF
--- a/example/src/main/java/io/netty/example/http/upload/HttpUploadClient.java
+++ b/example/src/main/java/io/netty/example/http/upload/HttpUploadClient.java
@@ -240,8 +240,9 @@ public final class HttpUploadClient {
         // test if request was chunked and if so, finish the write
         if (bodyRequestEncoder.isChunked()) { // could do either request.isChunked()
             // either do it through ChunkedWriteHandler
-            channel.write(bodyRequestEncoder).sync();
+            channel.write(bodyRequestEncoder);
         }
+        channel.flush();
 
         // Do not clear here since we will reuse the InterfaceHttpData on the next request
         // for the example (limit action on client side). Take this as a broadcast of the same
@@ -290,8 +291,9 @@ public final class HttpUploadClient {
 
         // test if request was chunked and if so, finish the write
         if (bodyRequestEncoder.isChunked()) {
-            channel.write(bodyRequestEncoder).sync();
+            channel.write(bodyRequestEncoder);
         }
+        channel.flush();
 
         // Now no more use of file representation (and list of HttpData)
         bodyRequestEncoder.cleanFiles();

--- a/example/src/main/java/io/netty/example/http/upload/HttpUploadServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/upload/HttpUploadServerHandler.java
@@ -145,7 +145,7 @@ public class HttpUploadServerHandler extends SimpleChannelInboundHandler<HttpObj
                 // GET Method: should not try to create a HttpPostRequestDecoder
                 // So stop here
                 responseContent.append("\r\n\r\nEND OF GET CONTENT\r\n");
-                writeResponse(ctx.channel());
+                // Not now: LastHttpContent will be sent writeResponse(ctx.channel());
                 return;
             }
             try {
@@ -195,6 +195,8 @@ public class HttpUploadServerHandler extends SimpleChannelInboundHandler<HttpObj
                     reset();
                 }
             }
+        } else {
+            writeResponse(ctx.channel());
         }
     }
 


### PR DESCRIPTION
Motivation:
The example mis handle two elements:
1) Last message is a LastHttpContent and is not taken into account by
the server handler
2) The client makes a sync on last write (chunked) but there is no flush
before, therefore the sync is waiting forever.

Modifications:
1) Take into account the message LastHttpContent in simple Get.
2) Removes sync but add flush for each post and multipost parts

Results:
Example is no more blocked after get test.

Should be done also in 4.0 and Master (similar changes)
