### PR TITLE
Add missing calls to childGroup().shutdownGraceFully()

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DelegatingHttp2HttpConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DelegatingHttp2HttpConnectionHandlerTest.java
@@ -117,6 +117,7 @@ public class DelegatingHttp2HttpConnectionHandlerTest {
     public void teardown() throws Exception {
         serverChannel.close().sync();
         sb.group().shutdownGracefully();
+        sb.childGroup().shutdownGracefully();
         cb.group().shutdownGracefully();
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -120,6 +120,7 @@ public class Http2ConnectionRoundtripTest {
     public void teardown() throws Exception {
         serverChannel.close().sync();
         sb.group().shutdownGracefully();
+        sb.childGroup().shutdownGracefully();
         cb.group().shutdownGracefully();
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -109,6 +109,7 @@ public class Http2FrameRoundtripTest {
     public void teardown() throws Exception {
         serverChannel.close().sync();
         sb.group().shutdownGracefully();
+        sb.childGroup().shutdownGracefully();
         cb.group().shutdownGracefully();
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -144,6 +144,7 @@ public class InboundHttp2ToHttpAdapterTest {
     public void teardown() throws Exception {
         serverChannel.close().sync();
         sb.group().shutdownGracefully();
+        sb.childGroup().shutdownGracefully();
         cb.group().shutdownGracefully();
         clientDelegator = null;
         serverDelegator = null;

--- a/handler/src/test/java/io/netty/handler/ssl/JettySslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JettySslEngineTest.java
@@ -103,6 +103,7 @@ public class JettySslEngineTest {
         if (serverChannel != null) {
             serverChannel.close().sync();
             sb.group().shutdownGracefully();
+            sb.childGroup().shutdownGracefully();
             cb.group().shutdownGracefully();
         }
         clientChannel = null;


### PR DESCRIPTION
Motivation:

The ServerBootrap's child group would not be shutdown.

Modification:

Add missing shutdownGracefully() call.

Result:

The child group is shutdown correctly
