### PR TITLE
Changing HTTP/2 inbound flow control to use Http2FrameWriter

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataObserver.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataObserver.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+
+/**
+ * An observer of HTTP/2 {@code DATA} frames.
+ */
+public interface Http2DataObserver {
+
+    /**
+     * Handles an inbound {@code DATA} frame.
+     *
+     * @param ctx the context from the handler where the frame was read.
+     * @param streamId the subject stream for the frame.
+     * @param data payload buffer for the frame. If this buffer needs to be retained by the observer
+     *            they must make a copy.
+     * @param padding the number of padding bytes found at the end of the frame.
+     * @param endOfStream Indicates whether this is the last frame to be sent from the remote
+     *            endpoint for this stream.
+     */
+    void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
+            boolean endOfStream) throws Http2Exception;
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameObserver.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameObserver.java
@@ -21,21 +21,7 @@ import io.netty.channel.ChannelHandlerContext;
 /**
  * An observer of HTTP/2 frames.
  */
-public interface Http2FrameObserver {
-
-    /**
-     * Handles an inbound DATA frame.
-     *
-     * @param ctx the context from the handler where the frame was read.
-     * @param streamId the subject stream for the frame.
-     * @param data payload buffer for the frame. If this buffer needs to be retained by the observer
-     *            they must make a copy.
-     * @param padding the number of padding bytes found at the end of the frame.
-     * @param endOfStream Indicates whether this is the last frame to be sent from the remote
-     *            endpoint for this stream.
-     */
-    void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
-            boolean endOfStream) throws Http2Exception;
+public interface Http2FrameObserver extends Http2DataObserver {
 
     /**
      * Handles an inbound HEADERS frame.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFlowController.java
@@ -15,24 +15,10 @@
 
 package io.netty.handler.codec.http2;
 
-import io.netty.buffer.ByteBuf;
-
 /**
  * Controls the inbound flow of data frames from the remote endpoint.
  */
-public interface Http2InboundFlowController {
-
-    /**
-     * A writer of window update frames.
-     * TODO: Use Http2FrameWriter instead.
-     */
-    interface FrameWriter {
-
-        /**
-         * Writes a window update frame to the remote endpoint.
-         */
-        void writeFrame(int streamId, int windowSizeIncrement) throws Http2Exception;
-    }
+public interface Http2InboundFlowController extends Http2DataObserver {
 
     /**
      * Sets the initial inbound flow control window size and updates all stream window sizes by the
@@ -47,17 +33,4 @@ public interface Http2InboundFlowController {
      * Gets the initial inbound flow control window size.
      */
     int initialInboundWindowSize();
-
-    /**
-     * Applies flow control for the received data frame.
-     *
-     * @param streamId the ID of the stream receiving the data
-     * @param data the data portion of the data frame. Does not contain padding.
-     * @param padding the amount of padding received in the original frame.
-     * @param endOfStream indicates whether this is the last frame for the stream.
-     * @param frameWriter allows this flow controller to send window updates to the remote endpoint.
-     * @throws Http2Exception thrown if any protocol-related error occurred.
-     */
-    void applyInboundFlowControl(int streamId, ByteBuf data, int padding, boolean endOfStream,
-            FrameWriter frameWriter) throws Http2Exception;
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandlerTest.java
@@ -254,8 +254,7 @@ public class DelegatingHttp2ConnectionHandlerTest {
     public void dataReadAfterGoAwayShouldApplyFlowControl() throws Exception {
         when(remote.isGoAwayReceived()).thenReturn(true);
         decode().onDataRead(ctx, STREAM_ID, dummyData(), 10, true);
-        verify(inboundFlow).applyInboundFlowControl(eq(STREAM_ID), eq(dummyData()), eq(10),
-                eq(true), any(Http2InboundFlowController.FrameWriter.class));
+        verify(inboundFlow).onDataRead(eq(ctx), eq(STREAM_ID), eq(dummyData()), eq(10), eq(true));
 
         // Verify that the event was absorbed and not propagated to the oberver.
         verify(observer, never()).onDataRead(eq(ctx), anyInt(), any(ByteBuf.class), anyInt(),
@@ -265,8 +264,7 @@ public class DelegatingHttp2ConnectionHandlerTest {
     @Test
     public void dataReadWithEndOfStreamShouldCloseRemoteSide() throws Exception {
         decode().onDataRead(ctx, STREAM_ID, dummyData(), 10, true);
-        verify(inboundFlow).applyInboundFlowControl(eq(STREAM_ID), eq(dummyData()), eq(10),
-                eq(true), any(Http2InboundFlowController.FrameWriter.class));
+        verify(inboundFlow).onDataRead(eq(ctx), eq(STREAM_ID), eq(dummyData()), eq(10), eq(true));
         verify(stream).closeRemoteSide();
         verify(observer).onDataRead(eq(ctx), eq(STREAM_ID), eq(dummyData()), eq(10), eq(true));
     }

--- a/example/src/main/java/io/netty/example/http2/client/Http2ClientInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/client/Http2ClientInitializer.java
@@ -69,7 +69,7 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
         Http2Connection connection = new DefaultHttp2Connection(false);
         Http2FrameWriter frameWriter = frameWriter();
         connectionHandler = new DelegatingHttp2HttpConnectionHandler(connection,
-                        frameReader(), frameWriter, new DefaultHttp2InboundFlowController(connection),
+                        frameReader(), frameWriter, new DefaultHttp2InboundFlowController(connection, frameWriter),
                         new DefaultHttp2OutboundFlowController(connection, frameWriter),
                         InboundHttp2ToHttpAdapter.newInstance(connection, maxContentLength));
         responseHandler = new HttpResponseHandler();

--- a/example/src/main/java/io/netty/example/http2/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/server/HelloWorldHttp2Handler.java
@@ -55,7 +55,7 @@ public class HelloWorldHttp2Handler extends AbstractHttp2ConnectionHandler {
     private HelloWorldHttp2Handler(Http2Connection connection, Http2FrameWriter frameWriter) {
         super(connection, new Http2InboundFrameLogger(new DefaultHttp2FrameReader(), logger),
                 frameWriter,
-                new DefaultHttp2InboundFlowController(connection),
+                new DefaultHttp2InboundFlowController(connection, frameWriter),
                 new DefaultHttp2OutboundFlowController(connection, frameWriter));
     }
 


### PR DESCRIPTION
Motivation:

This is just some general cleanup to get rid of the FrameWriter inner
interface withing Http2InboundFlowController.  It's not necessary since
the flow controller can just use the Http2FrameWriter to send
WINDOW_UPDATE frames.

Modifications:

Updated DefaultHttp2InboundFlowController to use Http2FrameWriter.

Result:

The inbound flow control code is somewhat less smelly :).
