### PR TITLE
NullPointerException fix in http/2 codec

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -85,17 +85,16 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         checkNotNull(encoderBuilder, "encoderBuilder");
 
         // Build the encoder.
-        decoderBuilder.lifecycleManager(this);
+        encoderBuilder.lifecycleManager(this);
         encoder = checkNotNull(encoderBuilder.build(), "encoder");
 
         // Build the decoder.
         decoderBuilder.encoder(encoder);
-        encoderBuilder.lifecycleManager(this);
+        decoderBuilder.lifecycleManager(this);
         decoder = checkNotNull(decoderBuilder.build(), "decoder");
 
         // Verify that the encoder and decoder use the same connection.
         checkNotNull(encoder.connection(), "encoder.connection");
-        checkNotNull(decoder.connection(), "decoder.connection");
         if (encoder.connection() != decoder.connection()) {
             throw new IllegalArgumentException("Encoder and Decoder do not share the same connection object");
         }


### PR DESCRIPTION
Motivation:
There is a NPE due to the order of builder initialization in the  class.

Modifications:
-Correct the ordering of initialization and building to avoid NPE.

Result:
No more NPE in  construction.
