### PR TITLE
HTTP Content Encoder allow EmptyLastHttpContent

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
@@ -230,12 +230,7 @@ public class HttpContentCompressorTest {
 
         ch.writeOutbound(LastHttpContent.EMPTY_LAST_CONTENT);
         HttpContent chunk = (HttpContent) ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("1f8b0800000000000000"));
-        chunk.release();
-
-        chunk = (HttpContent) ch.readOutbound();
-        assertThat(ByteBufUtil.hexDump(chunk.content()), is("03000000000000000000"));
-        assertThat(chunk, is(instanceOf(HttpContent.class)));
+        assertThat(ByteBufUtil.hexDump(chunk.content()), is("1f8b080000000000000003000000000000000000"));
         chunk.release();
 
         chunk = (HttpContent) ch.readOutbound();

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
@@ -279,12 +279,17 @@ public class JZlibEncoder extends ZlibEncoder {
     @Override
     protected void encode(ChannelHandlerContext ctx, ByteBuf in, ByteBuf out) throws Exception {
         if (finished) {
+            out.writeBytes(in);
+            return;
+        }
+
+        int inputLength = in.readableBytes();
+        if (inputLength == 0) {
             return;
         }
 
         try {
             // Configure input.
-            int inputLength = in.readableBytes();
             boolean inHasArray = in.hasArray();
             z.avail_in = inputLength;
             if (inHasArray) {

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -195,6 +195,10 @@ public class JdkZlibEncoder extends ZlibEncoder {
         }
 
         int len = uncompressed.readableBytes();
+        if (len == 0) {
+            return;
+        }
+
         int offset;
         byte[] inAry;
         if (uncompressed.hasArray()) {


### PR DESCRIPTION
Motiviation:
The HttpContentEncoder does not account for a EmptyLastHttpContent being provided as input.  This is useful in situations where the client is unable to determine if the current content chunk is the last content chunk (i.e. a proxy forwarding content when transfer encoding is chunked).

Modifications:
- HttpContentEncoder should not attempt to compress empty HttpContent objects

Result:
HttpContentEncoder supports a EmptyLastHttpContent to terminate the response.
