### PR TITLE
Generate Expires attribute along MaxAge one so IE can honor it, close #1466

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/ServerCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/ServerCookieEncoder.java
@@ -52,14 +52,13 @@ public final class ServerCookieEncoder {
         add(buf, cookie.getName(), cookie.getValue());
 
         if (cookie.getMaxAge() != Long.MIN_VALUE) {
-            if (cookie.getVersion() == 0) {
-                addUnquoted(buf, CookieHeaderNames.EXPIRES,
-                        HttpHeaderDateFormat.get().format(
-                                new Date(System.currentTimeMillis() +
-                                         cookie.getMaxAge() * 1000L)));
-            } else {
+            if (cookie.getVersion() != 0) {
                 add(buf, CookieHeaderNames.MAX_AGE, cookie.getMaxAge());
             }
+            addUnquoted(buf, CookieHeaderNames.EXPIRES,
+                    HttpHeaderDateFormat.get().format(
+                            new Date(System.currentTimeMillis() +
+                                    cookie.getMaxAge() * 1000L)));
         }
 
         if (cookie.getPath() != null) {


### PR DESCRIPTION
Motivation:

Internet Explorer doesn't honor Set-Cookie header Max-Age attribute. It only honors the Expires one.

Modification:

Always generate an Expires attribute along the Max-Age one.

Result:

Internet Explorer compatible expiring cookies. Close #1466.