### PR TITLE
Clean up code of HTTP/2 codec

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -92,9 +92,9 @@ public class CompressorHttp2ConnectionEncoder extends DefaultHttp2ConnectionEnco
         if (builder.memLevel < 1 || builder.memLevel > 9) {
             throw new IllegalArgumentException("memLevel: " + builder.memLevel + " (expected: 1-9)");
         }
-        this.compressionLevel = builder.compressionLevel;
-        this.windowBits = builder.windowBits;
-        this.memLevel = builder.memLevel;
+        compressionLevel = builder.compressionLevel;
+        windowBits = builder.windowBits;
+        memLevel = builder.memLevel;
 
         connection().addListener(CLEAN_UP_LISTENER);
     }
@@ -125,7 +125,7 @@ public class CompressorHttp2ConnectionEncoder extends DefaultHttp2ConnectionEnco
             ChannelPromiseAggregator aggregator = new ChannelPromiseAggregator(promise);
             for (;;) {
                 final ByteBuf nextBuf = nextReadableBuf(compressor);
-                final boolean endOfStreamForBuf = nextBuf == null ? endOfStream : false;
+                final boolean endOfStreamForBuf = nextBuf == null && endOfStream;
                 ChannelPromise newPromise = ctx.newPromise();
                 aggregator.add(newPromise);
 
@@ -252,7 +252,7 @@ public class CompressorHttp2ConnectionEncoder extends DefaultHttp2ConnectionEnco
      * Release remaining content from {@link EmbeddedChannel} and remove the compressor from the {@link Http2Stream}.
      *
      * @param stream The stream for which {@code compressor} is the compressor for
-     * @param decompressor The compressor for {@code stream}
+     * @param compressor The compressor for {@code stream}
      */
     private static void cleanup(Http2Stream stream, EmbeddedChannel compressor) {
         if (compressor.finish()) {
@@ -270,7 +270,7 @@ public class CompressorHttp2ConnectionEncoder extends DefaultHttp2ConnectionEnco
     /**
      * Read the next compressed {@link ByteBuf} from the {@link EmbeddedChannel} or {@code null} if one does not exist.
      *
-     * @param decompressor The channel to read from
+     * @param compressor The channel to read from
      * @return The next decoded {@link ByteBuf} from the {@link EmbeddedChannel} or {@code null} if one does not exist
      */
     private static ByteBuf nextReadableBuf(EmbeddedChannel compressor) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -419,7 +419,7 @@ public class DefaultHttp2Connection implements Http2Connection {
             weight(weight);
 
             if (newParent != parent() || exclusive) {
-                List<ParentChangedEvent> events = null;
+                List<ParentChangedEvent> events;
                 if (newParent.isDescendantOf(this)) {
                     events = new ArrayList<ParentChangedEvent>(2 + (exclusive ? newParent.children().size() : 0));
                     parent.takeChild(newParent, false, events);
@@ -607,15 +607,15 @@ public class DefaultHttp2Connection implements Http2Connection {
      * Allows a correlation to be made between a stream and its old parent before a parent change occurs
      */
     private final class ParentChangedEvent {
-        private Http2Stream stream;
-        private Http2Stream oldParent;
+        private final Http2Stream stream;
+        private final Http2Stream oldParent;
 
         /**
          * Create a new instance
          * @param stream The stream who has had a parent change
          * @param oldParent The previous parent
          */
-        public ParentChangedEvent(Http2Stream stream, Http2Stream oldParent) {
+        ParentChangedEvent(Http2Stream stream, Http2Stream oldParent) {
             this.stream = stream;
             this.oldParent = oldParent;
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -101,12 +101,12 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
     }
 
     protected DefaultHttp2ConnectionDecoder(Builder builder) {
-        this.connection = checkNotNull(builder.connection, "connection");
-        this.frameReader = checkNotNull(builder.frameReader, "frameReader");
-        this.lifecycleManager = checkNotNull(builder.lifecycleManager, "lifecycleManager");
-        this.encoder = checkNotNull(builder.encoder, "encoder");
-        this.inboundFlow = checkNotNull(builder.inboundFlow, "inboundFlow");
-        this.listener = checkNotNull(builder.listener, "listener");
+        connection = checkNotNull(builder.connection, "connection");
+        frameReader = checkNotNull(builder.frameReader, "frameReader");
+        lifecycleManager = checkNotNull(builder.lifecycleManager, "lifecycleManager");
+        encoder = checkNotNull(builder.encoder, "encoder");
+        inboundFlow = checkNotNull(builder.inboundFlow, "inboundFlow");
+        listener = checkNotNull(builder.listener, "listener");
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -86,10 +86,10 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
     }
 
     protected DefaultHttp2ConnectionEncoder(Builder builder) {
-        this.frameWriter = checkNotNull(builder.frameWriter, "frameWriter");
-        this.connection = checkNotNull(builder.connection, "connection");
-        this.outboundFlow = checkNotNull(builder.outboundFlow, "outboundFlow");
-        this.lifecycleManager = checkNotNull(builder.lifecycleManager, "lifecycleManager");
+        frameWriter = checkNotNull(builder.frameWriter, "frameWriter");
+        connection = checkNotNull(builder.connection, "connection");
+        outboundFlow = checkNotNull(builder.outboundFlow, "outboundFlow");
+        lifecycleManager = checkNotNull(builder.lifecycleManager, "lifecycleManager");
     }
 
     @Override
@@ -252,10 +252,10 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
                         "Sending non-trailing headers after data has been sent for stream: "
                                 + streamId);
             }
+        } catch (Http2NoMoreStreamIdsException e) {
+            lifecycleManager.onException(ctx, e);
+            return promise.setFailure(e);
         } catch (Throwable e) {
-            if (e instanceof Http2NoMoreStreamIdsException) {
-                lifecycleManager.onException(ctx, e);
-            }
             return promise.setFailure(e);
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -23,7 +23,6 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_MAX_FRAME_SIZ
 import static io.netty.handler.codec.http2.Http2CodecUtil.SETTING_ENTRY_LENGTH;
 import static io.netty.handler.codec.http2.Http2CodecUtil.isMaxFrameSizeValid;
 import static io.netty.handler.codec.http2.Http2CodecUtil.readUnsignedInt;
-import static io.netty.handler.codec.http2.Http2Error.FRAME_SIZE_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.protocolError;
 import static io.netty.handler.codec.http2.Http2FrameTypes.CONTINUATION;
 import static io.netty.handler.codec.http2.Http2FrameTypes.DATA;
@@ -87,7 +86,8 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
     @Override
     public void maxFrameSize(int max) throws Http2Exception {
         if (!isMaxFrameSizeValid(max)) {
-            Http2Exception.format(FRAME_SIZE_ERROR, "Invalid MAX_FRAME_SIZE specified in sent settings: %d", max);
+            Http2Exception.format(Http2Error.FRAME_SIZE_ERROR,
+                    "Invalid MAX_FRAME_SIZE specified in sent settings: %d", max);
         }
         maxFrameSize = max;
     }
@@ -560,8 +560,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
                 listener);
     }
 
-    private void readUnknownFrame(ChannelHandlerContext ctx, ByteBuf payload, Http2FrameListener listener)
-            throws Http2Exception {
+    private void readUnknownFrame(ChannelHandlerContext ctx, ByteBuf payload, Http2FrameListener listener) {
         payload = payload.readSlice(payload.readableBytes());
         listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
@@ -99,7 +99,7 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
         @Override
         public void maxHeaderTableSize(int max) throws Http2Exception {
             if (max < 0) {
-                throw Http2Exception.protocolError("Header Table Size must be non-negative but was %d", max);
+                throw protocolError("Header Table Size must be non-negative but was %d", max);
             }
             try {
                 decoder.setMaxHeaderTableSize(max);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoder.java
@@ -107,7 +107,7 @@ public class DefaultHttp2HeadersEncoder implements Http2HeadersEncoder, Http2Hea
     }
 
     private void encodeHeader(AsciiString key, AsciiString value, OutputStream stream) throws IOException {
-        boolean sensitive = sensitiveHeaders.contains(key);
+        boolean sensitive = sensitiveHeaders.contains(key.toString());
         encoder.encodeHeader(stream, key.array(), value.array(), sensitive);
     }
 
@@ -118,7 +118,7 @@ public class DefaultHttp2HeadersEncoder implements Http2HeadersEncoder, Http2Hea
         @Override
         public void maxHeaderTableSize(int max) throws Http2Exception {
             if (max < 0) {
-                throw Http2Exception.protocolError("Header Table Size must be non-negative but was %d", max);
+                throw protocolError("Header Table Size must be non-negative but was %d", max);
             }
             try {
                 // No headers should be emitted. If they are, we throw.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowController.java
@@ -136,7 +136,7 @@ public class DefaultHttp2InboundFlowController implements Http2InboundFlowContro
     }
 
     private InboundFlowState state(Http2Stream stream) {
-        return stream != null? (InboundFlowState) stream.inboundFlow() : null;
+        return stream != null ? (InboundFlowState) stream.inboundFlow() : null;
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2OutboundFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2OutboundFlowController.java
@@ -47,9 +47,9 @@ public class DefaultHttp2OutboundFlowController implements Http2OutboundFlowCont
     private static final Comparator<Http2Stream> DATA_WEIGHT = new Comparator<Http2Stream>() {
         @Override
         public int compare(Http2Stream o1, Http2Stream o2) {
-            final long result = ((long) state(o1).priorityBytes()) * o1.weight() -
-                                ((long) state(o2).priorityBytes()) * o2.weight();
-            return result > 0 ? 1 : (result < 0 ? -1 : 0);
+            final long result = (long) state(o1).priorityBytes() * o1.weight() -
+                                (long) state(o2).priorityBytes() * o2.weight();
+            return result > 0 ? 1 : result < 0 ? -1 : 0;
         }
     };
 
@@ -489,7 +489,7 @@ public class DefaultHttp2OutboundFlowController implements Http2OutboundFlowCont
         /**
          * Returns the the head of the pending queue, or {@code null} if empty.
          */
-        Frame peek() {
+        private Frame peek() {
             return pendingWriteQueue.peek();
         }
 
@@ -572,7 +572,7 @@ public class DefaultHttp2OutboundFlowController implements Http2OutboundFlowCont
                 this.padding = padding;
                 this.endStream = endStream;
                 this.promiseAggregator = promiseAggregator;
-                this.promise = ctx.newPromise();
+                promise = ctx.newPromise();
                 promiseAggregator.add(promise);
             }
 
@@ -619,7 +619,7 @@ public class DefaultHttp2OutboundFlowController implements Http2OutboundFlowCont
                 final Http2FrameSizePolicy frameSizePolicy = frameWriter.configuration().frameSizePolicy();
                 do {
                     int bytesToWrite = size();
-                    int frameBytes = Math.min(bytesToWrite, frameSizePolicy.maxFrameSize());
+                    int frameBytes = min(bytesToWrite, frameSizePolicy.maxFrameSize());
                     if (frameBytes == bytesToWrite) {
                         // All the bytes fit into a single HTTP/2 frame, just send it all.
                         connectionState().incrementStreamWindow(-bytesToWrite);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
@@ -86,7 +86,7 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
             } else {
                 for (;;) {
                     final ByteBuf nextBuf = nextReadableBuf(decompressor);
-                    final boolean endOfStreamForBuf = nextBuf == null ? endOfStream : false;
+                    final boolean endOfStreamForBuf = nextBuf == null && endOfStream;
 
                     listener.onDataRead(ctx, streamId, buf, padding, endOfStreamForBuf);
                     if (nextBuf == null) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -32,7 +32,7 @@ public final class Http2CodecUtil {
 
     private static final byte[] CONNECTION_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(UTF_8);
     private static final byte[] EMPTY_PING = new byte[8];
-    private static IgnoreSettingsHandler ignoreSettingsHandler = new IgnoreSettingsHandler();
+    private static final IgnoreSettingsHandler IGNORE_SETTINGS_HANDLER = new IgnoreSettingsHandler();
 
     public static final int CONNECTION_STREAM_ID = 0;
     public static final int HTTP_UPGRADE_STREAM_ID = 1;
@@ -48,8 +48,8 @@ public final class Http2CodecUtil {
     public static final int SETTING_ENTRY_LENGTH = 6;
     public static final int PRIORITY_ENTRY_LENGTH = 5;
     public static final int INT_FIELD_LENGTH = 4;
-    public static final short MAX_WEIGHT = (short) 256;
-    public static final short MIN_WEIGHT = (short) 1;
+    public static final short MAX_WEIGHT = 256;
+    public static final short MIN_WEIGHT = 1;
 
     public static final int SETTINGS_HEADER_TABLE_SIZE = 1;
     public static final int SETTINGS_ENABLE_PUSH = 2;
@@ -124,7 +124,7 @@ public final class Http2CodecUtil {
      * settings frames directly.
      */
     public static ChannelHandler ignoreSettingsHandler() {
-        return ignoreSettingsHandler;
+        return IGNORE_SETTINGS_HANDLER;
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
@@ -31,7 +31,7 @@ public interface Http2ConnectionDecoder extends Closeable {
     /**
      * Builder for new instances of {@link Http2ConnectionDecoder}.
      */
-    public interface Builder {
+    interface Builder {
 
         /**
          * Sets the {@link Http2Connection} to be used when building the decoder.
@@ -39,7 +39,7 @@ public interface Http2ConnectionDecoder extends Closeable {
         Builder connection(Http2Connection connection);
 
         /**
-         * Sets the {@link LifecycleManager} to be used when building the decoder.
+         * Sets the {@link Http2LifecycleManager} to be used when building the decoder.
          */
         Builder lifecycleManager(Http2LifecycleManager lifecycleManager);
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionEncoder.java
@@ -21,14 +21,14 @@ import io.netty.channel.ChannelPromise;
 
 
 /**
- * Handler for outbound traffic on behalf of {@link Http2ConectionHandler}.
+ * Handler for outbound HTTP/2 traffic.
  */
 public interface Http2ConnectionEncoder extends Http2FrameWriter, Http2OutboundFlowController {
 
     /**
      * Builder for new instances of {@link Http2ConnectionEncoder}.
      */
-    public interface Builder {
+    interface Builder {
 
         /**
          * Sets the {@link Http2Connection} to be used when building the encoder.
@@ -36,7 +36,7 @@ public interface Http2ConnectionEncoder extends Http2FrameWriter, Http2OutboundF
         Builder connection(Http2Connection connection);
 
         /**
-         * Sets the {@link LifecycleManager} to be used when building the encoder.
+         * Sets the {@link Http2LifecycleManager} to be used when building the encoder.
          */
         Builder lifecycleManager(Http2LifecycleManager lifecycleManager);
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -213,6 +213,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
      * @param stream the stream to be half closed.
      * @param future If closing, the future after which to close the channel.
      */
+    @Override
     public void closeLocalSide(Http2Stream stream, ChannelFuture future) {
         switch (stream.state()) {
             case HALF_CLOSED_LOCAL:
@@ -232,6 +233,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
      * @param stream the stream to be half closed.
      * @param future If closing, the future after which to close the channel.
      */
+    @Override
     public void closeRemoteSide(Http2Stream stream, ChannelFuture future) {
         switch (stream.state()) {
             case HALF_CLOSED_REMOTE:
@@ -310,6 +312,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     /**
      * Writes a {@code RST_STREAM} frame to the remote endpoint and updates the connection state appropriately.
      */
+    @Override
     public ChannelFuture writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
             ChannelPromise promise) {
         Http2Stream stream = connection().stream(streamId);
@@ -327,6 +330,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     /**
      * Sends a {@code GO_AWAY} frame to the remote endpoint and updates the connection state appropriately.
      */
+    @Override
     public ChannelFuture writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData,
             ChannelPromise promise) {
         Http2Connection connection = connection();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameReader.java
@@ -28,7 +28,7 @@ public interface Http2FrameReader extends Closeable {
     /**
      * Configuration specific to {@link Http2FrameReader}
      */
-    public interface Configuration {
+    interface Configuration {
         /**
          * Get the {@link Http2HeaderTable} for this {@link Http2FrameReader}
          */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
@@ -31,7 +31,7 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
     /**
      * Configuration specific to {@link Http2FrameWriter}
      */
-    public interface Configuration {
+    interface Configuration {
         /**
          * Get the {@link Http2HeaderTable} for this {@link Http2FrameWriter}
          */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersDecoder.java
@@ -24,7 +24,7 @@ public interface Http2HeadersDecoder {
     /**
      * Configuration related elements for the {@link Http2HeadersDecoder} interface
      */
-    public interface Configuration {
+    interface Configuration {
         /**
          * Access the Http2HeaderTable for this {@link Http2HeadersDecoder}
          */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersEncoder.java
@@ -24,7 +24,7 @@ public interface Http2HeadersEncoder {
     /**
      * Configuration related elements for the {@link Http2HeadersEncoder} interface
      */
-    public interface Configuration {
+    interface Configuration {
         /**
          * Access the Http2HeaderTable for this {@link Http2HeadersEncoder}
          */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OrHttpChooser.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OrHttpChooser.java
@@ -148,9 +148,8 @@ public abstract class Http2OrHttpChooser extends ByteToMessageDecoder {
     protected abstract ChannelHandler createHttp1RequestHandler();
 
     /**
-     * Create the {@link io.netty.channel.ChannelHandler} that is responsible for handling the http
-     * responses when the when the {@link SelectedProtocol} was {@link SelectedProtocol#HTTP_2}. The
-     * returned class should be a subclass of {@link DelegatingHttp2ConnectionHandler}.
+     * Create the {@link ChannelHandler} that is responsible for handling the http responses
+     * when the when the {@link SelectedProtocol} was {@link SelectedProtocol#HTTP_2}.
      */
-    protected abstract ChannelHandler createHttp2RequestHandler();
+    protected abstract Http2ConnectionHandler createHttp2RequestHandler();
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
@@ -24,8 +24,6 @@ import java.util.List;
  * Provides utilities related to security requirements specific to HTTP/2.
  */
 public final class Http2SecurityUtil {
-    private Http2SecurityUtil() { }
-
     /**
      * The following list is derived from <a
      * href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html">SunJSSE Supported
@@ -78,4 +76,6 @@ public final class Http2SecurityUtil {
         ciphers.addAll(CIPHERS_JAVA_DISABLED_DEFAULT);
         CIPHERS = Collections.unmodifiableList(ciphers);
     }
+
+    private Http2SecurityUtil() { }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
@@ -133,8 +133,7 @@ public class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.Upgrade
             final Http2Settings decodedSettings = new Http2Settings();
             frameReader.readFrame(ctx, frame, new Http2FrameAdapter() {
                 @Override
-                public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings)
-                        throws Http2Exception {
+                public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) {
                     decodedSettings.copyFrom(settings);
                 }
             });

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
@@ -177,7 +177,7 @@ public final class Http2Settings extends IntObjectHashMap<Long> {
         return value.intValue();
     }
 
-    private void verifyStandardSetting(int key, Long value) {
+    private static void verifyStandardSetting(int key, Long value) {
         checkNotNull(value, "value");
         switch (key) {
             case SETTINGS_HEADER_TABLE_SIZE:
@@ -215,6 +215,8 @@ public final class Http2Settings extends IntObjectHashMap<Long> {
                             + value);
                 }
                 break;
+            default:
+                throw new IllegalArgumentException("key");
         }
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ToHttpConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ToHttpConnectionHandler.java
@@ -22,7 +22,7 @@ import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.HttpHeaders;
 
 /**
- * Light weight wrapper around {@link DelegatingHttp2ConnectionHandler} to provide HTTP/1.x objects to HTTP/2 frames
+ * Translates HTTP/1.x object writes into HTTP/2 frames
  * <p>
  * See {@link InboundHttp2ToHttpAdapter} to get translation from HTTP/2 frames to HTTP/1.x objects
  */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpPriorityAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpPriorityAdapter.java
@@ -125,7 +125,7 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
      * @param msg The message containing the headers and trailing headers
      * @return The headers object which can be appended to or modified
      */
-    private HttpHeaders getActiveHeaders(FullHttpMessage msg) {
+    private static HttpHeaders getActiveHeaders(FullHttpMessage msg) {
         return msg.content().isReadable() ? msg.trailingHeaders() : msg.headers();
     }
 
@@ -159,7 +159,7 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
      * This will remove all headers which are related to priority tree events
      * @param headers The headers to remove the priority tree elements from
      */
-    private void removePriorityRelatedHeaders(HttpHeaders headers) {
+    private static void removePriorityRelatedHeaders(HttpHeaders headers) {
         headers.remove(HttpUtil.ExtensionHeaderNames.STREAM_DEPENDENCY_ID.text());
         headers.remove(HttpUtil.ExtensionHeaderNames.STREAM_WEIGHT.text());
     }
@@ -181,7 +181,7 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
      * @param httpHeaders The HTTP headers to translate to HTTP/2
      * @param http2Headers The target HTTP/2 headers
      */
-    private void addHttpHeadersToHttp2Headers(HttpHeaders httpHeaders, final Http2Headers http2Headers) {
+    private static void addHttpHeadersToHttp2Headers(HttpHeaders httpHeaders, final Http2Headers http2Headers) {
         try {
             httpHeaders.forEachEntry(new EntryVisitor() {
                 @Override
@@ -239,7 +239,7 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
     @Override
     public void onWeightChanged(Http2Stream stream, short oldWeight) {
         FullHttpMessage msg = messageMap.get(stream.id());
-        HttpHeaders headers = null;
+        HttpHeaders headers;
         if (msg == null) {
             // msg may be null if a HTTP/2 frame event in received outside the HTTP message flow
             // For example a PRIORITY frame can be received in any state besides IDLE

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -19,8 +19,7 @@ import static io.netty.handler.codec.http2.Http2TestUtil.as;
 import static io.netty.handler.codec.http2.Http2TestUtil.runInChannel;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
@@ -243,8 +242,8 @@ public class DataCompressionHttp2Test {
             assertEquals(data1, dataCapture.get(0));
             assertEquals(data2, dataCapture.get(1));
             List<Boolean> endStreamCapture = endStreamCaptor.getAllValues();
-            assertEquals(false, endStreamCapture.get(0));
-            assertEquals(true, endStreamCapture.get(1));
+            assertFalse(endStreamCapture.get(0));
+            assertTrue(endStreamCapture.get(1));
         } finally {
             data1.release();
             data2.release();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -345,7 +345,7 @@ public class DefaultHttp2ConnectionDecoderTest {
     public void rstStreamReadShouldCloseStream() throws Exception {
         decode().onRstStreamRead(ctx, STREAM_ID, PROTOCOL_ERROR.code());
         verify(lifecycleManager).closeStream(eq(stream), eq(future));
-        verify(listener).onRstStreamRead(eq(ctx), eq(STREAM_ID), eq((long) PROTOCOL_ERROR.code()));
+        verify(listener).onRstStreamRead(eq(ctx), eq(STREAM_ID), eq(PROTOCOL_ERROR.code()));
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -314,7 +314,7 @@ public class DefaultHttp2ConnectionEncoderTest {
     @Test
     public void rstStreamWriteShouldCloseStream() throws Exception {
         encoder.writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code(), promise);
-        verify(lifecycleManager).writeRstStream(eq(ctx), eq(STREAM_ID), eq((long) PROTOCOL_ERROR.code()), eq(promise));
+        verify(lifecycleManager).writeRstStream(eq(ctx), eq(STREAM_ID), eq(PROTOCOL_ERROR.code()), eq(promise));
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -33,7 +33,6 @@ import io.netty.handler.codec.http2.Http2Stream.State;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -304,7 +303,7 @@ public class DefaultHttp2ConnectionTest {
         reset(clientListener);
         streamD.setPriority(streamD.parent().id(), newWeight, false);
         verify(clientListener).onWeightChanged(eq(streamD), eq(oldWeight));
-        Assert.assertEquals(streamD.weight(), newWeight);
+        assertEquals(streamD.weight(), newWeight);
         verify(clientListener, never()).priorityTreeParentChanging(any(Http2Stream.class),
                         any(Http2Stream.class));
         verify(clientListener, never()).priorityTreeParentChanged(any(Http2Stream.class),
@@ -533,34 +532,34 @@ public class DefaultHttp2ConnectionTest {
     }
 
     private void verifyParentChanging(List<Http2Stream> expectedArg1, List<Http2Stream> expectedArg2) {
-        Assert.assertTrue(expectedArg1.size() == expectedArg2.size());
+        assertTrue(expectedArg1.size() == expectedArg2.size());
         ArgumentCaptor<Http2Stream> arg1Captor = ArgumentCaptor.forClass(Http2Stream.class);
         ArgumentCaptor<Http2Stream> arg2Captor = ArgumentCaptor.forClass(Http2Stream.class);
         verify(clientListener, times(expectedArg1.size())).priorityTreeParentChanging(arg1Captor.capture(),
                         arg2Captor.capture());
         List<Http2Stream> capturedArg1 = arg1Captor.getAllValues();
         List<Http2Stream> capturedArg2 = arg2Captor.getAllValues();
-        Assert.assertTrue(capturedArg1.size() == capturedArg2.size());
-        Assert.assertTrue(capturedArg1.size() == expectedArg1.size());
+        assertTrue(capturedArg1.size() == capturedArg2.size());
+        assertTrue(capturedArg1.size() == expectedArg1.size());
         for (int i = 0; i < capturedArg1.size(); ++i) {
-            Assert.assertEquals(expectedArg1.get(i), capturedArg1.get(i));
-            Assert.assertEquals(expectedArg2.get(i), capturedArg2.get(i));
+            assertEquals(expectedArg1.get(i), capturedArg1.get(i));
+            assertEquals(expectedArg2.get(i), capturedArg2.get(i));
         }
     }
 
     private void verifyParentsChanged(List<Http2Stream> expectedArg1, List<Http2Stream> expectedArg2) {
-        Assert.assertTrue(expectedArg1.size() == expectedArg2.size());
+        assertTrue(expectedArg1.size() == expectedArg2.size());
         ArgumentCaptor<Http2Stream> arg1Captor = ArgumentCaptor.forClass(Http2Stream.class);
         ArgumentCaptor<Http2Stream> arg2Captor = ArgumentCaptor.forClass(Http2Stream.class);
         verify(clientListener, times(expectedArg1.size())).priorityTreeParentChanged(arg1Captor.capture(),
                         arg2Captor.capture());
         List<Http2Stream> capturedArg1 = arg1Captor.getAllValues();
         List<Http2Stream> capturedArg2 = arg2Captor.getAllValues();
-        Assert.assertTrue(capturedArg1.size() == capturedArg2.size());
-        Assert.assertTrue(capturedArg1.size() == expectedArg1.size());
+        assertTrue(capturedArg1.size() == capturedArg2.size());
+        assertTrue(capturedArg1.size() == expectedArg1.size());
         for (int i = 0; i < capturedArg1.size(); ++i) {
-            Assert.assertEquals(expectedArg1.get(i), capturedArg1.get(i));
-            Assert.assertEquals(expectedArg2.get(i), capturedArg2.get(i));
+            assertEquals(expectedArg1.get(i), capturedArg1.get(i));
+            assertEquals(expectedArg2.get(i), capturedArg2.get(i));
         }
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoderTest.java
@@ -54,7 +54,7 @@ public class DefaultHttp2HeadersEncoderTest {
         encoder.encodeHeaders(headers, Unpooled.buffer());
     }
 
-    private Http2Headers headers() {
+    private static Http2Headers headers() {
         return new DefaultHttp2Headers().method(as("GET")).add(as("a"), as("1"))
                 .add(as("a"), as("2"));
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowControllerTest.java
@@ -167,7 +167,7 @@ public class DefaultHttp2InboundFlowControllerTest {
         return buffer;
     }
 
-    private void verifyWindowUpdateSent(int streamId, int windowSizeIncrement) throws Http2Exception {
+    private void verifyWindowUpdateSent(int streamId, int windowSizeIncrement) {
         verify(frameWriter).writeWindowUpdate(eq(ctx), eq(streamId), eq(windowSizeIncrement), eq(promise));
     }
 
@@ -175,7 +175,7 @@ public class DefaultHttp2InboundFlowControllerTest {
         verify(frameWriter, never()).writeWindowUpdate(eq(ctx), eq(streamId), anyInt(), eq(promise));
     }
 
-    private void verifyWindowUpdateNotSent() throws Http2Exception {
+    private void verifyWindowUpdateNotSent() {
         verify(frameWriter, never()).writeWindowUpdate(any(ChannelHandlerContext.class), anyInt(), anyInt(),
                 any(ChannelPromise.class));
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2OutboundFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2OutboundFlowControllerTest.java
@@ -20,6 +20,7 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGH
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotSame;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
@@ -151,7 +152,7 @@ public class DefaultHttp2OutboundFlowControllerTest {
 
             // Now write another and verify that the last write is updated.
             ChannelFuture future2 = controller.writeData(ctx, STREAM_A, data, 0, false, promise2);
-            assertTrue(future1 != future2);
+            assertNotSame(future1, future2);
             assertEquals(future2, controller.lastWriteForStream(STREAM_A));
         } finally {
             manualSafeRelease(data);
@@ -610,7 +611,7 @@ public class DefaultHttp2OutboundFlowControllerTest {
             assertEquals(0, window(CONNECTION_STREAM_ID));
             assertEquals(0, window(STREAM_A));
             assertEquals(DEFAULT_WINDOW_SIZE - 5, window(STREAM_B));
-            assertEquals((2 * DEFAULT_WINDOW_SIZE) - 5, window(STREAM_C) + window(STREAM_D));
+            assertEquals(2 * DEFAULT_WINDOW_SIZE - 5, window(STREAM_C) + window(STREAM_D));
 
             final ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
 
@@ -723,7 +724,7 @@ public class DefaultHttp2OutboundFlowControllerTest {
             assertEquals(0, window(CONNECTION_STREAM_ID));
             assertEquals(DEFAULT_WINDOW_SIZE - 5, window(STREAM_A));
             assertEquals(0, window(STREAM_B));
-            assertEquals((2 * DEFAULT_WINDOW_SIZE) - 5, window(STREAM_C) + window(STREAM_D));
+            assertEquals(2 * DEFAULT_WINDOW_SIZE - 5, window(STREAM_C) + window(STREAM_D));
 
             final ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
 
@@ -1241,7 +1242,7 @@ public class DefaultHttp2OutboundFlowControllerTest {
         return sum;
     }
 
-    private void send(int streamId, ByteBuf data, int padding) throws Http2Exception {
+    private void send(int streamId, ByteBuf data, int padding) {
         ChannelFuture future = controller.writeData(ctx, streamId, data, padding, false, promise);
         assertEquals(future, controller.lastWriteForStream(streamId));
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -163,7 +163,7 @@ public class Http2ConnectionHandlerTest {
         handler = newHandler();
         handler.channelRead(ctx, copiedBuffer("BAD_PREFACE", UTF_8));
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
-        verify(frameWriter).writeGoAway(eq(ctx), eq(0), eq((long) PROTOCOL_ERROR.code()),
+        verify(frameWriter).writeGoAway(eq(ctx), eq(0), eq(PROTOCOL_ERROR.code()),
                 captor.capture(), eq(promise));
         captor.getValue().release();
     }
@@ -187,7 +187,7 @@ public class Http2ConnectionHandlerTest {
         when(remote.lastStreamCreated()).thenReturn(STREAM_ID);
         handler.exceptionCaught(ctx, e);
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
-        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq((long) PROTOCOL_ERROR.code()),
+        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(PROTOCOL_ERROR.code()),
                 captor.capture(), eq(promise));
         captor.getValue().release();
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -394,7 +394,7 @@ public class Http2FrameRoundtripTest {
         return ctx().newPromise();
     }
 
-    private Http2Headers headers() {
+    private static Http2Headers headers() {
         return new DefaultHttp2Headers().method(as("GET")).scheme(as("https"))
                 .authority(as("example.org")).path(as("/some/path/resource2")).add(randomString(), randomString());
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2HeaderBlockIOTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2HeaderBlockIOTest.java
@@ -90,7 +90,7 @@ public class Http2HeaderBlockIOTest {
         assertEquals(in, out);
     }
 
-    private Http2Headers headers() {
+    private static Http2Headers headers() {
         return new DefaultHttp2Headers().method(as("GET")).scheme(as("https"))
         .authority(as("example.org")).path(as("/some/path/resource2"))
                 .add(as("accept"), as("image/png")).add(as("cache-control"), as("no-cache"))

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -115,7 +115,7 @@ final class Http2TestUtil {
             if (connection != null) {
                 Http2Stream stream = connection.stream(streamId);
                 if (stream == null) {
-                    if ((connection.isServer() && streamId % 2 == 0) || (!connection.isServer() && streamId % 2 != 0)) {
+                    if (connection.isServer() && streamId % 2 == 0 || !connection.isServer() && streamId % 2 != 0) {
                         stream = connection.local().createStream(streamId, halfClosed);
                     } else {
                         stream = connection.remote().createStream(streamId, halfClosed);
@@ -264,15 +264,15 @@ final class Http2TestUtil {
         private final CountDownLatch dataLatch;
         private final CountDownLatch trailersLatch;
 
-        public FrameCountDown(Http2FrameListener listener, CountDownLatch messageLatch) {
+        FrameCountDown(Http2FrameListener listener, CountDownLatch messageLatch) {
             this(listener, messageLatch, null);
         }
 
-        public FrameCountDown(Http2FrameListener listener, CountDownLatch messageLatch, CountDownLatch dataLatch) {
+        FrameCountDown(Http2FrameListener listener, CountDownLatch messageLatch, CountDownLatch dataLatch) {
             this(listener, messageLatch, dataLatch, null);
         }
 
-        public FrameCountDown(Http2FrameListener listener, CountDownLatch messageLatch,
+        FrameCountDown(Http2FrameListener listener, CountDownLatch messageLatch,
                 CountDownLatch dataLatch, CountDownLatch trailersLatch) {
             this.listener = listener;
             this.messageLatch = messageLatch;

--- a/example/src/main/java/io/netty/example/http2/server/Http2OrHttpHandler.java
+++ b/example/src/main/java/io/netty/example/http2/server/Http2OrHttpHandler.java
@@ -15,6 +15,7 @@
 package io.netty.example.http2.server;
 
 import io.netty.channel.ChannelHandler;
+import io.netty.handler.codec.http2.Http2ConnectionHandler;
 import io.netty.handler.codec.http2.Http2OrHttpChooser;
 
 import javax.net.ssl.SSLEngine;
@@ -51,7 +52,7 @@ public class Http2OrHttpHandler extends Http2OrHttpChooser {
     }
 
     @Override
-    protected ChannelHandler createHttp2RequestHandler() {
+    protected Http2ConnectionHandler createHttp2RequestHandler() {
         return new HelloWorldHttp2Handler();
     }
 }


### PR DESCRIPTION
Motivation:

Too many warnings from IntelliJ IDEA code inspector, PMD and FindBugs.

Modifications:
- Removed unnecessary casts, braces, modifiers, imports, throws on methods, etc.
- Added static modifiers where it is possible.
- Fixed incorrect links in javadoc.

Result:

Better code.
