### PR TITLE
Use ExtensionRegistryLite instead of ExtensionRegistry in ProtobufDecoder

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.codec.protobuf;
 
-import com.google.protobuf.ExtensionRegistry;
+import com.google.protobuf.ExtensionRegistryLite;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageLite;
 import io.netty.buffer.ByteBuf;
@@ -78,7 +78,7 @@ public class ProtobufDecoder extends MessageToMessageDecoder<ByteBuf> {
     }
 
     private final MessageLite prototype;
-    private final ExtensionRegistry extensionRegistry;
+    private final ExtensionRegistryLite extensionRegistry;
 
     /**
      * Creates a new instance.
@@ -87,7 +87,7 @@ public class ProtobufDecoder extends MessageToMessageDecoder<ByteBuf> {
         this(prototype, null);
     }
 
-    public ProtobufDecoder(MessageLite prototype, ExtensionRegistry extensionRegistry) {
+    public ProtobufDecoder(MessageLite prototype, ExtensionRegistryLite extensionRegistry) {
         if (prototype == null) {
             throw new NullPointerException("prototype");
         }


### PR DESCRIPTION
Motivation:

ExtensionRegistry is a subclass of ExtensionRegistryLite.  The ProtobufDecoder
doesn't use the registry directly, it simply passes it through to the Protobuf
API.  The Protobuf calls in question are themselves written in terms
ExtensionRegistryLite not ExtensionRegistry.

Modifications:

Require ExtensionRegistryLite instead of ExtensionRegistry in ProtobufDecoder.

Result:

Consumers can use ExtensionRegistryLite with ProtobufDecoder.
