### PR TITLE
Proposal to change the TrafficShapingHandlers for V3.9

### DIFF
--- a/src/main/java/org/jboss/netty/example/traffic/ChannelTrafficShapingHandlerWithLog.java
+++ b/src/main/java/org/jboss/netty/example/traffic/ChannelTrafficShapingHandlerWithLog.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.netty.example.traffic;
+
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.handler.traffic.ChannelTrafficShapingHandler;
+import org.jboss.netty.handler.traffic.TrafficCounter;
+import org.jboss.netty.logging.InternalLogger;
+import org.jboss.netty.logging.InternalLoggerFactory;
+import org.jboss.netty.util.ObjectSizeEstimator;
+import org.jboss.netty.util.Timer;
+
+public class ChannelTrafficShapingHandlerWithLog extends ChannelTrafficShapingHandler {
+    private static final InternalLogger logger =
+            InternalLoggerFactory.getInstance(ChannelTrafficShapingHandlerWithLog.class);
+
+    public ChannelTrafficShapingHandlerWithLog(Timer timer, long writeLimit, long readLimit,
+            long checkInterval) {
+        super(timer, writeLimit, readLimit, checkInterval);
+    }
+
+    public ChannelTrafficShapingHandlerWithLog(Timer timer, long writeLimit, long readLimit,
+            long checkInterval, long maxTime) {
+        super(timer, writeLimit, readLimit, checkInterval, maxTime);
+    }
+
+    public ChannelTrafficShapingHandlerWithLog(Timer timer, long writeLimit, long readLimit) {
+        super(timer, writeLimit, readLimit);
+    }
+
+    public ChannelTrafficShapingHandlerWithLog(Timer timer, long checkInterval) {
+        super(timer, checkInterval);
+    }
+
+    public ChannelTrafficShapingHandlerWithLog(Timer timer) {
+        super(timer);
+    }
+
+    public ChannelTrafficShapingHandlerWithLog(ObjectSizeEstimator objectSizeEstimator,
+            Timer timer, long writeLimit, long readLimit, long checkInterval) {
+        super(objectSizeEstimator, timer, writeLimit, readLimit, checkInterval);
+    }
+
+    public ChannelTrafficShapingHandlerWithLog(ObjectSizeEstimator objectSizeEstimator,
+            Timer timer, long writeLimit, long readLimit, long checkInterval, long maxTime) {
+        super(objectSizeEstimator, timer, writeLimit, readLimit, checkInterval, maxTime);
+    }
+
+    public ChannelTrafficShapingHandlerWithLog(ObjectSizeEstimator objectSizeEstimator,
+            Timer timer, long writeLimit, long readLimit) {
+        super(objectSizeEstimator, timer, writeLimit, readLimit);
+    }
+
+    public ChannelTrafficShapingHandlerWithLog(ObjectSizeEstimator objectSizeEstimator,
+            Timer timer, long checkInterval) {
+        super(objectSizeEstimator, timer, checkInterval);
+    }
+
+    public ChannelTrafficShapingHandlerWithLog(ObjectSizeEstimator objectSizeEstimator, Timer timer) {
+        super(objectSizeEstimator, timer);
+    }
+
+    @Override
+    protected void doAccounting(TrafficCounter counter) {
+        logger.warn(this.toString() + " QueueSize: " + queueSize());
+        super.doAccounting(counter);
+    }
+
+    @Override
+    protected long calculateSize(Object obj) {
+        if (obj instanceof ChannelBuffer) {
+            return ((ChannelBuffer) obj).readableBytes();
+        }
+        return super.calculateSize(obj);
+    }
+
+}

--- a/src/main/java/org/jboss/netty/example/traffic/GlobalTrafficShapingHandlerWithLog.java
+++ b/src/main/java/org/jboss/netty/example/traffic/GlobalTrafficShapingHandlerWithLog.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.netty.example.traffic;
+
+
+import org.jboss.netty.handler.traffic.GlobalTrafficShapingHandler;
+import org.jboss.netty.handler.traffic.TrafficCounter;
+import org.jboss.netty.logging.InternalLogger;
+import org.jboss.netty.logging.InternalLoggerFactory;
+import org.jboss.netty.util.ObjectSizeEstimator;
+import org.jboss.netty.util.Timer;
+
+public class GlobalTrafficShapingHandlerWithLog extends GlobalTrafficShapingHandler {
+    private static final InternalLogger logger =
+            InternalLoggerFactory.getInstance(GlobalTrafficShapingHandlerWithLog.class);
+
+    public GlobalTrafficShapingHandlerWithLog(Timer timer, long writeLimit, long readLimit,
+            long checkInterval) {
+        super(timer, writeLimit, readLimit, checkInterval);
+    }
+
+    public GlobalTrafficShapingHandlerWithLog(Timer timer, long writeLimit, long readLimit,
+            long checkInterval, long maxTime) {
+        super(timer, writeLimit, readLimit, checkInterval, maxTime);
+    }
+
+    public GlobalTrafficShapingHandlerWithLog(Timer timer, long writeLimit, long readLimit) {
+        super(timer, writeLimit, readLimit);
+    }
+
+    public GlobalTrafficShapingHandlerWithLog(Timer timer, long checkInterval) {
+        super(timer, checkInterval);
+    }
+
+    public GlobalTrafficShapingHandlerWithLog(Timer timer) {
+        super(timer);
+    }
+
+    public GlobalTrafficShapingHandlerWithLog(ObjectSizeEstimator objectSizeEstimator, Timer timer,
+            long writeLimit, long readLimit, long checkInterval) {
+        super(objectSizeEstimator, timer, writeLimit, readLimit, checkInterval);
+    }
+
+    public GlobalTrafficShapingHandlerWithLog(ObjectSizeEstimator objectSizeEstimator, Timer timer,
+            long writeLimit, long readLimit, long checkInterval, long maxTime) {
+        super(objectSizeEstimator, timer, writeLimit, readLimit, checkInterval, maxTime);
+    }
+
+    public GlobalTrafficShapingHandlerWithLog(ObjectSizeEstimator objectSizeEstimator, Timer timer,
+            long writeLimit, long readLimit) {
+        super(objectSizeEstimator, timer, writeLimit, readLimit);
+    }
+
+    public GlobalTrafficShapingHandlerWithLog(ObjectSizeEstimator objectSizeEstimator, Timer timer,
+            long checkInterval) {
+        super(objectSizeEstimator, timer, checkInterval);
+    }
+
+    public GlobalTrafficShapingHandlerWithLog(ObjectSizeEstimator objectSizeEstimator, Timer timer) {
+        super(objectSizeEstimator, timer);
+    }
+
+    @Override
+    protected void doAccounting(TrafficCounter counter) {
+        logger.warn(this.toString() + " QueuesSize: " + queuesSize());
+        super.doAccounting(counter);
+    }
+
+}

