### PR TITLE
invalid refernece decrement in AbstractNioByteChannel for issue 3369

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -116,6 +116,7 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
                     if (localReadAmount <= 0) {
                         // not was read release the buffer
                         byteBuf.release();
+                        byteBuf = null;
                         close = localReadAmount < 0;
                         break;
                     }


### PR DESCRIPTION
fix a double free bug in AbstractNioByteChannel for Netty4.0+

Motivation:

see issue #3369 .  

Modifications:

Add a line of code in line 119
                        byteBuf = null;
to set byteBuf to null to avoid another byteBuf.release() to be called in handleReadException()