### PR TITLE
Adding build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](http://clinker.netty.io/desktop/plugin/public/status/netty-build)](http://clinker.netty.io/jenkins/job/netty-build)
 # Netty Project
 
 Netty is an asynchronous event-driven network application framework for rapid development of maintainable high performance protocol servers & clients.


### PR DESCRIPTION
As @recena told me we already have the ClinkerHQ instance ready, I think we could use the build status badge in README
