### PR TITLE
HTTP/2 Stream ID unit tests

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -210,6 +210,16 @@ public class DefaultHttp2ConnectionTest {
         assertTrue(server.activeStreams().isEmpty());
     }
 
+    @Test(expected = Http2Exception.class)
+    public void localStreamInvalidStreamIdShouldThrow() throws Http2Exception {
+        client.createLocalStream(Integer.MAX_VALUE + 2, false);
+    }
+
+    @Test(expected = Http2Exception.class)
+    public void remoteStreamInvalidStreamIdShouldThrow() throws Http2Exception {
+        client.createRemoteStream(Integer.MAX_VALUE + 1, false);
+    }
+
     @Test
     public void prioritizeShouldUseDefaults() throws Exception {
         Http2Stream stream = client.local().createStream(1, false);


### PR DESCRIPTION
Motivation:
There should be a unit test for when the stream ID wraps around and is 'too large' or negative.
The lack of unit test masked an issue where this was not being throw.

Modifications:
Add a unit test to cover the case where creating a remote and local stream where stream id is 'too large'

Result:
Unit test scope increases.
