### PR TITLE
replaced broken &lt with &lt; and same for gt

### DIFF
--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -62,7 +62,7 @@ import java.util.concurrent.TimeUnit;
  * // for 30 seconds.  The connection is closed when there is no inbound traffic
  * // for 60 seconds.
  *
- * public class MyChannelInitializer extends {@link ChannelInitializer}&lt{@link Channel}&gt {
+ * public class MyChannelInitializer extends {@link ChannelInitializer}&lt;{@link Channel}&gt; {
  *     {@code @Override}
  *     public void initChannel({@link Channel} channel) {
  *         channel.pipeline().addLast("idleStateHandler", new {@link IdleStateHandler}(60, 30, 0));

--- a/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutHandler.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
  * // The connection is closed when there is no inbound traffic
  * // for 30 seconds.
  *
- * public class MyChannelInitializer extends {@link ChannelInitializer}&lt{@link Channel}&gt {
+ * public class MyChannelInitializer extends {@link ChannelInitializer}&lt;{@link Channel}&gt; {
  *     public void initChannel({@link Channel} channel) {
  *         channel.pipeline().addLast("readTimeoutHandler", new {@link ReadTimeoutHandler}(30);
  *         channel.pipeline().addLast("myHandler", new MyHandler());

--- a/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutHandler.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
  * // The connection is closed when there is no outbound traffic
  * // for 30 seconds.
  *
- * public class MyChannelInitializer extends {@link ChannelInitializer}&lt{@link Channel}&gt {
+ * public class MyChannelInitializer extends {@link ChannelInitializer}&lt;{@link Channel}&gt; {
  *     public void initChannel({@link Channel} channel) {
  *         channel.pipeline().addLast("writeTimeoutHandler", new {@link WriteTimeoutHandler}(30);
  *         channel.pipeline().addLast("myHandler", new MyHandler());

--- a/transport/src/main/java/io/netty/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandler.java
@@ -82,7 +82,7 @@ import java.net.SocketAddress;
  * <pre>
  * // Create a new handler instance per channel.
  * // See {@link ChannelInitializer#initChannel(Channel)}.
- * public class DataServerInitializer extends {@link ChannelInitializer}&lt{@link Channel}&gt {
+ * public class DataServerInitializer extends {@link ChannelInitializer}&lt;{@link Channel}&gt; {
  *     {@code @Override}
  *     public void initChannel({@link Channel} channel) {
  *         channel.pipeline().addLast("handler", <b>new DataServerHandler()</b>);
@@ -104,12 +104,12 @@ import java.net.SocketAddress;
  *
  * {@code @Sharable}
  * public class DataServerHandler extends {@link SimpleChannelInboundHandler}&lt;Message&gt; {
- *     private final {@link AttributeKey}&lt{@link Boolean}&gt auth =
+ *     private final {@link AttributeKey}&lt;{@link Boolean}&gt; auth =
  *           {@link AttributeKey#valueOf(String) AttributeKey.valueOf("auth")};
  *
  *     {@code @Override}
  *     protected void messageReceived({@link ChannelHandlerContext} ctx, Message message) {
- *         {@link Attribute}&lt{@link Boolean}&gt attr = ctx.attr(auth);
+ *         {@link Attribute}&lt;{@link Boolean}&gt; attr = ctx.attr(auth);
  *         {@link Channel} ch = ctx.channel();
  *
  *         if (message instanceof LoginMessage) {
@@ -129,7 +129,7 @@ import java.net.SocketAddress;
  * Now that the state of the handler is attached to the {@link ChannelHandlerContext}, you can add the
  * same handler instance to different pipelines:
  * <pre>
- * public class DataServerInitializer extends {@link ChannelInitializer}&lt{@link Channel}&gt {
+ * public class DataServerInitializer extends {@link ChannelInitializer}&lt;{@link Channel}&gt; {
  *
  *     private static final DataServerHandler <b>SHARED</b> = new DataServerHandler();
  *

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
@@ -88,13 +88,13 @@ import java.nio.channels.Channels;
  * <pre>
  * public class FactorialHandler extends {@link ChannelHandlerAdapter} {
  *
- *   private final {@link AttributeKey}&lt{@link Integer}&gt counter = {@link AttributeKey}.valueOf("counter");
+ *   private final {@link AttributeKey}&lt;{@link Integer}&gt; counter = {@link AttributeKey}.valueOf("counter");
  *
  *   // This handler will receive a sequence of increasing integers starting
  *   // from 1.
  *   {@code @Override}
  *   public void channelRead({@link ChannelHandlerContext} ctx, Object msg) {
- *     {@link Attribute}&lt{@link Integer}&gt attr = ctx.getAttr(counter);
+ *     {@link Attribute}&lt;{@link Integer}&gt; attr = ctx.getAttr(counter);
  *     Integer a = ctx.getAttr(counter).get();
  *
  *     if (a == null) {


### PR DESCRIPTION
trivial fix on escaped html entities in javadoc
