### PR TITLE
HTTP/2 unit test failure race condition

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -132,7 +132,6 @@ public class HttpToHttp2ConnectionHandlerTest {
                 eq(http2Headers), eq(0), anyShort(), anyBoolean(), eq(0), eq(true));
         verify(serverListener, never()).onDataRead(any(ChannelHandlerContext.class), anyInt(),
                 any(ByteBuf.class), anyInt(), anyBoolean());
-        assertEquals(0, request.refCnt());
     }
 
     @Test
@@ -174,7 +173,6 @@ public class HttpToHttp2ConnectionHandlerTest {
                 eq(true));
         assertEquals(1, receivedBuffers.size());
         assertEquals(text, receivedBuffers.get(0));
-        assertEquals(0, request.refCnt());
     }
 
     private void bootstrapEnv(int requestCountDown, int serverSettingsAckCount) throws Exception {


### PR DESCRIPTION
Motivation:
HttpToHttp2ConnectionHandler is awaiting on a future and a latch that may be competed before the buffers actually get released.  This test is attempting to validate that the buffer's refCnt() is 0 but there is no mechanism to wait on for a buffer's release() method to be called.

Modifications:
Remove the buffer refCnt() check.  The leak profile is designed to pick these up.

Result:
Unit tests that no longer have a race condition.
