### PR TITLE
Minor update to Http2LifecycleManager#closeLocalSide javadoc

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LifecycleManager.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LifecycleManager.java
@@ -26,7 +26,7 @@ import io.netty.channel.ChannelPromise;
 public interface Http2LifecycleManager {
 
     /**
-     * Closes the remote side of the given stream. If this causes the stream to be closed, adds a
+     * Closes the local side of the given stream. If this causes the stream to be closed, adds a
      * hook to close the channel after the given future completes.
      *
      * @param stream the stream to be half closed.


### PR DESCRIPTION
Modifications:
Changed "remote" to "local" in javadoc for closeLocalSide.
