### PR TITLE
HTTP/2 Unit Test Leak Fixes

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -182,7 +182,7 @@ public class DataCompressionHttp2Test {
                 }
             });
             awaitServer();
-            data.readerIndex(0);
+            data.resetReaderIndex();
             ArgumentCaptor<ByteBuf> dataCaptor = ArgumentCaptor.forClass(ByteBuf.class);
             verify(serverListener).onDataRead(any(ChannelHandlerContext.class), eq(3), dataCaptor.capture(), eq(0),
                             eq(true));
@@ -216,7 +216,7 @@ public class DataCompressionHttp2Test {
                 }
             });
             awaitServer();
-            data.readerIndex(0);
+            data.resetReaderIndex();
             ArgumentCaptor<ByteBuf> dataCaptor = ArgumentCaptor.forClass(ByteBuf.class);
             verify(serverListener).onDataRead(any(ChannelHandlerContext.class), eq(3), dataCaptor.capture(), eq(0),
                             eq(true));
@@ -254,8 +254,8 @@ public class DataCompressionHttp2Test {
                 }
             });
             awaitServer();
-            data1.readerIndex(0);
-            data2.readerIndex(0);
+            data1.resetReaderIndex();
+            data2.resetReaderIndex();
             ArgumentCaptor<ByteBuf> dataCaptor = ArgumentCaptor.forClass(ByteBuf.class);
             ArgumentCaptor<Boolean> endStreamCaptor = ArgumentCaptor.forClass(Boolean.class);
             verify(serverListener, times(2)).onDataRead(any(ChannelHandlerContext.class), eq(3), dataCaptor.capture(),
@@ -297,7 +297,7 @@ public class DataCompressionHttp2Test {
                 }
             });
             awaitServer();
-            data.readerIndex(0);
+            data.resetReaderIndex();
             ArgumentCaptor<ByteBuf> dataCaptor = ArgumentCaptor.forClass(ByteBuf.class);
             verify(serverListener).onDataRead(any(ChannelHandlerContext.class), eq(3), dataCaptor.capture(), eq(0),
                             eq(true));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameIOTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameIOTest.java
@@ -26,7 +26,6 @@ import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.CharsetUtil;
-import io.netty.util.ReferenceCountUtil;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -66,35 +65,56 @@ public class DefaultHttp2FrameIOTest {
 
     @Test
     public void emptyDataShouldRoundtrip() throws Exception {
-        ByteBuf data = Unpooled.EMPTY_BUFFER;
+        final ByteBuf data = Unpooled.EMPTY_BUFFER;
         writer.writeData(ctx, 1000, data, 0, false, promise);
 
-        ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onDataRead(eq(ctx), eq(1000), eq(data), eq(0), eq(false));
-        frame.release();
+        ByteBuf frame = null;
+        try {
+            frame = captureWrite();
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onDataRead(eq(ctx), eq(1000), eq(data), eq(0), eq(false));
+        } finally {
+            if (frame != null) {
+                frame.release();
+            }
+            data.release();
+        }
     }
 
     @Test
     public void dataShouldRoundtrip() throws Exception {
-        ByteBuf data = dummyData();
+        final ByteBuf data = dummyData();
         writer.writeData(ctx, 1000, data.retain().duplicate(), 0, false, promise);
 
-        ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onDataRead(eq(ctx), eq(1000), eq(data), eq(0), eq(false));
-        frame.release();
+        ByteBuf frame = null;
+        try {
+            frame = captureWrite();
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onDataRead(eq(ctx), eq(1000), eq(data), eq(0), eq(false));
+        } finally {
+            if (frame != null) {
+                frame.release();
+            }
+            data.release();
+        }
     }
 
     @Test
     public void dataWithPaddingShouldRoundtrip() throws Exception {
-        ByteBuf data = dummyData();
+        final ByteBuf data = dummyData();
         writer.writeData(ctx, 1, data.retain().duplicate(), 0xFF, true, promise);
 
-        ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onDataRead(eq(ctx), eq(1), eq(data), eq(0xFF), eq(true));
-        frame.release();
+        ByteBuf frame = null;
+        try {
+            frame = captureWrite();
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onDataRead(eq(ctx), eq(1), eq(data), eq(0xFF), eq(true));
+        } finally {
+            if (frame != null) {
+                frame.release();
+            }
+            data.release();
+        }
     }
 
     @Test
@@ -102,9 +122,12 @@ public class DefaultHttp2FrameIOTest {
         writer.writePriority(ctx, 1, 2, (short) 255, true, promise);
 
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onPriorityRead(eq(ctx), eq(1), eq(2), eq((short) 255), eq(true));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onPriorityRead(eq(ctx), eq(1), eq(2), eq((short) 255), eq(true));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
@@ -112,9 +135,12 @@ public class DefaultHttp2FrameIOTest {
         writer.writeRstStream(ctx, 1, MAX_UNSIGNED_INT, promise);
 
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onRstStreamRead(eq(ctx), eq(1), eq(MAX_UNSIGNED_INT));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onRstStreamRead(eq(ctx), eq(1), eq(MAX_UNSIGNED_INT));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
@@ -122,9 +148,12 @@ public class DefaultHttp2FrameIOTest {
         writer.writeSettings(ctx, new Http2Settings(), promise);
 
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onSettingsRead(eq(ctx), eq(new Http2Settings()));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onSettingsRead(eq(ctx), eq(new Http2Settings()));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
@@ -138,9 +167,12 @@ public class DefaultHttp2FrameIOTest {
         writer.writeSettings(ctx, settings, promise);
 
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onSettingsRead(eq(ctx), eq(settings));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onSettingsRead(eq(ctx), eq(settings));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
@@ -148,9 +180,12 @@ public class DefaultHttp2FrameIOTest {
         writer.writeSettingsAck(ctx, promise);
 
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onSettingsAckRead(eq(ctx));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onSettingsAckRead(eq(ctx));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
@@ -158,10 +193,17 @@ public class DefaultHttp2FrameIOTest {
         ByteBuf data = dummyData();
         writer.writePing(ctx, false, data.retain().duplicate(), promise);
 
-        ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onPingRead(eq(ctx), eq(data));
-        frame.release();
+        ByteBuf frame = null;
+        try {
+            frame = captureWrite();
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onPingRead(eq(ctx), eq(data));
+        } finally {
+            if (frame != null) {
+                frame.release();
+            }
+            data.release();
+        }
     }
 
     @Test
@@ -169,143 +211,206 @@ public class DefaultHttp2FrameIOTest {
         ByteBuf data = dummyData();
         writer.writePing(ctx, true, data.retain().duplicate(), promise);
 
-        ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onPingAckRead(eq(ctx), eq(data));
-        frame.release();
+        ByteBuf frame = null;
+        try {
+            frame = captureWrite();
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onPingAckRead(eq(ctx), eq(data));
+        } finally {
+            if (frame != null) {
+                frame.release();
+            }
+            data.release();
+        }
     }
 
     @Test
     public void goAwayShouldRoundtrip() throws Exception {
         ByteBuf data = dummyData();
         writer.writeGoAway(ctx, 1, MAX_UNSIGNED_INT, data.retain().duplicate(), promise);
-        ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onGoAwayRead(eq(ctx), eq(1), eq(MAX_UNSIGNED_INT), eq(data));
-        frame.release();
+
+        ByteBuf frame = null;
+        try {
+            frame = captureWrite();
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onGoAwayRead(eq(ctx), eq(1), eq(MAX_UNSIGNED_INT), eq(data));
+        } finally {
+            if (frame != null) {
+                frame.release();
+            }
+            data.release();
+        }
     }
 
     @Test
     public void windowUpdateShouldRoundtrip() throws Exception {
         writer.writeWindowUpdate(ctx, 1, Integer.MAX_VALUE, promise);
+
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onWindowUpdateRead(eq(ctx), eq(1), eq(Integer.MAX_VALUE));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onWindowUpdateRead(eq(ctx), eq(1), eq(Integer.MAX_VALUE));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
     public void emptyHeadersShouldRoundtrip() throws Exception {
         Http2Headers headers = Http2Headers.EMPTY_HEADERS;
         writer.writeHeaders(ctx, 1, headers, 0, true, promise);
+
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0), eq(true));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0), eq(true));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
     public void emptyHeadersWithPaddingShouldRoundtrip() throws Exception {
         Http2Headers headers = Http2Headers.EMPTY_HEADERS;
         writer.writeHeaders(ctx, 1, headers, 0xFF, true, promise);
+
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0xFF), eq(true));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0xFF), eq(true));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
     public void headersWithoutPriorityShouldRoundtrip() throws Exception {
         Http2Headers headers = dummyHeaders();
         writer.writeHeaders(ctx, 1, headers, 0, true, promise);
+
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0), eq(true));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0), eq(true));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
     public void headersWithPaddingWithoutPriorityShouldRoundtrip() throws Exception {
         Http2Headers headers = dummyHeaders();
         writer.writeHeaders(ctx, 1, headers, 0xFF, true, promise);
+
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0xFF), eq(true));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(0xFF), eq(true));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
     public void headersWithPriorityShouldRoundtrip() throws Exception {
         Http2Headers headers = dummyHeaders();
         writer.writeHeaders(ctx, 1, headers, 2, (short) 3, true, 0, true, promise);
+
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0),
-                eq(true));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener)
+                    .onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0), eq(true));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
     public void headersWithPaddingWithPriorityShouldRoundtrip() throws Exception {
         Http2Headers headers = dummyHeaders();
         writer.writeHeaders(ctx, 1, headers, 2, (short) 3, true, 0xFF, true, promise);
+
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0xFF),
-                eq(true));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0xFF),
+                    eq(true));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
     public void continuedHeadersShouldRoundtrip() throws Exception {
         Http2Headers headers = largeHeaders();
         writer.writeHeaders(ctx, 1, headers, 2, (short) 3, true, 0, true, promise);
+
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0),
-                eq(true));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener)
+                    .onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0), eq(true));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
     public void continuedHeadersWithPaddingShouldRoundtrip() throws Exception {
         Http2Headers headers = largeHeaders();
         writer.writeHeaders(ctx, 1, headers, 2, (short) 3, true, 0xFF, true, promise);
+
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0xFF),
-                eq(true));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onHeadersRead(eq(ctx), eq(1), eq(headers), eq(2), eq((short) 3), eq(true), eq(0xFF),
+                    eq(true));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
     public void emptypushPromiseShouldRoundtrip() throws Exception {
         Http2Headers headers = Http2Headers.EMPTY_HEADERS;
         writer.writePushPromise(ctx, 1, 2, headers, 0, promise);
+
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
     public void pushPromiseShouldRoundtrip() throws Exception {
         Http2Headers headers = dummyHeaders();
         writer.writePushPromise(ctx, 1, 2, headers, 0, promise);
+
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
     public void pushPromiseWithPaddingShouldRoundtrip() throws Exception {
         Http2Headers headers = dummyHeaders();
         writer.writePushPromise(ctx, 1, 2, headers, 0xFF, promise);
+
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0xFF));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0xFF));
+        } finally {
+            frame.release();
+        }
     }
 
     @Test
