### PR TITLE
HTTP/2 Draft 16

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -33,7 +33,7 @@ public class DefaultHttp2Headers extends DefaultBinaryHeaders implements Http2He
      * <p>
      *
      * <strong>Note</strong> that setting {@code forceKeyToLower} to {@code false} can violate the
-     * <a href="https://tools.ietf.org/html/draft-ietf-httpbis-http2-15#section-8.1.2">HTTP/2 specification</a>
+     * <a href="https://tools.ietf.org/html/draft-ietf-httpbis-http2-16#section-8.1.2">HTTP/2 specification</a>
      * which specifies that a request or response containing an uppercase header field MUST be treated
      * as malformed. Only set {@code forceKeyToLower} to {@code false} if you are explicitly using lowercase
      * header field names and want to avoid the conversion to lowercase.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -34,10 +34,8 @@ public final class Http2CodecUtil {
     public static final int CONNECTION_STREAM_ID = 0;
     public static final int HTTP_UPGRADE_STREAM_ID = 1;
     public static final String HTTP_UPGRADE_SETTINGS_HEADER = "HTTP2-Settings";
-    // Draft 15 is actually supported but because draft 15 and draft 14 are binary compatible draft 14 is advertised
-    // for interoperability with technologies that have not yet updated, or are also advertising the older draft.
-    public static final String HTTP_UPGRADE_PROTOCOL_NAME = "h2c-14";
-    public static final String TLS_UPGRADE_PROTOCOL_NAME = "h2-14";
+    public static final String HTTP_UPGRADE_PROTOCOL_NAME = "h2c-16";
+    public static final String TLS_UPGRADE_PROTOCOL_NAME = "h2-16";
 
     public static final int PING_FRAME_PAYLOAD_LENGTH = 8;
     public static final short MAX_UNSIGNED_BYTE = 0xFF;
@@ -57,7 +55,7 @@ public final class Http2CodecUtil {
     public static final int SETTINGS_MAX_FRAME_SIZE = 5;
     public static final int SETTINGS_MAX_HEADER_LIST_SIZE = 6;
 
-    public static final long MAX_HEADER_TABLE_SIZE = MAX_UNSIGNED_INT;
+    public static final int MAX_HEADER_TABLE_SIZE = Integer.MAX_VALUE; // Size limited by HPACK library
     public static final long MAX_CONCURRENT_STREAMS = MAX_UNSIGNED_INT;
     public static final int MAX_INITIAL_WINDOW_SIZE = Integer.MAX_VALUE;
     public static final int MAX_FRAME_SIZE_LOWER_BOUND = 0x4000;
@@ -80,16 +78,14 @@ public final class Http2CodecUtil {
      * Indicates whether or not the given value for max frame size falls within the valid range.
      */
     public static boolean isMaxFrameSizeValid(int maxFrameSize) {
-        return maxFrameSize >= MAX_FRAME_SIZE_LOWER_BOUND
-                && maxFrameSize <= MAX_FRAME_SIZE_UPPER_BOUND;
+        return maxFrameSize >= MAX_FRAME_SIZE_LOWER_BOUND && maxFrameSize <= MAX_FRAME_SIZE_UPPER_BOUND;
     }
 
     /**
      * Returns a buffer containing the the {@link #CONNECTION_PREFACE}.
      */
     public static ByteBuf connectionPrefaceBuf() {
-        // Return a duplicate so that modifications to the reader index will not affect the original
-        // buffer.
+        // Return a duplicate so that modifications to the reader index will not affect the original buffer.
         return Unpooled.wrappedBuffer(CONNECTION_PREFACE);
     }
 
@@ -97,8 +93,7 @@ public final class Http2CodecUtil {
      * Returns a buffer filled with all zeros that is the appropriate length for a PING frame.
      */
     public static ByteBuf emptyPingBuf() {
-        // Return a duplicate so that modifications to the reader index will not affect the original
-        // buffer.
+        // Return a duplicate so that modifications to the reader index will not affect the original buffer.
         return Unpooled.wrappedBuffer(EMPTY_PING);
     }
 
@@ -204,6 +199,5 @@ public final class Http2CodecUtil {
         throw cause;
     }
 
-    private Http2CodecUtil() {
-    }
+    private Http2CodecUtil() { }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -114,29 +114,32 @@ public interface Http2Connection {
 
         /**
          * Creates a stream initiated by this endpoint. This could fail for the following reasons:
-         * <p/>
-         * - The requested stream ID is not the next sequential ID for this endpoint. <br>
-         * - The stream already exists. <br>
-         * - The number of concurrent streams is above the allowed threshold for this endpoint. <br>
-         * - The connection is marked as going away}. <br>
-         *
+         * <ul>
+         * <li>The requested stream ID is not the next sequential ID for this endpoint.</li>
+         * <li>The stream already exists.</li>
+         * <li>The number of concurrent streams is above the allowed threshold for this endpoint.</li>
+         * <li>The connection is marked as going away.</li>
+         * </ul>
+         * <p>
+         * The caller is expected to {@link Http2Stream#open()} the stream.
          * @param streamId The ID of the stream
-         * @param halfClosed if true, the stream is created in the half-closed state with respect to
-         *            this endpoint. Otherwise it's created in the open state.
+         * @see Http2Stream#open()
+         * @see Http2Stream#open(boolean)
          */
-        Http2Stream createStream(int streamId, boolean halfClosed) throws Http2Exception;
+        Http2Stream createStream(int streamId) throws Http2Exception;
 
         /**
          * Creates a push stream in the reserved state for this endpoint and notifies all listeners.
          * This could fail for the following reasons:
-         * <p/>
-         * - Server push is not allowed to the opposite endpoint. <br>
-         * - The requested stream ID is not the next sequential stream ID for this endpoint. <br>
-         * - The number of concurrent streams is above the allowed threshold for this endpoint. <br>
-         * - The connection is marked as going away. <br>
-         * - The parent stream ID does not exist or is not open from the side sending the push
-         * promise. <br>
-         * - Could not set a valid priority for the new stream.
+         * <ul>
+         * <li>Server push is not allowed to the opposite endpoint.</li>
+         * <li>The requested stream ID is not the next sequential stream ID for this endpoint.</li>
+         * <li>The number of concurrent streams is above the allowed threshold for this endpoint.</li>
+         * <li>The connection is marked as going away.</li>
+         * <li>The parent stream ID does not exist or is not open from the side sending the push
+         * promise.</li>
+         * <li>Could not set a valid priority for the new stream.</li>
+         * </ul>
          *
          * @param streamId the ID of the push stream
          * @param parent the parent stream used to initiate the push stream.
@@ -250,9 +253,10 @@ public interface Http2Connection {
     Endpoint<Http2LocalFlowController> local();
 
     /**
-     * Creates a new stream initiated by the local endpoint. See {@link Endpoint#createStream(int, boolean)}.
+     * Creates a new stream initiated by the local endpoint
+     * @see Endpoint#createStream(int)
      */
-    Http2Stream createLocalStream(int streamId, boolean halfClosed) throws Http2Exception;
+    Http2Stream createLocalStream(int streamId) throws Http2Exception;
 
     /**
      * Gets a view of this connection from the remote {@link Endpoint}.
@@ -260,9 +264,10 @@ public interface Http2Connection {
     Endpoint<Http2RemoteFlowController> remote();
 
     /**
-     * Creates a new stream initiated by the remote endpoint. See {@link Endpoint#createStream(int, boolean)}.
+     * Creates a new stream initiated by the remote endpoint.
+     * @see Endpoint#createStream(int)
      */
-    Http2Stream createRemoteStream(int streamId, boolean halfClosed) throws Http2Exception;
+    Http2Stream createRemoteStream(int streamId) throws Http2Exception;
 
     /**
      * Indicates whether or not a {@code GOAWAY} was received from the remote endpoint.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -123,7 +123,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         }
 
         // Create a local stream used for the HTTP cleartext upgrade.
-        connection().createLocalStream(HTTP_UPGRADE_STREAM_ID, true);
+        connection().createLocalStream(HTTP_UPGRADE_STREAM_ID).open(true);
     }
 
     /**
@@ -142,7 +142,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         encoder.remoteSettings(settings);
 
         // Create a stream in the half-closed state.
-        connection().createRemoteStream(HTTP_UPGRADE_STREAM_ID, true);
+        connection().createRemoteStream(HTTP_UPGRADE_STREAM_ID).open(true);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
@@ -30,7 +30,7 @@ public final class Http2SecurityUtil {
      * Ciphers</a> and <a
      * href="https://wiki.mozilla.org/Security/Server_Side_TLS#Non-Backward_Compatible_Ciphersuite">Mozilla Cipher
      * Suites</a> in accordance with the <a
-     * href="https://tools.ietf.org/html/draft-ietf-httpbis-http2-14#section-9.2.2">HTTP/2 Specification</a>.
+     * href="https://tools.ietf.org/html/draft-ietf-httpbis-http2-16#section-9.2.2">HTTP/2 Specification</a>.
      */
     public static final List<String> CIPHERS;
 
@@ -40,7 +40,6 @@ public final class Http2SecurityUtil {
             "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", /* openssl = ECDHE-ECDSA-AES256-GCM-SHA384 */
             "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", /* openssl = ECDHE-ECDSA-AES128-GCM-SHA256 */
             "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", /* openssl = ECDHE-RSA-AES256-GCM-SHA384 */
-            "TLS_RSA_WITH_AES_256_GCM_SHA384", /* openssl = AES256-GCM-SHA384 */
             /* REQUIRED BY HTTP/2 SPEC */
             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", /* openssl = ECDHE-RSA-AES128-GCM-SHA256 */
             /* REQUIRED BY HTTP/2 SPEC */
@@ -50,25 +49,14 @@ public final class Http2SecurityUtil {
     private static final List<String> CIPHERS_JAVA_NO_MOZILLA_INCREASED_SECURITY = Collections.unmodifiableList(Arrays
             .asList(
             /* Java 8 */
-            "TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384", /* openssl = ECDH-ECDSA-AES256-GCM-SHA384 */
-            "TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384", /* openssl = ECDH-RSA-AES256-GCM-SHA384 */
             "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384", /* openssl = DHE-RSA-AES256-GCM-SHA384 */
-            "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384", /* openssl = DHE-DSS-AES256-GCM-SHA384 */
-            "TLS_RSA_WITH_AES_128_GCM_SHA256", /* openssl = AES128-GCM-SHA256 */
-            "TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256", /* openssl = ECDH-ECDSA-AES128-GCM-SHA256 */
-            "TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256" /* openssl = ECDH-RSA-AES128-GCM-SHA256 */));
-
-    private static final List<String> CIPHERS_JAVA_DISABLED_DEFAULT = Collections.unmodifiableList(Arrays.asList(
-            /* Java 8 */
-            "TLS_DH_anon_WITH_AES_256_GCM_SHA384", /* openssl = ADH-AES256-GCM-SHA384 */
-            "TLS_DH_anon_WITH_AES_128_GCM_SHA256" /* openssl = ADH-AES128-GCM-SHA256 */));
+            "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384" /* openssl = DHE-DSS-AES256-GCM-SHA384 */));
 
     static {
         List<String> ciphers = new ArrayList<String>(CIPHERS_JAVA_MOZILLA_INCREASED_SECURITY.size()
-                + CIPHERS_JAVA_NO_MOZILLA_INCREASED_SECURITY.size() + CIPHERS_JAVA_DISABLED_DEFAULT.size());
+                + CIPHERS_JAVA_NO_MOZILLA_INCREASED_SECURITY.size());
         ciphers.addAll(CIPHERS_JAVA_MOZILLA_INCREASED_SECURITY);
         ciphers.addAll(CIPHERS_JAVA_NO_MOZILLA_INCREASED_SECURITY);
-        ciphers.addAll(CIPHERS_JAVA_DISABLED_DEFAULT);
         CIPHERS = Collections.unmodifiableList(ciphers);
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
@@ -75,8 +75,8 @@ public final class Http2Settings extends IntObjectHashMap<Long> {
      *
      * @throws IllegalArgumentException if verification of the setting fails.
      */
-    public Http2Settings headerTableSize(long value) {
-        put(SETTINGS_HEADER_TABLE_SIZE, value);
+    public Http2Settings headerTableSize(int value) {
+        put(SETTINGS_HEADER_TABLE_SIZE, (long) value);
         return this;
     }
 
@@ -189,8 +189,7 @@ public final class Http2Settings extends IntObjectHashMap<Long> {
         switch (key) {
             case SETTINGS_HEADER_TABLE_SIZE:
                 if (value < MIN_HEADER_TABLE_SIZE || value > MAX_HEADER_TABLE_SIZE) {
-                    throw new IllegalArgumentException("Setting HEADER_TABLE_SIZE is invalid: "
-                            + value);
+                    throw new IllegalArgumentException("Setting HEADER_TABLE_SIZE is invalid: " + value);
                 }
                 break;
             case SETTINGS_ENABLE_PUSH:
@@ -212,14 +211,12 @@ public final class Http2Settings extends IntObjectHashMap<Long> {
                 break;
             case SETTINGS_MAX_FRAME_SIZE:
                 if (!isMaxFrameSizeValid(value.intValue())) {
-                    throw new IllegalArgumentException("Setting MAX_FRAME_SIZE is invalid: "
-                            + value);
+                    throw new IllegalArgumentException("Setting MAX_FRAME_SIZE is invalid: " + value);
                 }
                 break;
             case SETTINGS_MAX_HEADER_LIST_SIZE:
                 if (value < MIN_HEADER_LIST_SIZE || value > MAX_HEADER_LIST_SIZE) {
-                    throw new IllegalArgumentException("Setting MAX_HEADER_LIST_SIZE is invalid: "
-                            + value);
+                    throw new IllegalArgumentException("Setting MAX_HEADER_LIST_SIZE is invalid: " + value);
                 }
                 break;
             default:

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -46,9 +46,18 @@ public interface Http2Stream {
     State state();
 
     /**
-     * If this is a reserved push stream, opens the stream for push in one direction.
+     * Add this stream to {@link Http2Connection#activeStreams()} and transition state to:
+     * <ul>
+     * <li>{@link State#OPEN} if {@link #state()} is {@link State#IDLE} and {@code halfClosed} is {@code false}.</li>
+     * <li>{@link State#HALF_CLOSED_LOCAL} if {@link #state()} is {@link State#IDLE} and {@code halfClosed}
+     * is {@code true} and the stream is local.</li>
+     * <li>{@link State#HALF_CLOSED_REMOTE} if {@link #state()} is {@link State#IDLE} and {@code halfClosed}
+     * is {@code true} and the stream is remote.</li>
+     * <li>{@link State#RESERVED_LOCAL} if {@link #state()} is {@link State#HALF_CLOSED_REMOTE}.</li>
+     * <li>{@link State#RESERVED_REMOTE} if {@link #state()} is {@link State#HALF_CLOSED_LOCAL}.</li>
+     * </ul>
      */
-    Http2Stream openForPush() throws Http2Exception;
+    Http2Stream open(boolean halfClosed) throws Http2Exception;
 
     /**
      * Closes the stream.
@@ -160,8 +169,7 @@ public interface Http2Stream {
      *            This only applies if the stream has a parent.
      * @return this stream.
      */
-    Http2Stream setPriority(int parentStreamId, short weight, boolean exclusive)
-            throws Http2Exception;
+    Http2Stream setPriority(int parentStreamId, short weight, boolean exclusive) throws Http2Exception;
 
     /**
      * Indicates whether or not this stream is the root node of the priority tree.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -32,7 +32,7 @@ import static io.netty.util.internal.ObjectUtil.*;
 
 /**
  * This adapter provides just header/data events from the HTTP message flow defined
- * here <a href="http://tools.ietf.org/html/draft-ietf-httpbis-http2-14#section-8.1.">HTTP/2 Spec Message Flow</a>.
+ * here <a href="http://tools.ietf.org/html/draft-ietf-httpbis-http2-16#section-8.1.">HTTP/2 Spec Message Flow</a>.
  * <p>
  * See {@link HttpToHttp2ConnectionHandler} to get translation from HTTP/1.x objects to HTTP/2 frames for writes.
  */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpPriorityAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpPriorityAdapter.java
@@ -171,7 +171,7 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
         FullHttpMessage msg = messageMap.get(stream.id());
         if (msg == null) {
             // msg may be null if a HTTP/2 frame event in received outside the HTTP message flow
-            // For example a PRIORITY frame can be received in any state besides IDLE
+            // For example a PRIORITY frame can be received in any state
             // and the HTTP message flow exists in OPEN.
             if (parent != null && !parent.equals(connection.connectionStream())) {
                 HttpHeaders headers = new DefaultHttpHeaders();
@@ -192,10 +192,10 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
     @Override
     public void onWeightChanged(Http2Stream stream, short oldWeight) {
         FullHttpMessage msg = messageMap.get(stream.id());
-        HttpHeaders headers;
+        final HttpHeaders headers;
         if (msg == null) {
             // msg may be null if a HTTP/2 frame event in received outside the HTTP message flow
-            // For example a PRIORITY frame can be received in any state besides IDLE
+            // For example a PRIORITY frame can be received in any state
             // and the HTTP message flow exists in OPEN.
             headers = new DefaultHttpHeaders();
             importOutOfMessageFlowHeaders(stream.id(), headers);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
@@ -15,17 +15,20 @@
 
 package io.netty.handler.codec.http2;
 
-import com.twitter.hpack.Encoder;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_HEADER_TABLE_SIZE;
+import static io.netty.handler.codec.http2.Http2TestUtil.as;
+import static io.netty.handler.codec.http2.Http2TestUtil.randomBytes;
+import static io.netty.util.CharsetUtil.UTF_8;
+import static org.junit.Assert.assertEquals;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 
-import static io.netty.handler.codec.http2.Http2TestUtil.*;
-import static io.netty.util.CharsetUtil.*;
-import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.twitter.hpack.Encoder;
 
 /**
  * Tests for {@link DefaultHttp2HeadersDecoder}.
@@ -57,7 +60,7 @@ public class DefaultHttp2HeadersDecoderTest {
     }
 
     private static ByteBuf encode(byte[]... entries) throws Exception {
-        Encoder encoder = new Encoder();
+        Encoder encoder = new Encoder(MAX_HEADER_TABLE_SIZE);
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         for (int ix = 0; ix < entries.length;) {
             byte[] key = entries[ix++];

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -68,7 +68,7 @@ public class DefaultHttp2LocalFlowControllerTest {
         connection = new DefaultHttp2Connection(false);
         controller = new DefaultHttp2LocalFlowController(connection, frameWriter, updateRatio);
 
-        connection.local().createStream(STREAM_ID, false);
+        connection.local().createStream(STREAM_ID).open(false);
     }
 
     @Test
@@ -156,7 +156,7 @@ public class DefaultHttp2LocalFlowControllerTest {
     @Test
     public void connectionWindowShouldAdjustWithMultipleStreams() throws Http2Exception {
         int newStreamId = 3;
-        connection.local().createStream(newStreamId, false);
+        connection.local().createStream(newStreamId).open(false);
 
         try {
             assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_ID));
@@ -218,7 +218,7 @@ public class DefaultHttp2LocalFlowControllerTest {
             throws Http2Exception {
         int delta = newDefaultWindowSize - DEFAULT_WINDOW_SIZE;
         controller.incrementWindowSize(ctx, stream(0), delta);
-        Http2Stream stream = connection.local().createStream(newStreamId, false);
+        Http2Stream stream = connection.local().createStream(newStreamId).open(false);
         if (setStreamRatio) {
             controller.windowUpdateRatio(ctx, stream, ratio);
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -88,10 +88,10 @@ public class DefaultHttp2RemoteFlowControllerTest {
         connection = new DefaultHttp2Connection(false);
         controller = new DefaultHttp2RemoteFlowController(connection, frameWriter);
 
-        connection.local().createStream(STREAM_A, false);
-        connection.local().createStream(STREAM_B, false);
-        Http2Stream streamC = connection.local().createStream(STREAM_C, false);
-        Http2Stream streamD = connection.local().createStream(STREAM_D, false);
+        connection.local().createStream(STREAM_A).open(false);
+        connection.local().createStream(STREAM_B).open(false);
+        Http2Stream streamC = connection.local().createStream(STREAM_C).open(false);
+        Http2Stream streamD = connection.local().createStream(STREAM_D).open(false);
         streamC.setPriority(STREAM_A, DEFAULT_PRIORITY_WEIGHT, false);
         streamD.setPriority(STREAM_A, DEFAULT_PRIORITY_WEIGHT, false);
 
@@ -1158,7 +1158,7 @@ public class DefaultHttp2RemoteFlowControllerTest {
         Http2Stream streamC = connection.stream(STREAM_C);
         Http2Stream streamD = connection.stream(STREAM_D);
 
-        Http2Stream streamE = connection.local().createStream(STREAM_E, false);
+        Http2Stream streamE = connection.local().createStream(STREAM_E).open(false);
         streamE.setPriority(STREAM_A, DEFAULT_PRIORITY_WEIGHT, true);
 
         // Send a bunch of data on each stream.

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -60,10 +60,10 @@ public class Http2ConnectionHandlerTest {
     private Http2Connection connection;
 
     @Mock
-    private Http2Connection.Endpoint remote;
+    private Http2Connection.Endpoint<Http2RemoteFlowController> remote;
 
     @Mock
-    private Http2Connection.Endpoint local;
+    private Http2Connection.Endpoint<Http2LocalFlowController> local;
 
     @Mock
     private ChannelHandlerContext ctx;
@@ -110,20 +110,21 @@ public class Http2ConnectionHandlerTest {
         when(connection.remote()).thenReturn(remote);
         when(connection.local()).thenReturn(local);
         when(connection.activeStreams()).thenReturn(Collections.singletonList(stream));
+        when(stream.open(anyBoolean())).thenReturn(stream);
         doAnswer(new Answer<Http2Stream>() {
             @Override
             public Http2Stream answer(InvocationOnMock invocation) throws Throwable {
                 Object[] args = invocation.getArguments();
-                return local.createStream((Integer) args[0], (Boolean) args[1]);
+                return local.createStream((Integer) args[0]);
             }
-        }).when(connection).createLocalStream(anyInt(), anyBoolean());
+        }).when(connection).createLocalStream(anyInt());
         doAnswer(new Answer<Http2Stream>() {
             @Override
             public Http2Stream answer(InvocationOnMock invocation) throws Throwable {
                 Object[] args = invocation.getArguments();
-                return remote.createStream((Integer) args[0], (Boolean) args[1]);
+                return remote.createStream((Integer) args[0]);
             }
-        }).when(connection).createRemoteStream(anyInt(), anyBoolean());
+        }).when(connection).createRemoteStream(anyInt());
         when(encoder.writeSettings(eq(ctx), any(Http2Settings.class), eq(promise))).thenReturn(future);
         when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
         when(ctx.channel()).thenReturn(channel);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -116,9 +116,9 @@ final class Http2TestUtil {
                 Http2Stream stream = connection.stream(streamId);
                 if (stream == null) {
                     if (connection.isServer() && streamId % 2 == 0 || !connection.isServer() && streamId % 2 != 0) {
-                        stream = connection.local().createStream(streamId, halfClosed);
+                        stream = connection.local().createStream(streamId).open(halfClosed);
                     } else {
-                        stream = connection.remote().createStream(streamId, halfClosed);
+                        stream = connection.remote().createStream(streamId).open(halfClosed);
                     }
                 }
                 return stream;

--- a/pom.xml
+++ b/pom.xml
@@ -505,7 +505,7 @@
       <dependency>
         <groupId>com.twitter</groupId>
         <artifactId>hpack</artifactId>
-        <version>0.9.1</version>
+        <version>0.10.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.npn</groupId>


### PR DESCRIPTION
Motivation:
HTTP/2 draft 16 has been released https://tools.ietf.org/html/draft-ietf-httpbis-http2-16.

Modifications:
The HTTP/2 codec should be updated to support draft 16.

Result:
HTTP/2 codec is draft 16 compliant.
