### PR TITLE
Reset interrupted flag in SingleThreadEventLoopTest. Fixes #2841

### DIFF
--- a/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
@@ -738,6 +738,7 @@ public class SingleThreadEventLoopTest {
 
             if (interrupted) {
                 thread.interrupt();
+                interrupted = false;
             }
 
             // We use LockSupport.parkNanos() and NOT Thread.sleep() to eliminate the overhead of creating a new


### PR DESCRIPTION
Motivation:

Once the interrupted flag in SingleThreadEventLoopB was set it was never reset.
That way the eventloop thread was always in an interrupted state and all calls
to Thread.sleep/LockSupport.parkNanos would fail.

Modifications:

Reset interrupted flag.

Result:

Number of GC runs when executing the test is down to zero (from 20 - 50).
Looking at the heap dump shows >10x decrease in memory consumption e.g.
the number of ForkJoinTasks is down to 25k from 350k previously. Similar
is true for BlockingQueue.Node objects.
