### PR TITLE
[#2971] Fix the leak in the WebSocketClientProtocolHandshakeHandler

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -51,13 +51,18 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelHandlerAdapter {
             return;
         }
 
-        if (!handshaker.isHandshakeComplete()) {
-            handshaker.finishHandshake(ctx.channel(), (FullHttpResponse) msg);
-            ctx.fireUserEventTriggered(
-                    WebSocketClientProtocolHandler.ClientHandshakeStateEvent.HANDSHAKE_COMPLETE);
-            ctx.pipeline().remove(this);
-            return;
+        FullHttpResponse response = (FullHttpResponse) msg;
+        try {
+            if (!handshaker.isHandshakeComplete()) {
+                handshaker.finishHandshake(ctx.channel(), response);
+                ctx.fireUserEventTriggered(
+                        WebSocketClientProtocolHandler.ClientHandshakeStateEvent.HANDSHAKE_COMPLETE);
+                ctx.pipeline().remove(this);
+                return;
+            }
+            throw new IllegalStateException("WebSocketClientHandshaker should have been non finished yet");
+        } finally {
+            response.release();
         }
-        throw new IllegalStateException("WebSocketClientHandshaker should have been non finished yet");
     }
 }


### PR DESCRIPTION
Motivation:
The WebSocketClientProtocolHandshakeHandler never releases the received handshake response.

Modification:
Release the message in a finally block.

Result:
No more leak, fixes #2971 
