### PR TITLE
Fixing race condition in HTTP/2 test

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -699,7 +699,7 @@ public class InboundHttp2ToHttpAdapterTest {
 
     private final class HttpResponseDelegator extends SimpleChannelInboundHandler<HttpObject> {
         private final HttpResponseListener listener;
-        private CountDownLatch latch;
+        private volatile CountDownLatch latch;
 
         public HttpResponseDelegator(HttpResponseListener listener, CountDownLatch latch) {
             super(false);


### PR DESCRIPTION
Motivation:

InboundHttp2ToHttpAdapterTest swaps non-volatile CountDownLatches in
handlers, which seems to cause a race condition that can lead to missing
messages.

Modifications:

Make CountDownLatch variables in InboundHttp2ToHttpAdapterTest volatile.

Result:

InboundHttp2ToHttpAdapterTest should be more stable.
