### PR TITLE
Add @SafeVarargs to PromiseAggregator#add and PromiseNotifier#(...)

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/PromiseAggregator.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseAggregator.java
@@ -58,6 +58,7 @@ public class PromiseAggregator<V, F extends Future<V>> implements GenericFutureL
     /**
      * Add the given {@link Promise}s to the aggregator.
      */
+    @SafeVarargs
     public final PromiseAggregator<V, F> add(Promise<V>... promises) {
         if (promises == null) {
             throw new NullPointerException("promises");

--- a/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseNotifier.java
@@ -31,6 +31,7 @@ public class PromiseNotifier<V, F extends Future<V>> implements GenericFutureLis
      *
      * @param promises  the {@link Promise}s to notify once this {@link GenericFutureListener} is notified.
      */
+    @SafeVarargs
     public PromiseNotifier(Promise<? super V>... promises) {
         if (promises == null) {
             throw new NullPointerException("promises");


### PR DESCRIPTION
https://github.com/netty/netty/issues/3147

Motivation:

8fbc513 introduced stray warnings in callsites of
PromiseAggregator#add and PromiseNotifier#(...).

Modifications:

This commit adds the @SafeVarargs annotation to PromiseAggregator#add
and PromiseNotifier#(...). As Netty is built with JDK7, this is a
recognized annotation and should not affect runtime VM versions 1.5 and
1.6.

Result:

Building Netty with JDK7 will no longer produce warnings in the
callsites mentioned above.