@@ -322,10 +427,14 @@ public class DefaultHttp2FrameIOTest {
     public void continuedPushPromiseWithPaddingShouldRoundtrip() throws Exception {
         Http2Headers headers = largeHeaders();
         writer.writePushPromise(ctx, 1, 2, headers, 0xFF, promise);
+
         ByteBuf frame = captureWrite();
-        reader.readFrame(ctx, frame, listener);
-        verify(listener).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0xFF));
-        frame.release();
+        try {
+            reader.readFrame(ctx, frame, listener);
+            verify(listener).onPushPromiseRead(eq(ctx), eq(1), eq(2), eq(headers), eq(0xFF));
+        } finally {
+            frame.release();
+        }
     }
 
     private ByteBuf captureWrite() {
@@ -335,12 +444,12 @@ public class DefaultHttp2FrameIOTest {
     }
 
     private ByteBuf dummyData() {
-        return ReferenceCountUtil.releaseLater(alloc.buffer().writeBytes("abcdefgh".getBytes(CharsetUtil.UTF_8)));
+        return alloc.buffer().writeBytes("abcdefgh".getBytes(CharsetUtil.UTF_8));
     }
 
     private static Http2Headers dummyHeaders() {
-        return DefaultHttp2Headers.newBuilder().method("GET").scheme("https")
-                .authority("example.org").path("/some/path").add("accept", "*/*").build();
+        return DefaultHttp2Headers.newBuilder().method("GET").scheme("https").authority("example.org")
+                .path("/some/path").add("accept", "*/*").build();
     }
 
     private static Http2Headers largeHeaders() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 
 import com.twitter.hpack.Encoder;
 
-
 /**
  * Tests for {@link DefaultHttp2HeadersDecoder}.
  */
@@ -42,22 +41,30 @@ public class DefaultHttp2HeadersDecoderTest {
 
     @Test
     public void decodeShouldSucceed() throws Exception {
-        ByteBuf buf = encode(":method", "GET", "akey", "avalue");
-        Http2Headers headers = decoder.decodeHeaders(buf).build();
-        assertEquals(2, headers.size());
-        assertEquals("GET", headers.method());
-        assertEquals("avalue", headers.get("akey"));
+        final ByteBuf buf = encode(":method", "GET", "akey", "avalue");
+        try {
+            Http2Headers headers = decoder.decodeHeaders(buf).build();
+            assertEquals(2, headers.size());
+            assertEquals("GET", headers.method());
+            assertEquals("avalue", headers.get("akey"));
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = Http2Exception.class)
     public void decodeWithInvalidPseudoHeaderShouldFail() throws Exception {
-        ByteBuf buf = encode(":invalid", "GET", "akey", "avalue");
-        decoder.decodeHeaders(buf);
+        final ByteBuf buf = encode(":invalid", "GET", "akey", "avalue");
+        try {
+            decoder.decodeHeaders(buf);
+        } finally {
+            buf.release();
+        }
     }
 
     private ByteBuf encode(String... entries) throws Exception {
-        Encoder encoder = new Encoder();
-        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        final Encoder encoder = new Encoder();
+        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
         for (int ix = 0; ix < entries.length;) {
             String key = entries[ix++];
             String value = entries[ix++];

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoderTest.java
@@ -22,7 +22,6 @@ import io.netty.buffer.Unpooled;
 import org.junit.Before;
 import org.junit.Test;
 
-
 /**
  * Tests for {@link DefaultHttp2HeadersEncoder}.
  */
@@ -37,17 +36,21 @@ public class DefaultHttp2HeadersEncoderTest {
 
     @Test
     public void encodeShouldSucceed() throws Http2Exception {
-        DefaultHttp2Headers headers =
-                DefaultHttp2Headers.newBuilder().method("GET").add("a", "1").add("a", "2").build();
-        ByteBuf buf = Unpooled.buffer();
-        encoder.encodeHeaders(headers, buf);
-        assertTrue(buf.writerIndex() > 0);
+        DefaultHttp2Headers headers = DefaultHttp2Headers.newBuilder().method("GET").add("a", "1").add("a", "2")
+                .build();
+        final ByteBuf buf = Unpooled.buffer();
+        try {
+            encoder.encodeHeaders(headers, buf);
+            assertTrue(buf.writerIndex() > 0);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = Http2Exception.class)
     public void headersExceedMaxSetSizeShouldFail() throws Http2Exception {
-        DefaultHttp2Headers headers =
-                DefaultHttp2Headers.newBuilder().method("GET").add("a", "1").add("a", "2").build();
+        DefaultHttp2Headers headers = DefaultHttp2Headers.newBuilder().method("GET").add("a", "1").add("a", "2")
+                .build();
 
         encoder.maxHeaderListSize(2);
         encoder.encodeHeaders(headers, Unpooled.buffer());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowControllerTest.java
@@ -153,19 +153,21 @@ public class DefaultHttp2InboundFlowControllerTest {
     }
 
     private void applyFlowControl(int dataSize, int padding, boolean endOfStream) throws Http2Exception {
-        ByteBuf buf = dummyData(dataSize);
-        controller.onDataRead(ctx, STREAM_ID, buf, padding, endOfStream);
-        buf.release();
+        final ByteBuf buf = dummyData(dataSize);
+        try {
+            controller.onDataRead(ctx, STREAM_ID, buf, padding, endOfStream);
+        } finally {
+            buf.release();
+        }
     }
 
     private static ByteBuf dummyData(int size) {
-        ByteBuf buffer = Unpooled.buffer(size);
+        final ByteBuf buffer = Unpooled.buffer(size);
         buffer.writerIndex(size);
         return buffer;
     }
 
-    private void verifyWindowUpdateSent(int streamId, int windowSizeIncrement)
-            throws Http2Exception {
+    private void verifyWindowUpdateSent(int streamId, int windowSizeIncrement) throws Http2Exception {
         verify(frameWriter).writeWindowUpdate(eq(ctx), eq(streamId), eq(windowSizeIncrement), eq(promise));
     }
 
@@ -174,7 +176,7 @@ public class DefaultHttp2InboundFlowControllerTest {
     }
 
     private void verifyWindowUpdateNotSent() throws Http2Exception {
-        verify(frameWriter, never()).writeWindowUpdate(any(ChannelHandlerContext.class), anyInt(),
-                anyInt(), any(ChannelPromise.class));
+        verify(frameWriter, never()).writeWindowUpdate(any(ChannelHandlerContext.class), anyInt(), anyInt(),
+                any(ChannelPromise.class));
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2OutboundFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2OutboundFlowControllerTest.java
@@ -122,23 +122,31 @@ public class DefaultHttp2OutboundFlowControllerTest {
 
     @Test
     public void frameShouldBeSentImmediately() throws Http2Exception {
-        ByteBuf data = dummyData(5, 5);
-        send(STREAM_A, data.slice(0, 5), 5);
-        verifyWrite(STREAM_A, data.slice(0, 5), 5);
-        assertEquals(1, data.refCnt());
+        final ByteBuf data = dummyData(5, 5);
+        try {
+            send(STREAM_A, data.slice(0, 5), 5);
+            verifyWrite(STREAM_A, data.slice(0, 5), 5);
+            assertEquals(1, data.refCnt());
+        } finally {
+            manualSafeRelease(data);
+        }
     }
 
     @Test
     public void frameLargerThanMaxFrameSizeShouldBeSplit() throws Http2Exception {
         when(frameWriter.maxFrameSize()).thenReturn(3);
 
-        ByteBuf data = dummyData(5, 0);
-        send(STREAM_A, data.copy(), 5);
+        final ByteBuf data = dummyData(5, 0);
+        try {
+            send(STREAM_A, data.copy(), 5);
 
-        verifyWrite(STREAM_A, data.slice(0, 3), 0);
-        verifyWrite(STREAM_A, data.slice(3, 2), 1);
-        verifyWrite(STREAM_A, Unpooled.EMPTY_BUFFER, 3);
-        verifyWrite(STREAM_A, Unpooled.EMPTY_BUFFER, 1);
+            verifyWrite(STREAM_A, data.slice(0, 3), 0);
+            verifyWrite(STREAM_A, data.slice(3, 2), 1);
+            verifyWrite(STREAM_A, Unpooled.EMPTY_BUFFER, 3);
+            verifyWrite(STREAM_A, Unpooled.EMPTY_BUFFER, 1);
+        } finally {
+            manualSafeRelease(data);
+        }
     }
 
     @Test
@@ -150,109 +158,137 @@ public class DefaultHttp2OutboundFlowControllerTest {
     @Test
     public void frameShouldSplitForMaxFrameSize() throws Http2Exception {
         when(frameWriter.maxFrameSize()).thenReturn(5);
-        ByteBuf data = dummyData(10, 0);
-        ByteBuf slice1 = data.slice(0, 5);
-        ByteBuf slice2 = data.slice(5, 5);
-        send(STREAM_A, data.slice(), 0);
-        verifyWrite(STREAM_A, slice1, 0);
-        verifyWrite(STREAM_A, slice2, 0);
-        assertEquals(2, data.refCnt());
+        final ByteBuf data = dummyData(10, 0);
+        try {
+            ByteBuf slice1 = data.slice(0, 5);
+            ByteBuf slice2 = data.slice(5, 5);
+            send(STREAM_A, data.slice(), 0);
+            verifyWrite(STREAM_A, slice1, 0);
+            verifyWrite(STREAM_A, slice2, 0);
+            assertEquals(2, data.refCnt());
+        } finally {
+            manualSafeRelease(data);
+        }
     }
 
     @Test
     public void stalledStreamShouldQueueFrame() throws Http2Exception {
         controller.initialOutboundWindowSize(0);
 
-        ByteBuf data = dummyData(10, 5);
-        send(STREAM_A, data.slice(0, 10), 5);
-        verifyNoWrite(STREAM_A);
-        assertEquals(1, data.refCnt());
+        final ByteBuf data = dummyData(10, 5);
+        try {
+            send(STREAM_A, data.slice(0, 10), 5);
+            verifyNoWrite(STREAM_A);
+            assertEquals(1, data.refCnt());
+        } finally {
+            manualSafeRelease(data);
+        }
     }
 
     @Test
     public void frameShouldSplit() throws Http2Exception {
         controller.initialOutboundWindowSize(5);
 
-        ByteBuf data = dummyData(5, 5);
-        send(STREAM_A, data.slice(0, 5), 5);
+        final ByteBuf data = dummyData(5, 5);
+        try {
+            send(STREAM_A, data.slice(0, 5), 5);
 
-        // Verify that a partial frame of 5 was sent.
-        ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
-        // None of the padding should be sent in the frame.
-        captureWrite(STREAM_A, argument, 0, false);
-        ByteBuf writtenBuf = argument.getValue();
-        assertEquals(5, writtenBuf.readableBytes());
-        assertEquals(data.slice(0, 5), writtenBuf);
-        assertEquals(2, writtenBuf.refCnt());
-        assertEquals(2, data.refCnt());
+            // Verify that a partial frame of 5 was sent.
+            ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
+            // None of the padding should be sent in the frame.
+            captureWrite(STREAM_A, argument, 0, false);
+            final ByteBuf writtenBuf = argument.getValue();
+            assertEquals(5, writtenBuf.readableBytes());
+            assertEquals(data.slice(0, 5), writtenBuf);
+            assertEquals(2, writtenBuf.refCnt());
+            assertEquals(2, data.refCnt());
+        } finally {
+            manualSafeRelease(data);
+        }
     }
 
     @Test
     public void frameShouldSplitPadding() throws Http2Exception {
         controller.initialOutboundWindowSize(5);
 
-        ByteBuf data = dummyData(3, 7);
-        send(STREAM_A, data.slice(0, 3), 7);
+        final ByteBuf data = dummyData(3, 7);
+        try {
+            send(STREAM_A, data.slice(0, 3), 7);
 
-        // Verify that a partial frame of 5 was sent.
-        ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
-        captureWrite(STREAM_A, argument, 2, false);
-        ByteBuf writtenBuf = argument.getValue();
-        assertEquals(3, writtenBuf.readableBytes());
-        assertEquals(data.slice(0, 3), writtenBuf);
-        assertEquals(2, writtenBuf.refCnt());
-        assertEquals(2, data.refCnt());
+            // Verify that a partial frame of 5 was sent.
+            ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
+            captureWrite(STREAM_A, argument, 2, false);
+            final ByteBuf writtenBuf = argument.getValue();
+            assertEquals(3, writtenBuf.readableBytes());
+            assertEquals(data.slice(0, 3), writtenBuf);
+            assertEquals(2, writtenBuf.refCnt());
+            assertEquals(2, data.refCnt());
+        } finally {
+            manualSafeRelease(data);
+        }
     }
 
     @Test
     public void emptyFrameShouldSplitPadding() throws Http2Exception {
         controller.initialOutboundWindowSize(5);
 
-        ByteBuf data = dummyData(0, 10);
-        send(STREAM_A, data.slice(0, 0), 10);
+        final ByteBuf data = dummyData(0, 10);
+        try {
+            send(STREAM_A, data.slice(0, 0), 10);
 
-        // Verify that a partial frame of 5 was sent.
-        ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
-        captureWrite(STREAM_A, argument, 5, false);
-        ByteBuf writtenBuf = argument.getValue();
-        assertEquals(0, writtenBuf.readableBytes());
-        assertEquals(1, writtenBuf.refCnt());
-        assertEquals(1, data.refCnt());
+            // Verify that a partial frame of 5 was sent.
+            ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
+            captureWrite(STREAM_A, argument, 5, false);
+            final ByteBuf writtenBuf = argument.getValue();
+            assertEquals(0, writtenBuf.readableBytes());
+            assertEquals(1, writtenBuf.refCnt());
+            assertEquals(1, data.refCnt());
+        } finally {
+            manualSafeRelease(data);
+        }
     }
 
     @Test
     public void windowUpdateShouldSendFrame() throws Http2Exception {
         controller.initialOutboundWindowSize(10);
 
-        ByteBuf data = dummyData(10, 10);
-        send(STREAM_A, data.slice(0, 10), 10);
-        verifyWrite(STREAM_A, data.slice(0, 10), 0);
+        final ByteBuf data = dummyData(10, 10);
+        try {
+            send(STREAM_A, data.slice(0, 10), 10);
+            verifyWrite(STREAM_A, data.slice(0, 10), 0);
 
-        // Update the window and verify that the rest of the frame is written.
-        controller.updateOutboundWindowSize(STREAM_A, 10);
-        verifyWrite(STREAM_A, Unpooled.EMPTY_BUFFER, 10);
-        assertEquals(DEFAULT_WINDOW_SIZE - data.readableBytes(), window(CONNECTION_STREAM_ID));
-        assertEquals(0, window(STREAM_A));
-        assertEquals(10, window(STREAM_B));
-        assertEquals(10, window(STREAM_C));
-        assertEquals(10, window(STREAM_D));
+            // Update the window and verify that the rest of the frame is written.
+            controller.updateOutboundWindowSize(STREAM_A, 10);
+            verifyWrite(STREAM_A, Unpooled.EMPTY_BUFFER, 10);
+            assertEquals(DEFAULT_WINDOW_SIZE - data.readableBytes(), window(CONNECTION_STREAM_ID));
+            assertEquals(0, window(STREAM_A));
+            assertEquals(10, window(STREAM_B));
+            assertEquals(10, window(STREAM_C));
+            assertEquals(10, window(STREAM_D));
+        } finally {
+            manualSafeRelease(data);
+        }
     }
 
     @Test
     public void initialWindowUpdateShouldSendFrame() throws Http2Exception {
         controller.initialOutboundWindowSize(0);
 
-        ByteBuf data = dummyData(10, 0);
-        send(STREAM_A, data.slice(), 0);
-        verifyNoWrite(STREAM_A);
+        final ByteBuf data = dummyData(10, 0);
+        try {
+            send(STREAM_A, data.slice(), 0);
+            verifyNoWrite(STREAM_A);
 
-        // Verify that the entire frame was sent.
-        controller.initialOutboundWindowSize(10);
-        ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
-        captureWrite(STREAM_A, argument, 0, false);
-        ByteBuf writtenBuf = argument.getValue();
-        assertEquals(data, writtenBuf);
-        assertEquals(1, data.refCnt());
+            // Verify that the entire frame was sent.
+            controller.initialOutboundWindowSize(10);
+            ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
+            captureWrite(STREAM_A, argument, 0, false);
+            final ByteBuf writtenBuf = argument.getValue();
+            assertEquals(data, writtenBuf);
+            assertEquals(1, data.refCnt());
+        } finally {
+            manualSafeRelease(data);
+        }
     }
 
     @Test
@@ -260,38 +296,46 @@ public class DefaultHttp2OutboundFlowControllerTest {
         controller.initialOutboundWindowSize(0);
 
         // First send a frame that will get buffered.
-        ByteBuf data = dummyData(10, 0);
-        send(STREAM_A, data.slice(), 0);
-        verifyNoWrite(STREAM_A);
+        final ByteBuf data = dummyData(10, 0);
+        try {
+            send(STREAM_A, data.slice(), 0);
+            verifyNoWrite(STREAM_A);
 
-        // Now send an empty frame on the same stream and verify that it's also buffered.
-        send(STREAM_A, Unpooled.EMPTY_BUFFER, 0);
-        verifyNoWrite(STREAM_A);
+            // Now send an empty frame on the same stream and verify that it's also buffered.
+            send(STREAM_A, Unpooled.EMPTY_BUFFER, 0);
+            verifyNoWrite(STREAM_A);
 
-        // Re-expand the window and verify that both frames were sent.
-        controller.initialOutboundWindowSize(10);
+            // Re-expand the window and verify that both frames were sent.
+            controller.initialOutboundWindowSize(10);
 
-        verifyWrite(STREAM_A, data.slice(), 0);
-        verifyWrite(STREAM_A, Unpooled.EMPTY_BUFFER, 0);
+            verifyWrite(STREAM_A, data.slice(), 0);
+            verifyWrite(STREAM_A, Unpooled.EMPTY_BUFFER, 0);
+        } finally {
+            manualSafeRelease(data);
+        }
     }
 
     @Test
     public void initialWindowUpdateShouldSendPartialFrame() throws Http2Exception {
         controller.initialOutboundWindowSize(0);
 
-        ByteBuf data = dummyData(10, 0);
-        send(STREAM_A, data, 0);
-        verifyNoWrite(STREAM_A);
+        final ByteBuf data = dummyData(10, 0);
+        try {
+            send(STREAM_A, data, 0);
+            verifyNoWrite(STREAM_A);
 
-        // Verify that a partial frame of 5 was sent.
-        controller.initialOutboundWindowSize(5);
-        ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
-        captureWrite(STREAM_A, argument, 0, false);
-        ByteBuf writtenBuf = argument.getValue();
-        assertEquals(5, writtenBuf.readableBytes());
-        assertEquals(data.slice(0, 5), writtenBuf);
-        assertEquals(2, writtenBuf.refCnt());
-        assertEquals(2, data.refCnt());
+            // Verify that a partial frame of 5 was sent.
+            controller.initialOutboundWindowSize(5);
+            ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
+            captureWrite(STREAM_A, argument, 0, false);
+            ByteBuf writtenBuf = argument.getValue();
+            assertEquals(5, writtenBuf.readableBytes());
+            assertEquals(data.slice(0, 5), writtenBuf);
+            assertEquals(2, writtenBuf.refCnt());
+            assertEquals(2, data.refCnt());
+        } finally {
+            manualSafeRelease(data);
+        }
     }
 
     @Test
@@ -299,23 +343,27 @@ public class DefaultHttp2OutboundFlowControllerTest {
         // Set the connection window size to zero.
         exhaustStreamWindow(CONNECTION_STREAM_ID);
 
-        ByteBuf data = dummyData(10, 0);
-        send(STREAM_A, data.slice(), 0);
-        verifyNoWrite(STREAM_A);
+        final ByteBuf data = dummyData(10, 0);
+        try {
+            send(STREAM_A, data.slice(), 0);
+            verifyNoWrite(STREAM_A);
 
-        // Verify that the entire frame was sent.
-        controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 10);
-        assertEquals(0, window(CONNECTION_STREAM_ID));
-        assertEquals(DEFAULT_WINDOW_SIZE - data.readableBytes(), window(STREAM_A));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_B));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_D));
+            // Verify that the entire frame was sent.
+            controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 10);
+            assertEquals(0, window(CONNECTION_STREAM_ID));
+            assertEquals(DEFAULT_WINDOW_SIZE - data.readableBytes(), window(STREAM_A));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_B));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_D));
 
-        ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
-        captureWrite(STREAM_A, argument, 0, false);
-        ByteBuf writtenBuf = argument.getValue();
-        assertEquals(data, writtenBuf);
-        assertEquals(1, data.refCnt());
+            ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
+            captureWrite(STREAM_A, argument, 0, false);
+            final ByteBuf writtenBuf = argument.getValue();
+            assertEquals(data, writtenBuf);
+            assertEquals(1, data.refCnt());
+        } finally {
+            manualSafeRelease(data);
+        }
     }
 
     @Test
@@ -323,25 +371,29 @@ public class DefaultHttp2OutboundFlowControllerTest {
         // Set the connection window size to zero.
         exhaustStreamWindow(CONNECTION_STREAM_ID);
 
-        ByteBuf data = dummyData(10, 0);
-        send(STREAM_A, data, 0);
-        verifyNoWrite(STREAM_A);
+        final ByteBuf data = dummyData(10, 0);
+        try {
+            send(STREAM_A, data, 0);
+            verifyNoWrite(STREAM_A);
 
-        // Verify that a partial frame of 5 was sent.
-        controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 5);
-        assertEquals(0, window(CONNECTION_STREAM_ID));
-        assertEquals(DEFAULT_WINDOW_SIZE - data.readableBytes(), window(STREAM_A));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_B));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_D));
+            // Verify that a partial frame of 5 was sent.
+            controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 5);
+            assertEquals(0, window(CONNECTION_STREAM_ID));
+            assertEquals(DEFAULT_WINDOW_SIZE - data.readableBytes(), window(STREAM_A));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_B));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_D));
 
