### PR TITLE
Java ALPN provider version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,9 +108,54 @@
       <properties>
         <!-- Our Javadoc has poor enough quality to fail the build thanks to JDK8 javadoc which got more strict. -->
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
-        <!-- npn-boot does not work with JDK 8 -->
+      </properties>
+    </profile>
+    <profile>
+      <id>alpn-8</id>
+      <activation>
+        <property>
+          <name>java.version</name>
+          <value>1.8</value>
+        </property>
+      </activation>
+      <properties>
         <jetty.alpn.version>8.1.0.v20141016</jetty.alpn.version>
-        <argLine.bootcp>-Xbootclasspath/p:${jetty.alpn.path}</argLine.bootcp>
+      </properties>
+    </profile>
+    <profile>
+      <id>alpn-8u05</id>
+      <activation>
+        <property>
+          <name>java.version</name>
+          <value>1.8.0_05</value>
+        </property>
+      </activation>
+      <properties>
+        <jetty.alpn.version>8.1.0.v20141016</jetty.alpn.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>alpn-8u11</id>
+      <activation>
+        <property>
+          <name>java.version</name>
+          <value>1.8.0_11</value>
+        </property>
+      </activation>
+      <properties>
+        <jetty.alpn.version>8.1.0.v20141016</jetty.alpn.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>alpn-8u20</id>
+      <activation>
+        <property>
+          <name>java.version</name>
+          <value>1.8.0_20</value>
+        </property>
+      </activation>
+      <properties>
+        <jetty.alpn.version>8.1.0.v20141016</jetty.alpn.version>
       </properties>
     </profile>
     <profile>
@@ -122,7 +167,7 @@
         </property>
       </activation>
       <properties>
-        <jetty.alpn.version>8.1.1.v20141016</jetty.alpn.version>
+        <jetty.alpn.version>8.1.2.v20141202</jetty.alpn.version>
       </properties>
     </profile>
     <profile>
@@ -296,7 +341,6 @@
       <properties>
         <jetty.npn.version>1.1.6.v20130911</jetty.npn.version>
         <jetty.alpn.version>7.1.0.v20141016</jetty.alpn.version>
-        <!-- Defer definition of Xbootclasspath to default or forcenpn profile -->
       </properties>
     </profile>
     <profile>
@@ -310,7 +354,6 @@
       <properties>
         <jetty.npn.version>1.1.6.v20130911</jetty.npn.version>
         <jetty.alpn.version>7.1.0.v20141016</jetty.alpn.version>
-        <!-- Defer definition of Xbootclasspath to default or forcenpn profile -->
       </properties>
     </profile>
     <profile>
@@ -324,7 +367,6 @@
       <properties>
         <jetty.npn.version>1.1.6.v20130911</jetty.npn.version>
         <jetty.alpn.version>7.1.0.v20141016</jetty.alpn.version>
-        <!-- Defer definition of Xbootclasspath to default or forcenpn profile -->
       </properties>
     </profile>
     <profile>
@@ -338,7 +380,6 @@
       <properties>
         <jetty.npn.version>1.1.8.v20141013</jetty.npn.version>
         <jetty.alpn.version>7.1.0.v20141016</jetty.alpn.version>
-        <!-- Defer definition of Xbootclasspath to default or forcenpn profile -->
       </properties>
     </profile>
     <profile>
@@ -352,7 +393,6 @@
       <properties>
         <jetty.npn.version>1.1.8.v20141013</jetty.npn.version>
         <jetty.alpn.version>7.1.0.v20141016</jetty.alpn.version>
-        <!-- Defer definition of Xbootclasspath to default or forcenpn profile -->
       </properties>
     </profile>
     <profile>
@@ -366,7 +406,6 @@
       <properties>
         <jetty.npn.version>1.1.8.v20141013</jetty.npn.version>
         <jetty.alpn.version>7.1.0.v20141016</jetty.alpn.version>
-        <!-- Defer definition of Xbootclasspath to default or forcenpn profile -->
       </properties>
     </profile>
     <profile>
@@ -380,7 +419,6 @@
       <properties>
         <jetty.npn.version>1.1.8.v20141013</jetty.npn.version>
         <jetty.alpn.version>7.1.0.v20141016</jetty.alpn.version>
-        <!-- Defer definition of Xbootclasspath to default or forcenpn profile -->
       </properties>
     </profile>
     <profile>
@@ -393,8 +431,7 @@
       </activation>
       <properties>
         <jetty.npn.version>1.1.9.v20141016</jetty.npn.version>
-        <jetty.alpn.version>7.1.0.v20141016</jetty.alpn.version>
-        <!-- Defer definition of Xbootclasspath to default or forcenpn profile -->
+        <jetty.alpn.version>7.1.2.v20141202</jetty.alpn.version>
       </properties>
     </profile>
     <profile>
@@ -407,8 +444,7 @@
       </activation>
       <properties>
         <jetty.npn.version>1.1.9.v20141016</jetty.npn.version>
-        <jetty.alpn.version>7.1.0.v20141016</jetty.alpn.version>
-        <!-- Defer definition of Xbootclasspath to default or forcenpn profile -->
+        <jetty.alpn.version>7.1.2.v20141202</jetty.alpn.version>
       </properties>
     </profile>
     <profile>
@@ -436,7 +472,7 @@
     <jboss.marshalling.version>1.3.18.GA</jboss.marshalling.version>
     <jetty.npn.version>1.1.9.v20141016</jetty.npn.version>
     <jetty.npn.path>${settings.localRepository}/org/mortbay/jetty/npn/npn-boot/${jetty.npn.version}/npn-boot-${jetty.npn.version}.jar</jetty.npn.path>
-    <jetty.alpn.version>8.1.0.v20141016</jetty.alpn.version>
+    <jetty.alpn.version>8.1.2.v20141202</jetty.alpn.version>
     <jetty.alpn.path>${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${jetty.alpn.version}/alpn-boot-${jetty.alpn.version}.jar</jetty.alpn.path>
     <argLine.common>
       -server


### PR DESCRIPTION
Motivation:

There was a bug in the Java ALPN library we are using.  A new version was released to fix this bug and we should update our pom.xml to use the new version.

Modifications:

Update pom.xml to use new ALPN library.

Result:

Newer versions of JDK (1.7_u71, 1.7_u72, 1.8_u25) have the bug fixed.
