### PR TITLE
Headers Cleanup

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -340,43 +340,43 @@ public class DefaultHeaders<T> implements Headers<T> {
     }
 
     @Override
-    public boolean containsBoolean(T name, int value) {
-        return contains(name, valueConverter.convertObject(checkNotNull(value, "value")));
+    public boolean containsBoolean(T name, boolean value) {
+        return contains(name, valueConverter.convertBoolean(checkNotNull(value, "value")));
     }
 
     @Override
     public boolean containsByte(T name, byte value) {
-        return contains(name, valueConverter.convertObject(checkNotNull(value, "value")));
+        return contains(name, valueConverter.convertByte(checkNotNull(value, "value")));
     }
 
     @Override
     public boolean containsChar(T name, char value) {
-        return contains(name, valueConverter.convertObject(checkNotNull(value, "value")));
+        return contains(name, valueConverter.convertChar(checkNotNull(value, "value")));
     }
 
     @Override
-    public boolean containsShort(T name, byte value) {
-        return contains(name, valueConverter.convertObject(checkNotNull(value, "value")));
+    public boolean containsShort(T name, short value) {
+        return contains(name, valueConverter.convertShort(checkNotNull(value, "value")));
     }
 
     @Override
     public boolean containsInt(T name, int value) {
-        return contains(name, valueConverter.convertObject(checkNotNull(value, "value")));
+        return contains(name, valueConverter.convertInt(checkNotNull(value, "value")));
     }
 
     @Override
     public boolean containsLong(T name, long value) {
-        return contains(name, valueConverter.convertObject(checkNotNull(value, "value")));
+        return contains(name, valueConverter.convertLong(checkNotNull(value, "value")));
     }
 
     @Override
     public boolean containsFloat(T name, float value) {
-        return contains(name, valueConverter.convertObject(checkNotNull(value, "value")));
+        return contains(name, valueConverter.convertFloat(checkNotNull(value, "value")));
     }
 
     @Override
     public boolean containsDouble(T name, double value) {
-        return contains(name, valueConverter.convertObject(checkNotNull(value, "value")));
+        return contains(name, valueConverter.convertDouble(checkNotNull(value, "value")));
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/EmptyHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/EmptyHeaders.java
@@ -253,7 +253,7 @@ public class EmptyHeaders<T> implements Headers<T> {
     }
 
     @Override
-    public boolean containsBoolean(T name, int value) {
+    public boolean containsBoolean(T name, boolean value) {
         return false;
     }
 
@@ -268,7 +268,7 @@ public class EmptyHeaders<T> implements Headers<T> {
     }
 
     @Override
-    public boolean containsShort(T name, byte value) {
+    public boolean containsShort(T name, short value) {
         return false;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/Headers.java
+++ b/codec/src/main/java/io/netty/handler/codec/Headers.java
@@ -561,7 +561,7 @@ public interface Headers<T> extends Iterable<Map.Entry<T, T>> {
      * @param value the header value
      * @return {@code true} if it contains it {@code false} otherwise
      */
-    boolean containsBoolean(T name, int value);
+    boolean containsBoolean(T name, boolean value);
 
     /**
      * Returns {@code true} if a header with the name and value exists.
@@ -588,7 +588,7 @@ public interface Headers<T> extends Iterable<Map.Entry<T, T>> {
      * @param value the header value
      * @return {@code true} if it contains it {@code false} otherwise
      */
-    boolean containsShort(T name, byte value);
+    boolean containsShort(T name, short value);
 
     /**
      * Returns {@code true} if a header with the name and value exists.


### PR DESCRIPTION
Motiviation:
Some of the contains method signatures did not include the correct type of parameters for the method names.  Also these same methods were not using the correct conversion methods but instead the generic object conversion methods.

Modifications
-Correct the parameter types of the contains methods to match the method name
-Correct the implementation of these methods to use the correct conversion methods

Result:
Headers contains signatures are more correct and correct conversion methods are used.
