### PR TITLE
#2838 wip for codec-dns tcp support 

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessageFrameDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessageFrameDecoder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.AddressedEnvelope;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultAddressedEnvelope;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.handler.codec.MessageToMessageDecoder;
+
+import java.net.SocketAddress;
+import java.util.List;
+
+@ChannelHandler.Sharable
+public class DnsMessageFrameDecoder extends MessageToMessageDecoder {
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, Object msg, List out) throws Exception {
+        SocketAddress recipient;
+        SocketAddress sender;
+        ByteBuf payload;
+        int payloadSize;
+        int readerIndex;
+        AddressedEnvelope<ByteBuf, SocketAddress> r;
+        if (msg instanceof DatagramPacket) {
+            out.add(((DatagramPacket) msg).retain());
+        } else if (msg instanceof ByteBuf) {
+            ((ByteBuf) msg).resetReaderIndex();
+            payloadSize = ((ByteBuf) msg).readUnsignedShort();
+            readerIndex = ((ByteBuf) msg).readerIndex();
+            if (payloadSize > ((ByteBuf) msg).readableBytes()) {
+                return;
+            }
+            recipient = ctx.channel().localAddress();
+            sender = ctx.channel().remoteAddress();
+            payload = ((ByteBuf) msg).copy(readerIndex, payloadSize).retain();
+            r = new DefaultAddressedEnvelope<ByteBuf, SocketAddress>(payload, recipient, sender);
+            out.add(r);
+        } else {
+            // Error
+            throw new Error();
+        }
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponse.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponse.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.dns;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 
 /**
  * A DNS response packet which is sent to a client after a server receives a
@@ -23,9 +24,9 @@ import java.net.InetSocketAddress;
  */
 public final class DnsResponse extends DnsMessage {
 
-    private final InetSocketAddress sender;
+    private final SocketAddress sender;
 
-    public DnsResponse(int id, InetSocketAddress sender) {
+    public DnsResponse(int id, SocketAddress sender) {
         super(id);
         if (sender == null) {
             throw new NullPointerException("sender");
@@ -36,7 +37,7 @@ public final class DnsResponse extends DnsMessage {
     /**
      * The {@link InetSocketAddress} of the sender of this {@link DnsResponse}
      */
-    public InetSocketAddress sender() {
+    public SocketAddress sender() {
         return sender;
     }
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseDecoder.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.socket.DatagramPacket;
@@ -23,6 +24,7 @@ import io.netty.handler.codec.CorruptedFrameException;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.util.CharsetUtil;
 
+import java.net.SocketAddress;
 import java.util.List;
 
 /**
@@ -31,12 +33,12 @@ import java.util.List;
  * DnsResponses such as questions and resource records.
  */
 @ChannelHandler.Sharable
-public class DnsResponseDecoder extends MessageToMessageDecoder<DatagramPacket> {
+public class DnsResponseDecoder extends MessageToMessageDecoder<AddressedEnvelope<ByteBuf, SocketAddress>> {
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, DatagramPacket packet, List<Object> out) throws Exception {
+    protected void decode(ChannelHandlerContext ctx,
+                          AddressedEnvelope<ByteBuf, SocketAddress> packet, List<Object> out) throws Exception {
         ByteBuf buf = packet.content();
-
         int id = buf.readUnsignedShort();
 
         DnsResponse response = new DnsResponse(id, packet.sender());

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.dns;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.embedded.EmbeddedChannel;
 
 import io.netty.channel.socket.DatagramPacket;
@@ -48,8 +49,8 @@ public class DnsQueryTest {
             Assert.assertEquals("Invalid type, should be TYPE_QUERY (0)", DnsHeader.TYPE_QUERY, query.header()
                     .type());
             embedder.writeOutbound(query);
-            DatagramPacket packet = embedder.readOutbound();
-            Assert.assertTrue(packet.content().isReadable());
+            ByteBuf packet = embedder.readOutbound();
+            Assert.assertTrue(packet.isReadable());
             packet.release();
             Assert.assertNull(embedder.readOutbound());
         }

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsResponseTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsResponseTest.java
@@ -20,6 +20,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.CorruptedFrameException;
+import org.bouncycastle.jce.provider.JDKDSASigner;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,12 +41,6 @@ public class DnsResponseTest {
                     0, 0, 0, 0, 0, 0, 0, 0, 16
             },
             {
-                    0, 2, -127, -128, 0, 1, 0, 0, 0, 1, 0, 0, 3, 119, 119, 119, 7, 101, 120, 97, 109, 112, 108, 101, 3,
-                    99, 111, 109, 0, 0, 15, 0, 1, -64, 16, 0, 6, 0, 1, 0, 0, 3, -43, 0, 45, 3, 115, 110, 115, 3, 100,
-                    110, 115, 5, 105, 99, 97, 110, 110, 3, 111, 114, 103, 0, 3, 110, 111, 99, -64, 49, 119, -4, 39,
-                    112, 0, 0, 28, 32, 0, 0, 14, 16, 0, 18, 117, 0, 0, 0, 14, 16
-            },
-            {
                     0, 3, -127, -128, 0, 1, 0, 1, 0, 0, 0, 0, 3, 119, 119, 119, 7, 101, 120, 97, 109, 112, 108, 101, 3,
                     99, 111, 109, 0, 0, 16, 0, 1, -64, 12, 0, 16, 0, 1, 0, 0, 84, 75, 0, 12, 11, 118, 61, 115, 112,
                     102, 49, 32, 45, 97, 108, 108
@@ -60,6 +55,12 @@ public class DnsResponseTest {
                     0, 4, 1, 73, -64, 49, 0, 0, 2, 0, 1, 0, 7, -23, 0, 0, 4, 1, 66, -64, 49, 0, 0, 2, 0, 1, 0, 7, -23,
                     0, 0, 4, 1, 77, -64, 49, 0, 0, 2, 0, 1, 0, 7, -23, 0, 0, 4, 1, 65, -64, 49, 0, 0, 2, 0, 1, 0, 7,
                     -23, 0, 0, 4, 1, 72, -64, 49, 0, 0, 2, 0, 1, 0, 7, -23, 0, 0, 4, 1, 74, -64, 49
+            },
+            {
+                    0, 2, -127, -128, 0, 1, 0, 0, 0, 1, 0, 0, 3, 119, 119, 119, 7, 101, 120, 97, 109, 112, 108, 101, 3,
+                    99, 111, 109, 0, 0, 15, 0, 1, -64, 16, 0, 6, 0, 1, 0, 0, 3, -43, 0, 45, 3, 115, 110, 115, 3, 100,
+                    110, 115, 5, 105, 99, 97, 110, 110, 3, 111, 114, 103, 0, 3, 110, 111, 99, -64, 49, 119, -4, 39,
+                    112, 0, 0, 28, 32, 0, 0, 14, 16, 0, 18, 117, 0, 0, 0, 14, 16
             }
     };
 
@@ -68,11 +69,62 @@ public class DnsResponseTest {
     };
 
     @Test
-    public void readResponseTest() throws Exception {
-        EmbeddedChannel embedder = new EmbeddedChannel(new DnsResponseDecoder());
+    public void readDatagramResponseTest() throws Exception {
+        EmbeddedChannel embedder = new EmbeddedChannel(new DnsMessageFrameDecoder(), new DnsResponseDecoder());
         for (byte[] p: packets) {
             ByteBuf packet = embedder.alloc().buffer(512).writeBytes(p);
             embedder.writeInbound(new DatagramPacket(packet, null, new InetSocketAddress(0)));
+            DnsResponse decoded = embedder.readInbound();
+            ByteBuf raw = Unpooled.wrappedBuffer(p);
+            Assert.assertEquals("Invalid id, expected: " + raw.getUnsignedShort(0) + ", actual: "
+                    + decoded.header().id(), raw.getUnsignedShort(0), decoded.header().id());
+            Assert.assertEquals("Invalid resource count,  expected: " + raw.getUnsignedShort(4) + ", actual: "
+                    + decoded.questions().size(), raw.getUnsignedShort(4), decoded.questions().size());
+            Assert.assertEquals("Invalid resource count,  expected: " + raw.getUnsignedShort(6) + ", actual: "
+                    + decoded.answers().size(), raw.getUnsignedShort(6), decoded.answers().size());
+            Assert.assertEquals("Invalid resource count,  expected: " + raw.getUnsignedShort(8) + ", actual: "
+                    + decoded.authorityResources().size(), raw.getUnsignedShort(8), decoded.authorityResources()
+                    .size());
+            Assert.assertEquals("Invalid resource count,  expected: " + raw.getUnsignedShort(10) + ", actual: "
+                    + decoded.additionalResources().size(), raw.getUnsignedShort(10),
+                    decoded.additionalResources().size());
+            decoded.release();
+        }
+    }
+
+    @Test
+    public void readSocketResponseTest() throws Exception {
+        EmbeddedChannel embedder = new EmbeddedChannel(new DnsMessageFrameDecoder(), new DnsResponseDecoder());
+        for (byte[] p: packets) {
+            ByteBuf packet = embedder.alloc().buffer(512).writeShort(p.length).writeBytes(p);
+            embedder.writeInbound(packet);
+            DnsResponse decoded = embedder.readInbound();
+            ByteBuf raw = Unpooled.wrappedBuffer(p);
+            Assert.assertEquals("Invalid id, expected: " + raw.getUnsignedShort(0) + ", actual: "
+                    + decoded.header().id(), raw.getUnsignedShort(0), decoded.header().id());
+            Assert.assertEquals("Invalid resource count,  expected: " + raw.getUnsignedShort(4) + ", actual: "
+                    + decoded.questions().size(), raw.getUnsignedShort(4), decoded.questions().size());
+            Assert.assertEquals("Invalid resource count,  expected: " + raw.getUnsignedShort(6) + ", actual: "
+                    + decoded.answers().size(), raw.getUnsignedShort(6), decoded.answers().size());
+            Assert.assertEquals("Invalid resource count,  expected: " + raw.getUnsignedShort(8) + ", actual: "
+                    + decoded.authorityResources().size(), raw.getUnsignedShort(8), decoded.authorityResources()
+                    .size());
+            Assert.assertEquals("Invalid resource count,  expected: " + raw.getUnsignedShort(10) + ", actual: "
+                    + decoded.additionalResources().size(), raw.getUnsignedShort(10),
+                    decoded.additionalResources().size());
+            decoded.release();
+        }
+    }
+
+    @Test
+    public void readSocketMultipleWritesResponseTest() throws Exception {
+        EmbeddedChannel embedder = new EmbeddedChannel(new DnsMessageFrameDecoder(), new DnsResponseDecoder());
+        System.out.println("readSocketMultipleWritesResponseTest");
+        for (byte[] p: packets) {
+            ByteBuf prefix = embedder.alloc().buffer(514).writeShort(p.length);
+            embedder.writeInbound(prefix.retain());
+            Assert.assertNull(embedder.readInbound());
+            embedder.writeInbound(prefix.writeBytes(p));
             DnsResponse decoded = embedder.readInbound();
             ByteBuf raw = Unpooled.wrappedBuffer(p);
             Assert.assertEquals("Invalid id, expected: " + raw.getUnsignedShort(0) + ", actual: "


### PR DESCRIPTION
#2838 make DnsResponseDecoder use AddressedEnvelope<ByteBuf, SocketAddress>
add DnsMessageFrameDecoder that will output for DatagramChannel
DatagramPacket object and for SocketChannel will create
DefaultAddressedEnvelope. This is done not to change how decoder works
Make DnsQueryEncoder work with datagram and socket channels