### PR TITLE
HTTP/2 Cipher Suite Support

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Provides utilities related to security requirements specific to HTTP/2.
+ */
+public final class Http2SecurityUtil {
+    private Http2SecurityUtil() { }
+
+    /**
+     * The following list is derived from <a
+     * href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html">SunJSSE Supported
+     * Ciphers</a> and <a
+     * href="https://wiki.mozilla.org/Security/Server_Side_TLS#Non-Backward_Compatible_Ciphersuite">Mozilla Cipher
+     * Suites</a> in accordance with the <a
+     * href="https://tools.ietf.org/html/draft-ietf-httpbis-http2-14#section-9.2.2">HTTP/2 Specification</a>.
+     */
+    public static final List<String> CIPHERS;
+
+    private static final List<String> CIPHERS_JAVA_MOZILLA_INCREASED_SECURITY = Collections.unmodifiableList(Arrays
+            .asList(
+            /* Java 8 */
+            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", /* openssl = ECDHE-ECDSA-AES256-GCM-SHA384 */
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", /* openssl = ECDHE-ECDSA-AES128-GCM-SHA256 */
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", /* openssl = ECDHE-RSA-AES256-GCM-SHA384 */
+            "TLS_RSA_WITH_AES_256_GCM_SHA384", /* openssl = AES256-GCM-SHA384 */
+            /* REQUIRED BY HTTP/2 SPEC */
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", /* openssl = ECDHE-RSA-AES128-GCM-SHA256 */
+            /* REQUIRED BY HTTP/2 SPEC */
+            "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256", /* openssl = DHE-RSA-AES128-GCM-SHA256 */
+            "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256" /* openssl = DHE-DSS-AES128-GCM-SHA256 */));
+
+    private static final List<String> CIPHERS_JAVA_NO_MOZILLA_INCREASED_SECURITY = Collections.unmodifiableList(Arrays
+            .asList(
+            /* Java 6,7,8 */
+            "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA", /* openssl = ECDHE-ECDSA-RC4-SHA */
+            "TLS_ECDH_ECDSA_WITH_RC4_128_SHA", /* openssl = ECDH-ECDSA-RC4-SHA */
+            /* Java 8 */
+            "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384", /* openssl = ECDH-ECDSA-AES256-GCM-SHA384 */
+            "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384", /* openssl = ECDH-RSA-AES256-GCM-SHA384 */
+            "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384", /* openssl = DHE-RSA-AES256-GCM-SHA384 */
+            "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384", /* openssl = DHE-DSS-AES256-GCM-SHA384 */
+            "TLS_RSA_WITH_AES_128_GCM_SHA256", /* openssl = AES128-GCM-SHA256 */
+            "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256", /* openssl = ECDH-ECDSA-AES128-GCM-SHA256 */
+            "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256" /* openssl = ECDH-RSA-AES128-GCM-SHA256 */));
+
+    private static final List<String> CIPHERS_JAVA_DISABLED_DEFAULT = Collections.unmodifiableList(Arrays.asList(
+            /* Java 8 */
+            "TLS_DH_anon_WITH_AES_256_GCM_SHA384", /* openssl = ADH-AES256-GCM-SHA384 */
+            "TLS_DH_anon_WITH_AES_128_GCM_SHA256", /* openssl = ADH-AES128-GCM-SHA256 */
+            /* Java 6,7,8 */
+            "TLS_ECDH_anon_WITH_RC4_128_SHA" /* openssl = AECDH-RC4-SHA */));
+
+    static {
+        List<String> ciphers = new ArrayList<String>(CIPHERS_JAVA_MOZILLA_INCREASED_SECURITY.size()
+                + CIPHERS_JAVA_NO_MOZILLA_INCREASED_SECURITY.size() + CIPHERS_JAVA_DISABLED_DEFAULT.size());
+        ciphers.addAll(CIPHERS_JAVA_MOZILLA_INCREASED_SECURITY);
+        ciphers.addAll(CIPHERS_JAVA_NO_MOZILLA_INCREASED_SECURITY);
+        ciphers.addAll(CIPHERS_JAVA_DISABLED_DEFAULT);
+        CIPHERS = Collections.unmodifiableList(ciphers);
+    }
+}

