### PR TITLE
Renaming "Observer" to "Listener" for consistency in HTTP/2

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandler.java
@@ -45,7 +45,7 @@ import java.util.List;
  * as well as management of connection state and flow control for both inbound and outbound data
  * frames.
  * <p>
- * Subclasses need to implement the methods defined by the {@link Http2FrameObserver} interface for
+ * Subclasses need to implement the methods defined by the {@link Http2FrameListener} interface for
  * receiving inbound frames. Outbound frames are sent via one of the {@code writeXXX} methods.
  * <p>
  * It should be noted that the connection preface is sent upon either activation or addition of this
@@ -53,9 +53,9 @@ import java.util.List;
  * must call this class to write the preface to the remote endpoint.
  */
 public abstract class AbstractHttp2ConnectionHandler extends ByteToMessageDecoder implements
-        Http2FrameObserver {
+        Http2FrameListener {
 
-    private final Http2FrameObserver internalFrameObserver = new FrameReadObserver();
+    private final Http2FrameListener internalFrameListener = new FrameReadListener();
     private final Http2FrameReader frameReader;
     private final Http2FrameWriter frameWriter;
     private final Http2Connection connection;
@@ -539,7 +539,7 @@ public abstract class AbstractHttp2ConnectionHandler extends ByteToMessageDecode
                 return;
             }
 
-            frameReader.readFrame(ctx, in, internalFrameObserver);
+            frameReader.readFrame(ctx, in, internalFrameListener);
         } catch (Http2Exception e) {
             onHttp2Exception(ctx, e);
         } catch (Throwable e) {
@@ -812,7 +812,7 @@ public abstract class AbstractHttp2ConnectionHandler extends ByteToMessageDecode
     /**
      * Handles all inbound frames from the network.
      */
-    private final class FrameReadObserver implements Http2FrameObserver {
+    private final class FrameReadListener implements Http2FrameListener {
 
         @Override
         public void onDataRead(final ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -153,7 +153,7 @@ public class DefaultHttp2Connection implements Http2Connection {
     }
 
     private void removeStream(DefaultStream stream) {
-        // Notify the observers of the event first.
+        // Notify the listeners of the event first.
         for (Listener listener : listeners) {
             listener.streamRemoved(stream);
         }
@@ -724,7 +724,7 @@ public class DefaultHttp2Connection implements Http2Connection {
             List<ParentChangedEvent> events = new ArrayList<ParentChangedEvent>(1);
             connectionStream.takeChild(stream, false, events);
 
-            // Notify the observers of the event.
+            // Notify the listeners of the event.
             for (Listener listener : listeners) {
                 listener.streamAdded(stream);
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2ConnectionHandler.java
@@ -25,30 +25,30 @@ import io.netty.channel.ChannelPromise;
  * models, rather than having to subclass it directly.
  * <p>
  * Exposes all {@code writeXXX} methods as public and delegates all frame read events to a provided
- * {@link Http2FrameObserver}.
+ * {@link Http2FrameListener}.
  * <p>
  * The {@link #channelActive} and {@link #handlerAdded} should called when appropriate to ensure
  * that the initial SETTINGS frame is sent to the remote endpoint.
  */
 public class DelegatingHttp2ConnectionHandler extends AbstractHttp2ConnectionHandler {
-    private final Http2FrameObserver observer;
+    private final Http2FrameListener listener;
 
-    public DelegatingHttp2ConnectionHandler(boolean server, Http2FrameObserver observer) {
+    public DelegatingHttp2ConnectionHandler(boolean server, Http2FrameListener listener) {
         super(server);
-        this.observer = observer;
+        this.listener = listener;
     }
 
     public DelegatingHttp2ConnectionHandler(Http2Connection connection,
             Http2FrameReader frameReader, Http2FrameWriter frameWriter,
             Http2InboundFlowController inboundFlow, Http2OutboundFlowController outboundFlow,
-            Http2FrameObserver observer) {
+            Http2FrameListener listener) {
         super(connection, frameReader, frameWriter, inboundFlow, outboundFlow);
-        this.observer = observer;
+        this.listener = listener;
     }
 
-    public DelegatingHttp2ConnectionHandler(Http2Connection connection, Http2FrameObserver observer) {
+    public DelegatingHttp2ConnectionHandler(Http2Connection connection, Http2FrameListener listener) {
         super(connection);
-        this.observer = observer;
+        this.listener = listener;
     }
 
     @Override
@@ -103,70 +103,70 @@ public class DelegatingHttp2ConnectionHandler extends AbstractHttp2ConnectionHan
     @Override
     public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
             boolean endOfStream) throws Http2Exception {
-        observer.onDataRead(ctx, streamId, data, padding, endOfStream);
+        listener.onDataRead(ctx, streamId, data, padding, endOfStream);
     }
 
     @Override
     public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
             int streamDependency, short weight, boolean exclusive, int padding, boolean endStream)
             throws Http2Exception {
-        observer.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive,
+        listener.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive,
                 padding, endStream);
     }
 
     @Override
     public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency,
             short weight, boolean exclusive) throws Http2Exception {
-        observer.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
+        listener.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
     }
 
     @Override
     public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
             throws Http2Exception {
-        observer.onRstStreamRead(ctx, streamId, errorCode);
+        listener.onRstStreamRead(ctx, streamId, errorCode);
     }
 
     @Override
     public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
-        observer.onSettingsAckRead(ctx);
+        listener.onSettingsAckRead(ctx);
     }
 
     @Override
     public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception {
-        observer.onSettingsRead(ctx, settings);
+        listener.onSettingsRead(ctx, settings);
     }
 
     @Override
     public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
-        observer.onPingRead(ctx, data);
+        listener.onPingRead(ctx, data);
     }
 
     @Override
     public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
-        observer.onPingAckRead(ctx, data);
+        listener.onPingAckRead(ctx, data);
     }
 
     @Override
     public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
             Http2Headers headers, int padding) throws Http2Exception {
-        observer.onPushPromiseRead(ctx, streamId, promisedStreamId, headers, padding);
+        listener.onPushPromiseRead(ctx, streamId, promisedStreamId, headers, padding);
     }
 
     @Override
     public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData)
             throws Http2Exception {
-        observer.onGoAwayRead(ctx, lastStreamId, errorCode, debugData);
+        listener.onGoAwayRead(ctx, lastStreamId, errorCode, debugData);
     }
 
     @Override
     public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
             throws Http2Exception {
-        observer.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
+        listener.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
     }
 
     @Override
     public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
             ByteBuf payload) {
-        observer.onUnknownFrame(ctx, frameType, streamId, flags, payload);
+        listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2HttpConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingHttp2HttpConnectionHandler.java
@@ -31,18 +31,18 @@ import java.util.Map;
  */
 public class DelegatingHttp2HttpConnectionHandler extends DelegatingHttp2ConnectionHandler {
 
-    public DelegatingHttp2HttpConnectionHandler(boolean server, Http2FrameObserver observer) {
-        super(server, observer);
+    public DelegatingHttp2HttpConnectionHandler(boolean server, Http2FrameListener listener) {
+        super(server, listener);
     }
 
     public DelegatingHttp2HttpConnectionHandler(Http2Connection connection, Http2FrameReader frameReader,
                     Http2FrameWriter frameWriter, Http2InboundFlowController inboundFlow,
-                    Http2OutboundFlowController outboundFlow, Http2FrameObserver observer) {
-        super(connection, frameReader, frameWriter, inboundFlow, outboundFlow, observer);
+                    Http2OutboundFlowController outboundFlow, Http2FrameListener listener) {
+        super(connection, frameReader, frameWriter, inboundFlow, outboundFlow, listener);
     }
 
-    public DelegatingHttp2HttpConnectionHandler(Http2Connection connection, Http2FrameObserver observer) {
-        super(connection, observer);
+    public DelegatingHttp2HttpConnectionHandler(Http2Connection connection, Http2FrameListener listener) {
+        super(connection, listener);
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataListener.java
@@ -18,16 +18,16 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 
 /**
- * An observer of HTTP/2 {@code DATA} frames.
+ * An listener of HTTP/2 {@code DATA} frames.
  */
-public interface Http2DataObserver {
+public interface Http2DataListener {
 
     /**
      * Handles an inbound {@code DATA} frame.
      *
      * @param ctx the context from the handler where the frame was read.
      * @param streamId the subject stream for the frame.
-     * @param data payload buffer for the frame. If this buffer needs to be retained by the observer
+     * @param data payload buffer for the frame. If this buffer needs to be retained by the listener
      *            they must make a copy.
      * @param padding the number of padding bytes found at the end of the frame.
      * @param endOfStream Indicates whether this is the last frame to be sent from the remote

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
@@ -18,10 +18,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 
 /**
- * This class brings {@link Http2Connection.Listener} and {@link Http2FrameObserver} together to provide
+ * This class brings {@link Http2Connection.Listener} and {@link Http2FrameListener} together to provide
  * NOOP implementation so inheriting classes can selectively choose which methods to override.
  */
-public class Http2EventAdapter implements Http2Connection.Listener, Http2FrameObserver {
+public class Http2EventAdapter implements Http2Connection.Listener, Http2FrameListener {
     @Override
     public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding, boolean endOfStream)
             throws Http2Exception {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameAdapter.java
@@ -18,9 +18,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 
 /**
- * Convenience class that provides no-op implementations for all methods of {@link Http2FrameObserver}.
+ * Convenience class that provides no-op implementations for all methods of {@link Http2FrameListener}.
  */
-public class Http2FrameAdapter implements Http2FrameObserver {
+public class Http2FrameAdapter implements Http2FrameListener {
 
     @Override
     public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
@@ -19,9 +19,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 
 /**
- * An observer of HTTP/2 frames.
+ * An listener of HTTP/2 frames.
  */
-public interface Http2FrameObserver extends Http2DataObserver {
+public interface Http2FrameListener extends Http2DataListener {
 
     /**
      * Handles an inbound HEADERS frame.
@@ -117,7 +117,7 @@ public interface Http2FrameObserver extends Http2DataObserver {
      * Handles an inbound PING frame.
      *
      * @param ctx the context from the handler where the frame was read.
-     * @param data the payload of the frame. If this buffer needs to be retained by the observer
+     * @param data the payload of the frame. If this buffer needs to be retained by the listener
      *            they must make a copy.
      */
     void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception;
@@ -126,7 +126,7 @@ public interface Http2FrameObserver extends Http2DataObserver {
      * Handles an inbound PING acknowledgment.
      *
      * @param ctx the context from the handler where the frame was read.
-     * @param data the payload of the frame. If this buffer needs to be retained by the observer
+     * @param data the payload of the frame. If this buffer needs to be retained by the listener
      *            they must make a copy.
      */
     void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception;
@@ -162,7 +162,7 @@ public interface Http2FrameObserver extends Http2DataObserver {
      * @param lastStreamId the last known stream of the remote endpoint.
      * @param errorCode the error code, if abnormal closure.
      * @param debugData application-defined debug data. If this buffer needs to be retained by the
-     *            observer they must make a copy.
+     *            listener they must make a copy.
      */
     void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData)
             throws Http2Exception;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameReader.java
@@ -22,15 +22,15 @@ import java.io.Closeable;
 
 /**
  * Reads HTTP/2 frames from an input {@link ByteBuf} and notifies the specified
- * {@link Http2FrameObserver} when frames are complete.
+ * {@link Http2FrameListener} when frames are complete.
  */
 public interface Http2FrameReader extends Closeable {
 
     /**
      * Attempts to read the next frame from the input buffer. If enough data is available to fully
-     * read the frame, notifies the observer of the read frame.
+     * read the frame, notifies the listener of the read frame.
      */
-    void readFrame(ChannelHandlerContext ctx, ByteBuf input, Http2FrameObserver observer)
+    void readFrame(ChannelHandlerContext ctx, ByteBuf input, Http2FrameListener listener)
             throws Http2Exception;
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFlowController.java
@@ -18,7 +18,7 @@ package io.netty.handler.codec.http2;
 /**
  * Controls the inbound flow of data frames from the remote endpoint.
  */
-public interface Http2InboundFlowController extends Http2DataObserver {
+public interface Http2InboundFlowController extends Http2DataListener {
 
     /**
      * Sets the initial inbound flow control window size and updates all stream window sizes by the

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
@@ -21,7 +21,7 @@ import io.netty.channel.ChannelHandlerContext;
 
 /**
  * Decorator around a {@link Http2FrameReader} that logs all inbound frames before calling
- * back the observer.
+ * back the listener.
  */
 public class Http2InboundFrameLogger implements Http2FrameReader {
 
@@ -40,16 +40,16 @@ public class Http2InboundFrameLogger implements Http2FrameReader {
     }
 
     @Override
-    public void readFrame(ChannelHandlerContext ctx, ByteBuf input, final Http2FrameObserver observer)
+    public void readFrame(ChannelHandlerContext ctx, ByteBuf input, final Http2FrameListener listener)
             throws Http2Exception {
-        reader.readFrame(ctx, input, new Http2FrameObserver() {
+        reader.readFrame(ctx, input, new Http2FrameListener() {
 
             @Override
             public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data,
                     int padding, boolean endOfStream)
                     throws Http2Exception {
                 logger.logData(INBOUND, streamId, data, padding, endOfStream);
-                observer.onDataRead(ctx, streamId, data, padding, endOfStream);
+                listener.onDataRead(ctx, streamId, data, padding, endOfStream);
             }
 
             @Override
@@ -57,7 +57,7 @@ public class Http2InboundFrameLogger implements Http2FrameReader {
                     Http2Headers headers, int padding, boolean endStream)
                     throws Http2Exception {
                 logger.logHeaders(INBOUND, streamId, headers, padding, endStream);
-                observer.onHeadersRead(ctx, streamId, headers, padding, endStream);
+                listener.onHeadersRead(ctx, streamId, headers, padding, endStream);
             }
 
             @Override
@@ -66,7 +66,7 @@ public class Http2InboundFrameLogger implements Http2FrameReader {
                     int padding, boolean endStream) throws Http2Exception {
                 logger.logHeaders(INBOUND, streamId, headers, streamDependency, weight, exclusive,
                         padding, endStream);
-                observer.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive,
+                listener.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive,
                         padding, endStream);
             }
 
@@ -74,67 +74,67 @@ public class Http2InboundFrameLogger implements Http2FrameReader {
             public void onPriorityRead(ChannelHandlerContext ctx, int streamId,
                     int streamDependency, short weight, boolean exclusive) throws Http2Exception {
                 logger.logPriority(INBOUND, streamId, streamDependency, weight, exclusive);
-                observer.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
+                listener.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
             }
 
             @Override
             public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
                     throws Http2Exception {
                 logger.logRstStream(INBOUND, streamId, errorCode);
-                observer.onRstStreamRead(ctx, streamId, errorCode);
+                listener.onRstStreamRead(ctx, streamId, errorCode);
             }
 
             @Override
             public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
                 logger.logSettingsAck(INBOUND);
-                observer.onSettingsAckRead(ctx);
+                listener.onSettingsAckRead(ctx);
             }
 
             @Override
             public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings)
                     throws Http2Exception {
                 logger.logSettings(INBOUND, settings);
-                observer.onSettingsRead(ctx, settings);
+                listener.onSettingsRead(ctx, settings);
             }
 
             @Override
             public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
                 logger.logPing(INBOUND, data);
-                observer.onPingRead(ctx, data);
+                listener.onPingRead(ctx, data);
             }
 
             @Override
             public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
                 logger.logPingAck(INBOUND, data);
-                observer.onPingAckRead(ctx, data);
+                listener.onPingAckRead(ctx, data);
             }
 
             @Override
             public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId,
                     int promisedStreamId, Http2Headers headers, int padding) throws Http2Exception {
                 logger.logPushPromise(INBOUND, streamId, promisedStreamId, headers, padding);
-                observer.onPushPromiseRead(ctx, streamId, promisedStreamId, headers, padding);
+                listener.onPushPromiseRead(ctx, streamId, promisedStreamId, headers, padding);
             }
 
             @Override
             public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
                     ByteBuf debugData) throws Http2Exception {
                 logger.logGoAway(INBOUND, lastStreamId, errorCode, debugData);
-                observer.onGoAwayRead(ctx, lastStreamId, errorCode, debugData);
+                listener.onGoAwayRead(ctx, lastStreamId, errorCode, debugData);
             }
 
             @Override
             public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
                     throws Http2Exception {
                 logger.logWindowsUpdate(INBOUND, streamId, windowSizeIncrement);
-                observer.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
+                listener.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
             }
 
             @Override
             public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
                     Http2Flags flags, ByteBuf payload) {
                 logger.logUnknownFrame(INBOUND, frameType, streamId, flags, payload);
-                observer.onUnknownFrame(ctx, frameType, streamId, flags, payload);
+                listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
             }
         });
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameIOTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameIOTest.java
@@ -47,7 +47,7 @@ public class DefaultHttp2FrameIOTest {
     private ChannelHandlerContext ctx;
 
     @Mock
-    private Http2FrameObserver observer;
+    private Http2FrameListener listener;
 
     @Mock
     private ChannelPromise promise;
@@ -70,8 +70,8 @@ public class DefaultHttp2FrameIOTest {
         writer.writeData(ctx, 1000, data, 0, false, promise);
 
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onDataRead(eq(ctx), eq(1000), eq(data), eq(0), eq(false));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onDataRead(eq(ctx), eq(1000), eq(data), eq(0), eq(false));
         frame.release();
     }
 
@@ -81,8 +81,8 @@ public class DefaultHttp2FrameIOTest {
         writer.writeData(ctx, 1000, data.retain().duplicate(), 0, false, promise);
 
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onDataRead(eq(ctx), eq(1000), eq(data), eq(0), eq(false));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onDataRead(eq(ctx), eq(1000), eq(data), eq(0), eq(false));
         frame.release();
     }
 
@@ -92,8 +92,8 @@ public class DefaultHttp2FrameIOTest {
         writer.writeData(ctx, 1, data.retain().duplicate(), 0xFF, true, promise);
 
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onDataRead(eq(ctx), eq(1), eq(data), eq(0xFF), eq(true));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onDataRead(eq(ctx), eq(1), eq(data), eq(0xFF), eq(true));
         frame.release();
     }
 
@@ -102,8 +102,8 @@ public class DefaultHttp2FrameIOTest {
         writer.writePriority(ctx, 1, 2, (short) 255, true, promise);
 
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onPriorityRead(eq(ctx), eq(1), eq(2), eq((short) 255), eq(true));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onPriorityRead(eq(ctx), eq(1), eq(2), eq((short) 255), eq(true));
         frame.release();
     }
 
@@ -112,8 +112,8 @@ public class DefaultHttp2FrameIOTest {
         writer.writeRstStream(ctx, 1, MAX_UNSIGNED_INT, promise);
 
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onRstStreamRead(eq(ctx), eq(1), eq(MAX_UNSIGNED_INT));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onRstStreamRead(eq(ctx), eq(1), eq(MAX_UNSIGNED_INT));
         frame.release();
     }
 
@@ -122,8 +122,8 @@ public class DefaultHttp2FrameIOTest {
         writer.writeSettings(ctx, new Http2Settings(), promise);
 
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onSettingsRead(eq(ctx), eq(new Http2Settings()));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onSettingsRead(eq(ctx), eq(new Http2Settings()));
         frame.release();
     }
 
@@ -138,8 +138,8 @@ public class DefaultHttp2FrameIOTest {
         writer.writeSettings(ctx, settings, promise);
 
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onSettingsRead(eq(ctx), eq(settings));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onSettingsRead(eq(ctx), eq(settings));
         frame.release();
     }
 
@@ -148,8 +148,8 @@ public class DefaultHttp2FrameIOTest {
         writer.writeSettingsAck(ctx, promise);
 
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onSettingsAckRead(eq(ctx));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onSettingsAckRead(eq(ctx));
         frame.release();
     }
 
@@ -159,8 +159,8 @@ public class DefaultHttp2FrameIOTest {
         writer.writePing(ctx, false, data.retain().duplicate(), promise);
 
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onPingRead(eq(ctx), eq(data));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onPingRead(eq(ctx), eq(data));
         frame.release();
     }
 
@@ -170,8 +170,8 @@ public class DefaultHttp2FrameIOTest {
         writer.writePing(ctx, true, data.retain().duplicate(), promise);
 
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onPingAckRead(eq(ctx), eq(data));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onPingAckRead(eq(ctx), eq(data));
         frame.release();
     }
 
@@ -180,8 +180,8 @@ public class DefaultHttp2FrameIOTest {
         ByteBuf data = dummyData();
         writer.writeGoAway(ctx, 1, MAX_UNSIGNED_INT, data.retain().duplicate(), promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onGoAwayRead(eq(ctx), eq(1), eq(MAX_UNSIGNED_INT), eq(data));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onGoAwayRead(eq(ctx), eq(1), eq(MAX_UNSIGNED_INT), eq(data));
         frame.release();
     }
 
@@ -189,8 +189,8 @@ public class DefaultHttp2FrameIOTest {
     public void windowUpdateShouldRoundtrip() throws Exception {
         writer.writeWindowUpdate(ctx, 1, Integer.MAX_VALUE, promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onWindowUpdateRead(eq(ctx), eq(1), eq(Integer.MAX_VALUE));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onWindowUpdateRead(eq(ctx), eq(1), eq(Integer.MAX_VALUE));
         frame.release();
     }
 
@@ -199,8 +199,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = Http2Headers.EMPTY_HEADERS;
         writer.writeHeaders(ctx, 1, headers, 0, true, promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0), eq(true));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0), eq(true));
         frame.release();
     }
 
@@ -209,8 +209,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = Http2Headers.EMPTY_HEADERS;
         writer.writeHeaders(ctx, 1, headers, 0xFF, true, promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0xFF), eq(true));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0xFF), eq(true));
         frame.release();
     }
 
@@ -219,8 +219,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = dummyHeaders();
         writer.writeHeaders(ctx, 1, headers, 0, true, promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0), eq(true));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0), eq(true));
         frame.release();
     }
 
@@ -229,8 +229,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = dummyHeaders();
         writer.writeHeaders(ctx, 1, headers, 0xFF, true, promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0xFF), eq(true));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0xFF), eq(true));
         frame.release();
     }
 
@@ -239,8 +239,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = dummyHeaders();
         writer.writeHeaders(ctx, 1, headers, 2, (short) 3, true, 0, true, promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0),
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0),
                 eq(true));
         frame.release();
     }
