### PR TITLE
HTTP/2 unit test missed syncrhonized collection

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -290,7 +290,7 @@ public class Http2ConnectionRoundtripTest {
                 return null;
             }
         }).when(serverListener).onPingRead(any(ChannelHandlerContext.class), eq(pingData));
-        final List<String> receivedDataBuffers = new ArrayList<String>();
+        final List<String> receivedDataBuffers = Collections.synchronizedList(new ArrayList<String>(NUM_STREAMS));
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock in) throws Throwable {


### PR DESCRIPTION
Motiviation:
PR https://github.com/netty/netty/pull/2948 missed a collection to synchronize in the HTTP/2 unit tests.

Modifications:
synchronize the collection that was missed

Result:
Missed collection is syncronized and initial size is corrected
