### PR TITLE
TLS Server Name Indication(SNI) support

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SniSslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SniSslHandler.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.CharsetUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import java.net.IDN;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * SniSslHandler enables <a href="https://tools.ietf.org/html/rfc3546#section-3.1">
+ * SNI, Server Name Indication</a> extension for server side SSL. For clients
+ * support SNI, the server could have multiple host name bound on a single IP.
+ * The client will send host name in the handshake data so server could decide
+ * which certificate to choose for the host name.
+ *
+ * DNS wildcard is supported as hostname, so you can use <code>*.netty.io</code> to match both <code>netty.io</code>
+ * and <code>downloads.netty.io</code>.
+ */
+public class SniSslHandler extends SslHandler {
+
+    private static final InternalLogger logger =
+            InternalLoggerFactory.getInstance(SniSslHandler.class);
+
+    private static final Pattern DNS_WILDCARD_PATTERN = Pattern.compile("^\\*\\..*");
+
+    private final Map<String, SSLEngine> engines;
+    private String hostname;
+    private boolean handshaken;
+    private SSLEngine selectedEngine;
+
+    /**
+     * SniSslHandler builder. Use this class to generate SniSslHandler for each pipeline.
+     */
+    public static class Builder {
+
+        private final Map<String, SSLEngine> userProvidedEngines;
+
+        private SSLEngine defaultEngine;
+
+        /**
+         * Create a default, order-sensitive builder. If your hostnames are in conflict, the handler
+         * will choose the one you add first.
+         */
+        public Builder() {
+            this(4);
+        }
+
+        /**
+         * Create a default, order-sensitive builder. If your hostnames are in conflict, the handler
+         * will choose the one you add first.
+         *
+         * @param initialSize initial size for internal map
+         */
+        public Builder(int initialSize) {
+            userProvidedEngines = new LinkedHashMap<String, SSLEngine>(initialSize);
+        }
+
+        /**
+         * Create the builder with predefined certificates.
+         *
+         * @param userMap a map of configured ssl engines
+         */
+        public Builder(Map<String, SSLEngine> userMap) {
+            if (userMap == null) {
+                throw new NullPointerException("userMap is null");
+            }
+            userProvidedEngines = new LinkedHashMap<String, SSLEngine>(userMap.size());
+            for (Map.Entry<String, SSLEngine> entry : userMap.entrySet()) {
+                addEngine(entry.getKey(), entry.getValue());
+            }
+        }
+
+        /**
+         * Add a certificate to the handler.
+         *
+         * <a href="http://en.wikipedia.org/wiki/Wildcard_DNS_record">DNS wildcard</a> is supported as hostname, you can
+         * use "*.netty.io" to match "netty.io" and "downloads.netty.io".
+         *
+         * @param hostname hostname for the certificate.
+         * @param engine
+         */
+        public Builder addEngine(String hostname, SSLEngine engine) {
+            if (hostname == null) {
+                throw new NullPointerException("hostname is null");
+            }
+
+            if (engine == null) {
+                throw new NullPointerException("engine is null");
+            }
+
+            userProvidedEngines.put(normalizeHostname(hostname), engine);
+            return this;
+        }
+
+        public Builder defaultEngine(SSLEngine engine) {
+            if (engine == null) {
+                throw new NullPointerException("default engine is null");
+            }
+            defaultEngine = engine;
+            return this;
+        }
+
+        public SniSslHandler build() {
+             return new SniSslHandler(userProvidedEngines, defaultEngine);
+        }
+    }
+
+    /**
+     * IDNA ASCII conversion and case normalization
+     */
+    private static String normalizeHostname(String hostname) {
+        return IDN.toASCII(hostname, IDN.ALLOW_UNASSIGNED).toLowerCase();
+    }
+
+    /**
+     * Create a SNI enabled handler with a set of SSLEngines.
+     *
+     * <p>Currently we are matching host name by iterating the map. If you need order-sensitive matching, you can use
+     * LinkedHashMap here. </p>
+     *
+     * @param engines       hostname:SSLEngine map with DNS wildcard support
+     * @param defaultEngine default SSLEngine when the client doesn't support SNI
+     */
+    SniSslHandler(Map<String, SSLEngine> engines, SSLEngine defaultEngine) {
+        super(defaultEngine);
+        if (engines == null) {
+            throw new NullPointerException("engines");
+        }
+        this.engines = engines;
+
+        handshaken = false;
+    }
+
+    /**
+     * <p>Simple function to match <a href="http://en.wikipedia.org/wiki/Wildcard_DNS_record">DNS wildcard</a>.
+     * </p>
+     *
+     * <p><code>*.netty.io</code> will match both <code>netty.io</code> and <code>downloads.netty.io</code></p>
+     */
+    private static boolean matches(String hostNameTemplate, String hostName) {
+        // note that inputs are converted and lowercased already
+        if (DNS_WILDCARD_PATTERN.matcher(hostNameTemplate).matches()) {
+            return hostNameTemplate.substring(2).equals(hostName) ||
+                    hostName.endsWith(hostNameTemplate.substring(1));
+        } else {
+            return hostNameTemplate.equals(hostName);
+        }
+    }
+
+    /**
+     * @return the selected hostname
+     */
+    public String hostname() {
+        return hostname;
+    }
+
+    @Override
+    public SSLEngine engine() {
+        // use default engine when SNI is not available
+        return selectedEngine != null ? selectedEngine : super.engine();
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws SSLException {
+        if (!handshaken && in.readableBytes() > 5) {
+            String hostname = getSNIHostNameFromHandshakeInfo(in);
+
+            if (hostname != null) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Using hostname: {}", hostname);
+                }
+
+                // toASCII conversion and case normalization
+                hostname = normalizeHostname(hostname);
+                this.hostname = hostname;
+
+                for (Map.Entry<String, SSLEngine> entry : engines.entrySet()) {
+                    if (matches(entry.getKey(), hostname)) {
+                        selectedEngine = entry.getValue();
+                        break;
+                    }
+                }
+            }
+        }
+
+        super.decode(ctx, in, out);
+    }
+
+    private String getSNIHostNameFromHandshakeInfo(ByteBuf in) {
+        try {
+            int command = in.getUnsignedByte(0);
+
+            // tls, but not handshake command
+            switch (command) {
+                case SslConstants.SSL_CONTENT_TYPE_CHANGE_CIPHER_SPEC:
+                case SslConstants.SSL_CONTENT_TYPE_ALERT:
+                case SslConstants.SSL_CONTENT_TYPE_APPLICATION_DATA:
+                    return null;
+                case SslConstants.SSL_CONTENT_TYPE_HANDSHAKE:
+                    break;
+                default:
+                    //not tls or sslv3, do not try sni
+                    handshaken = true;
+                    return null;
+            }
+
+            int majorVersion = in.getUnsignedByte(1);
+
+            // SSLv3 or TLS
+            if (majorVersion == 3) {
+
+                int packetLength = in.getUnsignedShort(3) + 5;
+
+                if (in.readableBytes() >= packetLength) {
+                    // decode the ssl client hello packet
+                    // we have to skip some var-length fields
+                    int offset = 43;
+
+                    int sessionIdLength = in.getUnsignedByte(offset);
+                    offset += sessionIdLength + 1;
+
+                    int cipherSuitesLength = in.getUnsignedShort(offset);
+                    offset += cipherSuitesLength + 2;
+
+                    int compressionMethodLength = in.getUnsignedByte(offset);
+                    offset += compressionMethodLength + 1;
+
+                    int extensionsLength = in.getUnsignedShort(offset);
+                    offset += 2;
+                    int extensionsLimit = offset + extensionsLength;
+
+                    while (offset < extensionsLimit) {
+                        int extensionType = in.getUnsignedShort(offset);
+                        offset += 2;
+
+                        int extensionLength = in.getUnsignedShort(offset);
+                        offset += 2;
+
+                        // SNI
+                        if (extensionType == 0) {
+                            handshaken = true;
+                            int serverNameType = in.getUnsignedByte(offset + 2);
+                            if (serverNameType == 0) {
+                                int serverNameLength = in.getUnsignedShort(offset + 3);
+                                return in.toString(offset + 5, serverNameLength,
+                                        CharsetUtil.UTF_8);
+                            } else {
+                                // invalid enum value
+                                return null;
+                            }
+                        }
+
+                        offset += extensionLength;
+                    }
+
+                    handshaken = true;
+                    return null;
+                } else {
+                    // client hello incomplete
+                    return null;
+                }
+            } else {
+                handshaken = true;
+                return null;
+            }
+        } catch (Throwable e) {
+            // unexpected encoding, ignore sni and use default
+            if (logger.isDebugEnabled()) {
+                logger.debug("Unexpected client hello packet: " + ByteBufUtil.hexDump(in), e);
+            }
+            handshaken = true;
+            return null;
+        }
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/SslConstants.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslConstants.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+/**
+ * Constants for SSL packets.
+ */
+final class SslConstants {
+
+    /**
+     * change cipher spec
+     */
+    public static final int SSL_CONTENT_TYPE_CHANGE_CIPHER_SPEC = 20;
+
+    /**
+     * alert
+     */
+    public static final int SSL_CONTENT_TYPE_ALERT = 21;
+
+    /**
+     * handshake
+     */
+    public static final int SSL_CONTENT_TYPE_HANDSHAKE = 22;
+
+    /**
+     * application data
+     */
+    public static final int SSL_CONTENT_TYPE_APPLICATION_DATA = 23;
+
+    private SslConstants() {
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -340,7 +340,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         ctx.executor().execute(new Runnable() {
             @Override
             public void run() {
-                engine.closeOutbound();
+                engine().closeOutbound();
                 try {
                     write(ctx, Unpooled.EMPTY_BUFFER, future);
                     flush(ctx);
@@ -437,6 +437,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         ByteBuf out = null;
         ChannelPromise promise = null;
         try {
+            SSLEngine engine = engine();
             for (;;) {
                 Object msg = pendingUnencryptedWrites.current();
                 if (msg == null) {
@@ -520,6 +521,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     private void wrapNonAppData(ChannelHandlerContext ctx, boolean inUnwrap) throws SSLException {
         ByteBuf out = null;
         try {
+            SSLEngine engine = engine();
             for (;;) {
                 if (out == null) {
                     out = allocateOutNetBuf(ctx, 0);
@@ -731,10 +733,10 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         // SSLv3 or TLS - Check ContentType
         boolean tls;
         switch (buffer.getUnsignedByte(offset)) {
-            case 20:  // change_cipher_spec
-            case 21:  // alert
-            case 22:  // handshake
-            case 23:  // application_data
+            case SslConstants.SSL_CONTENT_TYPE_CHANGE_CIPHER_SPEC:
+            case SslConstants.SSL_CONTENT_TYPE_ALERT:
+            case SslConstants.SSL_CONTENT_TYPE_HANDSHAKE:
+            case SslConstants.SSL_CONTENT_TYPE_APPLICATION_DATA:
                 tls = true;
                 break;
             default:
@@ -852,7 +854,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             in.skipBytes(totalLength);
             final ByteBuffer inNetBuf = in.nioBuffer(startOffset, totalLength);
             unwrap(ctx, inNetBuf, totalLength);
-            assert !inNetBuf.hasRemaining() || engine.isInboundDone();
+            assert !inNetBuf.hasRemaining() || engine().isInboundDone();
         }
 
         if (nonSslRecord) {
@@ -903,6 +905,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
         boolean wrapLater = false;
         ByteBuf decodeOut = allocate(ctx, initialOutAppBufCapacity);
+        SSLEngine engine = engine();
         try {
             for (;;) {
                 final SSLEngineResult result = unwrap(engine, packet, decodeOut);
@@ -1005,6 +1008,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      * the {@link #delegatedTaskExecutor} and wait until the tasks are finished.
      */
     private void runDelegatedTasks() {
+        SSLEngine engine = engine();
         if (delegatedTaskExecutor == ImmediateExecutor.INSTANCE) {
             for (;;) {
                 Runnable task = engine.getDelegatedTask();
@@ -1080,6 +1084,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      * Notify all the handshake futures about the successfully handshake
      */
     private void setHandshakeSuccess() {
+        SSLEngine engine = engine();
         // Work around the JVM crash which occurs when a cipher suite with GCM enabled.
         final String cipherSuite = String.valueOf(engine.getSession().getCipherSuite());
         if (!wantsDirectBuffer && (cipherSuite.contains("_GCM_") || cipherSuite.contains("-GCM-"))) {
@@ -1098,6 +1103,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      * Notify all the handshake futures about the failure during the handshake.
      */
     private void setHandshakeFailure(Throwable cause) {
+        SSLEngine engine = engine();
         // Release all resources such as internal buffers that SSLEngine
         // is managing.
         engine.closeOutbound();
@@ -1136,7 +1142,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             return;
         }
 
-        engine.closeOutbound();
+        engine().closeOutbound();
 
         ChannelPromise closeNotifyFuture = ctx.newPromise();
         write(ctx, Unpooled.EMPTY_BUFFER, closeNotifyFuture);
@@ -1149,7 +1155,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         this.ctx = ctx;
         pendingUnencryptedWrites = new PendingWriteQueue(ctx);
 
-        if (ctx.channel().isActive() && engine.getUseClientMode()) {
+        if (ctx.channel().isActive() && engine().getUseClientMode()) {
             // channelActive() event has been fired already, which means this.channelActive() will
             // not be invoked. We have to initialize here instead.
             handshake();
@@ -1184,7 +1190,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             }
         });
         try {
-            engine.beginHandshake();
+            engine().beginHandshake();
             wrapNonAppData(ctx, false);
             ctx.flush();
         } catch (Exception e) {
@@ -1198,7 +1204,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      */
     @Override
     public void channelActive(final ChannelHandlerContext ctx) throws Exception {
-        if (!startTls && engine.getUseClientMode()) {
+        if (!startTls && engine().getUseClientMode()) {
             // issue and handshake and add a listener to it which will fire an exception event if
             // an exception was thrown while doing the handshake
             handshake().addListener(new GenericFutureListener<Future<Channel>>() {

--- a/handler/src/test/java/io/netty/handler/ssl/SniSslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniSslHandlerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.ssl;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderException;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.xml.bind.DatatypeConverter;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class SniSslHandlerTest {
+
+    private static SSLEngine makeSslEngine() throws Exception {
+        SSLEngine engine = SSLContext.getDefault().createSSLEngine();
+        engine.setUseClientMode(false);
+        return engine;
+    }
+
+    @Test
+    public void testServerNameParsing() throws Exception {
+        SniSslHandler.Builder builder = new SniSslHandler.Builder();
+
+        SSLEngine nettyEngine = makeSslEngine();
+        builder.addEngine("*.netty.io", nettyEngine);
+
+        SSLEngine leanEngine = makeSslEngine();
+        // input with custom cases
+        builder.addEngine("*.LEANCLOUD.CN", leanEngine);
+
+        // a hostname conflict with previous one, since we are using order-sensitive config, the engine won't
+        // be used with the handler.
+        SSLEngine leanEngin2 = makeSslEngine();
+        builder.addEngine("chat4.leancloud.cn", leanEngin2);
+
+        builder.defaultEngine(nettyEngine);
+
+        SniSslHandler handler = builder.build();
+        EmbeddedChannel ch = new EmbeddedChannel(handler);
+
+        // hex dump of a client hello packet, which contains hostname "CHAT4。LEANCLOUD。CN"
+        String tlsHandshakeMessageHex = "16030100bd010000b90303a74225676d1814ba57faff3b366" +
+                "3656ed05ee9dbb2a4dbb1bb1c32d2ea5fc39e0000000100008c0000001700150000164348" +
+                "415434E380824C45414E434C4F5544E38082434E000b000403000102000a00340032000e0" +
+                "00d0019000b000c00180009000a0016001700080006000700140015000400050012001300" +
+                "0100020003000f0010001100230000000d0020001e0601060206030501050205030401040" +
+                "20403030103020303020102020203000f00010133740000";
+        byte[] handshakeBytes = DatatypeConverter.parseHexBinary(tlsHandshakeMessageHex);
+
+        try {
+            // Push the handshake message.
+            // Decode should fail because no cipher suites in common, but SNI detection should be finished already
+            ch.writeInbound(Unpooled.wrappedBuffer(handshakeBytes));
+            fail();
+        } catch (DecoderException e) {
+            // expected
+        }
+
+        assertThat(ch.finish(), is(false));
+        assertThat(handler.hostname(), is("chat4.leancloud.cn"));
+        assertThat(handler.engine(), is(leanEngine));
+    }
+
+}


### PR DESCRIPTION
Added server side support for TLS SNI. With SNI, we can add multiple host names on a single secure server. The server will check hostname extension of TLS client hello, and wrap/unwrap the connection with proper certificate.

SNI is supported in a new class SniSslHandler extends SslHandler, with a map of String:SSLEngine as argument. You can use glob express like "*.leancloud,cn" as key to match all requests to the domain (as certificate supports that).

Tested on:
- Nodejs 0.10.x: support SNI,  works
- python2 urllib: doesn't send SNI, don't verify server host name in server hello
- python3 urllib: support SNI, works
- Apache HttpComponents on openjdk8: doesn't send SNI, and check server host name
