### PR TITLE
Fix bug #2848 - Recycler maxCapacity can be ignored

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -96,6 +96,10 @@ public abstract class Recycler<T> {
         return true;
     }
 
+    final int threadLocalCapacity() {
+        return threadLocal.get().elements.length;
+    }
+
     protected abstract T newObject(Handle<T> handle);
 
     public interface Handle<T> {
@@ -339,12 +343,12 @@ public abstract class Recycler<T> {
             item.recycleId = item.lastRecycledId = OWN_THREAD_ID;
 
             int size = this.size;
+            if (size == maxCapacity) {
+                // Hit the maximum capacity - drop the possibly youngest object.
+                return;
+            }
             if (size == elements.length) {
-                if (size == maxCapacity) {
-                    // Hit the maximum capacity - drop the possibly youngest object.
-                    return;
-                }
-                elements = Arrays.copyOf(elements, size << 1);
+                elements = Arrays.copyOf(elements, Math.min(size << 1, maxCapacity));
             }
 
             elements[size] = item;

--- a/common/src/test/java/io/netty/util/RecyclerTest.java
+++ b/common/src/test/java/io/netty/util/RecyclerTest.java
@@ -15,6 +15,8 @@
 */
 package io.netty.util;
 
+import java.util.Random;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -57,6 +59,49 @@ public class RecyclerTest {
 
         public void recycle() {
             RECYCLER.recycle(this, handle);
+        }
+    }
+
+    /**
+     * Test to make sure bug #2848 never happens again
+     * https://github.com/netty/netty/issues/2848
+     */
+    @Test
+    public void testMaxCapacity() {
+        testMaxCapacity(300);
+        Random rand = new Random();
+        for (int i = 0; i < 50; i++) {
+            testMaxCapacity(rand.nextInt(1000) + 256); // 256 - 1256
+        }
+    }
+
+    void testMaxCapacity(int maxCapacity) {
+        Recycler<HandledObject> recycler = new Recycler<HandledObject>(maxCapacity) {
+            @Override
+            protected HandledObject newObject(
+                    Recycler.Handle<HandledObject> handle) {
+                return new HandledObject(handle);
+            }
+        };
+
+        HandledObject[] objects = new HandledObject[maxCapacity * 3];
+        for (int i = 0; i < objects.length; i++) {
+            objects[i] = recycler.get();
+        }
+
+        for (int i = 0; i < objects.length; i++) {
+            recycler.recycle(objects[i], objects[i].handle);
+            objects[i] = null;
+        }
+
+        Assert.assertEquals(maxCapacity, recycler.threadLocalCapacity());
+    }
+
+    static final class HandledObject {
+        Recycler.Handle<HandledObject> handle;
+
+        HandledObject(Recycler.Handle<HandledObject> handle) {
+            this.handle = handle;
         }
     }
 }


### PR DESCRIPTION
`Recycler.Stack.push()` allows caching more objects than `maxCapacity` if `maxCapacity` is not a power of two.
