### PR TITLE
Add HTTP/2 codec to netty-all maven dependency

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -142,6 +142,13 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-http2</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-memcache</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>


### PR DESCRIPTION
Motivation:

The HTTP/2 codec is missing from the netty-all maven dependency.
This means third party libraries have to pull in additional dependencies
above netty-all to use this codec.

Modifications:

Add HTTP/2 codec to netty-all

Result:

Third party libraries don't need to pull in additional dependencies
to use HTTP/2 codec.
