### PR TITLE
Adding padding to HTTP/2 flow control.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowController.java
@@ -68,7 +68,7 @@ public class DefaultHttp2InboundFlowController implements Http2InboundFlowContro
     public void applyInboundFlowControl(int streamId, ByteBuf data, int padding,
             boolean endOfStream, FrameWriter frameWriter)
             throws Http2Exception {
-        int dataLength = data.readableBytes();
+        int dataLength = data.readableBytes() + padding;
         applyConnectionFlowControl(dataLength, frameWriter);
         applyStreamFlowControl(streamId, dataLength, endOfStream, frameWriter);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFlowController.java
@@ -24,6 +24,7 @@ public interface Http2InboundFlowController {
 
     /**
      * A writer of window update frames.
+     * TODO: Use Http2FrameWriter instead.
      */
     interface FrameWriter {
 


### PR DESCRIPTION
Motivation:

We're currently out-of-spec with HTTP/2 in that we don't include padding
in the flow control logic.

Modifications:

Modified both DefaultHttp2InboundFlowController and
DefaultHttp2OutboundFlowController to properly take padding into
account. Outbound is more complicated since padding has to be properly
accounted for when splitting frames.

Result:

HTTP/2 codec properly flow controls padding.
