### PR TITLE
Minor idiomatic changes to java docs

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -53,9 +53,9 @@ import java.util.List;
  * If a custom frame decoder is required, then one needs to be careful when implementing
  * one with {@link ByteToMessageDecoder}. Ensure there are enough bytes in the buffer for a
  * complete frame by checking {@link ByteBuf#readableBytes()}. If there are not enough bytes
- * for a complete frame, return without modify the reader index to allow more bytes to arrive.
+ * for a complete frame, return without modifying the reader index to allow more bytes to arrive.
  * <p>
- * To check for complete frames without modify the reader index, use methods like {@link ByteBuf#getInt(int)}.
+ * To check for complete frames without modifying the reader index, use methods like {@link ByteBuf#getInt(int)}.
  * One <strong>MUST</strong> use the reader index when using methods like {@link ByteBuf#getInt(int)}.
  * For example calling <tt>in.getInt(0)</tt> is assuming the frame starts at the beginning of the buffer, which
  * is not always the case. Use <tt>in.getInt(in.readerIndex())</tt> instead.

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutor.java
@@ -20,8 +20,8 @@ import java.util.Set;
 /**
  * The {@link EventExecutor} is a special {@link EventExecutorGroup} which comes
  * with some handy methods to see if a {@link Thread} is executed in a event loop.
- * Beside this it also extends the {@link EventExecutorGroup} to allow a generic way to
- * access methods.
+ * Besides this, it also extends the {@link EventExecutorGroup} to allow for a generic
+ * way to access methods.
  *
  */
 public interface EventExecutor extends EventExecutorGroup {

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java
@@ -22,9 +22,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
- * The {@link EventExecutorGroup} is responsible to provide {@link EventExecutor}'s to use via its
- * {@link #next()} method. Beside this it also is responsible to handle their live-cycle and allows
- * to shut them down in a global fashion.
+ * The {@link EventExecutorGroup} is responsible for providing the {@link EventExecutor}'s to use
+ * via its {@link #next()} method. Besides this, it is also responsible for handling their
+ * life-cycle and allows shutting them down in a global fashion.
  *
  */
 public interface EventExecutorGroup extends ScheduledExecutorService, AutoCloseable {

--- a/transport/src/main/java/io/netty/channel/EventLoop.java
+++ b/transport/src/main/java/io/netty/channel/EventLoop.java
@@ -19,7 +19,7 @@ package io.netty.channel;
 import io.netty.util.concurrent.EventExecutor;
 
 /**
- * Will handle all the I/O-Operations for a {@link Channel} once it was registered.
+ * Will handle all the I/O operations for a {@link Channel} once registered.
  *
  * One {@link EventLoop} instance will usually handle more then one {@link Channel} but this may depend on
  * implementation details and internals.

--- a/transport/src/main/java/io/netty/channel/EventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/EventLoopGroup.java
@@ -19,7 +19,7 @@ package io.netty.channel;
 import io.netty.util.concurrent.EventExecutorGroup;
 
 /**
- * Special {@link EventExecutorGroup} which allows to register {@link Channel}'s that get
+ * Special {@link EventExecutorGroup} which allows registering {@link Channel}s that get
  * processed for later selection during the event loop.
  */
 public interface EventLoopGroup extends EventExecutorGroup {


### PR DESCRIPTION
Whilst reading netty documentation I noticed that some of the comments were not using idiomatic English expressions. I've fixed a couple.