### PR TITLE
Add supporting MQTT 3.1.1

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttCodecUtil.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttCodecUtil.java
@@ -38,9 +38,16 @@ final class MqttCodecUtil {
         return messageId != 0;
     }
 
-    static boolean isValidClientId(String clientId) {
-        return clientId != null && clientId.length() >= MIN_CLIENT_ID_LENGTH &&
-            clientId.length() <= MAX_CLIENT_ID_LENGTH;
+    static boolean isValidClientId(MqttVersion mqttVersion, String clientId) {
+        if (mqttVersion == MqttVersion.MQTT_3_1) {
+            return clientId != null && clientId.length() >= MIN_CLIENT_ID_LENGTH &&
+                clientId.length() <= MAX_CLIENT_ID_LENGTH;
+        } else if (mqttVersion == MqttVersion.MQTT_3_1_1) {
+            // In 3.1.3.1 Client Identifier of MQTT 3.1.1 specification, The Server MAY allow ClientId’s
+            // that contain more than 23 encoded bytes. And, The Server MAY allow zero-length ClientId.
+            return clientId != null;
+        }
+        throw new IllegalArgumentException(mqttVersion + " is unknown mqtt version");
     }
 
     static MqttFixedHeader validateFixedHeader(MqttFixedHeader mqttFixedHeader) {

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static io.netty.handler.codec.mqtt.MqttCodecUtil.*;
-import static io.netty.handler.codec.mqtt.MqttVersion.*;
 
 /**
  * Decodes Mqtt messages from bytes, following
@@ -203,15 +202,15 @@ public class MqttDecoder extends ReplayingDecoder<DecoderState> {
 
     private static Result<MqttConnectVariableHeader> decodeConnectionVariableHeader(ByteBuf buffer) {
         final Result<String> protoString = decodeString(buffer);
-        if (!PROTOCOL_NAME.equals(protoString.value)) {
-            throw new MqttUnacceptableProtocolVersionException("missing " + PROTOCOL_NAME + " signature");
-        }
-
         int numberOfBytesConsumed = protoString.numberOfBytesConsumed;
 
-        final byte version = buffer.readByte();
+        final byte protocolLevel = buffer.readByte();
+        numberOfBytesConsumed += 1;
+
+        final MqttVersion mqttVersion = MqttVersion.fromProtocolNameAndLevel(protoString.value, protocolLevel);
+
         final int b1 = buffer.readUnsignedByte();
-        numberOfBytesConsumed += 2;
+        numberOfBytesConsumed += 1;
 
         final Result<Integer> keepAlive = decodeMsbLsb(buffer);
         numberOfBytesConsumed += keepAlive.numberOfBytesConsumed;
@@ -224,8 +223,8 @@ public class MqttDecoder extends ReplayingDecoder<DecoderState> {
         final boolean cleanSession = (b1 & 0x02) == 0x02;
 
         final MqttConnectVariableHeader mqttConnectVariableHeader = new MqttConnectVariableHeader(
-                PROTOCOL_NAME,
-                version,
+                mqttVersion.protocolName(),
+                mqttVersion.protocolLevel(),
                 hasUserName,
                 hasPassword,
                 willRetain,
@@ -321,7 +320,9 @@ public class MqttDecoder extends ReplayingDecoder<DecoderState> {
             MqttConnectVariableHeader mqttConnectVariableHeader) {
         final Result<String> decodedClientId = decodeString(buffer);
         final String decodedClientIdValue = decodedClientId.value;
-        if (!isValidClientId(decodedClientIdValue)) {
+        final MqttVersion mqttVersion = MqttVersion.fromProtocolNameAndLevel(mqttConnectVariableHeader.name(),
+                (byte) mqttConnectVariableHeader.version());
+        if (!isValidClientId(mqttVersion, decodedClientIdValue)) {
             throw new MqttIdentifierRejectedException("invalid clientIdentifier: " + decodedClientIdValue);
         }
         int numberOfBytesConsumed = decodedClientId.numberOfBytesConsumed;

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttQoS.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttQoS.java
@@ -18,7 +18,8 @@ package io.netty.handler.codec.mqtt;
 public enum MqttQoS {
     AT_MOST_ONCE(0),
     AT_LEAST_ONCE(1),
-    EXACTLY_ONCE(2);
+    EXACTLY_ONCE(2),
+    FAILURE(0x80);
 
     private final int value;
 

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttVersion.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttVersion.java
@@ -16,12 +16,47 @@
 
 package io.netty.handler.codec.mqtt;
 
+import io.netty.util.CharsetUtil;
+
 /**
- * Holds Constant values used by multiple classes in mqtt-codec.
+ * Mqtt version specific constant values used by multiple classes in mqtt-codec.
  */
-final class MqttVersion {
+public enum MqttVersion {
+    MQTT_3_1("MQIsdp", (byte) 3),
+    MQTT_3_1_1("MQTT", (byte) 4);
 
-    static final String PROTOCOL_NAME = "MQIsdp";
+    private String name;
+    private byte level;
 
-    private MqttVersion() { }
+    private MqttVersion(String protocolName, byte protocolLevel) {
+        this.name = protocolName;
+        this.level = protocolLevel;
+    }
+
+    public String protocolName() {
+        return name;
+    }
+
+    public byte[] protocolNameBytes() {
+        return name.getBytes(CharsetUtil.UTF_8);
+    }
+
+    public byte protocolLevel() {
+        return level;
+    }
+
+    public static MqttVersion fromProtocolNameAndLevel(String protocolName, byte protocolLevel) {
+        for (MqttVersion mv : values()) {
+            if (mv.name.equals(protocolName)) {
+                if (mv.level == protocolLevel) {
+                    return mv;
+                } else {
+                    throw new MqttUnacceptableProtocolVersionException(protocolName + " and " +
+                            protocolLevel + " are not match");
+                }
+            }
+        }
+        throw new MqttUnacceptableProtocolVersionException(protocolName + "is unknown protocol name");
+    }
+
 }


### PR DESCRIPTION
Motivation:

MQTT 3.1.1 became an OASIS Standard at 13 Nov 2014.
http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html
MQTT 3.1.1 is a minor update of 3.1. But, previous codec-mqtt supported only MQTT 3.1.

Modifications:
- Add protocol name `MQTT` with previous `MQIsdp` for `CONNECT`’s variable header.
- Update client identifier validation for 3.1 with 3.1.1.
- Add `FAILURE (0x80)` for `SUBACK`’s new error code.
- Add a test for encode/decode `CONNECT` of 3.1.1.

Result:

MqttEncoder/MqttDecoder can encode/decode frames of 3.1 or 3.1.1.
