### PR TITLE
Refactor LzfDecoder to use proper state machine

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/compression/LzfDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/LzfDecoderTest.java
@@ -60,9 +60,9 @@ public class LzfDecoderTest {
     }
 
     @Test
-    public void testUnexpectedSignatureOfChunk() throws Exception {
+    public void testUnexpectedBlockIdentifier() throws Exception {
         expected.expect(DecompressionException.class);
-        expected.expectMessage("Unexpected signature of chunk");
+        expected.expectMessage("unexpected block identifier");
 
         ByteBuf in = Unpooled.buffer();
         in.writeShort(0x1234);  //random value
@@ -75,7 +75,7 @@ public class LzfDecoderTest {
     @Test
     public void testUnknownTypeOfChunk() throws Exception {
         expected.expect(DecompressionException.class);
-        expected.expectMessage("Unknown type of chunk");
+        expected.expectMessage("unknown type of chunk");
 
         ByteBuf in = Unpooled.buffer();
         in.writeByte(BYTE_Z);


### PR DESCRIPTION
Motivation:

Make it much more readable code.

Modifications:
- Added states of decompression.
- Refactored decode(...) method to use this states.

Result:

Much more readable decoder which looks like other compression decoders.

@trustin wrote about it: https://github.com/netty/netty/pull/2755#issuecomment-51855712 and https://github.com/netty/netty/pull/2739#issuecomment-52146230
