### PR TITLE
Not execute shutdownOutput(...) and close(...) in the EventLoop if SO_LI...

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -342,25 +342,14 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel {
         return outputShutdown || !isActive();
     }
 
-    protected ChannelFuture shutdownOutput0(final ChannelPromise promise) {
-        EventLoop loop = eventLoop();
-        if (loop.inEventLoop()) {
-            try {
-                Native.shutdown(fd().intValue(), false, true);
-                outputShutdown = true;
-                promise.setSuccess();
-            } catch (Throwable t) {
-                promise.setFailure(t);
-            }
-        } else {
-            loop.execute(new Runnable() {
-                @Override
-                public void run() {
-                    shutdownOutput0(promise);
-                }
-            });
+    protected void shutdownOutput0(final ChannelPromise promise) {
+        try {
+            Native.shutdown(fd().intValue(), false, true);
+            outputShutdown = true;
+            promise.setSuccess();
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
         }
-        return promise;
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -33,6 +33,7 @@ import java.net.SocketAddress;
 import java.net.SocketException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.NotYetConnectedException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 
 /**
@@ -544,16 +545,48 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 return;
             }
 
+            if (outboundBuffer == null) {
+                // This means close() was called before so we just register a listener and return
+                closeFuture.addListener(new ChannelFutureListener() {
+                    @Override
+                    public void operationComplete(ChannelFuture future) throws Exception {
+                        promise.setSuccess();
+                    }
+                });
+                return;
+            }
+
             if (closeFuture.isDone()) {
                 // Closed already.
                 safeSetSuccess(promise);
                 return;
             }
 
-            boolean wasActive = isActive();
-            ChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
-            this.outboundBuffer = null; // Disallow adding any messages and flushes to outboundBuffer.
+            final boolean wasActive = isActive();
+            final ChannelOutboundBuffer buffer = outboundBuffer;
+            outboundBuffer = null; // Disallow adding any messages and flushes to outboundBuffer.
+            Executor closeExecutor = closeExecutor();
+            if (closeExecutor != null) {
+                closeExecutor.execute(new OneTimeTask() {
+                    @Override
+                    public void run() {
+                        doClose0(promise);
+                        // Call invokeLater so closeAndDeregister is executed in the EventLoop again!
+                        invokeLater(new OneTimeTask() {
+                            @Override
+                            public void run() {
+                                closeAndDeregister(buffer, wasActive);
+                            }
+                        });
+                    }
+                });
+            } else {
+                doClose0(promise);
+                closeAndDeregister(buffer, wasActive);
+            }
+        }
 
+        private void doClose0(ChannelPromise promise) {
             try {
                 doClose();
                 closeFuture.setClosed();
@@ -562,13 +595,14 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 closeFuture.setClosed();
                 safeSetFailure(promise, t);
             }
+        }
 
+        private void closeAndDeregister(ChannelOutboundBuffer outboundBuffer, final boolean wasActive) {
             // Fail all the queued messages
             try {
                 outboundBuffer.failFlushed(CLOSED_CHANNEL_EXCEPTION);
                 outboundBuffer.close(CLOSED_CHANNEL_EXCEPTION);
             } finally {
-
                 if (wasActive && !isActive()) {
                     invokeLater(new OneTimeTask() {
                         @Override
@@ -801,6 +835,15 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             }
 
             return cause;
+        }
+
+        /**
+         * @return {@link Executor} to execute {@link #doClose()} or {@code null} if it should be done in the
+         * {@link EventLoop}.
+         +
+         */
+        protected Executor closeExecutor() {
+            return null;
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -57,7 +57,7 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
         return new NioByteUnsafe();
     }
 
-    private final class NioByteUnsafe extends AbstractNioUnsafe {
+    protected class NioByteUnsafe extends AbstractNioUnsafe {
         private RecvByteBufAllocator.Handle allocHandle;
 
         private void closeOnRead(ChannelPipeline pipeline) {
@@ -91,7 +91,7 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
         }
 
         @Override
-        public void read() {
+        public final void read() {
             final ChannelConfig config = config();
             if (!config.isAutoRead() && !isReadPending()) {
                 // ChannelConfig.setAutoRead(false) was called in the meantime

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -28,6 +28,7 @@ import io.netty.channel.nio.AbstractNioByteChannel;
 import io.netty.channel.socket.DefaultSocketChannelConfig;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannelConfig;
+import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.internal.OneTimeTask;
 
 import java.io.IOException;
@@ -38,6 +39,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.spi.SelectorProvider;
+import java.util.concurrent.Executor;
 
 /**
  * {@link io.netty.channel.socket.SocketChannel} which uses NIO selector based implementation.
@@ -148,23 +150,37 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
 
     @Override
     public ChannelFuture shutdownOutput(final ChannelPromise promise) {
-        EventLoop loop = eventLoop();
-        if (loop.inEventLoop()) {
-            try {
-                javaChannel().socket().shutdownOutput();
-                promise.setSuccess();
-            } catch (Throwable t) {
-                promise.setFailure(t);
-            }
-        } else {
-            loop.execute(new OneTimeTask() {
+        Executor closeExecutor = ((NioSocketChannelUnsafe) unsafe()).closeExecutor();
+        if (closeExecutor != null) {
+            closeExecutor.execute(new OneTimeTask() {
                 @Override
                 public void run() {
-                    shutdownOutput(promise);
+                    shutdownOutput0(promise);
                 }
             });
+        } else {
+            EventLoop loop = eventLoop();
+            if (loop.inEventLoop()) {
+                shutdownOutput0(promise);
+            } else {
+                loop.execute(new OneTimeTask() {
+                    @Override
+                    public void run() {
+                        shutdownOutput0(promise);
+                    }
+                });
+            }
         }
         return promise;
+    }
+
+    private void shutdownOutput0(final ChannelPromise promise) {
+        try {
+            javaChannel().socket().shutdownOutput();
+            promise.setSuccess();
+        } catch (Throwable t) {
+            promise.setFailure(t);
+        }
     }
 
     @Override
@@ -305,6 +321,21 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
                 incompleteWrite(setOpWrite);
                 break;
             }
+        }
+    }
+
+    @Override
+    protected AbstractNioUnsafe newUnsafe() {
+        return new NioSocketChannelUnsafe();
+    }
+
+    private final class NioSocketChannelUnsafe extends NioByteUnsafe {
+        @Override
+        protected Executor closeExecutor() {
+            if (config().getSoLinger() > 0) {
+                return GlobalEventExecutor.INSTANCE;
+            }
+            return null;
         }
     }
 


### PR DESCRIPTION
...NGER is used.

Motivation:

If SO_LINGER is used shutdownOutput() and close() syscalls will block until either all data was send or until the timeout exceed. This is a problem when we try to execute them on the EventLoop as this means the EventLoop may be blocked and so can not process any other I/O.

Modifications:

- Add a new ChannelOption.SO_LINGER_IO_EXECUTOR which allows to config an Executor which is used for shutdownOutput() and close() when SO_LINGER is enabled
- Use this Executor when SO_LINGER is used.

Result:

No more blocking the EventLoop if SO_LINGER is used and shutdownOutput() or close() is called.