### PR TITLE
Adding missing asserts to HTTP/2 tests

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ToHttpConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ToHttpConnectionHandlerTest.java
@@ -224,7 +224,7 @@ public class DefaultHttp2ToHttpConnectionHandlerTest {
     }
 
     private void awaitRequests() throws Exception {
-        requestLatch.await(2, SECONDS);
+        assertTrue(requestLatch.await(2, SECONDS));
     }
 
     private ChannelHandlerContext ctx() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -367,7 +367,7 @@ public class Http2FrameRoundtripTest {
     }
 
     private void awaitRequests(long seconds) throws InterruptedException {
-        requestLatch.await(seconds, SECONDS);
+        assertTrue(requestLatch.await(seconds, SECONDS));
     }
 
     private void awaitRequests() throws InterruptedException {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -670,11 +670,11 @@ public class InboundHttp2ToHttpAdapterTest {
     }
 
     private void awaitRequests() throws Exception {
-        serverLatch.await(2, SECONDS);
+        assertTrue(serverLatch.await(2, SECONDS));
     }
 
     private void awaitResponses() throws Exception {
-        clientLatch.await(2, SECONDS);
+        assertTrue(clientLatch.await(2, SECONDS));
     }
 
     private ChannelHandlerContext ctxClient() {


### PR DESCRIPTION
We were missing assertions while awaiting requests and responses.
