### PR TITLE
Cleaning up HTTP/2 GOAWAY methods.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -187,17 +187,6 @@ public interface Http2Connection {
         int lastKnownStream();
 
         /**
-         * Indicates whether or not a GOAWAY was received by this endpoint.
-         */
-        boolean isGoAwayReceived();
-
-        /**
-         * Indicates that a GOAWAY was received from the opposite endpoint and sets the last known stream
-         * created by this endpoint.
-         */
-        void goAwayReceived(int lastKnownStream);
-
-        /**
          * Gets the {@link Endpoint} opposite this one.
          */
         Endpoint opposite();
@@ -264,6 +253,26 @@ public interface Http2Connection {
      * Creates a new stream initiated by the remote endpoint. See {@link Endpoint#createStream(int, boolean)}.
      */
     Http2Stream createRemoteStream(int streamId, boolean halfClosed) throws Http2Exception;
+
+    /**
+     * Indicates whether or not a {@code GOAWAY} was received from the remote endpoint.
+     */
+    boolean goAwayReceived();
+
+    /**
+     * Indicates that a {@code GOAWAY} was received from the remote endpoint and sets the last known stream.
+     */
+    void goAwayReceived(int lastKnownStream);
+
+    /**
+     * Indicates whether or not a {@code GOAWAY} was sent to the remote endpoint.
+     */
+    boolean goAwaySent();
+
+    /**
+     * Indicates that a {@code GOAWAY} was sent to the remote endpoint and sets the last known stream.
+     */
+    void goAwaySent(int lastKnownStream);
 
     /**
      * Indicates whether or not either endpoint has received a GOAWAY.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -343,7 +343,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         ChannelFuture future = frameWriter().writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
         ctx.flush();
 
-        connection().remote().goAwayReceived(lastStreamId);
+        connection().goAwaySent(lastStreamId);
         return future;
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -159,7 +159,7 @@ public class DefaultHttp2ConnectionDecoderTest {
 
     @Test
     public void dataReadAfterGoAwayShouldApplyFlowControl() throws Exception {
-        when(remote.isGoAwayReceived()).thenReturn(true);
+        when(connection.goAwaySent()).thenReturn(true);
         final ByteBuf data = dummyData();
         try {
             decode().onDataRead(ctx, STREAM_ID, data, 10, true);
@@ -187,7 +187,7 @@ public class DefaultHttp2ConnectionDecoderTest {
 
     @Test
     public void headersReadAfterGoAwayShouldBeIgnored() throws Exception {
-        when(remote.isGoAwayReceived()).thenReturn(true);
+        when(connection.goAwaySent()).thenReturn(true);
         decode().onHeadersRead(ctx, STREAM_ID, EmptyHttp2Headers.INSTANCE, 0, false);
         verify(remote, never()).createStream(eq(STREAM_ID), eq(false));
 
@@ -235,7 +235,7 @@ public class DefaultHttp2ConnectionDecoderTest {
 
     @Test
     public void pushPromiseReadAfterGoAwayShouldBeIgnored() throws Exception {
-        when(remote.isGoAwayReceived()).thenReturn(true);
+        when(connection.goAwaySent()).thenReturn(true);
         decode().onPushPromiseRead(ctx, STREAM_ID, PUSH_STREAM_ID, EmptyHttp2Headers.INSTANCE, 0);
         verify(remote, never()).reservePushStream(anyInt(), any(Http2Stream.class));
         verify(listener, never()).onPushPromiseRead(eq(ctx), anyInt(), anyInt(), any(Http2Headers.class), anyInt());
@@ -251,7 +251,7 @@ public class DefaultHttp2ConnectionDecoderTest {
 
     @Test
     public void priorityReadAfterGoAwayShouldBeIgnored() throws Exception {
-        when(remote.isGoAwayReceived()).thenReturn(true);
+        when(connection.goAwaySent()).thenReturn(true);
         decode().onPriorityRead(ctx, STREAM_ID, 0, (short) 255, true);
         verify(stream, never()).setPriority(anyInt(), anyShort(), anyBoolean());
         verify(listener, never()).onPriorityRead(eq(ctx), anyInt(), anyInt(), anyShort(), anyBoolean());
@@ -266,7 +266,7 @@ public class DefaultHttp2ConnectionDecoderTest {
 
     @Test
     public void windowUpdateReadAfterGoAwayShouldBeIgnored() throws Exception {
-        when(remote.isGoAwayReceived()).thenReturn(true);
+        when(connection.goAwaySent()).thenReturn(true);
         decode().onWindowUpdateRead(ctx, STREAM_ID, 10);
         verify(encoder, never()).updateOutboundWindowSize(anyInt(), anyInt());
         verify(listener, never()).onWindowUpdateRead(eq(ctx), anyInt(), anyInt());
@@ -287,7 +287,7 @@ public class DefaultHttp2ConnectionDecoderTest {
 
     @Test
     public void rstStreamReadAfterGoAwayShouldSucceed() throws Exception {
-        when(remote.isGoAwayReceived()).thenReturn(true);
+        when(connection.goAwaySent()).thenReturn(true);
         decode().onRstStreamRead(ctx, STREAM_ID, PROTOCOL_ERROR.code());
         verify(lifecycleManager).closeStream(eq(stream), eq(future));
         verify(listener).onRstStreamRead(eq(ctx), anyInt(), anyLong());
@@ -342,7 +342,7 @@ public class DefaultHttp2ConnectionDecoderTest {
     @Test
     public void goAwayShouldReadShouldUpdateConnectionState() throws Exception {
         decode().onGoAwayRead(ctx, 1, 2L, EMPTY_BUFFER);
-        verify(local).goAwayReceived(1);
+        verify(connection).goAwayReceived(1);
         verify(listener).onGoAwayRead(eq(ctx), eq(1), eq(2L), eq(EMPTY_BUFFER));
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -174,7 +174,7 @@ public class DefaultHttp2ConnectionTest {
 
     @Test(expected = Http2Exception.class)
     public void goAwayReceivedShouldDisallowCreation() throws Http2Exception {
-        server.local().goAwayReceived(0);
+        server.goAwayReceived(0);
         server.remote().createStream(3, true);
     }
 


### PR DESCRIPTION
Motivation:

The current GOAWAY methods are in each endpoint and are a little
confusing since their called connection.<endpoint>.goAwayReceived().

Modifications:

Moving GOAWAY methods to connection with more clear names
goAwaySent/goAwayReceived.

Result:

The GOAWAY method names are more clear.
