### PR TITLE
Add verification for websocket subprotocol on the client side.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -43,6 +43,11 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
     private final boolean handleCloseFrames;
 
     /**
+     * Returns the used handshaker
+     */
+    public WebSocketClientHandshaker handshaker() { return handshaker; }
+
+    /**
      * Events that are fired to notify about handshake status
      */
     public enum ClientHandshakeStateEvent {


### PR DESCRIPTION
This adds some verification functionality for the websocket subprotocol on the client side.
If the client requests to speak a subprotocol but the server replies none or a not-requested subprotocol it should be treated as an error. If we request no subprotocol  but the server replies one it's also an error.

I also added a getter for the WebSocketClientHandshaker in the WebSocketClientProtocolHandler, because you need to access it in order to extract the actual subprotocol but when you use one of the WebSocketClientProtocolHandler constructors which internally create a handshaker it is hidden from the user.
