### PR TITLE
Accept ';' in the filename of HTTP Content-Disposition header

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -1582,9 +1582,8 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
      * Split one header in Multipart
      * @return an array of String where rank 0 is the name of the header, follows by several
      *  values that were separated by ';' or ','
-     * @throws ErrorDataDecoderException
      */
-    private static String[] splitMultipartHeader(String sb) throws ErrorDataDecoderException {
+    private static String[] splitMultipartHeader(String sb) {
         ArrayList<String> headers = new ArrayList<String>(1);
         int nameStart;
         int nameEnd;
@@ -1627,38 +1626,34 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
     /**
      * Split one header value in Multipart
      * @return an array of String where values that were separated by ';' or ','
-     * @throws ErrorDataDecoderException
      */
-    private static String[] splitMultipartHeaderValues(String svalue) throws ErrorDataDecoderException {
+    private static String[] splitMultipartHeaderValues(String svalue) {
         ArrayList<String> values = new ArrayList<String>(1);
         boolean inQuote = false;
-        boolean quoteClosed = false;
+        boolean escapeNext = false;
         int start = 0;
         for (int i = 0; i < svalue.length(); i++) {
             char c = svalue.charAt(i);
             if (inQuote) {
-                if (c == '"') {
-                    inQuote = false;
-                    quoteClosed = true;
+                if (escapeNext) {
+                    escapeNext = false;
+                } else {
+                    if (c == '\\') {
+                        escapeNext = true;
+                    } else if (c == '"') {
+                        inQuote = false;
+                    }
                 }
             } else {
                 if (c == '"') {
-                    if (quoteClosed) {
-                        throw new ErrorDataDecoderException();
-                    } else {
-                        inQuote = true;
-                    }
+                    inQuote = true;
                 } else if (c == ';') {
                     values.add(svalue.substring(start, i));
                     start = i + 1;
-                    quoteClosed = false;
                 }
             }
         }
         values.add(svalue.substring(start));
-        if (inQuote && !quoteClosed) {
-            throw new ErrorDataDecoderException();
-        }
         return values.toArray(new String[values.size()]);
     }
 }

--- a/src/test/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/src/test/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -200,4 +200,34 @@ public class HttpPostRequestDecoderTest {
         decoder.offer(part4);
         decoder.offer(HttpChunk.LAST_CHUNK);
     }
+
+    // See https://github.com/netty/netty/issues/3326
+    @Test
+    public void testFilenameContainingSemicolon() throws Exception {
+        final String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
+
+        final DefaultHttpRequest req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
+                "http://localhost");
+
+        req.headers().add(HttpHeaders.Names.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
+
+        // Force to use memory-based data.
+        final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
+
+        final String data = "asdf";
+        final String filename = "tmp;0.txt";
+
+        final String body =
+                "--" + boundary + "\r\n" +
+                        "Content-Disposition: form-data; name=\"file\"; filename=\"" + filename + "\"\r\n" +
+                        "Content-Type: image/gif\r\n" +
+                        "\r\n" +
+                        data + "\r\n" +
+                        "--" + boundary + "--\r\n";
+
+        req.setContent(ChannelBuffers.wrappedBuffer(body.getBytes(CharsetUtil.UTF_8.name())));
+        // Create decoder instance to test.
+        final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        assertFalse(decoder.getBodyHttpDatas().isEmpty());
+    }
 }


### PR DESCRIPTION
I think this fix should also be included in Netty 4.x/5.0, but my current only interest is 3.x.

Motivation:

HttpPostMultipartRequestDecoder threw an ArrayIndexOutOfBoundsException when
trying to decode Content-Disposition header with filename containing ';'.
See issue #3326.

Modifications:

Added splitMultipartHeaderValues method which cares about quotes, and use it in
splitMultipartHeader method, instead of StringUtils.split.

Result:

Filenames can contain semicolons.