### PR TITLE
Change the operator order of TrafficCounter to calculate the throughput ...

### DIFF
--- a/src/main/java/org/jboss/netty/handler/traffic/TrafficCounter.java
+++ b/src/main/java/org/jboss/netty/handler/traffic/TrafficCounter.java
@@ -228,9 +228,9 @@ public class TrafficCounter {
             }
             lastReadBytes = currentReadBytes.getAndSet(0);
             lastWrittenBytes = currentWrittenBytes.getAndSet(0);
-            lastReadThroughput = lastReadBytes / interval * 1000;
+            lastReadThroughput = lastReadBytes * 1000 / interval;
             // nb byte / checkInterval in ms * 1000 (1s)
-            lastWriteThroughput = lastWrittenBytes / interval * 1000;
+            lastWriteThroughput = lastWrittenBytes * 1000 / interval;
             // nb byte / checkInterval in ms * 1000 (1s)
         }
         if (lastWrittenBytes > 0) {


### PR DESCRIPTION
...to get the correct result

Motivation:
Currently the last read/write throughput is calculated by first division,this will be 0 if the last read/write bytes < interval,change the order will get the correct result

Modifications:
Change the operator order from first do division to multiplication

Result:
Get the correct result instead of 0 when bytes are smaller than interval