@@ -250,8 +250,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = dummyHeaders();
         writer.writeHeaders(ctx, 1, headers, 2, (short) 3, true, 0xFF, true, promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0xFF),
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0xFF),
                 eq(true));
         frame.release();
     }
@@ -261,8 +261,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = largeHeaders();
         writer.writeHeaders(ctx, 1, headers, 2, (short) 3, true, 0, true, promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0),
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0),
                 eq(true));
         frame.release();
     }
@@ -272,8 +272,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = largeHeaders();
         writer.writeHeaders(ctx, 1, headers, 2, (short) 3, true, 0xFF, true, promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0xFF),
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0xFF),
                 eq(true));
         frame.release();
     }
@@ -283,8 +283,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = Http2Headers.EMPTY_HEADERS;
         writer.writePushPromise(ctx, 1, 2, headers, 0, promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0));
         frame.release();
     }
 
@@ -293,8 +293,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = dummyHeaders();
         writer.writePushPromise(ctx, 1, 2, headers, 0, promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0));
         frame.release();
     }
 
@@ -303,8 +303,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = dummyHeaders();
         writer.writePushPromise(ctx, 1, 2, headers, 0xFF, promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0xFF));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0xFF));
         frame.release();
     }
 
@@ -313,8 +313,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = largeHeaders();
         writer.writePushPromise(ctx, 1, 2, headers, 0, promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0));
         frame.release();
     }
 
