### PR TITLE
HTTP/2 Initial Settings Statics

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -58,8 +58,17 @@ public final class Http2CodecUtil {
     public static final int SETTINGS_MAX_FRAME_SIZE = 5;
     public static final int SETTINGS_MAX_HEADER_LIST_SIZE = 6;
 
+    public static final long MAX_HEADER_TABLE_SIZE = MAX_UNSIGNED_INT;
+    public static final long MAX_CONCURRENT_STREAMS = MAX_UNSIGNED_INT;
+    public static final int MAX_INITIAL_WINDOW_SIZE = Integer.MAX_VALUE;
     public static final int MAX_FRAME_SIZE_LOWER_BOUND = 0x4000;
     public static final int MAX_FRAME_SIZE_UPPER_BOUND = 0xFFFFFF;
+    public static final long MAX_HEADER_LIST_SIZE = Long.MAX_VALUE;
+
+    public static final long MIN_HEADER_TABLE_SIZE = 0;
+    public static final long MIN_CONCURRENT_STREAMS = 0;
+    public static final long MIN_INITIAL_WINDOW_SIZE = 0;
+    public static final long MIN_HEADER_LIST_SIZE = 0;
 
     public static final int DEFAULT_WINDOW_SIZE = 65535;
     public static final boolean DEFAULT_ENABLE_PUSH = true;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
@@ -15,7 +15,14 @@
 
 package io.netty.handler.codec.http2;
 
-import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_UNSIGNED_INT;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_CONCURRENT_STREAMS;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_HEADER_TABLE_SIZE;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_INITIAL_WINDOW_SIZE;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_HEADER_LIST_SIZE;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_HEADER_TABLE_SIZE;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_CONCURRENT_STREAMS;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_INITIAL_WINDOW_SIZE;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_HEADER_LIST_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_ENABLE_PUSH;
 import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_HEADER_TABLE_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.SETTINGS_INITIAL_WINDOW_SIZE;
@@ -181,7 +188,7 @@ public final class Http2Settings extends IntObjectHashMap<Long> {
         checkNotNull(value, "value");
         switch (key) {
             case SETTINGS_HEADER_TABLE_SIZE:
-                if (value < 0L || value > MAX_UNSIGNED_INT) {
+                if (value < MIN_HEADER_TABLE_SIZE || value > MAX_HEADER_TABLE_SIZE) {
                     throw new IllegalArgumentException("Setting HEADER_TABLE_SIZE is invalid: "
                             + value);
                 }
@@ -192,13 +199,13 @@ public final class Http2Settings extends IntObjectHashMap<Long> {
                 }
                 break;
             case SETTINGS_MAX_CONCURRENT_STREAMS:
-                if (value < 0L || value > MAX_UNSIGNED_INT) {
+                if (value < MIN_CONCURRENT_STREAMS || value > MAX_CONCURRENT_STREAMS) {
                     throw new IllegalArgumentException(
                             "Setting MAX_CONCURRENT_STREAMS is invalid: " + value);
                 }
                 break;
             case SETTINGS_INITIAL_WINDOW_SIZE:
-                if (value < 0L || value > Integer.MAX_VALUE) {
+                if (value < MIN_INITIAL_WINDOW_SIZE || value > MAX_INITIAL_WINDOW_SIZE) {
                     throw new IllegalArgumentException("Setting INITIAL_WINDOW_SIZE is invalid: "
                             + value);
                 }
@@ -210,7 +217,7 @@ public final class Http2Settings extends IntObjectHashMap<Long> {
                 }
                 break;
             case SETTINGS_MAX_HEADER_LIST_SIZE:
-                if (value < 0) {
+                if (value < MIN_HEADER_LIST_SIZE || value > MAX_HEADER_LIST_SIZE) {
                     throw new IllegalArgumentException("Setting MAX_HEADER_LIST_SIZE is invalid: "
                             + value);
                 }


### PR DESCRIPTION
Motivation:
The HTTP/2 codec currently does not expose the boundaries of the initial settings. This could be useful for applications to define their own initial settings.

Modifications:
Add new static final variables to Http2CodecUtil and make Http2Settings use these in the bounds checks.

Result:
Applications can use the max (or min) variables to initialize their settings.