--- a/example/src/main/java/io/netty/example/http2/client/Http2Client.java
+++ b/example/src/main/java/io/netty/example/http2/client/Http2Client.java
@@ -28,8 +28,10 @@ import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http2.Http2OrHttpChooser.SelectedProtocol;
+import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.ssl.JettyAlpnSslEngineWrapper;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.util.CharsetUtil;
 
@@ -57,12 +59,10 @@ public final class Http2Client {
         if (SSL) {
             sslCtx = SslContext.newClientContext(
                     null, InsecureTrustManagerFactory.INSTANCE,
-                    Arrays.asList("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-                            // NOTE: Block ciphers are prohibited by the HTTP/2 specification
-                            // http://tools.ietf.org/html/draft-ietf-httpbis-http2-14#section-9.2.2.
-                            // The following cipher exists to allow these examples to run with older JREs.
-                            // Please consult the HTTP/2 specification when selecting cipher suites.
-                            "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA"),
+                    Http2SecurityUtil.CIPHERS,
+                    /* NOTE: the following filter may not include all ciphers required by the HTTP/2 specification
+                     * Please refer to the HTTP/2 specification for cipher requirements. */
+                    SupportedCipherSuiteFilter.INSTANCE,
                     Arrays.asList(SelectedProtocol.HTTP_2.protocolName(), SelectedProtocol.HTTP_1_1.protocolName()),
                     JettyAlpnSslEngineWrapper.instance(),
                     0, 0);

--- a/example/src/main/java/io/netty/example/http2/server/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/server/Http2Server.java
@@ -23,10 +23,12 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.http2.Http2OrHttpChooser.SelectedProtocol;
+import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.JettyAlpnSslEngineWrapper;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 
 import java.util.Arrays;
@@ -47,12 +49,10 @@ public final class Http2Server {
             SelfSignedCertificate ssc = new SelfSignedCertificate();
             sslCtx = SslContext.newServerContext(
                     ssc.certificate(), ssc.privateKey(), null,
-                    Arrays.asList("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-                            // NOTE: Block ciphers are prohibited by the HTTP/2 specification
-                            // http://tools.ietf.org/html/draft-ietf-httpbis-http2-14#section-9.2.2.
-                            // The following cipher exists to allow these examples to run with older JREs.
-                            // Please consult the HTTP/2 specification when selecting cipher suites.
-                            "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA"),
+                    Http2SecurityUtil.CIPHERS,
+                    /* NOTE: the following filter may not include all ciphers required by the HTTP/2 specification
+                     * Please refer to the HTTP/2 specification for cipher requirements. */
+                    SupportedCipherSuiteFilter.INSTANCE,
                     Arrays.asList(
                             SelectedProtocol.HTTP_2.protocolName(),
                             SelectedProtocol.HTTP_1_1.protocolName()),

--- a/example/src/main/java/io/netty/example/memcache/binary/MemcacheClient.java
+++ b/example/src/main/java/io/netty/example/memcache/binary/MemcacheClient.java
@@ -24,11 +24,13 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.codec.http2.Http2OrHttpChooser.SelectedProtocol;
 import io.netty.handler.codec.memcache.binary.BinaryMemcacheClientCodec;
 import io.netty.handler.codec.memcache.binary.BinaryMemcacheObjectAggregator;
 import io.netty.handler.ssl.JettyAlpnSslEngineWrapper;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 
 import java.io.BufferedReader;
@@ -49,7 +51,10 @@ public final class MemcacheClient {
         final SslContext sslCtx;
         if (SSL) {
             sslCtx = SslContext.newClientContext(
-                    null, InsecureTrustManagerFactory.INSTANCE, null,
+                    null, InsecureTrustManagerFactory.INSTANCE, Http2SecurityUtil.CIPHERS,
+                    /* NOTE: the following filter may not include all ciphers required by the HTTP/2 specification
+                     * Please refer to the HTTP/2 specification for cipher requirements. */
+                    SupportedCipherSuiteFilter.INSTANCE,
                     Arrays.asList(SelectedProtocol.HTTP_2.protocolName(), SelectedProtocol.HTTP_1_1.protocolName()),
                     JettyAlpnSslEngineWrapper.instance(),
                     0, 0);

--- a/example/src/main/java/io/netty/example/spdy/client/SpdyClient.java
+++ b/example/src/main/java/io/netty/example/spdy/client/SpdyClient.java
@@ -27,6 +27,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.spdy.SpdyOrHttpChooser.SelectedProtocol;
+import io.netty.handler.ssl.IdentityCipherSuiteFilter;
 import io.netty.handler.ssl.JettyNpnSslEngineWrapper;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -55,7 +56,7 @@ public final class SpdyClient {
     public static void main(String[] args) throws Exception {
         // Configure SSL.
         final SslContext sslCtx = SslContext.newClientContext(
-                null, InsecureTrustManagerFactory.INSTANCE, null,
+                null, InsecureTrustManagerFactory.INSTANCE, null, IdentityCipherSuiteFilter.INSTANCE,
                 Arrays.asList(SelectedProtocol.SPDY_3_1.protocolName(), SelectedProtocol.HTTP_1_1.protocolName()),
                 JettyNpnSslEngineWrapper.instance(),
                 0, 0);

--- a/example/src/main/java/io/netty/example/spdy/server/SpdyServer.java
+++ b/example/src/main/java/io/netty/example/spdy/server/SpdyServer.java
@@ -24,6 +24,7 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.spdy.SpdyOrHttpChooser.SelectedProtocol;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.IdentityCipherSuiteFilter;
 import io.netty.handler.ssl.JettyNpnSslEngineWrapper;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -56,7 +57,7 @@ public final class SpdyServer {
         // Configure SSL.
         SelfSignedCertificate ssc = new SelfSignedCertificate();
         SslContext sslCtx = SslContext.newServerContext(
-                ssc.certificate(), ssc.privateKey(), null, null,
+                ssc.certificate(), ssc.privateKey(), null, null, IdentityCipherSuiteFilter.INSTANCE,
                 Arrays.asList(SelectedProtocol.SPDY_3_1.protocolName(), SelectedProtocol.HTTP_1_1.protocolName()),
                 JettyNpnSslEngineWrapper.instance(),
                 0, 0);

--- a/handler/src/main/java/io/netty/handler/ssl/CipherSuiteFilter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/CipherSuiteFilter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Provides a means to filter the supplied cipher suite based upon the supported and default cipher suites.
+ */
+public interface CipherSuiteFilter {
+    /**
+     * Filter the requested {@code ciphers} based upon other cipher characteristics.
+     * @param ciphers The requested ciphers
+     * @param defaultCiphers The default recommended ciphers for the current {@link SSLEngine} as determined by Netty
+     * @param supportedCiphers The supported ciphers for the current {@link SSLEngine}
+     * @return The filter list of ciphers. Must not return {@code null}.
+     */
+    String[] filterCipherSuites(Iterable<String> ciphers, List<String> defaultCiphers, Set<String> supportedCiphers);
+}

--- a/handler/src/main/java/io/netty/handler/ssl/DefaultSslWrapperFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/DefaultSslWrapperFactory.java
@@ -20,16 +20,12 @@ import java.util.List;
 import javax.net.ssl.SSLEngine;
 
 /**
- * Factory for not wrapping {@link SSLEngine} object and just returning it
+ * Factory for not wrapping {@link SSLEngine} object and just returning it.
  */
 public final class DefaultSslWrapperFactory implements SslEngineWrapperFactory {
-    private static final DefaultSslWrapperFactory INSTANCE = new DefaultSslWrapperFactory();
+    public static final DefaultSslWrapperFactory INSTANCE = new DefaultSslWrapperFactory();
 
     private DefaultSslWrapperFactory() {
-    }
-
-    public static DefaultSslWrapperFactory instance() {
-        return INSTANCE;
     }
 
     @Override

--- a/handler/src/main/java/io/netty/handler/ssl/IdentityCipherSuiteFilter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/IdentityCipherSuiteFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This class will not do any filtering of ciphers suites.
+ */
+public final class IdentityCipherSuiteFilter implements CipherSuiteFilter {
+    public static final IdentityCipherSuiteFilter INSTANCE = new IdentityCipherSuiteFilter();
+
+    private IdentityCipherSuiteFilter() { }
+
+    @Override
+    public String[] filterCipherSuites(Iterable<String> ciphers, List<String> defaultCiphers,
+            Set<String> supportedCiphers) {
+        if (ciphers == null) {
+            return defaultCiphers.toArray(new String[defaultCiphers.size()]);
+        } else {
+            List<String> newCiphers = new ArrayList<String>(supportedCiphers.size());
+            for (String c : ciphers) {
+                if (c == null) {
+                    break;
+                }
+                newCiphers.add(c);
+            }
+            return newCiphers.toArray(new String[newCiphers.size()]);
+        }
+    }
+
+}

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
@@ -79,7 +79,8 @@ public final class JdkSslClientContext extends JdkSslContext {
      *                            {@code null} to use the default.
      */
     public JdkSslClientContext(File certChainFile, TrustManagerFactory trustManagerFactory) throws SSLException {
-        this(certChainFile, trustManagerFactory, null, null, DefaultSslWrapperFactory.instance(), 0, 0);
+        this(certChainFile, trustManagerFactory, null, IdentityCipherSuiteFilter.INSTANCE,
+                null, DefaultSslWrapperFactory.INSTANCE, 0, 0);
     }
 
     /**
@@ -92,6 +93,7 @@ public final class JdkSslClientContext extends JdkSslContext {
      *                            {@code null} to use the default.
      * @param ciphers the cipher suites to enable, in the order of preference.
      *                {@code null} to use the default cipher suites.
+     * @param cipherFilter a filter to apply over the supplied list of ciphers
      * @param nextProtocols the application layer protocols to accept, in the order of preference.
      *                      {@code null} to disable TLS NPN/ALPN extension.
      * @param wrapperFactory a factory used to wrap the underlying {@link SSLEngine}.
@@ -103,11 +105,11 @@ public final class JdkSslClientContext extends JdkSslContext {
      */
     public JdkSslClientContext(
             File certChainFile, TrustManagerFactory trustManagerFactory,
-            Iterable<String> ciphers, Iterable<String> nextProtocols,
-            SslEngineWrapperFactory wrapperFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
+            Iterable<String> nextProtocols, SslEngineWrapperFactory wrapperFactory,
             long sessionCacheSize, long sessionTimeout) throws SSLException {
 
-        super(ciphers, wrapperFactory);
+        super(ciphers, cipherFilter, wrapperFactory);
 
         this.nextProtocols = translateProtocols(nextProtocols);
 

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslServerContext.java
@@ -74,7 +74,8 @@ public final class JdkSslServerContext extends JdkSslContext {
      *                    {@code null} if it's not password-protected.
      */
     public JdkSslServerContext(File certChainFile, File keyFile, String keyPassword) throws SSLException {
-        this(certChainFile, keyFile, keyPassword, null, null, DefaultSslWrapperFactory.instance(), 0, 0);
+        this(certChainFile, keyFile, keyPassword, null, IdentityCipherSuiteFilter.INSTANCE,
+                null, DefaultSslWrapperFactory.INSTANCE, 0, 0);
     }
 
     /**
@@ -86,6 +87,7 @@ public final class JdkSslServerContext extends JdkSslContext {
      *                    {@code null} if it's not password-protected.
      * @param ciphers the cipher suites to enable, in the order of preference.
      *                {@code null} to use the default cipher suites.
+     * @param cipherFilter a filter to apply over the supplied list of ciphers
      * @param nextProtocols the application layer protocols to accept, in the order of preference.
      *                      {@code null} to disable TLS NPN/ALPN extension.
      * @param wrapperFactory a factory used to wrap the underlying {@link SSLEngine}.
@@ -97,11 +99,11 @@ public final class JdkSslServerContext extends JdkSslContext {
      */
     public JdkSslServerContext(
             File certChainFile, File keyFile, String keyPassword,
-            Iterable<String> ciphers, Iterable<String> nextProtocols,
-            SslEngineWrapperFactory wrapperFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
+            Iterable<String> nextProtocols, SslEngineWrapperFactory wrapperFactory,
             long sessionCacheSize, long sessionTimeout) throws SSLException {
 
-        super(ciphers, wrapperFactory);
+        super(ciphers, cipherFilter, wrapperFactory);
 
         this.nextProtocols = translateProtocols(nextProtocols);
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -133,6 +133,7 @@ public abstract class SslContext {
      *                    {@code null} if it's not password-protected.
      * @param ciphers the cipher suites to enable, in the order of preference.
      *                {@code null} to use the default cipher suites.
+     * @param cipherFilter a filter to apply over the supplied list of ciphers
      * @param nextProtocols the application layer protocols to accept, in the order of preference.
      *                      {@code null} to disable TLS NPN/ALPN extension.
      * @param wrapperFactory a factory used to wrap the underlying {@link SSLEngine}.
@@ -146,12 +147,12 @@ public abstract class SslContext {
      */
     public static SslContext newServerContext(
             File certChainFile, File keyFile, String keyPassword,
-            Iterable<String> ciphers, Iterable<String> nextProtocols,
-            SslEngineWrapperFactory wrapperFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
+            Iterable<String> nextProtocols, SslEngineWrapperFactory wrapperFactory,
             long sessionCacheSize, long sessionTimeout) throws SSLException {
         return newServerContext(
                 null, certChainFile, keyFile, keyPassword,
-                ciphers, nextProtocols, wrapperFactory, sessionCacheSize, sessionTimeout);
+                ciphers, cipherFilter, nextProtocols, wrapperFactory, sessionCacheSize, sessionTimeout);
     }
 
     /**
@@ -181,8 +182,8 @@ public abstract class SslContext {
      */
     public static SslContext newServerContext(
             SslProvider provider, File certChainFile, File keyFile, String keyPassword) throws SSLException {
-        return newServerContext(provider, certChainFile, keyFile, keyPassword, null, null,
-                        DefaultSslWrapperFactory.instance(), 0, 0);
+        return newServerContext(provider, certChainFile, keyFile, keyPassword, null, IdentityCipherSuiteFilter.INSTANCE,
+                null, DefaultSslWrapperFactory.INSTANCE, 0, 0);
     }
 
     /**
@@ -196,6 +197,8 @@ public abstract class SslContext {
      *                    {@code null} if it's not password-protected.
      * @param ciphers the cipher suites to enable, in the order of preference.
      *                {@code null} to use the default cipher suites.
+     * @param cipherFilter a filter to apply over the supplied list of ciphers
+     *                Only required if {@code provider} is {@link SslProvider#JDK}
      * @param nextProtocols the application layer protocols to accept, in the order of preference.
      *                      {@code null} to disable TLS NPN/ALPN extension.
      * @param wrapperFactory a factory used to wrap the underlying {@link SSLEngine}.
@@ -210,8 +213,8 @@ public abstract class SslContext {
     public static SslContext newServerContext(
             SslProvider provider,
             File certChainFile, File keyFile, String keyPassword,
-            Iterable<String> ciphers, Iterable<String> nextProtocols,
-            SslEngineWrapperFactory wrapperFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
+            Iterable<String> nextProtocols, SslEngineWrapperFactory wrapperFactory,
             long sessionCacheSize, long sessionTimeout) throws SSLException {
 
         if (provider == null) {
@@ -222,7 +225,7 @@ public abstract class SslContext {
             case JDK:
                 return new JdkSslServerContext(
                         certChainFile, keyFile, keyPassword,
-                        ciphers, nextProtocols, wrapperFactory, sessionCacheSize, sessionTimeout);
+                        ciphers, cipherFilter, nextProtocols, wrapperFactory, sessionCacheSize, sessionTimeout);
             case OPENSSL:
                 return new OpenSslServerContext(
                         certChainFile, keyFile, keyPassword,
@@ -291,6 +294,7 @@ public abstract class SslContext {
      *                            {@code null} to use the default.
      * @param ciphers the cipher suites to enable, in the order of preference.
      *                {@code null} to use the default cipher suites.
+     * @param cipherFilter a filter to apply over the supplied list of ciphers
      * @param nextProtocols the application layer protocols to accept, in the order of preference.
      *                      {@code null} to disable TLS NPN/ALPN extension.
      * @param wrapperFactory a factory used to wrap the underlying {@link SSLEngine}.
@@ -305,12 +309,12 @@ public abstract class SslContext {
      */
     public static SslContext newClientContext(
             File certChainFile, TrustManagerFactory trustManagerFactory,
-            Iterable<String> ciphers, Iterable<String> nextProtocols,
-            SslEngineWrapperFactory wrapperFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
+            Iterable<String> nextProtocols, SslEngineWrapperFactory wrapperFactory,
             long sessionCacheSize, long sessionTimeout) throws SSLException {
         return newClientContext(
                 null, certChainFile, trustManagerFactory,
-                ciphers, nextProtocols, wrapperFactory, sessionCacheSize, sessionTimeout);
+                ciphers, cipherFilter, nextProtocols, wrapperFactory, sessionCacheSize, sessionTimeout);
     }
 
     /**
@@ -370,8 +374,8 @@ public abstract class SslContext {
      */
     public static SslContext newClientContext(
             SslProvider provider, File certChainFile, TrustManagerFactory trustManagerFactory) throws SSLException {
-        return newClientContext(provider, certChainFile, trustManagerFactory, null, null,
-                        DefaultSslWrapperFactory.instance(), 0, 0);
+        return newClientContext(provider, certChainFile, trustManagerFactory, null, IdentityCipherSuiteFilter.INSTANCE,
+                null, DefaultSslWrapperFactory.INSTANCE, 0, 0);
     }
 
     /**
@@ -386,6 +390,7 @@ public abstract class SslContext {
      *                            {@code null} to use the default.
      * @param ciphers the cipher suites to enable, in the order of preference.
      *                {@code null} to use the default cipher suites.
+     * @param cipherFilter a filter to apply over the supplied list of ciphers
      * @param nextProtocols the application layer protocols to accept, in the order of preference.
      *                      {@code null} to disable TLS NPN/ALPN extension.
      * @param wrapperFactory a factory used to wrap the underlying {@link SSLEngine}.
@@ -401,8 +406,8 @@ public abstract class SslContext {
     public static SslContext newClientContext(
             SslProvider provider,
             File certChainFile, TrustManagerFactory trustManagerFactory,
-            Iterable<String> ciphers, Iterable<String> nextProtocols,
-            SslEngineWrapperFactory wrapperFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
+            Iterable<String> nextProtocols, SslEngineWrapperFactory wrapperFactory,
             long sessionCacheSize, long sessionTimeout) throws SSLException {
 
         if (provider != null && provider != SslProvider.JDK) {
@@ -411,7 +416,7 @@ public abstract class SslContext {
 
         return new JdkSslClientContext(
                 certChainFile, trustManagerFactory,
-                ciphers, nextProtocols, wrapperFactory, sessionCacheSize, sessionTimeout);
+                ciphers, cipherFilter, nextProtocols, wrapperFactory, sessionCacheSize, sessionTimeout);
     }
 
     SslContext() { }

--- a/handler/src/main/java/io/netty/handler/ssl/SupportedCipherSuiteFilter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SupportedCipherSuiteFilter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This class will filter all requested ciphers out that are not supported by the current {@link SSLEngine}.
+ */
+public final class SupportedCipherSuiteFilter implements CipherSuiteFilter {
+    public static final SupportedCipherSuiteFilter INSTANCE = new SupportedCipherSuiteFilter();
+
+    private SupportedCipherSuiteFilter() { }
+
+    @Override
+    public String[] filterCipherSuites(Iterable<String> ciphers, List<String> defaultCiphers,
+            Set<String> supportedCiphers) {
+        if (defaultCiphers == null) {
+            throw new NullPointerException("defaultCiphers");
+        }
+        if (supportedCiphers == null) {
+            throw new NullPointerException("supportedCiphers");
+        }
+
+        final List<String> newCiphers;
+        if (ciphers == null) {
+            newCiphers = new ArrayList<String>(defaultCiphers.size());
+            ciphers = defaultCiphers;
+        } else {
+            newCiphers = new ArrayList<String>(supportedCiphers.size());
+        }
+        for (String c : ciphers) {
+            if (c == null) {
+                break;
+            }
+            if (supportedCiphers.contains(c)) {
+                newCiphers.add(c);
+            }
+        }
+        return newCiphers.toArray(new String[newCiphers.size()]);
+    }
+
+}

--- a/handler/src/test/java/io/netty/handler/ssl/CipherSuiteFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/CipherSuiteFilterTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+import org.mockito.internal.util.collections.Sets;
+
+public class CipherSuiteFilterTest {
+    @Test
+    public void supportedCipherSuiteFilterNonEmpty() {
+        List<String> ciphers = Arrays.asList("foo", "goo", "noooo", "aaaa");
+        List<String> defaultCiphers = Arrays.asList("FOO", "GOO");
+        Set<String> supportedCiphers = Sets.newSet("FOO", "aaaa", "bbbbbb", "GOO", "goo");
+        CipherSuiteFilter filter = SupportedCipherSuiteFilter.INSTANCE;
+        String[] results = filter.filterCipherSuites(ciphers, defaultCiphers, supportedCiphers);
+        assertEquals(2, results.length);
+        assertEquals("goo", results[0]);
+        assertEquals("aaaa", results[1]);
+    }
+
+    @Test
+    public void supportedCipherSuiteFilterToEmpty() {
+        List<String> ciphers = Arrays.asList("foo", "goo", "nooooo");
+        List<String> defaultCiphers = Arrays.asList("FOO", "GOO");
+        Set<String> supportedCiphers = Sets.newSet("FOO", "aaaa", "bbbbbb", "GOO");
+        CipherSuiteFilter filter = SupportedCipherSuiteFilter.INSTANCE;
+        String[] results = filter.filterCipherSuites(ciphers, defaultCiphers, supportedCiphers);
+        assertEquals(0, results.length);
+    }
+
+    @Test
+    public void supportedCipherSuiteFilterToDefault() {
+        List<String> defaultCiphers = Arrays.asList("FOO", "GOO");
+        Set<String> supportedCiphers = Sets.newSet("GOO", "FOO", "aaaa", "bbbbbb");
+        CipherSuiteFilter filter = SupportedCipherSuiteFilter.INSTANCE;
+        String[] results = filter.filterCipherSuites(null, defaultCiphers, supportedCiphers);
+        assertEquals(2, results.length);
+        assertEquals("FOO", results[0]);
+        assertEquals("GOO", results[1]);
+    }
+
+    @Test
+    public void defaulCipherSuiteNoFilter() {
+        List<String> ciphers = Arrays.asList("foo", "goo", "nooooo");
+        List<String> defaultCiphers = Arrays.asList("FOO", "GOO");
+        Set<String> supportedCiphers = Sets.newSet("FOO", "aaaa", "bbbbbb", "GOO");
+        CipherSuiteFilter filter = IdentityCipherSuiteFilter.INSTANCE;
+        String[] results = filter.filterCipherSuites(ciphers, defaultCiphers, supportedCiphers);
+        assertEquals(ciphers.size(), results.length);
+        for (int i = 0; i < ciphers.size(); ++i) {
+            assertEquals(ciphers.get(i), results[i]);
+        }
+    }
+
+    @Test
+    public void defaulCipherSuiteTakeDefault() {
+        List<String> defaultCiphers = Arrays.asList("FOO", "GOO");
+        Set<String> supportedCiphers = Sets.newSet("FOO", "aaaa", "bbbbbb", "GOO");
+        CipherSuiteFilter filter = IdentityCipherSuiteFilter.INSTANCE;
+        String[] results = filter.filterCipherSuites(null, defaultCiphers, supportedCiphers);
+        assertEquals(defaultCiphers.size(), results.length);
+        for (int i = 0; i < defaultCiphers.size(); ++i) {
+            assertEquals(defaultCiphers.get(i), results[i]);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
The HTTP/2 specification places restrictions on the cipher suites that can be used. There is no central place to pull the ciphers that are allowed by the specification, supported by different java versions, and recommended by the community.

Modifications:
-HTTP/2 will have a security utility class to define supported ciphers
-netty-handler will be modified to support filtering the supplied list of ciphers to the supported ciphers for the current SSLEngine

Result:
-Netty provides unified support for HTTP/2 cipher lists and ciphers can be pruned by currently supported ciphers
