### PR TITLE
Optimize IntObjectHashMap handling of negative keys.

### DIFF
--- a/common/src/main/java/io/netty/util/collection/IntObjectHashMap.java
+++ b/common/src/main/java/io/netty/util/collection/IntObjectHashMap.java
@@ -312,11 +312,9 @@ public class IntObjectHashMap<V> implements IntObjectMap<V>, Iterable<IntObjectM
      * Returns the hashed index for the given key.
      */
     private int hashIndex(int key) {
-        int hash = key % keys.length;
-        if (hash < 0) {
-            hash += keys.length;
-        }
-        return hash;
+        int length = keys.length;
+        // Allowing for negative keys by adding the length after the first mod operation.
+        return (key % length + length) % length;
     }
 
     /**


### PR DESCRIPTION
Motivation:

The hashIndex method currently uses a conditional to handle negative
keys. This could be done without a conditional to slightly improve
performance.

Modifications:

Modified hashIndex() to avoid using a conditional.

Result:

Slight performance improvement to hashIndex().
