### PR TITLE
Determine CompositeByteBuf implementation by using ByteBufAllocator

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
@@ -238,7 +238,7 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
             }
 
             // A streamed message - initialize the cumulative buffer, and wait for incoming chunks.
-            CompositeByteBuf content = Unpooled.compositeBuffer(maxCumulationBufferComponents);
+            CompositeByteBuf content = ctx.alloc().compositeBuffer(maxCumulationBufferComponents);
             if (m instanceof ByteBufHolder) {
                 appendPartialContent(content, ((ByteBufHolder) m).content());
             }


### PR DESCRIPTION
Motivation:

Currently, using a MessageAggregator in the pipeline always results in the creation of an unpooled heap ```CompositeByteBuf```. By using a ```ByteBufAllocator``` the ```CompositeByteBuf``` will use the settings specified by the ```ByteBufAllocator```.

Modifications:

Use the ```ChannelHandlerContext```'s ```ByteBufAllocator``` to create the ```CompositeByteBuf``` for message aggregation

Result:

The ```CompositeByteBuf``` is now configured based on the ```ByteBufAllocator```'s settings.