### PR TITLE
Recycler update

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -476,7 +476,7 @@ public final class ByteBufUtil {
                 super.deallocate();
             } else {
                 clear();
-                RECYCLER.recycle(this, handle);
+                handle.recycle();
             }
         }
     }
@@ -509,7 +509,7 @@ public final class ByteBufUtil {
                 super.deallocate();
             } else {
                 clear();
-                RECYCLER.recycle(this, handle);
+                handle.recycle();
             }
         }
     }

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -17,14 +17,13 @@
 package io.netty.buffer;
 
 import io.netty.util.Recycler;
-import io.netty.util.Recycler.Handle;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
 
-    private final Recycler.Handle<PooledByteBuf<T>> recyclerHandle;
+    private final Recycler.Handle recyclerHandle;
 
     protected PoolChunk<T> chunk;
     protected long handle;
@@ -36,9 +35,9 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
     private ByteBuffer tmpNioBuf;
 
     @SuppressWarnings("unchecked")
-    protected PooledByteBuf(Recycler.Handle<? extends PooledByteBuf<T>> recyclerHandle, int maxCapacity) {
+    protected PooledByteBuf(Recycler.Handle recyclerHandle, int maxCapacity) {
         super(maxCapacity);
-        this.recyclerHandle = (Handle<PooledByteBuf<T>>) recyclerHandle;
+        this.recyclerHandle = recyclerHandle;
     }
 
     void init(PoolChunk<T> chunk, long handle, int offset, int length, int maxLength) {
@@ -152,7 +151,7 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
     }
 
     private void recycle() {
-        recyclerHandle.recycle(this);
+        recyclerHandle.recycle();
     }
 
     protected final int idx(int index) {

--- a/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
@@ -30,7 +30,7 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
 
     private static final Recycler<PooledDirectByteBuf> RECYCLER = new Recycler<PooledDirectByteBuf>() {
         @Override
-        protected PooledDirectByteBuf newObject(Handle<PooledDirectByteBuf> handle) {
+        protected PooledDirectByteBuf newObject(Handle handle) {
             return new PooledDirectByteBuf(handle, 0);
         }
     };
@@ -42,7 +42,7 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
         return buf;
     }
 
-    private PooledDirectByteBuf(Recycler.Handle<PooledDirectByteBuf> recyclerHandle, int maxCapacity) {
+    private PooledDirectByteBuf(Recycler.Handle recyclerHandle, int maxCapacity) {
         super(recyclerHandle, maxCapacity);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
@@ -29,7 +29,7 @@ final class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
 
     private static final Recycler<PooledHeapByteBuf> RECYCLER = new Recycler<PooledHeapByteBuf>() {
         @Override
-        protected PooledHeapByteBuf newObject(Handle<PooledHeapByteBuf> handle) {
+        protected PooledHeapByteBuf newObject(Handle handle) {
             return new PooledHeapByteBuf(handle, 0);
         }
     };
@@ -41,7 +41,7 @@ final class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
         return buf;
     }
 
-    private PooledHeapByteBuf(Recycler.Handle<PooledHeapByteBuf> recyclerHandle, int maxCapacity) {
+    private PooledHeapByteBuf(Recycler.Handle recyclerHandle, int maxCapacity) {
         super(recyclerHandle, maxCapacity);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
@@ -34,7 +34,7 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
 
     private static final Recycler<PooledUnsafeDirectByteBuf> RECYCLER = new Recycler<PooledUnsafeDirectByteBuf>() {
         @Override
-        protected PooledUnsafeDirectByteBuf newObject(Handle<PooledUnsafeDirectByteBuf> handle) {
+        protected PooledUnsafeDirectByteBuf newObject(Handle handle) {
             return new PooledUnsafeDirectByteBuf(handle, 0);
         }
     };
@@ -48,7 +48,7 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
 
     private long memoryAddress;
 
-    private PooledUnsafeDirectByteBuf(Recycler.Handle<PooledUnsafeDirectByteBuf> recyclerHandle, int maxCapacity) {
+    private PooledUnsafeDirectByteBuf(Recycler.Handle recyclerHandle, int maxCapacity) {
         super(recyclerHandle, maxCapacity);
     }
 

--- a/common/src/main/java/io/netty/util/internal/PendingWrite.java
+++ b/common/src/main/java/io/netty/util/internal/PendingWrite.java
@@ -25,7 +25,7 @@ import io.netty.util.concurrent.Promise;
 public final class PendingWrite {
     private static final Recycler<PendingWrite> RECYCLER = new Recycler<PendingWrite>() {
         @Override
-        protected PendingWrite newObject(Handle<PendingWrite> handle) {
+        protected PendingWrite newObject(Handle handle) {
             return new PendingWrite(handle);
         }
     };
@@ -40,11 +40,11 @@ public final class PendingWrite {
         return pending;
     }
 
-    private final Recycler.Handle<PendingWrite> handle;
+    private final Recycler.Handle handle;
     private Object msg;
     private Promise<Void> promise;
 
-    private PendingWrite(Recycler.Handle<PendingWrite> handle) {
+    private PendingWrite(Recycler.Handle handle) {
         this.handle = handle;
     }
 
@@ -54,7 +54,7 @@ public final class PendingWrite {
     public boolean recycle() {
         msg = null;
         promise = null;
-        return RECYCLER.recycle(this, handle);
+        return handle.recycle();
     }
 
     /**

--- a/common/src/main/java/io/netty/util/internal/RecyclableArrayList.java
+++ b/common/src/main/java/io/netty/util/internal/RecyclableArrayList.java
@@ -35,7 +35,7 @@ public final class RecyclableArrayList extends ArrayList<Object> {
 
     private static final Recycler<RecyclableArrayList> RECYCLER = new Recycler<RecyclableArrayList>() {
         @Override
-        protected RecyclableArrayList newObject(Handle<RecyclableArrayList> handle) {
+        protected RecyclableArrayList newObject(Handle handle) {
             return new RecyclableArrayList(handle);
         }
     };
@@ -56,13 +56,13 @@ public final class RecyclableArrayList extends ArrayList<Object> {
         return ret;
     }
 
-    private final Handle<RecyclableArrayList> handle;
+    private final Handle handle;
 
-    private RecyclableArrayList(Handle<RecyclableArrayList> handle) {
+    private RecyclableArrayList(Handle handle) {
         this(handle, DEFAULT_INITIAL_CAPACITY);
     }
 
-    private RecyclableArrayList(Handle<RecyclableArrayList> handle, int initialCapacity) {
+    private RecyclableArrayList(Handle handle, int initialCapacity) {
         super(initialCapacity);
         this.handle = handle;
     }
@@ -127,6 +127,6 @@ public final class RecyclableArrayList extends ArrayList<Object> {
      */
     public boolean recycle() {
         clear();
-        return RECYCLER.recycle(this, handle);
+        return handle.recycle();
     }
 }

--- a/common/src/main/java/io/netty/util/internal/RecyclableMpscLinkedQueueNode.java
+++ b/common/src/main/java/io/netty/util/internal/RecyclableMpscLinkedQueueNode.java
@@ -19,14 +19,14 @@ package io.netty.util.internal;
 import io.netty.util.Recycler;
 
 /**
- * {@link MpscLinkedQueueNode} that will automatically call {@link Recycler.Handle#recycle(Object)} when the node was
+ * {@link MpscLinkedQueueNode} that will automatically call {@link Recycler.Handle#recycle()} when the node was
  * unlinked.
  */
 public abstract class RecyclableMpscLinkedQueueNode<T> extends MpscLinkedQueueNode<T> {
     @SuppressWarnings("rawtypes")
     private final Recycler.Handle handle;
 
-    protected RecyclableMpscLinkedQueueNode(Recycler.Handle<? extends RecyclableMpscLinkedQueueNode<T>> handle) {
+    protected RecyclableMpscLinkedQueueNode(Recycler.Handle handle) {
         if (handle == null) {
             throw new NullPointerException("handle");
         }
@@ -37,6 +37,6 @@ public abstract class RecyclableMpscLinkedQueueNode<T> extends MpscLinkedQueueNo
     @Override
     final void unlink() {
         super.unlink();
-        handle.recycle(this);
+        handle.recycle();
     }
 }

--- a/microbench/src/test/java/io/netty/microbench/internal/RecyclerBenchmark.java
+++ b/microbench/src/test/java/io/netty/microbench/internal/RecyclerBenchmark.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.internal;
+
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.Recycler;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * This class benchmarks a recyclers capability to provide instances in a multi thread scenario.
+ *
+ * For this benchmark Mode.Throughput it is not relevant but the number of offered instances by the recycler is.
+ * This benchmark uses a class cloned from RecyclableArrayList because it needs to count new instances built.
+ *
+ * For 2 threads = 1 extractor thread and 1 recycler thread.
+ * For 3 threads = 1 extractor thread and 2 recycler threads.
+ * For 4 threads = 2 extractor threads and 2 recycler threads.
+ */
+@Threads(3)
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class RecyclerBenchmark extends AbstractMicrobenchmark {
+
+    @Param({ "00000", "00256", "01024", "04096", "16384", "65536" })
+    public int size;
+
+    // Benchmark state used to count instances obtained from recycler, new instances built by recycler and instances
+    // recycled.
+    // It also contains the queue used to share instances between threads.
+    @State(Scope.Benchmark)
+    public static class BenchState {
+        // Maybe a better method exists to trigger some actions after warm-ups.
+        public static final int WARMUP_ITERATIONS = RecyclerBenchmark.class.getAnnotation(Warmup.class).iterations();
+        // Number that limit the queue size, when this number is reached only recyclers threads
+        // (threads that are executing recycle) are allowed to operate.
+        private static final int MAX_COLL_SIZE = 512;
+        // Queue shared by threads that extract from pool and threads that recycle back into pool.
+        private final ConcurrentLinkedQueue<TestList> collection = new ConcurrentLinkedQueue<TestList>();
+        // Counter for instances in queue waiting to be recycled back into recycler's pool.
+        public final AtomicInteger queueSize = new AtomicInteger(0);
+        // Counter for instances obtained from recycler.
+        public final AtomicInteger obtainedCounter = new AtomicInteger(0);
+        // Current benchmark iteration number.
+        public volatile int iteration;
+        // Total number of new instances built in this benchmark.
+        public volatile int totalNewInstances;
+        // Total number of obtained instances in this benchmark.
+        public volatile int totalObtained;
+
+        @TearDown(Level.Iteration)
+        public void tearDownIteration() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(" | Instances Constructed: " + String.format("%9d", TestList.newInstanceCounter.get()));
+            sb.append(" Instances Obtained: " + String.format("%9d", obtainedCounter.get()));
+            sb.append(" Queue size: " + String.format("%6d", size()) + " | ");
+            System.out.print(sb);
+
+            if (++iteration == WARMUP_ITERATIONS) {
+                // after warmup iteration we reset the counter for obtained instances.
+                totalObtained = 0;
+            }
+
+            totalNewInstances += TestList.newInstanceCounter.getAndSet(0);
+            totalObtained += obtainedCounter.getAndSet(0);
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDownTrial() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(" Total Instances Constructed: " + totalNewInstances);
+            sb.append(" Total Instances Obtained: " + totalObtained);
+            sb.append(" Constructed Percent: " + totalNewInstances / (float) totalObtained * 100 + '%');
+            sb.append(" Queue size: " + size());
+            System.out.println();
+            System.out.println(sb);
+        }
+
+        public int size() {
+            return queueSize.get();
+        }
+
+        public void offer(final TestList list) {
+            collection.offer(list);
+            obtainedCounter.incrementAndGet();
+            queueSize.incrementAndGet();
+        }
+
+        public TestList poll() {
+            TestList result = collection.poll();
+            if (result != null) {
+                queueSize.decrementAndGet();
+            }
+            return result;
+        }
+    }
+
+    /**
+     * Thread state used to classify threads into extractors (threads that obtain instances from recycler) and recyclers
+     * (threads that recycle back instances into recycler).
+     */
+    @State(Scope.Thread)
+    public static class ThreadState {
+        private static final AtomicInteger ID_GENERATOR = new AtomicInteger(0);
+        public boolean isExtracting;
+
+        public ThreadState() {
+            final int id = ID_GENERATOR.getAndIncrement();
+            isExtracting = id % 2 != 0;
+        }
+    }
+
+    @Benchmark
+    public void recycleProducerConsumer(BenchState benchState, ThreadState threadState) {
+        if (threadState.isExtracting) {
+            // Thread that extract instances from recycler.
+
+            if (benchState.size() >= BenchState.MAX_COLL_SIZE) {
+                // Threads that poll from queue are behind.
+                Thread.yield();
+                return;
+            }
+
+            TestList list = TestList.newInstance(size);
+            benchState.offer(list);
+        } else {
+            // Thread that recycles instances back to recycler.
+
+            TestList queueList = benchState.poll();
+            if (queueList != null) {
+                queueList.recycle();
+            }
+        }
+    }
+
+    // A clone for RecyclableArrayList class which counts new instances built.
+    public static final class TestList extends ArrayList<Object> {
+
+        private static final long serialVersionUID = -8605125654176467947L;
+
+        private static final int DEFAULT_INITIAL_CAPACITY = 8;
+
+        public static AtomicInteger newInstanceCounter = new AtomicInteger(0);
+
+        private static final Recycler<TestList> RECYCLER = new Recycler<TestList>() {
+            @Override
+            protected TestList newObject(Recycler.Handle handle) {
+                newInstanceCounter.incrementAndGet();
+                return new TestList(handle);
+            }
+        };
+
+        public static TestList newInstance() {
+            return newInstance(DEFAULT_INITIAL_CAPACITY);
+        }
+
+        public static TestList newInstance(int minCapacity) {
+            TestList ret = RECYCLER.get();
+            ret.ensureCapacity(minCapacity);
+            return ret;
+        }
+
+        private final Recycler.Handle handle;
+
+        private TestList(Recycler.Handle handle) {
+            this(handle, DEFAULT_INITIAL_CAPACITY);
+        }
+
+        private TestList(Recycler.Handle handle, int initialCapacity) {
+            super(initialCapacity);
+            this.handle = handle;
+        }
+
+        public boolean recycle() {
+            clear();
+            return handle.recycle();
+        }
+    }
+}

--- a/microbench/src/test/java/io/netty/microbench/util/AbstractMicrobenchmark.java
+++ b/microbench/src/test/java/io/netty/microbench/util/AbstractMicrobenchmark.java
@@ -56,7 +56,7 @@ public class AbstractMicrobenchmark {
     }
 
     protected static final String[] JVM_ARGS = {
-        "-server", "-dsa", "-da", "-ea:io.netty...", "-Xms768m", "-Xmx768m",
+        "-server", "-dsa", "-da", "-Xms768m", "-Xmx768m",
         "-XX:MaxDirectMemorySize=768m", "-XX:+AggressiveOpts", "-XX:+UseBiasedLocking",
         "-XX:+UseFastAccessorMethods", "-XX:+UseStringCache", "-XX:+OptimizeStringConcat",
         "-XX:+HeapDumpOnOutOfMemoryError", "-Dio.netty.noResourceLeakDetection",

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -728,7 +728,7 @@ public final class ChannelOutboundBuffer {
             pendingSize = 0;
             count = -1;
             cancelled = false;
-            RECYCLER.recycle(this, handle);
+            handle.recycle();
         }
 
         Entry recycleAndGetNext() {

--- a/transport/src/main/java/io/netty/channel/DefaultChannelHandlerInvoker.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelHandlerInvoker.java
@@ -408,7 +408,7 @@ public class DefaultChannelHandlerInvoker implements ChannelHandlerInvoker {
 
         private static final Recycler<WriteTask> RECYCLER = new Recycler<WriteTask>() {
             @Override
-            protected WriteTask newObject(Handle<WriteTask> handle) {
+            protected WriteTask newObject(Handle handle) {
                 return new WriteTask(handle);
             }
         };
@@ -423,7 +423,7 @@ public class DefaultChannelHandlerInvoker implements ChannelHandlerInvoker {
             return task;
         }
 
-        private WriteTask(Recycler.Handle<WriteTask> handle) {
+        private WriteTask(Recycler.Handle handle) {
             super(handle);
         }
 

--- a/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
+++ b/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
@@ -272,7 +272,7 @@ public final class PendingWriteQueue {
             next = null;
             msg = null;
             promise = null;
-            RECYCLER.recycle(this, handle);
+            handle.recycle();
         }
     }
 }

--- a/transport/src/main/java/io/netty/channel/ThreadLocalPooledDirectByteBuf.java
+++ b/transport/src/main/java/io/netty/channel/ThreadLocalPooledDirectByteBuf.java
@@ -56,7 +56,7 @@ final class ThreadLocalPooledDirectByteBuf {
         private static final Recycler<ThreadLocalUnsafeDirectByteBuf> RECYCLER =
                 new Recycler<ThreadLocalUnsafeDirectByteBuf>() {
             @Override
-            protected ThreadLocalUnsafeDirectByteBuf newObject(Handle<ThreadLocalUnsafeDirectByteBuf> handle) {
+            protected ThreadLocalUnsafeDirectByteBuf newObject(Handle handle) {
                 return new ThreadLocalUnsafeDirectByteBuf(handle);
             }
         };
@@ -67,9 +67,9 @@ final class ThreadLocalPooledDirectByteBuf {
             return buf;
         }
 
-        private final Recycler.Handle<ThreadLocalUnsafeDirectByteBuf> handle;
+        private final Recycler.Handle handle;
 
-        private ThreadLocalUnsafeDirectByteBuf(Recycler.Handle<ThreadLocalUnsafeDirectByteBuf> handle) {
+        private ThreadLocalUnsafeDirectByteBuf(Recycler.Handle handle) {
             super(UnpooledByteBufAllocator.DEFAULT, 256, Integer.MAX_VALUE);
             this.handle = handle;
         }
@@ -80,7 +80,7 @@ final class ThreadLocalPooledDirectByteBuf {
                 super.deallocate();
             } else {
                 clear();
-                RECYCLER.recycle(this, handle);
+                handle.recycle();
             }
         }
     }
@@ -89,7 +89,7 @@ final class ThreadLocalPooledDirectByteBuf {
 
         private static final Recycler<ThreadLocalDirectByteBuf> RECYCLER = new Recycler<ThreadLocalDirectByteBuf>() {
             @Override
-            protected ThreadLocalDirectByteBuf newObject(Handle<ThreadLocalDirectByteBuf> handle) {
+            protected ThreadLocalDirectByteBuf newObject(Handle handle) {
                 return new ThreadLocalDirectByteBuf(handle);
             }
         };
@@ -100,9 +100,9 @@ final class ThreadLocalPooledDirectByteBuf {
             return buf;
         }
 
-        private final Recycler.Handle<ThreadLocalDirectByteBuf> handle;
+        private final Recycler.Handle handle;
 
-        private ThreadLocalDirectByteBuf(Recycler.Handle<ThreadLocalDirectByteBuf> handle) {
+        private ThreadLocalDirectByteBuf(Recycler.Handle handle) {
             super(UnpooledByteBufAllocator.DEFAULT, 256, Integer.MAX_VALUE);
             this.handle = handle;
         }
@@ -113,7 +113,7 @@ final class ThreadLocalPooledDirectByteBuf {
                 super.deallocate();
             } else {
                 clear();
-                RECYCLER.recycle(this, handle);
+                handle.recycle();
             }
         }
     }


### PR DESCRIPTION
Statements made in commit: https://github.com/netty/netty/commit/580965f7753ad8aadc98e3d369499822ea2b7767 about an improved Recycler draw my attention.

Reviewing the code I did not see any improvement for the single thread
case. The improvement came from the fact that AbstractMicrobenchmark was
sending "-ea" as a startup argument for JVM and previous Recycler source
code had assertions trying to find out if an item is recycled already.
In fact from my testing I see a drop of performance around 20% in the
single thread scenario.

But the latest Recycler can now treat the multi thread scenario: one thread
gets a handle and another thread recycles the handle.
This scenario was not treated by the previous Recycler which dropped the
handle when recycled from another thread. So the pool was not working at
all in this scenario and can cause huge performance loss when elements
in pool are large (like 64KB buffers).

With current Recycler I saw some problems:
1. The "already recycled" exception is not triggered correctly or at
least as expected. I added a new test to prove this.
2. Strangely, the recycler keeps allocating new instances in a scenario
where 2 threads recycle the handles obtained for 1 thread. In the
classic 1 producer / 1 consumer scenario I did not see the problem. You
can see the problem in the new micro benchmark for the producer/consumer
scenario with 3 threads specified.
3. I think that each "recycler" thread (A) is now keeping a reference to
a stack from another thread (B), stack kept in a thread local. Even when
all condition are right for GC of thread B's thread local, the stack
will be referenced from thread A. Please search DELAYED_RECYCLED in
source code.

I suggest my version of Recycler because:
1. The "already recycled" exception thrown correctly.
2. Same performance as current Recycler for single thread and multi
thread scenario.
3. It can easily be improved by using another non-blocking collection
for sharing data between threads.

I don’t know how common the multi thread scenario is in netty. If it is
not common, I think a version using handles with a simple boolean value
(handle.inStack) will be enough.

This update alters 90% Recycler.java.
Adds a new @Test for Recycler and a new benchmark.
+Minor tweaks because the Handle is now non generic.

Thank you for your time and please excuse my poor english.
