### PR TITLE
HTTP/2 Unit Tests Synchronized Collections

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ToHttpConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ToHttpConnectionHandlerTest.java
@@ -53,6 +53,7 @@ import io.netty.util.concurrent.Future;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -175,7 +176,7 @@ public class DefaultHttp2ToHttpConnectionHandlerTest {
         requestLatch(new CountDownLatch(CONNECTION_SETUP_READ_COUNT + 2));
         final String text = "foooooogoooo";
         final ByteBuf data = Unpooled.copiedBuffer(text, UTF_8);
-        final List<String> receivedBuffers = new ArrayList<String>();
+        final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<String>());
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock in) throws Throwable {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -49,6 +49,7 @@ import io.netty.util.concurrent.Future;
 import java.io.ByteArrayOutputStream;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
@@ -199,7 +200,7 @@ public class Http2ConnectionRoundtripTest {
         final String pingMsg = "12345678";
         final ByteBuf data = Unpooled.copiedBuffer(text, UTF_8);
         final ByteBuf pingData = Unpooled.copiedBuffer(pingMsg, UTF_8);
-        final List<String> receivedPingBuffers = new ArrayList<String>(NUM_STREAMS);
+        final List<String> receivedPingBuffers = Collections.synchronizedList(new ArrayList<String>(NUM_STREAMS));
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock in) throws Throwable {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -47,6 +47,7 @@ import io.netty.util.concurrent.Future;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -132,7 +133,7 @@ public class Http2FrameRoundtripTest {
     public void dataFrameShouldMatch() throws Exception {
         final String text = "hello world";
         final ByteBuf data = Unpooled.copiedBuffer(text, UTF_8);
-        final List<String> receivedBuffers = new ArrayList<String>();
+        final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<String>());
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock in) throws Throwable {
@@ -194,7 +195,7 @@ public class Http2FrameRoundtripTest {
     public void goAwayFrameShouldMatch() throws Exception {
         final String text = "test";
         final ByteBuf data = Unpooled.copiedBuffer(text.getBytes());
-        final List<String> receivedBuffers = new ArrayList<String>();
+        final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<String>());
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock in) throws Throwable {
@@ -225,7 +226,7 @@ public class Http2FrameRoundtripTest {
     public void pingFrameShouldMatch() throws Exception {
         String text = "01234567";
         final ByteBuf data = Unpooled.copiedBuffer(text, UTF_8);
-        final List<String> receivedBuffers = new ArrayList<String>();
+        final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<String>());
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock in) throws Throwable {
@@ -332,7 +333,7 @@ public class Http2FrameRoundtripTest {
         final String text = "hello world";
         final ByteBuf data = Unpooled.copiedBuffer(text.getBytes());
         final int numStreams = 10000;
-        final List<String> receivedBuffers = new ArrayList<String>(numStreams);
+        final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<String>(numStreams));
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock in) throws Throwable {


### PR DESCRIPTION
Motivation:
The HTTP/2 unit tests are collecting responses read events which are happening in a multithreaded environment.
These collections are currently not synchronized or thread safe and are resulting in verification failures.

Modifications:
-Modify unit tests that use collections to store results for verifiction to be thread safe

Result:
Tests should not fail because of syncrhonization issues while verifying expected results.
