### PR TITLE
Pluggable algorithm to choose next EventLoop

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutorScheduler.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutorScheduler.java
@@ -30,8 +30,19 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public abstract class AbstractEventExecutorScheduler<T1 extends EventExecutor, T2 extends EventExecutorMetrics>
         implements EventExecutorScheduler<T1, T2> {
 
-    protected final ArrayList<T1> children = new ArrayList<T1>();
+    protected final ArrayList<T1> children;
     private Set<T1> readonlyChildren;
+
+    protected AbstractEventExecutorScheduler() {
+        children = new ArrayList<T1>();
+    }
+
+    /**
+     * @param nChildren the expected number of child {@linkplain EventExecutor}s.
+     */
+    protected AbstractEventExecutorScheduler(int nChildren) {
+        children = new ArrayList<T1>(nChildren);
+    }
 
     @Override
     public final void addChild(T1 executor, T2 metrics) {

--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutorScheduler.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutorScheduler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.util.concurrent;
+
+import io.netty.util.metrics.EventExecutorMetrics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Abstract base class for {@link EventExecutorScheduler} implementations.
+ */
+public abstract class AbstractEventExecutorScheduler<T1 extends EventExecutor, T2 extends EventExecutorMetrics>
+        implements EventExecutorScheduler<T1, T2> {
+
+    protected final ArrayList<T1> children = new ArrayList<T1>();
+    private Set<T1> readonlyChildren;
+
+    @Override
+    public final void addChild(T1 executor, T2 metrics) {
+        if (executor == null) {
+            throw new NullPointerException("executor");
+        }
+
+        children.add(executor);
+        readonlyChildren = null;
+    }
+
+    @Override
+    public final Set<T1> children() {
+        if (readonlyChildren == null) {
+            Set<T1> childrenSet = new LinkedHashSet<T1>(children);
+            readonlyChildren = Collections.unmodifiableSet(childrenSet);
+        }
+
+        return readonlyChildren;
+    }
+}

--- a/common/src/main/java/io/netty/util/concurrent/DefaultEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultEventExecutorGroup.java
@@ -15,13 +15,18 @@
  */
 package io.netty.util.concurrent;
 
+import io.netty.util.metrics.EventExecutorMetrics;
+import io.netty.util.metrics.NoEventExecutorMetrics;
+
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Default implementation of {@link MultithreadEventExecutorGroup} which will use {@link DefaultEventExecutor}
  * instances to handle the tasks.
  */
-public class DefaultEventExecutorGroup extends MultithreadEventExecutorGroup {
+public class DefaultEventExecutorGroup
+        extends MultithreadEventExecutorGroup<EventExecutor, EventExecutorMetrics<EventExecutor>> {
 
     /**
      * Create a new instance.
@@ -40,7 +45,7 @@ public class DefaultEventExecutorGroup extends MultithreadEventExecutorGroup {
      *                  this {@link EventExecutorGroup}.
      */
     public DefaultEventExecutorGroup(int nEventExecutors, Executor executor) {
-        super(nEventExecutors, executor);
+        super(nEventExecutors, executor, null, null);
     }
 
     /**
@@ -51,11 +56,32 @@ public class DefaultEventExecutorGroup extends MultithreadEventExecutorGroup {
      *                          executing the work handled by this {@link EventExecutorGroup}.
      */
     public DefaultEventExecutorGroup(int nEventExecutors, ExecutorFactory executorFactory) {
-        super(nEventExecutors, executorFactory);
+        super(nEventExecutors, executorFactory, null, null);
     }
 
     @Override
-    protected EventExecutor newChild(Executor executor, Object... args) throws Exception {
+    protected EventExecutor newChild(Executor executor, EventExecutorMetrics metrics, Object... args) throws Exception {
         return new DefaultEventExecutor(this, executor);
+    }
+
+    protected EventExecutorScheduler<EventExecutor, EventExecutorMetrics<EventExecutor>>
+    newDefaultScheduler(int nEventExecutors) {
+        return new RoundRobinEventExecutorScheduler();
+    }
+
+    private static final class RoundRobinEventExecutorScheduler
+            extends AbstractEventExecutorScheduler<EventExecutor, EventExecutorMetrics<EventExecutor>> {
+
+        private final AtomicInteger index = new AtomicInteger();
+
+        @Override
+        public EventExecutor next() {
+            return children.get(index.getAndIncrement() % children.size());
+        }
+
+        @Override
+        public EventExecutorMetrics<EventExecutor> newMetrics() {
+            return NoEventExecutorMetrics.INSTANCE;
+        }
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/DefaultEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultEventExecutorGroup.java
@@ -66,7 +66,7 @@ public class DefaultEventExecutorGroup
 
     protected EventExecutorScheduler<EventExecutor, EventExecutorMetrics<EventExecutor>>
     newDefaultScheduler(int nEventExecutors) {
-        return new RoundRobinEventExecutorScheduler();
+        return new RoundRobinEventExecutorScheduler(nEventExecutors);
     }
 
     private static final class RoundRobinEventExecutorScheduler
@@ -74,9 +74,13 @@ public class DefaultEventExecutorGroup
 
         private final AtomicInteger index = new AtomicInteger();
 
+        RoundRobinEventExecutorScheduler(int nEventExecutors) {
+            super(nEventExecutors);
+        }
+
         @Override
         public EventExecutor next() {
-            return children.get(index.getAndIncrement() % children.size());
+            return children.get(Math.abs(index.getAndIncrement() % children.size()));
         }
 
         @Override

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutorScheduler.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutorScheduler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.util.concurrent;
+
+import io.netty.util.metrics.EventExecutorMetrics;
+import io.netty.util.metrics.EventExecutorMetricsFactory;
+
+import java.util.Set;
+
+/**
+ * Derive from this interface to create your own {@link EventExecutorScheduler} implementation.
+ */
+public interface EventExecutorScheduler<T1 extends EventExecutor, T2 extends EventExecutorMetrics>
+        extends EventExecutorMetricsFactory<T2> {
+
+    /**
+     * Returns one of the {@linkplain EventExecutor}s managed by this {@link EventExecutorScheduler}.
+     * This method must be implemented thread-safe. This method must not return {@code null}.
+     */
+    T1 next();
+
+    /**
+     * Add an {@link EventExecutor} and its corresponding {@link EventExecutorMetrics} object.
+     */
+    void addChild(T1 executor, T2 metrics);
+
+    /**
+     * Returns an unmodifiable set of all {@linkplain EventExecutor}s managed by this {@link EventExecutorScheduler}.
+     */
+    Set<T1> children();
+}

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutorScheduler.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutorScheduler.java
@@ -29,7 +29,7 @@ public interface EventExecutorScheduler<T1 extends EventExecutor, T2 extends Eve
 
     /**
      * Returns one of the {@linkplain EventExecutor}s managed by this {@link EventExecutorScheduler}.
-     * This method must be implemented thread-safe. This method must not return {@code null}.
+     * This method must be implemented thread-safe. This method must <strong>NOT</strong> return {@code null}.
      */
     T1 next();
 
@@ -40,6 +40,8 @@ public interface EventExecutorScheduler<T1 extends EventExecutor, T2 extends Eve
 
     /**
      * Returns an unmodifiable set of all {@linkplain EventExecutor}s managed by this {@link EventExecutorScheduler}.
+     * The {@link Set} will not contain any {@linkplain EventExecutor}s that are added via
+     * {@link #addChild(EventExecutor, EventExecutorMetrics)} after it was retrieved.
      */
     Set<T1> children();
 }

--- a/common/src/main/java/io/netty/util/metrics/EventExecutorMetrics.java
+++ b/common/src/main/java/io/netty/util/metrics/EventExecutorMetrics.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.util.metrics;
+
+import io.netty.util.concurrent.EventExecutor;
+
+/**
+ * Derive from this interface to implement your own {@link EventExecutorMetrics} class.
+ */
+public interface EventExecutorMetrics<T extends EventExecutor> {
+    /**
+     * This method is called immediately after an {@link EventExecutorMetrics} object is passed to an
+     * {@link EventExecutor} and can be used for any additional initialization work that requires access to the
+     * {@link EventExecutor}. With exception to the constructor, this method is called before any other method of
+     * {@link EventExecutorMetrics}. This method is called exactly once.
+     *
+     * @param eventExecutor the {@link EventExecutor} to which the object is attached to.
+     */
+    void init(T eventExecutor);
+}

--- a/common/src/main/java/io/netty/util/metrics/EventExecutorMetricsFactory.java
+++ b/common/src/main/java/io/netty/util/metrics/EventExecutorMetricsFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.util.metrics;
+
+/**
+ * Derive from this interface to create your own {@link EventExecutorMetricsFactory} implementation.
+ */
+public interface EventExecutorMetricsFactory<T extends EventExecutorMetrics> {
+
+    /**
+     * Returns a new {@link EventExecutorMetrics} object.
+     */
+    T newMetrics();
+}

--- a/common/src/main/java/io/netty/util/metrics/NoEventExecutorMetrics.java
+++ b/common/src/main/java/io/netty/util/metrics/NoEventExecutorMetrics.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.util.metrics;
+
+import io.netty.util.concurrent.EventExecutor;
+
+/**
+ * An {@link EventExecutorMetrics} implementation that doesn't collect any metrics.
+ */
+public final class NoEventExecutorMetrics implements EventExecutorMetrics<EventExecutor> {
+
+    public static final NoEventExecutorMetrics INSTANCE = new NoEventExecutorMetrics();
+
+    private NoEventExecutorMetrics() { }
+
+    @Override
+    public void init(EventExecutor eventExecutor) {
+        // NOOP
+    }
+}

--- a/common/src/main/java/io/netty/util/metrics/package-info.java
+++ b/common/src/main/java/io/netty/util/metrics/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A collection of classes that allow to gather information about {@linkplain io.netty.util.concurrent.EventExecutor}s.
+ */
+package io.netty.util.metrics;

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -16,9 +16,13 @@
 package io.netty.channel.epoll;
 
 import io.netty.channel.EventLoop;
+import io.netty.channel.metrics.EventLoopMetrics;
+import io.netty.channel.EventLoopScheduler;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
+import io.netty.channel.metrics.EventLoopMetricsFactory;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.metrics.EventExecutorMetrics;
 import io.netty.util.concurrent.ExecutorFactory;
 
 import java.util.concurrent.Executor;
@@ -31,78 +35,201 @@ import io.netty.util.concurrent.DefaultExecutorFactory;
  */
 public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
 
+    private static final int DEFAULT_MAX_EVENTS_AT_ONCE = 128;
+
     /**
-     * Create a new instance that uses twice as many {@link EventLoop}s as there processors/cores
-     * available, as well as the default {@link Executor}.
-     *
-     * @see DefaultExecutorFactory
+     * Create a new instance that uses twice as many {@linkplain EventLoop}s as there are processors/cores available or
+     * whatever is specified by {@code -Dio.netty.eventLoopThreads}. Further, the {@link Executor} returned by
+     * {@link DefaultExecutorFactory} is used.
      */
     public EpollEventLoopGroup() {
         this(0);
     }
 
     /**
-     * Create a new instance that uses the default {@link Executor}.
+     * Create a new instance that uses the {@link DefaultExecutorFactory}.
      *
-     * @see DefaultExecutorFactory
-     *
-     * @param nEventLoops   the number of {@link EventLoop}s that will be used by this instance.
-     *                      If {@code executor} is {@code null} this number will also be the parallelism
-     *                      requested from the default executor. It is generally advised for the number
-     *                      of {@link EventLoop}s and the number of {@link Thread}s used by the
+     * @param nEventLoops   the number of {@linkplain EventLoop}s that will be used by this group. This will also
+     *                      be the number of threads requested from the {@link DefaultExecutorFactory}.
      */
     public EpollEventLoopGroup(int nEventLoops) {
         this(nEventLoops, (Executor) null);
     }
 
     /**
-     * @param nEventLoops   the number of {@link EventLoop}s that will be used by this instance.
-     *                      If {@code executor} is {@code null} this number will also be the parallelism
-     *                      requested from the default executor. It is generally advised for the number
-     *                      of {@link EventLoop}s and the number of {@link Thread}s used by the
-     *                      {@code executor} to lie very close together.
-     * @param executor  the {@link Executor} to use, or {@code null} if the default should be used.
+     * @param nEventLoops   the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                      If {@code Executor} is {@code null} this will also be the number of threads
+     *                      requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                      and the number of threads used by the {@code Executor} to lie very close together.
+     *                      You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                      {@linkplain EventLoop}s. See {@link #EpollEventLoopGroup()} for details.
+     * @param executor      the {@link Executor} to use, or {@code null} if the one returned
+     *                      by {@link DefaultExecutorFactory} should be used.
      */
     public EpollEventLoopGroup(int nEventLoops, Executor executor) {
-        this(nEventLoops, executor, 128);
+        this(nEventLoops, executor, DEFAULT_MAX_EVENTS_AT_ONCE);
     }
 
     /**
-     * @param nEventLoops   the number of {@link EventLoop}s that will be used by this instance.
-     *                      If {@code executor} is {@code null} this number will also be the parallelism
-     *                      requested from the default executor. It is generally advised for the number
-     *                      of {@link EventLoop}s and the number of {@link Thread}s used by the
-     *                      {@code executor} to lie very close together.
-     * @param executorFactory   the {@link ExecutorFactory} to use, or {@code null} if the default should be used.
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #EpollEventLoopGroup()} for details.
+     * @param executorFactory   the {@link ExecutorFactory} to use, or {@code null} if {@link DefaultExecutorFactory}
+     *                          should be used.
      */
     public EpollEventLoopGroup(int nEventLoops, ExecutorFactory executorFactory) {
-        this(nEventLoops, executorFactory, 128);
+        this(nEventLoops, executorFactory, DEFAULT_MAX_EVENTS_AT_ONCE);
     }
 
     /**
-     * @param nEventLoops   the number of {@link EventLoop}s that will be used by this instance.
-     *                      If {@code executor} is {@code null} this number will also be the parallelism
-     *                      requested from the default executor. It is generally advised for the number
-     *                      of {@link EventLoop}s and the number of {@link Thread}s used by the
-     *                      {@code executor} to lie very close together.
-     * @param executor   the {@link Executor} to use, or {@code null} if the default should be used.
-     * @param maxEventsAtOnce   the maximum number of epoll events to handle per epollWait(...).
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #EpollEventLoopGroup()} for details.
+     * @param executor          the {@link Executor} to use, or {@code null} if the one returned
+     *                          by {@link DefaultExecutorFactory} should be used.
+     * @param maxEventsAtOnce   the maximum number of epoll events to handle per epollWait(...). The default is
+     *                          {@value #DEFAULT_MAX_EVENTS_AT_ONCE}.
      */
     public EpollEventLoopGroup(int nEventLoops, Executor executor, int maxEventsAtOnce) {
-        super(nEventLoops, executor, maxEventsAtOnce);
+        super(nEventLoops, executor, null, null, maxEventsAtOnce);
     }
 
     /**
-     * @param nEventLoops   the number of {@link EventLoop}s that will be used by this instance.
-     *                      If {@code executor} is {@code null} this number will also be the parallelism
-     *                      requested from the default executor. It is generally advised for the number
-     *                      of {@link EventLoop}s and the number of {@link Thread}s used by the
-     *                      {@code executor} to lie very close together.
-     * @param executorFactory   the {@link ExecutorFactory} to use, or {@code null} if the default should be used.
-     * @param maxEventsAtOnce   the maximum number of epoll events to handle per epollWait(...).
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #EpollEventLoopGroup()} for details.
+     * @param executorFactory   the {@link ExecutorFactory} to use, or {@code null} if {@link DefaultExecutorFactory}
+     *                          should be used.
+     * @param maxEventsAtOnce   the maximum number of epoll events to handle per epollWait(...). The default is
+     *                          {@value #DEFAULT_MAX_EVENTS_AT_ONCE}.
      */
     public EpollEventLoopGroup(int nEventLoops, ExecutorFactory executorFactory, int maxEventsAtOnce) {
-        super(nEventLoops, executorFactory, maxEventsAtOnce);
+        this(nEventLoops, executorFactory, (EventLoopScheduler) null, maxEventsAtOnce);
+    }
+
+    /**
+     * Create a new instance that uses the {@link DefaultExecutorFactory}.
+     *
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #EpollEventLoopGroup()} for details.
+     * @param scheduler         the {@link EventLoopScheduler} that, on every call to {@link EventLoopGroup#next()},
+     *                          decides which {@link EventLoop} to return.
+     */
+    public EpollEventLoopGroup(int nEventLoops, EventLoopScheduler scheduler) {
+        super(nEventLoops, (Executor) null, scheduler, null, DEFAULT_MAX_EVENTS_AT_ONCE);
+    }
+
+    /**
+     * Create a new instance that uses the {@link DefaultExecutorFactory}.
+     *
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #EpollEventLoopGroup()} for details.
+     * @param metricsFactory    provide your own {@link EventLoopMetricsFactory} to gather information for every
+     *                          {@link EventLoop} of this group.
+     */
+    public EpollEventLoopGroup(int nEventLoops, EventLoopMetricsFactory metricsFactory) {
+        super(nEventLoops, (Executor) null, null, metricsFactory, DEFAULT_MAX_EVENTS_AT_ONCE);
+    }
+
+    /**
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #EpollEventLoopGroup()} for details.
+     * @param executor          the {@link Executor} to use, or {@code null} if the one returned
+     *                          by {@link DefaultExecutorFactory} should be used.
+     * @param scheduler         the {@link EventLoopScheduler} that, on every call to {@link EventLoopGroup#next()},
+     *                          decides which {@link EventLoop} to return.
+     * @param maxEventsAtOnce   the maximum number of epoll events to handle per epollWait(...). The default is
+     *                          {@value #DEFAULT_MAX_EVENTS_AT_ONCE}.
+     */
+    public EpollEventLoopGroup(int nEventLoops,
+                               Executor executor,
+                               EventLoopScheduler scheduler,
+                               int maxEventsAtOnce) {
+        super(nEventLoops, executor, scheduler, null, maxEventsAtOnce);
+    }
+
+    /**
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #EpollEventLoopGroup()} for details.
+     * @param executorFactory   the {@link ExecutorFactory} to use, or {@code null} if {@link DefaultExecutorFactory}
+     *                          should be used.
+     * @param scheduler         the {@link EventLoopScheduler} that, on every call to {@link EventLoopGroup#next()},
+     *                          decides which {@link EventLoop} to return.
+     * @param maxEventsAtOnce   the maximum number of epoll events to handle per epollWait(...). The default is
+     *                          {@value #DEFAULT_MAX_EVENTS_AT_ONCE}.
+     */
+    public EpollEventLoopGroup(int nEventLoops,
+                               ExecutorFactory executorFactory,
+                               EventLoopScheduler scheduler,
+                               int maxEventsAtOnce) {
+        super(nEventLoops, executorFactory, scheduler, null, maxEventsAtOnce);
+    }
+
+    /**
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #EpollEventLoopGroup()} for details.
+     * @param executor          the {@link Executor} to use, or {@code null} if the one returned
+     *                          by {@link DefaultExecutorFactory} should be used.
+     * @param metricsFactory    provide your own {@link EventLoopMetricsFactory} to gather information for every
+     *                          {@link EventLoop} of this group.
+     * @param maxEventsAtOnce   the maximum number of epoll events to handle per epollWait(...). The default is
+     *                          {@value #DEFAULT_MAX_EVENTS_AT_ONCE}.
+     */
+    public EpollEventLoopGroup(int nEventLoops,
+                               Executor executor,
+                               EventLoopMetricsFactory metricsFactory,
+                               int maxEventsAtOnce) {
+        super(nEventLoops, executor, null, metricsFactory, maxEventsAtOnce);
+    }
+
+    /**
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #EpollEventLoopGroup()} for details.
+     * @param executorFactory   the {@link ExecutorFactory} to use, or {@code null} if {@link DefaultExecutorFactory}
+     *                          should be used.
+     * @param metricsFactory    provide your own {@link EventLoopMetricsFactory} to gather information for every
+     *                          {@link EventLoop} of this group.
+     * @param maxEventsAtOnce   the maximum number of epoll events to handle per epollWait(...). The default is
+     *                          {@value #DEFAULT_MAX_EVENTS_AT_ONCE}.
+     */
+    public EpollEventLoopGroup(int nEventLoops,
+                               ExecutorFactory executorFactory,
+                               EventLoopMetricsFactory metricsFactory,
+                               int maxEventsAtOnce) {
+        super(nEventLoops, executorFactory, null, metricsFactory, maxEventsAtOnce);
     }
 
     /**
@@ -116,7 +243,7 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
     }
 
     @Override
-    protected EventLoop newChild(Executor executor, Object... args) throws Exception {
-        return new EpollEventLoop(this, executor, (Integer) args[0]);
+    protected EventLoop newChild(Executor executor, EventLoopMetrics metrics, Object... args) throws Exception {
+        return new EpollEventLoop(this, executor, metrics, (Integer) args[0]);
     }
 }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -74,7 +74,7 @@ public final class EpollServerSocketChannel extends AbstractEpollChannel impleme
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+    protected long doWrite(ChannelOutboundBuffer in) throws Exception {
         throw new UnsupportedOperationException();
     }
 

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpServerChannel.java
@@ -137,11 +137,11 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
     @Override
     protected int doReadMessages(List<Object> buf) throws Exception {
         SctpChannel ch = javaChannel().accept();
-        if (ch == null) {
-            return 0;
+        if (ch != null) {
+            buf.add(new NioSctpChannel(this, ch));
         }
-        buf.add(new NioSctpChannel(this, ch));
-        return 1;
+
+        return 0;
     }
 
     @Override
@@ -217,7 +217,7 @@ public class NioSctpServerChannel extends AbstractNioMessageChannel
     }
 
     @Override
-    protected boolean doWriteMessage(Object msg, ChannelOutboundBuffer in) throws Exception {
+    protected long doWriteMessage(Object msg, ChannelOutboundBuffer in) throws Exception {
         throw new UnsupportedOperationException();
     }
 

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpChannel.java
@@ -216,31 +216,34 @@ public class OioSctpChannel extends AbstractOioMessageChannel
         return readMessages;
     }
 
+    /**
+     * This method always returns {@code 0}, as the OIO transport doesn't use the value.
+     */
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+    protected long doWrite(ChannelOutboundBuffer in) throws Exception {
         if (!writeSelector.isOpen()) {
-            return;
+            return 0;
         }
         final int size = in.size();
         final int selectedKeys = writeSelector.select(SO_TIMEOUT);
         if (selectedKeys > 0) {
             final Set<SelectionKey> writableKeys = writeSelector.selectedKeys();
             if (writableKeys.isEmpty()) {
-                return;
+                return 0;
             }
             Iterator<SelectionKey> writableKeysIt = writableKeys.iterator();
             int written = 0;
             for (;;) {
                 if (written == size) {
                     // all written
-                    return;
+                    return 0;
                 }
                 writableKeysIt.next();
                 writableKeysIt.remove();
 
                 SctpMessage packet = (SctpMessage) in.current();
                 if (packet == null) {
-                    return;
+                    return 0;
                 }
 
                 ByteBuf data = packet.content();
@@ -264,10 +267,12 @@ public class OioSctpChannel extends AbstractOioMessageChannel
                 in.remove();
 
                 if (!writableKeysIt.hasNext()) {
-                    return;
+                    return 0;
                 }
             }
         }
+
+        return 0;
     }
 
     @Override

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
@@ -286,7 +286,7 @@ public class OioSctpServerChannel extends AbstractOioMessageChannel
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+    protected long doWrite(ChannelOutboundBuffer in) throws Exception {
         throw new UnsupportedOperationException();
     }
 

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtAcceptorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtAcceptorChannel.java
@@ -94,7 +94,7 @@ public abstract class NioUdtAcceptorChannel extends AbstractNioMessageChannel im
     }
 
     @Override
-    protected boolean doWriteMessage(Object msg, ChannelOutboundBuffer in) throws Exception {
+    protected long doWriteMessage(Object msg, ChannelOutboundBuffer in) throws Exception {
         throw new UnsupportedOperationException();
     }
 

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteAcceptorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteAcceptorChannel.java
@@ -35,12 +35,11 @@ public class NioUdtByteAcceptorChannel extends NioUdtAcceptorChannel {
     @Override
     protected int doReadMessages(List<Object> buf) throws Exception {
         final SocketChannelUDT channelUDT = javaChannel().accept();
-        if (channelUDT == null) {
-            return 0;
-        } else {
+        if (channelUDT != null) {
             buf.add(new NioUdtByteConnectorChannel(this, channelUDT));
-            return 1;
         }
+
+        return 0;
     }
 
     @Override

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageAcceptorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageAcceptorChannel.java
@@ -35,17 +35,14 @@ public class NioUdtMessageAcceptorChannel extends NioUdtAcceptorChannel {
     @Override
     protected int doReadMessages(List<Object> buf) throws Exception {
         final SocketChannelUDT channelUDT = javaChannel().accept();
-        if (channelUDT == null) {
-            return 0;
-        } else {
+        if (channelUDT != null) {
             buf.add(new NioUdtMessageConnectorChannel(this, channelUDT));
-            return 1;
         }
+        return 0;
     }
 
     @Override
     public ChannelMetadata metadata() {
         return METADATA;
     }
-
 }

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel.java
@@ -163,11 +163,11 @@ public class NioUdtMessageConnectorChannel extends AbstractNioMessageChannel imp
         // delivers a message
         buf.add(new UdtMessage(byteBuf));
 
-        return 1;
+        return receivedMessageSize;
     }
 
     @Override
-    protected boolean doWriteMessage(Object msg, ChannelOutboundBuffer in) throws Exception {
+    protected long doWriteMessage(Object msg, ChannelOutboundBuffer in) throws Exception {
         // expects a message
         final UdtMessage message = (UdtMessage) msg;
 
@@ -184,7 +184,7 @@ public class NioUdtMessageConnectorChannel extends AbstractNioMessageChannel imp
 
         // did not write the message
         if (writtenBytes <= 0 && messageSize > 0) {
-            return false;
+            return -1;
         }
 
         // wrote message completely
@@ -193,7 +193,7 @@ public class NioUdtMessageConnectorChannel extends AbstractNioMessageChannel imp
                     "Provider error: failed to write message. Provider library should be upgraded.");
         }
 
-        return true;
+        return writtenBytes;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/AbstractEventLoopScheduler.java
+++ b/transport/src/main/java/io/netty/channel/AbstractEventLoopScheduler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel;
+
+import io.netty.channel.metrics.EventLoopMetrics;
+import io.netty.util.concurrent.AbstractEventExecutorScheduler;
+
+/**
+ * Abstract base class for {@link EventLoopScheduler} implementations.
+ */
+public abstract class AbstractEventLoopScheduler
+        extends AbstractEventExecutorScheduler<EventLoop, EventLoopMetrics> implements EventLoopScheduler {
+
+    @Override
+    public abstract EventLoop next();
+
+    @Override
+    public abstract EventLoopMetrics newMetrics();
+}

--- a/transport/src/main/java/io/netty/channel/AbstractEventLoopScheduler.java
+++ b/transport/src/main/java/io/netty/channel/AbstractEventLoopScheduler.java
@@ -25,6 +25,13 @@ import io.netty.util.concurrent.AbstractEventExecutorScheduler;
 public abstract class AbstractEventLoopScheduler
         extends AbstractEventExecutorScheduler<EventLoop, EventLoopMetrics> implements EventLoopScheduler {
 
+    /**
+     * @param nChildren the expected number of child {@linkplain EventLoop}s.
+     */
+    protected AbstractEventLoopScheduler(int nChildren) {
+        super(nChildren);
+    }
+
     @Override
     public abstract EventLoop next();
 

--- a/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
@@ -65,7 +65,7 @@ public abstract class AbstractServerChannel extends AbstractChannel implements S
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+    protected long doWrite(ChannelOutboundBuffer in) throws Exception {
         throw new UnsupportedOperationException();
     }
 

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -550,8 +550,6 @@ public interface Channel extends AttributeMap, Comparable<Channel> {
 
         /**
          * Flush out all write operations scheduled via {@link #write(Object, ChannelPromise)}.
-         *
-         * @return  the number of bytes flushed.
          */
         void flush();
 

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -550,6 +550,8 @@ public interface Channel extends AttributeMap, Comparable<Channel> {
 
         /**
          * Flush out all write operations scheduled via {@link #write(Object, ChannelPromise)}.
+         *
+         * @return  the number of bytes flushed.
          */
         void flush();
 

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -839,12 +839,17 @@ final class DefaultChannelPipeline implements ChannelPipeline {
     @Override
     public ChannelPipeline fireChannelRegistered() {
         head.fireChannelRegistered();
+
+        channel().eventLoop().metrics().channelRegistered();
+
         return this;
     }
 
     @Override
     public ChannelPipeline fireChannelUnregistered() {
         head.fireChannelUnregistered();
+
+        channel().eventLoop().metrics().channelUnregistered();
 
         // Remove all handlers sequentially if channel is closed and unregistered.
         if (!channel.isOpen()) {
@@ -866,6 +871,8 @@ final class DefaultChannelPipeline implements ChannelPipeline {
     public ChannelPipeline fireChannelActive() {
         head.fireChannelActive();
 
+        channel().eventLoop().metrics().channelActive();
+
         if (channel.config().isAutoRead()) {
             channel.read();
         }
@@ -876,6 +883,9 @@ final class DefaultChannelPipeline implements ChannelPipeline {
     @Override
     public ChannelPipeline fireChannelInactive() {
         head.fireChannelInactive();
+
+        channel().eventLoop().metrics().channelInactive();
+
         return this;
     }
 

--- a/transport/src/main/java/io/netty/channel/DefaultEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/DefaultEventLoop.java
@@ -15,9 +15,11 @@
  */
 package io.netty.channel;
 
+import io.netty.channel.metrics.NoEventLoopMetrics;
 import io.netty.util.concurrent.DefaultExecutorFactory;
 
 import java.util.concurrent.Executor;
+
 public class DefaultEventLoop extends SingleThreadEventLoop {
 
     public DefaultEventLoop() {
@@ -33,7 +35,7 @@ public class DefaultEventLoop extends SingleThreadEventLoop {
     }
 
     public DefaultEventLoop(EventLoopGroup parent, Executor executor) {
-        super(parent, executor, true);
+        super(parent, executor, NoEventLoopMetrics.INSTANCE, true);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/DefaultEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/DefaultEventLoopGroup.java
@@ -15,6 +15,8 @@
  */
 package io.netty.channel;
 
+import io.netty.channel.metrics.EventLoopMetrics;
+import io.netty.util.metrics.EventExecutorMetrics;
 import io.netty.util.concurrent.ExecutorFactory;
 
 import java.util.concurrent.Executor;
@@ -54,7 +56,7 @@ public class DefaultEventLoopGroup extends MultithreadEventLoopGroup {
      * @param executor           the {@link Executor} to use, or {@code null} if the default should be used.
      */
     public DefaultEventLoopGroup(int nEventLoops, Executor executor) {
-        super(nEventLoops, executor);
+        super(nEventLoops, executor, null, null);
     }
 
     /**
@@ -66,11 +68,11 @@ public class DefaultEventLoopGroup extends MultithreadEventLoopGroup {
      * @param executorFactory   the {@link ExecutorFactory} to use, or {@code null} if the default should be used.
      */
     public DefaultEventLoopGroup(int nEventLoops, ExecutorFactory executorFactory) {
-        super(nEventLoops, executorFactory);
+        super(nEventLoops, executorFactory, null, null);
     }
 
     @Override
-    protected EventLoop newChild(Executor executor, Object... args) throws Exception {
+    protected EventLoop newChild(Executor executor, EventLoopMetrics metrics, Object... args) throws Exception {
         return new DefaultEventLoop(this, executor);
     }
 }

--- a/transport/src/main/java/io/netty/channel/EventLoop.java
+++ b/transport/src/main/java/io/netty/channel/EventLoop.java
@@ -16,12 +16,13 @@
 
 package io.netty.channel;
 
+import io.netty.channel.metrics.EventLoopMetrics;
 import io.netty.util.concurrent.EventExecutor;
 
 /**
  * Will handle all the I/O-Operations for a {@link Channel} once it was registered.
  *
- * One {@link EventLoop} instance will usually handle more then one {@link Channel} but this may depend on
+ * One {@link EventLoop} instance will usually handle more than one {@link Channel} but this may depend on
  * implementation details and internals.
  *
  */
@@ -37,4 +38,9 @@ public interface EventLoop extends EventExecutor, EventLoopGroup {
      * invoke event handler methods.
      */
     ChannelHandlerInvoker asInvoker();
+
+    /**
+     * Returns the {@link EventLoopMetrics} object attached to this {@link EventLoop}.
+     */
+    EventLoopMetrics metrics();
 }

--- a/transport/src/main/java/io/netty/channel/EventLoopScheduler.java
+++ b/transport/src/main/java/io/netty/channel/EventLoopScheduler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel;
+
+import io.netty.channel.metrics.EventLoopMetrics;
+import io.netty.util.concurrent.EventExecutorScheduler;
+
+
+import java.util.Set;
+
+/**
+ * Derive from this interface to create your own {@link EventLoopScheduler}. An {@link EventLoopScheduler} can be
+ * plugged into an {@link EventLoopGroup} to decide on how to distribute work among its {@linkplain EventLoop}s.
+ * <p>
+ * The central point of any {@link EventLoopScheduler} is the {@linkplain #next()} method. It is called whenever the
+ * {@link EventLoopGroup} needs an {@link EventLoop} to perform some piece of work (e.g. registering a {@link Channel}
+ * to an {@link EventLoop}). The default implementation of {@linkplain #next()} used throughout Netty is a simple
+ * round-robin like algorithm that returns {@linkplain EventLoop}s sequentially and begins again at the first
+ * {@link EventLoop} in a circular manner. However, more advanced algorithms may implement a different strategy and
+ * even take into account information gathered by {@link EventLoopMetrics}.
+ *
+ * @see AbstractEventLoopScheduler
+ */
+public interface EventLoopScheduler extends EventExecutorScheduler<EventLoop, EventLoopMetrics> {
+
+    /**
+     * Returns one of the {@linkplain EventLoop}s managed by this {@link EventLoopScheduler}.
+     * This method must be implemented thread-safe. This method must not return {@code null}.
+     */
+    @Override
+    EventLoop next();
+
+    /**
+     * Add an {@link EventLoop} and its corresponding {@link EventLoopMetrics} object.
+     */
+    @Override
+    void addChild(EventLoop executor, EventLoopMetrics metrics);
+
+    /**
+     * Returns an unmodifiable set of all {@link EventLoop}s managed by this {@link EventLoopScheduler}.
+     */
+    @Override
+    Set<EventLoop> children();
+
+    /**
+     * Factory method to create a new instance of {@link EventLoopMetrics}.
+     * <p>
+     * The main use case of this method is to create a new {@link EventLoopMetrics} object that is subsequently
+     * attached to an {@link EventLoop}. The two objects are then jointly passed to
+     * {@link #addChild(EventLoop, EventLoopMetrics)}.
+     */
+    @Override
+    EventLoopMetrics newMetrics();
+}

--- a/transport/src/main/java/io/netty/channel/MultithreadEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/MultithreadEventLoopGroup.java
@@ -117,17 +117,21 @@ public abstract class MultithreadEventLoopGroup
     @Override
     protected EventLoopScheduler newDefaultScheduler(int nEventLoops) {
         return isPowerOfTwo(nEventLoops)
-                ? new PowerOfTwoRoundRobinEventLoopScheduler()
-                : new RoundRobinEventLoopScheduler();
+                ? new PowerOfTwoRoundRobinEventLoopScheduler(nEventLoops)
+                : new RoundRobinEventLoopScheduler(nEventLoops);
     }
 
     private static final class RoundRobinEventLoopScheduler extends AbstractEventLoopScheduler {
 
         private final AtomicInteger index = new AtomicInteger();
 
+        RoundRobinEventLoopScheduler(int nEventLoops) {
+            super(nEventLoops);
+        }
+
         @Override
         public EventLoop next() {
-            return children.get(index.getAndIncrement() % children.size());
+            return children.get(Math.abs(index.getAndIncrement() % children.size()));
         }
 
         @Override
@@ -139,6 +143,10 @@ public abstract class MultithreadEventLoopGroup
     private static final class PowerOfTwoRoundRobinEventLoopScheduler extends AbstractEventLoopScheduler {
 
         private final AtomicInteger index = new AtomicInteger();
+
+        PowerOfTwoRoundRobinEventLoopScheduler(int nEventLoops) {
+            super(nEventLoops);
+        }
 
         @Override
         public EventLoop next() {

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -15,11 +15,10 @@
  */
 package io.netty.channel;
 
-import io.netty.util.concurrent.EventExecutor;
+import io.netty.channel.metrics.EventLoopMetrics;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
 
 import java.util.concurrent.Executor;
-import java.util.concurrent.ThreadFactory;
 
 /**
  * Abstract base class for {@link EventLoop}s that execute all its submitted tasks in a single thread.
@@ -28,9 +27,12 @@ import java.util.concurrent.ThreadFactory;
 public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor implements EventLoop {
 
     private final ChannelHandlerInvoker invoker = new DefaultChannelHandlerInvoker(this);
+    private final EventLoopMetrics metrics;
 
-    protected SingleThreadEventLoop(EventLoopGroup parent, Executor executor, boolean addTaskWakesUp) {
+    protected SingleThreadEventLoop(
+            EventLoopGroup parent, Executor executor, EventLoopMetrics metrics, boolean addTaskWakesUp) {
         super(parent, executor, addTaskWakesUp);
+        this.metrics = metrics;
     }
 
     @Override
@@ -64,6 +66,11 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
 
         channel.unsafe().register(this, promise);
         return promise;
+    }
+
+    @Override
+    public EventLoopMetrics metrics() {
+        return metrics;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
@@ -15,6 +15,8 @@
  */
 package io.netty.channel;
 
+import io.netty.channel.metrics.NoEventLoopMetrics;
+
 /**
  * {@link SingleThreadEventLoop} which is used to handle OIO {@link Channel}'s. So in general there will be
  * one {@link ThreadPerChannelEventLoop} per {@link Channel}.
@@ -26,7 +28,7 @@ public class ThreadPerChannelEventLoop extends SingleThreadEventLoop {
     private Channel ch;
 
     public ThreadPerChannelEventLoop(ThreadPerChannelEventLoopGroup parent) {
-        super(parent, parent.executor, true);
+        super(parent, parent.executor, NoEventLoopMetrics.INSTANCE, true);
         this.parent = parent;
     }
 

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -324,8 +324,11 @@ public class EmbeddedChannel extends AbstractChannel {
         return new DefaultUnsafe();
     }
 
+    /**
+     * This method always returns {@code 0}, as the {@link EmbeddedChannel} doesn't use the value.
+     */
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+    protected long doWrite(ChannelOutboundBuffer in) throws Exception {
         for (;;) {
             Object msg = in.current();
             if (msg == null) {
@@ -336,6 +339,8 @@ public class EmbeddedChannel extends AbstractChannel {
             outboundMessages.add(msg);
             in.remove();
         }
+
+        return 0;
     }
 
     private class DefaultUnsafe extends AbstractUnsafe {

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
@@ -22,6 +22,8 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelHandlerInvoker;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.metrics.EventLoopMetrics;
+import io.netty.channel.metrics.NoEventLoopMetrics;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 
@@ -115,6 +117,11 @@ final class EmbeddedEventLoop extends AbstractEventLoop implements ChannelHandle
     @Override
     public ChannelHandlerInvoker asInvoker() {
         return this;
+    }
+
+    @Override
+    public EventLoopMetrics metrics() {
+        return NoEventLoopMetrics.INSTANCE;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -274,8 +274,11 @@ public class LocalChannel extends AbstractChannel {
         }
     }
 
+    /**
+     * This method always returns {@code 0}, as the local transport doesn't use the value.
+     */
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+    protected long doWrite(ChannelOutboundBuffer in) throws Exception {
         switch (state) {
         case OPEN:
         case BOUND:
@@ -315,6 +318,8 @@ public class LocalChannel extends AbstractChannel {
                 }
             });
         }
+
+        return 0;
     }
 
     private static void finishPeerRead(LocalChannel peer, ChannelPipeline peerPipeline) {

--- a/transport/src/main/java/io/netty/channel/metrics/EventLoopMetrics.java
+++ b/transport/src/main/java/io/netty/channel/metrics/EventLoopMetrics.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.metrics;
+
+import io.netty.util.metrics.EventExecutorMetrics;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopScheduler;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.nio.NioEventLoop;
+import java.nio.channels.Selector;
+import java.nio.channels.SelectionKey;
+
+/**
+ * An {@link EventLoopMetrics} object is attached to an {@link EventLoop} and gathers information about it.
+ *
+ * @see EventLoopScheduler
+ */
+public interface EventLoopMetrics extends EventExecutorMetrics<EventLoop> {
+
+    @Override
+    void init(EventLoop eventLoop);
+
+    /**
+     * This method is called when the state of a {@link Channel} that is registered with the {@link EventLoop}
+     * changes to active.
+     */
+    void channelActive();
+
+    /**
+     * This method is called when the state of a {@link Channel} that is registered with the {@link EventLoop}
+     * changes to inactive.
+     */
+    void channelInactive();
+
+    /**
+     * This method is called when a {@link Channel} is registered with the {@link EventLoop}.
+     */
+    void channelRegistered();
+
+    /**
+     * This method is called when a {@link Channel} is deregistered from the {@link EventLoop}.
+     */
+    void channelUnregistered();
+
+    /**
+     * This method is called when a {@link Channel} that is registered with the {@link EventLoop} reads data.
+     *
+     * @param bytes number of bytes read.
+     */
+    void readBytes(long bytes);
+
+    /**
+     * This method is called when a {@link Channel} that is registered with the {@link EventLoop} writes data.
+     * <p>
+     * This method might be called concurrently from different threads and must therefore be be implemented
+     * threadsafe.
+     *
+     * @param bytes number of bytes written.
+     */
+    void writeBytes(long bytes);
+
+    /**
+     * This method is called before any {@link Channel} of the {@link EventLoop} reads/writes data and before
+     * any events are fired through the {@link ChannelPipeline}.
+     * <p>
+     * For example, in the case of the {@link NioEventLoop} it is called before the {@linkplain SelectionKey}s
+     * after a call to {@link Selector#select()} are processed.
+     * <p>
+     * This method can be used (together with {@link #stopProcessIo()}) to measure the time the {@link EventLoop}
+     * spends on processing I/O (incl. executing the {@linkplain ChannelHandler}s).
+     */
+    void startProcessIo();
+
+    /**
+     * This method is called after the {@link EventLoop} has finished with any I/O work as described in
+     * {@link #startProcessIo()}. It is guaranteed to be called after every call to {@link #startProcessIo()}.
+     */
+    void stopProcessIo();
+
+    /**
+     * This method is called before the {@link EventLoop} starts processing tasks from its task queue.
+     */
+    void startExecuteTasks();
+
+    /**
+     * This method is called after the {@link EventLoop} has finished processing tasks from its task queue. It is
+     * guaranteed to be called after every call to {@link #startExecuteTasks()}.
+     */
+    void stopExecuteTasks();
+}

--- a/transport/src/main/java/io/netty/channel/metrics/EventLoopMetricsAdapter.java
+++ b/transport/src/main/java/io/netty/channel/metrics/EventLoopMetricsAdapter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.metrics;
+
+import io.netty.channel.EventLoop;
+
+/**
+ * Skeleton implementation of {@link EventLoopMetrics}.
+ */
+public class EventLoopMetricsAdapter implements EventLoopMetrics {
+
+    @Override
+    public void channelActive() {
+        // NOOP
+    }
+
+    @Override
+    public void channelInactive() {
+        // NOOP
+    }
+
+    @Override
+    public void channelRegistered() {
+        // NOOP
+    }
+
+    @Override
+    public void channelUnregistered() {
+        // NOOP
+    }
+
+    @Override
+    public void readBytes(long bytes) {
+        // NOOP
+    }
+
+    @Override
+    public void writeBytes(long bytes) {
+        // NOOP
+    }
+
+    @Override
+    public void startProcessIo() {
+        // NOOP
+    }
+
+    @Override
+    public void stopProcessIo() {
+        // NOOP
+    }
+
+    @Override
+    public void startExecuteTasks() {
+        // NOOP
+    }
+
+    @Override
+    public void stopExecuteTasks() {
+        // NOOP
+    }
+
+    @Override
+    public void init(EventLoop eventLoop) {
+        // NOOP
+    }
+}

--- a/transport/src/main/java/io/netty/channel/metrics/EventLoopMetricsFactory.java
+++ b/transport/src/main/java/io/netty/channel/metrics/EventLoopMetricsFactory.java
@@ -18,6 +18,9 @@ package io.netty.channel.metrics;
 
 import io.netty.util.metrics.EventExecutorMetricsFactory;
 
+/**
+ * Derive from this interface to create your own {@link EventLoopMetricsFactory} implementation.
+ */
 public interface EventLoopMetricsFactory extends EventExecutorMetricsFactory {
 
     @Override

--- a/transport/src/main/java/io/netty/channel/metrics/EventLoopMetricsFactory.java
+++ b/transport/src/main/java/io/netty/channel/metrics/EventLoopMetricsFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.metrics;
+
+import io.netty.util.metrics.EventExecutorMetricsFactory;
+
+public interface EventLoopMetricsFactory extends EventExecutorMetricsFactory {
+
+    @Override
+    EventLoopMetrics newMetrics();
+}

--- a/transport/src/main/java/io/netty/channel/metrics/NoEventLoopMetrics.java
+++ b/transport/src/main/java/io/netty/channel/metrics/NoEventLoopMetrics.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.metrics;
+
+/**
+ * An {@link EventLoopMetrics} implementation that doesn't collect any metrics.
+ */
+public final class NoEventLoopMetrics extends EventLoopMetricsAdapter {
+
+    public static final NoEventLoopMetrics INSTANCE = new NoEventLoopMetrics();
+
+    private NoEventLoopMetrics() {
+    }
+}

--- a/transport/src/main/java/io/netty/channel/metrics/package-info.java
+++ b/transport/src/main/java/io/netty/channel/metrics/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A collection of classes that allow to gather information about {@linkplain io.netty.channel.EventLoop}s.
+ */
+package io.netty.channel.metrics;

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -154,9 +154,6 @@ public abstract class AbstractNioChannel extends AbstractChannel {
          */
         void read();
 
-        /**
-         * Returns the number of bytes flushed.
-         */
         void forceFlush();
     }
 

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -150,10 +150,13 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         void finishConnect();
 
         /**
-         * Read from underlying {@link SelectableChannel}
+         * Read from underlying {@link SelectableChannel}.
          */
         void read();
 
+        /**
+         * Returns the number of bytes flushed.
+         */
         void forceFlush();
     }
 

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
@@ -17,101 +17,223 @@ package io.netty.channel.nio;
 
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
+import io.netty.channel.metrics.EventLoopMetrics;
+import io.netty.channel.EventLoopScheduler;
 import io.netty.channel.MultithreadEventLoopGroup;
+import io.netty.channel.metrics.EventLoopMetricsFactory;
 import io.netty.util.concurrent.DefaultExecutorFactory;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.metrics.EventExecutorMetrics;
 import io.netty.util.concurrent.ExecutorFactory;
+import io.netty.channel.EventLoopGroup;
 
 import java.nio.channels.Selector;
 import java.nio.channels.spi.SelectorProvider;
 import java.util.concurrent.Executor;
 
 /**
- * A {@link MultithreadEventLoopGroup} implementation which is used for NIO {@link Selector} based {@link Channel}s.
+ * A {@link MultithreadEventLoopGroup} implementation which is used for NIO {@link Selector} based
+ * {@linkplain Channel}s.
  */
 public class NioEventLoopGroup extends MultithreadEventLoopGroup {
 
     /**
-     * Create a new instance that uses twice as many {@link EventLoop}s as there processors/cores
-     * available, as well as the default {@link Executor} and the {@link SelectorProvider} which
-     * is returned by {@link SelectorProvider#provider()}.
-     *
-     * @see DefaultExecutorFactory
+     * Create a new instance that uses twice as many {@linkplain EventLoop}s as there are processors/cores available or
+     * whatever is specified by {@code -Dio.netty.eventLoopThreads}. Further, the {@link Executor} returned by
+     * {@link DefaultExecutorFactory} and the {@link SelectorProvider} returned by {@link SelectorProvider#provider()}
+     * are used.
      */
     public NioEventLoopGroup() {
         this(0);
     }
 
     /**
-     * Create a new instance that uses the default {@link Executor} and the {@link SelectorProvider} which
+     * Create a new instance that uses the {@link DefaultExecutorFactory} and the {@link SelectorProvider} which
      * is returned by {@link SelectorProvider#provider()}.
      *
-     * @see DefaultExecutorFactory
-     *
-     * @param nEventLoops   the number of {@link EventLoop}s that will be used by this instance.
-     *                      If {@code executor} is {@code null} this number will also be the parallelism
-     *                      requested from the default executor. It is generally advised for the number
-     *                      of {@link EventLoop}s and the number of {@link Thread}s used by the
+     * @param nEventLoops   the number of {@linkplain EventLoop}s that will be used by this group. This will also
+     *                      be the number of threads requested from the {@link DefaultExecutorFactory}.
      */
     public NioEventLoopGroup(int nEventLoops) {
         this(nEventLoops, (Executor) null);
     }
 
     /**
-     * Create a new instance that uses the the {@link SelectorProvider} which is returned by
+     * Create a new instance that uses the {@link SelectorProvider} which is returned by
      * {@link SelectorProvider#provider()}.
      *
-     * @param nEventLoops   the number of {@link EventLoop}s that will be used by this instance.
-     *                      If {@code executor} is {@code null} this number will also be the parallelism
-     *                      requested from the default executor. It is generally advised for the number
-     *                      of {@link EventLoop}s and the number of {@link Thread}s used by the
-     *                      {@code executor} to lie very close together.
-     * @param executor   the {@link Executor} to use, or {@code null} if the default should be used.
+     * @param nEventLoops   the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                      If {@code Executor} is {@code null} this will also be the number of threads
+     *                      requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                      and the number of threads used by the {@code Executor} to lie very close together.
+     *                      You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                      {@linkplain EventLoop}s. See {@link #NioEventLoopGroup()} for details.
+     * @param executor      the {@link Executor} to use, or {@code null} if the one returned
+     *                      by {@link DefaultExecutorFactory} should be used.
      */
     public NioEventLoopGroup(int nEventLoops, Executor executor) {
         this(nEventLoops, executor, SelectorProvider.provider());
     }
 
     /**
-     * Create a new instance that uses the the {@link SelectorProvider} which is returned by
+     * Create a new instance that uses the {@link SelectorProvider} which is returned by
      * {@link SelectorProvider#provider()}.
      *
-     * @param nEventLoops   the number of {@link EventLoop}s that will be used by this instance.
-     *                      If {@code executor} is {@code null} this number will also be the parallelism
-     *                      requested from the default executor. It is generally advised for the number
-     *                      of {@link EventLoop}s and the number of {@link Thread}s used by the
-     *                      {@code executor} to lie very close together.
-     * @param executorFactory   the {@link ExecutorFactory} to use, or {@code null} if the default should be used.
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #NioEventLoopGroup()} for details.
+     * @param executorFactory   the {@link ExecutorFactory} to use, or {@code null} if {@link DefaultExecutorFactory}
+     *                          should be used.
      */
     public NioEventLoopGroup(int nEventLoops, ExecutorFactory executorFactory) {
         this(nEventLoops, executorFactory, SelectorProvider.provider());
     }
 
     /**
-     * @param nEventLoops   the number of {@link EventLoop}s that will be used by this instance.
-     *                      If {@code executor} is {@code null} this number will also be the parallelism
-     *                      requested from the default executor. It is generally advised for the number
-     *                      of {@link EventLoop}s and the number of {@link Thread}s used by the
-     *                      {@code executor} to lie very close together.
-     * @param executor  the {@link Executor} to use, or {@code null} if the default should be used.
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #NioEventLoopGroup()} for details.
+     * @param executor          the {@link Executor} to use, or {@code null} if the one returned
+     *                          by {@link DefaultExecutorFactory} should be used.
      * @param selectorProvider  the {@link SelectorProvider} to use. This value must not be {@code null}.
      */
-    public NioEventLoopGroup(int nEventLoops, Executor executor, final SelectorProvider selectorProvider) {
-        super(nEventLoops, executor, selectorProvider);
+    public NioEventLoopGroup(int nEventLoops, Executor executor, SelectorProvider selectorProvider) {
+        this(nEventLoops, executor, (EventLoopScheduler) null, selectorProvider);
     }
 
     /**
-     * @param nEventLoops   the number of {@link EventLoop}s that will be used by this instance.
-     *                      If {@code executor} is {@code null} this number will also be the parallelism
-     *                      requested from the default executor. It is generally advised for the number
-     *                      of {@link EventLoop}s and the number of {@link Thread}s used by the
-     *                      {@code executor} to lie very close together.
-     * @param executorFactory   the {@link ExecutorFactory} to use, or {@code null} if the default should be used.
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #NioEventLoopGroup()} for details.
+     * @param executorFactory   the {@link ExecutorFactory} to use, or {@code null} if {@link DefaultExecutorFactory}
+     *                          should be used.
      * @param selectorProvider  the {@link SelectorProvider} to use. This value must not be {@code null}.
      */
-    public NioEventLoopGroup(
-            int nEventLoops, ExecutorFactory executorFactory, final SelectorProvider selectorProvider) {
-        super(nEventLoops, executorFactory, selectorProvider);
+    public NioEventLoopGroup(int nEventLoops, ExecutorFactory executorFactory, SelectorProvider selectorProvider) {
+        this(nEventLoops, executorFactory, (EventLoopScheduler) null, selectorProvider);
+    }
+
+    /**
+     * Create a new instance that uses the {@link SelectorProvider} which is returned by
+     * {@link SelectorProvider#provider()}.
+     *
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #NioEventLoopGroup()} for details.
+     * @param scheduler         the {@link EventLoopScheduler} that, on every call to {@link EventLoopGroup#next()},
+     *                          decides which {@link EventLoop} to return.
+     */
+    public NioEventLoopGroup(int nEventLoops, EventLoopScheduler scheduler) {
+        this(nEventLoops, (Executor) null, scheduler, SelectorProvider.provider());
+    }
+
+    /**
+     * Create a new instance that uses the {@link SelectorProvider} which is returned by
+     * {@link SelectorProvider#provider()}.
+     *
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #NioEventLoopGroup()} for details.
+     * @param metricsFactory    provide your own {@link EventLoopMetricsFactory} to gather information for every
+     *                          {@link EventLoop} of this group.
+     */
+    public NioEventLoopGroup(int nEventLoops, EventLoopMetricsFactory metricsFactory) {
+        this(nEventLoops, (Executor) null, metricsFactory, SelectorProvider.provider());
+    }
+
+    /**
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #NioEventLoopGroup()} for details.
+     * @param executor          the {@link Executor} to use, or {@code null} if the one returned
+     *                          by {@link DefaultExecutorFactory} should be used.
+     * @param scheduler         the {@link EventLoopScheduler} that, on every call to {@link EventLoopGroup#next()},
+     *                          decides which {@link EventLoop} to return.
+     * @param selectorProvider  the {@link SelectorProvider} to use. This value must not be {@code null}.
+     */
+    public NioEventLoopGroup(int nEventLoops,
+                             Executor executor,
+                             EventLoopScheduler scheduler,
+                             SelectorProvider selectorProvider) {
+        super(nEventLoops, executor, scheduler, null, selectorProvider);
+    }
+
+    /**
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #NioEventLoopGroup()} for details.
+     * @param executorFactory   the {@link ExecutorFactory} to use, or {@code null} if {@link DefaultExecutorFactory}
+     *                          should be used.
+     * @param scheduler         the {@link EventLoopScheduler} that, on every call to {@link EventLoopGroup#next()},
+     *                          decides which {@link EventLoop} to return.
+     * @param selectorProvider  the {@link SelectorProvider} to use. This value must not be {@code null}.
+     */
+    public NioEventLoopGroup(int nEventLoops,
+                             ExecutorFactory executorFactory,
+                             EventLoopScheduler scheduler,
+                             SelectorProvider selectorProvider) {
+        super(nEventLoops, executorFactory, scheduler, null, selectorProvider);
+    }
+
+    /**
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #NioEventLoopGroup()} for details.
+     * @param executor          the {@link Executor} to use, or {@code null} if the one returned
+     *                          by {@link DefaultExecutorFactory} should be used.
+     * @param metricsFactory    provide your own {@link EventLoopMetricsFactory} to gather information for every
+     *                          {@link EventLoop} of this group.
+     * @param selectorProvider  the {@link SelectorProvider} to use. This value must not be {@code null}.
+     */
+    public NioEventLoopGroup(int nEventLoops,
+                             Executor executor,
+                             EventLoopMetricsFactory metricsFactory,
+                             SelectorProvider selectorProvider) {
+        super(nEventLoops, executor, null, metricsFactory, selectorProvider);
+    }
+
+    /**
+     * @param nEventLoops       the number of {@linkplain EventLoop}s that will be used by this instance.
+     *                          If {@code Executor} is {@code null} this will also be the number of threads
+     *                          requested from the {@link DefaultExecutorFactory}. It is advised for {@code nEventLoops}
+     *                          and the number of threads used by the {@code Executor} to lie very close together.
+     *                          You can set this parameter to {@code 0} if you want the system to chose the number of
+     *                          {@linkplain EventLoop}s. See {@link #NioEventLoopGroup()} for details.
+     * @param executorFactory   the {@link ExecutorFactory} to use, or {@code null} if {@link DefaultExecutorFactory}
+     *                          should be used.
+     * @param metricsFactory    provide your own {@link EventLoopMetricsFactory} to gather information for every
+     *                          {@link EventLoop} of this group.
+     * @param selectorProvider  the {@link SelectorProvider} to use. This value must not be {@code null}.
+     */
+    public NioEventLoopGroup(int nEventLoops,
+                             ExecutorFactory executorFactory,
+                             EventLoopMetricsFactory metricsFactory,
+                             SelectorProvider selectorProvider) {
+        super(nEventLoops, executorFactory, null, metricsFactory, selectorProvider);
     }
 
     /**
@@ -135,7 +257,7 @@ public class NioEventLoopGroup extends MultithreadEventLoopGroup {
     }
 
     @Override
-    protected EventLoop newChild(Executor executor, Object... args) throws Exception {
-        return new NioEventLoop(this, executor, (SelectorProvider) args[0]);
+    protected EventLoop newChild(Executor executor, EventLoopMetrics metrics, Object... args) throws Exception {
+        return new NioEventLoop(this, executor, metrics, (SelectorProvider) args[0]);
     }
 }

--- a/transport/src/main/java/io/netty/channel/oio/AbstractOioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/AbstractOioByteChannel.java
@@ -183,8 +183,11 @@ public abstract class AbstractOioByteChannel extends AbstractOioChannel {
         }
     }
 
+    /**
+     * This method always returns {@code 0}, as the OIO transport doesn't use the value.
+     */
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+    protected long doWrite(ChannelOutboundBuffer in) throws Exception {
         for (;;) {
             Object msg = in.current();
             if (msg == null) {
@@ -212,6 +215,8 @@ public abstract class AbstractOioByteChannel extends AbstractOioChannel {
                         "unsupported message type: " + StringUtil.simpleClassName(msg)));
             }
         }
+
+        return 0;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioServerSocketChannel.java
@@ -137,7 +137,6 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
         try {
             if (ch != null) {
                 buf.add(new NioSocketChannel(this, ch));
-                return 1;
             }
         } catch (Throwable t) {
             logger.warn("Failed to create a new channel from an accepted socket.", t);
@@ -175,7 +174,7 @@ public class NioServerSocketChannel extends AbstractNioMessageChannel
     }
 
     @Override
-    protected boolean doWriteMessage(Object msg, ChannelOutboundBuffer in) throws Exception {
+    protected long doWriteMessage(Object msg, ChannelOutboundBuffer in) throws Exception {
         throw new UnsupportedOperationException();
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioDatagramChannel.java
@@ -233,8 +233,11 @@ public class OioDatagramChannel extends AbstractOioMessageChannel
         }
     }
 
+    /**
+     * This method always returns {@code 0}, as the OIO transport doesn't use the value.
+     */
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+    protected long doWrite(ChannelOutboundBuffer in) throws Exception {
         for (;;) {
             final Object o = in.current();
             if (o == null) {
@@ -274,6 +277,8 @@ public class OioDatagramChannel extends AbstractOioMessageChannel
                 in.remove(e);
             }
         }
+
+        return 0;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
@@ -170,7 +170,7 @@ public class OioServerSocketChannel extends AbstractOioMessageChannel
     }
 
     @Override
-    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+    protected long doWrite(ChannelOutboundBuffer in) throws Exception {
         throw new UnsupportedOperationException();
     }
 

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -172,7 +172,7 @@ public class ChannelOutboundBufferTest {
         }
 
         @Override
-        protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+        protected long doWrite(ChannelOutboundBuffer in) throws Exception {
             throw new UnsupportedOperationException();
         }
 

--- a/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
@@ -19,7 +19,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import io.netty.channel.local.LocalChannel;
-import io.netty.util.concurrent.DefaultExecutorFactory;
+import io.netty.channel.metrics.NoEventLoopMetrics;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.PausableEventExecutor;
 import org.junit.After;
@@ -52,9 +52,7 @@ public class SingleThreadEventLoopTest {
         public void run() { }
     };
 
-    @SuppressWarnings({ "unused" })
     private SingleThreadEventLoopA loopA;
-    @SuppressWarnings({ "unused" })
     private SingleThreadEventLoopB loopB;
 
     @Before
@@ -691,7 +689,7 @@ public class SingleThreadEventLoopTest {
         final AtomicInteger cleanedUp = new AtomicInteger();
 
         SingleThreadEventLoopA() {
-            super(null, Executors.newSingleThreadExecutor(), true);
+            super(null, Executors.newSingleThreadExecutor(), NoEventLoopMetrics.INSTANCE, true);
         }
 
         @Override
@@ -721,7 +719,7 @@ public class SingleThreadEventLoopTest {
         private volatile boolean interrupted;
 
         SingleThreadEventLoopB() {
-            super(null, Executors.newSingleThreadExecutor(), false);
+            super(null, Executors.newSingleThreadExecutor(), NoEventLoopMetrics.INSTANCE, false);
         }
 
         @Override

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -26,6 +26,8 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.metrics.EventLoopMetrics;
+import io.netty.channel.metrics.NoEventLoopMetrics;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.SingleThreadEventLoop;
 import io.netty.util.internal.logging.InternalLogger;
@@ -190,9 +192,9 @@ public class LocalChannelTest {
         final EventLoopGroup serverGroup = new DefaultEventLoopGroup(1);
         final EventLoopGroup clientGroup = new DefaultEventLoopGroup(1) {
             @Override
-            protected EventLoop newChild(Executor executor, Object... args)
+            protected EventLoop newChild(Executor executor, EventLoopMetrics metrics, Object... args)
                     throws Exception {
-                return new SingleThreadEventLoop(this, executor, true) {
+                return new SingleThreadEventLoop(this, executor, NoEventLoopMetrics.INSTANCE, true) {
                     @Override
                     protected void run() {
                         Runnable task = takeTask();


### PR DESCRIPTION
Hello,

this PR introduces a way for developers to plug their own `Next-EventLoop Algorithm` into `NioEventLoopGroup` and `EpollEventLoopGroup`. Additionally an API to gather metrics from the `EventLoop`s is introduced.

This PR is still missing most of the tests. I haven't been able to execute on my GENIUS vision of a unified test class for all `Channel` / `EventLoop` implementations that use a `MetricsCollector` YET. So I didn't include this code here (it's coming and something to look forward to though :smile: ). Despite that, I think the code is ready to get some feedback from @normanmaurer and @trustin.

Some issues I would love to get you guys input on:
* I am not a fan of the name `MetricsCollector.(start|stop)processIo()`. Would be thankful for naming suggestions.
* I think `EventLoopChooser` sounds odd. How about `EventLoopScheduler`? That sounds more powerful.
* I think it would make sense to extend the `(Nio|Epoll)EventLoopGroup` constructors to additionally accept a standalone `MetricsCollectorFactory` object (and also have `EventLoopChooser` implement this interface). That way a user could only gather metrics and continue to use the default `EventLoopChooser`.
* Since @normanmaurer and I decided to gather metrics by integrating the metric hooks directly into the code, instead of using a separate `ChannelHandler` we have more freedom in which metrics to collect. Anything missing in the current implementation that would be useful?

Thanks,
Jakob