### PR TITLE
HTTP/2 Decompress Flow Control

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -41,7 +41,7 @@ public class CompressorHttp2ConnectionEncoder extends DefaultHttp2ConnectionEnco
     private static final Http2ConnectionAdapter CLEAN_UP_LISTENER = new Http2ConnectionAdapter() {
         @Override
         public void streamRemoved(Http2Stream stream) {
-            final EmbeddedChannel compressor = stream.compressor();
+            final EmbeddedChannel compressor = stream.getProperty(CompressorHttp2ConnectionEncoder.class);
             if (compressor != null) {
                 cleanup(stream, compressor);
             }
@@ -103,19 +103,24 @@ public class CompressorHttp2ConnectionEncoder extends DefaultHttp2ConnectionEnco
     public ChannelFuture writeData(final ChannelHandlerContext ctx, final int streamId, ByteBuf data, int padding,
             final boolean endOfStream, ChannelPromise promise) {
         final Http2Stream stream = connection().stream(streamId);
-        final EmbeddedChannel compressor = stream == null ? null : stream.compressor();
-        if (compressor == null) {
+        final EmbeddedChannel channel = stream == null ? null :
+            (EmbeddedChannel) stream.getProperty(CompressorHttp2ConnectionEncoder.class);
+        if (channel == null) {
             // The compressor may be null if no compatible encoding type was found in this stream's headers
             return super.writeData(ctx, streamId, data, padding, endOfStream, promise);
         }
 
         try {
             // call retain here as it will call release after its written to the channel
-            compressor.writeOutbound(data.retain());
-            ByteBuf buf = nextReadableBuf(compressor);
+            channel.writeOutbound(data.retain());
+            ByteBuf buf = nextReadableBuf(channel);
             if (buf == null) {
                 if (endOfStream) {
-                    return super.writeData(ctx, streamId, Unpooled.EMPTY_BUFFER, padding, endOfStream, promise);
+                    if (channel.finish()) {
+                        buf = nextReadableBuf(channel);
+                    }
+                    return super.writeData(ctx, streamId, buf == null ? Unpooled.EMPTY_BUFFER : buf, padding,
+                            true, promise);
                 }
                 // END_STREAM is not set and the assumption is data is still forthcoming.
                 promise.setSuccess();
@@ -123,23 +128,39 @@ public class CompressorHttp2ConnectionEncoder extends DefaultHttp2ConnectionEnco
             }
 
             ChannelPromiseAggregator aggregator = new ChannelPromiseAggregator(promise);
+            ChannelPromise bufPromise = ctx.newPromise();
+            aggregator.add(bufPromise);
             for (;;) {
-                final ByteBuf nextBuf = nextReadableBuf(compressor);
-                final boolean endOfStreamForBuf = nextBuf == null && endOfStream;
-                ChannelPromise newPromise = ctx.newPromise();
-                aggregator.add(newPromise);
+                ByteBuf nextBuf = nextReadableBuf(channel);
+                boolean compressedEndOfStream = nextBuf == null && endOfStream;
+                if (compressedEndOfStream && channel.finish()) {
+                    nextBuf = nextReadableBuf(channel);
+                    compressedEndOfStream = nextBuf == null;
+                }
 
-                super.writeData(ctx, streamId, buf, padding, endOfStreamForBuf, newPromise);
+                final ChannelPromise nextPromise;
+                if (nextBuf != null) {
+                    // We have to add the nextPromise to the aggregator before doing the current write. This is so
+                    // completing the current write before the next write is done won't complete the aggregate promise
+                    nextPromise = ctx.newPromise();
+                    aggregator.add(nextPromise);
+                } else {
+                    nextPromise = null;
+                }
+
+                super.writeData(ctx, streamId, buf, padding, compressedEndOfStream, bufPromise);
                 if (nextBuf == null) {
                     break;
                 }
 
+                padding = 0; // Padding is only communicated once on the first iteration
                 buf = nextBuf;
+                bufPromise = nextPromise;
             }
             return promise;
         } finally {
             if (endOfStream) {
-                cleanup(stream, compressor);
+                cleanup(stream, channel);
             }
         }
     }
@@ -215,7 +236,7 @@ public class CompressorHttp2ConnectionEncoder extends DefaultHttp2ConnectionEnco
             return;
         }
 
-        EmbeddedChannel compressor = stream.compressor();
+        EmbeddedChannel compressor = stream.getProperty(CompressorHttp2ConnectionEncoder.class);
         if (compressor == null) {
             if (!endOfStream) {
                 AsciiString encoding = headers.get(CONTENT_ENCODING);
@@ -225,6 +246,7 @@ public class CompressorHttp2ConnectionEncoder extends DefaultHttp2ConnectionEnco
                 try {
                     compressor = newContentCompressor(encoding);
                     if (compressor != null) {
+                        stream.setProperty(CompressorHttp2ConnectionEncoder.class, compressor);
                         AsciiString targetContentEncoding = getTargetContentEncoding(encoding);
                         if (IDENTITY.equalsIgnoreCase(targetContentEncoding)) {
                             headers.remove(CONTENT_ENCODING);
@@ -261,10 +283,11 @@ public class CompressorHttp2ConnectionEncoder extends DefaultHttp2ConnectionEnco
                 if (buf == null) {
                     break;
                 }
+
                 buf.release();
             }
         }
-        stream.compressor(null);
+        stream.removeProperty(CompressorHttp2ConnectionEncoder.class);
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -67,6 +67,11 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         }
 
         @Override
+        public Http2LifecycleManager lifecycleManager() {
+            return lifecycleManager;
+        }
+
+        @Override
         public Builder inboundFlow(Http2InboundFlowController inboundFlow) {
             this.inboundFlow = inboundFlow;
             return this;
@@ -193,7 +198,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
     }
 
     private static int unprocessedBytes(Http2Stream stream) {
-        return stream.inboundFlow().unProcessedBytes();
+        return stream.garbageCollector().unProcessedBytes();
     }
 
     /**
@@ -284,7 +289,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
             } finally {
                 // If appropriate, returned the processed bytes to the flow controller.
                 if (shouldApplyFlowControl && bytesToReturn > 0) {
-                    stream.inboundFlow().returnProcessedBytes(ctx, bytesToReturn);
+                    stream.garbageCollector().returnProcessedBytes(ctx, bytesToReturn);
                 }
 
                 if (endOfStream) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -61,6 +61,11 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
         }
 
         @Override
+        public Http2LifecycleManager lifecycleManager() {
+            return lifecycleManager;
+        }
+
+        @Override
         public Builder frameWriter(
                 Http2FrameWriter frameWriter) {
             this.frameWriter = frameWriter;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
@@ -29,6 +29,7 @@ import io.netty.handler.codec.AsciiString;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.compression.ZlibWrapper;
+import io.netty.util.CharsetUtil;
 
 /**
  * A HTTP2 frame listener that will decompress data frames according to the {@code content-encoding} header for each
@@ -38,7 +39,7 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
     private static final Http2ConnectionAdapter CLEAN_UP_LISTENER = new Http2ConnectionAdapter() {
         @Override
         public void streamRemoved(Http2Stream stream) {
-            final EmbeddedChannel decompressor = stream.decompressor();
+            final Http2Decompressor decompressor = stream.getProperty(Http2Decompressor.class);
             if (decompressor != null) {
                 cleanup(stream, decompressor);
             }
@@ -63,47 +64,59 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
 
     @Override
     public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding, boolean endOfStream)
-                    throws Http2Exception {
+            throws Http2Exception {
         final Http2Stream stream = connection.stream(streamId);
-        final EmbeddedChannel decompressor = stream == null ? null : stream.decompressor();
+        final Http2Decompressor decompressor = stream == null ? null :
+            (Http2Decompressor) stream.getProperty(Http2Decompressor.class);
         if (decompressor == null) {
             // The decompressor may be null if no compatible encoding type was found in this stream's headers
             return listener.onDataRead(ctx, streamId, data, padding, endOfStream);
         }
 
-        // When decompressing, always opt-out of application-level flow control.
-        // TODO: investigate how to apply application-level flow control when decompressing.
-        int processedBytes = data.readableBytes() + padding;
-        try {
-            // call retain here as it will call release after its written to the channel
-            decompressor.writeInbound(data.retain());
-            ByteBuf buf = nextReadableBuf(decompressor);
-            if (buf == null) {
-                if (endOfStream) {
-                    listener.onDataRead(ctx, streamId, Unpooled.EMPTY_BUFFER, padding, true);
-                }
-                // END_STREAM is not set and the data could not be decoded yet.
-                // The assumption has to be there will be more data frames to complete the decode.
-                // We don't have enough information here to know if this is an error.
-            } else {
-                for (;;) {
-                    final ByteBuf nextBuf = nextReadableBuf(decompressor);
-                    final boolean endOfStreamForBuf = nextBuf == null && endOfStream;
-
-                    listener.onDataRead(ctx, streamId, buf, padding, endOfStreamForBuf);
-                    if (nextBuf == null) {
-                        break;
-                    }
-
-                    buf = nextBuf;
-                }
-            }
-            return processedBytes;
-        } finally {
+        final EmbeddedChannel channel = decompressor.decompressor();
+        final int compressedBytes = data.readableBytes() + padding;
+        int processedBytes = 0;
+        decompressor.incrementCompressedBytes(compressedBytes);
+        // call retain here as it will call release after its written to the channel
+        channel.writeInbound(data.retain());
+        ByteBuf buf = nextReadableBuf(channel);
+        if (buf == null && endOfStream && channel.finish()) {
+            buf = nextReadableBuf(channel);
+        }
+        if (buf == null) {
             if (endOfStream) {
-                cleanup(stream, decompressor);
+                listener.onDataRead(ctx, streamId, Unpooled.EMPTY_BUFFER, padding, true);
+            }
+            // No new decompressed data was extracted from the compressed data. This means the application could not be
+            // provided with data and thus could not return how many bytes were processed. We will assume there is more
+            // data coming which will complete the decompression block. To allow for more data we return all bytes to
+            // the flow control window (so the peer can send more data).
+            decompressor.incrementDecompressedByes(compressedBytes);
+            processedBytes = compressedBytes;
+        } else {
+            decompressor.incrementDecompressedByes(padding);
+            for (;;) {
+                ByteBuf nextBuf = nextReadableBuf(channel);
+                boolean decompressedEndOfStream = nextBuf == null && endOfStream;
+                if (decompressedEndOfStream && channel.finish()) {
+                    nextBuf = nextReadableBuf(channel);
+                    decompressedEndOfStream = nextBuf == null;
+                }
+
+                decompressor.incrementDecompressedByes(buf.readableBytes());
+                processedBytes += listener.onDataRead(ctx, streamId, buf, padding, decompressedEndOfStream);
+                if (nextBuf == null) {
+                    break;
+                }
+
+                padding = 0; // Padding is only communicated once on the first iteration
+                buf = nextBuf;
             }
         }
+
+        decompressor.incrementProcessedBytes(processedBytes);
+        // The processed bytes will be translated to pre-decompressed byte amounts by DecompressorGarbageCollector
+        return processedBytes;
     }
 
     @Override
@@ -172,29 +185,27 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
             return;
         }
 
-        EmbeddedChannel decompressor = stream.decompressor();
-        if (decompressor == null) {
-            if (!endOfStream) {
-                // Determine the content encoding.
-                AsciiString contentEncoding = headers.get(CONTENT_ENCODING);
-                if (contentEncoding == null) {
-                    contentEncoding = IDENTITY;
-                }
-                decompressor = newContentDecompressor(contentEncoding);
-                if (decompressor != null) {
-                    stream.decompressor(decompressor);
-                    // Decode the content and remove or replace the existing headers
-                    // so that the message looks like a decoded message.
-                    AsciiString targetContentEncoding = getTargetContentEncoding(contentEncoding);
-                    if (IDENTITY.equalsIgnoreCase(targetContentEncoding)) {
-                        headers.remove(CONTENT_ENCODING);
-                    } else {
-                        headers.set(CONTENT_ENCODING, targetContentEncoding);
-                    }
+        Http2Decompressor decompressor = stream.getProperty(Http2Decompressor.class);
+        if (decompressor == null && !endOfStream) {
+            // Determine the content encoding.
+            AsciiString contentEncoding = headers.get(CONTENT_ENCODING);
+            if (contentEncoding == null) {
+                contentEncoding = IDENTITY;
+            }
+            final EmbeddedChannel channel = newContentDecompressor(contentEncoding);
+            if (channel != null) {
+                decompressor = new Http2Decompressor(channel);
+                stream.setProperty(Http2Decompressor.class, decompressor);
+                stream.garbageCollector(new DecompressorGarbageCollector(stream.garbageCollector()));
+                // Decode the content and remove or replace the existing headers
+                // so that the message looks like a decoded message.
+                AsciiString targetContentEncoding = getTargetContentEncoding(contentEncoding);
+                if (IDENTITY.equalsIgnoreCase(targetContentEncoding)) {
+                    headers.remove(CONTENT_ENCODING);
+                } else {
+                    headers.set(CONTENT_ENCODING, targetContentEncoding);
                 }
             }
-        } else if (endOfStream) {
-            cleanup(stream, decompressor);
         }
 
         if (decompressor != null) {
@@ -212,17 +223,22 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
      * @param stream The stream for which {@code decompressor} is the decompressor for
      * @param decompressor The decompressor for {@code stream}
      */
-    private static void cleanup(Http2Stream stream, EmbeddedChannel decompressor) {
-        if (decompressor.finish()) {
+    private static void cleanup(Http2Stream stream, Http2Decompressor decompressor) {
+        final EmbeddedChannel channel = decompressor.decompressor();
+        if (channel.finish()) {
             for (;;) {
-                final ByteBuf buf = decompressor.readInbound();
+                final ByteBuf buf = channel.readInbound();
                 if (buf == null) {
                     break;
                 }
                 buf.release();
             }
         }
-        stream.decompressor(null);
+        decompressor = stream.removeProperty(Http2Decompressor.class);
+        if (decompressor != null) {
+            DecompressorGarbageCollector gc = (DecompressorGarbageCollector) stream.garbageCollector();
+            stream.garbageCollector(gc.original());
+        }
     }
 
     /**
@@ -243,6 +259,130 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
                 continue;
             }
             return buf;
+        }
+    }
+
+    /**
+     * Garbage collector which translates post-decompression amounts the application knows about
+     * to pre-decompression amounts that flow control knows about.
+     */
+    private static final class DecompressorGarbageCollector implements Http2FlowControlWindowManager {
+        private final Http2FlowControlWindowManager original;
+
+        DecompressorGarbageCollector(Http2FlowControlWindowManager original) {
+            this.original = original;
+        }
+
+        @Override
+        public void returnProcessedBytes(ChannelHandlerContext ctx, int numBytes) throws Http2Exception {
+            final Http2Stream stream = stream();
+            final Http2Decompressor decompressor = stream.getProperty(Http2Decompressor.class);
+
+            // Make a copy before hand in case any exceptions occur we will roll back the state
+            Http2Decompressor copy = new Http2Decompressor(decompressor);
+            try {
+                original.returnProcessedBytes(ctx, decompressor.consumeProcessedBytes(numBytes));
+            } catch (Http2Exception e) {
+                stream.setProperty(Http2Decompressor.class, copy);
+                throw e;
+            } catch (Throwable t) {
+                stream.setProperty(Http2Decompressor.class, copy);
+                throw new Http2Exception(Http2Error.INTERNAL_ERROR,
+                        "Error while returning bytes to flow control window", t);
+            }
+        }
+
+        Http2FlowControlWindowManager original() {
+            return original;
+        }
+
+        @Override
+        public int unProcessedBytes() {
+            return original.unProcessedBytes();
+        }
+
+        @Override
+        public Http2Stream stream() {
+            return original.stream();
+        }
+    }
+
+    /**
+     * Provides the state for stream {@code DATA} frame decompression.
+     */
+    private static final class Http2Decompressor {
+        private final EmbeddedChannel decompressor;
+        private int processed;
+        private int compressed;
+        private int decompressed;
+
+        Http2Decompressor(Http2Decompressor rhs) {
+            this(rhs.decompressor);
+            processed = rhs.processed;
+            compressed = rhs.compressed;
+            decompressed = rhs.decompressed;
+        }
+
+        Http2Decompressor(EmbeddedChannel decompressor) {
+            this.decompressor = decompressor;
+        }
+
+        /**
+         * Responsible for taking compressed bytes in and producing decompressed bytes.
+         */
+        EmbeddedChannel decompressor() {
+            return decompressor;
+        }
+
+        /**
+         * Increment the number of decompressed bytes processed by the application.
+         */
+        void incrementProcessedBytes(int delta) {
+            if (processed + delta < 0) {
+                throw new IllegalArgumentException("processed bytes cannot be negative");
+            }
+            processed += delta;
+        }
+
+        /**
+         * Increment the number of bytes received prior to doing any decompression.
+         */
+        void incrementCompressedBytes(int delta) {
+            if (compressed + delta < 0) {
+                throw new IllegalArgumentException("compressed bytes cannot be negative");
+            }
+            compressed += delta;
+        }
+
+        /**
+         * Increment the number of bytes after the decompression process. Under normal circumstances this
+         * delta should not exceed {@link Http2Decompressor#processedBytes()}.
+         */
+        void incrementDecompressedByes(int delta) {
+            if (decompressed + delta < 0) {
+                throw new IllegalArgumentException("decompressed bytes cannot be negative");
+            }
+            decompressed += delta;
+        }
+
+        /**
+         * Decrements {@link Http2Decompressor#processedBytes()} by {@code processedBytes} and determines the ratio
+         * between {@code processedBytes} and {@link Http2Decompressor#decompressedBytes()}.
+         * This ratio is used to decrement {@link Http2Decompressor#decompressedBytes()} and
+         * {@link Http2Decompressor#compressedBytes()}.
+         * @param processedBytes The number of post-decompressed bytes that have been processed.
+         * @return The number of pre-decompressed bytes that have been consumed.
+         */
+        int consumeProcessedBytes(int processedBytes) {
+            // Consume the processed bytes first to verify that is is a valid amount
+            incrementProcessedBytes(-processedBytes);
+
+            double consumedRatio = processedBytes / (double) decompressed;
+            int consumedCompressed = Math.min(compressed, (int) Math.ceil(compressed * consumedRatio));
+            incrementDecompressedByes(-Math.min(decompressed, (int) Math.ceil(decompressed * consumedRatio)));
+            incrementCompressedBytes(-consumedCompressed);
+
+            return consumedCompressed;
         }
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
@@ -44,6 +44,11 @@ public interface Http2ConnectionDecoder extends Closeable {
         Builder lifecycleManager(Http2LifecycleManager lifecycleManager);
 
         /**
+         * Gets the {@link Http2LifecycleManager} to be used when building the decoder.
+         */
+        Http2LifecycleManager lifecycleManager();
+
+        /**
          * Sets the {@link Http2InboundFlowController} to be used when building the decoder.
          */
         Builder inboundFlow(Http2InboundFlowController inboundFlow);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionEncoder.java
@@ -41,6 +41,11 @@ public interface Http2ConnectionEncoder extends Http2FrameWriter, Http2OutboundF
         Builder lifecycleManager(Http2LifecycleManager lifecycleManager);
 
         /**
+         * Gets the {@link Http2LifecycleManager} to be used when building the encoder.
+         */
+        Http2LifecycleManager lifecycleManager();
+
+        /**
          * Sets the {@link Http2FrameWriter} to be used when building the encoder.
          */
         Builder frameWriter(Http2FrameWriter frameWriter);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FlowControlWindowManager.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FlowControlWindowManager.java
@@ -17,11 +17,9 @@ package io.netty.handler.codec.http2;
 import io.netty.channel.ChannelHandlerContext;
 
 /**
- * The inbound flow control state for a stream. This object is created and managed by the
- * {@link Http2InboundFlowController}.
+ * Allows data to be returned to the flow control window.
  */
-public interface Http2InboundFlowState extends Http2FlowState {
-
+public interface Http2FlowControlWindowManager {
     /**
      * Used by applications that participate in application-level inbound flow control. Allows the
      * application to return a number of bytes that has been processed and thereby enabling the
@@ -38,4 +36,9 @@ public interface Http2InboundFlowState extends Http2FlowState {
      * The number of bytes that are outstanding and have not yet been returned to the flow controller.
      */
     int unProcessedBytes();
+
+    /**
+     * Get the stream that is being managed
+     */
+    Http2Stream stream();
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -15,8 +15,6 @@
 
 package io.netty.handler.codec.http2;
 
-import io.netty.channel.embedded.EmbeddedChannel;
-
 import java.util.Collection;
 
 /**
@@ -135,43 +133,29 @@ public interface Http2Stream {
 
     /**
      * Associates the application-defined data with this stream.
+     * @return The value that was previously associated with {@code key}, or {@code null} if there was none.
      */
-    void data(Object data);
+    Object setProperty(Object key, Object value);
 
     /**
      * Returns application-defined data if any was associated with this stream.
      */
-    <T> T data();
+    <V> V getProperty(Object key);
 
     /**
-     * Associate an object responsible for decompressing data frames for this stream
+     * Returns and removes application-defined data if any was associated with this stream.
      */
-    void decompressor(EmbeddedChannel decompressor);
-
-    /**
-     * Get the object capable of decompressing data frames for this stream
-     */
-    EmbeddedChannel decompressor();
-
-    /**
-     * Associate an object responsible for compressing data frames for this stream
-     */
-    void compressor(EmbeddedChannel decompressor);
-
-    /**
-     * Get the object capable of compressing data frames for this stream
-     */
-    EmbeddedChannel compressor();
+    <V> V removeProperty(Object key);
 
     /**
      * Gets the in-bound flow control state for this stream.
      */
-    Http2InboundFlowState inboundFlow();
+    Http2FlowState inboundFlow();
 
     /**
      * Sets the in-bound flow control state for this stream.
      */
-    void inboundFlow(Http2InboundFlowState state);
+    void inboundFlow(Http2FlowState state);
 
     /**
      * Gets the out-bound flow control window for this stream.
@@ -182,6 +166,16 @@ public interface Http2Stream {
      * Sets the out-bound flow control window for this stream.
      */
     void outboundFlow(Http2FlowState state);
+
+    /**
+     * Gets the interface which allows bytes to be returned to the flow controller
+     */
+    Http2FlowControlWindowManager garbageCollector();
+
+    /**
+     * Sets the interface which allows bytes to be returned to the flow controller
+     */
+    void garbageCollector(Http2FlowControlWindowManager collector);
 
     /**
      * Updates an priority for this stream. Calling this method may affect the straucture of the

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -105,7 +105,7 @@ public class DefaultHttp2ConnectionDecoderTest {
     private Http2ConnectionEncoder encoder;
 
     @Mock
-    private Http2InboundFlowState inFlowState;
+    private Http2FlowControlWindowManager inFlowState;
 
     @Mock
     private Http2LifecycleManager lifecycleManager;
@@ -119,7 +119,7 @@ public class DefaultHttp2ConnectionDecoderTest {
         when(channel.isActive()).thenReturn(true);
         when(stream.id()).thenReturn(STREAM_ID);
         when(stream.state()).thenReturn(OPEN);
-        when(stream.inboundFlow()).thenReturn(inFlowState);
+        when(stream.garbageCollector()).thenReturn(inFlowState);
         when(pushStream.id()).thenReturn(PUSH_STREAM_ID);
         when(connection.activeStreams()).thenReturn(Collections.singletonList(stream));
         when(connection.stream(STREAM_ID)).thenReturn(stream);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowControllerTest.java
@@ -219,7 +219,7 @@ public class DefaultHttp2InboundFlowControllerTest {
     }
 
     private void returnProcessedBytes(int streamId, int processedBytes) throws Http2Exception {
-        connection.requireStream(streamId).inboundFlow().returnProcessedBytes(ctx, processedBytes);
+        connection.requireStream(streamId).garbageCollector().returnProcessedBytes(ctx, processedBytes);
     }
 
     private void verifyWindowUpdateSent(int streamId, int windowSizeIncrement) throws Http2Exception {


### PR DESCRIPTION
Motivation:
The current decompression frame listener currently opts-out of application level flow control. The application should still be able to control flow control even if decompression is in use.

Modifications:
- DecompressorFrameListener will maintain how many compressed bytes, decompressed bytes, and processed by the listener bytes.  A ratio will be used to translate these values into application level flow control amount.

Result:
HTTP/2 decompressor delegates the application level flow control to the listener processing the decompressed data.
