### PR TITLE
V4.0 Final proposal to extend Channel to support "softWritability"

### DIFF
--- a/example/src/main/java/io/netty/example/traffic/ChannelTrafficShapingHandlerWithLog.java
+++ b/example/src/main/java/io/netty/example/traffic/ChannelTrafficShapingHandlerWithLog.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.traffic;
+
+import io.netty.handler.traffic.ChannelTrafficShapingHandler;
+import io.netty.handler.traffic.TrafficCounter;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+public class ChannelTrafficShapingHandlerWithLog extends ChannelTrafficShapingHandler {
+    private static final InternalLogger logger =
+            InternalLoggerFactory.getInstance(ChannelTrafficShapingHandlerWithLog.class);
+
+    public ChannelTrafficShapingHandlerWithLog(long writeLimit, long readLimit, long checkInterval,
+            long maxTime) {
+        super(writeLimit, readLimit, checkInterval, maxTime);
+    }
+
+    public ChannelTrafficShapingHandlerWithLog(long writeLimit, long readLimit, long checkInterval) {
+        super(writeLimit, readLimit, checkInterval);
+    }
+
+    public ChannelTrafficShapingHandlerWithLog(long writeLimit, long readLimit) {
+        super(writeLimit, readLimit);
+    }
+
+    public ChannelTrafficShapingHandlerWithLog(long checkInterval) {
+        super(checkInterval);
+    }
+
+    // Shall be updated to fit the needs
+    @Override
+    protected void doAccounting(TrafficCounter counter) {
+        logger.warn(this.toString() + " QueueSize: " + queueSize());
+        super.doAccounting(counter);
+    }
+
+    // Shall be updated to fit the needs, in particular to detect other than ByteBuf
+    @Override
+    protected long calculateSize(Object msg) {
+        return super.calculateSize(msg);
+    }
+
+}

--- a/example/src/main/java/io/netty/example/traffic/GlobalTrafficShapingHandlerWithLog.java
+++ b/example/src/main/java/io/netty/example/traffic/GlobalTrafficShapingHandlerWithLog.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.traffic;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import io.netty.handler.traffic.GlobalTrafficShapingHandler;
+import io.netty.handler.traffic.TrafficCounter;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+public class GlobalTrafficShapingHandlerWithLog extends GlobalTrafficShapingHandler {
+    private static final InternalLogger logger =
+            InternalLoggerFactory.getInstance(GlobalTrafficShapingHandlerWithLog.class);
+
+    public GlobalTrafficShapingHandlerWithLog(ScheduledExecutorService executor, long writeLimit,
+            long readLimit, long checkInterval, long maxTime) {
+        super(executor, writeLimit, readLimit, checkInterval, maxTime);
+    }
+
+    public GlobalTrafficShapingHandlerWithLog(ScheduledExecutorService executor, long writeLimit,
+            long readLimit, long checkInterval) {
+        super(executor, writeLimit, readLimit, checkInterval);
+    }
+
+    public GlobalTrafficShapingHandlerWithLog(ScheduledExecutorService executor, long writeLimit,
+            long readLimit) {
+        super(executor, writeLimit, readLimit);
+    }
+
+    public GlobalTrafficShapingHandlerWithLog(ScheduledExecutorService executor, long checkInterval) {
+        super(executor, checkInterval);
+    }
+
+    public GlobalTrafficShapingHandlerWithLog(EventExecutor executor) {
+        super(executor);
+    }
+
+    // Shall be updated to fit the needs
+    @Override
+    protected void doAccounting(TrafficCounter counter) {
+        logger.warn(this.toString() + " QueuesSize: " + queuesSize());
+        super.doAccounting(counter);
+    }
+
+    // Shall be updated to fit the needs, in particular to detect other than ByteBuf
+    @Override
+    protected long calculateSize(Object msg) {
+        return super.calculateSize(msg);
+    }
+
+}

--- a/example/src/main/java/io/netty/example/traffic/HttpStaticFileServerTrafficShaping.java
+++ b/example/src/main/java/io/netty/example/traffic/HttpStaticFileServerTrafficShaping.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.traffic;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+
+/**
+ * Example for TrafficShaping: in the handler, several methods are implemented to show different
+ * variants on handling the write buffer, and then the memory consumption, in order to prevent
+ * Out Of Memory exception. You can try them by switching the modeTransfer to the desired value.
+ *<br><br>
+ * You can also change the behavior of the handler (long time task using simulLongTask) and adding
+ * a GlobalTransferShapingHandler (by default, only the ChannelTrafficShapingHandler is added).
+ *<br><br>
+ * useFutureListener = true
+ *     => best choice: 1 block at a time in memory, but lot of object creations (GenericFutureListener)<br>
+ * useSetFutureListener = true
+ *     => best choice: similar to useFutureListener by set of blocks<br>
+ * useCheckWritability = true (using default channelWritabilityChanged, isWritable with softWritable extension)
+ *     => second best choice: limited blocks in memory, but depending on application speed:
+ *     too quick could fill up the buffers, else will be fine.
+ * useChunkFile = true
+ *     => not recommended since will create all blocks in memory without taking into account contention<br>
+ * useDefault = true
+ *     => not recommended since will create all blocks in memory without taking into account contention<br>
+ *
+ * simulLongTask = true
+ *     => to show that it could impact object memory in useCheckWriteServerTrafficShaping mode<br>
+ * useGlobalTSH = true
+ *     => to show that individual speeds are divided by the number of concurrent requests<br>
+ *
+ *
+ */
+public final class HttpStaticFileServerTrafficShaping {
+
+    public static enum ModeTransfer {
+        useFutureListener, useSetFutureListener,
+        useCheckWritability, useChunkedFile, useDefault
+    }
+    static ModeTransfer modeTransfer = ModeTransfer.useCheckWritability;
+    static boolean simulLongTask;
+    static boolean useGlobalTSH;
+    /*
+     * useFutureListener = true
+     *     => best choice: 1 block at a time in memory, but lot of object creations (GenericFutureListener)
+     * useSetFutureListener = true
+     *     => best choice: similar to useFutureListener by set of blocks
+     * useCheckWritability = true (using default channelWritabilityChanged, isWritable with softWritable extension)
+     *     => second best choice: limited blocks in memory, but depending on application speed:
+     *     too quick could fill up the buffers, else will be fine.
+     * useChunkFile = true
+     *     => not recommended since will create all blocks in memory without taking into account contention
+     * useDefault = true
+     *     => not recommended since will create all blocks in memory without taking into account contention
+     *
+     * simulLongTask = true
+     *     => to show that it could impact object memory in useCheckWriteServerTrafficShaping mode
+     * useGlobalTSH = true
+     *     => to show that individual speeds are divided by the number of concurrent requests
+     */
+
+    static final boolean SSL = System.getProperty("ssl") != null;
+    static final int PORT = Integer.parseInt(System.getProperty("port", SSL? "8443" : "8080"));
+    public static EventLoopGroup businessGroup = new NioEventLoopGroup();
+    static GlobalTrafficShapingHandlerWithLog gtsh;
+
+    public static void main(String[] args) throws Exception {
+        // Configure SSL.
+        final SslContext sslCtx;
+        if (SSL) {
+            SelfSignedCertificate ssc = new SelfSignedCertificate();
+            sslCtx = SslContext.newServerContext(SslProvider.JDK, ssc.certificate(), ssc.privateKey());
+        } else {
+            sslCtx = null;
+        }
+        EventLoopGroup globalGroup = null;
+        if (useGlobalTSH) {
+            globalGroup = new NioEventLoopGroup();
+            gtsh = new GlobalTrafficShapingHandlerWithLog(globalGroup, 1024 * 1024, 1024 * 1024, 1000);
+        }
+        EventLoopGroup bossGroup = new NioEventLoopGroup();
+        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        try {
+            ServerBootstrap b = new ServerBootstrap();
+            b.group(bossGroup, workerGroup)
+             .channel(NioServerSocketChannel.class)
+             .handler(new LoggingHandler(LogLevel.INFO))
+             .childHandler(new HttpStaticFileServerTrafficShapingInitializer(sslCtx));
+
+            Channel ch = b.bind(PORT).sync().channel();
+
+            System.err.println("Open your web browser and navigate to " +
+                    (SSL? "https" : "http") + "://127.0.0.1:" + PORT + '/');
+
+            ch.closeFuture().sync();
+        } finally {
+            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully();
+            businessGroup.shutdownGracefully();
+            if (useGlobalTSH) {
+                globalGroup.shutdownGracefully();
+            }
+        }
+    }
+
+}

