### PR TITLE
Reduce threads used by NioEventLoopGroups during tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -882,7 +882,8 @@
             <exclude>**/TestUtil*</exclude>
           </excludes>
           <runOrder>random</runOrder>
-          <argLine>${argLine.common} ${argLine.bootcp} ${argLine.leak} ${argLine.coverage}</argLine>
+          <!-- See GitHub issue https://github.com/netty/netty/pull/2877 -->
+          <argLine>${argLine.common} -Dio.netty.eventLoopThreads=2 ${argLine.bootcp} ${argLine.leak} ${argLine.coverage}</argLine>
         </configuration>
       </plugin>
       <!-- always produce osgi bundles -->


### PR DESCRIPTION
Motivation:

Whenever a new (Nio|Epoll)EventLoopGroup is created it defaults to
creating twice as many threads as there are cores in the system.

It's quite common that a single unit test method create
2 - 3 (Nio|Epoll)EventLoopGroups. This leads to a lot of (unnecessary)
threads being created. For example, a unit test with 10 methods, each
using 2 NioEventLoopGroups creates 2 \* 10 \* 8 \* 2 = 320 threads if
run on an 8 core machine. It allocates 'only' 160 threads if run on a
4 core machine and only 80 threads if run on a 2 core machine.

Now each thread allocates some memory for e.g. its stack, tlab, ...
In GitHub issues #2841, #2870, #2872 OutOfMemory errors due to
too many active/not yet GCed threads were reported.

So while the thread count increases sharply on more powerful machines,
the default max heap size is limited to 1GB [1].

Modifications:

When used within a junit test each Epoll- and NioEventLoopGroup allocates
2 EventLoops and threads by default (independenly of the machine's core count).
This should be more than enough to handle the "load" generated by unit tests.

Result:

Radically reduce the number of threads created by JUnit tests.

[1] http://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/ergonomics.html#sthref5
