### PR TITLE
Headers set/add/contains timeMillis methods

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyHeaders.java
@@ -141,6 +141,12 @@ public class DefaultSpdyHeaders extends DefaultTextHeaders implements SpdyHeader
     }
 
     @Override
+    public SpdyHeaders addTimeMillis(CharSequence name, long value) {
+        super.addTimeMillis(name, value);
+        return this;
+    }
+
+    @Override
     public SpdyHeaders add(TextHeaders headers) {
         super.add(headers);
         return this;
@@ -227,6 +233,12 @@ public class DefaultSpdyHeaders extends DefaultTextHeaders implements SpdyHeader
     @Override
     public SpdyHeaders setDouble(CharSequence name, double value) {
         super.setDouble(name, value);
+        return this;
+    }
+
+    @Override
+    public SpdyHeaders setTimeMillis(CharSequence name, long value) {
+        super.setTimeMillis(name, value);
         return this;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaders.java
@@ -99,6 +99,9 @@ public interface SpdyHeaders extends TextHeaders {
     SpdyHeaders addDouble(CharSequence name, double value);
 
     @Override
+    SpdyHeaders addTimeMillis(CharSequence name, long value);
+
+    @Override
     SpdyHeaders add(TextHeaders headers);
 
     @Override
@@ -133,6 +136,9 @@ public interface SpdyHeaders extends TextHeaders {
 
     @Override
     SpdyHeaders setDouble(CharSequence name, double value);
+
+    @Override
+    SpdyHeaders setTimeMillis(CharSequence name, long value);
 
     @Override
     SpdyHeaders setObject(CharSequence name, Object value);

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeaders.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeaders.java
@@ -106,6 +106,12 @@ public class DefaultStompHeaders extends DefaultTextHeaders implements StompHead
     }
 
     @Override
+    public StompHeaders addTimeMillis(CharSequence name, long value) {
+        super.addTimeMillis(name, value);
+        return this;
+    }
+
+    @Override
     public StompHeaders add(TextHeaders headers) {
         super.add(headers);
         return this;
@@ -192,6 +198,12 @@ public class DefaultStompHeaders extends DefaultTextHeaders implements StompHead
     @Override
     public StompHeaders setDouble(CharSequence name, double value) {
         super.setDouble(name, value);
+        return this;
+    }
+
+    @Override
+    public StompHeaders setTimeMillis(CharSequence name, long value) {
+        super.setTimeMillis(name, value);
         return this;
     }
 

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompHeaders.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompHeaders.java
@@ -87,6 +87,9 @@ public interface StompHeaders extends TextHeaders {
     StompHeaders addDouble(CharSequence name, double value);
 
     @Override
+    StompHeaders addTimeMillis(CharSequence name, long value);
+
+    @Override
     StompHeaders add(TextHeaders headers);
 
     @Override
@@ -130,6 +133,9 @@ public interface StompHeaders extends TextHeaders {
 
     @Override
     StompHeaders setDouble(CharSequence name, double value);
+
+    @Override
+    StompHeaders setTimeMillis(CharSequence name, long value);
 
     @Override
     StompHeaders set(TextHeaders headers);

--- a/codec/src/main/java/io/netty/handler/codec/BinaryHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/BinaryHeaders.java
@@ -76,6 +76,9 @@ public interface BinaryHeaders extends Headers<AsciiString> {
     @Override
     BinaryHeaders addDouble(AsciiString name, double value);
 
+    @Override
+    BinaryHeaders addTimeMillis(AsciiString name, long value);
+
     /**
      * See {@link Headers#add(Headers)}
      */
@@ -122,6 +125,9 @@ public interface BinaryHeaders extends Headers<AsciiString> {
 
     @Override
     BinaryHeaders setDouble(AsciiString name, double value);
+
+    @Override
+    BinaryHeaders setTimeMillis(AsciiString name, long value);
 
     /**
      * See {@link Headers#set(Headers)}

--- a/codec/src/main/java/io/netty/handler/codec/DefaultBinaryHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultBinaryHeaders.java
@@ -82,6 +82,11 @@ public class DefaultBinaryHeaders extends DefaultHeaders<AsciiString> implements
         }
 
         @Override
+        public AsciiString convertTimeMillis(long value) {
+            return new AsciiString(String.valueOf(value));
+        }
+
+        @Override
         public long convertToTimeMillis(AsciiString value) {
             try {
                 return HeaderDateFormat.get().parse(value.toString());
@@ -240,6 +245,12 @@ public class DefaultBinaryHeaders extends DefaultHeaders<AsciiString> implements
     }
 
     @Override
+    public BinaryHeaders addTimeMillis(AsciiString name, long value) {
+        super.addTimeMillis(name, value);
+        return this;
+    }
+
+    @Override
     public BinaryHeaders add(BinaryHeaders headers) {
         super.add(headers);
         return this;
@@ -326,6 +337,12 @@ public class DefaultBinaryHeaders extends DefaultHeaders<AsciiString> implements
     @Override
     public BinaryHeaders setDouble(AsciiString name, double value) {
         super.setDouble(name, value);
+        return this;
+    }
+
+    @Override
+    public BinaryHeaders setTimeMillis(AsciiString name, long value) {
+        super.setTimeMillis(name, value);
         return this;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -379,6 +379,11 @@ public class DefaultHeaders<T> implements Headers<T> {
     }
 
     @Override
+    public boolean containsTimeMillis(T name, long value) {
+        return contains(name, valueConverter.convertTimeMillis(checkNotNull(value, "value")));
+    }
+
+    @Override
     public boolean contains(T name, T value, Comparator<? super T> comparator) {
         return contains(name, value, comparator, comparator);
     }
@@ -551,6 +556,11 @@ public class DefaultHeaders<T> implements Headers<T> {
     }
 
     @Override
+    public Headers<T> addTimeMillis(T name, long value) {
+        return add(name, valueConverter.convertTimeMillis(value));
+    }
+
+    @Override
     public Headers<T> addChar(T name, char value) {
         return add(name, valueConverter.convertChar(value));
     }
@@ -688,6 +698,11 @@ public class DefaultHeaders<T> implements Headers<T> {
     @Override
     public Headers<T> setDouble(T name, double value) {
         return set(name, valueConverter.convertDouble(value));
+    }
+
+    @Override
+    public Headers<T> setTimeMillis(T name, long value) {
+        return set(name, valueConverter.convertTimeMillis(value));
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/DefaultTextHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultTextHeaders.java
@@ -120,6 +120,11 @@ public class DefaultTextHeaders extends DefaultConvertibleHeaders<CharSequence, 
         }
 
         @Override
+        public AsciiString convertTimeMillis(long value) {
+            return new AsciiString(String.valueOf(value));
+        }
+
+        @Override
         public long convertToTimeMillis(CharSequence value) {
             try {
                 return HeaderDateFormat.get().parse(value.toString());
@@ -269,6 +274,12 @@ public class DefaultTextHeaders extends DefaultConvertibleHeaders<CharSequence, 
     }
 
     @Override
+    public TextHeaders addTimeMillis(CharSequence name, long value) {
+        super.addTimeMillis(name, value);
+        return this;
+    }
+
+    @Override
     public TextHeaders add(TextHeaders headers) {
         super.add(headers);
         return this;
@@ -355,6 +366,12 @@ public class DefaultTextHeaders extends DefaultConvertibleHeaders<CharSequence, 
     @Override
     public TextHeaders setDouble(CharSequence name, double value) {
         super.setDouble(name, value);
+        return this;
+    }
+
+    @Override
+    public TextHeaders setTimeMillis(CharSequence name, long value) {
+        super.setTimeMillis(name, value);
         return this;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/EmptyBinaryHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/EmptyBinaryHeaders.java
@@ -105,6 +105,12 @@ public class EmptyBinaryHeaders extends EmptyHeaders<AsciiString> implements Bin
     }
 
     @Override
+    public BinaryHeaders addTimeMillis(AsciiString name, long value) {
+        super.addTimeMillis(name, value);
+        return this;
+    }
+
+    @Override
     public BinaryHeaders add(BinaryHeaders headers) {
         super.add(headers);
         return this;
@@ -191,6 +197,12 @@ public class EmptyBinaryHeaders extends EmptyHeaders<AsciiString> implements Bin
     @Override
     public BinaryHeaders setDouble(AsciiString name, double value) {
         super.setDouble(name, value);
+        return this;
+    }
+
+    @Override
+    public BinaryHeaders setTimeMillis(AsciiString name, long value) {
+        super.setTimeMillis(name, value);
         return this;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/EmptyHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/EmptyHeaders.java
@@ -293,6 +293,11 @@ public class EmptyHeaders<T> implements Headers<T> {
     }
 
     @Override
+    public boolean containsTimeMillis(T name, long value) {
+        return false;
+    }
+
+    @Override
     public boolean contains(T name, T value, Comparator<? super T> comparator) {
         return false;
     }
@@ -405,6 +410,11 @@ public class EmptyHeaders<T> implements Headers<T> {
     }
 
     @Override
+    public Headers<T> addTimeMillis(T name, long value) {
+        throw new UnsupportedOperationException("read only");
+    }
+
+    @Override
     public Headers<T> add(Headers<T> headers) {
         throw new UnsupportedOperationException("read only");
     }
@@ -476,6 +486,11 @@ public class EmptyHeaders<T> implements Headers<T> {
 
     @Override
     public Headers<T> setDouble(T name, double value) {
+        throw new UnsupportedOperationException("read only");
+    }
+
+    @Override
+    public Headers<T> setTimeMillis(T name, long value) {
         throw new UnsupportedOperationException("read only");
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/EmptyTextHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/EmptyTextHeaders.java
@@ -115,6 +115,12 @@ public class EmptyTextHeaders extends EmptyConvertibleHeaders<CharSequence, Stri
     }
 
     @Override
+    public TextHeaders addTimeMillis(CharSequence name, long value) {
+        super.addTimeMillis(name, value);
+        return this;
+    }
+
+    @Override
     public TextHeaders add(TextHeaders headers) {
         super.add(headers);
         return this;
@@ -201,6 +207,12 @@ public class EmptyTextHeaders extends EmptyConvertibleHeaders<CharSequence, Stri
     @Override
     public TextHeaders setDouble(CharSequence name, double value) {
         super.setDouble(name, value);
+        return this;
+    }
+
+    @Override
+    public TextHeaders setTimeMillis(CharSequence name, long value) {
+        super.setTimeMillis(name, value);
         return this;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/Headers.java
+++ b/codec/src/main/java/io/netty/handler/codec/Headers.java
@@ -78,6 +78,8 @@ public interface Headers<T> extends Iterable<Map.Entry<T, T>> {
 
         long convertToLong(T value);
 
+        T convertTimeMillis(long value);
+
         long convertToTimeMillis(T value);
 
         T convertFloat(float value);
@@ -631,6 +633,15 @@ public interface Headers<T> extends Iterable<Map.Entry<T, T>> {
      *
      * @param name the header name
      * @param value the header value
+     * @return {@code true} if it contains it {@code false} otherwise
+     */
+    boolean containsTimeMillis(T name, long value);
+
+    /**
+     * Returns {@code true} if a header with the name and value exists.
+     *
+     * @param name the header name
+     * @param value the header value
      * @param comparator The comparator to use when comparing {@code name} and {@code value} to entries in this map
      * @return {@code true} if it contains it {@code false} otherwise
      */
@@ -858,6 +869,14 @@ public interface Headers<T> extends Iterable<Map.Entry<T, T>> {
     Headers<T> addDouble(T name, double value);
 
     /**
+     * Add the {@code name} to {@code value}.
+     * @param name The name to modify
+     * @param value The value
+     * @return {@code this}
+     */
+    Headers<T> addTimeMillis(T name, long value);
+
+    /**
      * Adds all header entries of the specified {@code headers}.
      *
      * @return {@code this}
@@ -1033,6 +1052,14 @@ public interface Headers<T> extends Iterable<Map.Entry<T, T>> {
      * @return {@code this}
      */
     Headers<T> setDouble(T name, double value);
+
+    /**
+     * Set the {@code name} to {@code value}. This will remove all previous values associated with {@code name}.
+     * @param name The name to modify
+     * @param value The value
+     * @return {@code this}
+     */
+    Headers<T> setTimeMillis(T name, long value);
 
     /**
      * Cleans the current header entries and copies all header entries of the specified {@code headers}.

--- a/codec/src/main/java/io/netty/handler/codec/TextHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/TextHeaders.java
@@ -95,6 +95,9 @@ public interface TextHeaders extends ConvertibleHeaders<CharSequence, String> {
     @Override
     TextHeaders addDouble(CharSequence name, double value);
 
+    @Override
+    TextHeaders addTimeMillis(CharSequence name, long value);
+
     /**
      * See {@link Headers#add(Headers)}
      */
@@ -141,6 +144,9 @@ public interface TextHeaders extends ConvertibleHeaders<CharSequence, String> {
 
     @Override
     TextHeaders setDouble(CharSequence name, double value);
+
+    @Override
+    TextHeaders setTimeMillis(CharSequence name, long value);
 
     /**
      * See {@link Headers#set(Headers)}


### PR DESCRIPTION
Motivation:
The new Headers interface contains methods to getTimeMillis but no add/set/contains variants.  These should be added for consistency.

Modifications:
- Add three new methods: addTimeMillis, setTimeMillis, containsTimeMillis to the Headers interface.
- Add a new method to the Headers.ValueConverter interface: T convertTimeMillis(long)
- Bring these new interfaces up the class hierarchy

Result:
All Headers classes have setters/getters for timeMillis.
