### PR TITLE
HTTP/2 Compressor buffer leak

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -111,8 +111,8 @@ public class CompressorHttp2ConnectionEncoder extends DefaultHttp2ConnectionEnco
         }
 
         try {
-            // call retain here as it will call release after its written to the channel
-            channel.writeOutbound(data.retain());
+            // The channel will release the buffer after being written
+            channel.writeOutbound(data);
             ByteBuf buf = nextReadableBuf(channel);
             if (buf == null) {
                 if (endOfStream) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -150,7 +150,7 @@ public class DataCompressionHttp2Test {
                 @Override
                 public void run() {
                     clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data, 0, true, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
                     ctxClient().flush();
                 }
             });
@@ -179,7 +179,7 @@ public class DataCompressionHttp2Test {
                 @Override
                 public void run() {
                     clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data, 0, true, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
                     ctxClient().flush();
                 }
             });
@@ -210,8 +210,8 @@ public class DataCompressionHttp2Test {
                 @Override
                 public void run() {
                     clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data1, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data2, 0, true, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data1.retain(), 0, false, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data2.retain(), 0, true, newPromiseClient());
                     ctxClient().flush();
                 }
             });
@@ -258,7 +258,7 @@ public class DataCompressionHttp2Test {
                 public void run() {
                     clientEncoder.writeSettings(ctxClient(), settings, newPromiseClient());
                     clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data, 0, true, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
                     ctxClient().flush();
                 }
             });
@@ -302,7 +302,7 @@ public class DataCompressionHttp2Test {
                 public void run() {
                     clientEncoder.writeSettings(ctxClient(), settings, newPromiseClient());
                     clientEncoder.writeHeaders(ctxClient(), 3, headers, 0, false, newPromiseClient());
-                    clientEncoder.writeData(ctxClient(), 3, data, 0, true, newPromiseClient());
+                    clientEncoder.writeData(ctxClient(), 3, data.retain(), 0, true, newPromiseClient());
                     ctxClient().flush();
                 }
             });


### PR DESCRIPTION
Motivation:
The HTTP/2 compressor does not release the input buffer when compression is done. This results in buffer leaks.

Modifications:
- Release the buffer in the HTTP/2 compressor
- Update tests to reflect the correct state

Result:
1 less buffer leak.
