### PR TITLE
DNS server support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ bin/
 # JVM crash logs
 hs_err_pid*.log
 
+# NetBeans config file
+nb-configuration.xml
+

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/CNameDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/CNameDnsRecord.java
@@ -36,6 +36,9 @@ public final class CNameDnsRecord extends DnsEntry {
 
     public CNameDnsRecord(String name, DnsType type, DnsClass dnsClass, long timeToLive, String cname) {
         super(name, type, dnsClass, timeToLive);
+        if (cname == null) {
+            throw new NullPointerException("cname");
+        }
         this.cname = cname;
     }
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/CNameDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/CNameDnsRecord.java
@@ -80,4 +80,9 @@ public final class CNameDnsRecord extends DnsEntry {
                 .append(", cname: ").append(cname())
                 .append(')').toString();
     }
+
+    @Override
+    public CNameDnsRecord withTimeToLive(long seconds) {
+        return new CNameDnsRecord(cname, type(), dnsClass(), seconds, cname);
+    }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/CNameDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/CNameDnsRecord.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.StringUtil;
+import java.nio.charset.Charset;
+
+/**
+ * Represents a CNAME DNS record.
+ */
+public final class CNameDnsRecord extends DnsEntry {
+
+    private final String cname;
+
+    public CNameDnsRecord(String name, long timeToLive, String cname) {
+        this(name, DnsType.CNAME, timeToLive, cname);
+    }
+
+    public CNameDnsRecord(String name, DnsType type, long timeToLive, String cname) {
+        this(name, type, DnsClass.IN, timeToLive, cname);
+    }
+
+    public CNameDnsRecord(String name, DnsType type, DnsClass dnsClass, long timeToLive, String cname) {
+        super(name, type, dnsClass, timeToLive);
+        this.cname = cname;
+    }
+
+    public String cname() {
+        return cname;
+    }
+
+    @Override
+    protected void writePayload(NameWriter nameWriter, ByteBuf into, Charset charset) {
+        nameWriter.writeName(cname, into, charset);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = super.hashCode();
+        hash = 83 * hash + (this.cname != null ? this.cname.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final CNameDnsRecord other = (CNameDnsRecord) obj;
+        if ((this.cname == null) ? (other.cname != null) : !this.cname.equals(other.cname)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(128).append(StringUtil.simpleClassName(this))
+                .append("(name: ").append(name())
+                .append(", type: ").append(type())
+                .append(", class: ").append(dnsClass())
+                .append(", ttl: ").append(timeToLive())
+                .append(", cname: ").append(cname())
+                .append(')').toString();
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsClass.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsClass.java
@@ -85,7 +85,7 @@ public final class DnsClass implements Comparable<DnsClass> {
      * Returns an instance of DnsClass for a custom type.
      *
      * @param clazz The class
-     * @param name The name
+     * @param name The namThe time to live of the resulting recorde
      */
     public static DnsClass valueOf(int clazz, String name) {
         return new DnsClass(clazz, name);

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsClass.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsClass.java
@@ -85,7 +85,7 @@ public final class DnsClass implements Comparable<DnsClass> {
      * Returns an instance of DnsClass for a custom type.
      *
      * @param clazz The class
-     * @param name The namThe time to live of the resulting recorde
+     * @param name The name of the resulting record
      */
     public static DnsClass valueOf(int clazz, String name) {
         return new DnsClass(clazz, name);

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsDecoderException.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsDecoderException.java
@@ -26,7 +26,7 @@ public class DnsDecoderException extends DecoderException {
     private final DnsResponseCode code;
 
     DnsDecoderException(DnsResponseCode code) {
-        super(code == null ? "" : code.toString());
+        super(code.toString());
         if (code == null) {
             throw new NullPointerException("code");
         }
@@ -34,7 +34,7 @@ public class DnsDecoderException extends DecoderException {
     }
 
     DnsDecoderException(DnsResponseCode code, Throwable cause) {
-        super(code == null ? "" : code.toString(), cause);
+        super(code.toString(), cause);
         if (code == null) {
             throw new NullPointerException("code");
         }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsDecoderException.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsDecoderException.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.handler.codec.DecoderException;
+
+/**
+ * Exception which can be thrown during parsing of a DNS query or response,
+ * which indicates the DNS error code that should be returned.
+ */
+public class DnsDecoderException extends DecoderException {
+
+    private final DnsResponseCode code;
+
+    DnsDecoderException(DnsResponseCode code) {
+        super(code.toString());
+        this.code = code;
+    }
+
+    DnsDecoderException(DnsResponseCode code, Throwable cause) {
+        super(code.toString(), cause);
+        this.code = code;
+    }
+
+    DnsDecoderException(DnsResponseCode code, String message, Throwable cause) {
+        super(message, cause);
+        this.code = code;
+    }
+
+    DnsDecoderException(DnsResponseCode code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public DnsResponseCode code() {
+        return code;
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsDecoderException.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsDecoderException.java
@@ -18,7 +18,7 @@ package io.netty.handler.codec.dns;
 import io.netty.handler.codec.DecoderException;
 
 /**
- * Exception which can be thrown during parsing of a DNS query or response,
+ * {@link DecoderException} which can be thrown during parsing of a DNS query or response,
  * which indicates the DNS error code that should be returned.
  */
 public class DnsDecoderException extends DecoderException {
@@ -26,22 +26,34 @@ public class DnsDecoderException extends DecoderException {
     private final DnsResponseCode code;
 
     DnsDecoderException(DnsResponseCode code) {
-        super(code.toString());
+        super(code == null ? "" : code.toString());
+        if (code == null) {
+            throw new NullPointerException("code");
+        }
         this.code = code;
     }
 
     DnsDecoderException(DnsResponseCode code, Throwable cause) {
-        super(code.toString(), cause);
+        super(code == null ? "" : code.toString(), cause);
+        if (code == null) {
+            throw new NullPointerException("code");
+        }
         this.code = code;
     }
 
     DnsDecoderException(DnsResponseCode code, String message, Throwable cause) {
         super(message, cause);
+        if (code == null) {
+            throw new NullPointerException("code");
+        }
         this.code = code;
     }
 
     DnsDecoderException(DnsResponseCode code, String message) {
         super(message);
+        if (code == null) {
+            throw new NullPointerException("code");
+        }
         this.code = code;
     }
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsEntry.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsEntry.java
@@ -48,6 +48,10 @@ public abstract class DnsEntry {
         this.timeToLive = timeToLive;
     }
 
+    /**
+     * Number of seconds that a cache may retain this record
+     * @return A number of seconds for which this entry may be treated as current
+     */
     public final long timeToLive() {
         return timeToLive;
     }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsEntry.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsEntry.java
@@ -49,8 +49,10 @@ public abstract class DnsEntry {
     }
 
     /**
-     * Number of seconds that a cache may retain this record
-     * @return A number of seconds for which this entry may be treated as current
+     * Number of seconds that a cache may retain this record.
+     *
+     * @return A number of seconds for which this entry may be treated as
+     * current
      */
     public final long timeToLive() {
         return timeToLive;
@@ -78,10 +80,11 @@ public abstract class DnsEntry {
     }
 
     /**
-     * Create a transformed DnsEntry with the passed time-to-live
+     * Create a transformed DnsEntry with the passed time-to-live.
+     *
      * @param seconds The number of seconds
-     * @return A new DnsEntry identical to this one other than that it
-     * uses the passed time-to-live value
+     * @return A new DnsEntry identical to this one other than that it uses the
+     * passed time-to-live value
      */
     public abstract DnsEntry withTimeToLive(long seconds);
 
@@ -93,11 +96,11 @@ public abstract class DnsEntry {
     @Override
     public String toString() {
         return new StringBuilder(128).append(StringUtil.simpleClassName(this))
-                                     .append("(name: ").append(name)
-                                     .append(", type: ").append(type)
-                                     .append(", class: ").append(dnsClass)
-                                     .append(", ttl: ").append(timeToLive)
-                                     .append(')').toString();
+                .append("(name: ").append(name)
+                .append(", type: ").append(type)
+                .append(", class: ").append(dnsClass)
+                .append(", ttl: ").append(timeToLive)
+                .append(')').toString();
     }
 
     @Override
@@ -110,13 +113,14 @@ public abstract class DnsEntry {
         }
 
         DnsEntry that = (DnsEntry) o;
-        return type().intValue() == that.type().intValue() &&
-               dnsClass().intValue() == that.dnsClass().intValue() &&
-               name().equals(that.name()) && timeToLive() == that.timeToLive();
+        return timeToLive() == that.timeToLive()
+                && type().intValue() == that.type().intValue()
+                && dnsClass().intValue() == that.dnsClass().intValue()
+                && name().equals(that.name());
     }
 
     /**
-     * Write this dns entry into a buffer
+     * Write this dns entry into a buffer.
      *
      * @param nameWriter Writes names, possibly using pointers for compression
      * @param into The buffer to write into
@@ -149,8 +153,8 @@ public abstract class DnsEntry {
     }
 
     /**
-     * Write the <i>payload</i> of this DNS entry.  The format varies by
-     * type.
+     * Write the <i>payload</i> of this DNS entry. The format varies by type.
+     *
      * @param nameWriter A thing which will write names
      * @param into The buffer to write into
      * @param charset The character set to use

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsEntry.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsEntry.java
@@ -77,6 +77,14 @@ public abstract class DnsEntry {
         return dnsClass;
     }
 
+    /**
+     * Create a transformed DnsEntry with the passed time-to-live
+     * @param seconds The number of seconds
+     * @return A new DnsEntry identical to this one other than that it
+     * uses the passed time-to-live value
+     */
+    public abstract DnsEntry withTimeToLive(long seconds);
+
     @Override
     public int hashCode() {
         return (name.hashCode() * 31 + type.hashCode()) * 31 + dnsClass.hashCode();

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsEntry.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsEntry.java
@@ -15,20 +15,23 @@
  */
 package io.netty.handler.codec.dns;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.util.internal.StringUtil;
+import java.nio.charset.Charset;
 
 /**
  * A class representing entries in a DNS packet (questions, and all resource
  * records). Contains data shared by entries such as name, type, and class.
  */
-public class DnsEntry {
+public abstract class DnsEntry {
 
     private final String name;
     private final DnsType type;
     private final DnsClass dnsClass;
+    private final long timeToLive;
 
     // only allow to extend from same package
-    DnsEntry(String name, DnsType type, DnsClass dnsClass) {
+    DnsEntry(String name, DnsType type, DnsClass dnsClass, long timeToLive) {
         if (name == null) {
             throw new NullPointerException("name");
         }
@@ -42,6 +45,11 @@ public class DnsEntry {
         this.name = name;
         this.type = type;
         this.dnsClass = dnsClass;
+        this.timeToLive = timeToLive;
+    }
+
+    public final long timeToLive() {
+        return timeToLive;
     }
 
     /**
@@ -76,6 +84,7 @@ public class DnsEntry {
                                      .append("(name: ").append(name)
                                      .append(", type: ").append(type)
                                      .append(", class: ").append(dnsClass)
+                                     .append(", ttl: ").append(timeToLive)
                                      .append(')').toString();
     }
 
@@ -91,6 +100,51 @@ public class DnsEntry {
         DnsEntry that = (DnsEntry) o;
         return type().intValue() == that.type().intValue() &&
                dnsClass().intValue() == that.dnsClass().intValue() &&
-               name().equals(that.name());
+               name().equals(that.name()) && timeToLive() == that.timeToLive();
+    }
+
+    /**
+     * Write this dns entry into a buffer
+     *
+     * @param nameWriter Writes names, possibly using pointers for compression
+     * @param into The buffer to write into
+     * @param charset The character set to use
+     */
+    public void writeTo(NameWriter nameWriter, ByteBuf into, Charset charset) {
+        nameWriter.writeName(name(), into, charset);
+        into.writeShort(type().intValue());
+        into.writeShort(dnsClass().intValue());
+        into.writeInt((int) timeToLive());
+        // Remember where to put the length field once we know what it is
+        int offset = into.writerIndex();
+        // Write a placeholder value
+        into.writeShort(0);
+        try {
+            writePayload(nameWriter, into, charset);
+            // newOffset - offset = number of bytes written for the payload
+            int newOffset = into.writerIndex();
+            // Rewind to the length field position and update it
+            into.writerIndex(offset);
+            into.writeShort(newOffset - (offset + 2));
+            // Fast forward back to the end of the buffer
+            into.writerIndex(newOffset);
+        } catch (RuntimeException ex) {
+            // We may have written garbage, so dump it
+            into.writerIndex(offset);
+            into.writeShort(0);
+            throw ex;
+        }
+    }
+
+    /**
+     * Write the <i>payload</i> of this DNS entry.  The format varies by
+     * type.
+     * @param nameWriter A thing which will write names
+     * @param into The buffer to write into
+     * @param charset The character set to use
+     */
+    protected void writePayload(NameWriter nameWriter, ByteBuf into, Charset charset) {
+        throw new UnsupportedOperationException("Either override writeTo or writePayload in "
+                + getClass().getSimpleName());
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsHeader.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsHeader.java
@@ -191,4 +191,10 @@ public class DnsHeader {
         this.z = z;
         return this;
     }
+
+    @Override
+    public String toString() {
+        return "DnsHeader{recursionDesired=" + recursionDesired
+                + ", opcode=" + opcode + ", id=" + id + ", type=" + type + ", z=" + z + '}';
+    }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsHeader.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsHeader.java
@@ -194,7 +194,10 @@ public class DnsHeader {
 
     @Override
     public String toString() {
-        return "DnsHeader{recursionDesired=" + recursionDesired
-                + ", opcode=" + opcode + ", id=" + id + ", type=" + type + ", z=" + z + '}';
+        return new StringBuilder(80).append("DnsHeader{recursionDesired=")
+                .append(recursionDesired).append(", opcode=")
+                .append(opcode).append(", id=").append(id)
+                .append(", type=").append(type).append(", z=")
+                .append(z).append('}').toString();
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsHeader.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsHeader.java
@@ -194,7 +194,7 @@ public class DnsHeader {
 
     @Override
     public String toString() {
-        return new StringBuilder(80).append("DnsHeader{recursionDesired=")
+        return new StringBuilder(128).append("DnsHeader{recursionDesired=")
                 .append(recursionDesired).append(", opcode=")
                 .append(opcode).append(", id=").append(id)
                 .append(", type=").append(type).append(", z=")

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessage.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessage.java
@@ -21,7 +21,6 @@ import io.netty.util.ReferenceCountUtil;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * The message super-class which contains core information concerning DNS
@@ -29,10 +28,10 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public abstract class DnsMessage extends AbstractReferenceCounted {
 
-    private final List<DnsQuestion> questions = new CopyOnWriteArrayList<DnsQuestion>();
-    private final List<DnsEntry> answers = new CopyOnWriteArrayList<DnsEntry>();
-    private final List<DnsEntry> authority = new CopyOnWriteArrayList<DnsEntry>();
-    private final List<DnsEntry> additional = new CopyOnWriteArrayList<DnsEntry>();
+    private List<DnsQuestion> questions;
+    private List<DnsEntry> answers;
+    private List<DnsEntry> authority;
+    private List<DnsEntry> additional;
 
     private final DnsHeader header;
 
@@ -55,6 +54,9 @@ public abstract class DnsMessage extends AbstractReferenceCounted {
      * @return this
      */
     public DnsMessage addQuestions(Iterable<DnsQuestion> questions) {
+        if (this.questions == null) {
+            this.questions = new LinkedList<DnsQuestion>();
+        }
         for (DnsQuestion q : questions) {
             this.questions.add(q);
         }
@@ -65,6 +67,9 @@ public abstract class DnsMessage extends AbstractReferenceCounted {
      * Returns a list of all the questions in this message.
      */
     public List<DnsQuestion> questions() {
+        if (questions == null) {
+            return Collections.emptyList();
+        }
         return Collections.unmodifiableList(questions);
     }
 
@@ -72,6 +77,9 @@ public abstract class DnsMessage extends AbstractReferenceCounted {
      * Returns a list of all the answer resource records in this message.
      */
     public List<DnsEntry> answers() {
+        if (answers == null) {
+            return Collections.emptyList();
+        }
         return Collections.unmodifiableList(answers);
     }
 
@@ -79,6 +87,9 @@ public abstract class DnsMessage extends AbstractReferenceCounted {
      * Returns a list of all the authority resource records in this message.
      */
     public List<DnsEntry> authorityResources() {
+        if (authority == null) {
+            return Collections.emptyList();
+        }
         return Collections.unmodifiableList(authority);
     }
 
@@ -86,6 +97,9 @@ public abstract class DnsMessage extends AbstractReferenceCounted {
      * Returns a list of all the additional resource records in this message.
      */
     public List<DnsEntry> additionalResources() {
+        if (additional == null) {
+            return Collections.emptyList();
+        }
         return Collections.unmodifiableList(additional);
     }
 
@@ -97,6 +111,9 @@ public abstract class DnsMessage extends AbstractReferenceCounted {
      * @return the message to allow method chaining
      */
     public DnsMessage addAnswer(DnsEntry answer) {
+        if (answers == null) {
+            answers = new LinkedList<DnsEntry>();
+        }
         answers.add(answer);
         return this;
     }
@@ -109,6 +126,9 @@ public abstract class DnsMessage extends AbstractReferenceCounted {
      * @return the message to allow method chaining
      */
     public DnsMessage addQuestion(DnsQuestion question) {
+        if (questions == null) {
+            questions = new LinkedList<DnsQuestion>();
+        }
         questions.add(question);
         return this;
     }
@@ -121,6 +141,9 @@ public abstract class DnsMessage extends AbstractReferenceCounted {
      * @return the message to allow method chaining
      */
     public DnsMessage addAuthorityResource(DnsEntry resource) {
+        if (authority == null) {
+            authority = new LinkedList<DnsEntry>();
+        }
         authority.add(resource);
         return this;
     }
@@ -133,6 +156,9 @@ public abstract class DnsMessage extends AbstractReferenceCounted {
      * @return the message to allow method chaining
      */
     public DnsMessage addAdditionalResource(DnsEntry resource) {
+        if (additional == null) {
+            additional = new LinkedList<DnsEntry>();
+        }
         additional.add(resource);
         return this;
     }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessage.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessage.java
@@ -21,6 +21,7 @@ import io.netty.util.ReferenceCountUtil;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * The message super-class which contains core information concerning DNS
@@ -28,10 +29,10 @@ import java.util.List;
  */
 public abstract class DnsMessage extends AbstractReferenceCounted {
 
-    private List<DnsQuestion> questions;
-    private List<DnsResource> answers;
-    private List<DnsResource> authority;
-    private List<DnsResource> additional;
+    private final List<DnsQuestion> questions = new CopyOnWriteArrayList<DnsQuestion>();
+    private final List<DnsEntry> answers = new CopyOnWriteArrayList<DnsEntry>();
+    private final List<DnsEntry> authority = new CopyOnWriteArrayList<DnsEntry>();
+    private final List<DnsEntry> additional = new CopyOnWriteArrayList<DnsEntry>();
 
     private final DnsHeader header;
 
@@ -48,42 +49,43 @@ public abstract class DnsMessage extends AbstractReferenceCounted {
     }
 
     /**
+     * Add multiple DNS questions to this message
+     *
+     * @param questions An iterable of dns questions
+     * @return this
+     */
+    public DnsMessage addQuestions(Iterable<DnsQuestion> questions) {
+        for (DnsQuestion q : questions) {
+            this.questions.add(q);
+        }
+        return this;
+    }
+
+    /**
      * Returns a list of all the questions in this message.
      */
     public List<DnsQuestion> questions() {
-        if (questions == null) {
-            return Collections.emptyList();
-        }
         return Collections.unmodifiableList(questions);
     }
 
     /**
      * Returns a list of all the answer resource records in this message.
      */
-    public List<DnsResource> answers() {
-        if (answers == null) {
-            return Collections.emptyList();
-        }
+    public List<DnsEntry> answers() {
         return Collections.unmodifiableList(answers);
     }
 
     /**
      * Returns a list of all the authority resource records in this message.
      */
-    public List<DnsResource> authorityResources() {
-        if (authority == null) {
-            return Collections.emptyList();
-        }
+    public List<DnsEntry> authorityResources() {
         return Collections.unmodifiableList(authority);
     }
 
     /**
      * Returns a list of all the additional resource records in this message.
      */
-    public List<DnsResource> additionalResources() {
-        if (additional == null) {
-            return Collections.emptyList();
-        }
+    public List<DnsEntry> additionalResources() {
         return Collections.unmodifiableList(additional);
     }
 
@@ -94,10 +96,7 @@ public abstract class DnsMessage extends AbstractReferenceCounted {
      *            the answer resource record to be added
      * @return the message to allow method chaining
      */
-    public DnsMessage addAnswer(DnsResource answer) {
-        if (answers == null) {
-            answers = new LinkedList<DnsResource>();
-        }
+    public DnsMessage addAnswer(DnsEntry answer) {
         answers.add(answer);
         return this;
     }
@@ -110,9 +109,6 @@ public abstract class DnsMessage extends AbstractReferenceCounted {
      * @return the message to allow method chaining
      */
     public DnsMessage addQuestion(DnsQuestion question) {
-        if (questions == null) {
-            questions = new LinkedList<DnsQuestion>();
-        }
         questions.add(question);
         return this;
     }
@@ -124,10 +120,7 @@ public abstract class DnsMessage extends AbstractReferenceCounted {
      *            the authority resource record to be added
      * @return the message to allow method chaining
      */
-    public DnsMessage addAuthorityResource(DnsResource resource) {
-        if (authority == null) {
-            authority = new LinkedList<DnsResource>();
-        }
+    public DnsMessage addAuthorityResource(DnsEntry resource) {
         authority.add(resource);
         return this;
     }
@@ -139,10 +132,7 @@ public abstract class DnsMessage extends AbstractReferenceCounted {
      *            the additional resource record to be added
      * @return the message to allow method chaining
      */
-    public DnsMessage addAdditionalResource(DnsResource resource) {
-        if (additional == null) {
-            additional = new LinkedList<DnsResource>();
-        }
+    public DnsMessage addAdditionalResource(DnsEntry resource) {
         additional.add(resource);
         return this;
     }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuery.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuery.java
@@ -109,7 +109,7 @@ public class DnsQuery extends DnsMessage implements Iterable<DnsQuestion> {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder(80);
+        StringBuilder sb = new StringBuilder(128);
         sb.append(DnsResponse.class.getSimpleName()).append('@').append(
                 System.identityHashCode(this)).append('{');
         sb.append("header=").append(header()).append(", answers=[");

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuery.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuery.java
@@ -107,8 +107,9 @@ public class DnsQuery extends DnsMessage implements Iterable<DnsQuestion> {
         return questions().iterator();
     }
 
+    @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(80);
         sb.append(DnsResponse.class.getSimpleName()).append('@').append(
                 System.identityHashCode(this)).append('{');
         sb.append("header=").append(header()).append(", answers=[");

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuery.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuery.java
@@ -16,12 +16,13 @@
 package io.netty.handler.codec.dns;
 
 import java.net.InetSocketAddress;
+import java.util.Iterator;
 
 /**
  * A DNS query packet which is sent to a server to receive a DNS response packet
  * with information answering a DnsQuery's questions.
  */
-public class DnsQuery extends DnsMessage {
+public class DnsQuery extends DnsMessage implements Iterable<DnsQuestion> {
 
     private final InetSocketAddress recipient;
 
@@ -44,7 +45,7 @@ public class DnsQuery extends DnsMessage {
     }
 
     @Override
-    public DnsQuery addAnswer(DnsResource answer) {
+    public DnsQuery addAnswer(DnsEntry answer) {
         super.addAnswer(answer);
         return this;
     }
@@ -56,13 +57,13 @@ public class DnsQuery extends DnsMessage {
     }
 
     @Override
-    public DnsQuery addAuthorityResource(DnsResource resource) {
+    public DnsQuery addAuthorityResource(DnsEntry resource) {
         super.addAuthorityResource(resource);
         return this;
     }
 
     @Override
-    public DnsQuery addAdditionalResource(DnsResource resource) {
+    public DnsQuery addAdditionalResource(DnsEntry resource) {
         super.addAdditionalResource(resource);
         return this;
     }
@@ -99,5 +100,30 @@ public class DnsQuery extends DnsMessage {
     @Override
     protected DnsQueryHeader newHeader(int id) {
         return new DnsQueryHeader(this, id);
+    }
+
+    @Override
+    public Iterator<DnsQuestion> iterator() {
+        return questions().iterator();
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(DnsResponse.class.getSimpleName()).append('@').append(
+                System.identityHashCode(this)).append('{');
+        sb.append("header=").append(header()).append(", answers=[");
+        for (DnsEntry ans : answers()) {
+            sb.append(ans).append(" ");
+        }
+        sb.append("], authorities=[");
+        for (DnsEntry ans : authorityResources()) {
+            sb.append(ans).append(" ");
+        }
+        sb.append("], additional=[");
+        for (DnsEntry ans : additionalResources()) {
+            sb.append(ans).append(" ");
+        }
+        sb.append("], recipient=").append(recipient);
+        return sb.append('}').toString();
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQueryDecoder.java
@@ -36,6 +36,14 @@ public class DnsQueryDecoder extends MessageToMessageDecoder<DatagramPacket> {
         out.add(decode(ctx, msg));
     }
 
+    /**
+     * Decode a DnsQuery from a DatagramPacket.
+     *
+     * @param ctx The channel context
+     * @param msg The message
+     * @return A DnsQuery
+     * @throws Exception If the data is invalid
+     */
     public static DnsQuery decode(ChannelHandlerContext ctx, DatagramPacket msg) throws Exception {
         ByteBuf buf = msg.content();
         int id = buf.readUnsignedShort();

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQueryDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2014 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -23,7 +23,7 @@ import io.netty.util.CharsetUtil;
 import java.util.List;
 
 /**
- *
+ * Decodes {@link DnsQuery} objects from {#link DatagramPacket}s
  */
 public class DnsQueryDecoder extends MessageToMessageDecoder<DatagramPacket> {
 
@@ -36,7 +36,7 @@ public class DnsQueryDecoder extends MessageToMessageDecoder<DatagramPacket> {
         out.add(decode(ctx, msg));
     }
 
-    public DnsQuery decode(ChannelHandlerContext ctx, DatagramPacket msg) throws Exception {
+    public static DnsQuery decode(ChannelHandlerContext ctx, DatagramPacket msg) throws Exception {
         ByteBuf buf = msg.content();
         int id = buf.readUnsignedShort();
         DnsQuery query = new DnsQuery(id, msg.sender());

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQueryDecoder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.util.CharsetUtil;
+import java.util.List;
+
+/**
+ *
+ */
+public class DnsQueryDecoder extends MessageToMessageDecoder<DatagramPacket> {
+
+    public DnsQueryDecoder() {
+        super(DatagramPacket.class);
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, DatagramPacket msg, List<Object> out) throws Exception {
+        out.add(decode(ctx, msg));
+    }
+
+    public DnsQuery decode(ChannelHandlerContext ctx, DatagramPacket msg) throws Exception {
+        ByteBuf buf = msg.content();
+        int id = buf.readUnsignedShort();
+        DnsQuery query = new DnsQuery(id, msg.sender());
+        DnsQueryHeader header = new DnsQueryHeader(query, id);
+        int flags = buf.readUnsignedShort();
+        header.setType(flags >> 15);
+        header.setOpcode(flags >> 11 & 0xf);
+        header.setRecursionDesired((flags >> 8 & 1) == 1);
+        header.setZ(flags >> 4 & 0x7);
+        int questionCount = buf.readUnsignedShort();
+        int answerCount = buf.readUnsignedShort(); //should be 0
+        int authorityCount = buf.readUnsignedShort(); //should be 0
+        int additionalCount = buf.readUnsignedShort(); //should be 0
+        for (int i = 0; i < questionCount; i++) {
+            StringBuilder content = new StringBuilder();
+            for (;;) {
+                int length = buf.readByte();
+                if (length == 0) {
+                    break;
+                }
+                String part = buf.toString(buf.readerIndex(), length, CharsetUtil.UTF_8);
+                if (content.length() != 0) {
+                    content.append('.');
+                }
+                content.append(part);
+                int next = buf.readerIndex() + length;
+                buf.readerIndex(next);
+            }
+            DnsType type = DnsType.valueOf(buf.readShort());
+            DnsClass dnsClass = DnsClass.valueOf(buf.readShort());
+            DnsQuestion question = new DnsQuestion(content.toString(), type, dnsClass);
+            query.addQuestion(question);
+        }
+        return query;
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQueryEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQueryEncoder.java
@@ -39,7 +39,7 @@ public class DnsQueryEncoder extends MessageToMessageEncoder<DnsQuery> {
     }
 
     /**
-     * Encode a DnsQuery into a {@link DatagramPacket}
+     * Encode a {@link DnsQuery} into a {@link DatagramPacket}.
      * @param ctx The channel context
      * @param query The query
      * @return a {@link DatagramPacket}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQueryEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQueryEncoder.java
@@ -38,7 +38,14 @@ public class DnsQueryEncoder extends MessageToMessageEncoder<DnsQuery> {
         out.add(encode(ctx, query));
     }
 
-    public DatagramPacket encode(ChannelHandlerContext ctx, DnsQuery query) throws Exception {
+    /**
+     * Encode a DnsQuery into a {@link DatagramPacket}
+     * @param ctx The channel context
+     * @param query The query
+     * @return a {@link DatagramPacket}
+     * @throws Exception
+     */
+    public static DatagramPacket encode(ChannelHandlerContext ctx, DnsQuery query) {
         ByteBuf buf = ctx.alloc().buffer();
         encodeHeader(query.header(), buf);
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuestion.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuestion.java
@@ -57,13 +57,13 @@ public final class DnsQuestion {
      */
     public DnsQuestion(String name, DnsType type, DnsClass qClass) {
         if (name == null) {
-            throw new NullPointerException("Name null");
+            throw new NullPointerException("name");
         }
         if (type == null) {
-            throw new NullPointerException("Type null");
+            throw new NullPointerException("type");
         }
         if (qClass == null) {
-            throw new NullPointerException("DNS class null");
+            throw new NullPointerException("qClass");
         }
         if (name.isEmpty()) {
             throw new IllegalArgumentException("name must not be left blank.");
@@ -73,18 +73,34 @@ public final class DnsQuestion {
         this.clazz = qClass;
     }
 
+    /**
+     * The name this question is asking about
+     */
     public String name() {
         return name;
     }
 
+    /**
+     * The DNS class
+     */
     public DnsClass dnsClass() {
         return clazz;
     }
 
+    /**
+     * The type of this question, such as A or AAAA
+     */
     public DnsType type() {
         return type;
     }
 
+    /**
+     * Write this question into a {@link ByteBuf}
+     * @param nameWriter Object which writes names, possibly using DNS
+     * compression pointers
+     * @param into The buffer to write the bytes into
+     * @param charset The character set, typically UTF-8
+     */
     public void writeTo(NameWriter nameWriter, ByteBuf into, Charset charset) {
         nameWriter.writeName(name(), into, charset);
         into.writeShort(type().intValue());

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuestion.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuestion.java
@@ -27,6 +27,7 @@ import java.nio.charset.Charset;
  * support multiple questions in a single query.
  */
 public final class DnsQuestion {
+
     private final String name;
     private final DnsType type;
     private final DnsClass clazz;
@@ -34,11 +35,9 @@ public final class DnsQuestion {
     /**
      * Constructs a question with the default class IN (Internet).
      *
-     * @param name
-     *            the domain name being queried i.e. "www.example.com"
-     * @param type
-     *            the question type, which represents the type of
-     *            {@link DnsResource} record that should be returned
+     * @param name the domain name being queried i.e. "www.example.com"
+     * @param type the question type, which represents the type of
+     * {@link DnsResource} record that should be returned
      */
     public DnsQuestion(String name, DnsType type) {
         this(name, type, IN);
@@ -47,13 +46,10 @@ public final class DnsQuestion {
     /**
      * Constructs a question with the given class.
      *
-     * @param name
-     *            the domain name being queried i.e. "www.example.com"
-     * @param type
-     *            the question type, which represents the type of
-     *            {@link DnsResource} record that should be returned
-     * @param qClass
-     *            the class of a DNS record
+     * @param name the domain name being queried i.e. "www.example.com"
+     * @param type the question type, which represents the type of
+     * {@link DnsResource} record that should be returned
+     * @param qClass the class of a DNS record
      */
     public DnsQuestion(String name, DnsType type, DnsClass qClass) {
         if (name == null) {
@@ -95,7 +91,8 @@ public final class DnsQuestion {
     }
 
     /**
-     * Write this question into a {@link ByteBuf}
+     * Write this question into a {@link ByteBuf}.
+     *
      * @param nameWriter Object which writes names, possibly using DNS
      * compression pointers
      * @param into The buffer to write the bytes into
@@ -126,13 +123,13 @@ public final class DnsQuestion {
             return false;
         }
         final DnsQuestion other = (DnsQuestion) obj;
-        if ((this.name == null) ? (other.name != null) : !this.name.equals(other.name)) {
-            return false;
-        }
         if (this.type != other.type && (this.type == null || !this.type.equals(other.type))) {
             return false;
         }
         if (this.clazz != other.clazz && (this.clazz == null || !this.clazz.equals(other.clazz))) {
+            return false;
+        }
+        if ((this.name == null) ? (other.name != null) : !this.name.equals(other.name)) {
             return false;
         }
         return true;

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResource.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResource.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
+import java.nio.charset.Charset;
 
 /**
  * Represents any resource record (answer, authority, or additional resource
@@ -30,28 +31,16 @@ public final class DnsResource extends DnsEntry implements ByteBufHolder {
     /**
      * Constructs a resource record.
      *
-     * @param name
-     *            the domain name
-     * @param type
-     *            the type of record being returned
-     * @param aClass
-     *            the class for this resource record
-     * @param ttl
-     *            the time to live after reading
-     * @param content
-     *            the data contained in this record
+     * @param name the domain name
+     * @param type the type of record being returned
+     * @param aClass the class for this resource record
+     * @param ttl the time to live after reading
+     * @param content the data contained in this record
      */
     public DnsResource(String name, DnsType type, DnsClass aClass, long ttl, ByteBuf content) {
-        super(name, type, aClass);
+        super(name, type, aClass, ttl);
         this.ttl = ttl;
         this.content = content;
-    }
-
-    /**
-     * Returns the time to live after reading for this resource record.
-     */
-    public long timeToLive() {
-        return ttl;
     }
 
     /**
@@ -115,5 +104,10 @@ public final class DnsResource extends DnsEntry implements ByteBufHolder {
     public DnsResource touch(Object hint) {
         content.touch(hint);
         return this;
+    }
+
+    @Override
+    public void writePayload(NameWriter nameWriter, ByteBuf into, Charset charset) {
+        into.writeBytes(content, content.readerIndex(), content.readableBytes());
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResource.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResource.java
@@ -110,4 +110,9 @@ public final class DnsResource extends DnsEntry implements ByteBufHolder {
     public void writePayload(NameWriter nameWriter, ByteBuf into, Charset charset) {
         into.writeBytes(content, content.readerIndex(), content.readableBytes());
     }
+
+    @Override
+    public DnsResource withTimeToLive(long seconds) {
+        return new DnsResource(name(), type(), dnsClass(), seconds, content.duplicate());
+    }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponse.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponse.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.dns;
 
+import io.netty.util.internal.StringUtil;
 import java.net.InetSocketAddress;
 
 /**
@@ -46,6 +47,7 @@ public final class DnsResponse extends DnsMessage {
         return this;
     }
 
+    @Override
     public DnsResponse addQuestions(Iterable<DnsQuestion> questions) {
         super.addQuestions(questions);
         return this;
@@ -125,8 +127,8 @@ public final class DnsResponse extends DnsMessage {
     }
 
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(DnsResponse.class.getSimpleName()).append('@').append(
+        StringBuilder sb = new StringBuilder(80);
+        sb.append(StringUtil.simpleClassName(DnsResponse.class)).append('@').append(
                 System.identityHashCode(this)).append('{');
         sb.append("header=").append(header()).append(", answers=[");
         for (DnsEntry ans : answers()) {

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponse.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponse.java
@@ -41,8 +41,13 @@ public final class DnsResponse extends DnsMessage {
     }
 
     @Override
-    public DnsResponse addAnswer(DnsResource answer) {
+    public DnsResponse addAnswer(DnsEntry answer) {
         super.addAnswer(answer);
+        return this;
+    }
+
+    public DnsResponse addQuestions(Iterable<DnsQuestion> questions) {
+        super.addQuestions(questions);
         return this;
     }
 
@@ -53,13 +58,13 @@ public final class DnsResponse extends DnsMessage {
     }
 
     @Override
-    public DnsResponse addAuthorityResource(DnsResource resource) {
+    public DnsResponse addAuthorityResource(DnsEntry resource) {
         super.addAuthorityResource(resource);
         return this;
     }
 
     @Override
-    public DnsResponse addAdditionalResource(DnsResource resource) {
+    public DnsResponse addAdditionalResource(DnsEntry resource) {
         super.addAdditionalResource(resource);
         return this;
     }
@@ -71,24 +76,6 @@ public final class DnsResponse extends DnsMessage {
     }
 
     @Override
-    public DnsResponse retain() {
-        super.retain();
-        return this;
-    }
-
-    @Override
-    public DnsResponse retain(int increment) {
-        super.retain(increment);
-        return this;
-    }
-
-    @Override
-    public DnsResponse touch() {
-        super.touch();
-        return this;
-    }
-
-    @Override
     public DnsResponseHeader header() {
         return (DnsResponseHeader) super.header();
     }
@@ -96,5 +83,65 @@ public final class DnsResponse extends DnsMessage {
     @Override
     protected DnsResponseHeader newHeader(int id) {
         return new DnsResponseHeader(this, id);
+    }
+
+    /**
+     * Copy the contents - questions, authorities and additional resources - of
+     * this DnsResponse into another one, <i>not</i>
+     * altering the ID or recipient of the other DnsResponse. Useful for proxy
+     * servers.
+     *
+     * @param other A DnsResponse which should be altered to contain the
+     * response resources of this one
+     */
+    public void copyInto(DnsResponse other) {
+        for (DnsQuestion question : questions()) {
+            other.addQuestion(question);
+        }
+        for (DnsEntry answers : answers()) {
+            other.addAnswer(duplicate(answers));
+        }
+        for (DnsEntry authority : authorityResources()) {
+            other.addAuthorityResource(duplicate(authority));
+        }
+        for (DnsEntry additional : additionalResources()) {
+            other.addAdditionalResource(duplicate(additional));
+        }
+        other.header()
+                .setAuthoritativeAnswer(header().isAuthoritativeAnswer())
+                .setResponseCode(header().responseCode())
+                .setOpcode(header().opcode())
+                .setRecursionAvailable(header().isRecursionAvailable())
+                .setRecursionDesired(header().isRecursionDesired())
+                .setType(header().type());
+    }
+
+    private DnsEntry duplicate(DnsEntry entry) {
+        if (entry instanceof DnsResource) {
+            return ((DnsResource) entry).duplicate();
+        } else {
+            return entry;
+        }
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(DnsResponse.class.getSimpleName()).append('@').append(
+                System.identityHashCode(this)).append('{');
+        sb.append("header=").append(header()).append(", answers=[");
+        for (DnsEntry ans : answers()) {
+            sb.append(ans).append(" ");
+        }
+        sb.append("], authorities=[");
+        for (DnsEntry ans : authorityResources()) {
+            sb.append(ans).append(" ");
+        }
+        sb.append("], additional=[");
+        for (DnsEntry ans : additionalResources()) {
+            sb.append(ans).append(" ");
+        }
+        sb.append("], sender=").append(sender);
+
+        return sb.append('}').toString();
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponse.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponse.java
@@ -93,8 +93,8 @@ public final class DnsResponse extends DnsMessage {
      * altering the ID or recipient of the other DnsResponse. Useful for proxy
      * servers.
      *
-     * @param other A DnsResponse which should be altered to contain the
-     * response resources of this one
+     * @param other A {@link DnsResponse} which should be altered to contain the
+     * response resources of this one.
      */
     public void copyInto(DnsResponse other) {
         for (DnsQuestion question : questions()) {
@@ -126,6 +126,7 @@ public final class DnsResponse extends DnsMessage {
         }
     }
 
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(80);
         sb.append(StringUtil.simpleClassName(DnsResponse.class)).append('@').append(

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseCode.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseCode.java
@@ -17,85 +17,105 @@ package io.netty.handler.codec.dns;
 
 /**
  * Represents the possible response codes a server may send after receiving a
- * query. A response code of 0 indicates no error.
+ * query, as described
+ * <a href="http://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml">
+ * by IANA</a>. A response code of 0 indicates no error.
  */
 public final class DnsResponseCode implements Comparable<DnsResponseCode> {
 
     /**
      * ID 0, no error
      */
-    public static final DnsResponseCode NOERROR = new DnsResponseCode(0, "no error");
+    public static final DnsResponseCode NOERROR = new DnsResponseCode(0, "No Error");
 
     /**
      * ID 1, format error
      */
-    public static final DnsResponseCode FORMERROR = new DnsResponseCode(1, "format error");
+    public static final DnsResponseCode FORMERROR = new DnsResponseCode(1, "Format Error");
 
     /**
      * ID 2, server failure
      */
-    public static final DnsResponseCode SERVFAIL = new DnsResponseCode(2, "server failure");
+    public static final DnsResponseCode SERVFAIL = new DnsResponseCode(2, "Server Failure");
 
     /**
-     * ID 3, name error
+     * ID 3, non-existent domain
      */
-    public static final DnsResponseCode NXDOMAIN = new DnsResponseCode(3, "name error");
+    public static final DnsResponseCode NXDOMAIN = new DnsResponseCode(3, "Non-Existent Domain");
 
     /**
      * ID 4, not implemented
      */
-    public static final DnsResponseCode NOTIMPL = new DnsResponseCode(4, "not implemented");
+    public static final DnsResponseCode NOTIMPL = new DnsResponseCode(4, "Not Implemented");
 
     /**
-     * ID 5, operation refused
+     * ID 5, query refused
      */
-    public static final DnsResponseCode REFUSED = new DnsResponseCode(5, "operation refused");
+    public static final DnsResponseCode REFUSED = new DnsResponseCode(5, "Query Refused");
 
     /**
-     * ID 6, domain name should not exist
+     * ID 6, domain name should not exist but does
      */
-    public static final DnsResponseCode YXDOMAIN = new DnsResponseCode(6, "domain name should not exist");
+    public static final DnsResponseCode YXDOMAIN = new DnsResponseCode(6, "Name Exists when it should not");
 
     /**
-     * ID 7, resource record set should not exist
+     * ID 7, resource record set should not exist but does
      */
-    public static final DnsResponseCode YXRRSET = new DnsResponseCode(7, "resource record set should not exist");
+    public static final DnsResponseCode YXRRSET = new DnsResponseCode(7, "RR Set Exists when it should not");
 
     /**
-     * ID 8, rrset does not exist
+     * ID 8, rrset should exist but does not exist
      */
-    public static final DnsResponseCode NXRRSET = new DnsResponseCode(8, "rrset does not exist");
+    public static final DnsResponseCode NXRRSET = new DnsResponseCode(8, "RR Set that should exist does not");
 
     /**
      * ID 9, not authoritative for zone
      */
-    public static final DnsResponseCode NOTAUTH = new DnsResponseCode(9, "not authoritative for zone");
+    public static final DnsResponseCode NOTAUTH = new DnsResponseCode(9, "Server Not Authoritative for zone");
 
     /**
      * ID 10, name not in zone
      */
-    public static final DnsResponseCode NOTZONE = new DnsResponseCode(10, "name not in zone");
+    public static final DnsResponseCode NOTZONE = new DnsResponseCode(10, "Name not contained in zone");
 
     /**
-     * ID 11, bad extension mechanism for version
+     * ID 16, bad extension mechanism for version.  <b>Note:</b>:
+     * <a href="http://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml">
+     * according to IANA</a> this has the same code as BADSIG, so results may be
+     * ambiguous.
      */
-    public static final DnsResponseCode BADVERS = new DnsResponseCode(11, "bad extension mechanism for version");
+    public static final DnsResponseCode BADVERS = new DnsResponseCode(16, "Bad OPT Version");
 
     /**
-     * ID 12, bad signature
+     * ID 16, TSIG Signature Failure.  Yes,
+     * <a href="http://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml">
+     * according to IANA</a> this has the same code as BADVERS.
+     *
      */
-    public static final DnsResponseCode BADSIG = new DnsResponseCode(12, "bad signature");
+    public static final DnsResponseCode BADSIG = new DnsResponseCode(16, "TSIG Signature Failure");
 
     /**
-     * ID 13, bad key
+     * ID 17, Key not recognized
      */
-    public static final DnsResponseCode BADKEY = new DnsResponseCode(13, "bad key");
+    public static final DnsResponseCode BADKEY = new DnsResponseCode(17, "Key not recognized");
 
     /**
-     * ID 14, bad timestamp
+     * ID 18, Signature out of time window
      */
-    public static final DnsResponseCode BADTIME = new DnsResponseCode(14, "bad timestamp");
+    public static final DnsResponseCode BADTIME = new DnsResponseCode(18, "Signature out of time window");
 
+    /**
+     * ID 19, Bad TKEY Mode
+     */
+    public static final DnsResponseCode BADMODE = new DnsResponseCode(19, "Bad TKEY Mode");
+    /**
+     * ID 20, Duplicate Key Mode
+     */
+    public static final DnsResponseCode BADNAME = new DnsResponseCode(20, "Duplicate Key Name");
+    /**
+     * ID 21, Algorithm not supported
+     */
+    public static final DnsResponseCode BADALG = new DnsResponseCode(21, "Algorithm not supported");
     private final int errorCode;
     private final String message;
 
@@ -131,14 +151,19 @@ public final class DnsResponseCode implements Comparable<DnsResponseCode> {
                 return NOTAUTH;
             case 10:
                 return NOTZONE;
-            case 11:
+            // 11-15 are undefined per the spec
+            case 16:
                 return BADVERS;
-            case 12:
+            case 17:
                 return BADSIG;
-            case 13:
+            case 18:
                 return BADKEY;
-            case 14:
+            case 19:
                 return BADTIME;
+            case 20:
+                return BADNAME;
+            case 21:
+                return BADALG;
             default:
                 return new DnsResponseCode(responseCode, null);
         }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseDecoder.java
@@ -25,9 +25,9 @@ import io.netty.util.CharsetUtil;
 import java.util.List;
 
 /**
- * DnsResponseDecoder accepts {@link io.netty.channel.socket.DatagramPacket} and
- * encodes to {@link DnsResponse}. This class also contains methods for decoding
- * parts of DnsResponses such as questions and resource records.
+ * DnsResponseDecoder accepts {@link DatagramPacket} and encodes to
+ * {@link DnsResponse}. This class also contains methods for decoding parts of
+ * {@link DnsResponse}s such as questions and resource records.
  */
 @ChannelHandler.Sharable
 public class DnsResponseDecoder extends MessageToMessageDecoder<DatagramPacket> {
@@ -41,6 +41,13 @@ public class DnsResponseDecoder extends MessageToMessageDecoder<DatagramPacket> 
         out.add(decode(ctx, packet));
     }
 
+    /**
+     * Decode a {@link DatagramPacket} into a DnsResponse.
+     *
+     * @param ctx The channel context
+     * @param packet The packet
+     * @return A DnsResponse
+     */
     public DnsResponse decode(ChannelHandlerContext ctx, DatagramPacket packet) {
         ByteBuf buf = packet.content();
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseDecoder.java
@@ -144,7 +144,7 @@ public class DnsResponseDecoder extends MessageToMessageDecoder<DatagramPacket> 
             return "";
         }
         if (name.length() > 253) {
-            // see http://blogs.msdn.com/b/oldnewthing/archive/2012/04/12/10292868.aspx for why
+            // See http://blogs.msdn.com/b/oldnewthing/archive/2012/04/12/10292868.aspx for why
             throw new DnsDecoderException(DnsResponseCode.BADNAME, "Name > 253 characters in length: " + name);
         }
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseEncoder.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.handler.codec.MessageToMessageEncoder;
+import static io.netty.handler.codec.dns.NameWriter.NAME_WRITER_KEY;
+import io.netty.util.Attribute;
+import io.netty.util.CharsetUtil;
+import java.nio.charset.Charset;
+import java.util.List;
+
+/**
+ * Encodes DNS responses into DatagramPackets for use when writing a DNS server.
+ */
+@ChannelHandler.Sharable
+public class DnsResponseEncoder extends MessageToMessageEncoder<DnsResponse> {
+
+    private static final int FLAGS_QR = 15;
+    private static final int FLAGS_Opcode = 11;
+    private static final int FLAGS_AA = 10;
+    private static final int FLAGS_TC = 9;
+    private static final int FLAGS_RD = 8;
+    private static final int FLAGS_RA = 7;
+    private static final int FLAGS_Z = 4;
+
+    public DnsResponseEncoder() {
+        super(DnsResponse.class);
+    }
+
+    private void encodeQuestion(NameWriter nameWriter, DnsQuestion question, Charset charset, ByteBuf buf) {
+        nameWriter.writeName(question.name(), buf, charset);
+        buf.writeShort(question.type().intValue());
+        buf.writeShort(question.dnsClass().intValue());
+    }
+
+    private int flip(int flags, int index, boolean is) {
+        int i = 1 << index;
+        if (is) {
+            flags |= i;
+        } else {
+            flags &= i ^ 0xFFFF;
+        }
+        return flags;
+    }
+
+    public DatagramPacket encode(ChannelHandlerContext ctx, DnsResponse msg) {
+        ByteBuf buf = ctx.alloc().buffer();
+        buf.writeShort(msg.header().id());
+        DnsResponseHeader h = msg.header();
+        int flags = h.responseCode().code();
+        flags |= h.opcode() << FLAGS_Opcode;
+        flags |= h.type() << FLAGS_QR;
+        flags = flip(flags, FLAGS_RD, h.isRecursionDesired());
+        flags = flip(flags, FLAGS_RA, h.isRecursionAvailable());
+        flags = flip(flags, FLAGS_AA, h.isAuthoritativeAnswer());
+        flags = flip(flags, FLAGS_TC, h.isTruncated());
+        flags |= h.z() << FLAGS_Z;
+        buf.writeShort(flags);
+        buf.writeShort(h.questionCount());
+        buf.writeShort(h.answerCount());
+        buf.writeShort(h.authorityResourceCount());
+        buf.writeShort(h.additionalResourceCount());
+
+        // Get the NameWriter - it can be stateful if doing compression,
+        // so look it up, don't hold it as a field, so we can use @Sharable
+        Attribute<NameWriter> nw = ctx.attr(NAME_WRITER_KEY);
+        NameWriter nameWriter = nw.get();
+        if (nameWriter == null) {
+            nameWriter = NameWriter.DEFAULT;
+        }
+
+        for (DnsQuestion q : msg.questions()) {
+            encodeQuestion(nameWriter, q, CharsetUtil.UTF_8, buf);
+        }
+        if (h.responseCode() != DnsResponseCode.NOERROR) {
+            DatagramPacket packet = new DatagramPacket(buf, msg.sender());
+            return packet;
+        }
+        for (DnsEntry r : msg.answers()) {
+            r.writeTo(nameWriter, buf, CharsetUtil.UTF_8);
+        }
+        for (DnsEntry r : msg.authorityResources()) {
+            r.writeTo(nameWriter, buf, CharsetUtil.UTF_8);
+        }
+        for (DnsEntry a : msg.additionalResources()) {
+            a.writeTo(nameWriter, buf, CharsetUtil.UTF_8);
+        }
+        DatagramPacket packet = new DatagramPacket(buf, msg.sender());
+        return packet;
+    }
+
+    @Override
+    protected void encode(ChannelHandlerContext ctx, DnsResponse msg, List<Object> out) {
+        out.add(encode(ctx, msg));
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseEncoder.java
@@ -44,20 +44,21 @@ public class DnsResponseEncoder extends MessageToMessageEncoder<DnsResponse> {
         super(DnsResponse.class);
     }
 
-    private void encodeQuestion(NameWriter nameWriter, DnsQuestion question, Charset charset, ByteBuf buf) {
-        nameWriter.writeName(question.name(), buf, charset);
-        buf.writeShort(question.type().intValue());
-        buf.writeShort(question.dnsClass().intValue());
-    }
-
-    private int flip(int flags, int index, boolean is) {
+    /**
+     * Flip the bit at position <code>index</code> on or off
+     * @param value The value to change
+     * @param index The bit-index
+     * @param on Whether or not the bit should be a 1
+     * @return The updated value
+     */
+    private static int flip(int value, int index, boolean on) {
         int i = 1 << index;
-        if (is) {
-            flags |= i;
+        if (on) {
+            value |= i;
         } else {
-            flags &= i ^ 0xFFFF;
+            value &= i ^ 0xFFFF;
         }
-        return flags;
+        return value;
     }
 
     public DatagramPacket encode(ChannelHandlerContext ctx, DnsResponse msg) {
@@ -87,7 +88,7 @@ public class DnsResponseEncoder extends MessageToMessageEncoder<DnsResponse> {
         }
 
         for (DnsQuestion q : msg.questions()) {
-            encodeQuestion(nameWriter, q, CharsetUtil.UTF_8, buf);
+            q.writeTo(nameWriter, buf, CharsetUtil.UTF_8);
         }
         if (h.responseCode() != DnsResponseCode.NOERROR) {
             DatagramPacket packet = new DatagramPacket(buf, msg.sender());

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseEncoder.java
@@ -23,7 +23,6 @@ import io.netty.handler.codec.MessageToMessageEncoder;
 import static io.netty.handler.codec.dns.NameWriter.NAME_WRITER_KEY;
 import io.netty.util.Attribute;
 import io.netty.util.CharsetUtil;
-import java.nio.charset.Charset;
 import java.util.List;
 
 /**
@@ -45,7 +44,8 @@ public class DnsResponseEncoder extends MessageToMessageEncoder<DnsResponse> {
     }
 
     /**
-     * Flip the bit at position <code>index</code> on or off
+     * Flip the bit at position <code>index</code> on or off.
+     *
      * @param value The value to change
      * @param index The bit-index
      * @param on Whether or not the bit should be a 1
@@ -61,7 +61,7 @@ public class DnsResponseEncoder extends MessageToMessageEncoder<DnsResponse> {
         return value;
     }
 
-    public DatagramPacket encode(ChannelHandlerContext ctx, DnsResponse msg) {
+    public static DatagramPacket encode(ChannelHandlerContext ctx, DnsResponse msg) {
         ByteBuf buf = ctx.alloc().buffer();
         buf.writeShort(msg.header().id());
         DnsResponseHeader h = msg.header();
@@ -87,6 +87,11 @@ public class DnsResponseEncoder extends MessageToMessageEncoder<DnsResponse> {
             nameWriter = NameWriter.DEFAULT;
         }
 
+        return createDatagramPacket(msg, nameWriter, buf, h);
+    }
+
+    private static DatagramPacket createDatagramPacket(DnsResponse msg, NameWriter nameWriter,
+            ByteBuf buf, DnsResponseHeader h) {
         for (DnsQuestion q : msg.questions()) {
             q.writeTo(nameWriter, buf, CharsetUtil.UTF_8);
         }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseHeader.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseHeader.java
@@ -168,10 +168,26 @@ public final class DnsResponseHeader extends DnsHeader {
 
     @Override
     public String toString() {
-        return "DnsResponseHeader{recursionDesired=" + isRecursionDesired()
-                + ", opcode=" + opcode() + ", id=" + id() + ", type=" + type()
-                + ", z=" + z() + " authoritativeAnswer=" + authoritativeAnswer
-                + ", truncated=" + truncated + ", recursionAvailable=" + recursionAvailable
-                + ", responseCode=" + responseCode + '}';
+        return new StringBuilder(140)
+                .append("DnsResponseHeader{recursionDesired=")
+                .append(isRecursionDesired())
+                .append(", opcode=")
+                .append(opcode())
+                .append(", id=")
+                .append(id())
+                .append(", type=")
+                .append(type())
+                .append(", z=")
+                .append(z())
+                .append(" authoritativeAnswer=")
+                .append(authoritativeAnswer)
+                .append(", truncated=")
+                .append(truncated)
+                .append(", recursionAvailable=")
+                .append(recursionAvailable)
+                .append(", responseCode=")
+                .append(responseCode)
+                .append('}')
+                .toString();
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseHeader.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponseHeader.java
@@ -165,4 +165,13 @@ public final class DnsResponseHeader extends DnsHeader {
         super.setZ(z);
         return this;
     }
+
+    @Override
+    public String toString() {
+        return "DnsResponseHeader{recursionDesired=" + isRecursionDesired()
+                + ", opcode=" + opcode() + ", id=" + id() + ", type=" + type()
+                + ", z=" + z() + " authoritativeAnswer=" + authoritativeAnswer
+                + ", truncated=" + truncated + ", recursionAvailable=" + recursionAvailable
+                + ", responseCode=" + responseCode + '}';
+    }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsType.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsType.java
@@ -336,7 +336,7 @@ public final class DnsType<RecordType extends DnsEntry> implements Comparable<Dn
 
     /**
      * Decode the <i>payload</i> of a record of this type into a record of type
-     * &lt;RecordType&gt;. The resulting object will be of {@link DnsClass.IN}
+     * &lt;RecordType&gt;. The resulting object will be of {@link DnsClass.IN}.
      *
      * @param name The name for the resulting record
      * @param timeToLive The time to live of the resulting record

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsType.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsType.java
@@ -336,13 +336,13 @@ public final class DnsType<RecordType extends DnsEntry> implements Comparable<Dn
 
     /**
      * Decode the <i>payload</i> of a record of this type into a record of type
-     * &lt;RecordType&gt;. The resulting object will be of DnsClass IN.
+     * &lt;RecordType&gt;. The resulting object will be of {@link DnsClass.IN}
      *
      * @param name The name for the resulting record
      * @param timeToLive The time to live of the resulting record
      * @param buf A buffer to read from
      * @param length The length of the payload in the buffer
-     * @return An object of type &lt;RecordType&gt; such as an Ipv4AddressRecord
+     * @return An object of type &lt;RecordType&gt; such as an {@link Ipv4AddressRecord}
      */
     public RecordType decode(String name, long timeToLive, ByteBuf buf, int length)
             throws DnsDecoderException {
@@ -358,7 +358,7 @@ public final class DnsType<RecordType extends DnsEntry> implements Comparable<Dn
      * @param timeToLive The time to live of the resulting record
      * @param buf A buffer to read from
      * @param length The length of the payload in the buffer
-     * @return An object of type &lt;RecordType&gt; such as an Ipv4AddressRecord
+     * @return An object of type &lt;RecordType&gt; such as an {@link Ipv4AddressRecord}
      */
     public RecordType decode(String name, DnsClass clazz, long timeToLive, ByteBuf buf,
             int length) throws DnsDecoderException {
@@ -369,6 +369,14 @@ public final class DnsType<RecordType extends DnsEntry> implements Comparable<Dn
         }
     }
 
+    /**
+     * Get the constant value of the code returned by a DNS response.
+     * If an unknown code is passed, will return a DnsType with the passed
+     * code and a name of "UNKNOWN".
+     *
+     * @param intValue The code
+     * @return The constant
+     */
     public static DnsType<?> valueOf(int intValue) {
         DnsType result = BY_TYPE.get(intValue);
         if (result == null) {
@@ -377,6 +385,13 @@ public final class DnsType<RecordType extends DnsEntry> implements Comparable<Dn
         return result;
     }
 
+    /**
+     * Look up a DnsType by its name according to the DNS spec
+     * @param name The name of a DNS record type as defined in one of the
+     * relevant RFCs
+     * @return A DnsType
+     * @throws IllegalArgumentException if the name is unknown
+     */
     public static DnsType<?> valueOf(String name) {
         DnsType result = BY_NAME.get(name);
         if (result == null) {
@@ -451,8 +466,29 @@ public final class DnsType<RecordType extends DnsEntry> implements Comparable<Dn
         return 0x00000000FFFFFFFFL & (long) val;
     }
 
+    /**
+     * Non-public interface for objects which can decode the payload
+     * of a received packet into the appropriate &lt;RecordType&gt;.
+     * @param <T> The record type
+     */
     interface Decoder<T extends DnsEntry> {
 
+        /**
+         * Decode the contents of a {@link ByteBuf}, using the passed
+         * name, type, time-to-live and class, along with the decoded
+         * payload to construct an {@link DnsEntry} of the appropriate
+         * type
+         * @param name The name this record asks or answers for
+         * @param type The type of record to be held by the resulting object
+         * @param clazz The DNS class
+         * @param timeToLive The length of time in seconds that the result
+         * should be considered current for
+         * @param buf The bytes to decode
+         * @param length The number of bytes from the current reader index
+         * of the buffer, which should be used when decodeing
+         * @return An object of the appropriate type
+         * @throws DnsDecoderException If the data is invalid in some way
+         */
         T decode(String name, DnsType<T> type, DnsClass clazz, long timeToLive, ByteBuf buf, int length)
                 throws DnsDecoderException;
     }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsType.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsType.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.dns;
 
+import io.netty.buffer.ByteBuf;
+import static io.netty.handler.codec.dns.DnsResponseDecoder.readName;
 import io.netty.util.collection.IntObjectHashMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -22,26 +24,28 @@ import java.util.Map;
 /**
  * Represents a DNS record type.
  */
-public final class DnsType implements Comparable<DnsType> {
+public final class DnsType<RecordType extends DnsEntry> implements Comparable<DnsType<?>> {
 
     /**
      * Address record RFC 1035 Returns a 32-bit IPv4 address, most commonly used
      * to map hostnames to an IP address of the host, but also used for DNSBLs,
      * storing subnet masks in RFC 1101, etc.
      */
-    public static final DnsType A = new DnsType(0x0001, "A");
+    public static final DnsType<Ipv4AddressRecord> A = new DnsType<Ipv4AddressRecord>(0x0001, "A", new Ipv4Decoder());
 
     /**
      * Name server record RFC 1035 Delegates a DNS zone to use the given
      * authoritative name servers
      */
-    public static final DnsType NS = new DnsType(0x0002, "NS");
+    public static final DnsType<NameServerDnsRecord> NS = new DnsType<NameServerDnsRecord>(0x0002, "NS",
+            new NsResourceDecoder());
 
     /**
      * Canonical name record RFC 1035 Alias of one name to another: the DNS
      * lookup will continue by retrying the lookup with the new name.
      */
-    public static final DnsType CNAME = new DnsType(0x0005, "CNAME");
+    public static final DnsType<CNameDnsRecord> CNAME = new DnsType<CNameDnsRecord>(0x0005, "CNAME",
+            new CnameDecoder());
 
     /**
      * Start of [a zone of] authority record RFC 1035 and RFC 2308 Specifies
@@ -49,7 +53,8 @@ public final class DnsType implements Comparable<DnsType> {
      * server, the email of the domain administrator, the domain serial number,
      * and several timers relating to refreshing the zone.
      */
-    public static final DnsType SOA = new DnsType(0x0006, "SOA");
+    public static final DnsType<StartOfAuthorityDnsRecord> SOA = new DnsType<StartOfAuthorityDnsRecord>(0x0006,
+            "SOA", new SoaDecoder());
 
     /**
      * Pointer record RFC 1035 Pointer to a canonical name. Unlike a CNAME, DNS
@@ -57,13 +62,14 @@ public final class DnsType implements Comparable<DnsType> {
      * use is for implementing reverse DNS lookups, but other uses include such
      * things as DNS-SD.
      */
-    public static final DnsType PTR = new DnsType(0x000c, "PTR");
+    public static final DnsType<PointerDnsRecord> PTR = new DnsType<PointerDnsRecord>(0x000c, "PTR", new PtrDecoder());
 
     /**
      * Mail exchange record RFC 1035 Maps a domain name to a list of message
      * transfer agents for that domain.
      */
-    public static final DnsType MX = new DnsType(0x000f, "MX");
+    public static final DnsType<MailExchangerDnsRecord> MX = new DnsType<MailExchangerDnsRecord>(0x000f, "MX",
+            new MxDecoder());
 
     /**
      * Text record RFC 1035 Originally for arbitrary human-readable text in a
@@ -72,14 +78,14 @@ public final class DnsType implements Comparable<DnsType> {
      * opportunistic encryption, Sender Policy Framework, DKIM, DMARC DNS-SD,
      * etc.
      */
-    public static final DnsType TXT = new DnsType(0x0010, "TXT");
+    public static final DnsType<DnsResource> TXT = new DnsType<DnsResource>(0x0010, "TXT");
 
     /**
      * Responsible person record RFC 1183 Information about the responsible
      * person(s) for the domain. Usually an email address with the @ replaced by
      * a .
      */
-    public static final DnsType RP = new DnsType(0x0011, "RP");
+    public static final DnsType<DnsResource> RP = new DnsType<DnsResource>(0x0011, "RP");
 
     /**
      * AFS database record RFC 1183 Location of database servers of an AFS cell.
@@ -87,14 +93,14 @@ public final class DnsType implements Comparable<DnsType> {
      * their local domain. A subtype of this record is used by the obsolete
      * DCE/DFS file system.
      */
-    public static final DnsType AFSDB = new DnsType(0x0012, "AFSDB");
+    public static final DnsType<DnsResource> AFSDB = new DnsType<DnsResource>(0x0012, "AFSDB");
 
     /**
      * Signature record RFC 2535 Signature record used in SIG(0) (RFC 2931) and
      * TKEY (RFC 2930). RFC 3755 designated RRSIG as the replacement for SIG for
      * use within DNSSEC.
      */
-    public static final DnsType SIG = new DnsType(0x0018, "SIG");
+    public static final DnsType<DnsResource> SIG = new DnsType<DnsResource>(0x0018, "SIG");
 
     /**
      * key record RFC 2535 and RFC 2930 Used only for SIG(0) (RFC 2931) and TKEY
@@ -103,32 +109,32 @@ public final class DnsType implements Comparable<DnsType> {
      * replacement within DNSSEC. RFC 4025 designates IPSECKEY as the
      * replacement for use with IPsec.
      */
-    public static final DnsType KEY = new DnsType(0x0019, "KEY");
+    public static final DnsType<DnsResource> KEY = new DnsType<DnsResource>(0x0019, "KEY");
 
     /**
      * IPv6 address record RFC 3596 Returns a 128-bit IPv6 address, most
      * commonly used to map hostnames to an IP address of the host.
      */
-    public static final DnsType AAAA = new DnsType(0x001c, "AAAA");
+    public static final DnsType<DnsResource> AAAA = new DnsType<DnsResource>(0x001c, "AAAA");
 
     /**
      * Location record RFC 1876 Specifies a geographical location associated
      * with a domain name.
      */
-    public static final DnsType LOC = new DnsType(0x001d, "LOC");
+    public static final DnsType<DnsResource> LOC = new DnsType<DnsResource>(0x001d, "LOC");
 
     /**
      * Service locator RFC 2782 Generalized service location record, used for
      * newer protocols instead of creating protocol-specific records such as MX.
      */
-    public static final DnsType SRV = new DnsType(0x0021, "SRV");
+    public static final DnsType<DnsResource> SRV = new DnsType<DnsResource>(0x0021, "SRV");
 
     /**
      * Naming Authority Pointer record RFC 3403 Allows regular expression based
      * rewriting of domain names which can then be used as URIs, further domain
      * names to lookups, etc.
      */
-    public static final DnsType NAPTR = new DnsType(0x0023, "NAPTR");
+    public static final DnsType<DnsResource> NAPTR = new DnsType<DnsResource>(0x0023, "NAPTR");
 
     /**
      * Key eXchanger record RFC 2230 Used with some cryptographic systems (not
@@ -137,12 +143,12 @@ public final class DnsType implements Comparable<DnsType> {
      * Informational status, rather than being on the IETF standards-track. It
      * has always had limited deployment, but is still in use.
      */
-    public static final DnsType KX = new DnsType(0x0024, "KX");
+    public static final DnsType<DnsResource> KX = new DnsType<DnsResource>(0x0024, "KX");
 
     /**
      * Certificate record RFC 4398 Stores PKIX, SPKI, PGP, etc.
      */
-    public static final DnsType CERT = new DnsType(0x0025, "CERT");
+    public static final DnsType<DnsResource> CERT = new DnsType<DnsResource>(0x0025, "CERT");
 
     /**
      * Delegation name record RFC 2672 DNAME creates an alias for a name and all
@@ -150,25 +156,25 @@ public final class DnsType implements Comparable<DnsType> {
      * label. Like the CNAME record, the DNS lookup will continue by retrying
      * the lookup with the new name.
      */
-    public static final DnsType DNAME = new DnsType(0x0027, "DNAME");
+    public static final DnsType<DnsResource> DNAME = new DnsType<DnsResource>(0x0027, "DNAME");
 
     /**
      * Option record RFC 2671 This is a pseudo DNS record type needed to support
      * EDNS.
      */
-    public static final DnsType OPT = new DnsType(0x0029, "OPT");
+    public static final DnsType<DnsResource> OPT = new DnsType<DnsResource>(0x0029, "OPT");
 
     /**
      * Address Prefix List record RFC 3123 Specify lists of address ranges, e.g.
      * in CIDR format, for various address families. Experimental.
      */
-    public static final DnsType APL = new DnsType(0x002a, "APL");
+    public static final DnsType<DnsResource> APL = new DnsType<DnsResource>(0x002a, "APL");
 
     /**
      * Delegation signer record RFC 4034 The record used to identify the DNSSEC
      * signing key of a delegated zone.
      */
-    public static final DnsType DS = new DnsType(0x002b, "DS");
+    public static final DnsType<DnsResource> DS = new DnsType<DnsResource>(0x002b, "DS");
 
     /**
      * SSH Public Key Fingerprint record RFC 4255 Resource record for publishing
@@ -176,47 +182,47 @@ public final class DnsType implements Comparable<DnsType> {
      * verifying the authenticity of the host. RFC 6594 defines ECC SSH keys and
      * SHA-256 hashes. See the IANA SSHFP RR parameters registry for details.
      */
-    public static final DnsType SSHFP = new DnsType(0x002c, "SSHFP");
+    public static final DnsType<DnsResource> SSHFP = new DnsType<DnsResource>(0x002c, "SSHFP");
 
     /**
      * IPsec Key record RFC 4025 Key record that can be used with IPsec.
      */
-    public static final DnsType IPSECKEY = new DnsType(0x002d, "IPSECKEY");
+    public static final DnsType<DnsResource> IPSECKEY = new DnsType<DnsResource>(0x002d, "IPSECKEY");
 
     /**
      * DNSSEC signature record RFC 4034 Signature for a DNSSEC-secured record
      * set. Uses the same format as the SIG record.
      */
-    public static final DnsType RRSIG = new DnsType(0x002e, "RRSIG");
+    public static final DnsType<DnsResource> RRSIG = new DnsType<DnsResource>(0x002e, "RRSIG");
 
     /**
      * Next-Secure record RFC 4034 Part of DNSSEC, used to prove a name does not
      * exist. Uses the same format as the (obsolete) NXT record.
      */
-    public static final DnsType NSEC = new DnsType(0x002f, "NSEC");
+    public static final DnsType<DnsResource> NSEC = new DnsType<DnsResource>(0x002f, "NSEC");
 
     /**
      * DNS Key record RFC 4034 The key record used in DNSSEC. Uses the same
      * format as the KEY record.
      */
-    public static final DnsType DNSKEY = new DnsType(0x0030, "DNSKEY");
+    public static final DnsType<DnsResource> DNSKEY = new DnsType<DnsResource>(0x0030, "DNSKEY");
 
     /**
      * DHCP identifier record RFC 4701 Used in conjunction with the FQDN option
      * to DHCP.
      */
-    public static final DnsType DHCID = new DnsType(0x0031, "DHCID");
+    public static final DnsType<DnsResource> DHCID = new DnsType<DnsResource>(0x0031, "DHCID");
 
     /**
      * NSEC record version 3 RFC 5155 An extension to DNSSEC that allows proof
      * of nonexistence for a name without permitting zonewalking.
      */
-    public static final DnsType NSEC3 = new DnsType(0x0032, "NSEC3");
+    public static final DnsType<DnsResource> NSEC3 = new DnsType<DnsResource>(0x0032, "NSEC3");
 
     /**
      * NSEC3 parameters record RFC 5155 Parameter record for use with NSEC3.
      */
-    public static final DnsType NSEC3PARAM = new DnsType(0x0033, "NSEC3PARAM");
+    public static final DnsType<DnsResource> NSEC3PARAM = new DnsType<DnsResource>(0x0033, "NSEC3PARAM");
 
     /**
      * TLSA certificate association record RFC 6698 A record for DNS-based
@@ -225,34 +231,34 @@ public final class DnsType implements Comparable<DnsType> {
      * key with the domain name where the record is found, thus forming a 'TLSA
      * certificate association'.
      */
-    public static final DnsType TLSA = new DnsType(0x0034, "TLSA");
+    public static final DnsType<DnsResource> TLSA = new DnsType<DnsResource>(0x0034, "TLSA");
 
     /**
      * Host Identity Protocol record RFC 5205 Method of separating the end-point
      * identifier and locator roles of IP addresses.
      */
-    public static final DnsType HIP = new DnsType(0x0037, "HIP");
+    public static final DnsType<DnsResource> HIP = new DnsType<DnsResource>(0x0037, "HIP");
 
     /**
      * Sender Policy Framework record RFC 4408 Specified as part of the SPF
      * protocol as an alternative to of storing SPF data in TXT records. Uses
      * the same format as the earlier TXT record.
      */
-    public static final DnsType SPF = new DnsType(0x0063, "SPF");
+    public static final DnsType<DnsResource> SPF = new DnsType<DnsResource>(0x0063, "SPF");
 
     /**
      * Secret key record RFC 2930 A method of providing keying material to be
      * used with TSIG that is encrypted under the public key in an accompanying
      * KEY RR..
      */
-    public static final DnsType TKEY = new DnsType(0x00f9, "TKEY");
+    public static final DnsType<DnsResource> TKEY = new DnsType<DnsResource>(0x00f9, "TKEY");
 
     /**
      * Transaction Signature record RFC 2845 Can be used to authenticate dynamic
      * updates as coming from an approved client, or to authenticate responses
      * as coming from an approved recursive name server similar to DNSSEC.
      */
-    public static final DnsType TSIG = new DnsType(0x00fa, "TSIG");
+    public static final DnsType<DnsResource> TSIG = new DnsType<DnsResource>(0x00fa, "TSIG");
 
     /**
      * Incremental Zone Transfer record RFC 1996 Requests a zone transfer of the
@@ -261,13 +267,13 @@ public final class DnsType implements Comparable<DnsType> {
      * authoritative server is unable to fulfill the request due to
      * configuration or lack of required deltas.
      */
-    public static final DnsType IXFR = new DnsType(0x00fb, "IXFR");
+    public static final DnsType<DnsResource> IXFR = new DnsType<DnsResource>(0x00fb, "IXFR");
 
     /**
      * Authoritative Zone Transfer record RFC 1035 Transfer entire zone file
      * from the master name server to secondary name servers.
      */
-    public static final DnsType AXFR = new DnsType(0x00fc, "AXFR");
+    public static final DnsType<DnsResource> AXFR = new DnsType<DnsResource>(0x00fc, "AXFR");
 
     /**
      * All cached records RFC 1035 Returns all records of all types known to the
@@ -278,43 +284,43 @@ public final class DnsType implements Comparable<DnsType> {
      * returned. Sometimes referred to as ANY, for example in Windows nslookup
      * and Wireshark.
      */
-    public static final DnsType ANY = new DnsType(0x00ff, "ANY");
+    public static final DnsType<DnsResource> ANY = new DnsType<DnsResource>(0x00ff, "ANY");
 
     /**
      * Certification Authority Authorization record RFC 6844 CA pinning,
      * constraining acceptable CAs for a host/domain.
      */
-    public static final DnsType CAA = new DnsType(0x0101, "CAA");
+    public static final DnsType<DnsResource> CAA = new DnsType<DnsResource>(0x0101, "CAA");
 
     /**
      * DNSSEC Trust Authorities record N/A Part of a deployment proposal for
      * DNSSEC without a signed DNS root. See the IANA database and Weiler Spec
      * for details. Uses the same format as the DS record.
      */
-    public static final DnsType TA = new DnsType(0x8000, "TA");
+    public static final DnsType<DnsResource> TA = new DnsType<DnsResource>(0x8000, "TA");
 
     /**
      * DNSSEC Lookaside Validation record RFC 4431 For publishing DNSSEC trust
      * anchors outside of the DNS delegation chain. Uses the same format as the
      * DS record. RFC 5074 describes a way of using these records.
      */
-    public static final DnsType DLV = new DnsType(0x8001, "DLV");
+    public static final DnsType<DnsResource> DLV = new DnsType<DnsResource>(0x8001, "DLV");
 
-    private static final Map<String, DnsType> BY_NAME = new HashMap<String, DnsType>();
-    private static final IntObjectHashMap<DnsType> BY_TYPE = new IntObjectHashMap<DnsType>();
+    private static final Map<String, DnsType<?>> BY_NAME = new HashMap<String, DnsType<?>>();
+    private static final IntObjectHashMap<DnsType<?>> BY_TYPE = new IntObjectHashMap<DnsType<?>>();
     private static final String EXPECTED;
 
     static {
         DnsType[] all = {
-                A, NS, CNAME, SOA, PTR, MX, TXT, RP, AFSDB, SIG, KEY, AAAA, LOC, SRV, NAPTR, KX, CERT, DNAME, OPT, APL,
-                DS, SSHFP, IPSECKEY, RRSIG, NSEC, DNSKEY, DHCID, NSEC3, NSEC3PARAM, TLSA, HIP, SPF, TKEY, TSIG, IXFR,
-                AXFR, ANY, CAA, TA, DLV
+            A, NS, CNAME, SOA, PTR, MX, TXT, RP, AFSDB, SIG, KEY, AAAA, LOC, SRV, NAPTR, KX, CERT, DNAME, OPT, APL,
+            DS, SSHFP, IPSECKEY, RRSIG, NSEC, DNSKEY, DHCID, NSEC3, NSEC3PARAM, TLSA, HIP, SPF, TKEY, TSIG, IXFR,
+            AXFR, ANY, CAA, TA, DLV
         };
 
-        StringBuilder expected = new StringBuilder(512);
+        StringBuilder expected = new StringBuilder(410);
         expected.append(" (expected: ");
 
-        for (DnsType type: all) {
+        for (DnsType<?> type : all) {
             BY_NAME.put(type.name(), type);
             BY_TYPE.put(type.intValue(), type);
             expected.append(type.name());
@@ -328,7 +334,42 @@ public final class DnsType implements Comparable<DnsType> {
         EXPECTED = expected.toString();
     }
 
-    public static DnsType valueOf(int intValue) {
+    /**
+     * Decode the <i>payload</i> of a record of this type into a record of type
+     * &lt;RecordType&gt;. The resulting object will be of DnsClass IN.
+     *
+     * @param name The name for the resulting record
+     * @param timeToLive The time to live of the resulting record
+     * @param buf A buffer to read from
+     * @param length The length of the payload in the buffer
+     * @return An object of type &lt;RecordType&gt; such as an Ipv4AddressRecord
+     */
+    public RecordType decode(String name, long timeToLive, ByteBuf buf, int length)
+            throws DnsDecoderException {
+        return decode(name, DnsClass.IN, timeToLive, buf, length);
+    }
+
+    /**
+     * Decode the <i>payload</i> of a record of this type into a record of type
+     * &lt;RecordType&gt;.
+     *
+     * @param name The name for the resulting record
+     * @param clazz The DNS class
+     * @param timeToLive The time to live of the resulting record
+     * @param buf A buffer to read from
+     * @param length The length of the payload in the buffer
+     * @return An object of type &lt;RecordType&gt; such as an Ipv4AddressRecord
+     */
+    public RecordType decode(String name, DnsClass clazz, long timeToLive, ByteBuf buf,
+            int length) throws DnsDecoderException {
+        try {
+            return decoder.decode(name, this, clazz, timeToLive, buf, length);
+        } catch (IndexOutOfBoundsException ex) {
+            throw new DnsDecoderException(DnsResponseCode.FORMERROR, ex);
+        }
+    }
+
+    public static DnsType<?> valueOf(int intValue) {
         DnsType result = BY_TYPE.get(intValue);
         if (result == null) {
             return new DnsType(intValue, "UNKNOWN");
@@ -336,7 +377,7 @@ public final class DnsType implements Comparable<DnsType> {
         return result;
     }
 
-    public static DnsType valueOf(String name) {
+    public static DnsType<?> valueOf(String name) {
         DnsType result = BY_NAME.get(name);
         if (result == null) {
             throw new IllegalArgumentException("name: " + name + EXPECTED);
@@ -347,19 +388,29 @@ public final class DnsType implements Comparable<DnsType> {
     /**
      * Returns a new instance.
      */
-    public static DnsType valueOf(int intValue, String name) {
+    public static DnsType<?> valueOf(int intValue, String name) {
         return new DnsType(intValue, name);
     }
 
     private final int intValue;
     private final String name;
+    private final Decoder<RecordType> decoder;
 
+    @SuppressWarnings("unchecked")
     private DnsType(int intValue, String name) {
+        this(intValue, name, (Decoder<RecordType>) DnsResourceDecoder.INSTANCE);
+    }
+
+    private DnsType(int intValue, String name, Decoder<RecordType> decoder) {
         if ((intValue & 0xffff) != intValue) {
             throw new IllegalArgumentException("intValue: " + intValue + " (expected: 0 ~ 65535)");
         }
+        if (decoder == null) {
+            throw new NullPointerException("decoder");
+        }
         this.intValue = intValue;
         this.name = name;
+        this.decoder = decoder;
     }
 
     /**
@@ -394,5 +445,98 @@ public final class DnsType implements Comparable<DnsType> {
     @Override
     public String toString() {
         return name;
+    }
+
+    static long toUnsignedLong(int val) {
+        return 0x00000000FFFFFFFFL & (long) val;
+    }
+
+    interface Decoder<T extends DnsEntry> {
+
+        T decode(String name, DnsType<T> type, DnsClass clazz, long timeToLive, ByteBuf buf, int length)
+                throws DnsDecoderException;
+    }
+
+    private static final class DnsResourceDecoder implements Decoder<DnsResource> {
+
+        static final Decoder<DnsResource> INSTANCE = new DnsResourceDecoder();
+
+        @Override
+        public DnsResource decode(String name, DnsType<DnsResource> type, DnsClass clazz, long timeToLive,
+                ByteBuf buf, int length) {
+            int readerIndex = buf.readerIndex();
+            ByteBuf payload = buf.duplicate().setIndex(readerIndex, readerIndex + length).retain();
+            buf.readerIndex(readerIndex + length);
+            return new DnsResource(name, type, clazz, timeToLive, payload);
+        }
+    }
+
+    private static final class NsResourceDecoder implements Decoder<NameServerDnsRecord> {
+
+        @Override
+        public NameServerDnsRecord decode(String name, DnsType<NameServerDnsRecord> type, DnsClass clazz,
+                long timeToLive, ByteBuf buf, int length) {
+            String ns = readName(buf);
+            return new NameServerDnsRecord(name, type, clazz, ns, timeToLive);
+        }
+    }
+
+    private static final class CnameDecoder implements Decoder<CNameDnsRecord> {
+
+        @Override
+        public CNameDnsRecord decode(String name, DnsType<CNameDnsRecord> type, DnsClass clazz,
+                long timeToLive, ByteBuf buf, int length) {
+            String cname = DnsResponseDecoder.readName(buf);
+            return new CNameDnsRecord(name, type, clazz, timeToLive, cname);
+        }
+    }
+
+    private static final class Ipv4Decoder implements Decoder<Ipv4AddressRecord> {
+
+        @Override
+        public Ipv4AddressRecord decode(String name, DnsType<Ipv4AddressRecord> type, DnsClass clazz,
+                long timeToLive, ByteBuf buf, int length) {
+            int addr = buf.readInt();
+            return new Ipv4AddressRecord(name, type, clazz, timeToLive, addr);
+        }
+    }
+
+    private static final class SoaDecoder implements Decoder<StartOfAuthorityDnsRecord> {
+
+        @Override
+        public StartOfAuthorityDnsRecord decode(String name, DnsType<StartOfAuthorityDnsRecord> type,
+                DnsClass clazz, long timeToLive, ByteBuf buf, int length) {
+            String primaryNs = readName(buf);
+            String adminMailbox = readName(buf);
+            long serialNumber = toUnsignedLong(buf.readInt());
+            long refreshInterval = toUnsignedLong(buf.readInt());
+            long retryInterval = toUnsignedLong(buf.readInt());
+            long expirationLimit = toUnsignedLong(buf.readInt());
+            long minimumTtl = toUnsignedLong(buf.readInt());
+            return new StartOfAuthorityDnsRecord(name, type, clazz,
+                    primaryNs, adminMailbox, serialNumber, refreshInterval,
+                    retryInterval, expirationLimit, minimumTtl, timeToLive);
+        }
+    }
+
+    private static final class PtrDecoder implements Decoder<PointerDnsRecord> {
+
+        @Override
+        public PointerDnsRecord decode(String name, DnsType<PointerDnsRecord> type, DnsClass clazz,
+                long timeToLive, ByteBuf buf, int length) {
+            String ptr = readName(buf);
+            return new PointerDnsRecord(name, type, clazz, ptr, timeToLive);
+        }
+    }
+
+    private static final class MxDecoder implements Decoder<MailExchangerDnsRecord> {
+
+        @Override
+        public MailExchangerDnsRecord decode(String name, DnsType<MailExchangerDnsRecord> type,
+                DnsClass clazz, long timeToLive, ByteBuf buf, int length) {
+            int pref = buf.readShort();
+            String mx = readName(buf);
+            return new MailExchangerDnsRecord(name, type, clazz, timeToLive, pref, mx);
+        }
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/Ipv4AddressRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/Ipv4AddressRecord.java
@@ -21,7 +21,7 @@ import java.net.Inet4Address;
 import java.nio.charset.Charset;
 
 /**
- * Represents an A record for an ipv4 address
+ * Represents an A record for an ipv4 address.
  */
 public final class Ipv4AddressRecord extends DnsEntry {
 
@@ -129,7 +129,7 @@ public final class Ipv4AddressRecord extends DnsEntry {
     }
 
     static String addressToString(int addr) {
-        StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder(32);
         int[] ints = toInts(addr);
         for (int i = 0; i < ints.length; i++) {
             sb.append(ints[i]);
@@ -149,11 +149,11 @@ public final class Ipv4AddressRecord extends DnsEntry {
     }
 
     private static int parse(String ipv4address) {
-        String[] nums = ipv4address.split("\\.");
+        String[] nums = StringUtil.split(ipv4address, '.');
         if (nums.length != 4) {
             throw new IllegalArgumentException("Not an ipv4 address: " + ipv4address);
         }
-        int[] result = new int[nums.length];
+        int[] result = new int[4];
         for (int i = 0; i < nums.length; i++) {
             result[i] = Integer.parseInt(nums[i]);
         }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/Ipv4AddressRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/Ipv4AddressRecord.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.StringUtil;
+import java.net.Inet4Address;
+import java.nio.charset.Charset;
+
+/**
+ * Represents an A record for an ipv4 address
+ */
+public final class Ipv4AddressRecord extends DnsEntry {
+
+    private final int address;
+
+    public Ipv4AddressRecord(String name, DnsType type, DnsClass dnsClass, long timeToLive,
+            int[] addressParts) {
+        this(name, type, dnsClass, timeToLive, pack(addressParts));
+    }
+
+    public Ipv4AddressRecord(String name, long timeToLive, Inet4Address address) {
+        this(name, timeToLive, address.getHostAddress());
+    }
+
+    public Ipv4AddressRecord(String name, long timeToLive, String address) {
+        this(name, DnsType.A, timeToLive, address);
+    }
+
+    public Ipv4AddressRecord(String name, DnsType type, long timeToLive, Inet4Address address) {
+        this(name, type, DnsClass.IN, timeToLive, address.getHostAddress());
+    }
+
+    public Ipv4AddressRecord(String name, DnsType type, long timeToLive, String address) {
+        this(name, type, DnsClass.IN, timeToLive, address);
+    }
+
+    public Ipv4AddressRecord(String name, DnsType type, DnsClass dnsClass, long timeToLive, Inet4Address address) {
+        this(name, type, DnsClass.IN, timeToLive, address.getHostAddress());
+    }
+
+    public Ipv4AddressRecord(String name, DnsType type, DnsClass dnsClass, long timeToLive, String address) {
+        this(name, type, dnsClass, timeToLive, parse(address));
+    }
+
+    public Ipv4AddressRecord(String name, long timeToLive, int address) {
+        this(name, DnsType.A, timeToLive, address);
+    }
+
+    public Ipv4AddressRecord(String name, DnsType type, long timeToLive, int address) {
+        this(name, type, DnsClass.IN, timeToLive, address);
+    }
+
+    public Ipv4AddressRecord(String name, DnsType type, DnsClass dnsClass, long timeToLive, int address) {
+        super(name, type, dnsClass, timeToLive);
+        assert DnsType.A.equals(type);
+        this.address = address;
+    }
+
+    public int address() {
+        return address;
+    }
+
+    public String stringValue() {
+        return addressToString(address());
+    }
+
+    public int[] addressParts() {
+        return toInts(address());
+    }
+
+    @Override
+    protected void writePayload(NameWriter nameWriter, ByteBuf into, Charset charset) {
+        into.writeInt(address());
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = super.hashCode();
+        hash = 97 * hash + this.address;
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Ipv4AddressRecord other = (Ipv4AddressRecord) obj;
+        if (this.address != other.address) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(128).append(StringUtil.simpleClassName(this))
+                .append("(name: ").append(name())
+                .append(", type: ").append(type())
+                .append(", class: ").append(dnsClass())
+                .append(", ttl: ").append(timeToLive())
+                .append(", address: ").append(addressToString(address()))
+                .append(')').toString();
+    }
+
+    static String addressToString(int addr) {
+        StringBuilder sb = new StringBuilder();
+        int[] ints = toInts(addr);
+        for (int i = 0; i < ints.length; i++) {
+            sb.append(ints[i]);
+            if (i != ints.length - 1) {
+                sb.append('.');
+            }
+        }
+        return sb.toString();
+    }
+
+    private static int[] toInts(int val) {
+        int[] ret = new int[4];
+        for (int j = 3; j >= 0; --j) {
+            ret[j] |= (val >>> 8 * (3 - j)) & 0xff;
+        }
+        return ret;
+    }
+
+    private static int parse(String ipv4address) {
+        String[] nums = ipv4address.split("\\.");
+        if (nums.length != 4) {
+            throw new IllegalArgumentException("Not an ipv4 address: " + ipv4address);
+        }
+        int[] result = new int[nums.length];
+        for (int i = 0; i < nums.length; i++) {
+            result[i] = Integer.parseInt(nums[i]);
+        }
+        return pack(result);
+    }
+
+    private static int pack(int... bytes) {
+        int val = 0;
+        for (int i = 0; i < bytes.length; i++) {
+            val <<= 8;
+            val |= bytes[i] & 0xff;
+        }
+        return val;
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/Ipv4AddressRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/Ipv4AddressRecord.java
@@ -168,4 +168,9 @@ public final class Ipv4AddressRecord extends DnsEntry {
         }
         return val;
     }
+
+    @Override
+    public Ipv4AddressRecord withTimeToLive(long seconds) {
+        return new Ipv4AddressRecord(name(), type(), dnsClass(), seconds, address);
+    }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/Ipv4AddressRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/Ipv4AddressRecord.java
@@ -66,18 +66,26 @@ public final class Ipv4AddressRecord extends DnsEntry {
 
     public Ipv4AddressRecord(String name, DnsType type, DnsClass dnsClass, long timeToLive, int address) {
         super(name, type, dnsClass, timeToLive);
-        assert DnsType.A.equals(type);
         this.address = address;
     }
 
+    /**
+     * Get the IP address as an integer.
+     */
     public int address() {
         return address;
     }
 
+    /**
+     * Get a string representation of the address.
+     */
     public String stringValue() {
         return addressToString(address());
     }
 
+    /**
+     * Get the address as an array of integers.
+     */
     public int[] addressParts() {
         return toInts(address());
     }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/MailExchangerDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/MailExchangerDnsRecord.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.StringUtil;
+import java.nio.charset.Charset;
+
+/**
+ * Represents a mail exchanger record dns record.
+ */
+public final class MailExchangerDnsRecord extends DnsEntry {
+
+    private final int preference;
+    private final String mailExchanger;
+
+    public MailExchangerDnsRecord(String name, long ttl, int preference, String mailExchanger) {
+        this(name, DnsType.MX, ttl, preference, mailExchanger);
+    }
+
+    public MailExchangerDnsRecord(String name, DnsType type, long ttl,
+            int preference, String mailExchanger) {
+        this(name, type, DnsClass.IN, ttl, preference, mailExchanger);
+    }
+
+    public MailExchangerDnsRecord(String name, DnsType type, DnsClass dnsClass, long ttl,
+            int preference, String mailExchanger) {
+        super(name, type, dnsClass, ttl);
+        assert type == DnsType.MX;
+        this.preference = preference;
+        this.mailExchanger = mailExchanger;
+    }
+
+    /**
+     * The preference the mail server has among other MX records returned in a
+     * response.
+     *
+     * @return the preference value
+     */
+    public int preference() {
+        return preference;
+    }
+
+    /**
+     * The mail exchanger host this record refers to
+     *
+     * @return The mail exchange server name
+     */
+    public String mailExchanger() {
+        return mailExchanger;
+    }
+
+    public boolean equals(Object o) {
+        return super.equals(o) && o instanceof MailExchangerDnsRecord
+                && ((MailExchangerDnsRecord) o).preference == preference
+                && ((MailExchangerDnsRecord) o).mailExchanger.equals(mailExchanger);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = super.hashCode();
+        hash = 23 * hash + this.preference;
+        hash = 23 * hash + (this.mailExchanger != null ? this.mailExchanger.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(128).append(StringUtil.simpleClassName(this))
+                .append("(name: ").append(name())
+                .append(", type: ").append(type())
+                .append(", class: ").append(dnsClass())
+                .append(", ttl: ").append(timeToLive())
+                .append(", preference: ").append(preference())
+                .append(", mailExchanger: ").append(mailExchanger())
+                .append(')').toString();
+    }
+
+    @Override
+    protected void writePayload(NameWriter nameWriter, ByteBuf into, Charset charset) {
+        into.writeShort(preference);
+        nameWriter.writeName(mailExchanger, into, charset);
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/MailExchangerDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/MailExchangerDnsRecord.java
@@ -39,7 +39,9 @@ public final class MailExchangerDnsRecord extends DnsEntry {
     public MailExchangerDnsRecord(String name, DnsType type, DnsClass dnsClass, long ttl,
             int preference, String mailExchanger) {
         super(name, type, dnsClass, ttl);
-        assert type == DnsType.MX;
+        if (mailExchanger == null) {
+            throw new NullPointerException("mailExchanger");
+        }
         this.preference = preference;
         this.mailExchanger = mailExchanger;
     }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/MailExchangerDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/MailExchangerDnsRecord.java
@@ -96,4 +96,9 @@ public final class MailExchangerDnsRecord extends DnsEntry {
         into.writeShort(preference);
         nameWriter.writeName(mailExchanger, into, charset);
     }
+
+    @Override
+    public MailExchangerDnsRecord withTimeToLive(long seconds) {
+        return new MailExchangerDnsRecord(name(), type(), dnsClass(), seconds, preference, mailExchanger);
+    }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/MailExchangerDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/MailExchangerDnsRecord.java
@@ -57,7 +57,7 @@ public final class MailExchangerDnsRecord extends DnsEntry {
     }
 
     /**
-     * The mail exchanger host this record refers to
+     * The mail exchanger host this record refers to.
      *
      * @return The mail exchange server name
      */
@@ -65,6 +65,7 @@ public final class MailExchangerDnsRecord extends DnsEntry {
         return mailExchanger;
     }
 
+    @Override
     public boolean equals(Object o) {
         return super.equals(o) && o instanceof MailExchangerDnsRecord
                 && ((MailExchangerDnsRecord) o).preference == preference

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/NameServerDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/NameServerDnsRecord.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.StringUtil;
+import java.nio.charset.Charset;
+
+/**
+ * Represents an NS DNS record.
+ */
+public final class NameServerDnsRecord extends DnsEntry {
+
+    private final String nameserver;
+
+    public NameServerDnsRecord(String name, String nameserver, long ttl) {
+        this(name, DnsType.NS, nameserver, ttl);
+    }
+
+    public NameServerDnsRecord(String name, DnsType type, String nameserver, long ttl) {
+        this(name, type, DnsClass.IN, nameserver, ttl);
+    }
+
+    public NameServerDnsRecord(String name, DnsType type, DnsClass dnsClass, String nameserver, long ttl) {
+        super(name, type, dnsClass, ttl);
+        assert type == DnsType.NS;
+        this.nameserver = nameserver;
+    }
+
+    public String nameserver() {
+        return nameserver;
+    }
+
+    public boolean equals(Object o) {
+        return super.equals(o) && o instanceof MailExchangerDnsRecord
+                && ((NameServerDnsRecord) o).nameserver.equals(nameserver);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = super.hashCode();
+        hash = 23 * hash + (this.nameserver != null ? this.nameserver.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(128).append(StringUtil.simpleClassName(this))
+                .append("(name: ").append(name())
+                .append(", type: ").append(type())
+                .append(", class: ").append(dnsClass())
+                .append(", ttl: ").append(timeToLive())
+                .append(", nameserver: ").append(nameserver())
+                .append(')').toString();
+    }
+
+    @Override
+    protected void writePayload(NameWriter nameWriter, ByteBuf into, Charset charset) {
+        nameWriter.writeName(nameserver, into, charset);
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/NameServerDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/NameServerDnsRecord.java
@@ -36,7 +36,9 @@ public final class NameServerDnsRecord extends DnsEntry {
 
     public NameServerDnsRecord(String name, DnsType type, DnsClass dnsClass, String nameserver, long ttl) {
         super(name, type, dnsClass, ttl);
-        assert type == DnsType.NS;
+        if (nameserver == null) {
+            throw new NullPointerException("nameserver");
+        }
         this.nameserver = nameserver;
     }
 
@@ -44,6 +46,7 @@ public final class NameServerDnsRecord extends DnsEntry {
         return nameserver;
     }
 
+    @Override
     public boolean equals(Object o) {
         return super.equals(o) && o instanceof MailExchangerDnsRecord
                 && ((NameServerDnsRecord) o).nameserver.equals(nameserver);

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/NameServerDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/NameServerDnsRecord.java
@@ -74,4 +74,9 @@ public final class NameServerDnsRecord extends DnsEntry {
     protected void writePayload(NameWriter nameWriter, ByteBuf into, Charset charset) {
         nameWriter.writeName(nameserver, into, charset);
     }
+
+    @Override
+    public NameServerDnsRecord withTimeToLive(long seconds) {
+        return new NameServerDnsRecord(name(), type(), dnsClass(), nameserver, seconds);
+    }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/NameWriter.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/NameWriter.java
@@ -25,12 +25,12 @@ import java.nio.charset.Charset;
  * be written that support DNS name compression, where names that contain
  * identical portions are addressed by reference.
  * <p>
- * The default implementation held by NameWriter.DEFAULT simply writes names out
+ * The default implementation held by {@link NameWriter#DEFAULT} simply writes names out
  * in-full, in accordance with the RFC. It is also possible to implement this to
  * do name compression, per the spec. Such implementations are stateful and need
- * to be created per-request. Attach such an implementation to the Channel or
- * ChannelHandlerContext using NAME_WRITER_KEY and it will be retrieved by
- * DnsResponseEncoder and DnsQueryEncoder and used.
+ * to be created per-request. Attach such an implementation to the {@link Channel} or
+ * {@link ChannelHandlerContext} using {@link NameWriter#NAME_WRITER_KEY} and it will be retrieved by
+ * {@link DnsResponseEncoder} and {@link DnsQueryEncoder} and used.
  */
 public interface NameWriter {
 
@@ -49,6 +49,7 @@ public interface NameWriter {
      * @return this
      */
     NameWriter writeName(String name, ByteBuf into, Charset encoding);
+
     /**
      * The default implementation simply writes names with no compression.
      */

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/NameWriter.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/NameWriter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.AttributeKey;
+import io.netty.util.internal.StringUtil;
+import java.nio.charset.Charset;
+
+/**
+ * Writes names into buffers. This interface exists so that implementations can
+ * be written that support DNS name compression, where names that contain
+ * identical portions are addressed by reference.
+ * <p>
+ * The default implementation held by NameWriter.DEFAULT simply writes names out
+ * in-full, in accordance with the RFC. It is also possible to implement this to
+ * do name compression, per the spec. Such implementations are stateful and need
+ * to be created per-request. Attach such an implementation to the Channel or
+ * ChannelHandlerContext using NAME_WRITER_KEY and it will be retrieved by
+ * DnsResponseEncoder and DnsQueryEncoder and used.
+ */
+public interface NameWriter {
+
+    /**
+     * Attribute key to look up a NameWriter associated with a specific
+     * ChannelHandlerContext
+     */
+    AttributeKey<NameWriter> NAME_WRITER_KEY = AttributeKey.valueOf("nameWriter");
+
+    /**
+     * Write a name to the byte buffer in wire-format.
+     *
+     * @param name The name
+     * @param into The buffer
+     * @param encoding The encoding
+     * @return this
+     */
+    NameWriter writeName(String name, ByteBuf into, Charset encoding);
+    /**
+     * The default implementation simply writes names with no compression.
+     */
+    NameWriter DEFAULT = new NameWriter() {
+
+        @Override
+        public NameWriter writeName(String name, ByteBuf into, Charset encoding) {
+            if (name == null) {
+                throw new NullPointerException("name");
+            }
+            if (into == null) {
+                throw new NullPointerException("buf");
+            }
+            if (encoding == null) {
+                throw new NullPointerException("charset");
+            }
+            String[] parts = StringUtil.split(name, '.');
+            for (String part : parts) {
+                final int partLen = part.length();
+                if (partLen == 0) {
+                    continue;
+                }
+                into.writeByte(partLen);
+                into.writeBytes(part.getBytes(encoding));
+            }
+            into.writeByte(0);
+            return this;
+        }
+    };
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/PointerDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/PointerDnsRecord.java
@@ -77,4 +77,9 @@ public final class PointerDnsRecord extends DnsEntry {
     protected void writePayload(NameWriter nameWriter, ByteBuf into, Charset charset) {
         nameWriter.writeName(hostName, into, charset);
     }
+
+    @Override
+    public PointerDnsRecord withTimeToLive(long seconds) {
+        return new PointerDnsRecord(name(), type(), dnsClass(), hostName, seconds);
+    }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/PointerDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/PointerDnsRecord.java
@@ -36,14 +36,20 @@ public final class PointerDnsRecord extends DnsEntry {
 
     public PointerDnsRecord(String name, DnsType type, DnsClass dnsClass, String hostName, long timeToLive) {
         super(name, type, dnsClass, timeToLive);
-        assert type == DnsType.PTR;
+        if (hostName == null) {
+            throw new NullPointerException("hostName");
+        }
         this.hostName = hostName;
     }
 
+    /**
+     * The host name this PTR record references.
+     */
     public String hostName() {
         return hostName;
     }
 
+    @Override
     public boolean equals(Object o) {
         return super.equals(o) && o instanceof PointerDnsRecord
                 && ((PointerDnsRecord) o).hostName.equals(hostName);

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/PointerDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/PointerDnsRecord.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.StringUtil;
+import java.nio.charset.Charset;
+
+/**
+ * Represents a DNS PTR record.
+ */
+public final class PointerDnsRecord extends DnsEntry {
+
+    private String hostName;
+
+    public PointerDnsRecord(String name, String hostName, long timeToLive) {
+        this(name, DnsType.PTR, hostName, timeToLive);
+    }
+
+    public PointerDnsRecord(String name, DnsType type, String hostName, long timeToLive) {
+        this(name, type, DnsClass.IN, hostName, timeToLive);
+    }
+
+    public PointerDnsRecord(String name, DnsType type, DnsClass dnsClass, String hostName, long timeToLive) {
+        super(name, type, dnsClass, timeToLive);
+        assert type == DnsType.PTR;
+        this.hostName = hostName;
+    }
+
+    public String hostName() {
+        return hostName;
+    }
+
+    public boolean equals(Object o) {
+        return super.equals(o) && o instanceof PointerDnsRecord
+                && ((PointerDnsRecord) o).hostName.equals(hostName);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = super.hashCode();
+        hash = 23 * hash + (this.hostName != null ? this.hostName.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(128).append(StringUtil.simpleClassName(this))
+                .append("(name: ").append(name())
+                .append(", type: ").append(type())
+                .append(", class: ").append(dnsClass())
+                .append(", ttl: ").append(timeToLive())
+                .append(", hostName: ").append(hostName())
+                .append(')').toString();
+    }
+
+    @Override
+    protected void writePayload(NameWriter nameWriter, ByteBuf into, Charset charset) {
+        nameWriter.writeName(hostName, into, charset);
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/StartOfAuthorityDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/StartOfAuthorityDnsRecord.java
@@ -174,4 +174,10 @@ public final class StartOfAuthorityDnsRecord extends DnsEntry {
                 .append(", minimumTimeToLive: ").append(minimumTimeToLive())
                 .append(')').toString();
     }
+
+    @Override
+    public StartOfAuthorityDnsRecord withTimeToLive(long seconds) {
+        return new StartOfAuthorityDnsRecord(name(), type(), dnsClass(), primaryNs, adminMailbox,
+                serialNumber, refreshInterval, retryInterval, expirationLimit, minimumTimeToLive, seconds);
+    }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/StartOfAuthorityDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/StartOfAuthorityDnsRecord.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.StringUtil;
+import java.nio.charset.Charset;
+
+/**
+ * Represents a DNS start-of-authority record.
+ */
+public final class StartOfAuthorityDnsRecord extends DnsEntry {
+
+    private final String primaryNs;
+    private final String adminMailbox;
+    private final long serialNumber;
+    private final long refreshInterval;
+    private final long retryInterval;
+    private final long expirationLimit;
+    private final long minimumTimeToLive;
+
+    public StartOfAuthorityDnsRecord(String name, String primaryNs,
+            String adminMailbox, long serialNumber, long refreshInterval, long retryInterval,
+            long expirationLimit, long minimumTtl, long timeToLive) {
+        this(name, DnsType.SOA, DnsClass.IN, primaryNs, adminMailbox, serialNumber, refreshInterval,
+                retryInterval, expirationLimit, minimumTtl, timeToLive);
+    }
+
+    public StartOfAuthorityDnsRecord(String name, DnsType type, String primaryNs,
+            String adminMailbox, long serialNumber, long refreshInterval, long retryInterval,
+            long expirationLimit, long minimumTtl, long timeToLive) {
+        this(name, type, DnsClass.IN, primaryNs, adminMailbox, serialNumber, refreshInterval,
+                retryInterval, expirationLimit, minimumTtl, timeToLive);
+    }
+
+    public StartOfAuthorityDnsRecord(String name, DnsType type, DnsClass dnsClass, String primaryNs,
+            String adminMailbox, long serialNumber, long refreshInterval, long retryInterval,
+            long expirationLimit, long minimumTtl, long timeToLive) {
+        super(name, type, dnsClass, timeToLive);
+        if (primaryNs == null) {
+            throw new NullPointerException("primaryNs");
+        }
+        if (adminMailbox == null) {
+            throw new NullPointerException("adminMailbox");
+        }
+        this.primaryNs = primaryNs;
+        this.adminMailbox = adminMailbox;
+        this.serialNumber = serialNumber;
+        this.refreshInterval = refreshInterval;
+        this.retryInterval = retryInterval;
+        this.expirationLimit = expirationLimit;
+        this.minimumTimeToLive = minimumTtl;
+    }
+
+    /**
+     * @return the primaryNs
+     */
+    public String primaryNameserver() {
+        return primaryNs;
+    }
+
+    /**
+     * @return the adminMailbox
+     */
+    public String adminMailbox() {
+        return adminMailbox;
+    }
+
+    /**
+     * @return the serialNumber
+     */
+    public long serialNumber() {
+        return serialNumber;
+    }
+
+    /**
+     * @return the refreshInterval
+     */
+    public long refreshInterval() {
+        return refreshInterval;
+    }
+
+    /**
+     * @return the retryInterval
+     */
+    public long retryInterval() {
+        return retryInterval;
+    }
+
+    /**
+     * @return the expirationLimit
+     */
+    public long expirationLimit() {
+        return expirationLimit;
+    }
+
+    /**
+     * @return the minimumTtl
+     */
+    public long minimumTimeToLive() {
+        return minimumTimeToLive;
+    }
+
+    @Override
+    protected void writePayload(NameWriter nameWriter, ByteBuf into, Charset charset) {
+        nameWriter.writeName(primaryNs, into, charset);
+        nameWriter.writeName(adminMailbox, into, charset);
+        into.writeInt((int) serialNumber);
+        into.writeInt((int) refreshInterval);
+        into.writeInt((int) retryInterval);
+        into.writeInt((int) expirationLimit);
+        into.writeInt((int) minimumTimeToLive);
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = super.hashCode();
+        hash = 47 * hash + (this.primaryNs != null ? this.primaryNs.hashCode() : 0);
+        hash = 47 * hash + (this.adminMailbox != null ? this.adminMailbox.hashCode() : 0);
+        hash = 47 * hash + (int) (this.serialNumber ^ (this.serialNumber >>> 32));
+        hash = 47 * hash + (int) (this.refreshInterval ^ (this.refreshInterval >>> 32));
+        hash = 47 * hash + (int) (this.retryInterval ^ (this.retryInterval >>> 32));
+        hash = 47 * hash + (int) (this.expirationLimit ^ (this.expirationLimit >>> 32));
+        hash = 47 * hash + (int) (this.minimumTimeToLive ^ (this.minimumTimeToLive >>> 32));
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        } else if (obj == null) {
+            return false;
+        } else if (!(obj instanceof StartOfAuthorityDnsRecord)) {
+            return false;
+        } else if (!super.equals(obj)) {
+            return false;
+        }
+        StartOfAuthorityDnsRecord other = (StartOfAuthorityDnsRecord) obj;
+        if ((this.primaryNs == null) ? (other.primaryNs != null) : !this.primaryNs.equals(other.primaryNs)) {
+            return false;
+        }
+        return adminMailbox.equals(other.adminMailbox) && serialNumber == other.serialNumber
+                && refreshInterval == other.refreshInterval && retryInterval == other.retryInterval
+                && expirationLimit == other.expirationLimit && minimumTimeToLive == other.minimumTimeToLive;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(128).append(StringUtil.simpleClassName(this))
+                .append("(name: ").append(name())
+                .append(", type: ").append(type())
+                .append(", class: ").append(dnsClass())
+                .append(", ttl: ").append(timeToLive())
+                .append(", primaryNameserver: ").append(primaryNameserver())
+                .append(", adminMailbox: ").append(adminMailbox())
+                .append(", serialNumber: ").append(serialNumber())
+                .append(", refreshInterval: ").append(refreshInterval())
+                .append(", retryInterval: ").append(retryInterval())
+                .append(", expirationLimit: ").append(expirationLimit())
+                .append(", minimumTimeToLive: ").append(minimumTimeToLive())
+                .append(')').toString();
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/server/DnsAnswerProvider.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/server/DnsAnswerProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns.server;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.dns.DnsQuery;
+import io.netty.handler.codec.dns.DnsResponse;
+
+/**
+ * Answers questions in response to DNS requests.  Used with DnsServerHandler
+ * to produce answers.
+ */
+public interface DnsAnswerProvider {
+
+    /**
+     * Called when a DNS query has been received.
+     *
+     * @param query The DNS query
+     * @param ctx The channel context
+     * @param callback Callback to call with a DnsResponse
+     * @throws Exception if something goes wrong
+     */
+    void respond(DnsQuery query, ChannelHandlerContext ctx, DnsResponseSender callback) throws Exception;
+
+    public interface DnsResponseSender {
+
+        void withResponse(DnsResponse response) throws Exception;
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/server/DnsAnswerProvider.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/server/DnsAnswerProvider.java
@@ -20,8 +20,8 @@ import io.netty.handler.codec.dns.DnsQuery;
 import io.netty.handler.codec.dns.DnsResponse;
 
 /**
- * Answers questions in response to DNS requests.  Used with DnsServerHandler
- * to produce answers.
+ * Answers questions in response to DNS requests. Used with DnsServerHandler to
+ * produce answers.
  */
 public interface DnsAnswerProvider {
 
@@ -35,8 +35,29 @@ public interface DnsAnswerProvider {
      */
     void respond(DnsQuery query, ChannelHandlerContext ctx, DnsResponseSender callback) throws Exception;
 
+    /**
+     * Called when the {@link DnsServerHandler} encounters an exception.
+     *
+     * @param ctx The context
+     * @param cause The exception
+     */
+    void exceptionCaught(ChannelHandlerContext ctx, Throwable cause);
+
+    /**
+     * Callback interface which you call with the response to a DNS query after
+     * it has been asynchronously computed (which could involve contacting a
+     * delegate DNS server or other activity which a synchronous API would not
+     * allow for cleanly).
+     */
     public interface DnsResponseSender {
 
+        /**
+         * Pass the response here.
+         *
+         * @param response The response
+         * @throws Exception If something goes wrong or if the response is
+         * invalid
+         */
         void withResponse(DnsResponse response) throws Exception;
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/server/DnsServerHandler.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/server/DnsServerHandler.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns.server;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.handler.codec.dns.DnsDecoderException;
+import io.netty.handler.codec.dns.server.DnsAnswerProvider.DnsResponseSender;
+import io.netty.handler.codec.dns.DnsQuery;
+import io.netty.handler.codec.dns.DnsQueryDecoder;
+import io.netty.handler.codec.dns.DnsQuestion;
+import io.netty.handler.codec.dns.DnsResponse;
+import io.netty.handler.codec.dns.DnsResponseEncoder;
+
+/**
+ * Handles some of the plumbing of writing a DNS server. To use, simply
+ * implement DnsAnswerProvider and pass it to the constructor.
+ *
+ * <pre>
+ *        NioEventLoopGroup group = new NioEventLoopGroup(4); // 4 threads
+ *
+ *        Bootstrap b = new Bootstrap();
+ *        b.group(group)
+ *                .channel(NioDatagramChannel.class)
+ *                .option(ChannelOption.SO_BROADCAST, true)
+ *                .handler(new DnsServerHandler(new AnswerProviderImpl()));
+ *
+ *        Channel channel = b.bind(5753).sync().channel();
+ *        channel.closeFuture().await();
+ * </pre>
+ */
+@ChannelHandler.Sharable
+public class DnsServerHandler extends SimpleChannelInboundHandler<DatagramPacket> {
+
+    private final DnsAnswerProvider answerer;
+    private final DnsResponseEncoder encoder = new DnsResponseEncoder();
+    private final DnsQueryDecoder decoder = new DnsQueryDecoder();
+
+    public DnsServerHandler(DnsAnswerProvider answerer) {
+        super(DatagramPacket.class);
+        this.answerer = answerer;
+    }
+
+    @Override
+    public void messageReceived(final ChannelHandlerContext ctx, DatagramPacket packet) throws Exception {
+        DnsQuery query = decoder.decode(ctx, packet);
+        try {
+            answerer.respond(query, ctx, new Responder(ctx, this));
+        } catch (DnsDecoderException ex) {
+            DnsResponse resp = new DnsResponse(query.header().id(), query.recipient());
+            resp.header().setResponseCode(ex.code())
+                    .setZ(query.header().z())
+                    .setOpcode(query.header().opcode());
+            for (DnsQuestion question : query) {
+                resp.addQuestion(question);
+            }
+        }
+    }
+
+    private static class Responder implements DnsResponseSender {
+
+        private final ChannelHandlerContext ctx;
+        private final DnsServerHandler handler;
+
+        public Responder(ChannelHandlerContext ctx, DnsServerHandler handler) {
+            this.ctx = ctx;
+            this.handler = handler;
+        }
+
+        @Override
+        public void withResponse(DnsResponse response) throws Exception {
+            try {
+                ctx.writeAndFlush(handler.encoder.encode(ctx, response));
+            } catch (Exception e) {
+                handler.exceptionCaught(ctx, e);
+            }
+        }
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.flush();
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        cause.printStackTrace();
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/server/DnsServerHandler.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/server/DnsServerHandler.java
@@ -53,6 +53,9 @@ public class DnsServerHandler extends SimpleChannelInboundHandler<DatagramPacket
 
     public DnsServerHandler(DnsAnswerProvider answerer) {
         super(DatagramPacket.class);
+        if (answerer == null) {
+            throw new NullPointerException("answerer");
+        }
         this.answerer = answerer;
     }
 
@@ -99,6 +102,6 @@ public class DnsServerHandler extends SimpleChannelInboundHandler<DatagramPacket
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        cause.printStackTrace();
+        answerer.exceptionCaught(ctx, cause);
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/server/package-info.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/server/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Minimalist support for writing DNS servers, with a ChannelHandler for
+ * receiving and decoding DNS queries, and a small API for answering those
+ * queries and handling sending the reponse.
+ */
+package io.netty.handler.codec.dns.server;

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsResponseTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsResponseTest.java
@@ -98,7 +98,7 @@ public class DnsResponseTest {
     public void readMalormedResponseTest() throws Exception {
         EmbeddedChannel embedder = new EmbeddedChannel(new DnsResponseDecoder());
         ByteBuf packet = embedder.alloc().buffer(512).writeBytes(malformedLoopPacket);
-        exception.expect(CorruptedFrameException.class);
+        exception.expect(DnsDecoderException.class);
         embedder.writeInbound(new DatagramPacket(packet, null, new InetSocketAddress(0)));
     }
 }

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/Ipv4AddressRecordTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/Ipv4AddressRecordTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.CharsetUtil;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class Ipv4AddressRecordTest {
+
+    @Test
+    public void test() {
+        Ipv4AddressRecord rec = new Ipv4AddressRecord("foo.com", DnsType.A, DnsClass.IN, 300, "192.168.2.1");
+        int val = rec.address();
+        assertEquals("192.168.2.1", rec.stringValue());
+        Ipv4AddressRecord rec2 = new Ipv4AddressRecord("foo.com", DnsType.A, DnsClass.IN, 300, val);
+        assertEquals(rec, rec2);
+        assertEquals("192.168.2.1", rec.stringValue());
+        Ipv4AddressRecord rec3 = new Ipv4AddressRecord("foo.com", DnsType.A, DnsClass.IN, 500, val);
+        assertNotEquals(rec, rec3);
+        assertEquals("192.168.2.1", rec.stringValue());
+        Ipv4AddressRecord rec4 = new Ipv4AddressRecord("bar.com", DnsType.A, DnsClass.IN, 300, val);
+        assertNotEquals(rec, rec4);
+        assertEquals("192.168.2.1", rec.stringValue());
+
+        ByteBufAllocator alloc = ByteBufAllocator.DEFAULT;
+        ByteBuf buf = alloc.buffer();
+
+        rec.writePayload(NameWriter.DEFAULT, buf, CharsetUtil.UTF_8);
+
+        Ipv4AddressRecord decoded = DnsType.A.decode("foo.com", DnsClass.IN, 300, buf, buf.readableBytes());
+        assertEquals(rec, decoded);
+
+        CNameDnsRecord cname = new CNameDnsRecord("foo.com", DnsType.CNAME, DnsClass.IN, 300, "bar.com");
+        buf = alloc.buffer();
+        cname.writePayload(NameWriter.DEFAULT, buf, CharsetUtil.UTF_8);
+        CNameDnsRecord cnameDecoded = DnsType.CNAME.decode("foo.com", DnsClass.IN, 300, buf, buf.readableBytes());
+        assertEquals(cname, cnameDecoded);
+
+        MailExchangerDnsRecord mx = new MailExchangerDnsRecord("foo.com", DnsType.MX, DnsClass.IN, 300, 5, "bar.com");
+        buf = alloc.buffer();
+        mx.writePayload(NameWriter.DEFAULT, buf, CharsetUtil.UTF_8);
+        MailExchangerDnsRecord mxDecoded = DnsType.MX.decode("foo.com", DnsClass.IN, 300, buf, buf.readableBytes());
+        assertEquals(mx, mxDecoded);
+
+        StartOfAuthorityDnsRecord soa = new StartOfAuthorityDnsRecord("foo.com", DnsType.SOA, DnsClass.IN,
+                "ns.com", "bo@ns.com", 1L, 2L, 3L, 4L, 5L, 6L);
+        buf = alloc.buffer();
+        soa.writePayload(NameWriter.DEFAULT, buf, CharsetUtil.UTF_8);
+        StartOfAuthorityDnsRecord soaDecoded = DnsType.SOA.decode("foo.com", DnsClass.IN, 6L, buf, buf.readableBytes());
+        assertEquals(soa, soaDecoded);
+
+        PointerDnsRecord ptr = new PointerDnsRecord("foo.com", DnsType.PTR, DnsClass.IN, "bar.com", 300);
+        buf = alloc.buffer();
+        ptr.writePayload(NameWriter.DEFAULT, buf, CharsetUtil.UTF_8);
+        PointerDnsRecord ptrDecoded = DnsType.PTR.decode("foo.com", DnsClass.IN, 300, buf, buf.readableBytes());
+        assertEquals(ptr, ptrDecoded);
+    }
+}

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -75,6 +75,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-dns</artifactId>
+      <version>${project.version}</version>
+    </dependency>    
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>

--- a/example/src/main/java/io/netty/example/dns/client/DnsClient.java
+++ b/example/src/main/java/io/netty/example/dns/client/DnsClient.java
@@ -17,7 +17,6 @@ package io.netty.example.dns.client;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DatagramPacket;
@@ -30,8 +29,6 @@ import io.netty.handler.codec.dns.DnsResponse;
 import io.netty.handler.codec.dns.DnsType;
 import java.net.InetSocketAddress;
 import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
@@ -51,7 +48,7 @@ public class DnsClient {
     // Map of Callbacks for IDs.  Note that in a production server you would
     // want to track when a callback was submitted, and discard callbacks
     // that have been waiting for an answer for too long - this will leak
-    // if the remote server does not respond at all
+    // if the remote server does not respond at all.
     private final ConcurrentMap<Integer, Callback> callbacks = new ConcurrentHashMap<Integer, Callback>();
     private final AtomicInteger ids = new AtomicInteger();
     private final Channel channel;
@@ -81,7 +78,7 @@ public class DnsClient {
     private int nextId() {
         // Note that sequentially incrementing IDs are not a good idea
         // in production, since guessable IDs can aid in DNS cache poisoning
-        // attacks
+        // attacks.
         return ids.getAndIncrement();
     }
 

--- a/example/src/main/java/io/netty/example/dns/client/DnsClient.java
+++ b/example/src/main/java/io/netty/example/dns/client/DnsClient.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.dns.client;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.handler.codec.dns.DnsClass;
+import io.netty.handler.codec.dns.DnsQuery;
+import io.netty.handler.codec.dns.DnsQueryEncoder;
+import io.netty.handler.codec.dns.DnsQuestion;
+import io.netty.handler.codec.dns.DnsResponse;
+import io.netty.handler.codec.dns.DnsType;
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A simple DNS client. Note that this is for <i>demonstration</i> purposes - in
+ * particular in a production implementation you would want to deal with
+ * failures where the remote server never responds at all, fail over across
+ * multiple servers; and sequentially incrementing IDs are a bad idea.
+ * <p>
+ * Caching is left as an exercise for the reader.
+ */
+public class DnsClient {
+
+    // Map of Callbacks for IDs.  Note that in a production server you would
+    // want to track when a callback was submitted, and discard callbacks
+    // that have been waiting for an answer for too long - this will leak
+    // if the remote server does not respond at all
+    private final ConcurrentMap<Integer, Callback> callbacks = new ConcurrentHashMap<Integer, Callback>();
+    private final AtomicInteger ids = new AtomicInteger();
+    private final Channel channel;
+    private final DnsQueryEncoder enc = new DnsQueryEncoder();
+    private final String remoteServer;
+    private final int remotePort;
+
+    public DnsClient(EventLoopGroup group) throws InterruptedException {
+        this(group, "8.8.8.8"); // Google Public DNS
+    }
+
+    public DnsClient(EventLoopGroup group, String remoteDnsServer) throws InterruptedException {
+        this(group, remoteDnsServer, 53);
+    }
+
+    public DnsClient(EventLoopGroup group, String remoteDnsServer, int port) throws InterruptedException {
+        remoteServer = remoteDnsServer;
+        remotePort = port;
+        Bootstrap b = new Bootstrap();
+        b.group(group)
+                .channel(NioDatagramChannel.class)
+                .handler(new DnsClientInboundHandler(callbacks));
+
+        channel = b.bind(0).sync().channel();
+    }
+
+    private int nextId() {
+        // Note that sequentially incrementing IDs are not a good idea
+        // in production, since guessable IDs can aid in DNS cache poisoning
+        // attacks
+        return ids.getAndIncrement();
+    }
+
+    public int query(String queryString, Callback callback) throws Exception {
+        DnsQuestion q = new DnsQuestion(queryString, DnsType.A, DnsClass.IN);
+        DnsQuery query = new DnsQuery(nextId(), new InetSocketAddress(remoteServer, remotePort));
+        query.addQuestion(q);
+        return query(query, callback);
+    }
+
+    public int query(Collection<DnsQuestion> questions, Callback callback) throws Exception {
+        DnsQuery query = new DnsQuery(nextId(), new InetSocketAddress(remoteServer, remotePort));
+        for (DnsQuestion q : questions) {
+            query.addQuestion(q);
+        }
+        return query(query, callback);
+    }
+
+    private int query(final DnsQuery query, final Callback callback) throws Exception {
+        DatagramPacket pkt = enc.encode(channel.pipeline().firstContext(), query);
+        callbacks.put(query.header().id(), callback);
+        channel.writeAndFlush(pkt);
+        return query.header().id();
+    }
+
+    public abstract static class Callback {
+
+        public abstract void onResponseReceived(DnsResponse response) throws Exception;
+    }
+
+    public static void main(String[] ignored) throws InterruptedException, Exception {
+        DnsClient client = new DnsClient(new NioEventLoopGroup());
+        final CountDownLatch latch = new CountDownLatch(1);
+        client.query("timboudreau.com", new Callback() {
+
+            @Override
+            public void onResponseReceived(DnsResponse response) throws Exception {
+                latch.countDown();
+            }
+        });
+        latch.await(1, TimeUnit.MINUTES);
+    }
+}

--- a/example/src/main/java/io/netty/example/dns/client/DnsClientInboundHandler.java
+++ b/example/src/main/java/io/netty/example/dns/client/DnsClientInboundHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.dns.client;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.socket.DatagramPacket;
+import io.netty.handler.codec.dns.DnsResponse;
+import io.netty.handler.codec.dns.DnsResponseDecoder;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Handles responses from remote DNS servers, looks up the Callback that
+ * requested a response and invokes it..
+ */
+public class DnsClientInboundHandler extends SimpleChannelInboundHandler<DatagramPacket> {
+
+    private final ConcurrentMap<Integer, DnsClient.Callback> callbacks;
+    private final DnsResponseDecoder drd = new DnsResponseDecoder();
+
+    DnsClientInboundHandler(ConcurrentMap<Integer, DnsClient.Callback> callbacks) {
+        this.callbacks = callbacks;
+    }
+
+    @Override
+    public void messageReceived(ChannelHandlerContext ctx, DatagramPacket msg) throws Exception {
+        DnsResponse resp = drd.decode(ctx, msg);
+        int id = resp.header().id();
+        DnsClient.Callback callback = callbacks.get(id);
+        if (callback != null) {
+            try {
+                callback.onResponseReceived(resp);
+            } catch (Exception e) {
+                exceptionCaught(ctx, e);
+            } finally {
+                callbacks.remove(id);
+            }
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        cause.printStackTrace();
+        ctx.close();
+    }
+}

--- a/example/src/main/java/io/netty/example/dns/server/DnsServer.java
+++ b/example/src/main/java/io/netty/example/dns/server/DnsServer.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.dns.server;
+
+import io.netty.handler.codec.dns.server.DnsServerHandler;
+import io.netty.handler.codec.dns.server.DnsAnswerProvider;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.handler.codec.dns.CNameDnsRecord;
+import io.netty.handler.codec.dns.DnsQuery;
+import io.netty.handler.codec.dns.DnsQuestion;
+import io.netty.handler.codec.dns.DnsResponse;
+import io.netty.handler.codec.dns.DnsResponseCode;
+import io.netty.handler.codec.dns.Ipv4AddressRecord;
+import io.netty.handler.codec.dns.NameServerDnsRecord;
+import java.net.InetSocketAddress;
+
+/**
+ * A demo DNS server that can answer one query, for git.timboudreau.com
+ */
+public class DnsServer {
+
+    public static void main(String[] ignored) throws InterruptedException {
+
+        NioEventLoopGroup group = new NioEventLoopGroup(4); // 4 threads
+
+        Bootstrap b = new Bootstrap();
+        b.group(group)
+                .channel(NioDatagramChannel.class)
+//                .option(ChannelOption.SO_BROADCAST, true)
+                .handler(new DnsServerHandler(new AnswerProviderImpl()));
+
+        Channel channel = b.bind(5753).sync().channel();
+        System.out.println("Started demo DNS server");
+        channel.closeFuture().await();
+    }
+
+    private static class AnswerProviderImpl implements DnsAnswerProvider {
+
+        @Override
+        public void respond(DnsQuery query, ChannelHandlerContext ctx,
+                DnsResponseSender callback) throws Exception {
+            // Find the destination we need to reply to
+            InetSocketAddress remoteAddress = query.recipient();
+            // Create a new response
+            DnsResponse resp = new DnsResponse(query.header().id(), remoteAddress);
+            // Set the headers
+            resp.header().setResponseCode(DnsResponseCode.NOERROR)
+                    .setOpcode(query.header().opcode())
+                    .setRecursionAvailable(false)
+                    .setRecursionDesired(query.header().isRecursionDesired())
+                    .setZ(query.header().z());
+            // Iterate all the questions
+            boolean found = false;
+            for (DnsQuestion q : query) {
+                // The one question we can answer
+                if ("git.timboudreau.com".equals(q.name())) {
+                    found = true;
+                    resp.addQuestion(q);
+                    resp.addAnswer(new CNameDnsRecord("git.timboudreau.com", 300, "timboudreau.com"));
+                    resp.addAnswer(new Ipv4AddressRecord("timboudreau.com", 300, "75.69.118.1"));
+                    resp.addAuthorityResource(new NameServerDnsRecord("timboudreau.com", "ns4145.dns.dyn.com", 8185));
+                    resp.addAdditionalResource(new Ipv4AddressRecord("ns4145.dns.dyn.com", 93492, "208.76.61.145"));
+                    resp.header().setAuthoritativeAnswer(true);
+                }
+            }
+            if (!found) {
+                resp.header().setResponseCode(DnsResponseCode.NOTZONE);
+                resp.addQuestions(query);
+                resp.header().setAuthoritativeAnswer(false);
+            }
+            callback.withResponse(resp);
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/dns/server/ProxyDnsServer.java
+++ b/example/src/main/java/io/netty/example/dns/server/ProxyDnsServer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.dns.server;
+
+import io.netty.handler.codec.dns.server.DnsServerHandler;
+import io.netty.handler.codec.dns.server.DnsAnswerProvider;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.example.dns.client.DnsClient;
+import io.netty.handler.codec.dns.DnsQuery;
+import io.netty.handler.codec.dns.DnsResponse;
+import io.netty.handler.codec.dns.DnsResponseCode;
+import java.net.InetSocketAddress;
+
+/**
+ * A demo proxy DNS server that simply delegates to Google Public DNS. To be
+ * useful in practice, one would want to implement caching.
+ */
+public class ProxyDnsServer {
+
+    public static void main(String[] ignored) throws InterruptedException {
+
+        NioEventLoopGroup group = new NioEventLoopGroup(8); // 4 threads
+
+        Bootstrap b = new Bootstrap();
+        b.group(group)
+                .channel(NioDatagramChannel.class)
+                .handler(new DnsServerHandler(new AnswerProviderImpl(group)));
+
+        Channel channel = b.bind(5753).sync().channel();
+        System.out.println("Started demo proxy DNS server");
+        channel.closeFuture().await();
+    }
+
+    private static class AnswerProviderImpl implements DnsAnswerProvider {
+
+        private final DnsClient client;
+
+        AnswerProviderImpl(EventLoopGroup group) throws InterruptedException {
+            client = new DnsClient(group);
+        }
+
+        @Override
+        public void respond(final DnsQuery query, ChannelHandlerContext ctx,
+                final DnsResponseSender responseSender) throws Exception {
+            client.query(query.questions(), new DnsClient.Callback() {
+                @Override
+                public void onResponseReceived(DnsResponse theirResponse) throws Exception {
+                    final DnsResponse ourResponse = new DnsResponse(query.header().id(), query.recipient());
+                    theirResponse.copyInto(ourResponse);
+                    responseSender.withResponse(ourResponse);
+                }
+            });
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/dns/server/ProxyDnsServer.java
+++ b/example/src/main/java/io/netty/example/dns/server/ProxyDnsServer.java
@@ -20,15 +20,12 @@ import io.netty.handler.codec.dns.server.DnsAnswerProvider;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.example.dns.client.DnsClient;
 import io.netty.handler.codec.dns.DnsQuery;
 import io.netty.handler.codec.dns.DnsResponse;
-import io.netty.handler.codec.dns.DnsResponseCode;
-import java.net.InetSocketAddress;
 
 /**
  * A demo proxy DNS server that simply delegates to Google Public DNS. To be
@@ -38,7 +35,7 @@ public class ProxyDnsServer {
 
     public static void main(String[] ignored) throws InterruptedException {
 
-        NioEventLoopGroup group = new NioEventLoopGroup(8); // 4 threads
+        NioEventLoopGroup group = new NioEventLoopGroup(8); // 8 threads
 
         Bootstrap b = new Bootstrap();
         b.group(group)
@@ -48,6 +45,7 @@ public class ProxyDnsServer {
         Channel channel = b.bind(5753).sync().channel();
         System.out.println("Started demo proxy DNS server");
         channel.closeFuture().await();
+        group.shutdownGracefully();
     }
 
     private static class AnswerProviderImpl implements DnsAnswerProvider {
@@ -69,6 +67,11 @@ public class ProxyDnsServer {
                     responseSender.withResponse(ourResponse);
                 }
             });
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            cause.printStackTrace();
         }
     }
 }


### PR DESCRIPTION
Support for writing DNS servers, and various API changes to accomplish that, specifically:

 - `DnsType` -> `DnsType<RecordType>` where RecordType is a subclass of `DnsEntry`, and has payload decoders for specific types
 - Introduced record-specific subclasses of `DnsEntry` for common types, with fallback to the ByteBuf-based `DnsResource`
 - `DnsEntry` gains public `writeTo()` and `writePayload()` to write itself correctly into a ByteBuf
 - Added `DnsQueryDecoder` and `DnsResponseEncoder`
 - Introduced `NameWriter` for writing names, so that it's possible to implement a stateful `NameWriter` to do DNS name compression
 - `DnsMessage` is threadsafe (needed for proxy DNS servers where multiple calls to remote DNS servers may contribute partial responses)
    - If someone really feels strongly that creating the `List` instances it uses internally should be lazy, that could be done, but it would be good to have some evidence that really accomplishes something - feels like premature optimization
 - `DnsQuestion` is no longer a subclass of `DnsEntry` (which now has a time-to-live, since that is common to all other record types).
 - Added the package io.netty.handler.codec.dns.server with `DnsServerHandler`, a `SimpleChannelInboundHandler<DatagramPacket>` that handles the common plumbing of writing a DNS server that is unlikely to differ between implementations
 - Corrected error codes in `DnsResponseCode` to match https://tools.ietf.org/html/rfc2929 (they were sequential, but in fact 11-15 are unused and numbering restarts at 16)
 - Added error codes that exist but were not included in `DnsResponseCode` but are part of the spec
 - Added `DnsDecoderException` which can specify a `DnsResponseCode`
 - `DnsQuery` implements `Iterable<DnsQuestion>`, simply because it's intuitive
 - Reasonable `toString()` implementations on entity classes for logging purposes
 - Added to netty-examples:  DNS server, DNS client, proxy DNS server
