### PR TITLE
documented decoder pitfalls

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -50,9 +50,8 @@ import java.util.List;
  * <p>
  * If a custom frame decoder is required, then one needs to be careful when implementing
  * one with {@link ByteToMessageDecoder}. Ensure there are enough bytes in the buffer for a
- * complete frame by checking {@link ByteBuf#readableBytes()}. While checking for complete
- * frame, one <strong>MUST NOT</strong> modify the reader index, otherwise the buffer will be
- * partially consumed without decoding an entire frame.
+ * complete frame by checking {@link ByteBuf#readableBytes()}. If there are not enough bytes
+ * for a complete frame, return without modify the reader index to allow more bytes to arrive.
  * <p>
  * To check for complete frames without modify the reader index, use methods like {@link ByteBuf#getInt(int)}.
  * One <strong>MUST</strong> use the reader index when using methods like {@link ByteBuf#getInt(int)}.


### PR DESCRIPTION
to avoid mistakes found in https://github.com/netty/netty/issues/3184
