### PR TITLE
Allow to use EmbeddedChannel.schedule*(...)

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -58,10 +58,10 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
             return;
         }
 
-        final ScheduledFutureTask<?>[] delayedTasks =
+        final ScheduledFutureTask<?>[] scheduledTasks =
                 scheduledTaskQueue.toArray(new ScheduledFutureTask<?>[scheduledTaskQueue.size()]);
 
-        for (ScheduledFutureTask<?> task: delayedTasks) {
+        for (ScheduledFutureTask<?> task: scheduledTasks) {
             task.cancel(false);
         }
 
@@ -83,14 +83,14 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         assert inEventLoop();
 
         Queue<ScheduledFutureTask<?>> scheduledTaskQueue = this.scheduledTaskQueue;
-        ScheduledFutureTask<?> delayedTask = scheduledTaskQueue == null ? null : scheduledTaskQueue.peek();
-        if (delayedTask == null) {
+        ScheduledFutureTask<?> scheduledTask = scheduledTaskQueue == null ? null : scheduledTaskQueue.peek();
+        if (scheduledTask == null) {
             return null;
         }
 
-        if (delayedTask.deadlineNanos() <= nanoTime) {
+        if (scheduledTask.deadlineNanos() <= nanoTime) {
             scheduledTaskQueue.remove();
-            return delayedTask;
+            return scheduledTask;
         }
         return null;
     }
@@ -102,11 +102,11 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         assert checkInEventLoop();
 
         Queue<ScheduledFutureTask<?>> scheduledTaskQueue = this.scheduledTaskQueue;
-        ScheduledFutureTask<?> delayedTask = scheduledTaskQueue == null ? null : scheduledTaskQueue.peek();
-        if (delayedTask == null) {
+        ScheduledFutureTask<?> scheduledTask = scheduledTaskQueue == null ? null : scheduledTaskQueue.peek();
+        if (scheduledTask == null) {
             return -1;
         }
-        return Math.max(0, delayedTask.deadlineNanos() - nanoTime());
+        return Math.max(0, scheduledTask.deadlineNanos() - nanoTime());
     }
 
     final ScheduledFutureTask<?> peekScheduledTask() {
@@ -126,8 +126,8 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         assert checkInEventLoop();
 
         Queue<ScheduledFutureTask<?>> scheduledTaskQueue = this.scheduledTaskQueue;
-        ScheduledFutureTask<?> delayedTask = scheduledTaskQueue == null ? null : scheduledTaskQueue.peek();
-        return delayedTask != null && delayedTask.deadlineNanos() <= nanoTime();
+        ScheduledFutureTask<?> scheduledTask = scheduledTaskQueue == null ? null : scheduledTaskQueue.peek();
+        return scheduledTask != null && scheduledTask.deadlineNanos() <= nanoTime();
     }
 
     @Override
@@ -221,6 +221,6 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
     }
 
     boolean checkInEventLoop() {
-        return true;
+        return inEventLoop();
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -99,8 +99,6 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
      * Return the nanoseconds when the next scheduled task is ready to be run or {@code -1} if no task is scheduled.
      */
     protected final long nextScheduledTaskNano() {
-        assert checkInEventLoop();
-
         Queue<ScheduledFutureTask<?>> scheduledTaskQueue = this.scheduledTaskQueue;
         ScheduledFutureTask<?> scheduledTask = scheduledTaskQueue == null ? null : scheduledTaskQueue.peek();
         if (scheduledTask == null) {
@@ -110,8 +108,6 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
     }
 
     final ScheduledFutureTask<?> peekScheduledTask() {
-        assert checkInEventLoop();
-
         Queue<ScheduledFutureTask<?>> scheduledTaskQueue = this.scheduledTaskQueue;
         if (scheduledTaskQueue == null) {
             return null;
@@ -123,8 +119,6 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
      * Returns {@code true} if a scheduled task is ready for processing.
      */
     protected final boolean hasScheduledTasks() {
-        assert checkInEventLoop();
-
         Queue<ScheduledFutureTask<?>> scheduledTaskQueue = this.scheduledTaskQueue;
         ScheduledFutureTask<?> scheduledTask = scheduledTaskQueue == null ? null : scheduledTaskQueue.peek();
         return scheduledTask != null && scheduledTask.deadlineNanos() <= nanoTime();
@@ -206,7 +200,6 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
     }
 
     void purgeCancelledScheduledTasks() {
-        assert checkInEventLoop();
         Queue<ScheduledFutureTask<?>> scheduledTaskQueue = this.scheduledTaskQueue;
         if (isNullOrEmpty(scheduledTaskQueue)) {
             return;
@@ -218,9 +211,5 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
                 i.remove();
             }
         }
-    }
-
-    boolean checkInEventLoop() {
-        return inEventLoop();
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/AbstractSchedulingEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractSchedulingEventExecutor.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Abstract base class for {@link EventExecutor}s that want to support scheduling.
+ */
+public abstract class AbstractSchedulingEventExecutor extends AbstractEventExecutor {
+
+    final Queue<ScheduledFutureTask<?>> delayedTaskQueue = new PriorityQueue<ScheduledFutureTask<?>>();
+
+    protected static long nanoTime() {
+        return ScheduledFutureTask.nanoTime();
+    }
+
+    protected final void cancelDelayedTasks() {
+        if (delayedTaskQueue.isEmpty()) {
+            return;
+        }
+
+        final ScheduledFutureTask<?>[] delayedTasks =
+                delayedTaskQueue.toArray(new ScheduledFutureTask<?>[delayedTaskQueue.size()]);
+
+        for (ScheduledFutureTask<?> task: delayedTasks) {
+            task.cancel(false);
+        }
+
+        delayedTaskQueue.clear();
+    }
+
+    /**
+     * @see {@link #pollScheduledTask(long)}
+     */
+    protected final Runnable pollScheduledTask() {
+        return pollScheduledTask(nanoTime());
+    }
+
+    /**
+     * Return the {@link Runnable} which is ready to be executed with the given {@code nanoTime}.
+     * You should use {@link #nanoTime()} to retrieve the the correct {@code nanoTime}.
+     */
+    protected final Runnable pollScheduledTask(long nanoTime) {
+        assert inEventLoop();
+
+        ScheduledFutureTask<?> delayedTask = delayedTaskQueue.peek();
+        if (delayedTask == null) {
+            return null;
+        }
+
+        if (delayedTask.deadlineNanos() <= nanoTime) {
+            delayedTaskQueue.remove();
+            return delayedTask;
+        }
+        return null;
+    }
+
+    /**
+     * Return the nanoseconds when the next scheduled task is ready to be run or {@code -1} if no task is scheduled.
+     */
+    protected final long nextScheduledTaskNano() {
+        assert inEventLoop();
+        ScheduledFutureTask<?> delayedTask = delayedTaskQueue.peek();
+        if (delayedTask == null) {
+            return -1;
+        }
+        return Math.max(0, delayedTask.deadlineNanos() - nanoTime());
+    }
+
+    /**
+     * Returns {@code true} if a scheduled task is ready for processing.
+     */
+    protected final boolean hasScheduledTasks() {
+        assert inEventLoop();
+        ScheduledFutureTask<?> delayedTask = delayedTaskQueue.peek();
+        return delayedTask != null && delayedTask.deadlineNanos() <= nanoTime();
+    }
+
+    @Override
+    public  ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        if (command == null) {
+            throw new NullPointerException("command");
+        }
+        if (unit == null) {
+            throw new NullPointerException("unit");
+        }
+        if (delay < 0) {
+            throw new IllegalArgumentException(
+                    String.format("delay: %d (expected: >= 0)", delay));
+        }
+        return schedule(new ScheduledFutureTask<Void>(
+                this, delayedTaskQueue, command, null, ScheduledFutureTask.deadlineNanos(unit.toNanos(delay))));
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        if (callable == null) {
+            throw new NullPointerException("callable");
+        }
+        if (unit == null) {
+            throw new NullPointerException("unit");
+        }
+        if (delay < 0) {
+            throw new IllegalArgumentException(
+                    String.format("delay: %d (expected: >= 0)", delay));
+        }
+        return schedule(new ScheduledFutureTask<V>(
+                this, delayedTaskQueue, callable, ScheduledFutureTask.deadlineNanos(unit.toNanos(delay))));
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        if (command == null) {
+            throw new NullPointerException("command");
+        }
+        if (unit == null) {
+            throw new NullPointerException("unit");
+        }
+        if (initialDelay < 0) {
+            throw new IllegalArgumentException(
+                    String.format("initialDelay: %d (expected: >= 0)", initialDelay));
+        }
+        if (period <= 0) {
+            throw new IllegalArgumentException(
+                    String.format("period: %d (expected: > 0)", period));
+        }
+
+        return schedule(new ScheduledFutureTask<Void>(
+                this, delayedTaskQueue, Executors.<Void>callable(command, null),
+                ScheduledFutureTask.deadlineNanos(unit.toNanos(initialDelay)), unit.toNanos(period)));
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        if (command == null) {
+            throw new NullPointerException("command");
+        }
+        if (unit == null) {
+            throw new NullPointerException("unit");
+        }
+        if (initialDelay < 0) {
+            throw new IllegalArgumentException(
+                    String.format("initialDelay: %d (expected: >= 0)", initialDelay));
+        }
+        if (delay <= 0) {
+            throw new IllegalArgumentException(
+                    String.format("delay: %d (expected: > 0)", delay));
+        }
+
+        return schedule(new ScheduledFutureTask<Void>(
+                this, delayedTaskQueue, Executors.<Void>callable(command, null),
+                ScheduledFutureTask.deadlineNanos(unit.toNanos(initialDelay)), -unit.toNanos(delay)));
+    }
+
+    private <V> ScheduledFuture<V> schedule(final ScheduledFutureTask<V> task) {
+        if (task == null) {
+            throw new NullPointerException("task");
+        }
+
+        if (inEventLoop()) {
+            delayedTaskQueue.add(task);
+        } else {
+            execute(new Runnable() {
+                @Override
+                public void run() {
+                    delayedTaskQueue.add(task);
+                }
+            });
+        }
+
+        return task;
+    }
+}

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -18,11 +18,8 @@ package io.netty.util.concurrent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import java.util.Iterator;
-import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
@@ -35,7 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * task pending in the task queue for 1 second.  Please note it is not scalable to schedule large number of tasks to
  * this executor; use a dedicated executor.
  */
-public final class GlobalEventExecutor extends AbstractEventExecutor {
+public final class GlobalEventExecutor extends AbstractScheduledEventExecutor {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(GlobalEventExecutor.class);
 
@@ -44,9 +41,8 @@ public final class GlobalEventExecutor extends AbstractEventExecutor {
     public static final GlobalEventExecutor INSTANCE = new GlobalEventExecutor();
 
     final BlockingQueue<Runnable> taskQueue = new LinkedBlockingQueue<Runnable>();
-    final Queue<ScheduledFutureTask<?>> delayedTaskQueue = new PriorityQueue<ScheduledFutureTask<?>>();
     final ScheduledFutureTask<Void> purgeTask = new ScheduledFutureTask<Void>(
-            this, delayedTaskQueue, Executors.<Void>callable(new PurgeTask(), null),
+            this, Executors.<Void>callable(new PurgeTask(), null),
             ScheduledFutureTask.deadlineNanos(SCHEDULE_PURGE_INTERVAL), -SCHEDULE_PURGE_INTERVAL);
 
     private final ThreadFactory threadFactory = new DefaultThreadFactory(getClass());
@@ -57,7 +53,7 @@ public final class GlobalEventExecutor extends AbstractEventExecutor {
     private final Future<?> terminationFuture = new FailedFuture<Object>(this, new UnsupportedOperationException());
 
     private GlobalEventExecutor() {
-        delayedTaskQueue.add(purgeTask);
+        scheduledTaskQueue().add(purgeTask);
     }
 
     @Override
@@ -73,7 +69,7 @@ public final class GlobalEventExecutor extends AbstractEventExecutor {
     Runnable takeTask() {
         BlockingQueue<Runnable> taskQueue = this.taskQueue;
         for (;;) {
-            ScheduledFutureTask<?> delayedTask = delayedTaskQueue.peek();
+            ScheduledFutureTask<?> delayedTask = peekScheduledTask();
             if (delayedTask == null) {
                 Runnable task = null;
                 try {
@@ -108,22 +104,14 @@ public final class GlobalEventExecutor extends AbstractEventExecutor {
     }
 
     private void fetchFromDelayedQueue() {
-        long nanoTime = 0L;
-        for (;;) {
-            ScheduledFutureTask<?> delayedTask = delayedTaskQueue.peek();
-            if (delayedTask == null) {
-                break;
-            }
-
-            if (nanoTime == 0L) {
-                nanoTime = ScheduledFutureTask.nanoTime();
-            }
-
-            if (delayedTask.deadlineNanos() <= nanoTime) {
-                delayedTaskQueue.remove();
+        if (hasScheduledTasks()) {
+            long nanoTime = AbstractScheduledEventExecutor.nanoTime();
+            for (;;) {
+                Runnable delayedTask = pollScheduledTask(nanoTime);
+                if (delayedTask == null) {
+                    break;
+                }
                 taskQueue.add(delayedTask);
-            } else {
-                break;
             }
         }
     }
@@ -223,101 +211,9 @@ public final class GlobalEventExecutor extends AbstractEventExecutor {
         }
     }
 
-    // ScheduledExecutorService implementation
-
     @Override
-    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-        if (command == null) {
-            throw new NullPointerException("command");
-        }
-        if (unit == null) {
-            throw new NullPointerException("unit");
-        }
-        if (delay < 0) {
-            throw new IllegalArgumentException(
-                    String.format("delay: %d (expected: >= 0)", delay));
-        }
-        return schedule(new ScheduledFutureTask<Void>(
-                this, delayedTaskQueue, command, null, ScheduledFutureTask.deadlineNanos(unit.toNanos(delay))));
-    }
-
-    @Override
-    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-        if (callable == null) {
-            throw new NullPointerException("callable");
-        }
-        if (unit == null) {
-            throw new NullPointerException("unit");
-        }
-        if (delay < 0) {
-            throw new IllegalArgumentException(
-                    String.format("delay: %d (expected: >= 0)", delay));
-        }
-        return schedule(new ScheduledFutureTask<V>(
-                this, delayedTaskQueue, callable, ScheduledFutureTask.deadlineNanos(unit.toNanos(delay))));
-    }
-
-    @Override
-    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
-        if (command == null) {
-            throw new NullPointerException("command");
-        }
-        if (unit == null) {
-            throw new NullPointerException("unit");
-        }
-        if (initialDelay < 0) {
-            throw new IllegalArgumentException(
-                    String.format("initialDelay: %d (expected: >= 0)", initialDelay));
-        }
-        if (period <= 0) {
-            throw new IllegalArgumentException(
-                    String.format("period: %d (expected: > 0)", period));
-        }
-
-        return schedule(new ScheduledFutureTask<Void>(
-                this, delayedTaskQueue, Executors.<Void>callable(command, null),
-                ScheduledFutureTask.deadlineNanos(unit.toNanos(initialDelay)), unit.toNanos(period)));
-    }
-
-    @Override
-    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
-        if (command == null) {
-            throw new NullPointerException("command");
-        }
-        if (unit == null) {
-            throw new NullPointerException("unit");
-        }
-        if (initialDelay < 0) {
-            throw new IllegalArgumentException(
-                    String.format("initialDelay: %d (expected: >= 0)", initialDelay));
-        }
-        if (delay <= 0) {
-            throw new IllegalArgumentException(
-                    String.format("delay: %d (expected: > 0)", delay));
-        }
-
-        return schedule(new ScheduledFutureTask<Void>(
-                this, delayedTaskQueue, Executors.<Void>callable(command, null),
-                ScheduledFutureTask.deadlineNanos(unit.toNanos(initialDelay)), -unit.toNanos(delay)));
-    }
-
-    private <V> ScheduledFuture<V> schedule(final ScheduledFutureTask<V> task) {
-        if (task == null) {
-            throw new NullPointerException("task");
-        }
-
-        if (inEventLoop()) {
-            delayedTaskQueue.add(task);
-        } else {
-            execute(new Runnable() {
-                @Override
-                public void run() {
-                    delayedTaskQueue.add(task);
-                }
-            });
-        }
-
-        return task;
+    boolean checkInEventLoop() {
+        return true;
     }
 
     private void startThread() {
@@ -345,8 +241,9 @@ public final class GlobalEventExecutor extends AbstractEventExecutor {
                     }
                 }
 
+                Queue<ScheduledFutureTask<?>> delayedTaskQueue = scheduledTaskQueue;
                 // Terminate if there is no task in the queue (except the purge task).
-                if (taskQueue.isEmpty() && delayedTaskQueue.size() == 1) {
+                if (taskQueue.isEmpty() && (delayedTaskQueue == null || delayedTaskQueue.size() == 1)) {
                     // Mark the current thread as stopped.
                     // The following CAS must always success and must be uncontended,
                     // because only one thread should be running at the same time.
@@ -354,7 +251,7 @@ public final class GlobalEventExecutor extends AbstractEventExecutor {
                     assert stopped;
 
                     // Check if there are pending entries added by execute() or schedule*() while we do CAS above.
-                    if (taskQueue.isEmpty() && delayedTaskQueue.size() == 1) {
+                    if (taskQueue.isEmpty() && (delayedTaskQueue == null || delayedTaskQueue.size() == 1)) {
                         // A) No new task was added and thus there's nothing to handle
                         //    -> safe to terminate because there's nothing left to do
                         // B) A new thread started and handled all the new tasks.
@@ -380,13 +277,7 @@ public final class GlobalEventExecutor extends AbstractEventExecutor {
     private final class PurgeTask implements Runnable {
         @Override
         public void run() {
-            Iterator<ScheduledFutureTask<?>> i = delayedTaskQueue.iterator();
-            while (i.hasNext()) {
-                ScheduledFutureTask<?> task = i.next();
-                if (task.isCancelled()) {
-                    i.remove();
-                }
-            }
+            purgeCancelledScheduledTasks();
         }
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -211,11 +211,6 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor {
         }
     }
 
-    @Override
-    boolean checkInEventLoop() {
-        return true;
-    }
-
     private void startThread() {
         if (started.compareAndSet(false, true)) {
             Thread t = threadFactory.newThread(taskRunner);

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -618,7 +618,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
             throw new IllegalStateException("must be invoked from an event loop");
         }
 
-        cancelDelayedTasks();
+        cancelScheduledTasks();
 
         if (gracefulShutdownStartTime == 0) {
             gracefulShutdownStartTime = ScheduledFutureTask.nanoTime();

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
@@ -67,8 +67,9 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
         return nextScheduledTaskNano();
     }
 
-    void cancelScheduledTasks() {
-        cancelDelayedTasks();
+    @Override
+    protected void cancelScheduledTasks() {
+        super.cancelScheduledTasks();
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
@@ -21,14 +21,14 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
-import io.netty.util.concurrent.AbstractEventExecutor;
+import io.netty.util.concurrent.AbstractSchedulingEventExecutor;
 import io.netty.util.concurrent.Future;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 
-final class EmbeddedEventLoop extends AbstractEventExecutor implements EventLoop {
+final class EmbeddedEventLoop extends AbstractSchedulingEventExecutor implements EventLoop {
 
     private final Queue<Runnable> tasks = new ArrayDeque<Runnable>(2);
 
@@ -49,6 +49,26 @@ final class EmbeddedEventLoop extends AbstractEventExecutor implements EventLoop
 
             task.run();
         }
+    }
+
+    long runScheduledTasks() {
+        long time = AbstractSchedulingEventExecutor.nanoTime();
+        for (;;) {
+            Runnable task = pollScheduledTask(time);
+            if (task == null) {
+                return nextScheduledTaskNano();
+            }
+
+            task.run();
+        }
+    }
+
+    long nextScheduledTask() {
+        return nextScheduledTaskNano();
+    }
+
+    void cancelScheduledTasks() {
+        cancelDelayedTasks();
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
@@ -21,14 +21,14 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
-import io.netty.util.concurrent.AbstractSchedulingEventExecutor;
+import io.netty.util.concurrent.AbstractScheduledEventExecutor;
 import io.netty.util.concurrent.Future;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 
-final class EmbeddedEventLoop extends AbstractSchedulingEventExecutor implements EventLoop {
+final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements EventLoop {
 
     private final Queue<Runnable> tasks = new ArrayDeque<Runnable>(2);
 
@@ -52,7 +52,7 @@ final class EmbeddedEventLoop extends AbstractSchedulingEventExecutor implements
     }
 
     long runScheduledTasks() {
-        long time = AbstractSchedulingEventExecutor.nanoTime();
+        long time = AbstractScheduledEventExecutor.nanoTime();
         for (;;) {
             Runnable task = pollScheduledTask(time);
             if (task == null) {

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -78,7 +78,9 @@ public class EmbeddedChannelTest {
         });
         long next = ch.runScheduledPendingTasks();
         Assert.assertTrue(next > 0);
-        Thread.sleep(TimeUnit.NANOSECONDS.toMillis(next));
+        // Sleep for the nanoseconds but also give extra 50ms as the clock my not be very precise and so fail the test
+        // otherwise.
+        Thread.sleep(TimeUnit.NANOSECONDS.toMillis(next) + 50);
         Assert.assertEquals(-1, ch.runScheduledPendingTasks());
         latch.await();
     }


### PR DESCRIPTION
Motivation:

At the moment when EmbeddedChannel is used and a ChannelHandler tries to schedule and task it will throw an UnsupportedOperationException. This makes it impossible to test these handlers or even reuse them with EmbeddedChannel.

Modifications:

- Factor out reusable scheduling code into AbstractSchedulingEventExecutor
- Let EmbeddedEventLoop and SingleThreadEventExecutor extend AbstractSchedulingEventExecutor
- add EmbbededChannel.runScheduledPendingTasks() which allows to run all scheduled tasks that are ready

Result:

Embeddedchannel is now usable even with ChannelHandler that try to schedule tasks.