### PR TITLE
SPDY: fix support for pushed resources in SpdyHttpEncoder

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpHeaders.java
@@ -39,10 +39,6 @@ public final class SpdyHttpHeaders {
          */
         public static final AsciiString PRIORITY = new AsciiString("X-SPDY-Priority");
         /**
-         * {@code "X-SPDY-URL"}
-         */
-        public static final AsciiString URL = new AsciiString("X-SPDY-URL");
-        /**
          * {@code "X-SPDY-Scheme"}
          */
         public static final AsciiString SCHEME = new AsciiString("X-SPDY-Scheme");


### PR DESCRIPTION
Motivation:

The SpdyHttpDecoder was modified to support pushed resources that are
divided into multiple frames. The decoder accepts a pushed
SpdySynStreamFrame containing the request headers, followed by a
SpdyHeadersFrame containing the response headers.

Modifications:

This commit modifies the SpdyHttpEncoder so that it encodes pushed
resources in a format that the SpdyHttpDecoder can decode. The encoder
will accept an HttpRequest object containing the request headers,
followed by an HttpResponse object containing the response headers.

Result:

The SpdyHttpEncoder will create a SpdySynStreamFrame followed by a
SpdyHeadersFrame when sending pushed resources.