### PR TITLE
Consolidating HTTP/2 stream state

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -72,15 +72,6 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
             }
 
             @Override
-            public void streamHalfClosed(Http2Stream stream) {
-                if (!stream.localSideOpen()) {
-                    // Any pending frames can never be written, clear and
-                    // write errors for any pending frames.
-                    state(stream).clear();
-                }
-            }
-
-            @Override
             public void streamInactive(Http2Stream stream) {
                 // Any pending frames can never be written, clear and
                 // write errors for any pending frames.
@@ -212,7 +203,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
     /**
      * Writes as many pending bytes as possible, according to stream priority.
      */
-    private void writePendingBytes() throws Http2Exception {
+    private void writePendingBytes() {
         Http2Stream connectionStream = connection.connectionStream();
         int connectionWindow = state(connectionStream).window();
 
@@ -390,10 +381,11 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
         }
 
         /**
-         * Returns the number of pending bytes for this node that will fit within the {@link #window}. This is used for
-         * the priority algorithm to determine the aggregate total for {@link #priorityBytes} at each node. Each node
-         * only takes into account it's stream window so that when a change occurs to the connection window, these
-         * values need not change (i.e. no tree traversal is required).
+         * Returns the number of pending bytes for this node that will fit within the
+         * {@link #window}. This is used for the priority algorithm to determine the aggregate
+         * number of bytes that can be written at each node. Each node only takes into account its
+         * stream window so that when a change occurs to the connection window, these values need
+         * not change (i.e. no tree traversal is required).
          */
         int streamableBytes() {
             return max(0, min(pendingBytes, window));

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -121,9 +121,8 @@ public interface Http2Connection {
          * <li>The connection is marked as going away.</li>
          * </ul>
          * <p>
-         * The caller is expected to {@link Http2Stream#open()} the stream.
+         * The caller is expected to {@link Http2Stream#open(boolean)} the stream.
          * @param streamId The ID of the stream
-         * @see Http2Stream#open()
          * @see Http2Stream#open(boolean)
          */
         Http2Stream createStream(int streamId) throws Http2Exception;
@@ -232,15 +231,25 @@ public interface Http2Connection {
     Http2Stream connectionStream();
 
     /**
-     * Gets the number of streams that are currently either open or half-closed.
+     * Gets the number of streams that actively in use. It is possible for a stream to be closed
+     * but still be considered active (e.g. there is still pending data to be written).
      */
     int numActiveStreams();
 
     /**
-     * Gets all streams that are currently either open or half-closed. The returned collection is
+     * Gets all streams that are actively in use. The returned collection is
      * sorted by priority.
      */
     Collection<Http2Stream> activeStreams();
+
+    /**
+     * Indicates that the given stream is no longer actively in use. If this stream was active,
+     * after calling this method it will no longer appear in the list returned by
+     * {@link #activeStreams()} and {@link #numActiveStreams()} will be decremented. In addition,
+     * all listeners will be notified of this event via
+     * {@link Listener#streamInactive(Http2Stream)}.
+     */
+    void deactivate(Http2Stream stream);
 
     /**
      * Indicates whether or not the local endpoint for this connection is the server.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -23,6 +23,7 @@ import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static io.netty.handler.codec.http2.Http2Exception.isStreamError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -36,12 +37,13 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Provides the default implementation for processing inbound frame events
- * and delegates to a {@link Http2FrameListener}
+ * Provides the default implementation for processing inbound frame events and delegates to a
+ * {@link Http2FrameListener}
  * <p>
  * This class will read HTTP/2 frames and delegate the events to a {@link Http2FrameListener}
  * <p>
- * This interface enforces inbound flow control functionality through {@link Http2InboundFlowController}
+ * This interface enforces inbound flow control functionality through
+ * {@link Http2LocalFlowController}
  */
 public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http2LifecycleManager {
     private final Http2ConnectionDecoder decoder;
@@ -254,14 +256,22 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
      * @param future the future after which to close the channel.
      */
     @Override
-    public void closeStream(Http2Stream stream, ChannelFuture future) {
+    public void closeStream(final Http2Stream stream, ChannelFuture future) {
         stream.close();
 
-        // If this connection is closing and there are no longer any
-        // active streams, close after the current operation completes.
-        if (closeListener != null && connection().numActiveStreams() == 0) {
-            future.addListener(closeListener);
-        }
+        future.addListener(new ChannelFutureListener() {
+          @Override
+          public void operationComplete(ChannelFuture future) throws Exception {
+            // Deactivate this stream.
+            connection().deactivate(stream);
+
+            // If this connection is closing and there are no longer any
+            // active streams, close after the current operation completes.
+            if (closeListener != null && connection().numActiveStreams() == 0) {
+                closeListener.operationComplete(future);
+            }
+          }
+        });
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LifecycleManager.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LifecycleManager.java
@@ -27,7 +27,7 @@ public interface Http2LifecycleManager {
 
     /**
      * Closes the local side of the given stream. If this causes the stream to be closed, adds a
-     * hook to close the channel after the given future completes.
+     * hook to deactivate the stream and close the channel after the given future completes.
      *
      * @param stream the stream to be half closed.
      * @param future If closing, the future after which to close the channel.
@@ -36,7 +36,7 @@ public interface Http2LifecycleManager {
 
     /**
      * Closes the remote side of the given stream. If this causes the stream to be closed, adds a
-     * hook to close the channel after the given future completes.
+     * hook to deactivate the stream and close the channel after the given future completes.
      *
      * @param stream the stream to be half closed.
      * @param future If closing, the future after which to close the channel.
@@ -44,8 +44,8 @@ public interface Http2LifecycleManager {
     void closeRemoteSide(Http2Stream stream, ChannelFuture future);
 
     /**
-     * Closes the given stream and adds a hook to close the channel after the given future
-     * completes.
+     * Closes the given stream and adds a hook to deactivate the stream and close the channel after
+     * the given future completes.
      *
      * @param stream the stream to be closed.
      * @param future the future after which to close the channel.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -77,41 +77,6 @@ public interface Http2Stream {
     Http2Stream closeRemoteSide();
 
     /**
-     * Indicates whether a frame with {@code END_STREAM} set was received from the remote endpoint
-     * for this stream.
-     */
-    boolean isEndOfStreamReceived();
-
-    /**
-     * Sets the flag indicating that a frame with {@code END_STREAM} set was received from the
-     * remote endpoint for this stream.
-     */
-    Http2Stream endOfStreamReceived();
-
-    /**
-     * Indicates whether a frame with {@code END_STREAM} set was sent to the remote endpoint for
-     * this stream.
-     */
-    boolean isEndOfStreamSent();
-
-    /**
-     * Sets the flag indicating that a frame with {@code END_STREAM} set was sent to the remote
-     * endpoint for this stream.
-     */
-    Http2Stream endOfStreamSent();
-
-    /**
-     * Indicates whether a {@code RST_STREAM} frame has been received from the remote endpoint for this stream.
-     */
-    boolean isResetReceived();
-
-    /**
-     * Sets the flag indicating that a {@code RST_STREAM} frame has been received from the remote endpoint
-     * for this stream. This does not affect the stream state.
-     */
-    Http2Stream resetReceived();
-
-    /**
      * Indicates whether a {@code RST_STREAM} frame has been sent from the local endpoint for this stream.
      */
     boolean isResetSent();
@@ -121,12 +86,6 @@ public interface Http2Stream {
      * for this stream. This does not affect the stream state.
      */
     Http2Stream resetSent();
-
-    /**
-     * Indicates whether or not this stream has been reset. This is a short form for
-     * {@link #isResetSent()} || {@link #isResetReceived()}.
-     */
-    boolean isReset();
 
     /**
      * Indicates whether the remote side of this stream is open (i.e. the state is either

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -225,7 +225,7 @@ public class DefaultHttp2ConnectionDecoderTest {
         final ByteBuf data = dummyData();
         try {
             decode().onDataRead(ctx, STREAM_ID, data, 10, true);
-            verify(localFlow, never()).receiveFlowControlledFrame(eq(ctx), eq(stream), eq(data), eq(10), eq(true));
+            verify(localFlow).receiveFlowControlledFrame(eq(ctx), eq(stream), eq(data), eq(10), eq(true));
             verify(listener, never()).onDataRead(eq(ctx), anyInt(), any(ByteBuf.class), anyInt(), anyBoolean());
         } finally {
             data.release();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
@@ -50,11 +51,6 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -62,6 +58,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Tests for {@link DefaultHttp2ConnectionEncoder}
@@ -239,7 +239,7 @@ public class DefaultHttp2ConnectionEncoderTest {
     }
 
     @Test
-    public void dataLargerThanMaxFrameSizeShouldBeSplit() throws Http2Exception {
+    public void dataLargerThanMaxFrameSizeShouldBeSplit() {
         when(frameSizePolicy.maxFrameSize()).thenReturn(3);
         final ByteBuf data = dummyData();
         encoder.writeData(ctx, STREAM_ID, data, 0, true, promise);
@@ -254,7 +254,7 @@ public class DefaultHttp2ConnectionEncoderTest {
     }
 
     @Test
-    public void paddingSplitOverFrame() throws Http2Exception {
+    public void paddingSplitOverFrame() {
         when(frameSizePolicy.maxFrameSize()).thenReturn(5);
         final ByteBuf data = dummyData();
         encoder.writeData(ctx, STREAM_ID, data, 5, true, promise);
@@ -272,7 +272,7 @@ public class DefaultHttp2ConnectionEncoderTest {
     }
 
     @Test
-    public void frameShouldSplitPadding() throws Http2Exception {
+    public void frameShouldSplitPadding() {
         when(frameSizePolicy.maxFrameSize()).thenReturn(5);
         ByteBuf data = dummyData();
         encoder.writeData(ctx, STREAM_ID, data, 10, true, promise);
@@ -292,18 +292,18 @@ public class DefaultHttp2ConnectionEncoderTest {
     }
 
     @Test
-    public void emptyFrameShouldSplitPadding() throws Http2Exception {
+    public void emptyFrameShouldSplitPadding() {
         ByteBuf data = Unpooled.buffer(0);
         assertSplitPaddingOnEmptyBuffer(data);
         assertEquals(0, data.refCnt());
     }
 
     @Test
-    public void singletonEmptyBufferShouldSplitPadding() throws Http2Exception {
+    public void singletonEmptyBufferShouldSplitPadding() {
         assertSplitPaddingOnEmptyBuffer(Unpooled.EMPTY_BUFFER);
     }
 
-    private void assertSplitPaddingOnEmptyBuffer(ByteBuf data) throws Http2Exception {
+    private void assertSplitPaddingOnEmptyBuffer(ByteBuf data) {
         when(frameSizePolicy.maxFrameSize()).thenReturn(5);
         encoder.writeData(ctx, STREAM_ID, data, 10, true, promise);
         assertEquals(payloadCaptor.getValue().size(), 10);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -273,7 +273,7 @@ public class DefaultHttp2LocalFlowControllerTest {
         controller.consumeBytes(ctx, stream(streamId), numBytes);
     }
 
-    private void verifyWindowUpdateSent(int streamId, int windowSizeIncrement) throws Http2Exception {
+    private void verifyWindowUpdateSent(int streamId, int windowSizeIncrement) {
         verify(frameWriter).writeWindowUpdate(eq(ctx), eq(streamId), eq(windowSizeIncrement), eq(promise));
     }
 


### PR DESCRIPTION
Motivation:

Http2Stream has several methods that provide state information. We need
to simplify how state is used and consolidate as many of these fields as
possible.

Modifications:

Since we already have a concept of a stream being active or inactive,
I'm now separating the deactivation of a stream from the act of closing
it.  The reason for this is the case of sending a frame with
endOfStream=true. In this case we want to close the stream immediately
in order to disallow further writing, but we don't want to mark the
stream as inactive until the write has completed since the inactive
event triggers the flow controller to cancel any pending writes on the
stream.

With deactivation separated out, we are able to eliminate most of the
additional state methods with the exception of `isResetSent`.  This is
still required because we need to ignore inbound frames in this case (as
per the spec), since the remote endpoint may not yet know that the
stream has been closed.

Result:

Fixes #3382