### PR TITLE
Correctly handle autoRead == false when epoll LT is used

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -16,6 +16,7 @@
 package io.netty.channel.epoll;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
@@ -75,14 +76,22 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
         @Override
         void epollInReady() {
             assert eventLoop().inEventLoop();
+            boolean edgeTriggered = isFlagSet(Native.EPOLLET);
+
+            final ChannelConfig config = config();
+            if (!readPending && !edgeTriggered && !config.isAutoRead()) {
+                // ChannelConfig.setAutoRead(false) was called in the meantime
+                clearEpollIn0();
+                return;
+            }
+
             final ChannelPipeline pipeline = pipeline();
             Throwable exception = null;
             try {
                 try {
-                    boolean edgeTriggered = isFlagSet(Native.EPOLLET);
                     // if edgeTriggered is used we need to read all messages as we are not notified again otherwise.
                     final int maxMessagesPerRead = edgeTriggered
-                            ? Integer.MAX_VALUE : config().getMaxMessagesPerRead();
+                            ? Integer.MAX_VALUE : config.getMaxMessagesPerRead();
                     int messages = 0;
                     do {
                         int socketFd = Native.accept(fd().intValue());
@@ -99,7 +108,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
                             pipeline.fireChannelReadComplete();
                             pipeline.fireExceptionCaught(t);
                         } finally {
-                            if (!edgeTriggered && !config().isAutoRead()) {
+                            if (!edgeTriggered && !config.isAutoRead()) {
                                 // This is not using EPOLLET so we can stop reading
                                 // ASAP as we will get notified again later with
                                 // pending data
@@ -122,7 +131,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
                 // * The user called Channel.read() or ChannelHandlerContext.read() in channelReadComplete(...) method
                 //
                 // See https://github.com/netty/netty/issues/2254
-                if (!config().isAutoRead() && !readPending) {
+                if (!readPending && !config.isAutoRead()) {
                     clearEpollIn0();
                 }
             }


### PR DESCRIPTION
Motivation:

When epoll LT is used and autoRead == false when entering epollIn() we need to return without reading any data.

Modifications:

Correctly respect autoRead == false if using epoll LT.

Result:

Consistent and correct behaviour.