@@ -323,8 +323,8 @@ public class DefaultHttp2FrameIOTest {
         Http2Headers headers = largeHeaders();
         writer.writePushPromise(ctx, 1, 2, headers, 0xFF, promise);
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, observer);
-        verify(observer).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0xFF));
+        reader.readFrame(ctx, frame, listener);
+        verify(listener).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0xFF));
         frame.release();
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -49,10 +49,10 @@ import static org.mockito.Mockito.*;
 public class Http2ConnectionRoundtripTest {
 
     @Mock
-    private Http2FrameObserver clientObserver;
+    private Http2FrameListener clientListener;
 
     @Mock
-    private Http2FrameObserver serverObserver;
+    private Http2FrameListener serverListener;
 
     private DelegatingHttp2ConnectionHandler http2Client;
     private ServerBootstrap sb;
@@ -86,7 +86,7 @@ public class Http2ConnectionRoundtripTest {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 ChannelPipeline p = ch.pipeline();
-                p.addLast(new DelegatingHttp2ConnectionHandler(false, clientObserver));
+                p.addLast(new DelegatingHttp2ConnectionHandler(false, clientListener));
                 p.addLast(Http2CodecUtil.ignoreSettingsHandler());
             }
         });
@@ -129,11 +129,11 @@ public class Http2ConnectionRoundtripTest {
         });
         // Wait for all frames to be received.
         awaitRequests();
