### PR TITLE
Fix a bug where Recycler's capacity can increase beyond its maximum

### DIFF
--- a/common/src/test/java/io/netty/util/RecyclerTest.java
+++ b/common/src/test/java/io/netty/util/RecyclerTest.java
@@ -15,10 +15,13 @@
 */
 package io.netty.util;
 
-import java.util.Random;
-
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Random;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 public class RecyclerTest {
 
@@ -95,6 +98,75 @@ public class RecyclerTest {
         }
 
         Assert.assertEquals(maxCapacity, recycler.threadLocalCapacity());
+    }
+
+    @Test
+    public void testRecycleAtDifferentThread() throws Exception {
+        final Recycler<HandledObject> recycler = new Recycler<HandledObject>(256) {
+            @Override
+            protected HandledObject newObject(
+                    Recycler.Handle<HandledObject> handle) {
+                return new HandledObject(handle);
+            }
+        };
+
+        final HandledObject o = recycler.get();
+        final Thread thread = new Thread() {
+            @Override
+            public void run() {
+                recycler.recycle(o, o.handle);
+            }
+        };
+        thread.start();
+        thread.join();
+
+        assertThat(recycler.get(), is(sameInstance(o)));
+    }
+
+    @Test
+    public void testMaxCapacityWithRecycleAtDifferentThread() throws Exception {
+        final int maxCapacity = 4; // Choose the number smaller than WeakOrderQueue.LINK_CAPACITY
+        final Recycler<HandledObject> recycler = new Recycler<HandledObject>(maxCapacity) {
+            @Override
+            protected HandledObject newObject(
+                    Recycler.Handle<HandledObject> handle) {
+                return new HandledObject(handle);
+            }
+        };
+
+        // Borrow 2 * maxCapacity objects.
+        // Return the half from the same thread.
+        // Return the other half from the different thread.
+
+        final HandledObject[] array = new HandledObject[maxCapacity * 3];
+        for (int i = 0; i < array.length; i ++) {
+            array[i] = recycler.get();
+        }
+
+        for (int i = 0; i < maxCapacity; i ++) {
+            recycler.recycle(array[i], array[i].handle);
+        }
+
+        final Thread thread = new Thread() {
+            @Override
+            public void run() {
+                for (int i = maxCapacity; i < array.length; i ++) {
+                    recycler.recycle(array[i], array[i].handle);
+                }
+            }
+        };
+        thread.start();
+        thread.join();
+
+        assertThat(recycler.threadLocalCapacity(), is(maxCapacity));
+        assertThat(recycler.threadLocalSize(), is(maxCapacity));
+
+        for (int i = 0; i < array.length; i ++) {
+            recycler.get();
+        }
+
+        assertThat(recycler.threadLocalCapacity(), is(maxCapacity));
+        assertThat(recycler.threadLocalSize(), is(0));
     }
 
     static final class HandledObject {


### PR DESCRIPTION
/cc @ylgrgyq and @belliottsmith

Related: #3166

Motivation:

When the recyclable object created at one thread is returned at the other thread, it is stored in a WeakOrderedQueue.

The objects stored in the WeakOrderedQueue is added back to the stack by WeakOrderedQueue.transfer() when the owner thread ran out of recyclable objects.

However, WeakOrderedQueue.transfer() does not have any mechanism that prevents the stack from growing beyond its maximum capacity.

Modifications:
- Make WeakOrderedQueue.transfer() increase the capacity of the stack only up to its maximum
- Add tests for the cases where the recyclable object is returned at the non-owner thread
- Fix a bug where Stack.scavengeSome() does not scavenge the objects when it's the first time it ran out of objects and thus its cursor is null.
- Overall clean-up of scavengeSome() and transfer()

Result:

The capacity of Stack never increases beyond its maximum.
