### PR TITLE
Explicit allow to enable / disable session cache

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
@@ -214,5 +214,15 @@ public final class OpenSslClientContext extends OpenSslContext {
         public int getSessionCacheSize() {
             return 0;
         }
+
+        @Override
+        public boolean setSessionCacheEnabled(boolean enabled) {
+            return false;
+        }
+
+        @Override
+        public boolean isSessionCacheEnabled() {
+            return false;
+        }
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -319,5 +319,16 @@ public final class OpenSslServerContext extends OpenSslContext {
         public int getSessionCacheSize() {
             return (int) SSLContext.getSessionCacheSize(context);
         }
+
+        @Override
+        public boolean setSessionCacheEnabled(boolean enabled) {
+            long mode = enabled ? SSL.SSL_SESS_CACHE_SERVER : SSL.SSL_SESS_CACHE_OFF;
+            return SSLContext.setSessionCacheMode(context, mode) == SSL.SSL_SESS_CACHE_SERVER;
+        }
+
+        @Override
+        public boolean isSessionCacheEnabled() {
+            return SSLContext.getSessionCacheMode(context) == SSL.SSL_SESS_CACHE_SERVER;
+        }
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
@@ -60,6 +60,17 @@ public abstract class OpenSslSessionContext implements SSLSessionContext {
     }
 
     /**
+     * If {@code true} caching of SSL sessions is enable, if {@code false} disabled.
+     * Will return the previous setting.
+     */
+    public abstract boolean setSessionCacheEnabled(boolean enabled);
+
+    /**
+     * Return {@code true} if caching of SSL sessions is enable, {@code false} otherwise.
+     */
+    public abstract boolean isSessionCacheEnabled();
+
+    /**
      * Returns the stats of this context.
      */
     public OpenSslSessionStats stats() {


### PR DESCRIPTION
Motivation:

It is sometimes useful to enable / disable the session cache.

Modifications:
- Add OpenSslSessionContext.setSessionCacheEnabled(...) and isSessionCacheEnabled()

Result:

It is now possible to enable / disable cache on the fly