-        verify(serverObserver, times(NUM_STREAMS)).onHeadersRead(any(ChannelHandlerContext.class),
+        verify(serverListener, times(NUM_STREAMS)).onHeadersRead(any(ChannelHandlerContext.class),
                 anyInt(), eq(headers), eq(0), eq((short) 16), eq(false), eq(0), eq(false));
-        verify(serverObserver, times(NUM_STREAMS)).onPingRead(any(ChannelHandlerContext.class),
+        verify(serverListener, times(NUM_STREAMS)).onPingRead(any(ChannelHandlerContext.class),
                 eq(Unpooled.copiedBuffer(pingMsg.getBytes())));
-        verify(serverObserver, times(NUM_STREAMS)).onDataRead(any(ChannelHandlerContext.class),
+        verify(serverListener, times(NUM_STREAMS)).onDataRead(any(ChannelHandlerContext.class),
                 anyInt(), eq(Unpooled.copiedBuffer(text.getBytes())), eq(0), eq(true));
     }
 
@@ -153,20 +153,20 @@ public class Http2ConnectionRoundtripTest {
      * A decorator around the serverObserver that counts down the latch so that we can await the
      * completion of the request.
      */
-    private final class FrameCountDown implements Http2FrameObserver {
+    private final class FrameCountDown implements Http2FrameListener {
 
         @Override
         public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
                                boolean endOfStream)
                 throws Http2Exception {
-            serverObserver.onDataRead(ctx, streamId, copy(data), padding, endOfStream);
+            serverListener.onDataRead(ctx, streamId, copy(data), padding, endOfStream);
             requestLatch.countDown();
         }
 
         @Override
         public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
                                   int padding, boolean endStream) throws Http2Exception {
-            serverObserver.onHeadersRead(ctx, streamId, headers, padding, endStream);
+            serverListener.onHeadersRead(ctx, streamId, headers, padding, endStream);
             requestLatch.countDown();
         }
 
@@ -174,7 +174,7 @@ public class Http2ConnectionRoundtripTest {
         public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
                                   int streamDependency, short weight, boolean exclusive, int padding,
                                   boolean endStream) throws Http2Exception {
-            serverObserver.onHeadersRead(ctx, streamId, headers, streamDependency, weight,
+            serverListener.onHeadersRead(ctx, streamId, headers, streamDependency, weight,
                     exclusive, padding, endStream);
             requestLatch.countDown();
         }
@@ -182,66 +182,66 @@ public class Http2ConnectionRoundtripTest {
         @Override
         public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency,
                                    short weight, boolean exclusive) throws Http2Exception {
-            serverObserver.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
+            serverListener.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
             requestLatch.countDown();
         }
 
         @Override
         public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
                 throws Http2Exception {
-            serverObserver.onRstStreamRead(ctx, streamId, errorCode);
+            serverListener.onRstStreamRead(ctx, streamId, errorCode);
             requestLatch.countDown();
         }
 
         @Override
         public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
-            serverObserver.onSettingsAckRead(ctx);
+            serverListener.onSettingsAckRead(ctx);
             requestLatch.countDown();
         }
 
         @Override
         public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception {
-            serverObserver.onSettingsRead(ctx, settings);
+            serverListener.onSettingsRead(ctx, settings);
             requestLatch.countDown();
         }
 
         @Override
         public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
-            serverObserver.onPingRead(ctx, copy(data));
+            serverListener.onPingRead(ctx, copy(data));
             requestLatch.countDown();
         }
 
         @Override
         public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
-            serverObserver.onPingAckRead(ctx, copy(data));
+            serverListener.onPingAckRead(ctx, copy(data));
             requestLatch.countDown();
         }
 
         @Override
         public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId,
                                       int promisedStreamId, Http2Headers headers, int padding) throws Http2Exception {
-            serverObserver.onPushPromiseRead(ctx, streamId, promisedStreamId, headers, padding);
+            serverListener.onPushPromiseRead(ctx, streamId, promisedStreamId, headers, padding);
             requestLatch.countDown();
         }
 
         @Override
         public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData)
                 throws Http2Exception {
-            serverObserver.onGoAwayRead(ctx, lastStreamId, errorCode, copy(debugData));
+            serverListener.onGoAwayRead(ctx, lastStreamId, errorCode, copy(debugData));
             requestLatch.countDown();
         }
 
         @Override
         public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId,
                                        int windowSizeIncrement) throws Http2Exception {
-            serverObserver.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
+            serverListener.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
             requestLatch.countDown();
         }
 
         @Override
         public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
                 Http2Flags flags, ByteBuf payload) {
-            serverObserver.onUnknownFrame(ctx, frameType, streamId, flags, payload);
+            serverListener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
             requestLatch.countDown();
         }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.*;
 public class Http2FrameRoundtripTest {
 
     @Mock
-    private Http2FrameObserver serverObserver;
+    private Http2FrameListener serverObserver;
 
     private ArgumentCaptor<ByteBuf> dataCaptor;
     private Http2FrameWriter frameWriter;
@@ -308,10 +308,10 @@ public class Http2FrameRoundtripTest {
 
     private final class FrameAdapter extends ByteToMessageDecoder {
 
-        private final Http2FrameObserver observer;
+        private final Http2FrameListener observer;
         private final DefaultHttp2FrameReader reader;
 
-        FrameAdapter(Http2FrameObserver observer) {
+        FrameAdapter(Http2FrameListener observer) {
             this.observer = observer;
             reader = new DefaultHttp2FrameReader();
         }
@@ -319,7 +319,7 @@ public class Http2FrameRoundtripTest {
         @Override
         protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out)
                 throws Exception {
-            reader.readFrame(ctx, in, new Http2FrameObserver() {
+            reader.readFrame(ctx, in, new Http2FrameListener() {
 
                 @Override
                 public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data,


### PR DESCRIPTION
Motivation:

We currently have a mix of "Observer" and "Listener" for interface
names. We should make them all "Listener" to be consistent.

Modifications:

Renamed Http2DataObserver->Http2DataListener and
Http2FrameObserver->Http2FrameListener.

Result:

Listener interface names are consistent.
