### PR TITLE
Fix client id validation in MQTT 3.1

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttCodecUtil.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttCodecUtil.java
@@ -21,6 +21,7 @@ import io.netty.handler.codec.DecoderException;
 final class MqttCodecUtil {
 
     private static final char[] TOPIC_WILDCARDS = {'#', '+'};
+    private static final int MIN_CLIENT_ID_LENGTH = 1;
     private static final int MAX_CLIENT_ID_LENGTH = 23;
 
     static boolean isValidPublishTopicName(String topicName) {
@@ -38,7 +39,8 @@ final class MqttCodecUtil {
     }
 
     static boolean isValidClientId(String clientId) {
-        return clientId != null && clientId.length() <= MAX_CLIENT_ID_LENGTH;
+        return clientId != null && clientId.length() >= MIN_CLIENT_ID_LENGTH &&
+            clientId.length() <= MAX_CLIENT_ID_LENGTH;
     }
 
     static MqttFixedHeader validateFixedHeader(MqttFixedHeader mqttFixedHeader) {


### PR DESCRIPTION
Motivation:

In MQTT 3.1 specification, "The Client Identifier (Client ID) is between
1 and 23 characters long, and uniquely identifies the client to the
server". But, current check range is 0~23 instead of 1~23.

Modifications:

Update isValidClientId method.

Result:

It'll be close to the specification.
