### PR TITLE
Upgrading HTTP/2 hpack to latest version

### DIFF
--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -43,7 +43,6 @@
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>hpack</artifactId>
-      <version>0.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -463,6 +463,11 @@
 
       <!-- SPDY and HTTP/2 - completely optional -->
       <dependency>
+        <groupId>com.twitter</groupId>
+        <artifactId>hpack</artifactId>
+        <version>0.9.1</version>
+      </dependency>
+      <dependency>
         <groupId>org.eclipse.jetty.npn</groupId>
         <artifactId>npn-api</artifactId>
         <version>1.1.0.v20120525</version>


### PR DESCRIPTION
Motivation:

Twitter hpack has upgraded to 0.9.1, we should upgrade to the latest.

Modifications:

Updated the parent pom to specify the dependency version. Updated the
http2 pom to use the version specified by the parent.

Result:

HTTP/2 updated to the latest hpack release.
