### PR TITLE
Add a pax-exam based OSGi test suite

### DIFF
--- a/osgitests/pom.xml
+++ b/osgitests/pom.xml
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-parent</artifactId>
+    <version>5.0.0.Alpha2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>netty-osgitests</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Netty/OsgiTests</name>
+
+  <properties>
+    <exam.version>4.4.0</exam.version>
+  </properties>
+
+  <dependencies>
+    <!-- All release modules -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-buffer</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-dns</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-haproxy</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-http</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-http2</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-memcache</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-mqtt</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-socks</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-stomp</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-common</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-handler</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-handler-proxy</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-resolver</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-resolver-dns</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport-rxtx</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport-sctp</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport-udt</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-container-native</artifactId>
+      <version>${exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-junit4</artifactId>
+      <version>${exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam</artifactId>
+      <version>${exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-spi</artifactId>
+      <version>${exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-link-mvn</artifactId>
+      <version>${exam.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ops4j.pax.url</groupId>
+      <artifactId>pax-url-wrap</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+      <version>5.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.framework</artifactId>
+      <version>4.6.0</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.ops4j.pax.exam</groupId>
+        <artifactId>maven-paxexam-plugin</artifactId>
+        <executions>
+           <execution>
+             <id>generate-config</id>
+             <goals>
+               <goal>generate-depends-file</goal>
+             </goals>
+           </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>
+

--- a/osgitests/src/test/java/io/netty/osgitests/OsgiBundleTest.java
+++ b/osgitests/src/test/java/io/netty/osgitests/OsgiBundleTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.osgitests;
+
+import static org.junit.Assert.assertFalse;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
+import static org.ops4j.pax.exam.CoreOptions.wrappedBundle;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Configuration;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+
+@RunWith(PaxExam.class)
+public class OsgiBundleTest {
+    private static final Pattern SLASH = Pattern.compile("/", Pattern.LITERAL);
+    private static final String DEPENCIES_LINE = "# dependencies";
+    private static final String GROUP = "io.netty";
+    private static final Collection<String> BUNDLES;
+
+    static {
+        final Set<String> artifacts = new HashSet<String>();
+        final File f = new File("target/classes/META-INF/maven/dependencies.properties");
+        try {
+            final BufferedReader r = new BufferedReader(new FileReader(f));
+            try {
+                boolean haveDeps = false;
+
+                while (true) {
+                    final String line = r.readLine();
+                    if (line == null) {
+                        // End-of-file
+                        break;
+                    }
+
+                    // We need to ignore any lines up to the dependencies
+                    // line, otherwise we would include ourselves.
+                    if (DEPENCIES_LINE.equals(line)) {
+                        haveDeps = true;
+                    } else if (haveDeps && line.startsWith(GROUP)) {
+                        final String[] split = SLASH.split(line);
+                        if (split.length > 1) {
+                            artifacts.add(split[1]);
+                        }
+                    }
+                }
+            } finally {
+                r.close();
+            }
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+
+        BUNDLES = artifacts;
+    }
+
+    @Configuration
+    public final Option[] config() {
+        final Collection<Option> options = new ArrayList<Option>();
+
+        options.add(systemProperty("pax.exam.osgi.unresolved.fail").value("true"));
+        options.addAll(Arrays.asList(junitBundles()));
+
+        options.add(mavenBundle("com.barchart.udt", "barchart-udt-bundle").versionAsInProject());
+        options.add(wrappedBundle(mavenBundle("com.twitter", "hpack").versionAsInProject()));
+        options.add(wrappedBundle(mavenBundle("org.rxtx", "rxtx").versionAsInProject()));
+
+        for (String name : BUNDLES) {
+            options.add(mavenBundle(GROUP, name).versionAsInProject());
+        }
+
+        return options.toArray(new Option[0]);
+    }
+
+    @Test
+    public void testResolvedBundles() {
+        // No-op, as we just want the bundles to be resolved. Just check if we tested something
+        assertFalse("At least one bundle needs to be tested", BUNDLES.isEmpty());
+    }
+}
+

--- a/osgitests/src/test/java/io/netty/osgitests/package-info.java
+++ b/osgitests/src/test/java/io/netty/osgitests/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Common test suite for verifying artifacts can be resolved in OSGi.
+ */
+package io.netty.osgitests;

--- a/pom.xml
+++ b/pom.xml
@@ -513,6 +513,7 @@
     <module>example</module>
     <module>testsuite</module>
     <module>microbench</module>
+    <module>osgitests</module>
     <module>all</module>
     <module>tarball</module>
   </modules>


### PR DESCRIPTION
Problems with artifacts not being well-formed bundles havee been
reported, so create a unit test suite to catch the most obvious ones.

Signed-off-by: Robert Varga <nite@hq.sk>