--- a/example/src/main/java/io/netty/example/traffic/HttpStaticFileServerTrafficShapingHandler.java
+++ b/example/src/main/java/io/netty/example/traffic/HttpStaticFileServerTrafficShapingHandler.java
@@ -1,0 +1,520 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.traffic;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelProgressiveFuture;
+import io.netty.channel.ChannelProgressiveFutureListener;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpChunkedInput;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.handler.stream.ChunkedFile;
+import io.netty.util.CharsetUtil;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.internal.SystemPropertyUtil;
+
+import javax.activation.MimetypesFileTypeMap;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.regex.Pattern;
+
+import static io.netty.handler.codec.http.HttpHeaders.Names.*;
+import static io.netty.handler.codec.http.HttpMethod.*;
+import static io.netty.handler.codec.http.HttpResponseStatus.*;
+import static io.netty.handler.codec.http.HttpVersion.*;
+
+/**
+ * Based on HttpStaticFileServer example, which serves incoming HTTP requests
+ * to send their respective HTTP responses, it shows several ways to implement
+ * Traffic shaping using the TrafficShapingHandler.
+ *
+ */
+public class HttpStaticFileServerTrafficShapingHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+
+    public static final String HTTP_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz";
+    public static final String HTTP_DATE_GMT_TIMEZONE = "GMT";
+    public static final int HTTP_CACHE_SECONDS = 60;
+
+    protected volatile RandomAccessFile raf;
+    protected volatile FullHttpRequest request;
+    protected volatile long fileLength;
+
+    @Override
+    public void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) throws Exception {
+        this.request = request;
+        if (!request.getDecoderResult().isSuccess()) {
+            sendError(ctx, BAD_REQUEST);
+            return;
+        }
+
+        if (request.getMethod() != GET) {
+            sendError(ctx, METHOD_NOT_ALLOWED);
+            return;
+        }
+
+        final String uri = request.getUri();
+        final String path = sanitizeUri(uri);
+        if (path == null) {
+            sendError(ctx, FORBIDDEN);
+            return;
+        }
+
+        File file = new File(path);
+        if (file.isHidden() || !file.exists()) {
+            sendError(ctx, NOT_FOUND);
+            return;
+        }
+
+        if (file.isDirectory()) {
+            if (uri.endsWith("/")) {
+                sendListing(ctx, file);
+            } else {
+                sendRedirect(ctx, uri + '/');
+            }
+            return;
+        }
+
+        if (!file.isFile()) {
+            sendError(ctx, FORBIDDEN);
+            return;
+        }
+
+        // Cache Validation
+        String ifModifiedSince = request.headers().get(IF_MODIFIED_SINCE);
+        if (ifModifiedSince != null && !ifModifiedSince.isEmpty()) {
+            SimpleDateFormat dateFormatter = new SimpleDateFormat(HTTP_DATE_FORMAT, Locale.US);
+            Date ifModifiedSinceDate = dateFormatter.parse(ifModifiedSince);
+
+            // Only compare up to the second because the datetime format we send to the client
+            // does not have milliseconds
+            long ifModifiedSinceDateSeconds = ifModifiedSinceDate.getTime() / 1000;
+            long fileLastModifiedSeconds = file.lastModified() / 1000;
+            if (ifModifiedSinceDateSeconds == fileLastModifiedSeconds) {
+                sendNotModified(ctx);
+                return;
+            }
+        }
+
+        try {
+            raf = new RandomAccessFile(file, "r");
+        } catch (FileNotFoundException ignore) {
+            sendError(ctx, NOT_FOUND);
+            return;
+        }
+        fileLength = raf.length();
+
+        HttpResponse response = new DefaultHttpResponse(HTTP_1_1, OK);
+        HttpHeaders.setContentLength(response, fileLength);
+        setContentTypeHeader(response, file);
+        setDateAndCacheHeaders(response, file);
+        if (HttpHeaders.isKeepAlive(request)) {
+            response.headers().set(CONNECTION, HttpHeaders.Values.KEEP_ALIVE);
+        }
+
+        // Write the initial line and the header.
+        ctx.write(response);
+
+        // Write the content.
+        doSend(ctx);
+    }
+
+    private synchronized void doSend(final ChannelHandlerContext ctx) throws Exception {
+        switch (HttpStaticFileServerTrafficShaping.modeTransfer) {
+            case useCheckWritability:
+                doSendCheckWritabilityChanged(ctx);
+                break;
+            case useChunkedFile:
+                doSendChunkedFile(ctx);
+                break;
+            case useDefault:
+                doSendSimple(ctx);
+                break;
+            case useFutureListener:
+                doSendFutureListener(ctx);
+                break;
+            case useSetFutureListener:
+                doSendFutureListenerSet(ctx);
+                break;
+            default:
+                doSendSimple(ctx);
+                break;
+        }
+    }
+
+    volatile ChannelFuture nextFuture;
+    /**
+     * Using explicit future listener on send to send one element while the next one is prepared.
+     *
+     * The advantage of this method is to only have one element in the buffer of the TrafficShapingHandler.
+     *
+     * @param ctx
+     * @throws Exception
+     */
+    private synchronized void doSendFutureListener(final ChannelHandlerContext ctx) throws Exception {
+        byte[] bytes = new byte[8192];
+        int read = raf.read(bytes);
+        ChannelFuture future = nextFuture;
+        if (read > 0) {
+            final ByteBuf buf = ctx.alloc().buffer(read, read);
+            buf.writeBytes(bytes, 0, read);
+            if (future != null) {
+                future.addListener(new GenericFutureListener<Future<? super Void>>() {
+                    public void operationComplete(Future<? super Void> future) throws Exception {
+                        nextFuture = ctx.writeAndFlush(buf);
+                        if (HttpStaticFileServerTrafficShaping.simulLongTask) {
+                            Thread.sleep(5);
+                        }
+                        doSendFutureListener(ctx);
+                    }
+                });
+                return;
+            }
+            nextFuture = ctx.writeAndFlush(buf);
+            doSendFutureListener(ctx);
+        } else {
+            raf.close();
+            raf = null;
+            finalizeSend(ctx);
+        }
+    }
+    /**
+     * Using explicit future listener on send to send one element while the next one is prepared.
+     *
+     * The advantage of this method is to only have one fix set of blocks in the buffer of the TrafficShapingHandler.
+     *
+     * @param ctx
+     * @throws Exception
+     */
+    private synchronized void doSendFutureListenerSet(final ChannelHandlerContext ctx) throws Exception {
+        byte[] bytes = new byte[8192];
+        int read = raf.read(bytes);
+        ChannelFuture future = null;
+        for (int i = 0; i < 9 && read > 0; i++) {
+            final ByteBuf buf = ctx.alloc().buffer(read, read);
+            buf.writeBytes(bytes, 0, read);
+            ctx.write(buf);
+        }
+        if (read > 0) {
+            final ByteBuf buf = ctx.alloc().buffer(read, read);
+            buf.writeBytes(bytes, 0, read);
+            future = ctx.writeAndFlush(buf);
+            future.addListener(new GenericFutureListener<Future<? super Void>>() {
+                public void operationComplete(Future<? super Void> future) throws Exception {
+                    if (HttpStaticFileServerTrafficShaping.simulLongTask) {
+                        Thread.sleep(10);
+                    }
+                    doSendFutureListenerSet(ctx);
+                }
+            });
+            return;
+        }
+        if (read < 0) {
+            raf.close();
+            raf = null;
+            finalizeSend(ctx);
+        }
+    }
+    /**
+     * Using Channel.isWritable to check if the buffer is full or not.
+     * Use then the channelWritabilityChanged to restart the sending operation.
+     *
+     * @param ctx
+     * @throws Exception
+     */
+    private synchronized void doSendCheckWritabilityChanged(final ChannelHandlerContext ctx) throws Exception {
+        byte[] bytes = new byte[8192];
+        int read = raf.read(bytes);
+        while (read > 0) {
+            final ByteBuf buf = ctx.alloc().buffer(read, read);
+            buf.writeBytes(bytes, 0, read);
+            ctx.write(buf);
+            if (! ctx.channel().isWritable()) {
+                ctx.flush();
+                return;
+            }
+            if (HttpStaticFileServerTrafficShaping.simulLongTask) {
+                Thread.sleep(5);
+            }
+            read = raf.read(bytes);
+        }
+        raf.close();
+        raf = null;
+        finalizeSend(ctx);
+    }
+
+    @Override
+    public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+        if (HttpStaticFileServerTrafficShaping.modeTransfer !=
+                HttpStaticFileServerTrafficShaping.ModeTransfer.useCheckWritability
+                || raf == null || ! ctx.channel().isWritable()) {
+            ctx.fireChannelWritabilityChanged();
+            return;
+        }
+        doSendCheckWritabilityChanged(ctx);
+        ctx.fireChannelWritabilityChanged();
+    }
+
+    /**
+     * Simple send, using ChunkedFile
+     *
+     * @param ctx
+     * @throws Exception
+     */
+    private synchronized void doSendChunkedFile(final ChannelHandlerContext ctx) throws Exception {
+        // note: this is not compatible with traffic shaping, as for SSL
+        // ctx.write(new DefaultFileRegion(raf.getChannel(), 0, fileLength), ctx.newProgressivePromise());
+        ChannelFuture sendFileFuture;
+            sendFileFuture =
+                    ctx.write(new HttpChunkedInput(new ChunkedFile(raf, 0, fileLength, 8192)),
+                            ctx.newProgressivePromise());
+
+        sendFileFuture.addListener(new ChannelProgressiveFutureListener() {
+            @Override
+            public void operationProgressed(ChannelProgressiveFuture future, long progress, long total) {
+            }
+
+            @Override
+            public void operationComplete(ChannelProgressiveFuture future) {
+                System.err.println(future.channel() + " Transfer complete.");
+            }
+        });
+        raf = null;
+        finalizeSend(ctx);
+    }
+
+    /**
+     * Simple send, chunk by chunk by hand
+     *
+     * @param ctx
+     * @throws Exception
+     */
+    private synchronized void doSendSimple(final ChannelHandlerContext ctx) throws Exception {
+        byte[] bytes = new byte[8192];
+        int read = raf.read(bytes);
+        while (read > 0) {
+            final ByteBuf buf = ctx.alloc().buffer(read, read);
+            buf.writeBytes(bytes, 0, read);
+            ctx.write(buf);
+            if (HttpStaticFileServerTrafficShaping.simulLongTask) {
+                Thread.sleep(5);
+            }
+            read = raf.read(bytes);
+        }
+        raf.close();
+        raf = null;
+        finalizeSend(ctx);
+    }
+
+    private void finalizeSend(ChannelHandlerContext ctx) throws IOException {
+        // Write the end marker
+        ChannelFuture lastContentFuture = ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
+        // Decide whether to close the connection or not.
+        if (!HttpHeaders.isKeepAlive(request)) {
+            // Close the connection when the whole content is written out.
+            lastContentFuture.addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        cause.printStackTrace();
+        if (ctx.channel().isActive()) {
+            sendError(ctx, INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private static final Pattern INSECURE_URI = Pattern.compile(".*[<>&\"].*");
+
+    private static String sanitizeUri(String uri) {
+        // Decode the path.
+        try {
+            uri = URLDecoder.decode(uri, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new Error(e);
+        }
+
+        if (!uri.startsWith("/")) {
+            return null;
+        }
+
+        // Convert file separators.
+        uri = uri.replace('/', File.separatorChar);
+
+        // Simplistic dumb security check.
+        // You will have to do something serious in the production environment.
+        if (uri.contains(File.separator + '.') ||
+            uri.contains('.' + File.separator) ||
+            uri.startsWith(".") || uri.endsWith(".") ||
+            INSECURE_URI.matcher(uri).matches()) {
+            return null;
+        }
+
+        // Convert to absolute path.
+        return SystemPropertyUtil.get("user.dir") + File.separator + uri;
+    }
+
+    private static final Pattern ALLOWED_FILE_NAME = Pattern.compile("[A-Za-z0-9][-_A-Za-z0-9\\.]*");
+
+    private static void sendListing(ChannelHandlerContext ctx, File dir) {
+        FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, OK);
+        response.headers().set(CONTENT_TYPE, "text/html; charset=UTF-8");
+
+        StringBuilder buf = new StringBuilder();
+        String dirPath = dir.getPath();
+
+        buf.append("<!DOCTYPE html>\r\n");
+        buf.append("<html><head><title>");
+        buf.append("Listing of: ");
+        buf.append(dirPath);
+        buf.append("</title></head><body>\r\n");
+
+        buf.append("<h3>Listing of: ");
+        buf.append(dirPath);
+        buf.append("</h3>\r\n");
+
+        buf.append("<ul>");
+        buf.append("<li><a href=\"../\">..</a></li>\r\n");
+
+        for (File f: dir.listFiles()) {
+            if (f.isHidden() || !f.canRead()) {
+                continue;
+            }
+
+            String name = f.getName();
+            if (!ALLOWED_FILE_NAME.matcher(name).matches()) {
+                continue;
+            }
+
+            buf.append("<li><a href=\"");
+            buf.append(name);
+            buf.append("\">");
+            buf.append(name);
+            buf.append("</a></li>\r\n");
+        }
+
+        buf.append("</ul></body></html>\r\n");
+        ByteBuf buffer = Unpooled.copiedBuffer(buf, CharsetUtil.UTF_8);
+        response.content().writeBytes(buffer);
+        buffer.release();
+
+        // Close the connection as soon as the error message is sent.
+        ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    private static void sendRedirect(ChannelHandlerContext ctx, String newUri) {
+        FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, FOUND);
+        response.headers().set(LOCATION, newUri);
+
+        // Close the connection as soon as the error message is sent.
+        ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    private static void sendError(ChannelHandlerContext ctx, HttpResponseStatus status) {
+        FullHttpResponse response = new DefaultFullHttpResponse(
+                HTTP_1_1, status, Unpooled.copiedBuffer("Failure: " + status + "\r\n", CharsetUtil.UTF_8));
+        response.headers().set(CONTENT_TYPE, "text/plain; charset=UTF-8");
+
+        // Close the connection as soon as the error message is sent.
+        ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    /**
+     * When file timestamp is the same as what the browser is sending up, send a "304 Not Modified"
+     *
+     * @param ctx
+     *            Context
+     */
+    private static void sendNotModified(ChannelHandlerContext ctx) {
+        FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, NOT_MODIFIED);
+        setDateHeader(response);
+
+        // Close the connection as soon as the error message is sent.
+        ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    /**
+     * Sets the Date header for the HTTP response
+     *
+     * @param response
+     *            HTTP response
+     */
+    private static void setDateHeader(FullHttpResponse response) {
+        SimpleDateFormat dateFormatter = new SimpleDateFormat(HTTP_DATE_FORMAT, Locale.US);
+        dateFormatter.setTimeZone(TimeZone.getTimeZone(HTTP_DATE_GMT_TIMEZONE));
+
+        Calendar time = new GregorianCalendar();
+        response.headers().set(DATE, dateFormatter.format(time.getTime()));
+    }
+
+    /**
+     * Sets the Date and Cache headers for the HTTP Response
+     *
+     * @param response
+     *            HTTP response
+     * @param fileToCache
+     *            file to extract content type
+     */
+    private static void setDateAndCacheHeaders(HttpResponse response, File fileToCache) {
+        SimpleDateFormat dateFormatter = new SimpleDateFormat(HTTP_DATE_FORMAT, Locale.US);
+        dateFormatter.setTimeZone(TimeZone.getTimeZone(HTTP_DATE_GMT_TIMEZONE));
+
+        // Date header
+        Calendar time = new GregorianCalendar();
+        response.headers().set(DATE, dateFormatter.format(time.getTime()));
+
+        // Add cache headers
+        time.add(Calendar.SECOND, HTTP_CACHE_SECONDS);
+        response.headers().set(EXPIRES, dateFormatter.format(time.getTime()));
+        response.headers().set(CACHE_CONTROL, "private, max-age=" + HTTP_CACHE_SECONDS);
+        response.headers().set(
+                LAST_MODIFIED, dateFormatter.format(new Date(fileToCache.lastModified())));
+    }
+
+    /**
+     * Sets the content type header for the HTTP Response
+     *
+     * @param response
+     *            HTTP response
+     * @param file
+     *            file to extract content type
+     */
+    private static void setContentTypeHeader(HttpResponse response, File file) {
+        MimetypesFileTypeMap mimeTypesMap = new MimetypesFileTypeMap();
+        response.headers().set(CONTENT_TYPE, mimeTypesMap.getContentType(file.getPath()));
+    }
+}

--- a/example/src/main/java/io/netty/example/traffic/HttpStaticFileServerTrafficShapingInitializer.java
+++ b/example/src/main/java/io/netty/example/traffic/HttpStaticFileServerTrafficShapingInitializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.traffic;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.example.traffic.HttpStaticFileServerTrafficShaping.ModeTransfer;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.stream.ChunkedWriteHandler;
+
+public class HttpStaticFileServerTrafficShapingInitializer extends ChannelInitializer<SocketChannel> {
+
+    private final SslContext sslCtx;
+
+    public HttpStaticFileServerTrafficShapingInitializer(SslContext sslCtx) {
+        this.sslCtx = sslCtx;
+    }
+
+    @Override
+    public void initChannel(SocketChannel ch) {
+        ChannelPipeline pipeline = ch.pipeline();
+        if (sslCtx != null) {
+            pipeline.addLast(sslCtx.newHandler(ch.alloc()));
+        }
+        if (HttpStaticFileServerTrafficShaping.useGlobalTSH) {
+            pipeline.addLast(HttpStaticFileServerTrafficShaping.gtsh);
+        }
+        pipeline.addLast(new ChannelTrafficShapingHandlerWithLog(1024 * 1024, 1024 * 1024, 1000));
+        pipeline.addLast(new HttpServerCodec());
+        pipeline.addLast(new HttpObjectAggregator(65536));
+        if (HttpStaticFileServerTrafficShaping.modeTransfer == ModeTransfer.useChunkedFile) {
+            pipeline.addLast(new ChunkedWriteHandler());
+        }
+        // Note that one may use a different EventLoopGroup than
+        // TrafficShapingHandler to ensure triggered event are sent in time
+        if (HttpStaticFileServerTrafficShaping.modeTransfer == ModeTransfer.useCheckWritability) {
+            pipeline.addLast(HttpStaticFileServerTrafficShaping.businessGroup,
+                new HttpStaticFileServerTrafficShapingHandler());
+        } else {
+            pipeline.addLast(new HttpStaticFileServerTrafficShapingHandler());
+        }
+    }
+}

--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -42,7 +42,8 @@ import java.util.concurrent.TimeUnit;
  * </ul>
  */
 public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler {
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractTrafficShapingHandler.class);
+    private static final InternalLogger logger =
+            InternalLoggerFactory.getInstance(AbstractTrafficShapingHandler.class);
 
     /**
      * Default delay between two checks: 1s
@@ -55,6 +56,11 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
      * Shall be less than TIMEOUT. Here half of "standard" 30s
      */
     public static final long DEFAULT_MAX_TIME = 15000;
+
+    /**
+     * Default max size to not exceed in buffer (write only).
+     */
+    public static final long DEFAULT_MAX_SIZE = 4 * 1024 * 1024L;
 
     /**
      * Default minimal time to wait
@@ -85,6 +91,15 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
      * Delay between two performance snapshots
      */
     protected long checkInterval = DEFAULT_CHECK_INTERVAL; // default 1 s
+
+    /**
+     * Max time to delay before proposing to stop writing new objects from next handlers
+     */
+    protected long maxWriteDelay = 4 * DEFAULT_CHECK_INTERVAL; // default 4 s
+    /**
+     * Max size in the list before proposing to stop writing new objects from next handlers
+     */
+    protected long maxWriteSize = DEFAULT_MAX_SIZE; // default 4MB
 
     private static final AttributeKey<Boolean> READ_SUSPENDED = AttributeKey
             .valueOf(AbstractTrafficShapingHandler.class.getName() + ".READ_SUSPENDED");
@@ -247,7 +262,7 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
     }
 
     /**
-     * @param checkInterval the checkInterval to set
+     * @param checkInterval the interval in ms between each step check to set
      */
     public void setCheckInterval(long checkInterval) {
         this.checkInterval = checkInterval;
@@ -266,10 +281,39 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
     }
 
     /**
-     * @return the max delay in wait
+     * @return the max delay in wait to prevent TIME OUT
      */
     public long getMaxTimeWait() {
         return maxTime;
+    }
+
+    /**
+     * @return the maxWriteDelay
+     */
+    public long getMaxWriteDelay() {
+        return maxWriteDelay;
+    }
+
+    /**
+     * @param maxWriteDelay the maximum Write Delay in ms in the buffer allowed before write suspended is set
+     */
+    public void setMaxWriteDelay(long maxWriteDelay) {
+        this.maxWriteDelay = maxWriteDelay;
+    }
+
+    /**
+     * @return the maxWriteSize
+     */
+    public long getMaxWriteSize() {
+        return maxWriteSize;
+    }
+
+    /**
+     * @param maxWriteSize the maximum Write Size allowed in the buffer
+     *            per channel before write suspended is set
+     */
+    public void setMaxWriteSize(long maxWriteSize) {
+        this.maxWriteSize = maxWriteSize;
     }
 
     /**
@@ -294,24 +338,24 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
         }
 
         public void run() {
-            if (!ctx.channel().config().isAutoRead() && isHandlerActive(ctx)) {
+            if (!ctx.channel().config().isAutoRead() && isHandlerReadActive(ctx)) {
                 // If AutoRead is False and Active is True, user make a direct setAutoRead(false)
                 // Then Just reset the status
                 if (logger.isDebugEnabled()) {
                     logger.debug("Channel:" + ctx.channel().hashCode() +
-                            " Not Unsuspend: " + ctx.channel().config().isAutoRead() + ":" + isHandlerActive(ctx));
+                            " Not Unsuspend: " + ctx.channel().config().isAutoRead() + ":" + isHandlerReadActive(ctx));
                 }
                 ctx.attr(READ_SUSPENDED).set(false);
             } else {
                 // Anything else allows the handler to reset the AutoRead
                 if (logger.isDebugEnabled()) {
-                    if (ctx.channel().config().isAutoRead() && !isHandlerActive(ctx)) {
+                    if (ctx.channel().config().isAutoRead() && !isHandlerReadActive(ctx)) {
                         logger.debug("Channel:" + ctx.channel().hashCode() +
-                                " Unsuspend: " + ctx.channel().config().isAutoRead() + ":" + isHandlerActive(ctx));
+                                " Unsuspend: " + ctx.channel().config().isAutoRead() + ":" + isHandlerReadActive(ctx));
                     } else {
                         logger.debug("Channel:" + ctx.channel().hashCode() +
                                 " Normal Unsuspend: " + ctx.channel().config().isAutoRead() + ":"
-                                + isHandlerActive(ctx));
+                                + isHandlerReadActive(ctx));
                     }
                 }
                 ctx.attr(READ_SUSPENDED).set(false);
@@ -321,7 +365,7 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
             if (logger.isDebugEnabled()) {
                 logger.debug("Channel:" + ctx.channel().hashCode() +
                         " Unsupsend final status => " + ctx.channel().config().isAutoRead() + ":"
-                        + isHandlerActive(ctx));
+                        + isHandlerReadActive(ctx));
             }
         }
     }
@@ -333,15 +377,16 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
         if (size > 0 && trafficCounter != null) {
             // compute the number of ms to wait before reopening the channel
             long wait = trafficCounter.readTimeToWait(size, readLimit, maxTime);
+            wait = checkWaitReadTime(ctx, wait);
             if (wait >= MINIMAL_WAIT) { // At least 10ms seems a minimal
                 // time in order to try to limit the traffic
                 // Only AutoRead AND HandlerActive True means Context Active
                 if (logger.isDebugEnabled()) {
                     logger.debug("Channel:" + ctx.channel().hashCode() +
                             " Read Suspend: " + wait + ":" + ctx.channel().config().isAutoRead() + ":"
-                            + isHandlerActive(ctx));
+                            + isHandlerReadActive(ctx));
                 }
-                if (ctx.channel().config().isAutoRead() && isHandlerActive(ctx)) {
+                if (ctx.channel().config().isAutoRead() && isHandlerReadActive(ctx)) {
                     ctx.channel().config().setAutoRead(false);
                     ctx.attr(READ_SUSPENDED).set(true);
                     // Create a Runnable to reactive the read if needed. If one was create before it will just be
@@ -356,23 +401,42 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
                     if (logger.isDebugEnabled()) {
                         logger.debug("Channel:" + ctx.channel().hashCode() +
                                 " Suspend final status => " + ctx.channel().config().isAutoRead() + ":"
-                                + isHandlerActive(ctx) +
+                                + isHandlerReadActive(ctx) +
                                 " will reopened at: " + wait);
                     }
                 }
             }
         }
+        informReadOperation(ctx);
         ctx.fireChannelRead(msg);
     }
 
-    protected static boolean isHandlerActive(ChannelHandlerContext ctx) {
+    /**
+     * Method overridden in GTSH to take into account specific timer for the channel
+     * @param ctx
+     * @param wait
+     * @return the wait to use according to the context
+     */
+    protected long checkWaitReadTime(final ChannelHandlerContext ctx, long wait) {
+        // no change by default
+        return wait;
+    }
+
+    /**
+     * Method overridden in GTSH to take into account specific timer for the channel
+     * @param ctx
+     */
+    protected void informReadOperation(final ChannelHandlerContext ctx) {
+        // default noop
+    }
+    protected static boolean isHandlerReadActive(ChannelHandlerContext ctx) {
         Boolean suspended = ctx.attr(READ_SUSPENDED).get();
         return suspended == null || Boolean.FALSE.equals(suspended);
     }
 
     @Override
     public void read(ChannelHandlerContext ctx) {
-        if (isHandlerActive(ctx)) {
+        if (isHandlerReadActive(ctx)) {
             // For Global Traffic (and Read when using EventLoop in pipeline) : check if READ_SUSPENDED is False
             ctx.read();
         }
@@ -387,29 +451,57 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
             // compute the number of ms to wait before continue with the channel
             long wait = trafficCounter.writeTimeToWait(size, writeLimit, maxTime);
             if (wait >= MINIMAL_WAIT) {
-                /*
-                 * Option 2: but issue with ctx.executor().schedule()
-                 * Thread.sleep(wait);
-                 * System.out.println("Write unsuspended");
-                 * Option 1: use an ordered list of messages to send
-                 * Warning of memory pressure!
-                 */
                 if (logger.isDebugEnabled()) {
                     logger.debug("Channel:" + ctx.channel().hashCode() +
                             " Write suspend: " + wait + ":" + ctx.channel().config().isAutoRead() + ":"
-                            + isHandlerActive(ctx));
+                            + isHandlerReadActive(ctx));
                 }
-                submitWrite(ctx, msg, wait, promise);
+                submitWrite(ctx, msg, size, wait, promise);
                 return;
             }
         }
         // to keep message order if not using option 2
-        submitWrite(ctx, msg, 0, promise);
+        submitWrite(ctx, msg, size, 0, promise);
     }
 
-    protected abstract void submitWrite(final ChannelHandlerContext ctx, final Object msg, final long delay,
-            final ChannelPromise promise);
+    protected abstract void submitWrite(final ChannelHandlerContext ctx, final Object msg, final long size,
+            final long delay, final ChannelPromise promise);
 
+    @Override
+    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+        ctx.channel().softWritable(true);
+        super.channelRegistered(ctx);
+    }
+
+    /**
+     * Check the writability according to delay and size for the channel.
+     * Set if necessary WRITE_SUSPENDED status.
+     * @param ctx
+     * @param delay
+     * @param queueSize
+     */
+    protected void checkWriteSuspend(ChannelHandlerContext ctx, long delay, long queueSize) {
+        if (queueSize > maxWriteSize || delay > maxWriteDelay) {
+            ctx.channel().softWritable(false);
+            ctx.fireChannelWritabilityChanged();
+        }
+    }
+    /**
+     * Explicitly release the Write suspended status and trigger the event WRITE_ENABLED
+     * @param ctx
+     */
+    protected void releaseWriteSuspended(ChannelHandlerContext ctx) {
+        ctx.channel().softWritable(true);
+        ctx.fireChannelWritabilityChanged();
+    }
+    /**
+     * Check if the current channel is Soft Write Suspended by a TrafficShapingHandler
+     * @param ctx
+     * @return True if write is in Suspended status
+     */
+    public static boolean checkWriteSuspended(ChannelHandlerContext ctx) {
+        return ! ctx.channel().isSoftWritable();
+    }
     /**
      *
      * @return the current TrafficCounter (if
@@ -422,7 +514,8 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
     @Override
     public String toString() {
         return "TrafficShaping with Write Limit: " + writeLimit + " Read Limit: " + readLimit +
-                " CheckInterval: " + checkInterval + " and Counter: "
+                " CheckInterval: " + checkInterval + " maxDelay: " + maxWriteDelay +
+                " maxSize: " + maxWriteSize + " and Counter: "
                 + (trafficCounter != null ? trafficCounter.toString() : "none");
     }
 

--- a/handler/src/main/java/io/netty/handler/traffic/ChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/ChannelTrafficShapingHandler.java
@@ -52,6 +52,7 @@ import io.netty.channel.ChannelPromise;
  */
 public class ChannelTrafficShapingHandler extends AbstractTrafficShapingHandler {
     private List<ToSend> messagesQueue = new LinkedList<ToSend>();
+    private long queueSize;
 
     /**
      * Create a new instance
@@ -147,14 +148,20 @@ public class ChannelTrafficShapingHandler extends AbstractTrafficShapingHandler 
     }
 
     @Override
-    protected synchronized void submitWrite(final ChannelHandlerContext ctx, final Object msg, final long delay,
+    protected synchronized void submitWrite(final ChannelHandlerContext ctx, final Object msg,
+            final long size, final long delay,
             final ChannelPromise promise) {
         if (delay == 0 && messagesQueue.isEmpty()) {
+            if (trafficCounter != null) {
+                trafficCounter.bytesRealWriteFlowControl(size);
+            }
             ctx.write(msg, promise);
             return;
         }
         final ToSend newToSend = new ToSend(delay, msg, promise);
         messagesQueue.add(newToSend);
+        queueSize += size;
+        checkWriteSuspend(ctx, delay, queueSize);
         ctx.executor().schedule(new Runnable() {
             @Override
             public void run() {
@@ -167,12 +174,27 @@ public class ChannelTrafficShapingHandler extends AbstractTrafficShapingHandler 
         while (!messagesQueue.isEmpty()) {
             ToSend newToSend = messagesQueue.remove(0);
             if (newToSend.date <= System.currentTimeMillis()) {
+                long size = calculateSize(newToSend.toSend);
+                if (trafficCounter != null) {
+                    trafficCounter.bytesRealWriteFlowControl(size);
+                }
+                queueSize -= size;
                 ctx.write(newToSend.toSend, newToSend.promise);
             } else {
                 messagesQueue.add(0, newToSend);
                 break;
             }
         }
+        if (messagesQueue.isEmpty()) {
+            releaseWriteSuspended(ctx);
+        }
         ctx.flush();
+    }
+    /**
+     *
+     * @return current size in bytes of the write buffer
+     */
+    public long queueSize() {
+        return queueSize;
     }
 }

--- a/handler/src/main/java/io/netty/handler/traffic/TrafficCounter.java
+++ b/handler/src/main/java/io/netty/handler/traffic/TrafficCounter.java
@@ -49,6 +49,16 @@ public class TrafficCounter {
     private final AtomicLong currentReadBytes = new AtomicLong();
 
     /**
+     * Last writing time during current check interval
+     */
+    private long writingTime = System.currentTimeMillis();
+
+    /**
+     * Last reading delay during current check interval
+     */
+    private long readingTime = System.currentTimeMillis();
+
+    /**
      * Long life written bytes
      */
     private final AtomicLong cumulativeWrittenBytes = new AtomicLong();
@@ -89,24 +99,24 @@ public class TrafficCounter {
     private long lastReadBytes;
 
     /**
-     * Last non 0 written bytes number during last check interval
+     * Last future writing time during last check interval
      */
-    private long lastNonNullWrittenBytes;
+    private long lastWritingTime = System.currentTimeMillis();
 
     /**
-     * Last time written bytes with non 0 written bytes
+     * Last reading time during last check interval
      */
-    private long lastNonNullWrittenTime;
+    private long lastReadingTime = System.currentTimeMillis();
 
     /**
-     * Last time read bytes with non 0 written bytes
+     * Real written bytes
      */
-    private long lastNonNullReadTime;
+    private final AtomicLong realWrittenBytes = new AtomicLong();
 
     /**
-     * Last non 0 read bytes number during last check interval
+     * Real writing bandwidth
      */
-    private long lastNonNullReadBytes;
+    private long realWriteThroughput;
 
     /**
      * Delay between two captures
@@ -237,14 +247,9 @@ public class TrafficCounter {
         // nb byte / checkInterval in ms * 1000 (1s)
         lastWriteThroughput = lastWrittenBytes * 1000 / interval;
         // nb byte / checkInterval in ms * 1000 (1s)
-        if (lastWrittenBytes > 0) {
-            lastNonNullWrittenBytes = lastWrittenBytes;
-            lastNonNullWrittenTime = newLastTime;
-        }
-        if (lastReadBytes > 0) {
-            lastNonNullReadBytes = lastReadBytes;
-            lastNonNullReadTime = newLastTime;
-        }
+        realWriteThroughput = realWrittenBytes.getAndSet(0) * 1000 / interval;
+        lastWritingTime = Math.max(lastWritingTime, writingTime);
+        lastReadingTime = Math.max(lastReadingTime, readingTime);
     }
 
     /**
@@ -310,6 +315,18 @@ public class TrafficCounter {
     void bytesWriteFlowControl(long write) {
         currentWrittenBytes.addAndGet(write);
         cumulativeWrittenBytes.addAndGet(write);
+    }
+
+    /**
+     * Computes counters for Real Write.
+     *
+     * @param write
+     *            the size in bytes to write
+     * @param schedule
+     *            the time when this write was scheduled
+     */
+    void bytesRealWriteFlowControl(long write) {
+        realWrittenBytes.addAndGet(write);
     }
 
     /**
@@ -399,6 +416,20 @@ public class TrafficCounter {
     }
 
     /**
+     * @return the realWrittenBytes
+     */
+    public AtomicLong getRealWrittenBytes() {
+        return realWrittenBytes;
+    }
+
+    /**
+     * @return the realWriteThroughput
+     */
+    public long getRealWriteThroughput() {
+        return realWriteThroughput;
+    }
+
+    /**
      * Reset both read and written cumulative bytes counters and the associated time.
      */
     public void resetCumulativeTime() {
@@ -426,48 +457,50 @@ public class TrafficCounter {
      *            the max time in ms to wait in case of excess of traffic
      * @return the current time to wait (in ms) if needed for Read operation
      */
-    public synchronized long readTimeToWait(final long size, final long limitTraffic, final long maxTime) {
+    public long readTimeToWait(final long size, final long limitTraffic, final long maxTime) {
         final long now = System.currentTimeMillis();
         bytesRecvFlowControl(size);
-        if (limitTraffic == 0) {
+        if (size == 0 || limitTraffic == 0) {
             return 0;
         }
+        if (size == 0 || limitTraffic == 0) {
+            return 0;
+        }
+        final long lastTimeCheck = lastTime.get();
+        final long interval = now - lastTimeCheck;
+        long pastDelay = Math.max(lastReadingTime - lastTimeCheck, 0);
         long sum = currentReadBytes.get();
-        long interval = now - lastTime.get();
-        // Short time checking
-        if (interval > AbstractTrafficShapingHandler.MINIMAL_WAIT && sum > 0) {
-            long time = (sum * 1000 / limitTraffic - interval) / 10 * 10;
+        if (interval > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
+            // Enough interval time to compute shaping
+            long time = (sum * 1000 / limitTraffic - interval + pastDelay) / 10 * 10;
             if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Time: " + time + ":" + sum + ":" + interval);
+                    logger.debug("Time: " + time + ":" + sum + ":" + interval + ":" + pastDelay);
                 }
-                return time > maxTime ? maxTime : time;
+                if (time > maxTime && now + time - readingTime > maxTime) {
+                    time = maxTime;
+                }
+                readingTime = Math.max(readingTime, now + time);
+                return time;
             }
+            readingTime = Math.max(readingTime, now);
             return 0;
         }
-        // long time checking
-        if (lastNonNullReadBytes > 0 && lastNonNullReadTime + AbstractTrafficShapingHandler.MINIMAL_WAIT < now) {
-            long lastsum = sum + lastNonNullReadBytes;
-            long lastinterval = now - lastNonNullReadTime;
-            long time = (lastsum * 1000 / limitTraffic - lastinterval) / 10 * 10;
-            if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Time: " + time + ":" + lastsum + ":" + lastinterval);
-                }
-                return time > maxTime ? maxTime : time;
+        // take the last read interval check to get enough interval time
+        long lastsum = sum + lastReadBytes;
+        long lastinterval = interval + checkInterval.get();
+        long time = (lastsum * 1000 / limitTraffic - lastinterval + pastDelay) / 10 * 10;
+        if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Time: " + time + ":" + lastsum + ":" + lastinterval + ":" + pastDelay);
             }
-        } else {
-            // final "middle" time checking in case resetAccounting called very recently
-            sum += lastReadBytes;
-            long lastinterval = AbstractTrafficShapingHandler.MINIMAL_WAIT;
-            long time = (sum * 1000 / limitTraffic - lastinterval) / 10 * 10;
-            if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Time: " + time + ":" + sum + ":" + lastinterval);
-                }
-                return time > maxTime ? maxTime : time;
+            if (time > maxTime && now + time - readingTime > maxTime) {
+                time = maxTime;
             }
+            readingTime = Math.max(readingTime, now + time);
+            return time;
         }
+        readingTime = Math.max(readingTime, now);
         return 0;
     }
 
@@ -483,45 +516,47 @@ public class TrafficCounter {
      *            the max time in ms to wait in case of excess of traffic
      * @return the current time to wait (in ms) if needed for Write operation
      */
-    public synchronized long writeTimeToWait(final long size, final long limitTraffic, final long maxTime) {
+    public long writeTimeToWait(final long size, final long limitTraffic, final long maxTime) {
         bytesWriteFlowControl(size);
-        if (limitTraffic == 0) {
+        if (size == 0 || limitTraffic == 0) {
             return 0;
         }
-        long sum = currentWrittenBytes.get();
         final long now = System.currentTimeMillis();
-        long interval = now - lastTime.get();
-        if (interval > AbstractTrafficShapingHandler.MINIMAL_WAIT && sum > 0) {
-            long time = (sum * 1000 / limitTraffic - interval) / 10 * 10;
+        final long lastTimeCheck = lastTime.get();
+        final long interval = now - lastTimeCheck;
+        long pastDelay = Math.max(lastWritingTime - lastTimeCheck, 0);
+        long sum = currentWrittenBytes.get();
+        if (interval > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
+            // Enough interval time to compute shaping
+            long time = (sum * 1000 / limitTraffic - interval + pastDelay) / 10 * 10;
             if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Time: " + time + ":" + sum + ":" + interval);
+                    logger.debug("Time: " + time + ":" + sum + ":" + interval + ":" + pastDelay);
                 }
-                return time > maxTime ? maxTime : time;
+                if (time > maxTime && now + time - writingTime > maxTime) {
+                    time = maxTime;
+                }
+                writingTime = Math.max(writingTime, now + time);
+                return time;
             }
+            writingTime = Math.max(writingTime, now);
             return 0;
         }
-        if (lastNonNullWrittenBytes > 0 && lastNonNullWrittenTime + AbstractTrafficShapingHandler.MINIMAL_WAIT < now) {
-            long lastsum = sum + lastNonNullWrittenBytes;
-            long lastinterval = now - lastNonNullWrittenTime;
-            long time = (lastsum * 1000 / limitTraffic - lastinterval) / 10 * 10;
-            if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Time: " + time + ":" + lastsum + ":" + lastinterval);
-                }
-                return time > maxTime ? maxTime : time;
+        // take the last write interval check to get enough interval time
+        long lastsum = sum + lastWrittenBytes;
+        long lastinterval = interval + checkInterval.get();
+        long time = (lastsum * 1000 / limitTraffic - lastinterval + pastDelay) / 10 * 10;
+        if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Time: " + time + ":" + lastsum + ":" + lastinterval + ":" + pastDelay);
             }
-        } else {
-            sum += lastWrittenBytes;
-            long lastinterval = AbstractTrafficShapingHandler.MINIMAL_WAIT + Math.abs(interval);
-            long time = (sum * 1000 / limitTraffic - lastinterval) / 10 * 10;
-            if (time > AbstractTrafficShapingHandler.MINIMAL_WAIT) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Time: " + time + ":" + sum + ":" + lastinterval);
-                }
-                return time > maxTime ? maxTime : time;
+            if (time > maxTime && now + time - writingTime > maxTime) {
+                time = maxTime;
             }
+            writingTime = Math.max(writingTime, now + time);
+            return time;
         }
+        writingTime = Math.max(writingTime, now);
         return 0;
     }
 
@@ -530,8 +565,11 @@ public class TrafficCounter {
      */
     @Override
     public String toString() {
-        return "Monitor " + name + " Current Speed Read: " + (lastReadThroughput >> 10) + " KB/s, Write: "
-                + (lastWriteThroughput >> 10) + " KB/s Current Read: " + (currentReadBytes.get() >> 10)
-                + " KB Current Write: " + (currentWrittenBytes.get() >> 10) + " KB";
+        return "Monitor " + name + " Current Speed Read: " + (lastReadThroughput >> 10) + " KB/s, " +
+                "Asked Write: " + (lastWriteThroughput >> 10) + " KB/s, " +
+                "Real Write: " + (realWriteThroughput >> 10) + " KB/s, " +
+                "Current Read: " + (currentReadBytes.get() >> 10)
+                + " KB, Current asked Write: " + (currentWrittenBytes.get() >> 10) + " KB, " +
+                "Current real Write: " + (realWrittenBytes.get() >> 10) + " KB";
     }
 }

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -65,6 +65,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     private volatile SocketAddress remoteAddress;
     private volatile EventLoop eventLoop;
     private volatile boolean registered;
+    private volatile boolean softWritable = true;
 
     /** Cache for the string representation of this channel */
     private boolean strValActive;
@@ -85,7 +86,17 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     @Override
     public boolean isWritable() {
         ChannelOutboundBuffer buf = unsafe.outboundBuffer();
-        return buf != null && buf.isWritable();
+        return buf != null && buf.isWritable() && softWritable;
+    }
+
+    @Override
+    public boolean isSoftWritable() {
+        return softWritable;
+    }
+
+    @Override
+    public void softWritable(boolean softWritable) {
+        this.softWritable = softWritable;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -157,7 +157,19 @@ public interface Channel extends AttributeMap, Comparable<Channel> {
      * ready to process the queued write requests.
      */
     boolean isWritable();
+    /**
+     *
+     * @return the current status of soft Writable property. False means
+     * an handler is willing to block the write operation. If False,
+     * isWritable() will also returns False.
+     */
+    boolean isSoftWritable();
 
+    /**
+     * Allow to set the soft writable status for this channel.
+     * @param softWritable
+     */
+    void softWritable(boolean softWritable);
     /**
      * Returns an <em>internal-use-only</em> object that provides unsafe operations.
      */


### PR DESCRIPTION
Motivation:
Several issues were shown by various ticket (#2900 #2956).

Issue #2900
When a huge amount of data are written, the current behavior of the
TrafficShaping handler is to limit the delay to 15s, whatever the delay
the previous write has. This is wrong, and when a huge amount of writes
are done in a short time, the traffic is not correctly shapened.

Moreover, there is a high risk of OOM if one is not using in his/her own
handler for instance ChannelFuture.addListener() to handle the write
bufferisation in the TrafficShapingHandler.

As for autoRead (setAutoRead), I think it could be useful to allow
someone to set a "softWritability" property to the channel. Doing this,
this will allow some handlers to "soft" managed writability directly, as
for reading, without the need to create another Attribute neither
another event, but using current isWritable() and
channelWritabilityChanged().
This allows for instance HttpChunkedInput to be fully compatible.

The "bandwidth" compute on write is only on "acquired" write orders, not
on "real" write orders, which is wrong from statistic point of view.

Issue #2956
When using GlobalTrafficShaping, every write (and read) are
synchronized, thus leading to a drop of performance.
ChannelTrafficShaping is not touched by this issue since synchronzed is
then correct (handler is per channel, so the synchronized).

Modifications:
The current write delay computation takes into account the previous
write delay and time to check is the 15s delay (maxTime) is really
exceeded or not (using last scheduled write time). The algorithm is
simplified and in the same time more accurate.

This proposal adds 2 new methods to Channel (isSoftWritable() and
softWritable) in order to manage this value, and to change isWritable()
by taking into account this new softWritable property.

When the real write occurs, the statistics are update accordingly on a
new attribute (getRealWriteThroughput()).

To limit the synchronisations, all synchronized on
GlobalTrafficShapingHandler on submitWrite were removed. They are
replaced with a lock per channel (since synchronization is still needed
to prevent unordered write per channel), as in the sendAllValid method
for the very same reason.
Also all synchronized on TrafficCounter on read/writeTimeToWait() are
removed as they are unnecessary since already locked before by the
caller.
Still the creation and remove operations on lock per channel (PerChannel
object) are synchronized to prevent concurrency issue on this critical
part, but then limited.

Result:
The traffic shaping is more stable, even with a huge number of writes in
short time by taking into consideration last scheduled write time.

When changing the current proposal implementation of
TrafficShapingHandler using softWritability management and default
fireChannelWritabilityChanged, it works like a charm and does not need
those extra Attribute/user event. Could be used anywhere else too where
a "bufferisation" is made in front of the channel default bufferisation.

The statistics are more valuable (asked write vs real write).

Various examples are shown in one added example (example/traffic), and
in particular how a user handler might managed the write to prevent OOM:

using the ChannelFuture.addListener(new GenericFutureListener>() one by
one, or by set of writes
using the ctx.channel().isWritable() and channelWritabilityChanged()
using a code as HttpChunkedInput to send the chunks according to the
channelWritabilityChanged() (softWritability is needed)
using no specific check, but with the risk of OOM (no control on the
bufferisation made by the TSH)

The Global TrafficShapingHandler should now have less "global"
synchronization, hoping to the minimum, but still per Channel as needed.
