### PR TITLE
Remove OpenSSL version information from netty-tcnative

### DIFF
--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -230,11 +230,14 @@ public final class NativeLibraryLoader {
 
     private static void patch(byte[] buf, int offset, int length) {
         patch(buf, offset, length,
+              new byte[] { '@', '@', 'l', 'i', 'b', 's', 's', 'l', '.', 's', 'o', '.', '1', '0', 0 },
+              new byte[] { 0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0 });
+        patch(buf, offset, length,
+              new byte[] { '@', '@', 'l', 'i', 'b', 'c', 'r', 'y', 'p', 't', 'o', '.', 's', 'o', '.', '1', '0', 0 },
+              new byte[] { 0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0 });
+        patch(buf, offset, length,
               new byte[] { '.', 's', 'o', '.', '1', '0', 0 },
               new byte[] { '.', 's', 'o', 0,   0,   0,   0 });
-        patch(buf, offset, length,
-              new byte[] { '.', 's', 'o', '.', '1', '.', '0', '.', '0', 0 },
-              new byte[] { '.', 's', 'o', 0,   0,   0,   0,   0,   0,   0 });
     }
 
     private static void patch(byte[] buf, int offset, int length, byte[] needle, byte[] replacement) {


### PR DESCRIPTION
This is an experimental patch that removes the version information of OpenSSL from libnetty-tcnative.so when it is loaded by `NativeLibraryLoader`, by patching the .so file.

It is not ready for a review. I created it to let our CI machine pick this up and run the tests, to see if this fix really works.