### PR TITLE
Add exceptions for CONNACK's return code for MQTT 3.1 specification

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -204,7 +204,7 @@ public class MqttDecoder extends ReplayingDecoder<DecoderState> {
     private static Result<MqttConnectVariableHeader> decodeConnectionVariableHeader(ByteBuf buffer) {
         final Result<String> protoString = decodeString(buffer);
         if (!PROTOCOL_NAME.equals(protoString.value)) {
-            throw new DecoderException("missing " + PROTOCOL_NAME + " signature");
+            throw new MqttUnacceptableProtocolVersionException("missing " + PROTOCOL_NAME + " signature");
         }
 
         int numberOfBytesConsumed = protoString.numberOfBytesConsumed;
@@ -322,7 +322,7 @@ public class MqttDecoder extends ReplayingDecoder<DecoderState> {
         final Result<String> decodedClientId = decodeString(buffer);
         final String decodedClientIdValue = decodedClientId.value;
         if (!isValidClientId(decodedClientIdValue)) {
-            throw new DecoderException("invalid clientIdentifier: " + decodedClientIdValue);
+            throw new MqttIdentifierRejectedException("invalid clientIdentifier: " + decodedClientIdValue);
         }
         int numberOfBytesConsumed = decodedClientId.numberOfBytesConsumed;
 

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttIdentifierRejectedException.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttIdentifierRejectedException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.mqtt;
+
+import io.netty.handler.codec.DecoderException;
+
+/**
+ * A {@link MqttIdentifierRejectedException} which is thrown when a CONNECT request contains invalid client identifier.
+ */
+public class MqttIdentifierRejectedException extends DecoderException {
+
+    private static final long serialVersionUID = -1323503322689614981L;
+
+    /**
+     * Creates a new instance
+     */
+    public MqttIdentifierRejectedException() { }
+
+    /**
+     * Creates a new instance
+     */
+    public MqttIdentifierRejectedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new instance
+     */
+    public MqttIdentifierRejectedException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance
+     */
+    public MqttIdentifierRejectedException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnacceptableProtocolVersionException.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnacceptableProtocolVersionException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.mqtt;
+
+import io.netty.handler.codec.DecoderException;
+
+/**
+ * A {@link MqttUnacceptableProtocolVersionException} which is thrown when
+ * a CONNECT request contains unacceptable protocol version.
+ */
+public class MqttUnacceptableProtocolVersionException extends DecoderException {
+
+    private static final long serialVersionUID = 4914652213232455749L;
+
+    /**
+     * Creates a new instance
+     */
+    public MqttUnacceptableProtocolVersionException() { }
+
+    /**
+     * Creates a new instance
+     */
+    public MqttUnacceptableProtocolVersionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new instance
+     */
+    public MqttUnacceptableProtocolVersionException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance
+     */
+    public MqttUnacceptableProtocolVersionException(Throwable cause) {
+        super(cause);
+    }
+
+}


### PR DESCRIPTION
Motivation:

http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#connack
In MQTT 3.1, MQTT server must send a CONNACK with return code if CONNECT
request contains an invalid client identifier or an unacceptable protocol
version. The return code is one of MqttConnectReturnCode.
But, MqttDecoder throws DecoderException when CONNECT request contains
invalid value without distinguish situations. This makes it difficult
for codec-mqtt users to send a response with return code to clients.

Modifications:

Added exceptions for client identifier rejected and unacceptable
protocol version. MqttDecoder will throw those exceptions instead of
DecoderException.

Result:

Users of codec-mqtt can distinguish which is invalid when CONNECT
contains invalid client identifier or invalid protocol version. And, users can
send CONNACK with return code to clients.
