### PR TITLE
Fixes call to equals() comparing different types

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
@@ -453,7 +453,7 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
                 int code = Integer.parseInt(status.substring(0, space));
                 String reasonPhrase = status.substring(space + 1);
                 HttpResponseStatus responseStatus = valueOf(code);
-                if (responseStatus.reasonPhrase().equals(reasonPhrase)) {
+                if (responseStatus.reasonPhrase().toString().equals(reasonPhrase)) {
                     return responseStatus;
                 } else {
                     return new HttpResponseStatus(code, reasonPhrase);

--- a/codec/src/test/java/io/netty/handler/codec/AsciiStringTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/AsciiStringTest.java
@@ -23,6 +23,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -77,6 +78,13 @@ public class AsciiStringTest {
             byte[] actual = AsciiString.getBytes(new AsciiString(bString), charset);
             assertArrayEquals("failure for " + charset, expected, actual);
         }
+    }
+
+    @Test
+    public void testComparisonWithString() {
+        String string = "shouldn't fail";
+        AsciiString ascii = new AsciiString(string.toCharArray());
+        Assert.assertEquals(string, ascii.toString());
     }
 
     private static byte[] getBytesWithEncoder(CharSequence value, Charset charset) {


### PR DESCRIPTION
Motivation:
Sonar points out an equals comparison, where the types compared are different and don't share any common parent
http://clinker.netty.io/sonar/drilldown/issues/io.netty:netty-parent:master?severity=CRITICAL#

Modifications:
Converted AsciiString into a String by calling toString() method before comparing with equals(). Also added a unit-test to show that it works.

Result:
Major violation is gone. Code is correct.
