### PR TITLE
HTTP/2 Server Example Not Using Flow Controller

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -64,15 +64,10 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     public Http2ConnectionHandler(Http2Connection connection, Http2FrameReader frameReader,
             Http2FrameWriter frameWriter, Http2InboundFlowController inboundFlow,
             Http2OutboundFlowController outboundFlow, Http2FrameListener listener) {
-        this.encoder =
-                DefaultHttp2ConnectionEncoder.newBuilder().connection(connection)
-                        .frameWriter(frameWriter).outboundFlow(outboundFlow).lifecycleManager(this)
-                        .build();
-        this.decoder =
-                DefaultHttp2ConnectionDecoder.newBuilder().connection(connection)
-                        .frameReader(frameReader).inboundFlow(inboundFlow).encoder(encoder)
-                        .listener(listener).lifecycleManager(this).build();
-        clientPrefaceString = clientPrefaceString(connection);
+        this(DefaultHttp2ConnectionDecoder.newBuilder().connection(connection)
+                .frameReader(frameReader).inboundFlow(inboundFlow).listener(listener),
+             DefaultHttp2ConnectionEncoder.newBuilder().connection(connection)
+                .frameWriter(frameWriter).outboundFlow(outboundFlow));
     }
 
     /**


### PR DESCRIPTION
Motiviation:
The HTTP/2 server example is not using the outbound flow control.  It is instead using a FrameWriter directly.
This can lead to flow control errors and other comm. related errors

Modifications:
-Force server example to use outbound flow controller

Result:
-Server example should use follow flow control rules.
