### PR TITLE
Upgrading HTTP/2 hpack to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -543,7 +543,7 @@
       <dependency>
         <groupId>com.twitter</groupId>
         <artifactId>hpack</artifactId>
-        <version>0.10.0</version>
+        <version>0.10.1</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.npn</groupId>


### PR DESCRIPTION
Motivation:

Twitter hpack has upgraded to 0.10.1 to fix a parsing bug.

Modifications:

Updated the parent pom to specify the dependency version.

Result:

HTTP/2 updated to the latest hpack release.