-        ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
-        captureWrite(STREAM_A, argument, 0, false);
-        ByteBuf writtenBuf = argument.getValue();
-        assertEquals(5, writtenBuf.readableBytes());
-        assertEquals(data.slice(0, 5), writtenBuf);
-        assertEquals(2, writtenBuf.refCnt());
-        assertEquals(2, data.refCnt());
+            ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
+            captureWrite(STREAM_A, argument, 0, false);
+            final ByteBuf writtenBuf = argument.getValue();
+            assertEquals(5, writtenBuf.readableBytes());
+            assertEquals(data.slice(0, 5), writtenBuf);
+            assertEquals(2, writtenBuf.refCnt());
+            assertEquals(2, data.refCnt());
+        } finally {
+            manualSafeRelease(data);
+        }
     }
 
     @Test
@@ -349,23 +401,27 @@ public class DefaultHttp2OutboundFlowControllerTest {
         // Set the stream window size to zero.
         exhaustStreamWindow(STREAM_A);
 
-        ByteBuf data = dummyData(10, 0);
-        send(STREAM_A, data.slice(), 0);
-        verifyNoWrite(STREAM_A);
+        final ByteBuf data = dummyData(10, 0);
+        try {
+            send(STREAM_A, data.slice(), 0);
+            verifyNoWrite(STREAM_A);
 
-        // Verify that the entire frame was sent.
-        controller.updateOutboundWindowSize(STREAM_A, 10);
-        assertEquals(DEFAULT_WINDOW_SIZE - data.readableBytes(), window(CONNECTION_STREAM_ID));
-        assertEquals(0, window(STREAM_A));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_B));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_D));
+            // Verify that the entire frame was sent.
+            controller.updateOutboundWindowSize(STREAM_A, 10);
+            assertEquals(DEFAULT_WINDOW_SIZE - data.readableBytes(), window(CONNECTION_STREAM_ID));
+            assertEquals(0, window(STREAM_A));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_B));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_D));
 
