### PR TITLE
HTTP/2 Use Draft14 Identifier

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -34,8 +34,9 @@ public final class Http2CodecUtil {
     public static final int CONNECTION_STREAM_ID = 0;
     public static final int HTTP_UPGRADE_STREAM_ID = 1;
     public static final String HTTP_UPGRADE_SETTINGS_HEADER = "HTTP2-Settings";
-    public static final String HTTP_UPGRADE_PROTOCOL_NAME = "h2c-16";
-    public static final String TLS_UPGRADE_PROTOCOL_NAME = "h2-16";
+    // Draft 14 is the latest "implementation draft" as defined by https://http2.github.io/
+    public static final String HTTP_UPGRADE_PROTOCOL_NAME = "h2c-14";
+    public static final String TLS_UPGRADE_PROTOCOL_NAME = "h2-14";
 
     public static final int PING_FRAME_PAYLOAD_LENGTH = 8;
     public static final short MAX_UNSIGNED_BYTE = 0xFF;


### PR DESCRIPTION
Motivation:
Draft 14 is the latest implementation draft as specified by https://http2.github.io/. For interop we should be using this draft identifier.

Modifications:
Change the draft identifier from 16 back to 14.

Result:
Easier to use with other http/2 protocol implementations.
