### PR TITLE
CompositeByteBuf.nioBuffers(...) must not return an empty ByteBuffer arr...

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -45,6 +45,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf {
     private final List<Component> components = new ArrayList<Component>();
     private final int maxNumComponents;
     private static final ByteBuffer FULL_BYTEBUFFER = (ByteBuffer) ByteBuffer.allocate(1).position(1);
+    private static final ByteBuffer EMPTY_BYTEBUFFER = ByteBuffer.allocateDirect(0);
 
     private boolean freed;
 
@@ -1137,7 +1138,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf {
     public ByteBuffer[] nioBuffers(int index, int length) {
         checkIndex(index, length);
         if (length == 0) {
-            return EmptyArrays.EMPTY_BYTE_BUFFERS;
+            return new ByteBuffer[] { EMPTY_BYTEBUFFER };
         }
 
         List<ByteBuffer> buffers = new ArrayList<ByteBuffer>(components.size());

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -2470,6 +2470,16 @@ public abstract class AbstractByteBufTest {
         testRefCnt0(true);
     }
 
+    @Test
+    public void testEmptyNioBuffers() throws Exception {
+        ByteBuf buffer = releaseLater(newBuffer(8));
+        buffer.clear();
+        assertFalse(buffer.isReadable());
+        ByteBuffer[] nioBuffers = buffer.nioBuffers();
+        assertEquals(1, nioBuffers.length);
+        assertFalse(nioBuffers[0].hasRemaining());
+    }
+
     private void testRefCnt0(final boolean parameter) throws Exception {
         for (int i = 0; i < 10; i++) {
             final CountDownLatch latch = new CountDownLatch(1);


### PR DESCRIPTION
...ay

Motivation:

CompositeByteBuf.nioBuffers(...) returns an empty ByteBuffer array if the specified length is 0. This is not consistent with other ByteBuf implementations which return an ByteBuffer array of size 1 with an empty ByteBuffer included.

Modifications:

Make CompositeByteBuf.nioBuffers(...) consistent with other ByteBuf implementations.

Result:

Consistent and correct behaviour of nioBufffers(...)
