### PR TITLE
Lazily check for root, avoids unnecessary errors & resources

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -60,7 +60,7 @@ public final class PlatformDependent {
 
     private static final boolean IS_ANDROID = isAndroid0();
     private static final boolean IS_WINDOWS = isWindows0();
-    private static final boolean IS_ROOT = isRoot0();
+    private static volatile Boolean IS_ROOT = null;
 
     private static final int JAVA_VERSION = javaVersion0();
 
@@ -114,6 +114,13 @@ public final class PlatformDependent {
      * {@code false} if on Windows.
      */
     public static boolean isRoot() {
+    	if (IS_ROOT == null) {
+            synchronized (PlatformDependent.class) {
+                if (IS_ROOT == null) {
+                    IS_ROOT = isRoot0();
+                }
+            }
+        }
         return IS_ROOT;
     }
 


### PR DESCRIPTION
Motivation:

io.netty.util.internal.PlatformDependent.isRoot() depends on the IS_ROOT field which is filled in during class initialization. This spawns processes and consumes resources, which are not generally necessary to the complete functioning of that class.

Modifications:

This switches the class to use lazy initialization this field inside of the isRoot() method using double-checked locking (http://en.wikipedia.org/wiki/Double-checked_locking).

Result:

The first call to isRoot() will be slightly slower, at a tradeoff that class loading is faster, uses fewer resources and platform errors are avoided unless necessary.
