### PR TITLE
HTTP Client Upgrade Handler Compare Issue

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
@@ -182,7 +182,7 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator {
                 throw new IllegalStateException(
                         "Switching Protocols response missing UPGRADE header");
             }
-            if (AsciiString.equalsIgnoreCase(upgradeCodec.protocol(), upgradeHeader)) {
+            if (!AsciiString.equalsIgnoreCase(upgradeCodec.protocol(), upgradeHeader)) {
                 throw new IllegalStateException(
                         "Switching Protocols response with unexpected UPGRADE protocol: "
                                 + upgradeHeader);


### PR DESCRIPTION
Motivation:
The HttpClientUpgradeHandler attempts to compare a supported codec against the input codec but the comparison logic is reversed.

Modification:
Negate the logic in HttpClientUpgradeHandler so an error is detected in the error condition.

Result:
HttpClientUpgradeHandler should not fail the upgrade when the input protocol is valid.
