### PR TITLE
Ensure buffer is not released when call array() / memoryAddress()

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
@@ -277,6 +277,7 @@ final class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
 
     @Override
     public byte[] array() {
+        ensureAccessible();
         return memory;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
@@ -375,6 +375,7 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
 
     @Override
     public long memoryAddress() {
+        ensureAccessible();
         return memoryAddress;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
@@ -211,6 +211,7 @@ public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf
 
     @Override
     public long memoryAddress() {
+        ensureAccessible();
         return memoryAddress;
     }
 

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -2430,6 +2430,32 @@ public abstract class AbstractByteBufTest {
         releasedBuffer().nioBuffers(0, 1);
     }
 
+    @Test
+    public void testArrayAfterRelease() {
+        ByteBuf buf = releasedBuffer();
+        if (buf.hasArray()) {
+            try {
+                buf.array();
+                fail();
+            } catch (IllegalReferenceCountException e) {
+                // expected
+            }
+        }
+    }
+
+    @Test
+    public void testMemoryAddressAfterRelease() {
+        ByteBuf buf = releasedBuffer();
+        if (buf.hasMemoryAddress()) {
+            try {
+                buf.memoryAddress();
+                fail();
+            } catch (IllegalReferenceCountException e) {
+                // expected
+            }
+        }
+    }
+
     // Test-case trying to reproduce:
     // https://github.com/netty/netty/issues/2843
     @Test


### PR DESCRIPTION
Motivation:

Before we missed to check if a buffer was released before we return the backing byte array or memoryaddress. This could lead to JVM crashes when someone tried various bulk operations on the Unsafe*ByteBuf implementations.

Modifications:

Always check if the buffer is released before all to return the byte array and memoryaddress.

Result:

No more JVM crashes because of released buffers when doing bulk operations on Unsafe*ByteBuf implementations.
