### PR TITLE
Fixing concurrency issue with HTTP/2 test mocking

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -79,8 +79,277 @@ public class Http2FrameRoundtripTest {
     @Before
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
+    }
 
-        serverLatch(new CountDownLatch(1));
+    @After
+    public void teardown() throws Exception {
+        serverChannel.close().sync();
+        Future<?> serverGroup = sb.group().shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
+        Future<?> serverChildGroup = sb.childGroup().shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
+        Future<?> clientGroup = cb.group().shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
+        serverGroup.sync();
+        serverChildGroup.sync();
+        clientGroup.sync();
+        serverAdapter = null;
+    }
+
+    @Test
+    public void dataFrameShouldMatch() throws Exception {
+        final String text = "hello world";
+        final ByteBuf data = Unpooled.copiedBuffer(text, UTF_8);
+        final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<String>());
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock in) throws Throwable {
+                receivedBuffers.add(((ByteBuf) in.getArguments()[2]).toString(UTF_8));
+                return null;
+            }
+        }).when(serverListener).onDataRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
+                any(ByteBuf.class), eq(100), eq(true));
+        try {
+            bootstrapEnv(1);
+            runInChannel(clientChannel, new Http2Runnable() {
+                @Override
+                public void run() {
+                    frameWriter.writeData(ctx(), 0x7FFFFFFF, data.slice().retain(), 100, true, newPromise());
+                    ctx().flush();
+                }
+            });
+            awaitRequests();
+            verify(serverListener).onDataRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
+                    any(ByteBuf.class), eq(100), eq(true));
+            assertEquals(1, receivedBuffers.size());
+            assertEquals(text, receivedBuffers.get(0));
+        } finally {
+            data.release();
+        }
+    }
+
+    @Test
+    public void headersFrameWithoutPriorityShouldMatch() throws Exception {
+        final Http2Headers headers = headers();
+        bootstrapEnv(1);
+        runInChannel(clientChannel, new Http2Runnable() {
+            @Override
+            public void run() {
+                frameWriter.writeHeaders(ctx(), 0x7FFFFFFF, headers, 0, true, newPromise());
+                ctx().flush();
+            }
+        });
+        awaitRequests();
+        verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
+                eq(headers), eq(0), eq(true));
+    }
+
+    @Test
+    public void headersFrameWithPriorityShouldMatch() throws Exception {
+        final Http2Headers headers = headers();
+        bootstrapEnv(1);
+        runInChannel(clientChannel, new Http2Runnable() {
+            @Override
+            public void run() {
+                frameWriter.writeHeaders(ctx(), 0x7FFFFFFF, headers, 4, (short) 255,
+                        true, 0, true, newPromise());
+                ctx().flush();
+            }
+        });
+        awaitRequests();
+        verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
+                eq(headers), eq(4), eq((short) 255), eq(true), eq(0), eq(true));
+    }
+
+    @Test
+    public void goAwayFrameShouldMatch() throws Exception {
+        final String text = "test";
+        final ByteBuf data = Unpooled.copiedBuffer(text.getBytes());
+        final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<String>());
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock in) throws Throwable {
+                receivedBuffers.add(((ByteBuf) in.getArguments()[3]).toString(UTF_8));
+                return null;
+            }
+        }).when(serverListener).onGoAwayRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
+                eq(0xFFFFFFFFL), eq(data));
+        bootstrapEnv(1);
+        try {
+            runInChannel(clientChannel, new Http2Runnable() {
+                @Override
+                public void run() {
+                    frameWriter.writeGoAway(ctx(), 0x7FFFFFFF, 0xFFFFFFFFL, data.retain(), newPromise());
+                    ctx().flush();
+                }
+            });
+            awaitRequests();
+            verify(serverListener).onGoAwayRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
+                    eq(0xFFFFFFFFL), any(ByteBuf.class));
+            assertEquals(1, receivedBuffers.size());
+            assertEquals(text, receivedBuffers.get(0));
+        } finally {
+            data.release();
+        }
+    }
+
+    @Test
+    public void pingFrameShouldMatch() throws Exception {
+        String text = "01234567";
+        final ByteBuf data = Unpooled.copiedBuffer(text, UTF_8);
+        final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<String>());
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock in) throws Throwable {
+                receivedBuffers.add(((ByteBuf) in.getArguments()[1]).toString(UTF_8));
+                return null;
+            }
+        }).when(serverListener).onPingAckRead(any(ChannelHandlerContext.class), eq(data));
+        try {
+            bootstrapEnv(1);
+            runInChannel(clientChannel, new Http2Runnable() {
+                @Override
+                public void run() {
+                    frameWriter.writePing(ctx(), true, data.retain(), newPromise());
+                    ctx().flush();
+                }
+            });
+            awaitRequests();
+            verify(serverListener).onPingAckRead(any(ChannelHandlerContext.class), any(ByteBuf.class));
+            assertEquals(1, receivedBuffers.size());
+            for (String receivedData : receivedBuffers) {
+                assertEquals(text, receivedData);
+            }
+        } finally {
+            data.release();
+        }
+    }
+
+    @Test
+    public void priorityFrameShouldMatch() throws Exception {
+        bootstrapEnv(1);
+        runInChannel(clientChannel, new Http2Runnable() {
+            @Override
+            public void run() {
+                frameWriter.writePriority(ctx(), 0x7FFFFFFF, 1, (short) 1, true, newPromise());
+                ctx().flush();
+            }
+        });
+        awaitRequests();
+        verify(serverListener).onPriorityRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
+                eq(1), eq((short) 1), eq(true));
+    }
+
+    @Test
+    public void pushPromiseFrameShouldMatch() throws Exception {
+        final Http2Headers headers = headers();
+        bootstrapEnv(1);
+        runInChannel(clientChannel, new Http2Runnable() {
+            @Override
+            public void run() {
+                frameWriter.writePushPromise(ctx(), 0x7FFFFFFF, 1, headers, 5, newPromise());
+                ctx().flush();
+            }
+        });
+        awaitRequests();
+        verify(serverListener).onPushPromiseRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
+                eq(1), eq(headers), eq(5));
+    }
+
+    @Test
+    public void rstStreamFrameShouldMatch() throws Exception {
+        bootstrapEnv(1);
+        runInChannel(clientChannel, new Http2Runnable() {
+            @Override
+            public void run() {
+                frameWriter.writeRstStream(ctx(), 0x7FFFFFFF, 0xFFFFFFFFL, newPromise());
+                ctx().flush();
+            }
+        });
+        awaitRequests();
+        verify(serverListener).onRstStreamRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
+                eq(0xFFFFFFFFL));
+    }
+
+    @Test
+    public void settingsFrameShouldMatch() throws Exception {
+        bootstrapEnv(1);
+        final Http2Settings settings = new Http2Settings();
+        settings.initialWindowSize(10);
+        settings.maxConcurrentStreams(1000);
+        settings.headerTableSize(4096);
+        runInChannel(clientChannel, new Http2Runnable() {
+            @Override
+            public void run() {
+                frameWriter.writeSettings(ctx(), settings, newPromise());
+                ctx().flush();
+            }
+        });
+        awaitRequests();
+        verify(serverListener).onSettingsRead(any(ChannelHandlerContext.class), eq(settings));
+    }
+
+    @Test
+    public void windowUpdateFrameShouldMatch() throws Exception {
+        bootstrapEnv(1);
+        runInChannel(clientChannel, new Http2Runnable() {
+            @Override
+            public void run() {
+                frameWriter.writeWindowUpdate(ctx(), 0x7FFFFFFF, 0x7FFFFFFF, newPromise());
+                ctx().flush();
+            }
+        });
+        awaitRequests();
+        verify(serverListener).onWindowUpdateRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
+                eq(0x7FFFFFFF));
+    }
+
+    @Test
+    public void stressTest() throws Exception {
+        final Http2Headers headers = headers();
+        final String text = "hello world";
+        final ByteBuf data = Unpooled.copiedBuffer(text.getBytes());
+        final int numStreams = 10000;
+        final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<String>(numStreams));
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock in) throws Throwable {
+                receivedBuffers.add(((ByteBuf) in.getArguments()[2]).toString(UTF_8));
+                return null;
+            }
+        }).when(serverListener).onDataRead(any(ChannelHandlerContext.class), anyInt(), eq(data), eq(0), eq(true));
+        try {
+            final int expectedFrames = numStreams * 2;
+            bootstrapEnv(expectedFrames);
+            runInChannel(clientChannel, new Http2Runnable() {
+                @Override
+                public void run() {
+                    for (int i = 1; i < numStreams + 1; ++i) {
+                        frameWriter.writeHeaders(ctx(), i, headers, 0, (short) 16, false, 0, false, newPromise());
+                        frameWriter.writeData(ctx(), i, data.retain(), 0, true, newPromise());
+                        ctx().flush();
+                    }
+                }
+            });
+            awaitRequests(30);
+            verify(serverListener, times(numStreams)).onDataRead(any(ChannelHandlerContext.class), anyInt(),
+                    any(ByteBuf.class), eq(0), eq(true));
+            assertEquals(numStreams, receivedBuffers.size());
+            for (String receivedData : receivedBuffers) {
+                assertEquals(text, receivedData);
+            }
+        } finally {
+            data.release();
+        }
+    }
+
+    private void awaitRequests(long seconds) throws InterruptedException {
+        assertTrue(requestLatch.await(seconds, SECONDS));
+    }
+
+    private void awaitRequests() throws InterruptedException {
+        awaitRequests(5);
+    }
+
+    private void bootstrapEnv(int requestCountDown) throws Exception {
+        requestLatch = new CountDownLatch(requestCountDown);
         frameWriter = new DefaultHttp2FrameWriter();
 
         sb = new ServerBootstrap();
@@ -115,270 +384,6 @@ public class Http2FrameRoundtripTest {
         ChannelFuture ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
         assertTrue(ccf.awaitUninterruptibly().isSuccess());
         clientChannel = ccf.channel();
-    }
-
-    @After
-    public void teardown() throws Exception {
-        serverChannel.close().sync();
-        Future<?> serverGroup = sb.group().shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
-        Future<?> serverChildGroup = sb.childGroup().shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
-        Future<?> clientGroup = cb.group().shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
-        serverGroup.sync();
-        serverChildGroup.sync();
-        clientGroup.sync();
-        serverAdapter = null;
-    }
-
-    @Test
-    public void dataFrameShouldMatch() throws Exception {
-        final String text = "hello world";
-        final ByteBuf data = Unpooled.copiedBuffer(text, UTF_8);
-        final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<String>());
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock in) throws Throwable {
-                receivedBuffers.add(((ByteBuf) in.getArguments()[2]).toString(UTF_8));
-                return null;
-            }
-        }).when(serverListener).onDataRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
-                any(ByteBuf.class), eq(100), eq(true));
-        try {
-            runInChannel(clientChannel, new Http2Runnable() {
-                @Override
-                public void run() {
-                    frameWriter.writeData(ctx(), 0x7FFFFFFF, data.slice().retain(), 100, true, newPromise());
-                    ctx().flush();
-                }
-            });
-            awaitRequests();
-            verify(serverListener).onDataRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
-                    any(ByteBuf.class), eq(100), eq(true));
-            assertEquals(1, receivedBuffers.size());
-            assertEquals(text, receivedBuffers.get(0));
-        } finally {
-            data.release();
-        }
-    }
-
-    @Test
-    public void headersFrameWithoutPriorityShouldMatch() throws Exception {
-        final Http2Headers headers = headers();
-        runInChannel(clientChannel, new Http2Runnable() {
-            @Override
-            public void run() {
-                frameWriter.writeHeaders(ctx(), 0x7FFFFFFF, headers, 0, true, newPromise());
-                ctx().flush();
-            }
-        });
-        awaitRequests();
-        verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
-                eq(headers), eq(0), eq(true));
-    }
-
-    @Test
-    public void headersFrameWithPriorityShouldMatch() throws Exception {
-        final Http2Headers headers = headers();
-        runInChannel(clientChannel, new Http2Runnable() {
-            @Override
-            public void run() {
-                frameWriter.writeHeaders(ctx(), 0x7FFFFFFF, headers, 4, (short) 255,
-                        true, 0, true, newPromise());
-                ctx().flush();
-            }
-        });
-        awaitRequests();
-        verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
-                eq(headers), eq(4), eq((short) 255), eq(true), eq(0), eq(true));
-    }
-
-    @Test
-    public void goAwayFrameShouldMatch() throws Exception {
-        final String text = "test";
-        final ByteBuf data = Unpooled.copiedBuffer(text.getBytes());
-        final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<String>());
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock in) throws Throwable {
-                receivedBuffers.add(((ByteBuf) in.getArguments()[3]).toString(UTF_8));
-                return null;
-            }
-        }).when(serverListener).onGoAwayRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
-                eq(0xFFFFFFFFL), eq(data));
-        try {
-            runInChannel(clientChannel, new Http2Runnable() {
-                @Override
-                public void run() {
-                    frameWriter.writeGoAway(ctx(), 0x7FFFFFFF, 0xFFFFFFFFL, data.retain(), newPromise());
-                    ctx().flush();
-                }
-            });
-            awaitRequests();
-            verify(serverListener).onGoAwayRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
-                    eq(0xFFFFFFFFL), any(ByteBuf.class));
-            assertEquals(1, receivedBuffers.size());
-            assertEquals(text, receivedBuffers.get(0));
-        } finally {
-            data.release();
-        }
-    }
-
-    @Test
-    public void pingFrameShouldMatch() throws Exception {
-        String text = "01234567";
-        final ByteBuf data = Unpooled.copiedBuffer(text, UTF_8);
-        final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<String>());
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock in) throws Throwable {
-                receivedBuffers.add(((ByteBuf) in.getArguments()[1]).toString(UTF_8));
-                return null;
-            }
-        }).when(serverListener).onPingAckRead(any(ChannelHandlerContext.class), eq(data));
-        try {
-            runInChannel(clientChannel, new Http2Runnable() {
-                @Override
-                public void run() {
-                    frameWriter.writePing(ctx(), true, data.retain(), newPromise());
-                    ctx().flush();
-                }
-            });
-            awaitRequests();
-            verify(serverListener).onPingAckRead(any(ChannelHandlerContext.class), any(ByteBuf.class));
-            assertEquals(1, receivedBuffers.size());
-            for (String receivedData : receivedBuffers) {
-                assertEquals(text, receivedData);
-            }
-        } finally {
-            data.release();
-        }
-    }
-
-    @Test
-    public void priorityFrameShouldMatch() throws Exception {
-        runInChannel(clientChannel, new Http2Runnable() {
-            @Override
-            public void run() {
-                frameWriter.writePriority(ctx(), 0x7FFFFFFF, 1, (short) 1, true, newPromise());
-                ctx().flush();
-            }
-        });
-        awaitRequests();
-        verify(serverListener).onPriorityRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
-                eq(1), eq((short) 1), eq(true));
-    }
-
-    @Test
-    public void pushPromiseFrameShouldMatch() throws Exception {
-        final Http2Headers headers = headers();
-        runInChannel(clientChannel, new Http2Runnable() {
-            @Override
-            public void run() {
-                frameWriter.writePushPromise(ctx(), 0x7FFFFFFF, 1, headers, 5, newPromise());
-                ctx().flush();
-            }
-        });
-        awaitRequests();
-        verify(serverListener).onPushPromiseRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
-                eq(1), eq(headers), eq(5));
-    }
-
-    @Test
-    public void rstStreamFrameShouldMatch() throws Exception {
-        runInChannel(clientChannel, new Http2Runnable() {
-            @Override
-            public void run() {
-                frameWriter.writeRstStream(ctx(), 0x7FFFFFFF, 0xFFFFFFFFL, newPromise());
-                ctx().flush();
-            }
-        });
-        awaitRequests();
-        verify(serverListener).onRstStreamRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
-                eq(0xFFFFFFFFL));
-    }
-
-    @Test
-    public void settingsFrameShouldMatch() throws Exception {
-        final Http2Settings settings = new Http2Settings();
-        settings.initialWindowSize(10);
-        settings.maxConcurrentStreams(1000);
-        settings.headerTableSize(4096);
-        runInChannel(clientChannel, new Http2Runnable() {
-            @Override
-            public void run() {
-                frameWriter.writeSettings(ctx(), settings, newPromise());
-                ctx().flush();
-            }
-        });
-        awaitRequests();
-        verify(serverListener).onSettingsRead(any(ChannelHandlerContext.class), eq(settings));
-    }
-
-    @Test
-    public void windowUpdateFrameShouldMatch() throws Exception {
-        runInChannel(clientChannel, new Http2Runnable() {
-            @Override
-            public void run() {
-                frameWriter.writeWindowUpdate(ctx(), 0x7FFFFFFF, 0x7FFFFFFF, newPromise());
-                ctx().flush();
-            }
-        });
-        awaitRequests();
-        verify(serverListener).onWindowUpdateRead(any(ChannelHandlerContext.class), eq(0x7FFFFFFF),
-                eq(0x7FFFFFFF));
-    }
-
-    @Test
-    public void stressTest() throws Exception {
-        final Http2Headers headers = headers();
-        final String text = "hello world";
-        final ByteBuf data = Unpooled.copiedBuffer(text.getBytes());
-        final int numStreams = 10000;
-        final List<String> receivedBuffers = Collections.synchronizedList(new ArrayList<String>(numStreams));
-        doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock in) throws Throwable {
-                receivedBuffers.add(((ByteBuf) in.getArguments()[2]).toString(UTF_8));
-                return null;
-            }
-        }).when(serverListener).onDataRead(any(ChannelHandlerContext.class), anyInt(), eq(data), eq(0), eq(true));
-        try {
-            final int expectedFrames = numStreams * 2;
-            serverLatch(new CountDownLatch(expectedFrames));
-            runInChannel(clientChannel, new Http2Runnable() {
-                @Override
-                public void run() {
-                    for (int i = 1; i < numStreams + 1; ++i) {
-                        frameWriter.writeHeaders(ctx(), i, headers, 0, (short) 16, false, 0, false, newPromise());
-                        frameWriter.writeData(ctx(), i, data.retain(), 0, true, newPromise());
-                        ctx().flush();
-                    }
-                }
-            });
-            awaitRequests(30);
-            verify(serverListener, times(numStreams)).onDataRead(any(ChannelHandlerContext.class), anyInt(),
-                    any(ByteBuf.class), eq(0), eq(true));
-            assertEquals(numStreams, receivedBuffers.size());
-            for (String receivedData : receivedBuffers) {
-                assertEquals(text, receivedData);
-            }
-        } finally {
-            data.release();
-        }
-    }
-
-    private void awaitRequests(long seconds) throws InterruptedException {
-        assertTrue(requestLatch.await(seconds, SECONDS));
-    }
-
-    private void awaitRequests() throws InterruptedException {
-        awaitRequests(5);
-    }
-
-    private void serverLatch(CountDownLatch latch) {
-        requestLatch = latch;
-        if (serverAdapter != null) {
-            serverAdapter.latch(latch);
-        }
     }
 
     private ChannelHandlerContext ctx() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -88,7 +88,7 @@ final class Http2TestUtil {
         private final Http2Connection connection;
         private final Http2FrameListener listener;
         private final DefaultHttp2FrameReader reader;
-        private volatile CountDownLatch latch;
+        private final CountDownLatch latch;
 
         FrameAdapter(Http2FrameListener listener, CountDownLatch latch) {
             this(null, listener, latch);
@@ -103,10 +103,6 @@ final class Http2TestUtil {
             this.connection = connection;
             this.listener = listener;
             this.reader = reader;
-            latch(latch);
-        }
-
-        public void latch(CountDownLatch latch) {
             this.latch = latch;
         }
 
@@ -264,8 +260,8 @@ final class Http2TestUtil {
      */
     static class FrameCountDown implements Http2FrameListener {
         private final Http2FrameListener listener;
-        private volatile CountDownLatch messageLatch;
-        private volatile CountDownLatch dataLatch;
+        private final CountDownLatch messageLatch;
+        private final CountDownLatch dataLatch;
 
         public FrameCountDown(Http2FrameListener listener, CountDownLatch messageLatch) {
             this(listener, messageLatch, null);
@@ -275,14 +271,6 @@ final class Http2TestUtil {
             this.listener = listener;
             this.messageLatch = messageLatch;
             this.dataLatch = dataLatch;
-        }
-
-        public void messageLatch(CountDownLatch latch) {
-            messageLatch = latch;
-        }
-
-        public void dataLatch(CountDownLatch latch) {
-            dataLatch = latch;
         }
 
         @Override


### PR DESCRIPTION
Motivation:

Some tests occasionally appear unstable, throwing a
org.mockito.exceptions.misusing.UnfinishedStubbingException. Mockito
stubbing does not work properly in multi-threaded environments, so any
stubbing has to be done before the threads are started.

Modifications:

Modified tests to perform any custom stubbing before the client/server
bootstrap logic executes.

Result:

HTTP/2 tests should be more stable.
