### PR TITLE
Provide helper methods in ByteBufUtil to write UTF-8/ASCII CharSequences...

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ByteBufUtilTest {
+
+    @Test
+    public void testWriteUsAscii() {
+        String usAscii = "NettyRocks";
+        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(16));
+        buf.writeBytes(usAscii.getBytes(CharsetUtil.US_ASCII));
+        ByteBuf buf2 = ReferenceCountUtil.releaseLater(Unpooled.buffer(16));
+        ByteBufUtil.writeAscii(buf2, usAscii);
+
+        Assert.assertEquals(buf, buf2);
+    }
+
+    @Test
+    public void testWriteUtf8() {
+        String usAscii = "Some UTF-8 like äÄ∏ŒŒ";
+        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(16));
+        buf.writeBytes(usAscii.getBytes(CharsetUtil.UTF_8));
+        ByteBuf buf2 = ReferenceCountUtil.releaseLater(Unpooled.buffer(16));
+        ByteBufUtil.writeUtf8(buf2, usAscii);
+
+        Assert.assertEquals(buf, buf2);
+    }
+}

--- a/microbench/src/test/java/io/netty/microbench/buffer/ByteBufUtilBenchmark.java
+++ b/microbench/src/test/java/io/netty/microbench/buffer/ByteBufUtilBenchmark.java
@@ -1,0 +1,167 @@
+/*
+* Copyright 2014 The Netty Project
+*
+* The Netty Project licenses this file to you under the Apache License,
+* version 2.0 (the "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at:
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+package io.netty.microbench.buffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.CharsetUtil;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 10)
+@Measurement(iterations = 25)
+public class ByteBufUtilBenchmark extends AbstractMicrobenchmark {
+    private ByteBuf buffer;
+    private ByteBuf wrapped;
+
+    private StringBuilder asciiSequence;
+    private String ascii;
+
+    private StringBuilder utf8Sequence;
+    private String utf8;
+
+    @Setup
+    public void setup() {
+        // Use buffer sizes that will also allow to write UTF-8 without grow the buffer
+        buffer = Unpooled.directBuffer(512);
+        wrapped = Unpooled.unreleasableBuffer(Unpooled.directBuffer(512));
+        asciiSequence = new StringBuilder(128);
+        for (int i = 0; i < 128; i++) {
+            asciiSequence.append('a');
+        }
+        ascii = asciiSequence.toString();
+
+        // Generate some mixed UTF-8 String for benchmark
+        utf8Sequence = new StringBuilder(128);
+        char[] chars = "Some UTF-8 like äÄ∏ŒŒ".toCharArray();
+        for (int i = 0; i < 128; i++) {
+            utf8Sequence.append(chars[i % chars.length]);
+        }
+        utf8 = utf8Sequence.toString();
+        asciiSequence = utf8Sequence;
+    }
+
+    @TearDown
+    public void tearDown() {
+        buffer.release();
+        wrapped.release();
+    }
+
+    @Benchmark
+    public void writeAsciiStringViaArray() {
+        buffer.resetWriterIndex();
+        buffer.writeBytes(ascii.getBytes(CharsetUtil.US_ASCII));
+    }
+
+    @Benchmark
+    public void writeAsciiStringViaArrayWrapped() {
+        wrapped.resetWriterIndex();
+        wrapped.writeBytes(ascii.getBytes(CharsetUtil.US_ASCII));
+    }
+
+    @Benchmark
+    public void writeAsciiString() {
+        buffer.resetWriterIndex();
+        ByteBufUtil.writeAscii(buffer, ascii);
+    }
+
+    @Benchmark
+    public void writeAsciiStringWrapped() {
+        wrapped.resetWriterIndex();
+        ByteBufUtil.writeAscii(wrapped, ascii);
+    }
+
+    @Benchmark
+    public void writeAsciiViaArray() {
+        buffer.resetWriterIndex();
+        buffer.writeBytes(asciiSequence.toString().getBytes(CharsetUtil.US_ASCII));
+    }
+
+    @Benchmark
+    public void writeAsciiViaArrayWrapped() {
+        wrapped.resetWriterIndex();
+        wrapped.writeBytes(asciiSequence.toString().getBytes(CharsetUtil.US_ASCII));
+    }
+
+    @Benchmark
+    public void writeAscii() {
+        buffer.resetWriterIndex();
+        ByteBufUtil.writeAscii(buffer, asciiSequence);
+    }
+
+    @Benchmark
+    public void writeAsciiWrapped() {
+        wrapped.resetWriterIndex();
+        ByteBufUtil.writeAscii(wrapped, asciiSequence);
+    }
+
+    @Benchmark
+    public void writeUtf8StringViaArray() {
+        buffer.resetWriterIndex();
+        buffer.writeBytes(utf8.getBytes(CharsetUtil.US_ASCII));
+    }
+
+    @Benchmark
+    public void writeUtf8StringViaArrayWrapped() {
+        wrapped.resetWriterIndex();
+        wrapped.writeBytes(utf8.getBytes(CharsetUtil.US_ASCII));
+    }
+
+    @Benchmark
+    public void writeUtf8String() {
+        buffer.resetWriterIndex();
+        ByteBufUtil.writeUtf8(buffer, utf8);
+    }
+
+    @Benchmark
+    public void writeUtf8StringWrapped() {
+        wrapped.resetWriterIndex();
+        ByteBufUtil.writeUtf8(wrapped, utf8);
+    }
+
+    @Benchmark
+    public void writeUtf8ViaArray() {
+        buffer.resetWriterIndex();
+        buffer.writeBytes(utf8Sequence.toString().getBytes(CharsetUtil.US_ASCII));
+    }
+
+    @Benchmark
+    public void writeUtf8ViaArrayWrapped() {
+        wrapped.resetWriterIndex();
+        wrapped.writeBytes(utf8Sequence.toString().getBytes(CharsetUtil.US_ASCII));
+    }
+
+    @Benchmark
+    public void writeUtf8() {
+        buffer.resetWriterIndex();
+        ByteBufUtil.writeUtf8(buffer, utf8Sequence);
+    }
+
+    @Benchmark
+    public void writeUtf8Wrapped() {
+        wrapped.resetWriterIndex();
+        ByteBufUtil.writeUtf8(wrapped, utf8Sequence);
+    }
+}


### PR DESCRIPTION
.... Related to [#909]

Motivation:

We expose no methods in ByteBuf to directly write a CharSequence into it. This leads to have the user either convert the CharSequence first to a byte array or use CharsetEncoder. Both cases have some overheads and we can do a lot better for well known Charsets like UTF-8 and ASCII.

Modifications:

Add ByteBufUtil.writeAsciiCharSequence(...) and ByteBufUtil.writeUtf8CharSequence(...) which can do the task in an optimized way. This is especially true if the passed in ByteBuf extends AbstractByteBuf which is true for all of our implementations which not wrap another ByteBuf.

Result:

Writing an ASCII and UTF-8 CharSequence into a AbstractByteBuf is a lot faster then what the user could do by himself as we can make use of some package private methods and so eliminate reference and range checks. When the Charseq is not ASCII or UTF-8 we can still do a very good job and are on par in most of the cases with what the user would do.

The following bechmark shows the improvements:

```
Benchmark                                                              Mode   Samples        Score  Score error    Units
i.n.m.b.ByteBufUtilBenchmark.writeAsciiCharSequence                   thrpt        50  9071736,721   587948,771    ops/s
i.n.m.b.ByteBufUtilBenchmark.writeAsciiCharSequenceViaArray           thrpt        50  3043807,652   208008,698    ops/s
i.n.m.b.ByteBufUtilBenchmark.writeAsciiCharSequenceViaArrayWrapped    thrpt        50  3024189,530   198905,388    ops/s
i.n.m.b.ByteBufUtilBenchmark.writeAsciiCharSequenceWrapped            thrpt        50  3409030,169    91543,588    ops/s
i.n.m.b.ByteBufUtilBenchmark.writeAsciiString                         thrpt        50 10089151,297   286351,733    ops/s
i.n.m.b.ByteBufUtilBenchmark.writeAsciiStringViaArray                 thrpt        50  4906278,232   172291,820    ops/s
i.n.m.b.ByteBufUtilBenchmark.writeAsciiStringViaArrayWrapped          thrpt        50  4511319,426   280382,742    ops/s
i.n.m.b.ByteBufUtilBenchmark.writeAsciiStringWrapped                  thrpt        50  4458570,751   227097,569    ops/s
i.n.m.b.ByteBufUtilBenchmark.writeUtf8CharSequence                    thrpt        50  9847334,965   515519,775    ops/s
i.n.m.b.ByteBufUtilBenchmark.writeUtf8CharSequenceViaArray            thrpt        50  3321834,254   119002,597    ops/s
i.n.m.b.ByteBufUtilBenchmark.writeUtf8CharSequenceViaArrayWrapped     thrpt        50  3143624,224   148331,202    ops/s
i.n.m.b.ByteBufUtilBenchmark.writeUtf8CharSequenceWrapped             thrpt        50  3442477,836    98653,095    ops/s
i.n.m.b.ByteBufUtilBenchmark.writeUtf8String                          thrpt        50  9571479,473   582890,330    ops/s
i.n.m.b.ByteBufUtilBenchmark.writeUtf8StringViaArray                  thrpt        50  3639893,464    84165,504    ops/s
i.n.m.b.ByteBufUtilBenchmark.writeUtf8StringViaArrayWrapped           thrpt        50  3613282,539    95278,392    ops/s
i.n.m.b.ByteBufUtilBenchmark.writeUtf8StringWrapped                   thrpt        50  3424367,302   167819,611    ops/s
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1,370.56 sec - in io.netty.microbench.buffer.ByteBufUtilBenchmark

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

The *ViaArray benchmarks are basically doing a `toString().getBytes(Charset)` which the others are using `ByteBufUtil.write\*CharSequence(...)`.
