### PR TITLE
Correcting HttpContentDecoder SuppressWarnings parameter

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentDecoder.java
@@ -185,7 +185,7 @@ public abstract class HttpContentDecoder extends MessageToMessageDecoder<HttpObj
      * @return the expected content encoding of the new content
      */
     protected CharSequence getTargetContentEncoding(
-            @SuppressWarnings("unused") String contentEncoding) throws Exception {
+            @SuppressWarnings("UnusedParameters") String contentEncoding) throws Exception {
         return HttpHeaders.Values.IDENTITY;
     }
 


### PR DESCRIPTION
Motiviation:
The HttpContentDecoder.getTargetContentEncoding has a SuppressWarnings(unused) on its parameter.
This should be SuppressWarnings(UnusedParameters).

Modifications:
SuppressWarnings(unused) -> SuppressWarnings(UnusedParameters)

Result:
Correctly suppressing warnings due to HttpContentDecoder.getTargetContentEncoding