--- a/src/main/java/org/jboss/netty/example/traffic/HttpStaticFileServerTrafficShaping.java
+++ b/src/main/java/org/jboss/netty/example/traffic/HttpStaticFileServerTrafficShaping.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.netty.example.traffic;
+
+import org.jboss.netty.bootstrap.ServerBootstrap;
+import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
+import org.jboss.netty.handler.execution.ExecutionHandler;
+import org.jboss.netty.handler.execution.OrderedMemoryAwareThreadPoolExecutor;
+import org.jboss.netty.handler.ssl.SslContext;
+import org.jboss.netty.handler.ssl.util.SelfSignedCertificate;
+import org.jboss.netty.util.HashedWheelTimer;
+import org.jboss.netty.util.Timer;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.Executors;
+/**
+ * Example for TrafficShaping: in the handler, several methods are implemented to show different
+ * variants on handling the write buffer, and then the memory consumption, in order to prevent
+ * Out Of Memory exception. You can try them by switching the modeTransfer to the desired value.
+ *<br><br>
+ * You can also change the behavior of the handler (long time task using simulLongTask) and adding
+ * a GlobalTransferShapingHandler (by default, only the ChannelTrafficShapingHandler is added).
+ *<br><br>
+ * useFutureListener = true
+ *     => best choice: 1 block at a time in memory, but lot of object creations (GenericFutureListener)<br>
+ * useSetFutureListener = true
+ *     => best choice: similar to useFutureListener by set of blocks<br>
+ * useCheckWritability = true
+ *     => second best choice: limited blocks in memory, but depending on application speed:
+ *     too quick could fill up the buffers, else will be fine<br>
+ * useChunkFile = true
+ *     => not recommended since will create all blocks in memory without taking into account contention<br>
+ * useDefault = true
+ *     => not recommended since will create all blocks in memory without taking into account contention<br>
+ *
+ * simulLongTask = true
+ *     => to show that it could impact object memory in useCheckWriteServerTrafficShaping mode<br>
+ * useGlobalTSH = true
+ *     => to show that individual speeds are divided by the number of concurrent requests<br>
+ *
+ */
+public final class HttpStaticFileServerTrafficShaping {
+    public static enum ModeTransfer {
+        useFutureListener, useSetFutureListener,
+        useCheckWritability, useChunkedFile, useDefault
+    }
+    static ModeTransfer modeTransfer = ModeTransfer.useChunkedFile;
+    static boolean simulLongTask = true;
+    static boolean useGlobalTSH;
+
+    static final boolean SSL = System.getProperty("ssl") != null;
+    static final int PORT = Integer.parseInt(System.getProperty("port", SSL? "8443" : "8080"));
+    static GlobalTrafficShapingHandlerWithLog gtsh;
+    static Timer timer = new HashedWheelTimer();
+    static ExecutionHandler eh = new ExecutionHandler(new OrderedMemoryAwareThreadPoolExecutor(10, 0, 0));
+
+    public static void main(String[] args) throws Exception {
+        // Configure SSL.
+        final SslContext sslCtx;
+        if (SSL) {
+            SelfSignedCertificate ssc = new SelfSignedCertificate();
+            sslCtx = SslContext.newServerContext(ssc.certificate(), ssc.privateKey());
+        } else {
+            sslCtx = null;
+        }
+        if (useGlobalTSH) {
+            gtsh = new GlobalTrafficShapingHandlerWithLog(timer, 1024 * 1024, 1024 * 1024, 1000);
+        }
+        // Configure the server.
+        ServerBootstrap bootstrap = new ServerBootstrap(
+                new NioServerSocketChannelFactory(
+                        Executors.newCachedThreadPool(),
+                        Executors.newCachedThreadPool()));
+
+        // Set up the event pipeline factory.
+        bootstrap.setPipelineFactory(new HttpStaticFileServerTrafficShapingPipelineFactory(sslCtx));
+
+        // Bind and start to accept incoming connections.
+        bootstrap.bind(new InetSocketAddress(PORT));
+    }
+}

