### PR TITLE
Allow to recv and send file descriptors when using EpollDomainSocketChan...

### DIFF
--- a/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.h
+++ b/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.h
@@ -67,7 +67,8 @@ jint Java_io_netty_channel_epoll_Native_socketDomain(JNIEnv * env, jclass clazz)
 
 jint Java_io_netty_channel_epoll_Native_bind(JNIEnv * env, jclass clazz, jint fd, jbyteArray address, jint scopeId, jint port);
 jint Java_io_netty_channel_epoll_Native_bindDomainSocket(JNIEnv * env, jclass clazz, jint fd, jstring address);
-jint Java_io_netty_channel_epoll_Native_recvFd(JNIEnv* env, jclass clazz, jint fd);
+jint Java_io_netty_channel_epoll_Native_recvFd0(JNIEnv* env, jclass clazz, jint fd);
+jint Java_io_netty_channel_epoll_Native_sendFd0(JNIEnv* env, jclass clazz, jint socketFd, jint fd);
 
 jint Java_io_netty_channel_epoll_Native_listen0(JNIEnv * env, jclass clazz, jint fd, jint backlog);
 jint Java_io_netty_channel_epoll_Native_connect(JNIEnv * env, jclass clazz, jint fd, jbyteArray address, jint scopeId, jint port);

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -75,7 +75,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
             try {
                 try {
                     for (;;) {
-                        int socketFd = Native.accept(fd);
+                        int socketFd = Native.accept(fd().intValue());
                         if (socketFd == -1) {
                             // this means everything was handled for now
                             break;

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelOption.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelOption.java
@@ -26,6 +26,9 @@ public final class EpollChannelOption<T> extends ChannelOption<T> {
 
     public static final ChannelOption<Boolean> SO_REUSEPORT = valueOf("SO_REUSEPORT");
 
+    public static final ChannelOption<EpollDomainSocketReadMode> DOMAIN_SOCKET_READ_MODE =
+            valueOf("DOMAIN_SOCKET_READ_MODE");
+
     @SuppressWarnings({ "unused", "deprecation" })
     private EpollChannelOption(String name) {
         super(name);

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannelConfig.java
@@ -192,56 +192,56 @@ public final class EpollDatagramChannelConfig extends DefaultChannelConfig imple
 
     @Override
     public int getSendBufferSize() {
-        return Native.getSendBufferSize(datagramChannel.fd);
+        return Native.getSendBufferSize(datagramChannel.fd().intValue());
     }
 
     @Override
     public EpollDatagramChannelConfig setSendBufferSize(int sendBufferSize) {
-        Native.setSendBufferSize(datagramChannel.fd, sendBufferSize);
+        Native.setSendBufferSize(datagramChannel.fd().intValue(), sendBufferSize);
         return this;
     }
 
     @Override
     public int getReceiveBufferSize() {
-        return Native.getReceiveBufferSize(datagramChannel.fd);
+        return Native.getReceiveBufferSize(datagramChannel.fd().intValue());
     }
 
     @Override
     public EpollDatagramChannelConfig setReceiveBufferSize(int receiveBufferSize) {
-        Native.setReceiveBufferSize(datagramChannel.fd, receiveBufferSize);
+        Native.setReceiveBufferSize(datagramChannel.fd().intValue(), receiveBufferSize);
         return this;
     }
 
     @Override
     public int getTrafficClass() {
-        return Native.getTrafficClass(datagramChannel.fd);
+        return Native.getTrafficClass(datagramChannel.fd().intValue());
     }
 
     @Override
     public EpollDatagramChannelConfig setTrafficClass(int trafficClass) {
-        Native.setTrafficClass(datagramChannel.fd, trafficClass);
+        Native.setTrafficClass(datagramChannel.fd().intValue(), trafficClass);
         return this;
     }
 
     @Override
     public boolean isReuseAddress() {
-        return Native.isReuseAddress(datagramChannel.fd) == 1;
+        return Native.isReuseAddress(datagramChannel.fd().intValue()) == 1;
     }
 
     @Override
     public EpollDatagramChannelConfig setReuseAddress(boolean reuseAddress) {
-        Native.setReuseAddress(datagramChannel.fd, reuseAddress ? 1 : 0);
+        Native.setReuseAddress(datagramChannel.fd().intValue(), reuseAddress ? 1 : 0);
         return this;
     }
 
     @Override
     public boolean isBroadcast() {
-        return Native.isBroadcast(datagramChannel.fd) == 1;
+        return Native.isBroadcast(datagramChannel.fd().intValue()) == 1;
     }
 
     @Override
     public EpollDatagramChannelConfig setBroadcast(boolean broadcast) {
-        Native.setBroadcast(datagramChannel.fd, broadcast ? 1 : 0);
+        Native.setBroadcast(datagramChannel.fd().intValue(), broadcast ? 1 : 0);
         return this;
     }
 
@@ -289,7 +289,7 @@ public final class EpollDatagramChannelConfig extends DefaultChannelConfig imple
      * Returns {@code true} if the SO_REUSEPORT option is set.
      */
     public boolean isReusePort() {
-        return Native.isReusePort(datagramChannel.fd) == 1;
+        return Native.isReusePort(datagramChannel.fd().intValue()) == 1;
     }
 
     /**
@@ -300,7 +300,7 @@ public final class EpollDatagramChannelConfig extends DefaultChannelConfig imple
      * any affect.
      */
     public EpollDatagramChannelConfig setReusePort(boolean reusePort) {
-        Native.setReusePort(datagramChannel.fd, reusePort ? 1 : 0);
+        Native.setReusePort(datagramChannel.fd().intValue(), reusePort ? 1 : 0);
         return this;
     }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.DefaultChannelConfig;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.RecvByteBufAllocator;
+
+import java.util.Map;
+
+public final class EpollDomainSocketChannelConfig extends DefaultChannelConfig {
+    private volatile EpollDomainSocketReadMode mode =
+            EpollDomainSocketReadMode.BYTES;
+
+    EpollDomainSocketChannelConfig(Channel channel) {
+        super(channel);
+    }
+
+    @Override
+    public Map<ChannelOption<?>, Object> getOptions() {
+        return getOptions(super.getOptions(), EpollChannelOption.DOMAIN_SOCKET_READ_MODE);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getOption(ChannelOption<T> option) {
+        if (option == EpollChannelOption.DOMAIN_SOCKET_READ_MODE) {
+            return (T) getReadMode();
+        }
+        return super.getOption(option);
+    }
+
+    @Override
+    public <T> boolean setOption(ChannelOption<T> option, T value) {
+        validate(option, value);
+
+        if (option == EpollChannelOption.DOMAIN_SOCKET_READ_MODE) {
+            setReadMode((EpollDomainSocketReadMode) value);
+        } else {
+            return super.setOption(option, value);
+        }
+
+        return true;
+    }
+    @Override
+    public EpollDomainSocketChannelConfig setMaxMessagesPerRead(int maxMessagesPerRead) {
+        super.setMaxMessagesPerRead(maxMessagesPerRead);
+        return this;
+    }
+
+    @Override
+    public EpollDomainSocketChannelConfig setConnectTimeoutMillis(int connectTimeoutMillis) {
+        super.setConnectTimeoutMillis(connectTimeoutMillis);
+        return this;
+    }
+
+    @Override
+    public EpollDomainSocketChannelConfig setWriteSpinCount(int writeSpinCount) {
+        super.setWriteSpinCount(writeSpinCount);
+        return this;
+    }
+
+    @Override
+    public EpollDomainSocketChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
+        super.setRecvByteBufAllocator(allocator);
+        return this;
+    }
+
+    @Override
+    public EpollDomainSocketChannelConfig setAllocator(ByteBufAllocator allocator) {
+        super.setAllocator(allocator);
+        return this;
+    }
+
+    @Override
+    public EpollDomainSocketChannelConfig setAutoClose(boolean autoClose) {
+        super.setAutoClose(autoClose);
+        return this;
+    }
+
+    @Override
+    public EpollDomainSocketChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
+        super.setMessageSizeEstimator(estimator);
+        return this;
+    }
+
+    @Override
+    public EpollDomainSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
+        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
+        return this;
+    }
+
+    @Override
+    public EpollDomainSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
+        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
+        return this;
+    }
+
+    @Override
+    public EpollDomainSocketChannelConfig setAutoRead(boolean autoRead) {
+        super.setAutoRead(autoRead);
+        return this;
+    }
+
+    /**
+     * Change the {@link EpollDomainSocketReadMode} for the channel. The default is
+     * {@link EpollDomainSocketReadMode#BYTES} which means bytes will be read from the
+     * {@link Channel} and passed through the pipeline. If
+     * {@link EpollDomainSocketReadMode#FILE_DESCRIPTORS} is used
+     * {@link EpollFileDescriptor}s will be passed through the {@link ChannelPipeline}.
+     *
+     * This setting can be modified on the fly if needed.
+     */
+    public EpollDomainSocketChannelConfig setReadMode(EpollDomainSocketReadMode mode) {
+        if (mode == null) {
+            throw new NullPointerException("mode");
+        }
+        this.mode = mode;
+        return this;
+    }
+
+    /**
+     * Return the {@link EpollDomainSocketReadMode} for the channel.
+     */
+    public EpollDomainSocketReadMode getReadMode() {
+        return mode;
+    }
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketReadMode.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketReadMode.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+public enum EpollDomainSocketReadMode {
+
+    /**
+     * Read (@link ByteBuf)s from the {@link EpollSocketChannel}.
+     */
+    BYTES,
+
+    /**
+     * Read (@link FileDscriptor)s from the {@link EpollSocketChannel}.
+     */
+    FILE_DESCRIPTORS
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -126,7 +126,7 @@ final class EpollEventLoop extends SingleThreadEventLoop {
     void add(AbstractEpollChannel ch) {
         assert inEventLoop();
         int id = nextId();
-        Native.epollCtlAdd(epollFd, ch.fd, ch.flags, id);
+        Native.epollCtlAdd(epollFd, ch.fd().intValue(), ch.flags, id);
         ch.id = id;
         ids.put(id, ch);
     }
@@ -136,7 +136,7 @@ final class EpollEventLoop extends SingleThreadEventLoop {
      */
     void modify(AbstractEpollChannel ch) {
         assert inEventLoop();
-        Native.epollCtlMod(epollFd, ch.fd, ch.flags, ch.id);
+        Native.epollCtlMod(epollFd, ch.fd().intValue(), ch.flags, ch.id);
     }
 
     /**
@@ -147,7 +147,7 @@ final class EpollEventLoop extends SingleThreadEventLoop {
         if (ids.remove(ch.id) != null && ch.isOpen()) {
             // Remove the epoll. This is only needed if it's still open as otherwise it will be automatically
             // removed once the file-descriptor is closed.
-            Native.epollCtlDel(epollFd, ch.fd);
+            Native.epollCtlDel(epollFd, ch.fd().intValue());
         }
     }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollFileDescriptor.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollFileDescriptor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.channel.FileDescriptor;
+
+import java.io.IOException;
+
+final class EpollFileDescriptor implements FileDescriptor {
+
+    private final int fd;
+
+    EpollFileDescriptor(int fd) {
+        if (fd < 0) {
+            throw new IllegalArgumentException("fd must be >= 0");
+        }
+        this.fd = fd;
+    }
+
+    @Override
+    public int intValue() {
+        return fd;
+    }
+
+    @Override
+    public void close() throws IOException {
+        Native.close(fd);
+    }
+
+    @Override
+    public String toString() {
+        return "FileDescriptor{" +
+                "fd=" + fd +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof EpollFileDescriptor)) {
+            return false;
+        }
+
+        return fd == ((EpollFileDescriptor) o).fd;
+    }
+
+    @Override
+    public int hashCode() {
+        return fd;
+    }
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerChannelConfig.java
@@ -75,20 +75,20 @@ public class EpollServerChannelConfig extends DefaultChannelConfig {
     }
 
     public boolean isReuseAddress() {
-        return Native.isReuseAddress(channel.fd) == 1;
+        return Native.isReuseAddress(channel.fd().intValue()) == 1;
     }
 
     public EpollServerChannelConfig setReuseAddress(boolean reuseAddress) {
-        Native.setReuseAddress(channel.fd, reuseAddress ? 1 : 0);
+        Native.setReuseAddress(channel.fd().intValue(), reuseAddress ? 1 : 0);
         return this;
     }
 
     public int getReceiveBufferSize() {
-        return Native.getReceiveBufferSize(channel.fd);
+        return Native.getReceiveBufferSize(channel.fd().intValue());
     }
 
     public EpollServerChannelConfig setReceiveBufferSize(int receiveBufferSize) {
-        Native.setReceiveBufferSize(channel.fd, receiveBufferSize);
+        Native.setReceiveBufferSize(channel.fd().intValue(), receiveBufferSize);
         return this;
     }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerDomainSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerDomainSocketChannel.java
@@ -46,6 +46,7 @@ public final class EpollServerDomainSocketChannel extends AbstractEpollServerCha
 
     @Override
     protected void doBind(SocketAddress localAddress) throws Exception {
+        int fd = fd().intValue();
         Native.bind(fd, localAddress);
         Native.listen(fd, config.getBacklog());
         local = (DomainSocketAddress) localAddress;

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -45,6 +45,7 @@ public final class EpollServerSocketChannel extends AbstractEpollServerChannel i
     protected void doBind(SocketAddress localAddress) throws Exception {
         InetSocketAddress addr = (InetSocketAddress) localAddress;
         checkResolvable(addr);
+        int fd = fd().intValue();
         Native.bind(fd, addr);
         local = Native.localAddress(fd);
         Native.listen(fd, config.getBacklog());

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannelConfig.java
@@ -143,7 +143,7 @@ public final class EpollServerSocketChannelConfig extends EpollServerChannelConf
      * Returns {@code true} if the SO_REUSEPORT option is set.
      */
     public boolean isReusePort() {
-        return Native.isReusePort(channel.fd) == 1;
+        return Native.isReusePort(channel.fd().intValue()) == 1;
     }
 
     /**
@@ -154,7 +154,7 @@ public final class EpollServerSocketChannelConfig extends EpollServerChannelConf
      * any affect.
      */
     public EpollServerSocketChannelConfig setReusePort(boolean reusePort) {
-        Native.setReusePort(channel.fd, reusePort ? 1 : 0);
+        Native.setReusePort(channel.fd().intValue(), reusePort ? 1 : 0);
         return this;
     }
 }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -72,6 +72,7 @@ public final class EpollSocketChannel extends AbstractEpollStreamChannel impleme
     @Override
     protected void doBind(SocketAddress local) throws Exception {
         InetSocketAddress localAddress = (InetSocketAddress) local;
+        int fd = fd().intValue();
         Native.bind(fd, localAddress);
         this.local = Native.localAddress(fd);
     }
@@ -113,6 +114,7 @@ public final class EpollSocketChannel extends AbstractEpollStreamChannel impleme
         }
         checkResolvable((InetSocketAddress) remoteAddress);
         if (super.doConnect(remoteAddress, localAddress)) {
+            int fd = fd().intValue();
             local = Native.localAddress(fd);
             remote = Native.remoteAddress(fd);
             return true;

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
@@ -132,70 +132,70 @@ public final class EpollSocketChannelConfig extends DefaultChannelConfig impleme
 
     @Override
     public int getReceiveBufferSize() {
-        return Native.getReceiveBufferSize(channel.fd);
+        return Native.getReceiveBufferSize(channel.fd().intValue());
     }
 
     @Override
     public int getSendBufferSize() {
-        return Native.getSendBufferSize(channel.fd);
+        return Native.getSendBufferSize(channel.fd().intValue());
     }
 
     @Override
     public int getSoLinger() {
-        return Native.getSoLinger(channel.fd);
+        return Native.getSoLinger(channel.fd().intValue());
     }
 
     @Override
     public int getTrafficClass() {
-        return Native.getTrafficClass(channel.fd);
+        return Native.getTrafficClass(channel.fd().intValue());
     }
 
     @Override
     public boolean isKeepAlive() {
-        return Native.isKeepAlive(channel.fd) == 1;
+        return Native.isKeepAlive(channel.fd().intValue()) == 1;
     }
 
     @Override
     public boolean isReuseAddress() {
-        return Native.isReuseAddress(channel.fd) == 1;
+        return Native.isReuseAddress(channel.fd().intValue()) == 1;
     }
 
     @Override
     public boolean isTcpNoDelay() {
-        return Native.isTcpNoDelay(channel.fd) == 1;
+        return Native.isTcpNoDelay(channel.fd().intValue()) == 1;
     }
 
     /**
      * Get the {@code TCP_CORK} option on the socket. See {@code man 7 tcp} for more details.
      */
     public boolean isTcpCork() {
-        return Native.isTcpCork(channel.fd) == 1;
+        return Native.isTcpCork(channel.fd().intValue()) == 1;
     }
 
     /**
      * Get the {@code TCP_KEEPIDLE} option on the socket. See {@code man 7 tcp} for more details.
      */
     public int getTcpKeepIdle() {
-        return Native.getTcpKeepIdle(channel.fd);
+        return Native.getTcpKeepIdle(channel.fd().intValue());
     }
 
     /**
      * Get the {@code TCP_KEEPINTVL} option on the socket. See {@code man 7 tcp} for more details.
      */
     public int getTcpKeepIntvl() {
-        return Native.getTcpKeepIntvl(channel.fd);
+        return Native.getTcpKeepIntvl(channel.fd().intValue());
     }
 
     /**
      * Get the {@code TCP_KEEPCNT} option on the socket. See {@code man 7 tcp} for more details.
      */
     public int getTcpKeepCnt() {
-        return Native.getTcpKeepCnt(channel.fd);
+        return Native.getTcpKeepCnt(channel.fd().intValue());
     }
 
     @Override
     public EpollSocketChannelConfig setKeepAlive(boolean keepAlive) {
-        Native.setKeepAlive(channel.fd, keepAlive ? 1 : 0);
+        Native.setKeepAlive(channel.fd().intValue(), keepAlive ? 1 : 0);
         return this;
     }
 
@@ -207,31 +207,31 @@ public final class EpollSocketChannelConfig extends DefaultChannelConfig impleme
 
     @Override
     public EpollSocketChannelConfig setReceiveBufferSize(int receiveBufferSize) {
-        Native.setReceiveBufferSize(channel.fd, receiveBufferSize);
+        Native.setReceiveBufferSize(channel.fd().intValue(), receiveBufferSize);
         return this;
     }
 
     @Override
     public EpollSocketChannelConfig setReuseAddress(boolean reuseAddress) {
-        Native.setReuseAddress(channel.fd, reuseAddress ? 1 : 0);
+        Native.setReuseAddress(channel.fd().intValue(), reuseAddress ? 1 : 0);
         return this;
     }
 
     @Override
     public EpollSocketChannelConfig setSendBufferSize(int sendBufferSize) {
-        Native.setSendBufferSize(channel.fd, sendBufferSize);
+        Native.setSendBufferSize(channel.fd().intValue(), sendBufferSize);
         return this;
     }
 
     @Override
     public EpollSocketChannelConfig setSoLinger(int soLinger) {
-        Native.setSoLinger(channel.fd, soLinger);
+        Native.setSoLinger(channel.fd().intValue(), soLinger);
         return this;
     }
 
     @Override
     public EpollSocketChannelConfig setTcpNoDelay(boolean tcpNoDelay) {
-        Native.setTcpNoDelay(channel.fd, tcpNoDelay ? 1 : 0);
+        Native.setTcpNoDelay(channel.fd().intValue(), tcpNoDelay ? 1 : 0);
         return this;
     }
 
@@ -239,13 +239,13 @@ public final class EpollSocketChannelConfig extends DefaultChannelConfig impleme
      * Set the {@code TCP_CORK} option on the socket. See {@code man 7 tcp} for more details.
      */
     public EpollSocketChannelConfig setTcpCork(boolean tcpCork) {
-        Native.setTcpCork(channel.fd, tcpCork ? 1 : 0);
+        Native.setTcpCork(channel.fd().intValue(), tcpCork ? 1 : 0);
         return this;
     }
 
     @Override
     public EpollSocketChannelConfig setTrafficClass(int trafficClass) {
-        Native.setTrafficClass(channel.fd, trafficClass);
+        Native.setTrafficClass(channel.fd().intValue(), trafficClass);
         return this;
     }
 
@@ -253,7 +253,7 @@ public final class EpollSocketChannelConfig extends DefaultChannelConfig impleme
      * Set the {@code TCP_KEEPIDLE} option on the socket. See {@code man 7 tcp} for more details.
      */
     public EpollSocketChannelConfig setTcpKeepIdle(int seconds) {
-        Native.setTcpKeepIdle(channel.fd, seconds);
+        Native.setTcpKeepIdle(channel.fd().intValue(), seconds);
         return this;
     }
 
@@ -261,7 +261,7 @@ public final class EpollSocketChannelConfig extends DefaultChannelConfig impleme
      * Set the {@code TCP_KEEPINTVL} option on the socket. See {@code man 7 tcp} for more details.
      */
     public EpollSocketChannelConfig setTcpKeepIntvl(int seconds) {
-        Native.setTcpKeepIntvl(channel.fd, seconds);
+        Native.setTcpKeepIntvl(channel.fd().intValue(), seconds);
         return this;
     }
 
@@ -269,7 +269,7 @@ public final class EpollSocketChannelConfig extends DefaultChannelConfig impleme
      * Set the {@code TCP_KEEPCNT} option on the socket. See {@code man 7 tcp} for more details.
      */
     public EpollSocketChannelConfig setTcpKeepCntl(int probes) {
-        Native.setTcpKeepCnt(channel.fd, probes);
+        Native.setTcpKeepCnt(channel.fd().intValue(), probes);
         return this;
     }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -501,6 +501,24 @@ final class Native {
 
     public static int recvFd(int fd) throws IOException {
         int res = recvFd0(fd);
+        if (res > 0) {
+            return res;
+        }
+        if (res == 0) {
+            return -1;
+        }
+
+        if (res == ERRNO_EAGAIN_NEGATIVE || res == ERRNO_EWOULDBLOCK_NEGATIVE) {
+            // Everything consumed so just return -1 here.
+            return 0;
+        }
+        throw newIOException("recvFd", res);
+    }
+
+    private static native int recvFd0(int fd);
+
+    public static int sendFd(int socketFd, int fd) throws IOException {
+        int res = sendFd0(socketFd, fd);
         if (res >= 0) {
             return res;
         }
@@ -508,10 +526,10 @@ final class Native {
             // Everything consumed so just return -1 here.
             return -1;
         }
-        throw newIOException("recvFd", res);
+        throw newIOException("sendFd", res);
     }
 
-    private static native int recvFd0(int fd);
+    private static native int sendFd0(int socketFd, int fd);
 
     public static void shutdown(int fd, boolean read, boolean write) throws IOException {
         int res = shutdown0(fd, read, write);

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.AbstractSocketTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.SocketAddress;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+
+public class EpollDomainSocketFdTest extends AbstractSocketTest {
+    @Override
+    protected SocketAddress newSocketAddress() {
+        return EpollSocketTestPermutation.newSocketAddress();
+    }
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return EpollSocketTestPermutation.INSTANCE.domainSocket();
+    }
+
+    @Test(timeout = 30000)
+    public void testSendRecvFd() throws Throwable {
+        run();
+    }
+
+    public void testSendRecvFd(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        final BlockingQueue<Object> queue = new LinkedBlockingQueue<Object>(1);
+        sb.childHandler(new ChannelInboundHandlerAdapter() {
+            @Override
+            public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                // Create new channel and obtain a file descriptor from it.
+                final EpollDomainSocketChannel ch = new EpollDomainSocketChannel();
+
+                ctx.writeAndFlush(ch.fd()).addListener(new ChannelFutureListener() {
+                    @Override
+                    public void operationComplete(ChannelFuture future) throws Exception {
+                        if (!future.isSuccess()) {
+                            Throwable cause = future.cause();
+                            queue.offer(cause);
+                        }
+                    }
+                });
+            }
+        });
+        cb.handler(new ChannelInboundHandlerAdapter() {
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                EpollFileDescriptor fd = (EpollFileDescriptor) msg;
+                queue.offer(fd);
+            }
+
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                queue.add(cause);
+                ctx.close();
+            }
+        });
+        cb.option(EpollChannelOption.DOMAIN_SOCKET_READ_MODE,
+                EpollDomainSocketReadMode.FILE_DESCRIPTORS);
+        Channel sc = sb.bind().sync().channel();
+        Channel cc = cb.connect().sync().channel();
+
+        Object received = queue.take();
+        cc.close().sync();
+        sc.close().sync();
+
+        if (received instanceof EpollFileDescriptor) {
+            Assert.assertNotSame(EpollFileDescriptor.INVALID, received);
+            ((EpollFileDescriptor) received).close();
+            Assert.assertNull(queue.poll());
+        } else {
+            throw (Throwable) received;
+        }
+    }
+}

--- a/transport/src/main/java/io/netty/channel/FileDescriptor.java
+++ b/transport/src/main/java/io/netty/channel/FileDescriptor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import java.io.IOException;
+
+public interface FileDescriptor {
+
+    /**
+     * An invalid file descriptor which was closed before.
+     */
+    FileDescriptor INVALID = new FileDescriptor() {
+        @Override
+        public int intValue() {
+            return -1;
+        }
+
+        @Override
+        public void close() {
+            // MOOP
+        }
+    };
+
+    /**
+     * Return the int value of the filedescriptor.
+     */
+    int intValue();
+
+    /**
+     * Close the file descriptor.
+     */
+    void close() throws IOException;
+}


### PR DESCRIPTION
...nel.

Motiviation:

When using domain sockets on linux it is supported to recv and send file descriptors. This can be used to pass around for example sockets.

Modifications:
- Add support for recv and send file descriptors when using EpollDomainSocketChannel.
- Allow to obtain the file descriptor for an Epoll*Channel so it can be send via domain sockets.

Result:
recv and send of file descriptors is supported now.