### PR TITLE
Fixing HTTP/2 processed byte accounting during exception

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFlowState.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFlowState.java
@@ -33,4 +33,9 @@ public interface Http2InboundFlowState extends Http2FlowState {
      * @param numBytes the number of bytes to be returned to the flow control window.
      */
     void returnProcessedBytes(ChannelHandlerContext ctx, int numBytes) throws Http2Exception;
+
+    /**
+     * The number of bytes that are outstanding and have not yet been returned to the flow controller.
+     */
+    int unProcessedBytes();
 }


### PR DESCRIPTION
Motivation:
Currently when an exception occurs during a listener.onDataRead
callback, we return all bytes as processed. However, the listener may
choose to return bytes via the InboundFlowState object rather than
returning the integer. If the listener returns a few bytes and then
throws, we will attempt to return too many bytes.

Modifications:
Added InboundFlowState.unProcessedBytes() to indicate how many
unprocessed bytes are outstanding.

Updated DefaultHttp2ConnectionDecoder to compare the unprocessed bytes
before and after the listener.onDataRead callback when an exception was
encountered.  If there is a difference, it is subtracted off the total
processed bytes to be returned to the flow controller.

Result:
HTTP/2 data frame delivery properly accounts for processed bytes through
an exception.
