### PR TITLE
Fix overriden method not called

### DIFF
--- a/src/main/java/org/jboss/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/src/main/java/org/jboss/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -608,7 +608,7 @@ public abstract class AbstractTrafficShapingHandler extends
     @Override
     public String toString() {
         return "TrafficShaping with Write Limit: " + writeLimit +
-                " Read Limit: " + readLimit + " and Counter: " +
+                " Read Limit: " + readLimit + " every: " + checkInterval + " and Counter: " +
                 (trafficCounter != null? trafficCounter.toString() : "none");
     }
 }

--- a/src/main/java/org/jboss/netty/handler/traffic/GlobalTrafficShapingHandler.java
+++ b/src/main/java/org/jboss/netty/handler/traffic/GlobalTrafficShapingHandler.java
@@ -208,6 +208,7 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
         Integer key = ctx.getChannel().getId();
         List<ToSend> messagesQueue = new LinkedList<ToSend>();
         messagesQueues.put(key, messagesQueue);
+        super.channelConnected(ctx, e);
     }
 
     @Override


### PR DESCRIPTION
Motivation:
channelConnected was override but super was never called, while it
should. It prevents next handlers to be informed of the connection.
Also add one missing information in the toString method.

Modifications:
Add the super corresponding call, and add checkInterval  to the
toString() method

Result;
Now, if the channelConnected method is correctly passed to the the next
handler.
