### PR TITLE
Headers set/add timeMillis for master branch

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -328,6 +328,12 @@ public class DefaultHttpHeaders extends DefaultTextHeaders implements HttpHeader
     }
 
     @Override
+    public HttpHeaders addTimeMillis(CharSequence name, long value) {
+        super.addTimeMillis(name, value);
+        return this;
+    }
+
+    @Override
     public HttpHeaders add(TextHeaders headers) {
         super.add(headers);
         return this;
@@ -414,6 +420,12 @@ public class DefaultHttpHeaders extends DefaultTextHeaders implements HttpHeader
     @Override
     public HttpHeaders setDouble(CharSequence name, double value) {
         super.setDouble(name, value);
+        return this;
+    }
+
+    @Override
+    public HttpHeaders setTimeMillis(CharSequence name, long value) {
+        super.setTimeMillis(name, value);
         return this;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/EmptyHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/EmptyHttpHeaders.java
@@ -111,6 +111,12 @@ public class EmptyHttpHeaders extends EmptyTextHeaders implements HttpHeaders {
     }
 
     @Override
+    public HttpHeaders addTimeMillis(CharSequence name, long value) {
+        super.addTimeMillis(name, value);
+        return this;
+    }
+
+    @Override
     public HttpHeaders add(TextHeaders headers) {
         super.add(headers);
         return this;
@@ -197,6 +203,12 @@ public class EmptyHttpHeaders extends EmptyTextHeaders implements HttpHeaders {
     @Override
     public HttpHeaders setDouble(CharSequence name, double value) {
         super.setDouble(name, value);
+        return this;
+    }
+
+    @Override
+    public HttpHeaders setTimeMillis(CharSequence name, long value) {
+        super.setTimeMillis(name, value);
         return this;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -66,6 +66,9 @@ public interface HttpHeaders extends TextHeaders {
     HttpHeaders addDouble(CharSequence name, double value);
 
     @Override
+    HttpHeaders addTimeMillis(CharSequence name, long value);
+
+    @Override
     HttpHeaders add(TextHeaders headers);
 
     @Override
@@ -109,6 +112,9 @@ public interface HttpHeaders extends TextHeaders {
 
     @Override
     HttpHeaders setDouble(CharSequence name, double value);
+
+    @Override
+    HttpHeaders setTimeMillis(CharSequence name, long value);
 
     @Override
     HttpHeaders set(TextHeaders headers);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -129,6 +129,12 @@ public class DefaultHttp2Headers extends DefaultBinaryHeaders implements Http2He
     }
 
     @Override
+    public Http2Headers addTimeMillis(AsciiString name, long value) {
+        super.addTimeMillis(name, value);
+        return this;
+    }
+
+    @Override
     public Http2Headers add(BinaryHeaders headers) {
         super.add(headers);
         return this;
@@ -215,6 +221,12 @@ public class DefaultHttp2Headers extends DefaultBinaryHeaders implements Http2He
     @Override
     public Http2Headers setDouble(AsciiString name, double value) {
         super.setDouble(name, value);
+        return this;
+    }
+
+    @Override
+    public Http2Headers setTimeMillis(AsciiString name, long value) {
+        super.setTimeMillis(name, value);
         return this;
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/EmptyHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/EmptyHttp2Headers.java
@@ -110,6 +110,12 @@ public final class EmptyHttp2Headers extends EmptyBinaryHeaders implements Http2
     }
 
     @Override
+    public Http2Headers addTimeMillis(AsciiString name, long value) {
+        super.addTimeMillis(name, value);
+        return this;
+    }
+
+    @Override
     public Http2Headers add(BinaryHeaders headers) {
         super.add(headers);
         return this;
@@ -196,6 +202,12 @@ public final class EmptyHttp2Headers extends EmptyBinaryHeaders implements Http2
     @Override
     public Http2Headers setDouble(AsciiString name, double value) {
         super.setDouble(name, value);
+        return this;
+    }
+
+    @Override
+    public Http2Headers setTimeMillis(AsciiString name, long value) {
+        super.setTimeMillis(name, value);
         return this;
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -123,6 +123,9 @@ public interface Http2Headers extends BinaryHeaders {
     Http2Headers addDouble(AsciiString name, double value);
 
     @Override
+    Http2Headers addTimeMillis(AsciiString name, long value);
+
+    @Override
     Http2Headers add(BinaryHeaders headers);
 
     @Override
@@ -166,6 +169,9 @@ public interface Http2Headers extends BinaryHeaders {
 
     @Override
     Http2Headers setDouble(AsciiString name, double value);
+
+    @Override
+    Http2Headers setTimeMillis(AsciiString name, long value);
 
     @Override
     Http2Headers set(BinaryHeaders headers);


### PR DESCRIPTION
Motivation:
Commit eb0e127ee903364814e0710f435d4b92ecf2ed37 was designed for the 4.1 branch.  The 5.0 branch had a few additional classes which required updates to get the new timeMillis methods for all the header classes.

Modifications:
Update the *Headers interfaces/classes that were not updated in the 4.1 branch.

Result:
All *Headers interfaces support set/add timeMillis methods.
