### PR TITLE
Fix Native EPOLL Build Failure

### DIFF
--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -78,6 +78,9 @@
               <platform>.</platform>
               <forceConfigure>true</forceConfigure>
               <forceAutogen>true</forceAutogen>
+              <configureArgs>
+                <arg>${jni.compiler.args}</arg>
+              </configureArgs>
             </configuration>
             <goals>
               <goal>generate</goal>
@@ -108,6 +111,104 @@
             </goals>
             <configuration>
               <classifier>${os.detected.classifier}</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.7</version>
+        <executions>
+          <execution>
+            <!-- Phase must be before regex-glibc-sendmmsg and regex-linux-sendmmsg -->
+            <phase>validate</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <id>ant-get-systeminfo</id>
+            <configuration>
+              <exportAntProperties>true</exportAntProperties>
+              <tasks>
+                <exec executable="sh" outputproperty="ldd_version">
+                  <arg value="-c"/>
+                  <arg value="ldd --version | head -1"/>
+                </exec>
+                <exec executable="uname" outputproperty="uname_os_version">
+                  <arg value="-r"/>
+                </exec>
+              </tasks>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.7</version>
+        <executions>
+          <execution>
+            <!-- Phase must be before regex-combined-sendmmsg -->
+            <phase>initialize</phase>
+            <id>regex-glibc-sendmmsg</id>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <name>glibc.sendmmsg.support</name>
+              <value>${ldd_version}</value>
+              <!-- Version must be >= 2.14 - set to IO_NETTY_SENDMSSG_NOT_FOUND if this version is not satisfied -->
+              <regex>^((?!^[^)]+\)\s+(0*2\.1[4-9]|0*2\.[2-9][0-9]+|0*[3-9][0-9]*|0*[1-9]+[0-9]+).*).)*$</regex>
+              <replacement>IO_NETTY_SENDMSSG_NOT_FOUND</replacement>
+              <failIfNoMatch>false</failIfNoMatch>
+            </configuration>
+          </execution>
+          <execution>
+            <!-- Phase must be before regex-combined-sendmmsg -->
+            <phase>initialize</phase>
+            <id>regex-linux-sendmmsg</id>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <name>linux.sendmmsg.support</name>
+              <value>${uname_os_version}</value>
+              <!-- Version must be >= 3 - set to IO_NETTY_SENDMSSG_NOT_FOUND if this version is not satisfied -->
+              <regex>^((?!^[0-9]*[3-9]\.?.*).)*$</regex>
+              <replacement>IO_NETTY_SENDMSSG_NOT_FOUND</replacement>
+              <failIfNoMatch>false</failIfNoMatch>
+            </configuration>
+          </execution>
+          <execution>
+            <!-- Phase must be before regex-unset-if-needed-sendmmsg -->
+            <phase>generate-sources</phase>
+            <id>regex-combined-sendmmsg</id>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <name>jni.compiler.args</name>
+              <value>${linux.sendmmsg.support}${glibc.sendmmsg.support}</value>
+              <!-- If glibc and linux kernel are both not sufficient...then define the CFLAGS -->
+              <regex>.*IO_NETTY_SENDMSSG_NOT_FOUND.*</regex>
+              <replacement>CFLAGS="-DIO_NETTY_SENDMMSG_NOT_FOUND"</replacement>
+              <failIfNoMatch>false</failIfNoMatch>
+            </configuration>
+          </execution>
+          <execution>
+            <!-- Phase must be before build-native-lib -->
+            <phase>generate-sources</phase>
+            <id>regex-unset-if-needed-sendmmsg</id>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <name>jni.compiler.args</name>
+              <value>${jni.compiler.args}</value>
+              <!-- If glibc and linux kernel are both not sufficient...then define the CFLAGS -->
+              <regex>^((?!CFLAGS=).)*$</regex>
+              <replacement>CFLAGS=""</replacement>
+              <failIfNoMatch>false</failIfNoMatch>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Motiviation:
If sendmmsg is already defined then the native epoll module failed to build because of conflicting definitions.
The mmsghdr type was also redefined on systems that already supported this structure.

Modifications:
Provide a way so that systems which already define sendmmsg and mmsghdr can build
Provide a way so that systems which don't define sendmmsg and mmsghdr can build

Result:
The native EPOLL module can build in more environments
