### PR TITLE
Add support for OpenSslEngine.getSupportedCipherSuites() / getEnabledCip...

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -138,6 +138,36 @@ public final class OpenSsl {
         return OPENSSL_TO_JDK_CIPHER_SUITES.get(cipher);
     }
 
+    static String[] supportedCiphers() {
+        return JDK_TO_OPENSSL_CIPHER_SUITES.keySet().toArray(new String[JDK_TO_OPENSSL_CIPHER_SUITES.size()]);
+    }
+
+    static String cipherIfSupported(String cipher) {
+        String mapped = JDK_TO_OPENSSL_CIPHER_SUITES.get(cipher);
+        if (mapped == null) {
+            if (OPENSSL_TO_JDK_CIPHER_SUITES.containsKey(cipher)) {
+                mapped = cipher;
+            }
+        }
+        return mapped;
+    }
+
+    static String ciphers(String[] ciphers) {
+        // Convert the cipher list into a colon-separated string.
+        StringBuilder cipherBuf = new StringBuilder();
+        for (String c: ciphers) {
+            // Support JDK cipher names and OpenSSL ones.
+            String mapped = JDK_TO_OPENSSL_CIPHER_SUITES.get(c);
+            if (mapped == null) {
+                mapped = c;
+            }
+            cipherBuf.append(mapped);
+            cipherBuf.append(':');
+        }
+        cipherBuf.setLength(cipherBuf.length() - 1);
+        return cipherBuf.toString();
+    }
+
     /**
      * Returns {@code true} if and only if
      * <a href="http://netty.io/wiki/forked-tomcat-native.html">{@code netty-tcnative}</a> and its OpenSSL support

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -138,14 +138,8 @@ public abstract class OpenSslContext extends SslContext {
                 /* List the ciphers that are permitted to negotiate. */
                 try {
                     // Convert the cipher list into a colon-separated string.
-                    StringBuilder cipherBuf = new StringBuilder();
-                    for (String c: this.ciphers) {
-                        cipherBuf.append(c);
-                        cipherBuf.append(':');
-                    }
-                    cipherBuf.setLength(cipherBuf.length() - 1);
-
-                    SSLContext.setCipherSuite(ctx, cipherBuf.toString());
+                    SSLContext.setCipherSuite(ctx, OpenSsl.ciphers(
+                            this.ciphers.toArray(new String[this.ciphers.size()])));
                 } catch (SSLException e) {
                     throw e;
                 } catch (Exception e) {


### PR DESCRIPTION
...herSuites() / setEnabledCipherSuites(...)

Motivation:

To make OpenSslEgnine a full drop-in replacement we need to support OpenSslEngine.getSupportedCipherSuites() / getEnabledCipherSuites() / setEnabledCipherSuites(...)

Modifications:

Implement OpenSslEngine.getSupportedCipherSuites() / getEnabledCipherSuites() / setEnabledCipherSuites(...)

Result:

Better compability
