### PR TITLE
Allow to override response for 100-continue requests

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -112,6 +112,15 @@ public class HttpObjectAggregator extends MessageToMessageDecoder<HttpObject> {
         }
     }
 
+    /**
+     * Returns the {@link FullHttpResponse} for a {@code Expect: 100-continue} {@link HttpRequest}.
+     * The default implementation will always create a {@link HttpRequest} with {@link HttpResponseStatus#CONTINUE}.
+     */
+    protected FullHttpResponse response100ContinueExpected(
+            @SuppressWarnings("unused") ChannelHandlerContext ctx, @SuppressWarnings("unused") HttpRequest request) {
+        return CONTINUE;
+    }
+
     @Override
     protected void decode(final ChannelHandlerContext ctx, HttpObject msg, List<Object> out) throws Exception {
         AggregatedFullHttpMessage currentMessage = this.currentMessage;
@@ -128,7 +137,8 @@ public class HttpObjectAggregator extends MessageToMessageDecoder<HttpObject> {
             //       No need to notify the upstream handlers - just log.
             //       If decoding a response, just throw an exception.
             if (is100ContinueExpected(m)) {
-                ctx.writeAndFlush(CONTINUE).addListener(new ChannelFutureListener() {
+                ctx.writeAndFlush(response100ContinueExpected(ctx, (HttpRequest) m))
+                        .addListener(new ChannelFutureListener() {
                     @Override
                     public void operationComplete(ChannelFuture future) throws Exception {
                         if (!future.isSuccess()) {


### PR DESCRIPTION
Motivation:

At the moment we alway response with CONTINUE when a 100-continue request is received. This is something not the best solution as the 100-continue request should help a client to test if a server will accept the body of a request.

Modifications:

- Allow to override how the response is created. This allows the user to override and add proper handling for their use-case.

Result:

More flexible implementation.