### PR TITLE
Exclude bin directory from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .project
 .classpath
 .settings
+bin/
 
 # IntelliJ IDEA project files and directories
 *.iml


### PR DESCRIPTION
Motivation:

The 'bin/' directory is currently not in the .gitignore file.
Eclipse creates this directory to support IDE operations.
These directory is generated and not related to source code and therefore does not belong in git.

Modifications:
-Add 'bin/' to .gitignore

Result:
-No more 'bin/' directory confusion for eclipse users.
