### PR TITLE
Closure of stream with pending frames causes GO_AWAY.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2OutboundFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2OutboundFlowController.java
@@ -18,8 +18,7 @@ package io.netty.handler.codec.http2;
 import static io.netty.handler.codec.http2.Http2CodecUtil.CONNECTION_STREAM_ID;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
 import static io.netty.handler.codec.http2.Http2Error.FLOW_CONTROL_ERROR;
-import static io.netty.handler.codec.http2.Http2Error.STREAM_CLOSED;
-import static io.netty.handler.codec.http2.Http2Exception.format;
+import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.protocolError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static java.lang.Math.max;
@@ -486,7 +485,8 @@ public class DefaultHttp2OutboundFlowController implements Http2OutboundFlowCont
                 if (frame == null) {
                     break;
                 }
-                frame.writeError(format(STREAM_CLOSED, "Stream closed before write could take place"));
+                frame.writeError(Http2StreamException.format(stream.id(), INTERNAL_ERROR,
+                        "Stream closed before write could take place"));
             }
         }
 


### PR DESCRIPTION
Motivation:

The current logic in DefaultHttp2OutboundFlowController for handling the
case of a stream shutdown results in a Http2Exception (not a
Http2StreamException). This results in a GO_AWAY being sent for what
really could just be a stream-specific error.

Modifications:

Modified DefaultHttp2OutboundFlowController to set a stream exception
rather than a connection-wide exception.  Also using the error code of
INTERNAL_ERROR rather than STREAM_CLOSED, since it's more appropriate
for this case.

Result:

Should not be triggering GO_AWAY when a stream closes prematurely.
