### PR TITLE
SPDY: add support for pushed resources in SpdyHttpDecoder

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
@@ -137,7 +137,7 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
                 int associatedToStreamId = spdySynStreamFrame.associatedStreamId();
 
                 // If a client receives a SYN_STREAM with an Associated-To-Stream-ID of 0
-                // it must reply with a RST_STREAM with error code INVALID_STREAM
+                // it must reply with a RST_STREAM with error code INVALID_STREAM.
                 if (associatedToStreamId == 0) {
                     SpdyRstStreamFrame spdyRstStreamFrame =
                         new DefaultSpdyRstStreamFrame(streamId, SpdyStreamStatus.INVALID_STREAM);
@@ -145,12 +145,10 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
                     return;
                 }
 
-                CharSequence URL = spdySynStreamFrame.headers().get(PATH);
-                spdySynStreamFrame.headers().remove(PATH);
-
-                // If a client receives a SYN_STREAM without a 'url' header
-                // it must reply with a RST_STREAM with error code PROTOCOL_ERROR
-                if (URL == null) {
+                // If a client receives a SYN_STREAM with isLast set,
+                // reply with a RST_STREAM with error code PROTOCOL_ERROR
+                // (we only support pushed resources divided into two header blocks).
+                if (spdySynStreamFrame.isLast()) {
                     SpdyRstStreamFrame spdyRstStreamFrame =
                         new DefaultSpdyRstStreamFrame(streamId, SpdyStreamStatus.PROTOCOL_ERROR);
                     ctx.writeAndFlush(spdyRstStreamFrame);
@@ -167,22 +165,15 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
                 }
 
                 try {
-                    FullHttpResponse httpResponseWithEntity =
-                            createHttpResponse(ctx, spdySynStreamFrame, validateHeaders);
+                    FullHttpRequest httpRequestWithEntity = createHttpRequest(spdyVersion, spdySynStreamFrame);
 
-                    // Set the Stream-ID, Associated-To-Stream-ID, Priority, and URL as headers
-                    httpResponseWithEntity.headers().setInt(Names.STREAM_ID, streamId);
-                    httpResponseWithEntity.headers().setInt(Names.ASSOCIATED_TO_STREAM_ID, associatedToStreamId);
-                    httpResponseWithEntity.headers().setByte(Names.PRIORITY, spdySynStreamFrame.priority());
-                    httpResponseWithEntity.headers().set(Names.URL, URL);
+                    // Set the Stream-ID, Associated-To-Stream-ID, and Priority as headers
+                    httpRequestWithEntity.headers().setInt(Names.STREAM_ID, streamId);
+                    httpRequestWithEntity.headers().setInt(Names.ASSOCIATED_TO_STREAM_ID, associatedToStreamId);
+                    httpRequestWithEntity.headers().setByte(Names.PRIORITY, spdySynStreamFrame.priority());
 
-                    if (spdySynStreamFrame.isLast()) {
-                        HttpHeaderUtil.setContentLength(httpResponseWithEntity, 0);
-                        out.add(httpResponseWithEntity);
-                    } else {
-                        // Response body will follow in a series of Data Frames
-                        putMessage(streamId, httpResponseWithEntity);
-                    }
+                    out.add(httpRequestWithEntity);
+
                 } catch (Exception ignored) {
                     SpdyRstStreamFrame spdyRstStreamFrame =
                         new DefaultSpdyRstStreamFrame(streamId, SpdyStreamStatus.PROTOCOL_ERROR);
@@ -269,8 +260,40 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
             int streamId = spdyHeadersFrame.streamId();
             FullHttpMessage fullHttpMessage = getMessage(streamId);
 
-            // If message is not in map discard HEADERS frame.
             if (fullHttpMessage == null) {
+                // HEADERS frames may initiate a pushed response
+                if (SpdyCodecUtil.isServerId(streamId)) {
+
+                    // If a client receives a HEADERS with a truncated header block,
+                    // reply with a RST_STREAM frame with error code INTERNAL_ERROR.
+                    if (spdyHeadersFrame.isTruncated()) {
+                        SpdyRstStreamFrame spdyRstStreamFrame =
+                            new DefaultSpdyRstStreamFrame(streamId, SpdyStreamStatus.INTERNAL_ERROR);
+                        ctx.writeAndFlush(spdyRstStreamFrame);
+                        return;
+                    }
+
+                    try {
+                        fullHttpMessage = createHttpResponse(ctx, spdyHeadersFrame, validateHeaders);
+
+                        // Set the Stream-ID as a header
+                        fullHttpMessage.headers().setInt(Names.STREAM_ID, streamId);
+
+                        if (spdyHeadersFrame.isLast()) {
+                            HttpHeaderUtil.setContentLength(fullHttpMessage, 0);
+                            out.add(fullHttpMessage);
+                        } else {
+                            // Response body will follow in a series of Data Frames
+                            putMessage(streamId, fullHttpMessage);
+                        }
+                    } catch (Exception e) {
+                        // If a client receives a SYN_REPLY without valid getStatus and version headers
+                        // the client must reply with a RST_STREAM frame indicating a PROTOCOL_ERROR
+                        SpdyRstStreamFrame spdyRstStreamFrame =
+                            new DefaultSpdyRstStreamFrame(streamId, SpdyStreamStatus.PROTOCOL_ERROR);
+                        ctx.writeAndFlush(spdyRstStreamFrame);
+                    }
+                }
                 return;
             }
 


### PR DESCRIPTION
Support pushed resources that are divided into multiple header blocks:
SpdySynStreamFrame (request) followed by SpdyHeadersFrame (response)
