### PR TITLE
Parent pom inconsistent between baselines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
       -XX:+OptimizeStringConcat
       -XX:+HeapDumpOnOutOfMemoryError
     </argLine.common>
-    <argLine.bootcp>-Xbootclasspath/p:${jetty.npn.path}</argLine.bootcp>
+    <argLine.bootcp>-Xbootclasspath/p:${jetty.alpn.path}</argLine.bootcp>
     <argLine.leak>-verbose:gc</argLine.leak> <!-- Overridden when 'leak' profile is active -->
     <argLine.coverage>-D_</argLine.coverage> <!-- Overridden when 'coverage' profile is active -->
   </properties>


### PR DESCRIPTION
Motivation:
ALPN version updates revealed an inconsistency visible by defaulting to npn when alpn was expected.

Modifications:
Default to ALPN.

Result:
Build and unit tests should pass.
