### PR TITLE
Fix NPE when remote address can not be obtained

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -94,6 +94,14 @@ public final class EpollSocketChannel extends AbstractEpollChannel implements So
 
     @Override
     protected SocketAddress remoteAddress0() {
+        if (remote == null) {
+            // Remote address not know, try to get it now.
+            InetSocketAddress address = Native.remoteAddress(fd);
+            if (address != null) {
+                remote = address;
+            }
+            return address;
+        }
         return remote;
     }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -399,11 +399,21 @@ final class Native {
 
     public static InetSocketAddress remoteAddress(int fd) {
         byte[] addr = remoteAddress0(fd);
+        // addr may be null if getpeername failed.
+        // See https://github.com/netty/netty/issues/3328
+        if (addr == null) {
+            return null;
+        }
         return address(addr);
     }
 
     public static InetSocketAddress localAddress(int fd) {
         byte[] addr = localAddress0(fd);
+        // addr may be null if getpeername failed.
+        // See https://github.com/netty/netty/issues/3328
+        if (addr == null) {
+            return null;
+        }
         return address(addr);
     }
 


### PR DESCRIPTION
Motivation:

In the native transport we use getpeername to obtain the remote address from the file descriptor. This may fail for various reasons in which case NULL is returned.

Modifications:

- Check for null when try to obtain remote / local address

Result:

No more NPE