### PR TITLE
AbstractNioBoss(Worker)Pool may initialize more than once

### DIFF
--- a/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioBossPool.java
+++ b/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioBossPool.java
@@ -22,6 +22,7 @@ import org.jboss.netty.util.internal.ExecutorUtil;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class AbstractNioBossPool<E extends Boss>
@@ -37,7 +38,7 @@ public abstract class AbstractNioBossPool<E extends Boss>
     private final Boss[] bosses;
     private final AtomicInteger bossIndex = new AtomicInteger();
     private final Executor bossExecutor;
-    private volatile boolean initialized;
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
 
     /**
      * Create a new instance
@@ -66,10 +67,9 @@ public abstract class AbstractNioBossPool<E extends Boss>
     }
 
     protected void init() {
-        if (initialized) {
+        if (!initialized.compareAndSet(false, true)) {
             throw new IllegalStateException("initialized already");
         }
-        initialized = true;
 
         for (int i = 0; i < bosses.length; i++) {
             bosses[i] = newBoss(bossExecutor);

--- a/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioWorkerPool.java
+++ b/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioWorkerPool.java
@@ -24,6 +24,7 @@ import org.jboss.netty.util.internal.ExecutorUtil;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -43,7 +44,7 @@ public abstract class AbstractNioWorkerPool<E extends AbstractNioWorker>
     private final AbstractNioWorker[] workers;
     private final AtomicInteger workerIndex = new AtomicInteger();
     private final Executor workerExecutor;
-    private volatile boolean initialized;
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
 
     /**
      * Create a new instance
@@ -71,11 +72,9 @@ public abstract class AbstractNioWorkerPool<E extends AbstractNioWorker>
     }
 
     protected void init() {
-        if (initialized) {
+        if (!initialized.compareAndSet(false, true)) {
             throw new IllegalStateException("initialized already");
         }
-
-        initialized = true;
 
         for (int i = 0; i < workers.length; i++) {
             workers[i] = newWorker(workerExecutor);


### PR DESCRIPTION
Netty version: 3.9.5.Final

Context:
It's not safe to use one volatile variable to prevent the initialization sequence from invoking more than once. You can see that 2 threads can pass the "if(initialized)" check at the same time(refer to the discussion in https://github.com/netty/netty/issues/3249), but not with the atomic CAS.
