### PR TITLE
Add OpenSslClientContext to allow creating SslEngine for client side

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
@@ -16,7 +16,6 @@
 
 package io.netty.handler.ssl;
 
-
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -30,8 +30,7 @@ public final class OpenSsl {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(OpenSsl.class);
     private static final Throwable UNAVAILABILITY_CAUSE;
-
-    static final String IGNORABLE_ERROR_PREFIX = "error:00000000:";
+    private static final String IGNORABLE_ERROR_PREFIX = "error:00000000:";
 
     static {
         Throwable cause = null;
@@ -78,6 +77,10 @@ public final class OpenSsl {
      */
     public static Throwable unavailabilityCause() {
         return UNAVAILABILITY_CAUSE;
+    }
+
+    static boolean isError(String error) {
+        return error != null && !error.startsWith(IGNORABLE_ERROR_PREFIX);
     }
 
     private OpenSsl() { }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.buffer.ByteBufAllocator;
+import org.apache.tomcat.jni.SSL;
+import org.apache.tomcat.jni.SSLContext;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import java.io.File;
+import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A client-side {@link SslContext} which uses OpenSSL's SSL/TLS implementation.
+ */
+public final class OpenSslClientContext extends OpenSslContext {
+
+    private final X509TrustManager[] managers;
+
+    /**
+     * Creates a new instance.
+     */
+    public OpenSslClientContext() throws SSLException {
+        this(null, null, null, null, 0, 0);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param certChainFile an X.509 certificate chain file in PEM format.
+     *                      {@code null} to use the system default
+     */
+    public OpenSslClientContext(File certChainFile) throws SSLException {
+        this(certChainFile, null);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param trustManagerFactory the {@link TrustManagerFactory} that provides the {@link TrustManager}s
+     *                            that verifies the certificates sent from servers.
+     *                            {@code null} to use the default.
+     */
+    public OpenSslClientContext(TrustManagerFactory trustManagerFactory) throws SSLException {
+        this(null, trustManagerFactory);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param certChainFile an X.509 certificate chain file in PEM format.
+     *                      {@code null} to use the system default
+     * @param trustManagerFactory the {@link TrustManagerFactory} that provides the {@link TrustManager}s
+     *                            that verifies the certificates sent from servers.
+     *                            {@code null} to use the default.
+     */
+    public OpenSslClientContext(File certChainFile, TrustManagerFactory trustManagerFactory) throws SSLException {
+        this(certChainFile, trustManagerFactory, null, null, 0, 0);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param certChainFile an X.509 certificate chain file in PEM format
+     * @param trustManagerFactory the {@link TrustManagerFactory} that provides the {@link TrustManager}s
+     *                            that verifies the certificates sent from servers.
+     *                            {@code null} to use the default..
+     * @param ciphers the cipher suites to enable, in the order of preference.
+     *                {@code null} to use the default cipher suites.
+     * @param apn Provides a means to configure parameters related to application protocol negotiation.
+     * @param sessionCacheSize the size of the cache used for storing SSL session objects.
+     *                         {@code 0} to use the default value.
+     * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
+     *                       {@code 0} to use the default value.
+     */
+    public OpenSslClientContext(File certChainFile, TrustManagerFactory trustManagerFactory, Iterable<String> ciphers,
+                                ApplicationProtocolConfig apn, long sessionCacheSize, long sessionTimeout)
+            throws SSLException {
+        super(ciphers, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_CLIENT);
+        boolean success = false;
+        try {
+            if (certChainFile != null && !certChainFile.isFile()) {
+                throw new IllegalArgumentException("certChainFile is not a file: " + certChainFile);
+            }
+
+            synchronized (OpenSslContext.class) {
+                if (certChainFile != null) {
+                    /* Load the certificate chain. We must skip the first cert when server mode */
+                    if (!SSLContext.setCertificateChainFile(ctx, certChainFile.getPath(), true)) {
+                        String error = SSL.getLastError();
+                        if (OpenSsl.isError(error)) {
+                            throw new SSLException(
+                                    "failed to set certificate chain: "
+                                            + certChainFile + " (" + SSL.getLastError() + ')');
+                        }
+                    }
+                }
+                SSLContext.setVerify(ctx, SSL.SSL_VERIFY_NONE, VERIFY_DEPTH);
+
+                // check if verification should take place or not.
+                if (trustManagerFactory != null) {
+                    try {
+                        if (certChainFile == null) {
+                            trustManagerFactory.init((KeyStore) null);
+                        } else {
+                            initTrustManagerFactory(certChainFile, trustManagerFactory);
+                        }
+                    } catch (Exception e) {
+                        throw new SSLException("failed to initialize the client-side SSL context", e);
+                    }
+                    TrustManager[] tms = trustManagerFactory.getTrustManagers();
+                    if (tms == null || tms.length == 0) {
+                        managers = null;
+                    } else {
+                        List<X509TrustManager> managerList = new ArrayList<X509TrustManager>(tms.length);
+                        for (TrustManager tm: tms) {
+                            if (tm instanceof X509TrustManager) {
+                                managerList.add((X509TrustManager) tm);
+                            }
+                        }
+                        managers = managerList.toArray(new X509TrustManager[managerList.size()]);
+                    }
+                } else {
+                    managers = null;
+               }
+            }
+            success = true;
+        } finally {
+            if (!success) {
+                destroyPools();
+            }
+        }
+    }
+
+    @Override
+    public SSLEngine newEngine(ByteBufAllocator alloc) {
+        List<String> protos = applicationProtocolNegotiator().protocols();
+        if (protos.isEmpty()) {
+            return new OpenSslEngine(ctx, alloc, null, isClient(), managers);
+        } else {
+            return new OpenSslEngine(ctx, alloc, protos.get(protos.size() - 1), isClient(), managers);
+        }
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.apache.tomcat.jni.Pool;
+import org.apache.tomcat.jni.SSL;
+import org.apache.tomcat.jni.SSLContext;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+public abstract class OpenSslContext extends SslContext {
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(OpenSslContext.class);
+    private static final List<String> DEFAULT_CIPHERS;
+    private static final AtomicIntegerFieldUpdater<OpenSslContext> DESTROY_UPDATER;
+
+    // TODO: Maybe make configurable ?
+    protected static final int VERIFY_DEPTH = 10;
+
+    private final long aprPool;
+    @SuppressWarnings("unused")
+    private volatile int aprPoolDestroyed;
+    private final List<String> ciphers = new ArrayList<String>();
+    private final List<String> unmodifiableCiphers = Collections.unmodifiableList(ciphers);
+    private final long sessionCacheSize;
+    private final long sessionTimeout;
+    private final OpenSslApplicationProtocolNegotiator apn;
+    /** The OpenSSL SSL_CTX object */
+    protected final long ctx;
+    private final int mode;
+    private final OpenSslSessionStats stats;
+
+    static {
+        List<String> ciphers = new ArrayList<String>();
+        // XXX: Make sure to sync this list with JdkSslEngineFactory.
+        Collections.addAll(
+                ciphers,
+                "ECDHE-RSA-AES128-GCM-SHA256",
+                "ECDHE-RSA-AES128-SHA",
+                "ECDHE-RSA-AES256-SHA",
+                "AES128-GCM-SHA256",
+                "AES128-SHA",
+                "AES256-SHA",
+                "DES-CBC3-SHA",
+                "RC4-SHA");
+        DEFAULT_CIPHERS = Collections.unmodifiableList(ciphers);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Default cipher suite (OpenSSL): " + ciphers);
+        }
+
+        AtomicIntegerFieldUpdater<OpenSslContext> updater =
+                PlatformDependent.newAtomicIntegerFieldUpdater(OpenSslContext.class, "aprPoolDestroyed");
+        if (updater == null) {
+            updater = AtomicIntegerFieldUpdater.newUpdater(OpenSslContext.class, "aprPoolDestroyed");
+        }
+        DESTROY_UPDATER = updater;
+    }
+
+    OpenSslContext(Iterable<String> ciphers, ApplicationProtocolConfig apnCfg, long sessionCacheSize,
+                   long sessionTimeout, int mode) throws SSLException {
+        this(ciphers, toNegotiator(apnCfg, mode == SSL.SSL_MODE_SERVER), sessionCacheSize, sessionTimeout, mode);
+    }
+
+    OpenSslContext(Iterable<String> ciphers, OpenSslApplicationProtocolNegotiator apn, long sessionCacheSize,
+                   long sessionTimeout, int mode) throws SSLException {
+        OpenSsl.ensureAvailability();
+
+        if (mode != SSL.SSL_MODE_SERVER && mode != SSL.SSL_MODE_CLIENT) {
+            throw new IllegalArgumentException("mode most be either SSL.SSL_MODE_SERVER or SSL.SSL_MODE_CLIENT");
+        }
+        this.mode = mode;
+
+        if (ciphers == null) {
+            ciphers = DEFAULT_CIPHERS;
+        }
+
+        for (String c: ciphers) {
+            if (c == null) {
+                break;
+            }
+            this.ciphers.add(c);
+        }
+
+        this.apn = checkNotNull(apn, "apn");
+
+        // Allocate a new APR pool.
+        aprPool = Pool.create(0);
+
+        // Create a new SSL_CTX and configure it.
+        boolean success = false;
+        try {
+            synchronized (OpenSslContext.class) {
+                try {
+                    ctx = SSLContext.make(aprPool, SSL.SSL_PROTOCOL_ALL, mode);
+                } catch (Exception e) {
+                    throw new SSLException("failed to create an SSL_CTX", e);
+                }
+
+                SSLContext.setOptions(ctx, SSL.SSL_OP_ALL);
+                SSLContext.setOptions(ctx, SSL.SSL_OP_NO_SSLv2);
+                SSLContext.setOptions(ctx, SSL.SSL_OP_NO_SSLv3);
+                SSLContext.setOptions(ctx, SSL.SSL_OP_CIPHER_SERVER_PREFERENCE);
+                SSLContext.setOptions(ctx, SSL.SSL_OP_SINGLE_ECDH_USE);
+                SSLContext.setOptions(ctx, SSL.SSL_OP_SINGLE_DH_USE);
+                SSLContext.setOptions(ctx, SSL.SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
+
+                /* List the ciphers that are permitted to negotiate. */
+                try {
+                    // Convert the cipher list into a colon-separated string.
+                    StringBuilder cipherBuf = new StringBuilder();
+                    for (String c: this.ciphers) {
+                        cipherBuf.append(c);
+                        cipherBuf.append(':');
+                    }
+                    cipherBuf.setLength(cipherBuf.length() - 1);
+
+                    SSLContext.setCipherSuite(ctx, cipherBuf.toString());
+                } catch (SSLException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new SSLException("failed to set cipher suite: " + this.ciphers, e);
+                }
+
+                List<String> nextProtoList = apn.protocols();
+                /* Set next protocols for next protocol negotiation extension, if specified */
+                if (!nextProtoList.isEmpty()) {
+                    // Convert the protocol list into a comma-separated string.
+                    StringBuilder nextProtocolBuf = new StringBuilder();
+                    for (String p: nextProtoList) {
+                        nextProtocolBuf.append(p);
+                        nextProtocolBuf.append(',');
+                    }
+                    nextProtocolBuf.setLength(nextProtocolBuf.length() - 1);
+
+                    SSLContext.setNextProtos(ctx, nextProtocolBuf.toString());
+                }
+
+                /* Set session cache size, if specified */
+                if (sessionCacheSize > 0) {
+                    this.sessionCacheSize = sessionCacheSize;
+                    SSLContext.setSessionCacheSize(ctx, sessionCacheSize);
+                } else {
+                    // Get the default session cache size using SSLContext.setSessionCacheSize()
+                    this.sessionCacheSize = sessionCacheSize = SSLContext.setSessionCacheSize(ctx, 20480);
+                    // Revert the session cache size to the default value.
+                    SSLContext.setSessionCacheSize(ctx, sessionCacheSize);
+                }
+
+                /* Set session timeout, if specified */
+                if (sessionTimeout > 0) {
+                    this.sessionTimeout = sessionTimeout;
+                    SSLContext.setSessionCacheTimeout(ctx, sessionTimeout);
+                } else {
+                    // Get the default session timeout using SSLContext.setSessionCacheTimeout()
+                    this.sessionTimeout = sessionTimeout = SSLContext.setSessionCacheTimeout(ctx, 300);
+                    // Revert the session timeout to the default value.
+                    SSLContext.setSessionCacheTimeout(ctx, sessionTimeout);
+                }
+            }
+            success = true;
+        } finally {
+            if (!success) {
+                destroyPools();
+            }
+        }
+
+        stats = new OpenSslSessionStats(ctx);
+    }
+
+    @Override
+    public final List<String> cipherSuites() {
+        return unmodifiableCiphers;
+    }
+
+    @Override
+    public final long sessionCacheSize() {
+        return sessionCacheSize;
+    }
+
+    @Override
+    public final long sessionTimeout() {
+        return sessionTimeout;
+    }
+
+    @Override
+    public ApplicationProtocolNegotiator applicationProtocolNegotiator() {
+        return apn;
+    }
+
+    @Override
+    public final boolean isClient() {
+        return mode == SSL.SSL_MODE_CLIENT;
+    }
+
+    @Override
+    public final SSLEngine newEngine(ByteBufAllocator alloc, String peerHost, int peerPort) {
+        throw new UnsupportedOperationException();
+    }
+    /**
+     * Returns the {@code SSL_CTX} object of this context.
+     */
+    public final long context() {
+        return ctx;
+    }
+
+    /**
+     * Returns the stats of this context.
+     */
+    public final OpenSslSessionStats stats() {
+        return stats;
+    }
+
+    @Override
+    @SuppressWarnings("FinalizeDeclaration")
+    protected final void finalize() throws Throwable {
+        super.finalize();
+        synchronized (OpenSslContext.class) {
+            if (ctx != 0) {
+                SSLContext.free(ctx);
+            }
+        }
+
+        destroyPools();
+    }
+
+    /**
+     * Sets the SSL session ticket keys of this context.
+     */
+    public final void setTicketKeys(byte[] keys) {
+        if (keys == null) {
+            throw new NullPointerException("keys");
+        }
+        SSLContext.setSessionTicketKeys(ctx, keys);
+    }
+
+    protected final void destroyPools() {
+        // Guard against multiple destroyPools() calls triggered by construction exception and finalize() later
+        if (aprPool != 0 && DESTROY_UPDATER.compareAndSet(this, 0, 1)) {
+            Pool.destroy(aprPool);
+        }
+    }
+
+    /**
+     * Translate a {@link ApplicationProtocolConfig} object to a
+     * {@link OpenSslApplicationProtocolNegotiator} object.
+     * @param config The configuration which defines the translation
+     * @param isServer {@code true} if a server {@code false} otherwise.
+     * @return The results of the translation
+     */
+    static OpenSslApplicationProtocolNegotiator toNegotiator(ApplicationProtocolConfig config,
+                                                                     boolean isServer) {
+        if (config == null) {
+            return OpenSslDefaultApplicationProtocolNegotiator.INSTANCE;
+        }
+
+        switch(config.protocol()) {
+            case NONE:
+                return OpenSslDefaultApplicationProtocolNegotiator.INSTANCE;
+            case NPN:
+                if (isServer) {
+                    switch(config.selectedListenerFailureBehavior()) {
+                        case CHOOSE_MY_LAST_PROTOCOL:
+                            return new OpenSslNpnApplicationProtocolNegotiator(config.supportedProtocols());
+                        default:
+                            throw new UnsupportedOperationException(
+                                    new StringBuilder("OpenSSL provider does not support ")
+                                    .append(config.selectedListenerFailureBehavior()).append(" behavior").toString());
+                    }
+                } else {
+                    throw new UnsupportedOperationException("OpenSSL provider does not support client mode");
+                }
+            default:
+                throw new UnsupportedOperationException(new StringBuilder("OpenSSL provider does not support ")
+                        .append(config.protocol()).append(" protocol").toString());
+        }
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -16,7 +16,9 @@
 
 package io.netty.handler.ssl;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.ByteBufInputStream;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
@@ -30,7 +32,15 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
+import javax.security.auth.x500.X500Principal;
 import java.io.File;
+import java.io.IOException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.util.List;
 
 /**
@@ -56,6 +66,15 @@ import java.util.List;
  * </pre>
  */
 public abstract class SslContext {
+    static final CertificateFactory X509_CERT_FACTORY;
+    static {
+        try {
+            X509_CERT_FACTORY = CertificateFactory.getInstance("X.509");
+        } catch (CertificateException e) {
+            throw new IllegalStateException("unable to instance X.509 CertificateFactory", e);
+        }
+    }
+
     /**
      * Returns the default server-side implementation provider currently in use.
      *
@@ -509,7 +528,6 @@ public abstract class SslContext {
             File certChainFile, TrustManagerFactory trustManagerFactory,
             Iterable<String> ciphers, Iterable<String> nextProtocols,
             long sessionCacheSize, long sessionTimeout) throws SSLException {
-
         return newClientContext(
                 provider, certChainFile, trustManagerFactory, null, null, null, null,
                 ciphers, IdentityCipherSuiteFilter.INSTANCE,
@@ -593,9 +611,20 @@ public abstract class SslContext {
         if (provider != null && provider != SslProvider.JDK) {
             throw new SSLException("client context unsupported for: " + provider);
         }
-
-        return new JdkSslClientContext(trustCertChainFile, trustManagerFactory, keyCertChainFile, keyFile, keyPassword,
-                keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
+        if (provider == null) {
+            provider = SslProvider.JDK;
+        }
+        switch (provider) {
+            case JDK:
+                new JdkSslClientContext(trustCertChainFile, trustManagerFactory, keyCertChainFile, keyFile, keyPassword,
+                    keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
+            case OPENSSL:
+                return new OpenSslClientContext(
+                        trustCertChainFile, trustManagerFactory,
+                        ciphers, apn, sessionCacheSize, sessionTimeout);
+        }
+        // Should never happen!!
+        throw new Error();
     }
 
     static ApplicationProtocolConfig toApplicationProtocolConfig(Iterable<String> nextProtocols) {
@@ -692,5 +721,25 @@ public abstract class SslContext {
 
     private static SslHandler newHandler(SSLEngine engine) {
         return new SslHandler(engine);
+    }
+
+    static void initTrustManagerFactory(File certChainFile, TrustManagerFactory trustManagerFactory)
+            throws KeyStoreException, CertificateException, NoSuchAlgorithmException, IOException {
+        KeyStore ks = KeyStore.getInstance("JKS");
+        ks.load(null, null);
+        ByteBuf[] certs = PemReader.readCertificates(certChainFile);
+        try {
+            for (ByteBuf buf: certs) {
+                X509Certificate cert = (X509Certificate) X509_CERT_FACTORY.generateCertificate(
+                        new ByteBufInputStream(buf));
+                X500Principal principal = cert.getSubjectX500Principal();
+                ks.setCertificateEntry(principal.getName("RFC2253"), cert);
+            }
+        } finally {
+            for (ByteBuf buf: certs) {
+                buf.release();
+            }
+        }
+        trustManagerFactory.init(ks);
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/util/InsecureTrustManagerFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/InsecureTrustManagerFactory.java
@@ -28,10 +28,10 @@ import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 
 /**
- * An insecure {@link javax.net.ssl.TrustManagerFactory} that trusts all X.509 certificates without any verification.
+ * An insecure {@link TrustManagerFactory} that trusts all X.509 certificates without any verification.
  * <p>
  * <strong>NOTE:</strong>
- * Never use this {@link javax.net.ssl.TrustManagerFactory} in production.
+ * Never use this {@link TrustManagerFactory} in production.
  * It is purely for testing purposes, and thus it is very insecure.
  * </p>
  */

--- a/pom.xml
+++ b/pom.xml
@@ -559,7 +559,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>1.1.30.Fork2</version>
+        <version>1.1.30.Fork3-SNAPSHOT</version>
         <classifier>${os.detected.classifier}</classifier>
         <scope>compile</scope>
         <optional>true</optional>

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -30,6 +30,7 @@ import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.JdkSslClientContext;
 import io.netty.handler.ssl.JdkSslServerContext;
 import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.OpenSslClientContext;
 import io.netty.handler.ssl.OpenSslServerContext;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -84,9 +85,7 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
         boolean hasOpenSsl = OpenSsl.isAvailable();
         if (hasOpenSsl) {
             serverContexts.add(new OpenSslServerContext(CERT_FILE, KEY_FILE));
-
-            // TODO: Client mode is not supported yet.
-            // clientContexts.add(new OpenSslContext(CERT_FILE));
+            clientContexts.add(new OpenSslClientContext(CERT_FILE));
         } else {
             logger.warn("OpenSSL is unavailable and thus will not be tested.", OpenSsl.unavailabilityCause());
         }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStartTlsTest.java
@@ -32,6 +32,7 @@ import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.JdkSslClientContext;
 import io.netty.handler.ssl.JdkSslServerContext;
 import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.OpenSslClientContext;
 import io.netty.handler.ssl.OpenSslServerContext;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
@@ -91,9 +92,7 @@ public class SocketStartTlsTest extends AbstractSocketTest {
         boolean hasOpenSsl = OpenSsl.isAvailable();
         if (hasOpenSsl) {
             serverContexts.add(new OpenSslServerContext(CERT_FILE, KEY_FILE));
-
-            // TODO: Client mode is not supported yet.
-            // clientContexts.add(new OpenSslContext(CERT_FILE));
+            clientContexts.add(new OpenSslClientContext(CERT_FILE));
         } else {
             logger.warn("OpenSSL is unavailable and thus will not be tested.", OpenSsl.unavailabilityCause());
         }


### PR DESCRIPTION
Motivation:

We only support openssl for server side at the moment but it would be also useful for client side.

Modification:
- Upgrade to new netty-tcnative snapshot to support client side openssl support
- Add OpenSslClientContext which can be used to create SslEngine for client side usage
- Factor out common logic between OpenSslClientContext and OpenSslServerContent into new abstract base class called OpenSslContext
- Correctly detect handshake failures as soon as possible
- Guard against segfault caused by multiple calls to destroyPools(). This can happen if OpenSslContext throws an exception in the constructor and the finalize() method is called later during GC

Result:

openssl can be used for client and servers now.
