### PR TITLE
Respect ChannelConfig.getWriteSpinCount() when using epoll transport

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -236,14 +236,14 @@ abstract class AbstractEpollChannel extends AbstractChannel {
         return localReadAmount;
     }
 
-    protected final int doWriteBytes(ByteBuf buf) throws Exception {
+    protected final int doWriteBytes(ByteBuf buf, int writeSpinCount) throws Exception {
         int readableBytes = buf.readableBytes();
         int writtenBytes = 0;
         if (buf.hasMemoryAddress()) {
             long memoryAddress = buf.memoryAddress();
             int readerIndex = buf.readerIndex();
             int writerIndex = buf.writerIndex();
-            for (;;) {
+            for (int i = writeSpinCount - 1; i >= 0; i--) {
                 int localFlushedAmount = Native.writeAddress(
                         fileDescriptor.intValue(), memoryAddress, readerIndex, writerIndex);
                 if (localFlushedAmount > 0) {
@@ -253,9 +253,7 @@ abstract class AbstractEpollChannel extends AbstractChannel {
                     }
                     readerIndex += localFlushedAmount;
                 } else {
-                    // Returned EAGAIN need to set EPOLLOUT
-                    setFlag(Native.EPOLLOUT);
-                    return writtenBytes;
+                    break;
                 }
             }
         } else {
@@ -265,7 +263,7 @@ abstract class AbstractEpollChannel extends AbstractChannel {
             } else {
                 nioBuf = buf.nioBuffer();
             }
-            for (;;) {
+            for (int i = writeSpinCount - 1; i >= 0; i--) {
                 int pos = nioBuf.position();
                 int limit = nioBuf.limit();
                 int localFlushedAmount = Native.write(fileDescriptor.intValue(), nioBuf, pos, limit);
@@ -276,13 +274,15 @@ abstract class AbstractEpollChannel extends AbstractChannel {
                         return writtenBytes;
                     }
                 } else {
-                    // Returned EAGAIN need to set EPOLLOUT
-                    setFlag(Native.EPOLLOUT);
                     break;
                 }
             }
-            return writtenBytes;
         }
+        if (writtenBytes < readableBytes) {
+            // Returned EAGAIN need to set EPOLLOUT
+            setFlag(Native.EPOLLOUT);
+        }
+        return writtenBytes;
     }
 
     protected abstract class AbstractEpollUnsafe extends AbstractUnsafe {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
@@ -88,14 +88,14 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel {
     }
 
     @Override
-    protected boolean doWriteSingle(ChannelOutboundBuffer in) throws Exception {
+    protected boolean doWriteSingle(ChannelOutboundBuffer in, int writeSpinCount) throws Exception {
         Object msg = in.current();
         if (msg instanceof FileDescriptor && Native.sendFd(fd().intValue(), ((FileDescriptor) msg).intValue()) > 0) {
             // File descriptor was written, so remove it.
             in.remove();
             return true;
         }
-        return super.doWriteSingle(in);
+        return super.doWriteSingle(in, writeSpinCount);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

The writeSpinCount was ignored in the epoll transport and it just kept on trying writing. This could cause unnessary cpu spinning if a slow remote peer was reading the data very very slow.

Modification:

- Correctly take writeSpinCount into account when writing.

Result:

Less cpu spinning when writing to a slow remote peer.