### PR TITLE
Fix bug caused by slopiness.

### DIFF
--- a/transport/src/main/java/io/netty/channel/PausableChannelEventExecutor.java
+++ b/transport/src/main/java/io/netty/channel/PausableChannelEventExecutor.java
@@ -200,7 +200,7 @@ abstract class PausableChannelEventExecutor implements PausableEventExecutor, Ch
     @Override
     @Deprecated
     public void shutdown() {
-        unwrap().terminationFuture();
+        unwrap().shutdown();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

`PausableChannelEventExecutor().shutdown()` used to call `unwrap().terminationFuture()` instead of `unwrap.shutdown()`.
This error was reported by @xfrag in a comment to a commit message [1]. Tyvm.

Modifications:

`PausableChannelEventExecutor.shutdown()` now correctly invokes `unwrap().shutdown()` instead of `unwrap().terminationFuture()`.

Result:

Correct code.

[1] https://github.com/netty/netty/commit/220660e351b2a22112b19c4af45e403eab1f73ab#commitcomment-8489643
