### PR TITLE
HTTP/2 inbound flow controller always throws connection error

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2InboundFlowController.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http2;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.CONNECTION_STREAM_ID;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
+import static io.netty.handler.codec.http2.Http2Error.FLOW_CONTROL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.flowControlError;
 import static io.netty.handler.codec.http2.Http2Exception.protocolError;
@@ -265,9 +266,10 @@ public class DefaultHttp2InboundFlowController implements Http2InboundFlowContro
             // and is cleared once we send a WINDOW_UPDATE frame.
             if (delta < 0 && window < lowerBound) {
                 if (streamId == CONNECTION_STREAM_ID) {
-                    throw protocolError("Connection flow control window exceeded");
+                    throw flowControlError("Connection flow control window exceeded");
                 } else {
-                    throw flowControlError("Flow control window exceeded for stream: %d", streamId);
+                    throw Http2StreamException.format(streamId, FLOW_CONTROL_ERROR,
+                            "Flow control window exceeded for stream: %d", streamId);
                 }
             }
 


### PR DESCRIPTION
Motivation:
When the inbound flow controller recognizes that the flow control window
has been violated on a stream (not connection-wide), it throws a
connection error.

Modifications:
Changed the DefaultHttp2InboundFlowController to properly throw
connection error if the connection window is violated and stream error
if a stream window is violated.

Result:
inbound flow control throws the correct error for window violations.
