### PR TITLE
Extend JdkZlibDecoder to decode more than once

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/compression/JZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/JZlibTest.java
@@ -26,4 +26,9 @@ public class JZlibTest extends ZlibTest {
     protected ZlibDecoder createDecoder(ZlibWrapper wrapper) {
         return new JZlibDecoder(wrapper);
     }
+
+    @Override
+    protected ZlibDecoder createDecoder(ZlibWrapper wrapper, boolean streaming) {
+        return new JZlibDecoder(wrapper, streaming);
+    }
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
@@ -30,6 +30,11 @@ public class JdkZlibTest extends ZlibTest {
         return new JdkZlibDecoder(wrapper);
     }
 
+    @Override
+    protected ZlibDecoder createDecoder(ZlibWrapper wrapper, boolean streaming) {
+        return new JdkZlibDecoder(wrapper, streaming);
+    }
+
     @Test(expected = DecompressionException.class)
     @Override
     public void testZLIB_OR_NONE3() throws Exception {

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest1.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest1.java
@@ -26,4 +26,9 @@ public class ZlibCrossTest1 extends ZlibTest {
     protected ZlibDecoder createDecoder(ZlibWrapper wrapper) {
         return new JZlibDecoder(wrapper);
     }
+
+    @Override
+    protected ZlibDecoder createDecoder(ZlibWrapper wrapper, boolean streaming) {
+        return new JZlibDecoder(wrapper, streaming);
+    }
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest2.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest2.java
@@ -29,6 +29,11 @@ public class ZlibCrossTest2 extends ZlibTest {
         return new JdkZlibDecoder(wrapper);
     }
 
+    @Override
+    protected ZlibDecoder createDecoder(ZlibWrapper wrapper, boolean streaming) {
+        return new JdkZlibDecoder(wrapper, streaming);
+    }
+
     @Test(expected = DecompressionException.class)
     @Override
     public void testZLIB_OR_NONE3() throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -597,7 +597,7 @@
       <dependency>
         <groupId>com.jcraft</groupId>
         <artifactId>jzlib</artifactId>
-        <version>1.1.2</version>
+        <version>1.1.3</version>
       </dependency>
       <dependency>
         <groupId>com.ning</groupId>


### PR DESCRIPTION
Motivation:

For certain custom protocols, messages can be compressed in batches. Current
decoder stops decompressing after first message.  This change allows the
JdkZlibDecoder to be part of a static pipeline instead of dynamically
adding/removing/adding after each message.

Modifications:

Add 'streaming' instance variable to determine whether we want old or new
behavior.  New behavior resets inflater for next message instead of setting
'finished' to true.

Result:

JdkZlibDecoder can decode multiple messages