### PR TITLE
HTTP/2 Decompress buffer leak

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -341,7 +341,6 @@ public class DataCompressionHttp2Test {
                 int processedBytes = buf.readableBytes() + padding;
 
                 buf.readBytes(serverOut, buf.readableBytes());
-                buf.release();
                 return processedBytes;
             }
         }).when(serverListener).onDataRead(any(ChannelHandlerContext.class), anyInt(),


### PR DESCRIPTION
Motivation:
The interface for HTTP/2 onDataRead states that buffers will be released by the codec.  The decompressor and compressor methods are not releasing buffers created during the decompression/compression process.

Modifications:
After onDataRead calls the decompressor and compressor classes will release the data buffer.

Result:
HTTP/2 compressor/decompressors are consistent with onDataRead interface assumptions.
