### PR TITLE
Restoring access to HTTP/2 decoder's listener.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -118,6 +118,11 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
     }
 
     @Override
+    public Http2FrameListener listener() {
+        return listener;
+    }
+
+    @Override
     public boolean prefaceReceived() {
         return prefaceReceived;
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
@@ -72,6 +72,11 @@ public interface Http2ConnectionDecoder extends Closeable {
     Http2Connection connection();
 
     /**
+     * Provides direct access to the underlying frame listener.
+     */
+    Http2FrameListener listener();
+
+    /**
      * Called by the {@link Http2ConnectionHandler} to decode the next frame from the input buffer.
      */
     void decodeFrame(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Http2Exception;


### PR DESCRIPTION
Motivation:

This was lost in recent changes, just adding it back in.

Modifications:

Added listener() accessor to Http2ConnectionDecoder and the default
impl.

Result:

The Http2FrameListener can be obtained from the decoder.
