### PR TITLE
HTTP/2 Unit Test race condition

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -32,7 +32,6 @@ public final class Http2CodecUtil {
 
     private static final byte[] CONNECTION_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(UTF_8);
     private static final byte[] EMPTY_PING = new byte[8];
-    private static final IgnoreSettingsHandler IGNORE_SETTINGS_HANDLER = new IgnoreSettingsHandler();
 
     public static final int CONNECTION_STREAM_ID = 0;
     public static final int HTTP_UPGRADE_STREAM_ID = 1;
@@ -130,15 +129,6 @@ public final class Http2CodecUtil {
     }
 
     /**
-     * Creates a new {@link ChannelHandler} that does nothing but ignore inbound settings frames.
-     * This is a useful utility to avoid verbose logging output for pipelines that don't handle
-     * settings frames directly.
-     */
-    public static ChannelHandler ignoreSettingsHandler() {
-        return IGNORE_SETTINGS_HANDLER;
-    }
-
-    /**
      * Iteratively looks through the causaility chain for the given exception and returns the first
      * {@link Http2Exception} or {@code null} if none.
      */
@@ -214,21 +204,6 @@ public final class Http2CodecUtil {
             promise.setFailure(cause);
         }
         throw cause;
-    }
-
-    /**
-     * A{@link ChannelHandler} that does nothing but ignore inbound settings frames. This is a
-     * useful utility to avoid verbose logging output for pipelines that don't handle settings
-     * frames directly.
-     */
-    @ChannelHandler.Sharable
-    private static class IgnoreSettingsHandler extends ChannelHandlerAdapter {
-        @Override
-        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-            if (!(msg instanceof Http2Settings)) {
-                super.channelRead(ctx, msg);
-            }
-        }
     }
 
     private Http2CodecUtil() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -363,7 +363,6 @@ public class Http2FrameRoundtripTest {
                 ChannelPipeline p = ch.pipeline();
                 serverAdapter = new Http2TestUtil.FrameAdapter(serverListener, requestLatch);
                 p.addLast("reader", serverAdapter);
-                p.addLast(Http2CodecUtil.ignoreSettingsHandler());
             }
         });
 
@@ -374,7 +373,6 @@ public class Http2FrameRoundtripTest {
             protected void initChannel(Channel ch) throws Exception {
                 ChannelPipeline p = ch.pipeline();
                 p.addLast("reader", new Http2TestUtil.FrameAdapter(null, null));
-                p.addLast(Http2CodecUtil.ignoreSettingsHandler());
             }
         });
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -262,21 +262,19 @@ final class Http2TestUtil {
     static class FrameCountDown implements Http2FrameListener {
         private final Http2FrameListener listener;
         private final CountDownLatch messageLatch;
+        private final CountDownLatch settingsAckLatch;
         private final CountDownLatch dataLatch;
         private final CountDownLatch trailersLatch;
 
-        FrameCountDown(Http2FrameListener listener, CountDownLatch messageLatch) {
-            this(listener, messageLatch, null);
+        FrameCountDown(Http2FrameListener listener, CountDownLatch settingsAckLatch, CountDownLatch messageLatch) {
+            this(listener, settingsAckLatch, messageLatch, null, null);
         }
 
-        FrameCountDown(Http2FrameListener listener, CountDownLatch messageLatch, CountDownLatch dataLatch) {
-            this(listener, messageLatch, dataLatch, null);
-        }
-
-        FrameCountDown(Http2FrameListener listener, CountDownLatch messageLatch,
+        FrameCountDown(Http2FrameListener listener, CountDownLatch settingsAckLatch, CountDownLatch messageLatch,
                 CountDownLatch dataLatch, CountDownLatch trailersLatch) {
             this.listener = listener;
             this.messageLatch = messageLatch;
+            this.settingsAckLatch = settingsAckLatch;
             this.dataLatch = dataLatch;
             this.trailersLatch = trailersLatch;
         }
@@ -331,7 +329,7 @@ final class Http2TestUtil {
         @Override
         public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
             listener.onSettingsAckRead(ctx);
-            messageLatch.countDown();
+            settingsAckLatch.countDown();
         }
 
         @Override


### PR DESCRIPTION
Motivation:
The Http2ConnectionRoundtripTest.noMoreStreamIdsShouldSendGoAway unit test had a race condition where it would sometimes receive a SETINGS_ACK message that was not anticipated. This caused the test to fail because of bad test code.

Modifications:
The bad unit test should be updated to handle the message exchange for a good connection setup, and then the GO_AWAY frame.

Result:
Http2ConnectionRoundtripTest.noMoreStreamIdsShouldSendGoAway should no longer sporadically fail.
