### PR TITLE
HTTP Content Decoder Cleanup Bug

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecoder.java
@@ -184,8 +184,8 @@ public abstract class HttpContentDecoder extends MessageToMessageDecoder<HttpObj
      * @param contentEncoding the value of the {@code "Content-Encoding"} header
      * @return the expected content encoding of the new content
      */
-    @SuppressWarnings("unused")
-    protected CharSequence getTargetContentEncoding(String contentEncoding) throws Exception {
+    protected CharSequence getTargetContentEncoding(
+            @SuppressWarnings("unused") String contentEncoding) throws Exception {
         return HttpHeaders.Values.IDENTITY;
     }
 
@@ -203,10 +203,10 @@ public abstract class HttpContentDecoder extends MessageToMessageDecoder<HttpObj
 
     private void cleanup() {
         if (decoder != null) {
-            // Clean-up the previous encoder if not cleaned up correctly.
+            // Clean-up the previous decoder if not cleaned up correctly.
             if (decoder.finish()) {
                 for (;;) {
-                    ByteBuf buf = decoder.readOutbound();
+                    ByteBuf buf = decoder.readInbound();
                     if (buf == null) {
                         break;
                     }


### PR DESCRIPTION
Motiviation:
The HTTP content decoder's cleanup method is not cleaning up the decoder correctly.
The cleanup method is currently doing a readOutbound on the EmbeddedChannel but
for decoding the call should be readInbound.

Modifications:
-Change readOutbound to readInbound in the cleanup method

Result:
The cleanup method should be correctly releaseing unused resources