-        ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
-        captureWrite(STREAM_A, argument, 0, false);
-        ByteBuf writtenBuf = argument.getValue();
-        assertEquals(data, writtenBuf);
-        assertEquals(1, data.refCnt());
+            ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
+            captureWrite(STREAM_A, argument, 0, false);
+            final ByteBuf writtenBuf = argument.getValue();
+            assertEquals(data, writtenBuf);
+            assertEquals(1, data.refCnt());
+        } finally {
+            manualSafeRelease(data);
+        }
     }
 
     @Test
@@ -373,24 +429,28 @@ public class DefaultHttp2OutboundFlowControllerTest {
         // Set the stream window size to zero.
         exhaustStreamWindow(STREAM_A);
 
-        ByteBuf data = dummyData(10, 0);
-        send(STREAM_A, data, 0);
-        verifyNoWrite(STREAM_A);
+        final ByteBuf data = dummyData(10, 0);
+        try {
+            send(STREAM_A, data, 0);
+            verifyNoWrite(STREAM_A);
 
-        // Verify that a partial frame of 5 was sent.
-        controller.updateOutboundWindowSize(STREAM_A, 5);
-        assertEquals(DEFAULT_WINDOW_SIZE - data.readableBytes(), window(CONNECTION_STREAM_ID));
-        assertEquals(0, window(STREAM_A));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_B));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_D));
+            // Verify that a partial frame of 5 was sent.
+            controller.updateOutboundWindowSize(STREAM_A, 5);
+            assertEquals(DEFAULT_WINDOW_SIZE - data.readableBytes(), window(CONNECTION_STREAM_ID));
+            assertEquals(0, window(STREAM_A));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_B));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_D));
 
