### PR TITLE
MaxAge should output only digits.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultCookie.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultCookie.java
@@ -340,8 +340,7 @@ public class DefaultCookie implements Cookie {
         }
         if (maxAge() >= 0) {
             buf.append(", maxAge=")
-               .append(maxAge())
-               .append('s');
+               .append(maxAge());
         }
         if (isSecure()) {
             buf.append(", secure");

--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultCookieTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultCookieTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DefaultCookieTest {
+
+    @Test
+    public void testMaxAge() {
+        DefaultCookie cookie = new DefaultCookie("key", "value");
+        cookie.setMaxAge(10);
+        assertEquals("key=value, maxAge=10",cookie.toString());
+    }
+}


### PR DESCRIPTION
- according to RFC6265
http://tools.ietf.org/search/rfc6265#section-4.1.2.2
 http://tools.ietf.org/search/rfc6265#section-5.2.2

#3355 