### PR TITLE
update JZlibEncoder to cater for zero length input. this caused a test...

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
@@ -282,9 +282,13 @@ public class JZlibEncoder extends ZlibEncoder {
             return;
         }
 
+        int inputLength = in.readableBytes();
+        if (inputLength == 0) {
+            return;
+        }
+
         try {
             // Configure input.
-            int inputLength = in.readableBytes();
             boolean inHasArray = in.hasArray();
             z.avail_in = inputLength;
             if (inHasArray) {


### PR DESCRIPTION
... case to error out

  with Z_BUF_ERROR (-5). was not able to reproduce this using either HttpContentCompressorTest or
  JZlibTest. see also #3070 for an example stack trace and context.