-        ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
-        captureWrite(STREAM_A, argument, 0, false);
-        ByteBuf writtenBuf = argument.getValue();
-        assertEquals(5, writtenBuf.readableBytes());
-        assertEquals(2, writtenBuf.refCnt());
-        assertEquals(2, data.refCnt());
+            ArgumentCaptor<ByteBuf> argument = ArgumentCaptor.forClass(ByteBuf.class);
+            captureWrite(STREAM_A, argument, 0, false);
+            ByteBuf writtenBuf = argument.getValue();
+            assertEquals(5, writtenBuf.readableBytes());
+            assertEquals(2, writtenBuf.refCnt());
+            assertEquals(2, data.refCnt());
+        } finally {
+            manualSafeRelease(data);
+        }
     }
 
     /**
@@ -409,27 +469,32 @@ public class DefaultHttp2OutboundFlowControllerTest {
 
         // Try sending 10 bytes on each stream. They will be pending until we free up the
         // connection.
-        send(STREAM_A, dummyData(3, 0), 7);
-        send(STREAM_B, dummyData(10, 0), 0);
-        verifyNoWrite(STREAM_A);
-        verifyNoWrite(STREAM_B);
+        final ByteBuf[] bufs = { dummyData(3, 0), dummyData(10, 0) };
+        try {
+            send(STREAM_A, bufs[0], 7);
+            send(STREAM_B, bufs[1], 0);
+            verifyNoWrite(STREAM_A);
+            verifyNoWrite(STREAM_B);
 
-        // Open up the connection window.
-        controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 10);
-        assertEquals(0, window(CONNECTION_STREAM_ID));
-        assertEquals(DEFAULT_WINDOW_SIZE - 5, window(STREAM_A));
-        assertEquals(DEFAULT_WINDOW_SIZE - 5, window(STREAM_B));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_D));
+            // Open up the connection window.
+            controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 10);
+            assertEquals(0, window(CONNECTION_STREAM_ID));
+            assertEquals(DEFAULT_WINDOW_SIZE - 5, window(STREAM_A));
+            assertEquals(DEFAULT_WINDOW_SIZE - 5, window(STREAM_B));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_D));
 
-        ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
+            final ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
 
-        // Verify that 5 bytes from A were written: 3 from data and 2 from padding.
-        captureWrite(STREAM_A, captor, 2, false);
-        assertEquals(3, captor.getValue().readableBytes());
+            // Verify that 5 bytes from A were written: 3 from data and 2 from padding.
+            captureWrite(STREAM_A, captor, 2, false);
+            assertEquals(3, captor.getValue().readableBytes());
 
-        captureWrite(STREAM_B, captor, 0, false);
-        assertEquals(5, captor.getValue().readableBytes());
+            captureWrite(STREAM_B, captor, 0, false);
+            assertEquals(5, captor.getValue().readableBytes());
+        } finally {
+            manualSafeRelease(bufs);
+        }
     }
 
     /**
@@ -454,38 +519,43 @@ public class DefaultHttp2OutboundFlowControllerTest {
 
         // Try sending 10 bytes on each stream. They will be pending until we free up the
         // connection.
-        send(STREAM_A, dummyData(10, 0), 0);
-        send(STREAM_B, dummyData(10, 0), 0);
-        send(STREAM_C, dummyData(10, 0), 0);
-        send(STREAM_D, dummyData(10, 0), 0);
-        verifyNoWrite(STREAM_A);
-        verifyNoWrite(STREAM_B);
-        verifyNoWrite(STREAM_C);
-        verifyNoWrite(STREAM_D);
+        final ByteBuf[] bufs = { dummyData(10, 0), dummyData(10, 0), dummyData(10, 0), dummyData(10, 0) };
+        try {
+            send(STREAM_A, bufs[0], 0);
+            send(STREAM_B, bufs[1], 0);
+            send(STREAM_C, bufs[2], 0);
+            send(STREAM_D, bufs[3], 0);
+            verifyNoWrite(STREAM_A);
+            verifyNoWrite(STREAM_B);
+            verifyNoWrite(STREAM_C);
+            verifyNoWrite(STREAM_D);
 
-        // Verify that the entire frame was sent.
-        controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 10);
-        assertEquals(0, window(CONNECTION_STREAM_ID));
-        assertEquals(0, window(STREAM_A));
-        assertEquals(DEFAULT_WINDOW_SIZE - 5, window(STREAM_B));
-        assertEquals((2 * DEFAULT_WINDOW_SIZE) - 5, window(STREAM_C) + window(STREAM_D));
+            // Verify that the entire frame was sent.
+            controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 10);
+            assertEquals(0, window(CONNECTION_STREAM_ID));
+            assertEquals(0, window(STREAM_A));
+            assertEquals(DEFAULT_WINDOW_SIZE - 5, window(STREAM_B));
+            assertEquals((2 * DEFAULT_WINDOW_SIZE) - 5, window(STREAM_C) + window(STREAM_D));
 
-        ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
+            final ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
 
-        // Verify that no write was done for A, since it's blocked.
-        verifyNoWrite(STREAM_A);
+            // Verify that no write was done for A, since it's blocked.
+            verifyNoWrite(STREAM_A);
 
-        captureWrite(STREAM_B, captor, 0, false);
-        assertEquals(5, captor.getValue().readableBytes());
+            captureWrite(STREAM_B, captor, 0, false);
+            assertEquals(5, captor.getValue().readableBytes());
 
-        // Verify that C and D each shared half of A's allowance. Since A's allowance (5) cannot
-        // be split evenly, one will get 3 and one will get 2.
-        captureWrite(STREAM_C, captor, 0, false);
-        int c = captor.getValue().readableBytes();
-        captureWrite(STREAM_D, captor, 0, false);
-        int d = captor.getValue().readableBytes();
-        assertEquals(5, c + d);
-        assertEquals(1, Math.abs(c - d));
+            // Verify that C and D each shared half of A's allowance. Since A's allowance (5) cannot
+            // be split evenly, one will get 3 and one will get 2.
+            captureWrite(STREAM_C, captor, 0, false);
+            int c = captor.getValue().readableBytes();
+            captureWrite(STREAM_D, captor, 0, false);
+            int d = captor.getValue().readableBytes();
+            assertEquals(5, c + d);
+            assertEquals(1, Math.abs(c - d));
+        } finally {
+            manualSafeRelease(bufs);
+        }
     }
 
     /**
@@ -509,31 +579,36 @@ public class DefaultHttp2OutboundFlowControllerTest {
         exhaustStreamWindow(CONNECTION_STREAM_ID);
 
         // Send 10 bytes to each.
-        send(STREAM_A, dummyData(10, 0), 0);
-        send(STREAM_B, dummyData(10, 0), 0);
-        send(STREAM_C, dummyData(10, 0), 0);
-        send(STREAM_D, dummyData(10, 0), 0);
-        verifyNoWrite(STREAM_A);
-        verifyNoWrite(STREAM_B);
-        verifyNoWrite(STREAM_C);
-        verifyNoWrite(STREAM_D);
+        final ByteBuf[] bufs = { dummyData(10, 0), dummyData(10, 0), dummyData(10, 0), dummyData(10, 0) };
+        try {
+            send(STREAM_A, bufs[0], 0);
+            send(STREAM_B, bufs[1], 0);
+            send(STREAM_C, bufs[2], 0);
+            send(STREAM_D, bufs[3], 0);
+            verifyNoWrite(STREAM_A);
+            verifyNoWrite(STREAM_B);
+            verifyNoWrite(STREAM_C);
+            verifyNoWrite(STREAM_D);
 
-        // Verify that the entire frame was sent.
-        controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 10);
-        assertEquals(0, window(CONNECTION_STREAM_ID));
-        assertEquals(DEFAULT_WINDOW_SIZE - 10, window(STREAM_A));
-        assertEquals(0, window(STREAM_B));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_D));
+            // Verify that the entire frame was sent.
+            controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 10);
+            assertEquals(0, window(CONNECTION_STREAM_ID));
+            assertEquals(DEFAULT_WINDOW_SIZE - 10, window(STREAM_A));
+            assertEquals(0, window(STREAM_B));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_D));
 
-        ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
+            final ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
 
-        // Verify that A received all the bytes.
-        captureWrite(STREAM_A, captor, 0, false);
-        assertEquals(10, captor.getValue().readableBytes());
-        verifyNoWrite(STREAM_B);
-        verifyNoWrite(STREAM_C);
-        verifyNoWrite(STREAM_D);
+            // Verify that A received all the bytes.
+            captureWrite(STREAM_A, captor, 0, false);
+            assertEquals(10, captor.getValue().readableBytes());
+            verifyNoWrite(STREAM_B);
+            verifyNoWrite(STREAM_C);
+            verifyNoWrite(STREAM_D);
+        } finally {
+            manualSafeRelease(bufs);
+        }
     }
 
     /**
@@ -557,38 +632,43 @@ public class DefaultHttp2OutboundFlowControllerTest {
         exhaustStreamWindow(CONNECTION_STREAM_ID);
 
         // Only send 5 to A so that it will allow data from its children.
-        send(STREAM_A, dummyData(5, 0), 0);
-        send(STREAM_B, dummyData(10, 0), 0);
-        send(STREAM_C, dummyData(10, 0), 0);
-        send(STREAM_D, dummyData(10, 0), 0);
-        verifyNoWrite(STREAM_A);
-        verifyNoWrite(STREAM_B);
-        verifyNoWrite(STREAM_C);
-        verifyNoWrite(STREAM_D);
+        final ByteBuf[] bufs = { dummyData(5, 0), dummyData(10, 0), dummyData(10, 0), dummyData(10, 0) };
+        try {
+            send(STREAM_A, bufs[0], 0);
+            send(STREAM_B, bufs[1], 0);
+            send(STREAM_C, bufs[2], 0);
+            send(STREAM_D, bufs[3], 0);
+            verifyNoWrite(STREAM_A);
+            verifyNoWrite(STREAM_B);
+            verifyNoWrite(STREAM_C);
+            verifyNoWrite(STREAM_D);
 
-        // Verify that the entire frame was sent.
-        controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 10);
-        assertEquals(0, window(CONNECTION_STREAM_ID));
-        assertEquals(DEFAULT_WINDOW_SIZE - 5, window(STREAM_A));
-        assertEquals(0, window(STREAM_B));
-        assertEquals((2 * DEFAULT_WINDOW_SIZE) - 5, window(STREAM_C) + window(STREAM_D));
+            // Verify that the entire frame was sent.
+            controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 10);
+            assertEquals(0, window(CONNECTION_STREAM_ID));
+            assertEquals(DEFAULT_WINDOW_SIZE - 5, window(STREAM_A));
+            assertEquals(0, window(STREAM_B));
+            assertEquals((2 * DEFAULT_WINDOW_SIZE) - 5, window(STREAM_C) + window(STREAM_D));
 
-        ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
+            final ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
 
-        // Verify that no write was done for B, since it's blocked.
-        verifyNoWrite(STREAM_B);
+            // Verify that no write was done for B, since it's blocked.
+            verifyNoWrite(STREAM_B);
 
-        captureWrite(STREAM_A, captor, 0, false);
-        assertEquals(5, captor.getValue().readableBytes());
+            captureWrite(STREAM_A, captor, 0, false);
+            assertEquals(5, captor.getValue().readableBytes());
 
-        // Verify that C and D each shared half of A's allowance. Since A's allowance (5) cannot
-        // be split evenly, one will get 3 and one will get 2.
-        captureWrite(STREAM_C, captor, 0, false);
-        int c = captor.getValue().readableBytes();
-        captureWrite(STREAM_D, captor, 0, false);
-        int d = captor.getValue().readableBytes();
-        assertEquals(5, c + d);
-        assertEquals(1, Math.abs(c - d));
+            // Verify that C and D each shared half of A's allowance. Since A's allowance (5) cannot
+            // be split evenly, one will get 3 and one will get 2.
+            captureWrite(STREAM_C, captor, 0, false);
+            int c = captor.getValue().readableBytes();
+            captureWrite(STREAM_D, captor, 0, false);
+            int d = captor.getValue().readableBytes();
+            assertEquals(5, c + d);
+            assertEquals(1, Math.abs(c - d));
+        } finally {
+            manualSafeRelease(bufs);
+        }
     }
 
     /**
@@ -623,35 +703,40 @@ public class DefaultHttp2OutboundFlowControllerTest {
         exhaustStreamWindow(CONNECTION_STREAM_ID);
 
         // Send 10 bytes to each.
-        send(STREAM_A, dummyData(10, 0), 0);
-        send(STREAM_B, dummyData(10, 0), 0);
-        send(STREAM_C, dummyData(10, 0), 0);
-        send(STREAM_D, dummyData(10, 0), 0);
-        verifyNoWrite(STREAM_A);
-        verifyNoWrite(STREAM_B);
-        verifyNoWrite(STREAM_C);
-        verifyNoWrite(STREAM_D);
+        final ByteBuf[] bufs = { dummyData(10, 0), dummyData(10, 0), dummyData(10, 0), dummyData(10, 0) };
+        try {
+            send(STREAM_A, bufs[0], 0);
+            send(STREAM_B, bufs[1], 0);
+            send(STREAM_C, bufs[2], 0);
+            send(STREAM_D, bufs[3], 0);
+            verifyNoWrite(STREAM_A);
+            verifyNoWrite(STREAM_B);
+            verifyNoWrite(STREAM_C);
+            verifyNoWrite(STREAM_D);
 
-        // Re-prioritize D as a direct child of the connection.
-        setPriority(STREAM_D, 0, DEFAULT_PRIORITY_WEIGHT, false);
+            // Re-prioritize D as a direct child of the connection.
+            setPriority(STREAM_D, 0, DEFAULT_PRIORITY_WEIGHT, false);
 
-        // Verify that the entire frame was sent.
-        controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 10);
-        assertEquals(0, window(CONNECTION_STREAM_ID));
-        assertEquals(DEFAULT_WINDOW_SIZE - 5, window(STREAM_A));
-        assertEquals(0, window(STREAM_B));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
-        assertEquals(DEFAULT_WINDOW_SIZE - 5, window(STREAM_D));
+            // Verify that the entire frame was sent.
+            controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 10);
+            assertEquals(0, window(CONNECTION_STREAM_ID));
+            assertEquals(DEFAULT_WINDOW_SIZE - 5, window(STREAM_A));
+            assertEquals(0, window(STREAM_B));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
+            assertEquals(DEFAULT_WINDOW_SIZE - 5, window(STREAM_D));
 
-        ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
+            final ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
 
-        // Verify that A received all the bytes.
-        captureWrite(STREAM_A, captor, 0, false);
-        assertEquals(5, captor.getValue().readableBytes());
-        captureWrite(STREAM_D, captor, 0, false);
-        assertEquals(5, captor.getValue().readableBytes());
-        verifyNoWrite(STREAM_B);
-        verifyNoWrite(STREAM_C);
+            // Verify that A received all the bytes.
+            captureWrite(STREAM_A, captor, 0, false);
+            assertEquals(5, captor.getValue().readableBytes());
+            captureWrite(STREAM_D, captor, 0, false);
+            assertEquals(5, captor.getValue().readableBytes());
+            verifyNoWrite(STREAM_B);
+            verifyNoWrite(STREAM_C);
+        } finally {
+            manualSafeRelease(bufs);
+        }
     }
 
     /**
@@ -676,51 +761,56 @@ public class DefaultHttp2OutboundFlowControllerTest {
         setPriority(STREAM_D, 0, (short) 100, false);
 
         // Send a bunch of data on each stream.
-        send(STREAM_A, dummyData(1000, 0), 0);
-        send(STREAM_B, dummyData(1000, 0), 0);
-        send(STREAM_C, dummyData(1000, 0), 0);
-        send(STREAM_D, dummyData(1000, 0), 0);
-        verifyNoWrite(STREAM_A);
-        verifyNoWrite(STREAM_B);
-        verifyNoWrite(STREAM_C);
-        verifyNoWrite(STREAM_D);
+        final ByteBuf[] bufs = { dummyData(1000, 0), dummyData(1000, 0), dummyData(1000, 0), dummyData(1000, 0) };
+        try {
+            send(STREAM_A, bufs[0], 0);
+            send(STREAM_B, bufs[1], 0);
+            send(STREAM_C, bufs[2], 0);
+            send(STREAM_D, bufs[3], 0);
+            verifyNoWrite(STREAM_A);
+            verifyNoWrite(STREAM_B);
+            verifyNoWrite(STREAM_C);
+            verifyNoWrite(STREAM_D);
 
-        // Allow 1000 bytes to be sent.
-        controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 1000);
-        ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
+            // Allow 1000 bytes to be sent.
+            controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 1000);
+            final ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
 
-        captureWrite(STREAM_A, captor, 0, false);
-        int aWritten = captor.getValue().readableBytes();
-        int min = aWritten;
-        int max = aWritten;
+            captureWrite(STREAM_A, captor, 0, false);
+            int aWritten = captor.getValue().readableBytes();
+            int min = aWritten;
+            int max = aWritten;
 
-        captureWrite(STREAM_B, captor, 0, false);
-        int bWritten = captor.getValue().readableBytes();
-        min = Math.min(min, bWritten);
-        max = Math.max(max, bWritten);
+            captureWrite(STREAM_B, captor, 0, false);
+            int bWritten = captor.getValue().readableBytes();
+            min = Math.min(min, bWritten);
+            max = Math.max(max, bWritten);
 
-        captureWrite(STREAM_C, captor, 0, false);
-        int cWritten = captor.getValue().readableBytes();
-        min = Math.min(min, cWritten);
-        max = Math.max(max, cWritten);
+            captureWrite(STREAM_C, captor, 0, false);
+            int cWritten = captor.getValue().readableBytes();
+            min = Math.min(min, cWritten);
+            max = Math.max(max, cWritten);
 
-        captureWrite(STREAM_D, captor, 0, false);
-        int dWritten = captor.getValue().readableBytes();
-        min = Math.min(min, dWritten);
-        max = Math.max(max, dWritten);
+            captureWrite(STREAM_D, captor, 0, false);
+            int dWritten = captor.getValue().readableBytes();
+            min = Math.min(min, dWritten);
+            max = Math.max(max, dWritten);
 
-        assertEquals(1000, aWritten + bWritten + cWritten + dWritten);
-        assertEquals(aWritten, min);
-        assertEquals(bWritten, max);
-        assertTrue(aWritten < cWritten);
-        assertEquals(cWritten, dWritten);
-        assertTrue(cWritten < bWritten);
+            assertEquals(1000, aWritten + bWritten + cWritten + dWritten);
+            assertEquals(aWritten, min);
+            assertEquals(bWritten, max);
+            assertTrue(aWritten < cWritten);
+            assertEquals(cWritten, dWritten);
+            assertTrue(cWritten < bWritten);
 
-        assertEquals(0, window(CONNECTION_STREAM_ID));
-        assertEquals(DEFAULT_WINDOW_SIZE - aWritten, window(STREAM_A));
-        assertEquals(DEFAULT_WINDOW_SIZE - bWritten, window(STREAM_B));
-        assertEquals(DEFAULT_WINDOW_SIZE - cWritten, window(STREAM_C));
-        assertEquals(DEFAULT_WINDOW_SIZE - dWritten, window(STREAM_D));
+            assertEquals(0, window(CONNECTION_STREAM_ID));
+            assertEquals(DEFAULT_WINDOW_SIZE - aWritten, window(STREAM_A));
+            assertEquals(DEFAULT_WINDOW_SIZE - bWritten, window(STREAM_B));
+            assertEquals(DEFAULT_WINDOW_SIZE - cWritten, window(STREAM_C));
+            assertEquals(DEFAULT_WINDOW_SIZE - dWritten, window(STREAM_D));
+        } finally {
+            manualSafeRelease(bufs);
+        }
     }
 
     /**
@@ -745,40 +835,45 @@ public class DefaultHttp2OutboundFlowControllerTest {
         setPriority(STREAM_D, 0, DEFAULT_PRIORITY_WEIGHT, false);
 
         // Send a bunch of data on each stream.
-        send(STREAM_A, dummyData(400, 0), 0);
-        send(STREAM_B, dummyData(500, 0), 0);
-        send(STREAM_C, dummyData(0, 0), 0);
-        send(STREAM_D, dummyData(700, 0), 0);
-        verifyNoWrite(STREAM_A);
-        verifyNoWrite(STREAM_B);
-        verifyNoWrite(STREAM_D);
+        final ByteBuf[] bufs = { dummyData(400, 0), dummyData(500, 0), dummyData(0, 0), dummyData(700, 0) };
+        try {
+            send(STREAM_A, bufs[0], 0);
+            send(STREAM_B, bufs[1], 0);
+            send(STREAM_C, bufs[2], 0);
+            send(STREAM_D, bufs[3], 0);
+            verifyNoWrite(STREAM_A);
+            verifyNoWrite(STREAM_B);
+            verifyNoWrite(STREAM_D);
 
-        // The write will occur on C, because it's an empty frame.
-        ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
-        captureWrite(STREAM_C, captor, 0, false);
-        assertEquals(0, captor.getValue().readableBytes());
+            // The write will occur on C, because it's an empty frame.
+            final ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
+            captureWrite(STREAM_C, captor, 0, false);
+            assertEquals(0, captor.getValue().readableBytes());
 
-        // Allow 1000 bytes to be sent.
-        controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 999);
-        assertEquals(0, window(CONNECTION_STREAM_ID));
-        assertEquals(DEFAULT_WINDOW_SIZE - 333, window(STREAM_A));
-        assertEquals(DEFAULT_WINDOW_SIZE - 333, window(STREAM_B));
-        assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
-        assertEquals(DEFAULT_WINDOW_SIZE - 333, window(STREAM_D));
+            // Allow 1000 bytes to be sent.
+            controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, 999);
+            assertEquals(0, window(CONNECTION_STREAM_ID));
+            assertEquals(DEFAULT_WINDOW_SIZE - 333, window(STREAM_A));
+            assertEquals(DEFAULT_WINDOW_SIZE - 333, window(STREAM_B));
+            assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_C));
+            assertEquals(DEFAULT_WINDOW_SIZE - 333, window(STREAM_D));
 
-        captureWrite(STREAM_A, captor, 0, false);
-        int aWritten = captor.getValue().readableBytes();
+            captureWrite(STREAM_A, captor, 0, false);
+            int aWritten = captor.getValue().readableBytes();
 
-        captureWrite(STREAM_B, captor, 0, false);
-        int bWritten = captor.getValue().readableBytes();
+            captureWrite(STREAM_B, captor, 0, false);
+            int bWritten = captor.getValue().readableBytes();
 
-        captureWrite(STREAM_D, captor, 0, false);
-        int dWritten = captor.getValue().readableBytes();
+            captureWrite(STREAM_D, captor, 0, false);
+            int dWritten = captor.getValue().readableBytes();
 
-        assertEquals(999, aWritten + bWritten + dWritten);
-        assertEquals(333, aWritten);
-        assertEquals(333, bWritten);
-        assertEquals(333, dWritten);
+            assertEquals(999, aWritten + bWritten + dWritten);
+            assertEquals(333, aWritten);
+            assertEquals(333, bWritten);
+            assertEquals(333, dWritten);
+        } finally {
+            manualSafeRelease(bufs);
+        }
     }
 
     /**
@@ -804,35 +899,38 @@ public class DefaultHttp2OutboundFlowControllerTest {
         Http2Stream streamD = connection.stream(STREAM_D);
 
         // Send a bunch of data on each stream.
-        IntObjectMap<Integer> streamSizes = new IntObjectHashMap<Integer>(4);
+        final IntObjectMap<Integer> streamSizes = new IntObjectHashMap<Integer>(4);
         streamSizes.put(STREAM_A, 400);
         streamSizes.put(STREAM_B, 500);
         streamSizes.put(STREAM_C, 600);
         streamSizes.put(STREAM_D, 700);
-        send(STREAM_A, dummyData(streamSizes.get(STREAM_A), 0), 0);
-        send(STREAM_B, dummyData(streamSizes.get(STREAM_B), 0), 0);
-        send(STREAM_C, dummyData(streamSizes.get(STREAM_C), 0), 0);
-        send(STREAM_D, dummyData(streamSizes.get(STREAM_D), 0), 0);
-        verifyNoWrite(STREAM_A);
-        verifyNoWrite(STREAM_B);
-        verifyNoWrite(STREAM_C);
-        verifyNoWrite(STREAM_D);
+        final ByteBuf[] bufs = { dummyData(streamSizes.get(STREAM_A), 0), dummyData(streamSizes.get(STREAM_B), 0),
+                dummyData(streamSizes.get(STREAM_C), 0), dummyData(streamSizes.get(STREAM_D), 0) };
+        try {
+            send(STREAM_A, bufs[0], 0);
+            send(STREAM_B, bufs[1], 0);
+            send(STREAM_C, bufs[2], 0);
+            send(STREAM_D, bufs[3], 0);
+            verifyNoWrite(STREAM_A);
+            verifyNoWrite(STREAM_B);
+            verifyNoWrite(STREAM_C);
+            verifyNoWrite(STREAM_D);
 
-        OutboundFlowState state = state(stream0);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_A, STREAM_B, STREAM_C, STREAM_D)), state.priorityBytes());
-        state = state(streamA);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_A, STREAM_C, STREAM_D)), state.priorityBytes());
-        state = state(streamB);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_B)), state.priorityBytes());
-        state = state(streamC);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_C)), state.priorityBytes());
-        state = state(streamD);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_D)), state.priorityBytes());
+            OutboundFlowState state = state(stream0);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_A, STREAM_B, STREAM_C, STREAM_D)),
+                    state.priorityBytes());
+            state = state(streamA);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_A, STREAM_C, STREAM_D)),
+                    state.priorityBytes());
+            state = state(streamB);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_B)), state.priorityBytes());
+            state = state(streamC);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_C)), state.priorityBytes());
+            state = state(streamD);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_D)), state.priorityBytes());
+        } finally {
+            manualSafeRelease(bufs);
+        }
     }
 
     /**
@@ -847,6 +945,7 @@ public class DefaultHttp2OutboundFlowControllerTest {
      * </pre>
      *
      * After the tree shift:
+     *
      * <pre>
      *        [0]
      *         |
@@ -869,36 +968,40 @@ public class DefaultHttp2OutboundFlowControllerTest {
         Http2Stream streamD = connection.stream(STREAM_D);
 
         // Send a bunch of data on each stream.
-        IntObjectMap<Integer> streamSizes = new IntObjectHashMap<Integer>(4);
+        final IntObjectMap<Integer> streamSizes = new IntObjectHashMap<Integer>(4);
         streamSizes.put(STREAM_A, 400);
         streamSizes.put(STREAM_B, 500);
         streamSizes.put(STREAM_C, 600);
         streamSizes.put(STREAM_D, 700);
-        send(STREAM_A, dummyData(streamSizes.get(STREAM_A), 0), 0);
-        send(STREAM_B, dummyData(streamSizes.get(STREAM_B), 0), 0);
-        send(STREAM_C, dummyData(streamSizes.get(STREAM_C), 0), 0);
-        send(STREAM_D, dummyData(streamSizes.get(STREAM_D), 0), 0);
-        verifyNoWrite(STREAM_A);
-        verifyNoWrite(STREAM_B);
-        verifyNoWrite(STREAM_C);
-        verifyNoWrite(STREAM_D);
+        final ByteBuf[] bufs = { dummyData(streamSizes.get(STREAM_A), 0), dummyData(streamSizes.get(STREAM_B), 0),
+                dummyData(streamSizes.get(STREAM_C), 0), dummyData(streamSizes.get(STREAM_D), 0) };
+        try {
+            send(STREAM_A, bufs[0], 0);
+            send(STREAM_B, bufs[1], 0);
+            send(STREAM_C, bufs[2], 0);
+            send(STREAM_D, bufs[3], 0);
+            verifyNoWrite(STREAM_A);
+            verifyNoWrite(STREAM_B);
+            verifyNoWrite(STREAM_C);
+            verifyNoWrite(STREAM_D);
 
-        streamB.setPriority(STREAM_A, DEFAULT_PRIORITY_WEIGHT, true);
-        OutboundFlowState state = state(stream0);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_A, STREAM_B, STREAM_C, STREAM_D)), state.priorityBytes());
-        state = state(streamA);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_A, STREAM_B, STREAM_C, STREAM_D)), state.priorityBytes());
-        state = state(streamB);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_B, STREAM_C, STREAM_D)), state.priorityBytes());
-        state = state(streamC);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_C)), state.priorityBytes());
-        state = state(streamD);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_D)), state.priorityBytes());
+            streamB.setPriority(STREAM_A, DEFAULT_PRIORITY_WEIGHT, true);
+            OutboundFlowState state = state(stream0);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_A, STREAM_B, STREAM_C, STREAM_D)),
+                    state.priorityBytes());
+            state = state(streamA);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_A, STREAM_B, STREAM_C, STREAM_D)),
+                    state.priorityBytes());
+            state = state(streamB);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_B, STREAM_C, STREAM_D)),
+                    state.priorityBytes());
+            state = state(streamC);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_C)), state.priorityBytes());
+            state = state(streamD);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_D)), state.priorityBytes());
+        } finally {
+            manualSafeRelease(bufs);
+        }
     }
 
     /**
@@ -913,6 +1016,7 @@ public class DefaultHttp2OutboundFlowControllerTest {
      * </pre>
      *
      * After the tree shift:
+     *
      * <pre>
      *        [0]
      *        / \
@@ -938,41 +1042,47 @@ public class DefaultHttp2OutboundFlowControllerTest {
         streamE.setPriority(STREAM_A, DEFAULT_PRIORITY_WEIGHT, true);
 
         // Send a bunch of data on each stream.
-        IntObjectMap<Integer> streamSizes = new IntObjectHashMap<Integer>(4);
+        final IntObjectMap<Integer> streamSizes = new IntObjectHashMap<Integer>(4);
         streamSizes.put(STREAM_A, 400);
         streamSizes.put(STREAM_B, 500);
         streamSizes.put(STREAM_C, 600);
         streamSizes.put(STREAM_D, 700);
         streamSizes.put(STREAM_E, 900);
-        send(STREAM_A, dummyData(streamSizes.get(STREAM_A), 0), 0);
-        send(STREAM_B, dummyData(streamSizes.get(STREAM_B), 0), 0);
-        send(STREAM_C, dummyData(streamSizes.get(STREAM_C), 0), 0);
-        send(STREAM_D, dummyData(streamSizes.get(STREAM_D), 0), 0);
-        send(STREAM_E, dummyData(streamSizes.get(STREAM_E), 0), 0);
-        verifyNoWrite(STREAM_A);
-        verifyNoWrite(STREAM_B);
-        verifyNoWrite(STREAM_C);
-        verifyNoWrite(STREAM_D);
-        verifyNoWrite(STREAM_E);
+        final ByteBuf[] bufs = { dummyData(streamSizes.get(STREAM_A), 0), dummyData(streamSizes.get(STREAM_B), 0),
+                dummyData(streamSizes.get(STREAM_C), 0), dummyData(streamSizes.get(STREAM_D), 0),
+                dummyData(streamSizes.get(STREAM_E), 0) };
+        try {
+            send(STREAM_A, bufs[0], 0);
+            send(STREAM_B, bufs[1], 0);
+            send(STREAM_C, bufs[2], 0);
+            send(STREAM_D, bufs[3], 0);
+            send(STREAM_E, bufs[4], 0);
+            verifyNoWrite(STREAM_A);
+            verifyNoWrite(STREAM_B);
+            verifyNoWrite(STREAM_C);
+            verifyNoWrite(STREAM_D);
+            verifyNoWrite(STREAM_E);
 
-        OutboundFlowState state = state(stream0);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_A, STREAM_B, STREAM_C, STREAM_D, STREAM_E)), state.priorityBytes());
-        state = state(streamA);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_A, STREAM_E, STREAM_C, STREAM_D)), state.priorityBytes());
-        state = state(streamB);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_B)), state.priorityBytes());
-        state = state(streamC);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_C)), state.priorityBytes());
-        state = state(streamD);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_D)), state.priorityBytes());
-        state = state(streamE);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_E, STREAM_C, STREAM_D)), state.priorityBytes());
+            OutboundFlowState state = state(stream0);
+            assertEquals(
+                    calculateStreamSizeSum(streamSizes,
+                            Arrays.asList(STREAM_A, STREAM_B, STREAM_C, STREAM_D, STREAM_E)),
+                    state.priorityBytes());
+            state = state(streamA);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_A, STREAM_E, STREAM_C, STREAM_D)),
+                    state.priorityBytes());
+            state = state(streamB);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_B)), state.priorityBytes());
+            state = state(streamC);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_C)), state.priorityBytes());
+            state = state(streamD);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_D)), state.priorityBytes());
+            state = state(streamE);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_E, STREAM_C, STREAM_D)),
+                    state.priorityBytes());
+        } finally {
+            manualSafeRelease(bufs);
+        }
     }
 
     /**
@@ -987,6 +1097,7 @@ public class DefaultHttp2OutboundFlowControllerTest {
      * </pre>
      *
      * After the tree shift:
+     *
      * <pre>
      *        [0]
      *       / | \
@@ -1005,36 +1116,39 @@ public class DefaultHttp2OutboundFlowControllerTest {
         Http2Stream streamD = connection.stream(STREAM_D);
 
         // Send a bunch of data on each stream.
-        IntObjectMap<Integer> streamSizes = new IntObjectHashMap<Integer>(4);
+        final IntObjectMap<Integer> streamSizes = new IntObjectHashMap<Integer>(4);
         streamSizes.put(STREAM_A, 400);
         streamSizes.put(STREAM_B, 500);
         streamSizes.put(STREAM_C, 600);
         streamSizes.put(STREAM_D, 700);
-        send(STREAM_A, dummyData(streamSizes.get(STREAM_A), 0), 0);
-        send(STREAM_B, dummyData(streamSizes.get(STREAM_B), 0), 0);
-        send(STREAM_C, dummyData(streamSizes.get(STREAM_C), 0), 0);
-        send(STREAM_D, dummyData(streamSizes.get(STREAM_D), 0), 0);
-        verifyNoWrite(STREAM_A);
-        verifyNoWrite(STREAM_B);
-        verifyNoWrite(STREAM_C);
-        verifyNoWrite(STREAM_D);
+        final ByteBuf[] bufs = { dummyData(streamSizes.get(STREAM_A), 0), dummyData(streamSizes.get(STREAM_B), 0),
+                dummyData(streamSizes.get(STREAM_C), 0), dummyData(streamSizes.get(STREAM_D), 0) };
+        try {
+            send(STREAM_A, bufs[0], 0);
+            send(STREAM_B, bufs[1], 0);
+            send(STREAM_C, bufs[2], 0);
+            send(STREAM_D, bufs[3], 0);
+            verifyNoWrite(STREAM_A);
+            verifyNoWrite(STREAM_B);
+            verifyNoWrite(STREAM_C);
+            verifyNoWrite(STREAM_D);
 
-        streamA.close();
+            streamA.close();
 
-        OutboundFlowState state = state(stream0);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_B, STREAM_C, STREAM_D)), state.priorityBytes());
-        state = state(streamA);
-        assertEquals(0, state.priorityBytes());
-        state = state(streamB);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_B)), state.priorityBytes());
-        state = state(streamC);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_C)), state.priorityBytes());
-        state = state(streamD);
-        assertEquals(calculateStreamSizeSum(streamSizes,
-                        Arrays.asList(STREAM_D)), state.priorityBytes());
+            OutboundFlowState state = state(stream0);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_B, STREAM_C, STREAM_D)),
+                    state.priorityBytes());
+            state = state(streamA);
+            assertEquals(0, state.priorityBytes());
+            state = state(streamB);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_B)), state.priorityBytes());
+            state = state(streamC);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_C)), state.priorityBytes());
+            state = state(streamD);
+            assertEquals(calculateStreamSizeSum(streamSizes, Arrays.asList(STREAM_D)), state.priorityBytes());
+        } finally {
+            manualSafeRelease(bufs);
+        }
     }
 
     private static OutboundFlowState state(Http2Stream stream) {
@@ -1062,11 +1176,10 @@ public class DefaultHttp2OutboundFlowControllerTest {
 
     private void verifyNoWrite(int streamId) {
         verify(frameWriter, never()).writeData(eq(ctx), eq(streamId), any(ByteBuf.class), anyInt(), anyBoolean(),
-                        eq(promise));
+                eq(promise));
     }
 
-    private void captureWrite(int streamId, ArgumentCaptor<ByteBuf> captor, int padding,
-            boolean endStream) {
+    private void captureWrite(int streamId, ArgumentCaptor<ByteBuf> captor, int padding, boolean endStream) {
         verify(frameWriter).writeData(eq(ctx), eq(streamId), captor.capture(), eq(padding), eq(endStream), eq(promise));
     }
 
@@ -1075,33 +1188,37 @@ public class DefaultHttp2OutboundFlowControllerTest {
     }
 
     private void exhaustStreamWindow(int streamId) throws Http2Exception {
-        int dataLength = window(streamId);
-
-        if (streamId == CONNECTION_STREAM_ID) {
-            // Find a stream that we can use to shrink the connection window.
-            int streamToWrite = 0;
-            for (Http2Stream stream : connection.activeStreams()) {
-                if (stream.outboundFlow().window() >= dataLength) {
-                    streamToWrite = stream.id();
-                    break;
+        final int dataLength = window(streamId);
+        final ByteBuf data = dummyData(dataLength, 0);
+        try {
+            if (streamId == CONNECTION_STREAM_ID) {
+                // Find a stream that we can use to shrink the connection window.
+                int streamToWrite = 0;
+                for (Http2Stream stream : connection.activeStreams()) {
+                    if (stream.outboundFlow().window() >= dataLength) {
+                        streamToWrite = stream.id();
+                        break;
+                    }
                 }
+
+                // Write to STREAM_A to decrease the connection window and then restore STREAM_A's window.
+                int prevWindow = window(streamToWrite);
+                send(streamToWrite, data, 0);
+                int delta = prevWindow - window(streamToWrite);
+                controller.updateOutboundWindowSize(streamToWrite, delta);
+            } else {
+                // Write to the stream and then restore the connection window.
+                int prevWindow = window(CONNECTION_STREAM_ID);
+                send(streamId, data, 0);
+                int delta = prevWindow - window(CONNECTION_STREAM_ID);
+                controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, delta);
             }
 
-            // Write to STREAM_A to decrease the connection window and then restore STREAM_A's window.
-            int prevWindow = window(streamToWrite);
-            send(streamToWrite, dummyData(dataLength, 0), 0);
-            int delta = prevWindow - window(streamToWrite);
-            controller.updateOutboundWindowSize(streamToWrite, delta);
-        } else {
-            // Write to the stream and then restore the connection window.
-            int prevWindow = window(CONNECTION_STREAM_ID);
-            send(streamId, dummyData(dataLength, 0), 0);
-            int delta = prevWindow - window(CONNECTION_STREAM_ID);
-            controller.updateOutboundWindowSize(CONNECTION_STREAM_ID, delta);
+            // Reset the frameWriter so that this write doesn't interfere with other tests.
+            resetFrameWriter();
+        } finally {
+            manualSafeRelease(data);
         }
-
-        // Reset the frameWriter so that this write doesn't interfere with other tests.
-        resetFrameWriter();
     }
 
     private void resetFrameWriter() {
@@ -1114,12 +1231,24 @@ public class DefaultHttp2OutboundFlowControllerTest {
     }
 
     private static ByteBuf dummyData(int size, int padding) {
-        String repeatedData = "0123456789";
-        ByteBuf buffer = Unpooled.buffer(size + padding);
+        final String repeatedData = "0123456789";
+        final ByteBuf buffer = Unpooled.buffer(size + padding);
         for (int index = 0; index < size; ++index) {
             buffer.writeByte(repeatedData.charAt(index % repeatedData.length()));
         }
         buffer.writeZero(padding);
         return buffer;
+    }
+
+    private static void manualSafeRelease(ByteBuf data) {
+        while (data.refCnt() > 0) { // Manually release just to be safe if the test fails
+            data.release();
+        }
+    }
+
+    private static void manualSafeRelease(ByteBuf[] bufs) {
+        for (int i = 0; i < bufs.length; ++i) {
+            manualSafeRelease(bufs[i]);
+        }
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -21,10 +21,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import io.netty.bootstrap.Bootstrap;
@@ -41,9 +39,11 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http2.Http2TestUtil.Http2Runnable;
+import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
 
 import java.net.InetSocketAddress;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -51,17 +51,16 @@ import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 /**
  * Tests the full HTTP/2 framing stack including the connection and preface handlers.
  */
 public class Http2ConnectionRoundtripTest {
-
-    private static final int NUM_STREAMS = 1000;
+    private static final int STRESS_TIMEOUT_SECONDS = 30;
+    private static final int NUM_STREAMS = 5000;
     private final byte[] DATA_TEXT = "hello world".getBytes(UTF_8);
 
     @Mock
@@ -75,13 +74,16 @@ public class Http2ConnectionRoundtripTest {
     private Bootstrap cb;
     private Channel serverChannel;
     private Channel clientChannel;
-    private final CountDownLatch requestLatch = new CountDownLatch(NUM_STREAMS * 3);
-    private CountDownLatch dataLatch = new CountDownLatch(NUM_STREAMS * DATA_TEXT.length);
+    private Http2TestUtil.FrameCountDown serverFrameCountDown;
+    private CountDownLatch requestLatch;
+    private CountDownLatch dataLatch;
 
     @Before
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
 
+        requestLatch(new CountDownLatch(NUM_STREAMS * 3));
+        dataLatch(new CountDownLatch(NUM_STREAMS * DATA_TEXT.length));
         sb = new ServerBootstrap();
         cb = new Bootstrap();
 
@@ -91,7 +93,8 @@ public class Http2ConnectionRoundtripTest {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 ChannelPipeline p = ch.pipeline();
-                p.addLast(new DelegatingHttp2ConnectionHandler(true, new FrameCountDown()));
+                serverFrameCountDown = new Http2TestUtil.FrameCountDown(serverListener, requestLatch, dataLatch);
+                p.addLast(new DelegatingHttp2ConnectionHandler(true, serverFrameCountDown));
                 p.addLast(Http2CodecUtil.ignoreSettingsHandler());
             }
         });
