### PR TITLE
Make autoRead an AtomicBoolean instead of a volatile field.

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -18,7 +18,9 @@ package io.netty.channel;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.nio.AbstractNioByteChannel;
 import io.netty.channel.socket.SocketChannelConfig;
+import io.netty.util.internal.PlatformDependent;
 
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -35,6 +37,17 @@ public class DefaultChannelConfig implements ChannelConfig {
 
     private static final int DEFAULT_CONNECT_TIMEOUT = 30000;
 
+    private static final AtomicIntegerFieldUpdater<DefaultChannelConfig> AUTOREAD_UPDATER;
+
+    static {
+        AtomicIntegerFieldUpdater<DefaultChannelConfig> autoReadUpdater =
+            PlatformDependent.newAtomicIntegerFieldUpdater(DefaultChannelConfig.class, "autoRead");
+        if (autoReadUpdater == null) {
+            autoReadUpdater = AtomicIntegerFieldUpdater.newUpdater(DefaultChannelConfig.class, "autoRead");
+        }
+        AUTOREAD_UPDATER = autoReadUpdater;
+    }
+
     protected final Channel channel;
 
     private volatile ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
@@ -44,7 +57,7 @@ public class DefaultChannelConfig implements ChannelConfig {
     private volatile int connectTimeoutMillis = DEFAULT_CONNECT_TIMEOUT;
     private volatile int maxMessagesPerRead;
     private volatile int writeSpinCount = 16;
-    private volatile boolean autoRead = true;
+    private volatile int autoRead = 1;
     private volatile int writeBufferHighWaterMark = 64 * 1024;
     private volatile int writeBufferLowWaterMark = 32 * 1024;
 
@@ -249,13 +262,12 @@ public class DefaultChannelConfig implements ChannelConfig {
 
     @Override
     public boolean isAutoRead() {
-        return autoRead;
+        return autoRead == 1;
     }
 
     @Override
     public ChannelConfig setAutoRead(boolean autoRead) {
-        boolean oldAutoRead = this.autoRead;
-        this.autoRead = autoRead;
+        boolean oldAutoRead = AUTOREAD_UPDATER.getAndSet(this, autoRead ? 1 : 0) == 1;
         if (autoRead && !oldAutoRead) {
             channel.read();
         } else if (!autoRead && oldAutoRead) {


### PR DESCRIPTION
This solves the problem I mention in #2958 and https://gist.github.com/lw346/a93359b938344e205f5f whereby if multiple threads are mutating the state of the autoRead property, we can end up in a live-lock situation whereby autoRead is set to true, but the channel is not being read from.

By converting the volatile field into an AtomicBoolean, I introduce locking around the field using a CAS operation - is that a problem?

Note that it is the only field in DefaultChannelConfig that needs this modification, as we take immediate action on the before and after value of the field in the setAutoRead(boolean) method.
