### PR TITLE
Use Triple DES in JdkSslContext cipher suite list.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -123,7 +123,7 @@ public abstract class JdkSslContext extends SslContext {
                 "TLS_RSA_WITH_AES_128_CBC_SHA",
                 // AES256 requires JCE unlimited strength jurisdiction policy files.
                 "TLS_RSA_WITH_AES_256_CBC_SHA",
-                "SSL_RSA_WITH_DES_CBC_SHA",
+                "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
                 "SSL_RSA_WITH_RC4_128_SHA");
 
         if (!ciphers.isEmpty()) {


### PR DESCRIPTION
JdkSslContext used SSL_RSA_WITH_DES_CBC_SHA in its cipher suite list - meaning it was out of sync with OpenSslServerContext (which uses DES-CBC3-SHA in the same place) and used DES, which is weak. This pull request replaces it with SSL_RSA_WITH_3DES_EDE_CBC_SHA to keep the lists in sync and uses Triple DES, which is stronger than DES.

I've tested this PR with openssl s_client and it fixes the problem. (`openssl s_client -tls1 -cipher DES -connect localhost:8992` fails and `openssl s_client -tls1 -cipher DES3 -connect localhost:8992` succeeds. When JdkSslContext was used, the reverse was true before the fix.)
