### PR TITLE
example: memcache: fix set

### DIFF
--- a/example/src/main/java/io/netty/example/memcache/binary/MemcacheClientHandler.java
+++ b/example/src/main/java/io/netty/example/memcache/binary/MemcacheClientHandler.java
@@ -54,6 +54,7 @@ public class MemcacheClientHandler extends ChannelHandlerAdapter {
 
             ByteBuf content = Unpooled.wrappedBuffer(value.getBytes(CharsetUtil.UTF_8));
             ByteBuf extras = ctx.alloc().buffer(8);
+            extras.writeZero(8);
 
             BinaryMemcacheRequest req = new DefaultFullBinaryMemcacheRequest(key, extras, content);
             req.setOpcode(BinaryMemcacheOpcodes.SET);


### PR DESCRIPTION
Motivation:

The example MemcacheClient set command doesn't work.

Modifications:

Fill the extras field buffer with zeros so that it gets written to the
request payload.

Result:

The example MemcacheClient set command works.
