### PR TITLE
Fix premature cancelation of pending frames in HTTP2 Flow Control.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
@@ -52,18 +52,37 @@ public interface Http2RemoteFlowController extends Http2FlowController {
         int size();
 
         /**
-         * Signal an error and release any retained buffers.
+         * Called to indicate that an error occurred before this object could be completely written.
+         * <p>
+         * The {@link Http2RemoteFlowController} will make exactly one call to either {@link #error(Throwable)} or
+         * {@link #writeComplete()}.
+         * </p>
+         *
          * @param cause of the error.
          */
         void error(Throwable cause);
+
+        /**
+         * Called after this object has been successfully written.
+         * <p>
+         * The {@link Http2RemoteFlowController} will make exactly one call to either {@link #error(Throwable)} or
+         * {@link #writeComplete()}.
+         * </p>
+         */
+        void writeComplete();
 
         /**
          * Writes up to {@code allowedBytes} of the encapsulated payload to the stream. Note that
          * a value of 0 may be passed which will allow payloads with flow-control size == 0 to be
          * written. The flow-controller may call this method multiple times with different values until
          * the payload is fully written.
+         * <p>
+         * When an exception is thrown the {@link Http2RemoteFlowController} will make a call to
+         * {@link #error(Throwable)}.
+         * </p>
          *
          * @param allowedBytes an upper bound on the number of bytes the payload can write at this time.
+         * @throws Exception if an error occurs. The method must not call {@link #error(Throwable)} by itself.
          * @return {@code true} if a flush is required, {@code false} otherwise.
          */
         boolean write(int allowedBytes);


### PR DESCRIPTION
Motivation:

If HEADERS or DATA frames are pending due to a too small flow control
window, a frame with the END_STREAM flag set will wrongfully cancel
all pending frames (including itself).

Also see https://github.com/grpc/grpc-java/issues/145

Modifications:

The transition of the stream state to CLOSE / HALF_CLOSE due to a
set END_STREAM flag is delayed until the frame with the flag is
actually written to the Channel.

Result:

Flow control works correctly. Frames with END_STREAM flag will no
longer cancel their preceding frames.

@nmittler @Scottmitch @louiscryan