@@ -126,84 +129,113 @@ public class Http2ConnectionRoundtripTest {
 
     @Test
     public void flowControlProperlyChunksLargeMessage() throws Exception {
-        final Http2Headers headers =
-                new DefaultHttp2Headers.Builder().method("GET").scheme("https")
-                        .authority("example.org").path("/some/path/resource2").build();
+        final Http2Headers headers = new DefaultHttp2Headers.Builder().method("GET").scheme("https")
+                .authority("example.org").path("/some/path/resource2").build();
 
         // Create a large message to send.
-        int length = 10485760; // 10MB
+        final int length = 10485760; // 10MB
 
         // Create a buffer filled with random bytes.
-        byte[] bytes = new byte[length];
+        final byte[] bytes = new byte[length];
         new Random().nextBytes(bytes);
         final ByteBuf data = Unpooled.wrappedBuffer(bytes);
+        List<ByteBuf> capturedData = null;
+        try {
+            // Initialize the data latch based on the number of bytes expected.
+            requestLatch(new CountDownLatch(2));
+            dataLatch(new CountDownLatch(length));
 
-        // Prepare a receive buffer and populate it as DATA frames are received by the server.
-        final ByteBuf receivedData = Unpooled.buffer(length);
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                ByteBuf buf = (ByteBuf) invocation.getArguments()[2];
-                receivedData.writeBytes(buf);
-                return null;
-            }
-        }).when(serverListener).onDataRead(any(ChannelHandlerContext.class), eq(3),
-                any(ByteBuf.class), eq(0), anyBoolean());
+            // Create the stream and send all of the data at once.
+            runInChannel(clientChannel, new Http2Runnable() {
+                @Override
+                public void run() {
+                    http2Client.writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0, false, newPromise());
+                    http2Client.writeData(ctx(), 3, data.retain(), 0, true, newPromise());
+                }
+            });
 
