### PR TITLE
Fix AbstractDiskHttpData int conversion from long

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -331,11 +331,11 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
             FileOutputStream outputStream = new FileOutputStream(dest);
             FileChannel in = inputStream.getChannel();
             FileChannel out = outputStream.getChannel();
-            int chunkSize = 8196;
+            long chunkSize = 8196;
             long position = 0;
             while (position < size) {
                 if (chunkSize < size - position) {
-                    chunkSize = (int) (size - position);
+                    chunkSize = size - position;
                 }
                 position += in.transferTo(position, chunkSize , out);
             }


### PR DESCRIPTION
Motivations:
The chunkSize might be oversized after comparison (size being > of int
capacity) if file size is bigger than an integer.

Modifications:
Removing the test and changing of chunkSize value, letting it be
standard at 8K.

Result:
There is no need to change the chunksize as it has not to be less or
equal to the number of bytes available.
There is no more int oversized.

Same fix for 4.1 and Master
