### PR TITLE
Add log-level property to enable different log levels for the examples.

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -113,6 +113,11 @@
       <artifactId>netty-transport-rxtx</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/example/src/main/resources/logback.xml
+++ b/example/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration debug="false">
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="${log-level:-info}">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/run-example.sh
+++ b/run-example.sh
@@ -74,6 +74,7 @@ if [[ -z "$EXAMPLE" ]] || [[ -z "$EXAMPLE_CLASS" ]] || [[ $# -ne 0 ]]; then
   echo "  Usage: $0 [-D<name>[=<value>] ...] <example-name>" >&2
   echo "Example: $0 -Dport=8443 -Dssl http-server" >&2
   echo "         $0 -Dhost=127.0.0.1 -Dport=8009 echo-client" >&2
+  echo "         $0 -Dlog-level=debug -Dhost=127.0.0.1 -Dport=8009 echo-client" >&2
   echo >&2
   echo "Available examples:" >&2
   echo >&2


### PR DESCRIPTION
Motivation:
When running the examples using the provided run-examples.sh script the
log level is 'info' level. It can be handy to be able to configure a
different level, for example 'debug', while learning and trying out the
the examples.

Modifications:
Added a dependency to logback-classic to the examples pom.xml, and also
added a logback configuration file. The log level can be configured by
setting the 'log-level' system property, and if that property is not set
the default will be 'info' level.
The run-examples.sh was updated to show an example of using the system
property to set the log level to 'debug'

Result:
It is now possible to turn on debug logging by settnig a system property
on the command line.