-        // Initialize the data latch based on the number of bytes expected.
-        dataLatch = new CountDownLatch(length);
+            // Wait for all DATA frames to be received at the server.
+            assertTrue(dataLatch.await(5, TimeUnit.SECONDS));
 
-        // Create the stream and send all of the data at once.
-        runInChannel(clientChannel, new Http2Runnable() {
-            @Override
-            public void run() {
-                http2Client.writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0, false,
-                        newPromise());
-                http2Client.writeData(ctx(), 3, data.copy(), 0, true, newPromise());
-            }
-        });
+            // Verify that headers were received and only one DATA frame was received with endStream set.
+            final ArgumentCaptor<ByteBuf> dataCaptor = ArgumentCaptor.forClass(ByteBuf.class);
+            verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(headers), eq(0),
+                    eq((short) 16), eq(false), eq(0), eq(false));
+            verify(serverListener).onDataRead(any(ChannelHandlerContext.class), eq(3), dataCaptor.capture(), eq(0),
+                    eq(true));
 
-        // Wait for all DATA frames to be received at the server.
-        assertTrue(dataLatch.await(5, TimeUnit.SECONDS));
-
-        // Verify that headers were received and only one DATA frame was received with endStream set.
-        verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(headers),
-                eq(0), eq((short) 16), eq(false), eq(0), eq(false));
-        verify(serverListener).onDataRead(any(ChannelHandlerContext.class), eq(3),
-                any(ByteBuf.class), eq(0), eq(true));
-
-        // Verify we received all the bytes.
-        assertEquals(data, receivedData);
+            // Verify we received all the bytes.
+            capturedData = dataCaptor.getAllValues();
+            assertEquals(data, capturedData.get(0));
+        } finally {
+            data.release();
+            release(capturedData);
+        }
     }
 
     @Test
     public void stressTest() throws Exception {
-        final Http2Headers headers =
-                new DefaultHttp2Headers.Builder().method("GET").scheme("https")
-                        .authority("example.org").path("/some/path/resource2").build();
+        final Http2Headers headers = new DefaultHttp2Headers.Builder().method("GET").scheme("https")
+                .authority("example.org").path("/some/path/resource2").build();
         final String text = "hello world";
         final String pingMsg = "12345678";
-        runInChannel(clientChannel, new Http2Runnable() {
-            @Override
-            public void run() {
-                for (int i = 0, nextStream = 3; i < NUM_STREAMS; ++i, nextStream += 2) {
-                    http2Client.writeHeaders(ctx(), nextStream, headers, 0, (short) 16, false, 0,
-                            false, newPromise());
-                    http2Client.writePing(ctx(), Unpooled.copiedBuffer(pingMsg.getBytes()),
-                            newPromise());
-                    http2Client.writeData(ctx(), nextStream,
-                            Unpooled.copiedBuffer(text.getBytes()), 0, true, newPromise());
+        final ByteBuf data = Unpooled.copiedBuffer(text.getBytes());
+        final ByteBuf pingData = Unpooled.copiedBuffer(pingMsg.getBytes());
+        List<ByteBuf> capturedData = null;
+        List<ByteBuf> capturedPingData = null;
+        try {
+            runInChannel(clientChannel, new Http2Runnable() {
+                @Override
+                public void run() {
+                    for (int i = 0, nextStream = 3; i < NUM_STREAMS; ++i, nextStream += 2) {
+                        http2Client.writeHeaders(ctx(), nextStream, headers, 0, (short) 16, false, 0, false,
+                                newPromise());
+                        http2Client.writePing(ctx(), pingData.retain(), newPromise());
+                        http2Client.writeData(ctx(), nextStream, data.retain(), 0, true, newPromise());
+                    }
                 }
+            });
+            // Wait for all frames to be received.
+            assertTrue(requestLatch.await(STRESS_TIMEOUT_SECONDS, SECONDS));
+            verify(serverListener, times(NUM_STREAMS)).onHeadersRead(any(ChannelHandlerContext.class), anyInt(),
+                    eq(headers), eq(0), eq((short) 16), eq(false), eq(0), eq(false));
+            final ArgumentCaptor<ByteBuf> dataCaptor = ArgumentCaptor.forClass(ByteBuf.class);
+            final ArgumentCaptor<ByteBuf> pingDataCaptor = ArgumentCaptor.forClass(ByteBuf.class);
+            verify(serverListener, times(NUM_STREAMS)).onPingRead(any(ChannelHandlerContext.class),
+                    pingDataCaptor.capture());
+            capturedPingData = pingDataCaptor.getAllValues();
+            verify(serverListener, times(NUM_STREAMS)).onDataRead(any(ChannelHandlerContext.class), anyInt(),
+                    dataCaptor.capture(), eq(0), eq(true));
+            capturedData = dataCaptor.getAllValues();
+            data.resetReaderIndex();
+            pingData.resetReaderIndex();
+            int i;
+            for (i = 0; i < capturedPingData.size(); ++i) {
+                assertEquals(pingData, capturedPingData.get(i));
             }
-        });
-        // Wait for all frames to be received.
-        assertTrue(requestLatch.await(5, SECONDS));
-        verify(serverListener, times(NUM_STREAMS)).onHeadersRead(any(ChannelHandlerContext.class),
-                anyInt(), eq(headers), eq(0), eq((short) 16), eq(false), eq(0), eq(false));
-        verify(serverListener, times(NUM_STREAMS)).onPingRead(any(ChannelHandlerContext.class),
-                eq(Unpooled.copiedBuffer(pingMsg.getBytes())));
-        verify(serverListener, times(NUM_STREAMS)).onDataRead(any(ChannelHandlerContext.class),
-                anyInt(), eq(Unpooled.copiedBuffer(text.getBytes())), eq(0), eq(true));
+            for (i = 0; i < capturedData.size(); ++i) {
+                assertEquals(capturedData.get(i).toString(CharsetUtil.UTF_8), data, capturedData.get(i));
+            }
+        } finally {
+            data.release();
+            pingData.release();
+            release(capturedData);
+            release(capturedPingData);
+        }
+    }
+
+    private void dataLatch(CountDownLatch latch) {
+        dataLatch = latch;
+        if (serverFrameCountDown != null) {
+            serverFrameCountDown.dataLatch(latch);
+        }
+    }
+
+    private void requestLatch(CountDownLatch latch) {
+        requestLatch = latch;
+        if (serverFrameCountDown != null) {
+            serverFrameCountDown.messageLatch(latch);
+        }
     }
 
     private ChannelHandlerContext ctx() {
@@ -214,107 +246,11 @@ public class Http2ConnectionRoundtripTest {
         return ctx().newPromise();
     }
 
-    /**
-     * A decorator around the serverObserver that counts down the latch so that we can await the
-     * completion of the request.
-     */
-    private final class FrameCountDown implements Http2FrameListener {
-
-        @Override
-        public void onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
-                               boolean endOfStream)
-                throws Http2Exception {
-            serverListener.onDataRead(ctx, streamId, copy(data), padding, endOfStream);
-            requestLatch.countDown();
-            for (int i = 0; i < data.readableBytes(); ++i) {
-                dataLatch.countDown();
+    private static void release(List<ByteBuf> capturedData) {
+        if (capturedData != null) {
+            for (int i = 0; i < capturedData.size(); ++i) {
+                capturedData.get(i).release();
             }
-        }
-
-        @Override
-        public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
-                                  int padding, boolean endStream) throws Http2Exception {
-            serverListener.onHeadersRead(ctx, streamId, headers, padding, endStream);
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
-                                  int streamDependency, short weight, boolean exclusive, int padding,
-                                  boolean endStream) throws Http2Exception {
-            serverListener.onHeadersRead(ctx, streamId, headers, streamDependency, weight,
-                    exclusive, padding, endStream);
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency,
-                                   short weight, boolean exclusive) throws Http2Exception {
-            serverListener.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
-                throws Http2Exception {
-            serverListener.onRstStreamRead(ctx, streamId, errorCode);
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
-            serverListener.onSettingsAckRead(ctx);
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception {
-            serverListener.onSettingsRead(ctx, settings);
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
-            serverListener.onPingRead(ctx, copy(data));
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
-            serverListener.onPingAckRead(ctx, copy(data));
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId,
-                                      int promisedStreamId, Http2Headers headers, int padding) throws Http2Exception {
-            serverListener.onPushPromiseRead(ctx, streamId, promisedStreamId, headers, padding);
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData)
-                throws Http2Exception {
-            serverListener.onGoAwayRead(ctx, lastStreamId, errorCode, copy(debugData));
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId,
-                                       int windowSizeIncrement) throws Http2Exception {
-            serverListener.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
-            requestLatch.countDown();
-        }
-
-        @Override
-        public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
-                Http2Flags flags, ByteBuf payload) {
-            serverListener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
-            requestLatch.countDown();
-        }
-
-        ByteBuf copy(ByteBuf buffer) {
-            return Unpooled.copiedBuffer(buffer);
         }
     }
 }


### PR DESCRIPTION
Motivation:
The HTTP/2 tests do not always clean up ByteBuf resources reliably. There are issues with the refCnt, over allocating buffers, and potentially not waiting long enough to reclaim resources for stress tests.

Modifications:
Scrub the HTTP/2 unit tests for ByteBuf leaks.

Result:
Less leaks (hopefully none) in the HTTP/2 unit tests.  No OOME from HTTP/2 unit tests.
