### PR TITLE
Websocket: Send a close frame with status code when receiving invalid frames

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoder.java
@@ -300,8 +300,8 @@ public class WebSocket08FrameDecoder extends ByteToMessageDecoder
                             return;
                         }
                         if (frameOpcode == OPCODE_CLOSE) {
-                            checkCloseFrameBody(ctx, payloadBuffer);
                             receivedClosingHandshake = true;
+                            checkCloseFrameBody(ctx, payloadBuffer);
                             out.add(new CloseWebSocketFrame(frameFinalFlag, frameRsv, payloadBuffer));
                             payloadBuffer = null;
                             return;
@@ -368,7 +368,13 @@ public class WebSocket08FrameDecoder extends ByteToMessageDecoder
     private void protocolViolation(ChannelHandlerContext ctx, CorruptedFrameException ex) {
         state = State.CORRUPT;
         if (ctx.channel().isActive()) {
-            ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
+            Object closeMessage;
+            if (receivedClosingHandshake) {
+                closeMessage = Unpooled.EMPTY_BUFFER;
+            } else {
+                closeMessage = new CloseWebSocketFrame(1002, null);
+            }
+            ctx.writeAndFlush(closeMessage).addListener(ChannelFutureListener.CLOSE);
         }
         throw ex;
     }


### PR DESCRIPTION
According to the websocket specification peers may send a close frame when they detect a protocol violation (with status code 1002). The current implementation simply closes the connection. This update should add this functionality. The functionality is optional - but it might help other implementations with debugging when they receive such a frame.
