### PR TITLE
HTTP/2 stress test timeout

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -328,7 +328,7 @@ public class Http2FrameRoundtripTest {
                     }
                 }
             });
-            awaitRequests(30);
+            awaitRequests(60);
             verify(serverListener, times(numStreams)).onDataRead(any(ChannelHandlerContext.class), anyInt(),
                     any(ByteBuf.class), eq(0), eq(true));
             assertEquals(numStreams, receivedBuffers.size());


### PR DESCRIPTION
Motivation:
The stress tests have been observed to fail on the CI server. The average run time of the stress tests has recently been 26+ seconds.  Our timeout is currently set to 30 seconds.

Modifications:
Increase the timeout for the stress test so when the leak profile is active we will have more time to complete the test (with the additional overhead).

Result:
Stress tests fail less frequently (hopefully not at all).