--- a/src/main/java/org/jboss/netty/example/traffic/HttpStaticFileServerTrafficShapingHandler.java
+++ b/src/main/java/org/jboss/netty/example/traffic/HttpStaticFileServerTrafficShapingHandler.java
@@ -1,0 +1,446 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.netty.example.traffic;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelFuture;
+import org.jboss.netty.channel.ChannelFutureListener;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.channel.ChannelState;
+import org.jboss.netty.channel.ChannelStateEvent;
+import org.jboss.netty.channel.ExceptionEvent;
+import org.jboss.netty.channel.MessageEvent;
+import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
+import org.jboss.netty.channel.SucceededChannelFuture;
+import org.jboss.netty.handler.codec.frame.TooLongFrameException;
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
+import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.stream.ChunkedFile;
+import org.jboss.netty.util.CharsetUtil;
+
+import javax.activation.MimetypesFileTypeMap;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.*;
+import static org.jboss.netty.handler.codec.http.HttpHeaders.*;
+import static org.jboss.netty.handler.codec.http.HttpMethod.*;
+import static org.jboss.netty.handler.codec.http.HttpResponseStatus.*;
+import static org.jboss.netty.handler.codec.http.HttpVersion.*;
+
+/**
+ * Based on HttpStaticFileServer example, which serves incoming HTTP requests
+ * to send their respective HTTP responses, it shows several ways to implement
+ * Traffic shaping using the TrafficShapingHandler.
+ *
+ */
+public class HttpStaticFileServerTrafficShapingHandler extends SimpleChannelUpstreamHandler {
+
+    static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz";
+    static final String HTTP_DATE_GMT_TIMEZONE = "GMT";
+    static final int HTTP_CACHE_SECONDS = 60;
+
+    protected volatile RandomAccessFile raf;
+    protected volatile HttpRequest request;
+    protected volatile long fileLength;
+
+    @Override
+    public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
+        request = (HttpRequest) e.getMessage();
+        if (request.getMethod() != GET) {
+            sendError(ctx, METHOD_NOT_ALLOWED);
+            return;
+        }
+
+        final String path = sanitizeUri(request.getUri());
+        if (path == null) {
+            sendError(ctx, FORBIDDEN);
+            return;
+        }
+
+        File file = new File(path);
+        if (file.isHidden() || !file.exists()) {
+            sendError(ctx, NOT_FOUND);
+            return;
+        }
+        if (!file.isFile()) {
+            sendError(ctx, FORBIDDEN);
+            return;
+        }
+
+        // Cache Validation
+        String ifModifiedSince = request.headers().get(IF_MODIFIED_SINCE);
+        if (ifModifiedSince != null && ifModifiedSince.length() != 0) {
+            SimpleDateFormat dateFormatter = new SimpleDateFormat(HTTP_DATE_FORMAT, Locale.US);
+            Date ifModifiedSinceDate = dateFormatter.parse(ifModifiedSince);
+
+            // Only compare up to the second because the datetime format we send to the client does
+            // not have milliseconds
+            long ifModifiedSinceDateSeconds = ifModifiedSinceDate.getTime() / 1000;
+            long fileLastModifiedSeconds = file.lastModified() / 1000;
+            if (ifModifiedSinceDateSeconds == fileLastModifiedSeconds) {
+                sendNotModified(ctx);
+                return;
+            }
+        }
+
+        try {
+            raf = new RandomAccessFile(file, "r");
+        } catch (FileNotFoundException fnfe) {
+            sendError(ctx, NOT_FOUND);
+            return;
+        }
+        fileLength = raf.length();
+
+        HttpResponse response = new DefaultHttpResponse(HTTP_1_1, OK);
+        setContentLength(response, fileLength);
+        setContentTypeHeader(response, file);
+        setDateAndCacheHeaders(response, file);
+        if (HttpHeaders.isKeepAlive(request)) {
+            response.headers().set(CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+        }
+
+        Channel ch = e.getChannel();
+
+        // Write the initial line and the header.
+        ch.write(response);
+
+        // Write the content.
+        doSend(ctx);
+    }
+
+    private synchronized void doSend(final ChannelHandlerContext ctx) throws Exception {
+        switch (HttpStaticFileServerTrafficShaping.modeTransfer) {
+            case useCheckWritability:
+                doSendCheckWritabilityChanged(ctx);
+                break;
+            case useChunkedFile:
+                doSendChunkedFile(ctx);
+                break;
+            case useDefault:
+                doSendSimple(ctx);
+                break;
+            case useFutureListener:
+                doSendFutureListener(ctx);
+                break;
+            case useSetFutureListener:
+                doSendFutureListenerSet(ctx);
+                break;
+            default:
+                doSendSimple(ctx);
+                break;
+        }
+    }
+
+    volatile ChannelFuture nextFuture;
+    /**
+     * Using explicit future listener on send to send one element while the next one is prepared.
+     *
+     * The advantage of this method is to only have one element in the buffer of the TrafficShapingHandler.
+     *
+     * @param ctx
+     * @throws Exception
+     */
+    private synchronized void doSendFutureListener(final ChannelHandlerContext ctx) throws Exception {
+        byte[] bytes = new byte[8192];
+        int read = raf.read(bytes);
+        ChannelFuture future = nextFuture;
+        if (read > 0) {
+            final ChannelBuffer buf = ChannelBuffers.copiedBuffer(bytes, 0, read);
+            if (future != null) {
+                future.addListener(new ChannelFutureListener() {
+                    @Override
+                    public void operationComplete(ChannelFuture future) throws Exception {
+                        nextFuture = future.getChannel().write(buf);
+                        if (HttpStaticFileServerTrafficShaping.simulLongTask) {
+                            Thread.sleep(5);
+                        }
+                        doSendFutureListener(ctx);
+                    }
+                });
+                return;
+            }
+            nextFuture = ctx.getChannel().write(buf);
+            doSendFutureListener(ctx);
+        } else {
+            raf.close();
+            raf = null;
+            if (future == null) {
+                future = new SucceededChannelFuture(ctx.getChannel());
+            }
+            finalizeSend(ctx, future);
+        }
+    }
+    /**
+     * Using explicit future listener on send to send one element while the next one is prepared.
+     *
+     * The advantage of this method is to only have one fix set of blocks in the buffer of the TrafficShapingHandler.
+     *
+     * @param ctx
+     * @throws Exception
+     */
+    private synchronized void doSendFutureListenerSet(final ChannelHandlerContext ctx) throws Exception {
+        byte[] bytes = new byte[8192];
+        int read = raf.read(bytes);
+        ChannelFuture future = null;
+        for (int i = 0; i < 9 && read > 0; i++) {
+            final ChannelBuffer buf = ChannelBuffers.copiedBuffer(bytes, 0, read);
+            future = ctx.getChannel().write(buf);
+            read = raf.read(bytes);
+        }
+        if (read > 0) {
+            final ChannelBuffer buf = ChannelBuffers.copiedBuffer(bytes, 0, read);
+            future = ctx.getChannel().write(buf);
+            future.addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture future) throws Exception {
+                    if (HttpStaticFileServerTrafficShaping.simulLongTask) {
+                        Thread.sleep(10);
+                    }
+                    doSendFutureListenerSet(ctx);
+                }
+            });
+            return;
+        }
+        if (read < 0) {
+            raf.close();
+            raf = null;
+            if (future == null) {
+                future = new SucceededChannelFuture(ctx.getChannel());
+            }
+            finalizeSend(ctx, future);
+        }
+    }
+    protected volatile boolean writable = true;
+    /**
+     * Using Channel.isWritable to check if the buffer is full or not.
+     * Use then the channelWritabilityChanged to restart the sending operation.
+     *
+     * @param ctx
+     * @throws Exception
+     */
+    private synchronized void doSendCheckWritabilityChanged(final ChannelHandlerContext ctx) throws Exception {
+        byte[] bytes = new byte[8192];
+        int read = raf.read(bytes);
+        ChannelFuture future = null;
+        while (read > 0) {
+            final ChannelBuffer buf = ChannelBuffers.copiedBuffer(bytes, 0, read);
+            future = ctx.getChannel().write(buf);
+            if (! ctx.getChannel().isWritable() || ! writable) {
+                writable = false;
+                return;
+            }
+            if (HttpStaticFileServerTrafficShaping.simulLongTask) {
+                Thread.sleep(5);
+            }
+            read = raf.read(bytes);
+        }
+        raf.close();
+        raf = null;
+        if (future == null) {
+            future = new SucceededChannelFuture(ctx.getChannel());
+        }
+        finalizeSend(ctx, future);
+    }
+
+    @Override
+    public synchronized void channelInterestChanged(ChannelHandlerContext ctx, ChannelStateEvent e)
+            throws Exception {
+        if (HttpStaticFileServerTrafficShaping.modeTransfer ==
+                HttpStaticFileServerTrafficShaping.ModeTransfer.useCheckWritability
+                && raf != null) {
+            if (e.getState() == ChannelState.INTEREST_OPS &&
+                    (((Integer) e.getValue()).intValue() & Channel.OP_WRITE) != 0) {
+                writable = false;
+            } else if (! writable) {
+                writable = true;
+                doSendCheckWritabilityChanged(ctx);
+            }
+        }
+        super.channelInterestChanged(ctx, e);
+    }
+
+    /**
+     * Simple send, using ChunkedFile
+     *
+     * @param ctx
+     * @throws Exception
+     */
+    private synchronized void doSendChunkedFile(final ChannelHandlerContext ctx) throws Exception {
+        // note: this is not compatible with traffic shaping, as for SSL
+        // ctx.write(new DefaultFileRegion(raf.getChannel(), 0, fileLength));
+        ChannelFuture writeFuture = ctx.getChannel().write(new ChunkedFile(raf, 0, fileLength, 8192));
+        raf = null;
+        finalizeSend(ctx, writeFuture);
+    }
+
+    /**
+     * Simple send, chunk by chunk by hand
+     *
+     * @param ctx
+     * @throws Exception
+     */
+    private synchronized void doSendSimple(final ChannelHandlerContext ctx) throws Exception {
+        byte[] bytes = new byte[8192];
+        int read = raf.read(bytes);
+        ChannelFuture future = null;
+        while (read > 0) {
+            final ChannelBuffer buf = ChannelBuffers.copiedBuffer(bytes, 0, read);
+            future = ctx.getChannel().write(buf);
+            if (HttpStaticFileServerTrafficShaping.simulLongTask) {
+                Thread.sleep(5);
+            }
+            read = raf.read(bytes);
+        }
+        raf.close();
+        raf = null;
+        if (future == null) {
+            future = new SucceededChannelFuture(ctx.getChannel());
+        }
+        finalizeSend(ctx, future);
+    }
+
+    private void finalizeSend(ChannelHandlerContext ctx, ChannelFuture lastContentFuture) throws IOException {
+        // Decide whether to close the connection or not.
+        if (!HttpHeaders.isKeepAlive(request)) {
+            // Close the connection when the whole content is written out.
+            lastContentFuture.addListener(ChannelFutureListener.CLOSE);
+        }
+        lastContentFuture.addListener(new ChannelFutureListener() {
+            public void operationComplete(ChannelFuture future) throws Exception {
+                System.err.println("Write finished");
+            }
+        });
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e) {
+        Channel ch = e.getChannel();
+        Throwable cause = e.getCause();
+        if (cause instanceof TooLongFrameException) {
+            sendError(ctx, BAD_REQUEST);
+            return;
+        }
+
+        cause.printStackTrace();
+        if (ch.isConnected()) {
+            sendError(ctx, INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private static String sanitizeUri(String uri) {
+        // Decode the path.
+        try {
+            uri = URLDecoder.decode(uri, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            try {
+                uri = URLDecoder.decode(uri, "ISO-8859-1");
+            } catch (UnsupportedEncodingException e1) {
+                throw new Error();
+            }
+        }
+
+        // Convert file separators.
+        uri = uri.replace('/', File.separatorChar);
+
+        // Simplistic dumb security check.
+        // You will have to do something serious in the production environment.
+        if (uri.contains(File.separator + '.') ||
+            uri.contains('.' + File.separator) ||
+            uri.startsWith(".") || uri.endsWith(".")) {
+            return null;
+        }
+
+        // Convert to absolute path.
+        return System.getProperty("user.dir") + File.separator + uri;
+    }
+
+    private static void sendError(ChannelHandlerContext ctx, HttpResponseStatus status) {
+        HttpResponse response = new DefaultHttpResponse(HTTP_1_1, status);
+        response.headers().set(CONTENT_TYPE, "text/plain; charset=UTF-8");
+        response.setContent(ChannelBuffers.copiedBuffer("Failure: " + status + "\r\n", CharsetUtil.UTF_8));
+
+        // Close the connection as soon as the error message is sent.
+        ctx.getChannel().write(response).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    /**
+     * When file timestamp is the same as what the browser is sending up, send a "304 Not Modified"
+     */
+    private static void sendNotModified(ChannelHandlerContext ctx) {
+        HttpResponse response = new DefaultHttpResponse(HTTP_1_1, NOT_MODIFIED);
+        setDateHeader(response);
+
+        // Close the connection as soon as the error message is sent.
+        ctx.getChannel().write(response).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    /**
+     * Sets the Date header for the HTTP response
+     */
+    private static void setDateHeader(HttpResponse response) {
+        SimpleDateFormat dateFormatter = new SimpleDateFormat(HTTP_DATE_FORMAT, Locale.US);
+        dateFormatter.setTimeZone(TimeZone.getTimeZone(HTTP_DATE_GMT_TIMEZONE));
+
+        Calendar time = new GregorianCalendar();
+        response.headers().set(DATE, dateFormatter.format(time.getTime()));
+    }
+
+    /**
+     * Sets the Date and Cache headers for the HTTP Response
+     *
+     * @param fileToCache the file to extract content type
+     */
+    private static void setDateAndCacheHeaders(HttpResponse response, File fileToCache) {
+        SimpleDateFormat dateFormatter = new SimpleDateFormat(HTTP_DATE_FORMAT, Locale.US);
+        dateFormatter.setTimeZone(TimeZone.getTimeZone(HTTP_DATE_GMT_TIMEZONE));
+
+        // Date header
+        Calendar time = new GregorianCalendar();
+        response.headers().set(DATE, dateFormatter.format(time.getTime()));
+
+        // Add cache headers
+        time.add(Calendar.SECOND, HTTP_CACHE_SECONDS);
+        response.headers().set(EXPIRES, dateFormatter.format(time.getTime()));
+        response.headers().set(CACHE_CONTROL, "private, max-age=" + HTTP_CACHE_SECONDS);
+        response.headers().set(LAST_MODIFIED, dateFormatter.format(new Date(fileToCache.lastModified())));
+    }
+
+    /**
+     * Sets the content type header for the HTTP Response
+     *
+     * @param file the file to extract content type
+     */
+    private static void setContentTypeHeader(HttpResponse response, File file) {
+        MimetypesFileTypeMap mimeTypesMap = new MimetypesFileTypeMap();
+        response.headers().set(CONTENT_TYPE, mimeTypesMap.getContentType(file.getPath()));
+    }
+}

--- a/src/main/java/org/jboss/netty/example/traffic/HttpStaticFileServerTrafficShapingPipelineFactory.java
+++ b/src/main/java/org/jboss/netty/example/traffic/HttpStaticFileServerTrafficShapingPipelineFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.netty.example.traffic;
+
+import org.jboss.netty.channel.ChannelPipeline;
+import org.jboss.netty.channel.ChannelPipelineFactory;
+import org.jboss.netty.example.traffic.HttpStaticFileServerTrafficShaping.ModeTransfer;
+import org.jboss.netty.handler.codec.http.HttpChunkAggregator;
+import org.jboss.netty.handler.codec.http.HttpRequestDecoder;
+import org.jboss.netty.handler.codec.http.HttpResponseEncoder;
+import org.jboss.netty.handler.ssl.SslContext;
+import org.jboss.netty.handler.stream.ChunkedWriteHandler;
+
+import static org.jboss.netty.channel.Channels.*;
+
+public class HttpStaticFileServerTrafficShapingPipelineFactory implements ChannelPipelineFactory {
+
+    private final SslContext sslCtx;
+
+    public HttpStaticFileServerTrafficShapingPipelineFactory(SslContext sslCtx) {
+        this.sslCtx = sslCtx;
+    }
+
+    public ChannelPipeline getPipeline() {
+        // Create a default pipeline implementation.
+        ChannelPipeline pipeline = pipeline();
+
+        if (sslCtx != null) {
+            pipeline.addLast("ssl", sslCtx.newHandler());
+        }
+        if (HttpStaticFileServerTrafficShaping.useGlobalTSH) {
+            pipeline.addLast("global", HttpStaticFileServerTrafficShaping.gtsh);
+        }
+        pipeline.addLast("channel", new ChannelTrafficShapingHandlerWithLog(
+                HttpStaticFileServerTrafficShaping.timer, 1024 * 1024, 1024 * 1024, 1000));
+        pipeline.addLast("Executor", HttpStaticFileServerTrafficShaping.eh);
+        pipeline.addLast("decoder", new HttpRequestDecoder());
+        pipeline.addLast("aggregator", new HttpChunkAggregator(65536));
+        pipeline.addLast("encoder", new HttpResponseEncoder());
+        if (HttpStaticFileServerTrafficShaping.modeTransfer == ModeTransfer.useChunkedFile) {
+            pipeline.addLast("chunkedWriter", new ChunkedWriteHandler());
+        }
+        pipeline.addLast("handler", new HttpStaticFileServerTrafficShapingHandler());
+        return pipeline;
+    }
+}

--- a/src/main/java/org/jboss/netty/handler/traffic/GlobalTrafficShapingHandler.java
+++ b/src/main/java/org/jboss/netty/handler/traffic/GlobalTrafficShapingHandler.java
@@ -20,6 +20,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.jboss.netty.channel.ChannelHandler.Sharable;
 import org.jboss.netty.channel.ChannelHandlerContext;
@@ -73,8 +74,24 @@ import org.jboss.netty.util.TimerTask;
  */
 @Sharable
 public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
-    private Map<Integer, List<ToSend>> messagesQueues = new HashMap<Integer, List<ToSend>>();
+    private Map<Integer, PerChannel> channelQueues = new HashMap<Integer, PerChannel>();
+    /**
+     * Global queues size
+     */
+    private long queuesSize;
+    /**
+     * Max size in the list before proposing to stop writing new objects from next handlers
+     * for all channel (global)
+     */
+    protected long maxGlobalWriteSize = DEFAULT_MAX_SIZE * 100; // default 400MB
 
+    private static class PerChannel {
+        List<ToSend> messagesQueue;
+        long queueSize;
+        long lastWrite;
+        long lastRead;
+        ReentrantLock channelLock;
+    }
     /**
      * Create the global TrafficCounter
      */
@@ -150,6 +167,41 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
         createGlobalTrafficCounter();
     }
 
+    /**
+     * @return the maxGlobalWriteSize
+     */
+    public long getMaxGlobalWriteSize() {
+        return maxGlobalWriteSize;
+    }
+
+    /**
+     * @param maxGlobalWriteSize the maximum Global Write Size allowed in the buffer
+     *            globally for all channels before write suspended is set
+     */
+    public void setMaxGlobalWriteSize(long maxGlobalWriteSize) {
+        this.maxGlobalWriteSize = maxGlobalWriteSize;
+    }
+
+    /**
+     * @return the global size of the buffers for all queues
+     */
+    public long queuesSize() {
+        return queuesSize;
+    }
+
+    private synchronized PerChannel getOrSetPerChannel(Integer key) {
+        PerChannel perChannel = channelQueues.get(key);
+        if (perChannel == null) {
+            perChannel = new PerChannel();
+            perChannel.messagesQueue = new LinkedList<ToSend>();
+            perChannel.queueSize = 0L;
+            perChannel.lastRead = System.currentTimeMillis();
+            perChannel.lastWrite = System.currentTimeMillis();
+            perChannel.channelLock = new ReentrantLock(true);
+            channelQueues.put(key, perChannel);
+        }
+        return perChannel;
+    }
     private static final class ToSend {
         final long date;
         final MessageEvent toSend;
@@ -161,44 +213,105 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
     }
 
     @Override
-    protected synchronized void submitWrite(final ChannelHandlerContext ctx, final MessageEvent evt, final long delay)
-            throws Exception {
-        Integer key = ctx.getChannel().getId();
-        List<ToSend> messagesQueue = messagesQueues.get(key);
-        if (delay == 0 && (messagesQueue == null || messagesQueue.isEmpty())) {
-            internalSubmitWrite(ctx, evt);
-            return;
-        }
-        if (timer == null) {
-            // Sleep since no executor
-            Thread.sleep(delay);
-            internalSubmitWrite(ctx, evt);
-            return;
-        }
-        if (messagesQueue == null) {
-            messagesQueue = new LinkedList<ToSend>();
-            messagesQueues.put(key, messagesQueue);
-        }
-        final ToSend newToSend = new ToSend(delay, evt);
-        messagesQueue.add(newToSend);
-        final List<ToSend> mqfinal = messagesQueue;
-        timer.newTimeout(new TimerTask() {
-            public void run(Timeout timeout) throws Exception {
-                sendAllValid(ctx, mqfinal);
+    protected long checkWaitReadTime(final ChannelHandlerContext ctx, long wait) {
+        Integer key = ctx.getChannel().hashCode();
+        PerChannel perChannel = channelQueues.get(key);
+        if (perChannel != null) {
+            if (wait > maxTime && System.currentTimeMillis() + wait - perChannel.lastRead > maxTime) {
+                wait = maxTime;
             }
-        }, delay + 1, TimeUnit.MILLISECONDS);
+        }
+        return wait;
+    }
+    @Override
+    protected void informReadOperation(final ChannelHandlerContext ctx) {
+        Integer key = ctx.getChannel().hashCode();
+        PerChannel perChannel = channelQueues.get(key);
+        if (perChannel != null) {
+            perChannel.lastRead = System.currentTimeMillis();
+        }
     }
 
-    private synchronized void sendAllValid(ChannelHandlerContext ctx, final List<ToSend> messagesQueue)
+    @Override
+    protected void submitWrite(final ChannelHandlerContext ctx, final MessageEvent evt,
+            final long size, final long writedelay)
             throws Exception {
-        while (!messagesQueue.isEmpty()) {
-            ToSend newToSend = messagesQueue.remove(0);
-            if (newToSend.date <= System.currentTimeMillis()) {
-                internalSubmitWrite(ctx, newToSend.toSend);
-            } else {
-                messagesQueue.add(0, newToSend);
-                break;
+        Integer key = ctx.getChannel().getId();
+        PerChannel perChannel = channelQueues.get(key);
+        if (perChannel == null) {
+            // in case write occurs before handlerAdded is raized for this handler
+            // imply a synchronized only if needed
+            perChannel = getOrSetPerChannel(key);
+        }
+        perChannel.channelLock.lock();
+        try {
+            if (writedelay == 0 && (perChannel == null || perChannel.messagesQueue == null ||
+                    perChannel.messagesQueue.isEmpty())) {
+                if (trafficCounter != null) {
+                    trafficCounter.bytesRealWriteFlowControl(size);
+                }
+                internalSubmitWrite(ctx, evt);
+                perChannel.lastWrite = System.currentTimeMillis();
+                return;
             }
+            long delay = writedelay;
+            if (delay > maxTime && System.currentTimeMillis() + delay - perChannel.lastWrite > maxTime) {
+                delay = maxTime;
+            }
+            if (timer == null) {
+                // Sleep since no executor
+                Thread.sleep(delay);
+                if (trafficCounter != null) {
+                    trafficCounter.bytesRealWriteFlowControl(size);
+                }
+                internalSubmitWrite(ctx, evt);
+                perChannel.lastWrite = System.currentTimeMillis();
+                return;
+            }
+            final ToSend newToSend = new ToSend(delay, evt);
+            perChannel.messagesQueue.add(newToSend);
+            perChannel.queueSize += size;
+            queuesSize += size;
+            checkWriteSuspend(ctx, delay, perChannel.queueSize);
+            if (queuesSize > maxGlobalWriteSize) {
+                setWritable(ctx, false);
+            }
+            final PerChannel forSchedule = perChannel;
+            timer.newTimeout(new TimerTask() {
+                public void run(Timeout timeout) throws Exception {
+                    sendAllValid(ctx, forSchedule);
+                }
+            }, delay, TimeUnit.MILLISECONDS);
+        } finally {
+            perChannel.channelLock.unlock();
+        }
+    }
+
+    private void sendAllValid(ChannelHandlerContext ctx, final PerChannel perChannel)
+            throws Exception {
+        perChannel.channelLock.lock();
+        try {
+            while (!perChannel.messagesQueue.isEmpty()) {
+                ToSend newToSend = perChannel.messagesQueue.remove(0);
+                if (newToSend.date <= System.currentTimeMillis()) {
+                    long size = calculateSize(newToSend.toSend.getMessage());
+                    if (trafficCounter != null) {
+                        trafficCounter.bytesRealWriteFlowControl(size);
+                    }
+                    perChannel.queueSize -= size;
+                    queuesSize -= size;
+                    internalSubmitWrite(ctx, newToSend.toSend);
+                    perChannel.lastWrite = System.currentTimeMillis();
+                } else {
+                    perChannel.messagesQueue.add(0, newToSend);
+                    break;
+                }
+            }
+            if (perChannel.messagesQueue.isEmpty()) {
+                releaseWriteSuspended(ctx);
+            }
+        } finally {
+            perChannel.channelLock.unlock();
         }
     }
 
@@ -206,8 +319,7 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
     public void channelConnected(ChannelHandlerContext ctx, ChannelStateEvent e)
             throws Exception {
         Integer key = ctx.getChannel().getId();
-        List<ToSend> messagesQueue = new LinkedList<ToSend>();
-        messagesQueues.put(key, messagesQueue);
+        getOrSetPerChannel(key);
         super.channelConnected(ctx, e);
     }
 
@@ -215,9 +327,17 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
     public void channelClosed(ChannelHandlerContext ctx, ChannelStateEvent e)
             throws Exception {
         Integer key = ctx.getChannel().hashCode();
-        List<ToSend> mq = messagesQueues.remove(key);
-        if (mq != null) {
-            mq.clear();
+        PerChannel perChannel = channelQueues.remove(key);
+        if (perChannel != null) {
+            perChannel.channelLock.lock();
+            try {
+                for (ToSend toSend : perChannel.messagesQueue) {
+                    queuesSize -= calculateSize(toSend.toSend.getMessage());
+                }
+                perChannel.messagesQueue.clear();
+            } finally {
+                perChannel.channelLock.unlock();
+            }
         }
         super.channelClosed(ctx, e);
     }

--- a/src/main/java/org/jboss/netty/handler/traffic/TrafficCounter.java
+++ b/src/main/java/org/jboss/netty/handler/traffic/TrafficCounter.java
@@ -48,6 +48,16 @@ public class TrafficCounter {
     private final AtomicLong currentReadBytes = new AtomicLong();
 
     /**
+     * Last writing time during current check interval
+     */
+    private long writingTime = System.currentTimeMillis();
+
+    /**
+     * Last reading delay during current check interval
+     */
+    private long readingTime = System.currentTimeMillis();
+
+    /**
      * Long life written bytes
      */
     private final AtomicLong cumulativeWrittenBytes = new AtomicLong();
@@ -88,24 +98,24 @@ public class TrafficCounter {
     private long lastReadBytes;
 
     /**
-     * Last non 0 written bytes number during last check interval
+     * Last future writing time during last check interval
      */
-    private long lastNonNullWrittenBytes;
+    private long lastWritingTime = System.currentTimeMillis();
 
     /**
-     * Last time written bytes with non 0 written bytes
+     * Last reading time during last check interval
      */
-    private long lastNonNullWrittenTime;
+    private long lastReadingTime = System.currentTimeMillis();
 
     /**
-     * Last time read bytes with non 0 written bytes
+     * Real written bytes
      */
-    private long lastNonNullReadTime;
+    private final AtomicLong realWrittenBytes = new AtomicLong();
 
     /**
-     * Last non 0 read bytes number during last check interval
+     * Real writing bandwidth
      */
-    private long lastNonNullReadBytes;
+    private long realWriteThroughput;
 
     /**
      * Delay between two captures
@@ -232,14 +242,9 @@ public class TrafficCounter {
             // nb byte / checkInterval in ms * 1000 (1s)
             lastWriteThroughput = lastWrittenBytes * 1000 / interval;
             // nb byte / checkInterval in ms * 1000 (1s)
-        }
-        if (lastWrittenBytes > 0) {
-            lastNonNullWrittenBytes = lastWrittenBytes;
-            lastNonNullWrittenTime = newLastTime;
-        }
-        if (lastReadBytes > 0) {
-            lastNonNullReadBytes = lastReadBytes;
-            lastNonNullReadTime = newLastTime;
+            realWriteThroughput = realWrittenBytes.getAndSet(0) * 1000 / interval;
+            lastWritingTime = Math.max(lastWritingTime, writingTime);
+            lastReadingTime = Math.max(lastReadingTime, readingTime);
         }
     }
 
@@ -302,6 +307,18 @@ public class TrafficCounter {
     void bytesWriteFlowControl(long write) {
         currentWrittenBytes.addAndGet(write);
         cumulativeWrittenBytes.addAndGet(write);
+    }
+
+    /**
+     * Computes counters for Real Write.
+     *
+     * @param write
+     *            the size in bytes to write
+     * @param schedule
+     *            the time when this write was scheduled
+     */
+    void bytesRealWriteFlowControl(long write) {
+        realWrittenBytes.addAndGet(write);
     }
 
     /**
@@ -391,6 +408,20 @@ public class TrafficCounter {
     }
 
     /**
+     * @return the realWrittenBytes
+     */
+    public AtomicLong getRealWrittenBytes() {
+        return realWrittenBytes;
+    }
+
+    /**
+     * @return the realWriteThroughput
+     */
+    public long getRealWriteThroughput() {
+        return realWriteThroughput;
+    }
+
+    /**
      * Reset both read and written cumulative bytes counters and the associated time.
      */
     public void resetCumulativeTime() {
@@ -411,48 +442,47 @@ public class TrafficCounter {
      *            the max time in ms to wait in case of excess of traffic
      * @return the current time to wait (in ms) if needed for Read operation
      */
-    public synchronized long readTimeToWait(final long size, final long limitTraffic, final long maxTime) {
+    public long readTimeToWait(final long size, final long limitTraffic, final long maxTime) {
         final long now = System.currentTimeMillis();
         bytesRecvFlowControl(size);
-        if (limitTraffic == 0) {
+        if (size == 0 || limitTraffic == 0) {
             return 0;
         }
+        final long lastTimeCheck = lastTime.get();
+        final long interval = now - lastTimeCheck;
+        long pastDelay = Math.max(lastReadingTime - lastTimeCheck, 0);
         long sum = currentReadBytes.get();
-        long interval = now - lastTime.get();
-        // Short time checking
-        if (interval > AbstractTrafficShapingHandler.MINIMAL_WAIT && sum > 0) {
-            long time = (sum * 1000 / limitTraffic - interval) / 10 * 10;
+        if (interval > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
+            // Enough interval time to compute shaping
+            long time = (sum * 1000 / limitTraffic - interval + pastDelay) / 10 * 10;
             if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Time: " + time + ":" + sum + ":" + interval);
+                    logger.debug("Time: " + time + ":" + sum + ":" + interval + ":" + pastDelay);
                 }
-                return time > maxTime ? maxTime : time;
+                if (time > maxTime && now + time - readingTime > maxTime) {
+                    time = maxTime;
+                }
+                readingTime = Math.max(readingTime, now + time);
+                return time;
             }
+            readingTime = Math.max(readingTime, now);
             return 0;
         }
-        // long time checking
-        if (lastNonNullReadBytes > 0 && lastNonNullReadTime + AbstractTrafficShapingHandler.MINIMAL_WAIT < now) {
-            long lastsum = sum + lastNonNullReadBytes;
-            long lastinterval = now - lastNonNullReadTime;
-            long time = (lastsum * 1000 / limitTraffic - lastinterval) / 10 * 10;
-            if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Time: " + time + ":" + lastsum + ":" + lastinterval);
-                }
-                return time > maxTime ? maxTime : time;
+        // take the last read interval check to get enough interval time
+        long lastsum = sum + lastReadBytes;
+        long lastinterval = interval + checkInterval.get();
+        long time = (lastsum * 1000 / limitTraffic - lastinterval + pastDelay) / 10 * 10;
+        if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Time: " + time + ":" + lastsum + ":" + lastinterval + ":" + pastDelay);
             }
-        } else {
-            // final "middle" time checking in case resetAccounting called very recently
-            sum += lastReadBytes;
-            long lastinterval = AbstractTrafficShapingHandler.MINIMAL_WAIT;
-            long time = (sum * 1000 / limitTraffic - lastinterval) / 10 * 10;
-            if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Time: " + time + ":" + sum + ":" + lastinterval);
-                }
-                return time > maxTime ? maxTime : time;
+            if (time > maxTime && now + time - readingTime > maxTime) {
+                time = maxTime;
             }
+            readingTime = Math.max(readingTime, now + time);
+            return time;
         }
+        readingTime = Math.max(readingTime, now);
         return 0;
     }
 
@@ -468,45 +498,47 @@ public class TrafficCounter {
      *            the max time in ms to wait in case of excess of traffic
      * @return the current time to wait (in ms) if needed for Write operation
      */
-    public synchronized long writeTimeToWait(final long size, final long limitTraffic, final long maxTime) {
+    public long writeTimeToWait(final long size, final long limitTraffic, final long maxTime) {
         bytesWriteFlowControl(size);
-        if (limitTraffic == 0) {
+        if (size == 0 || limitTraffic == 0) {
             return 0;
         }
-        long sum = currentWrittenBytes.get();
         final long now = System.currentTimeMillis();
-        long interval = now - lastTime.get();
-        if (interval > AbstractTrafficShapingHandler.MINIMAL_WAIT && sum > 0) {
-            long time = (sum * 1000 / limitTraffic - interval) / 10 * 10;
+        final long lastTimeCheck = lastTime.get();
+        final long interval = now - lastTimeCheck;
+        long pastDelay = Math.max(lastWritingTime - lastTimeCheck, 0);
+        long sum = currentWrittenBytes.get();
+        if (interval > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
+            // Enough interval time to compute shaping
+            long time = (sum * 1000 / limitTraffic - interval + pastDelay) / 10 * 10;
             if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Time: " + time + ":" + sum + ":" + interval);
+                    logger.debug("Time: " + time + ":" + sum + ":" + interval + ":" + pastDelay);
                 }
-                return time > maxTime ? maxTime : time;
+                if (time > maxTime && now + time - writingTime > maxTime) {
+                    time = maxTime;
+                }
+                writingTime = Math.max(writingTime, now + time);
+                return time;
             }
+            writingTime = Math.max(writingTime, now);
             return 0;
         }
-        if (lastNonNullWrittenBytes > 0 && lastNonNullWrittenTime + AbstractTrafficShapingHandler.MINIMAL_WAIT < now) {
-            long lastsum = sum + lastNonNullWrittenBytes;
-            long lastinterval = now - lastNonNullWrittenTime;
-            long time = (lastsum * 1000 / limitTraffic - lastinterval) / 10 * 10;
-            if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Time: " + time + ":" + lastsum + ":" + lastinterval);
-                }
-                return time > maxTime ? maxTime : time;
+        // take the last write interval check to get enough interval time
+        long lastsum = sum + lastWrittenBytes;
+        long lastinterval = interval + checkInterval.get();
+        long time = (lastsum * 1000 / limitTraffic - lastinterval + pastDelay) / 10 * 10;
+        if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Time: " + time + ":" + lastsum + ":" + lastinterval + ":" + pastDelay);
             }
-        } else {
-            sum += lastWrittenBytes;
-            long lastinterval = AbstractTrafficShapingHandler.MINIMAL_WAIT + Math.abs(interval);
-            long time = (sum * 1000 / limitTraffic - lastinterval) / 10 * 10;
-            if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Time: " + time + ":" + sum + ":" + lastinterval);
-                }
-                return time > maxTime ? maxTime : time;
+            if (time > maxTime && now + time - writingTime > maxTime) {
+                time = maxTime;
             }
+            writingTime = Math.max(writingTime, now + time);
+            return time;
         }
+        writingTime = Math.max(writingTime, now);
         return 0;
     }
 
@@ -523,9 +555,11 @@ public class TrafficCounter {
     @Override
     public String toString() {
         return "Monitor " + name + " Current Speed Read: " +
-                (lastReadThroughput >> 10) + " KB/s, Write: " +
-                (lastWriteThroughput >> 10) + " KB/s Current Read: " +
-                (currentReadBytes.get() >> 10) + " KB Current Write: " +
-                (currentWrittenBytes.get() >> 10) + " KB";
+                (lastReadThroughput >> 10) + " KB/s, Asked Write: " +
+                (lastWriteThroughput >> 10) + " KB/s, " +
+                "Real Write: " + (realWriteThroughput >> 10) + " KB/s, Current Read: " +
+                (currentReadBytes.get() >> 10) + " KB, Current Asked Write: " +
+                (currentWrittenBytes.get() >> 10) + " KB, " +
+                "Current real Write: " + (realWrittenBytes.get() >> 10) + " KB";
     }
 }


### PR DESCRIPTION
Motivation:
Several issues were shown by various ticket (#2900 #2956).

Issue #2900
When a huge amount of data are written, the current behavior of the TrafficShaping handler is to limit the delay to 15s, whatever the delay the previous write has. This is wrong, and when a huge amount of writes are done in a short time, the traffic is not correctly shapened.

Moreover, there is a high risk of OOM if one is not using in his/her own handler for instance ChannelFuture.addListener() to handle the write bufferisation in the TrafficShapingHandler.

Without "softWritability" capability added to the channel, partial writability could be managed, using isWritable() and channelInterestChanged().
This allows for instance HttpChunkedInput to be partially compatible.

The "bandwidth" compute on write is only on "acquired" write orders, not on "real" write orders, which is wrong from statistic point of view.

Issue #2956
When using GlobalTrafficShaping, every write (and read) are synchronized, thus leading to a drop of performance.
ChannelTrafficShaping is not touched by this issue since synchronzed is then correct (handler is per channel, so the synchronized).

Modifications:
The current write delay computation takes into account the previous write delay and time to check is the 15s delay (maxTime) is really exceeded or not (using last scheduled write time). The algorithm is simplified and in the same time more accurate.

This proposal handles the channelInterestChanged(), filtering the events. This allows in some extent the compatibility with code using natively channelInterestChanged(). However, wihtout "softWritability" as proposed in 4.X, one should add a special management of those events in the final handler, as exposed in the example.

When the real write occurs, the statistics are update accordingly on a new attribute (getRealWriteThroughput()).

To limit the synchronisations, all synchronized on GlobalTrafficShapingHandler on submitWrite were removed. They are replaced with a lock per channel (since synchronization is still needed to prevent unordered write per channel), as in the sendAllValid method for the very same reason.
Also all synchronized on TrafficCounter on read/writeTimeToWait() are removed as they are unnecessary since already locked before by the caller.
Still the creation and remove operations on lock per channel (PerChannel object) are synchronized to prevent concurrency issue on this critical part, but then limited.

Result:
The traffic shaping is more stable, even with a huge number of writes in short time by taking into consideration last scheduled write time.

The traffic shaping is more compatible with code as ChunkedWriteHandler, but up to a certain extent, in the sens that it does not prevent fully OOM since isWritable is only managed by the channel properties, not by adding a "softWritability". However, globally, it seems limiting natively even for ChunkedWriteHandler correctly the memory usage.

The statistics are more valuable (asked write vs real write).

Various examples are shown in one added example (example/traffic), and in particular how a user handler might managed the write to prevent OOM:

```
using the ChannelFuture.addListener(new GenericFutureListener>() one by one, or by set of writes
using the ctx.getChannel().isWritable() in conjunction of channelInterestChanged()
using a code as ChunkedFile to send the chunks according to the channelInterestChanged()
using no specific check, but with the risk of OOM (no control on the bufferisation made by the TSH)
```

The Global TrafficShapingHandler should now have less "global" synchronization, hoping to the minimum, but still per Channel as needed.
