### PR TITLE
Allowing negative keys in IntObjectHashMap.

### DIFF
--- a/common/src/main/java/io/netty/util/collection/IntObjectHashMap.java
+++ b/common/src/main/java/io/netty/util/collection/IntObjectHashMap.java
@@ -312,7 +312,11 @@ public class IntObjectHashMap<V> implements IntObjectMap<V>, Iterable<IntObjectM
      * Returns the hashed index for the given key.
      */
     private int hashIndex(int key) {
-        return key % keys.length;
+        int hash = key % keys.length;
+        if (hash < 0) {
+            hash += keys.length;
+        }
+        return hash;
     }
 
     /**

--- a/common/src/test/java/io/netty/util/collection/IntObjectHashMapTest.java
+++ b/common/src/test/java/io/netty/util/collection/IntObjectHashMapTest.java
@@ -117,6 +117,14 @@ public class IntObjectHashMapTest {
     }
 
     @Test
+    public void negativeKeyShouldSucceed() {
+        Value v = new Value("v");
+        map.put(-3, v);
+        assertEquals(1, map.size());
+        assertEquals(v, map.get(-3));
+    }
+
+    @Test
     public void removeMissingValueShouldReturnNull() {
         assertNull(map.remove(1));
         assertEquals(0, map.size());


### PR DESCRIPTION
Motivation:

IntObjectHashMap throws an exception when using negative values for
keys.

Modifications:

Changed hashIndex() to normalize the index if the mod operation returns
a negative number.

Result:

IntObjectHashMap supports negative key values.
