### PR TITLE
HTTP/2 Rename HTTP to HTTP2 object write converter

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
@@ -22,25 +22,25 @@ import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.HttpHeaders;
 
 /**
- * Translates HTTP/1.x object writes into HTTP/2 frames
+ * Translates HTTP/1.x object writes into HTTP/2 frames.
  * <p>
- * See {@link InboundHttp2ToHttpAdapter} to get translation from HTTP/2 frames to HTTP/1.x objects
+ * See {@link InboundHttp2ToHttpAdapter} to get translation from HTTP/2 frames to HTTP/1.x objects.
  */
-public class Http2ToHttpConnectionHandler extends Http2ConnectionHandler {
-    public Http2ToHttpConnectionHandler(boolean server, Http2FrameListener listener) {
+public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
+    public HttpToHttp2ConnectionHandler(boolean server, Http2FrameListener listener) {
         super(server, listener);
     }
 
-    public Http2ToHttpConnectionHandler(Http2Connection connection, Http2FrameListener listener) {
+    public HttpToHttp2ConnectionHandler(Http2Connection connection, Http2FrameListener listener) {
         super(connection, listener);
     }
 
-    public Http2ToHttpConnectionHandler(Http2Connection connection, Http2FrameReader frameReader,
+    public HttpToHttp2ConnectionHandler(Http2Connection connection, Http2FrameReader frameReader,
             Http2FrameWriter frameWriter, Http2FrameListener listener) {
         super(connection, frameReader, frameWriter, listener);
     }
 
-    public Http2ToHttpConnectionHandler(Http2Connection connection, Http2FrameReader frameReader,
+    public HttpToHttp2ConnectionHandler(Http2Connection connection, Http2FrameReader frameReader,
             Http2FrameWriter frameWriter, Http2InboundFlowController inboundFlow,
             Http2OutboundFlowController outboundFlow, Http2FrameListener listener) {
         super(connection, frameReader, frameWriter, inboundFlow, outboundFlow, listener);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -24,12 +24,13 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderUtil;
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
-
 import static io.netty.util.internal.ObjectUtil.*;
 
 /**
  * This adapter provides just header/data events from the HTTP message flow defined
- * here <a href="http://tools.ietf.org/html/draft-ietf-httpbis-http2-14#section-8.1.">HTTP/2 Spec Message Flow</a>
+ * here <a href="http://tools.ietf.org/html/draft-ietf-httpbis-http2-14#section-8.1.">HTTP/2 Spec Message Flow</a>.
+ * <p>
+ * See {@link HttpToHttp2ConnectionHandler} to get translation from HTTP/1.x objects to HTTP/2 frames for writes.
  */
 public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
     private static final ImmediateSendDetector DEFAULT_SEND_DETECTOR = new ImmediateSendDetector() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -58,9 +58,9 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 /**
- * Testing the {@link Http2ToHttpConnectionHandler} for {@link FullHttpRequest} objects into HTTP/2 frames
+ * Testing the {@link HttpToHttp2ConnectionHandler} for {@link FullHttpRequest} objects into HTTP/2 frames
  */
-public class DefaultHttp2ToHttpConnectionHandlerTest {
+public class HttpToHttp2ConnectionHandlerTest {
 
     @Mock
     private Http2FrameListener clientListener;
@@ -185,7 +185,7 @@ public class DefaultHttp2ToHttpConnectionHandlerTest {
             protected void initChannel(Channel ch) throws Exception {
                 ChannelPipeline p = ch.pipeline();
                 serverFrameCountDown = new FrameCountDown(serverListener, requestLatch);
-                p.addLast(new Http2ToHttpConnectionHandler(true, serverFrameCountDown));
+                p.addLast(new HttpToHttp2ConnectionHandler(true, serverFrameCountDown));
                 p.addLast(ignoreSettingsHandler());
             }
         });
@@ -196,7 +196,7 @@ public class DefaultHttp2ToHttpConnectionHandlerTest {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 ChannelPipeline p = ch.pipeline();
-                p.addLast(new Http2ToHttpConnectionHandler(false, clientListener));
+                p.addLast(new HttpToHttp2ConnectionHandler(false, clientListener));
                 p.addLast(ignoreSettingsHandler());
             }
         });

--- a/example/src/main/java/io/netty/example/http2/client/Http2ClientInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/client/Http2ClientInitializer.java
@@ -38,7 +38,7 @@ import io.netty.handler.codec.http2.Http2FrameReader;
 import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2InboundFrameLogger;
 import io.netty.handler.codec.http2.Http2OutboundFrameLogger;
-import io.netty.handler.codec.http2.Http2ToHttpConnectionHandler;
+import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler;
 import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapter;
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -52,7 +52,7 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
 
     private final SslContext sslCtx;
     private final int maxContentLength;
-    private Http2ToHttpConnectionHandler connectionHandler;
+    private HttpToHttp2ConnectionHandler connectionHandler;
     private HttpResponseHandler responseHandler;
     private Http2SettingsHandler settingsHandler;
 
@@ -65,7 +65,7 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
     public void initChannel(SocketChannel ch) throws Exception {
         final Http2Connection connection = new DefaultHttp2Connection(false);
         final Http2FrameWriter frameWriter = frameWriter();
-        connectionHandler = new Http2ToHttpConnectionHandler(connection,
+        connectionHandler = new HttpToHttp2ConnectionHandler(connection,
                 frameReader(),
                 frameWriter,
                 new DefaultHttp2InboundFlowController(connection, frameWriter),


### PR DESCRIPTION
Motivation:
The current name of the class which converts from HTTP objects to HTTP/2 frames contains the text Http2ToHttp. This is misleading and opposite of what is being done.

Modifications:
Rename this class name to be HttpToHttp2.

Result:
Class names that more clearly identify what they do.
