### PR TITLE
HTTP Content Encoder allow EmptyLastHttpContent

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -177,7 +177,11 @@ public class JdkZlibEncoder extends OneToOneStrictEncoder implements LifeCycleAw
         }
 
         ChannelBuffer uncompressed = (ChannelBuffer) msg;
-        byte[] in = new byte[uncompressed.readableBytes()];
+        final int readableBytes = uncompressed.readableBytes();
+        if (readableBytes == 0) {
+            return msg;
+        }
+        byte[] in = new byte[readableBytes];
         uncompressed.readBytes(in);
 
         int sizeEstimate = (int) Math.ceil(in.length * 1.001) + 12;

--- a/src/main/java/org/jboss/netty/handler/codec/compression/ZlibEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/compression/ZlibEncoder.java
@@ -266,7 +266,11 @@ public class ZlibEncoder extends OneToOneStrictEncoder implements LifeCycleAware
             try {
                 // Configure input.
                 ChannelBuffer uncompressed = (ChannelBuffer) msg;
-                byte[] in = new byte[uncompressed.readableBytes()];
+                final int readableBytes = uncompressed.readableBytes();
+                if (readableBytes == 0) {
+                    return msg;
+                }
+                byte[] in = new byte[readableBytes];
                 uncompressed.readBytes(in);
                 z.next_in = in;
                 z.next_in_index = 0;


### PR DESCRIPTION
Motiviation:
The HttpContentEncoder does not account for a EmptyLastHttpContent being provided as input.  This is useful in situations where the client is unable to determine if the current content chunk is the last content chunk (i.e. a proxy forwarding content when transfer encoding is chunked).

Modifications:
- HttpContentEncoder should not attempt to compress empty HttpContent objects

Result:
HttpContentEncoder supports a EmptyLastHttpContent to terminate the response.
