### PR TITLE
Allow to set the context for which sessions can be used.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -46,7 +46,7 @@ import static io.netty.util.internal.ObjectUtil.*;
 public final class OpenSslServerContext extends OpenSslContext {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(OpenSslServerContext.class);
 
-    private final OpenSslSessionContext sessionContext;
+    private final OpenSslServerSessionContext sessionContext;
 
     /**
      * Creates a new instance.
@@ -285,50 +285,7 @@ public final class OpenSslServerContext extends OpenSslContext {
     }
 
     @Override
-    public OpenSslSessionContext sessionContext() {
+    public OpenSslServerSessionContext sessionContext() {
         return sessionContext;
-    }
-
-    private static final class OpenSslServerSessionContext extends OpenSslSessionContext {
-        private OpenSslServerSessionContext(long context) {
-            super(context);
-        }
-
-        @Override
-        public void setSessionTimeout(int seconds) {
-            if (seconds < 0) {
-                throw new IllegalArgumentException();
-            }
-            SSLContext.setSessionCacheTimeout(context, seconds);
-        }
-
-        @Override
-        public int getSessionTimeout() {
-            return (int) SSLContext.getSessionCacheTimeout(context);
-        }
-
-        @Override
-        public void setSessionCacheSize(int size) {
-            if (size < 0) {
-                throw new IllegalArgumentException();
-            }
-            SSLContext.setSessionCacheSize(context, size);
-        }
-
-        @Override
-        public int getSessionCacheSize() {
-            return (int) SSLContext.getSessionCacheSize(context);
-        }
-
-        @Override
-        public boolean setSessionCacheEnabled(boolean enabled) {
-            long mode = enabled ?SSL.SSL_SESS_CACHE_SERVER : SSL.SSL_SESS_CACHE_OFF;
-            return SSLContext.setSessionCacheMode(context, mode) == SSL.SSL_SESS_CACHE_SERVER;
-        }
-
-        @Override
-        public boolean isSessionCacheEnabled() {
-            return SSLContext.getSessionCacheMode(context) == SSL.SSL_SESS_CACHE_SERVER;
-        }
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerSessionContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerSessionContext.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import org.apache.tomcat.jni.SSL;
+import org.apache.tomcat.jni.SSLContext;
+
+
+/**
+ * {@link OpenSslSessionContext} implementation which offers extra methods which are only useful for the server-side.
+ */
+public final class OpenSslServerSessionContext extends OpenSslSessionContext {
+    OpenSslServerSessionContext(long context) {
+        super(context);
+    }
+
+    @Override
+    public void setSessionTimeout(int seconds) {
+        if (seconds < 0) {
+            throw new IllegalArgumentException();
+        }
+        SSLContext.setSessionCacheTimeout(context, seconds);
+    }
+
+    @Override
+    public int getSessionTimeout() {
+        return (int) SSLContext.getSessionCacheTimeout(context);
+    }
+
+    @Override
+    public void setSessionCacheSize(int size) {
+        if (size < 0) {
+            throw new IllegalArgumentException();
+        }
+        SSLContext.setSessionCacheSize(context, size);
+    }
+
+    @Override
+    public int getSessionCacheSize() {
+        return (int) SSLContext.getSessionCacheSize(context);
+    }
+
+    @Override
+    public boolean setSessionCacheEnabled(boolean enabled) {
+        long mode = enabled ? SSL.SSL_SESS_CACHE_SERVER : SSL.SSL_SESS_CACHE_OFF;
+        return SSLContext.setSessionCacheMode(context, mode) == SSL.SSL_SESS_CACHE_SERVER;
+    }
+
+    @Override
+    public boolean isSessionCacheEnabled() {
+        return SSLContext.getSessionCacheMode(context) == SSL.SSL_SESS_CACHE_SERVER;
+    }
+
+    /**
+     * Set the context within which session be reused (server side only)
+     * See <a href="http://www.openssl.org/docs/ssl/SSL_CTX_set_session_id_context.html">
+     *     man SSL_CTX_set_session_id_context</a>
+     *
+     * @param sidCtx can be any kind of binary data, it is therefore possible to use e.g. the name
+     *               of the application and/or the hostname and/or service name
+     * @return {@code true} if success, {@code false} otherwise.
+     */
+    public boolean setSessionIdContext(byte[] sidCtx) {
+        return SSLContext.setSessionIdContext(context, sidCtx);
+    }
+}


### PR DESCRIPTION
Motivation:

Openssl supports the SSL_CTX_set_session_id_context function to limit for which context a session can be used. We should support this.

Modifications:

Add OpenSslServerSessionContext that exposes a setSessionIdContext(...) method now.

Result:

It's now possible to use SSL_CTX_set_session_id_context.
