### PR TITLE
Properly handle characters outside of charset

### DIFF
--- a/common/src/main/java/io/netty/util/CharsetUtil.java
+++ b/common/src/main/java/io/netty/util/CharsetUtil.java
@@ -74,14 +74,14 @@ public final class CharsetUtil {
         CharsetEncoder e = map.get(charset);
         if (e != null) {
             e.reset();
-            e.onMalformedInput(CodingErrorAction.REPLACE);
-            e.onUnmappableCharacter(CodingErrorAction.REPLACE);
+            e.onMalformedInput(CodingErrorAction.REPORT);
+            e.onUnmappableCharacter(CodingErrorAction.REPORT);
             return e;
         }
 
         e = charset.newEncoder();
-        e.onMalformedInput(CodingErrorAction.REPLACE);
-        e.onUnmappableCharacter(CodingErrorAction.REPLACE);
+        e.onMalformedInput(CodingErrorAction.REPORT);
+        e.onUnmappableCharacter(CodingErrorAction.REPORT);
         map.put(charset, e);
         return e;
     }
@@ -99,14 +99,14 @@ public final class CharsetUtil {
         CharsetDecoder d = map.get(charset);
         if (d != null) {
             d.reset();
-            d.onMalformedInput(CodingErrorAction.REPLACE);
-            d.onUnmappableCharacter(CodingErrorAction.REPLACE);
+            d.onMalformedInput(CodingErrorAction.REPORT);
+            d.onUnmappableCharacter(CodingErrorAction.REPORT);
             return d;
         }
 
         d = charset.newDecoder();
-        d.onMalformedInput(CodingErrorAction.REPLACE);
-        d.onUnmappableCharacter(CodingErrorAction.REPLACE);
+        d.onMalformedInput(CodingErrorAction.REPORT);
+        d.onUnmappableCharacter(CodingErrorAction.REPORT);
         map.put(charset, d);
         return d;
     }


### PR DESCRIPTION
The current behavior of using REPLACE on CharsetEncoders and Decoders
means that characters outside of the specified charset will be silently
replaced with another character ('?' for ASCII, \uFFFD for UTF-8, etc).

As indicated by the usage in ByteBufUtil, REPORT is the desired
behavior.  When a character outside of the charset is found, either an
exception is thrown or a CoderResult is returned.  It looks like all
of the code using getEncoder() and getDecoder() expect the REPORT
behavior, not the REPLACE behavior.