### PR TITLE
Fix Http/2 example response timeout

### DIFF
--- a/example/src/main/java/io/netty/example/http2/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/server/HelloWorldHttp2Handler.java
@@ -120,6 +120,7 @@ public class HelloWorldHttp2Handler extends Http2ConnectionHandler {
             Http2Headers headers = new DefaultHttp2Headers().status(new AsciiString("200"));
             frameWriter.writeHeaders(ctx, streamId, headers, 0, false, ctx.newPromise());
             frameWriter.writeData(ctx, streamId, payload, 0, true, ctx.newPromise());
+            ctx.flush();
         }
     };
 }


### PR DESCRIPTION
Motivation:

The HTTP/2 example can timeout at the client waiting for a response due
to the server not flushing after writing the response.

Modifications:

Updated the server's HelloWorldHttp2Handler to flush after writing the
response.

Result:

The HTTP/2 example runs successfully.
