### PR TITLE
Fix overriden method not called in TrafficShaping

### DIFF
--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -421,7 +421,8 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
 
     @Override
     public String toString() {
-        return "TrafficShaping with Write Limit: " + writeLimit + " Read Limit: " + readLimit + " and Counter: "
+        return "TrafficShaping with Write Limit: " + writeLimit + " Read Limit: " + readLimit +
+                " CheckInterval: " + checkInterval + " and Counter: "
                 + (trafficCounter != null ? trafficCounter.toString() : "none");
     }
 

--- a/handler/src/main/java/io/netty/handler/traffic/ChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/ChannelTrafficShapingHandler.java
@@ -117,6 +117,7 @@ public class ChannelTrafficShapingHandler extends AbstractTrafficShapingHandler 
                 ctx.channel().hashCode(), checkInterval);
         setTrafficCounter(trafficCounter);
         trafficCounter.start();
+        super.handlerAdded(ctx);
     }
 
     @Override
@@ -130,6 +131,7 @@ public class ChannelTrafficShapingHandler extends AbstractTrafficShapingHandler 
             }
         }
         messagesQueue.clear();
+        super.handlerRemoved(ctx);
     }
 
     private static final class ToSend {

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
@@ -172,6 +172,7 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
         Integer key = ctx.channel().hashCode();
         List<ToSend> mq = new LinkedList<ToSend>();
         messagesQueues.put(key, mq);
+        super.handlerAdded(ctx);
     }
 
     @Override
@@ -186,6 +187,7 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
             }
             mq.clear();
         }
+        super.handlerRemoved(ctx);
     }
 
     private static final class ToSend {


### PR DESCRIPTION
Motivation:
handlerAdded and handlerRemoved were overriden but super was never
called, while it should.
Also add one missing information in the toString method.

Modifications:
Add the super corresponding call, and add checkInterval to the
toString() method

Result;
super method calls are correctly passed to the super implementation
part.

This should be applied to 4.1 and master too as is.
