### PR TITLE
SslHander wrap conditional direct buffer allocation

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -182,7 +182,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     // BEGIN Platform-dependent flags
 
     /**
-     * {@code trus} if and only if {@link SSLEngine} expects a direct buffer.
+     * {@code true} if and only if {@link SSLEngine} expects a direct buffer.
      */
     private final boolean wantsDirectBuffer;
     /**
@@ -581,7 +581,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         ByteBuf newDirectIn = null;
         try {
             final ByteBuffer in0;
-            if (in.isDirect()) {
+            if (in.isDirect() || !wantsDirectBuffer) {
                 in0 = in.nioBuffer();
             } else {
                 int readableBytes = in.readableBytes();


### PR DESCRIPTION
Motivation:
The SslHandler currently forces the use of a direct buffer for the input to the SSLEngine.wrap(..) operation. This allocation may not always be desired and should be conditionally done.

Modifications:
- Use the pre-existing  `wantsDirectBuffer` variable as the condition to do the conversion.

Result:
- An allocation of a direct byte buffer and a copy of data is now not required for every SslHandler wrap operation.
