### PR TITLE
Generate Expires attribute so IE can honor MaxAge, close #1466

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/ServerCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/ServerCookieEncoder.java
@@ -15,12 +15,13 @@
  */
 package io.netty.handler.codec.http;
 
+import static io.netty.handler.codec.http.CookieEncoderUtil.*;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
-
-import static io.netty.handler.codec.http.CookieEncoderUtil.*;
 
 /**
  * A <a href="http://tools.ietf.org/html/rfc6265">RFC6265</a> compliant cookie encoder to be used server side,
@@ -68,6 +69,8 @@ public final class ServerCookieEncoder {
 
         if (cookie.maxAge() != Long.MIN_VALUE) {
             add(buf, CookieHeaderNames.MAX_AGE, cookie.maxAge());
+            Date expires = new Date(cookie.maxAge() * 1000 + System.currentTimeMillis());
+            addUnquoted(buf, CookieHeaderNames.EXPIRES, HttpHeaderDateFormat.get().format(expires));
         }
 
         if (cookie.path() != null) {


### PR DESCRIPTION
Motivation:

Internet Explorer doesn't honor Set-Cookie header Max-Age attribute. It only honors the Expires one.

Modification:

Always generate an Expires attribute along the Max-Age one.

Result:

Internet Explorer compatible expiring cookies. Close #1466.