### PR TITLE
Accept ';' '\\"' in the filename of HTTP Content-Disposition header

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -1784,7 +1784,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
         String svalue = sb.substring(valueStart, valueEnd);
         String[] values;
         if (svalue.indexOf(';') >= 0) {
-            values = StringUtil.split(svalue, ';');
+            values = splitMultipartHeaderValues(svalue);
         } else {
             values = StringUtil.split(svalue, ',');
         }
@@ -1796,5 +1796,39 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
             array[i] = headers.get(i);
         }
         return array;
+    }
+
+    /**
+     * Split one header value in Multipart
+     * @return an array of String where values that were separated by ';' or ','
+     */
+    private static String[] splitMultipartHeaderValues(String svalue) {
+        ArrayList<String> values = new ArrayList<String>(1);
+        boolean inQuote = false;
+        boolean escapeNext = false;
+        int start = 0;
+        for (int i = 0; i < svalue.length(); i++) {
+            char c = svalue.charAt(i);
+            if (inQuote) {
+                if (escapeNext) {
+                    escapeNext = false;
+                } else {
+                    if (c == '\\') {
+                        escapeNext = true;
+                    } else if (c == '"') {
+                        inQuote = false;
+                    }
+                }
+            } else {
+                if (c == '"') {
+                    inQuote = true;
+                } else if (c == ';') {
+                    values.add(svalue.substring(start, i));
+                    start = i + 1;
+                }
+            }
+        }
+        values.add(svalue.substring(start));
+        return values.toArray(new String[values.size()]);
     }
 }


### PR DESCRIPTION
Motivation:
HttpPostMultipartRequestDecoder threw an ArrayIndexOutOfBoundsException when trying to decode Content-Disposition header with filename containing ';' or protected \\".
See issue #3326 and #3327.

Modifications:
Added splitMultipartHeaderValues method which cares about quotes, and use it in splitMultipartHeader method, instead of StringUtils.split.

Result:
Filenames can contain semicolons and protected \\".