### PR TITLE
HttpObjectAggregator only set Content-Length is not already set.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -140,10 +140,12 @@ public class HttpObjectAggregator
 
     @Override
     protected void finishAggregation(FullHttpMessage aggregated) throws Exception {
-        // Set the 'Content-Length' header.
-        aggregated.headers().set(
-                HttpHeaderNames.CONTENT_LENGTH,
-                String.valueOf(aggregated.content().readableBytes()));
+        // Set the 'Content-Length' header. If one isn't already set.
+        if (!HttpHeaderUtil.isContentLengthSet(aggregated)) {
+            aggregated.headers().set(
+                    HttpHeaderNames.CONTENT_LENGTH,
+                    String.valueOf(aggregated.content().readableBytes()));
+        }
     }
 
     @Override


### PR DESCRIPTION
Motivation:
HEAD requests will have a Content-Length set that doesn't match the
actual length. So we only want to set Content-Length header if it isn't
already set.

Modifications:
If check around setting the Content-Length

Result:
A HEAD request will no correctly return the specified Content-Length
instead of the body length
