### PR TITLE
FingerprintTrustManagerFactory constructor bug

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/util/FingerprintTrustManagerFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/FingerprintTrustManagerFactory.java
@@ -190,6 +190,7 @@ public final class FingerprintTrustManagerFactory extends SimpleTrustManagerFact
                 int strIdx = i << 1;
                 farr[i] = (byte) Integer.parseInt(f.substring(strIdx, strIdx + 2), 16);
             }
+            list.add(farr);
         }
 
         return list.toArray(new byte[list.size()][]);


### PR DESCRIPTION
When constructing a FingerprintTrustManagerFactory from an Iterable of Strings, the fingerprints were correctly parsed but never added to the result array. The constructed FingerprintTrustManagerFactory consequently fails to validate any certificate.

The bug exists on master as well as 4.1.
