### PR TITLE
Correctly map openssl ciphersuite names to jdk names.

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -42,6 +42,14 @@ Base64 Encoder and Decoder, which can be obtained at:
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
+This product contains modified parts of Android for its OpenSsl support,
+which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.android.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://source.android.com/index.html
+
 This product contains a modified portion of 'Webbit', an event based  
 WebSocket and HTTP server, which can be obtained at:
 

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -22,11 +22,17 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.apache.tomcat.jni.Library;
 import org.apache.tomcat.jni.SSL;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Tells if <a href="http://netty.io/wiki/forked-tomcat-native.html">{@code netty-tcnative}</a> and its OpenSSL support
  * are available.
  */
 public final class OpenSsl {
+
+    private static final Map<String, String> OPENSSL_TO_JDK_CIPHER_SUITES = new HashMap<String, String>();
+    private static final Map<String, String> JDK_TO_OPENSSL_CIPHER_SUITES = new HashMap<String, String>();
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(OpenSsl.class);
     private static final Throwable UNAVAILABILITY_CAUSE;
@@ -44,6 +50,92 @@ public final class OpenSsl {
                             OpenSslEngine.class.getSimpleName() + " will be unavailable.", t);
         }
         UNAVAILABILITY_CAUSE = cause;
+        initCipherSuiteMappings();
+    }
+
+    private static void initCipherSuiteMappings() {
+        // This conversation was adapted from android source.
+        // See https://android.googlesource.com/platform/libcore/+/android-cts-4.1_r2/
+        //     luni/src/main/java/org/apache/harmony/xnet/provider/jsse/NativeCrypto.java
+        // Note these are added in priority order
+        addCipherSuite("SSL_RSA_WITH_RC4_128_MD5",              "RC4-MD5");
+        addCipherSuite("SSL_RSA_WITH_RC4_128_SHA",              "RC4-SHA");
+        addCipherSuite("TLS_RSA_WITH_AES_128_CBC_SHA",          "AES128-SHA");
+        addCipherSuite("TLS_RSA_WITH_AES_256_CBC_SHA",          "AES256-SHA");
+        addCipherSuite("TLS_ECDH_ECDSA_WITH_RC4_128_SHA",       "ECDH-ECDSA-RC4-SHA");
+        addCipherSuite("TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",   "ECDH-ECDSA-AES128-SHA");
+        addCipherSuite("TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA",   "ECDH-ECDSA-AES256-SHA");
+        addCipherSuite("TLS_ECDH_RSA_WITH_RC4_128_SHA",         "ECDH-RSA-RC4-SHA");
+        addCipherSuite("TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",     "ECDH-RSA-AES128-SHA");
+        addCipherSuite("TLS_ECDH_RSA_WITH_AES_256_CBC_SHA",     "ECDH-RSA-AES256-SHA");
+        addCipherSuite("TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",      "ECDHE-ECDSA-RC4-SHA");
+        addCipherSuite("TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",  "ECDHE-ECDSA-AES128-SHA");
+        addCipherSuite("TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",  "ECDHE-ECDSA-AES256-SHA");
+        addCipherSuite("TLS_ECDHE_RSA_WITH_RC4_128_SHA",        "ECDHE-RSA-RC4-SHA");
+        addCipherSuite("TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",    "ECDHE-RSA-AES128-SHA");
+        addCipherSuite("TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",    "ECDHE-RSA-AES256-SHA");
+        addCipherSuite("TLS_DHE_RSA_WITH_AES_128_CBC_SHA",      "DHE-RSA-AES128-SHA");
+        addCipherSuite("TLS_DHE_RSA_WITH_AES_256_CBC_SHA",      "DHE-RSA-AES256-SHA");
+        addCipherSuite("TLS_DHE_DSS_WITH_AES_128_CBC_SHA",      "DHE-DSS-AES128-SHA");
+        addCipherSuite("TLS_DHE_DSS_WITH_AES_256_CBC_SHA",      "DHE-DSS-AES256-SHA");
+        addCipherSuite("SSL_RSA_WITH_3DES_EDE_CBC_SHA",         "DES-CBC3-SHA");
+        addCipherSuite("TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA",  "ECDH-ECDSA-DES-CBC3-SHA");
+        addCipherSuite("TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA",    "ECDH-RSA-DES-CBC3-SHA");
+        addCipherSuite("TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA", "ECDHE-ECDSA-DES-CBC3-SHA");
+        addCipherSuite("TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",   "ECDHE-RSA-DES-CBC3-SHA");
+        addCipherSuite("SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA",     "EDH-RSA-DES-CBC3-SHA");
+        addCipherSuite("SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA",     "EDH-DSS-DES-CBC3-SHA");
+        addCipherSuite("SSL_RSA_WITH_DES_CBC_SHA",              "DES-CBC-SHA");
+        addCipherSuite("SSL_DHE_RSA_WITH_DES_CBC_SHA",          "EDH-RSA-DES-CBC-SHA");
+        addCipherSuite("SSL_DHE_DSS_WITH_DES_CBC_SHA",          "EDH-DSS-DES-CBC-SHA");
+        addCipherSuite("SSL_RSA_EXPORT_WITH_RC4_40_MD5",        "EXP-RC4-MD5");
+        addCipherSuite("SSL_RSA_EXPORT_WITH_DES40_CBC_SHA",     "EXP-DES-CBC-SHA");
+        addCipherSuite("SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA", "EXP-EDH-RSA-DES-CBC-SHA");
+        addCipherSuite("SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA", "EXP-EDH-DSS-DES-CBC-SHA");
+        addCipherSuite("SSL_RSA_WITH_NULL_MD5",                 "NULL-MD5");
+        addCipherSuite("SSL_RSA_WITH_NULL_SHA",                 "NULL-SHA");
+        addCipherSuite("TLS_ECDH_ECDSA_WITH_NULL_SHA",          "ECDH-ECDSA-NULL-SHA");
+        addCipherSuite("TLS_ECDH_RSA_WITH_NULL_SHA",            "ECDH-RSA-NULL-SHA");
+        addCipherSuite("TLS_ECDHE_ECDSA_WITH_NULL_SHA",         "ECDHE-ECDSA-NULL-SHA");
+        addCipherSuite("TLS_ECDHE_RSA_WITH_NULL_SHA",           "ECDHE-RSA-NULL-SHA");
+        addCipherSuite("SSL_DH_anon_WITH_RC4_128_MD5",          "ADH-RC4-MD5");
+        addCipherSuite("TLS_DH_anon_WITH_AES_128_CBC_SHA",      "ADH-AES128-SHA");
+        addCipherSuite("TLS_DH_anon_WITH_AES_256_CBC_SHA",      "ADH-AES256-SHA");
+        addCipherSuite("SSL_DH_anon_WITH_3DES_EDE_CBC_SHA",     "ADH-DES-CBC3-SHA");
+        addCipherSuite("SSL_DH_anon_WITH_DES_CBC_SHA",          "ADH-DES-CBC-SHA");
+        addCipherSuite("TLS_ECDH_anon_WITH_RC4_128_SHA",        "AECDH-RC4-SHA");
+        addCipherSuite("TLS_ECDH_anon_WITH_AES_128_CBC_SHA",    "AECDH-AES128-SHA");
+        addCipherSuite("TLS_ECDH_anon_WITH_AES_256_CBC_SHA",    "AECDH-AES256-SHA");
+        addCipherSuite("TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA",   "AECDH-DES-CBC3-SHA");
+        addCipherSuite("SSL_DH_anon_EXPORT_WITH_RC4_40_MD5",    "EXP-ADH-RC4-MD5");
+        addCipherSuite("SSL_DH_anon_EXPORT_WITH_DES40_CBC_SHA", "EXP-ADH-DES-CBC-SHA");
+        addCipherSuite("TLS_ECDH_anon_WITH_NULL_SHA",           "AECDH-NULL-SHA");
+        addCipherSuite("TLS_KRB5_WITH_RC4_128_SHA",           "KRB5-RC4-SHA");
+        addCipherSuite("TLS_KRB5_WITH_RC4_128_MD5",           "KRB5-RC4-MD5");
+        addCipherSuite("TLS_KRB5_WITH_3DES_EDE_CBC_SHA",      "KRB5-DES-CBC3-SHA");
+        addCipherSuite("TLS_KRB5_WITH_3DES_EDE_CBC_MD5",      "KRB5-DES-CBC3-MD5");
+        addCipherSuite("TLS_KRB5_WITH_DES_CBC_SHA",           "KRB5-DES-CBC-SHA");
+        addCipherSuite("TLS_KRB5_WITH_DES_CBC_MD5",           "KRB5-DES-CBC-MD5");
+        addCipherSuite("TLS_KRB5_EXPORT_WITH_RC4_40_SHA",     "EXP-KRB5-RC4-SHA");
+        addCipherSuite("TLS_KRB5_EXPORT_WITH_RC4_40_MD5",     "EXP-KRB5-RC4-MD5");
+        addCipherSuite("TLS_KRB5_EXPORT_WITH_DES_CBC_40_SHA", "EXP-KRB5-DES-CBC-SHA");
+        addCipherSuite("TLS_KRB5_EXPORT_WITH_DES_CBC_40_MD5", "EXP-KRB5-DES-CBC-MD5");
+        addCipherSuite("SSL_RSA_EXPORT_WITH_RC2_CBC_40_MD5",  "EXP-RC2-CBC-MD5");
+        addCipherSuite("TLS_KRB5_EXPORT_WITH_RC2_CBC_40_SHA", "EXP-KRB5-RC2-CBC-SHA");
+        addCipherSuite("TLS_KRB5_EXPORT_WITH_RC2_CBC_40_MD5", "EXP-KRB5-RC2-CBC-MD5");
+    }
+
+    private static void addCipherSuite(String jdk, String openssl) {
+        JDK_TO_OPENSSL_CIPHER_SUITES.put(jdk, openssl);
+        OPENSSL_TO_JDK_CIPHER_SUITES.put(openssl, jdk);
+    }
+
+    static String openSslCipher(String cipher) {
+        return JDK_TO_OPENSSL_CIPHER_SUITES.get(cipher);
+    }
+
+    static String jdkSslCipher(String cipher) {
+        return OPENSSL_TO_JDK_CIPHER_SUITES.get(cipher);
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -105,7 +105,11 @@ public abstract class OpenSslContext extends SslContext {
             if (c == null) {
                 break;
             }
-            this.ciphers.add(c);
+            String cipher = OpenSsl.openSslCipher(c);
+            if (cipher == null) {
+                cipher = c;
+            }
+            this.ciphers.add(cipher);
         }
 
         this.apn = checkNotNull(apn, "apn");

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -1004,9 +1004,13 @@ public final class OpenSslEngine extends SSLEngine {
                 handshakeFinished = true;
                 String c = SSL.getCipherForSSL(ssl);
                 if (c != null) {
-                    // OpenSSL returns the ciphers seperated by '-' but the JDK SSLEngine does by '_', so replace '-'
-                    // with '_' to match the behaviour.
-                    cipher = CIPHER_REPLACE_PATTERN.matcher(c).replaceAll("_");
+                    // Map returned cipher
+                    String mappedCipher = OpenSsl.jdkSslCipher(c);
+                    if (mappedCipher == null) {
+                        // No mapping found, replace - with _
+                        mappedCipher = CIPHER_REPLACE_PATTERN.matcher(c).replaceAll("-");
+                    }
+                    cipher = mappedCipher;
                 }
                 String applicationProtocol = SSL.getNextProtoNegotiated(ssl);
                 if (applicationProtocol == null) {

--- a/license/LICENSE.android.txt
+++ b/license/LICENSE.android.txt
@@ -1,0 +1,177 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+


### PR DESCRIPTION
Motivation:

The ciphersuite names used by openssl do not match the names used by the jdk implementation for ssl. This sometimes makes it harder to use the OpenSslEngine as a drop in replacement.

Modifications:

Map the openssl ciphersuite name to the one used by the jdk impl.

Result:

Better compatibility.
