### PR TITLE
Fix header and initial line length counting

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -17,16 +17,81 @@ package io.netty.handler.codec.http;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.http.HttpHeaders.Names;
 import io.netty.util.CharsetUtil;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 public class HttpResponseDecoderTest {
+
+    /**
+     * The size of headers should be calculated correctly even if a single header is split into multiple fragments.
+     * @see https://github.com/netty/netty/issues/3445
+     */
+    @Test
+    public void testMaxHeaderSize1() {
+        final int maxHeaderSize = 8192;
+
+        final EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder(4096, maxHeaderSize, 8192));
+        final char[] bytes = new char[maxHeaderSize / 2 - 2];
+        Arrays.fill(bytes, 'a');
+
+        ch.writeInbound(Unpooled.copiedBuffer("HTTP/1.1 200 OK\r\n", CharsetUtil.US_ASCII));
+
+        // Write two 4096-byte headers (= 8192 bytes)
+        ch.writeInbound(Unpooled.copiedBuffer("A:", CharsetUtil.US_ASCII));
+        ch.writeInbound(Unpooled.copiedBuffer(bytes, CharsetUtil.US_ASCII));
+        ch.writeInbound(Unpooled.copiedBuffer("\r\n", CharsetUtil.US_ASCII));
+        assertNull(ch.readInbound());
+        ch.writeInbound(Unpooled.copiedBuffer("B:", CharsetUtil.US_ASCII));
+        ch.writeInbound(Unpooled.copiedBuffer(bytes, CharsetUtil.US_ASCII));
+        ch.writeInbound(Unpooled.copiedBuffer("\r\n", CharsetUtil.US_ASCII));
+        ch.writeInbound(Unpooled.copiedBuffer("\r\n", CharsetUtil.US_ASCII));
+
+        HttpResponse res = (HttpResponse) ch.readInbound();
+        assertNull(res.getDecoderResult().cause());
+        assertTrue(res.getDecoderResult().isSuccess());
+
+        assertNull(ch.readInbound());
+        assertTrue(ch.finish());
+        assertThat(ch.readInbound(), instanceOf(LastHttpContent.class));
+    }
+
+    /**
+     * Complementary test case of {@link #testHeaderReplay()}. When it actually exceeds the maximum, it should fail.
+     */
+    @Test
+    public void testMaxHeaderSize2() {
+        final int maxHeaderSize = 8192;
+
+        final EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder(4096, maxHeaderSize, 8192));
+        final char[] bytes = new char[maxHeaderSize / 2 - 2];
+        Arrays.fill(bytes, 'a');
+
+        ch.writeInbound(Unpooled.copiedBuffer("HTTP/1.1 200 OK\r\n", CharsetUtil.US_ASCII));
+
+        // Write a 4096-byte header and a 4097-byte header to test an off-by-one case (= 8193 bytes)
+        ch.writeInbound(Unpooled.copiedBuffer("A:", CharsetUtil.US_ASCII));
+        ch.writeInbound(Unpooled.copiedBuffer(bytes, CharsetUtil.US_ASCII));
+        ch.writeInbound(Unpooled.copiedBuffer("\r\n", CharsetUtil.US_ASCII));
+        assertNull(ch.readInbound());
+        ch.writeInbound(Unpooled.copiedBuffer("B: ", CharsetUtil.US_ASCII)); // Note an extra space.
+        ch.writeInbound(Unpooled.copiedBuffer(bytes, CharsetUtil.US_ASCII));
+        ch.writeInbound(Unpooled.copiedBuffer("\r\n", CharsetUtil.US_ASCII));
+        ch.writeInbound(Unpooled.copiedBuffer("\r\n", CharsetUtil.US_ASCII));
+
+        HttpResponse res = (HttpResponse) ch.readInbound();
+        assertTrue(res.getDecoderResult().cause() instanceof TooLongFrameException);
+
+        assertFalse(ch.finish());
+        assertNull(ch.readInbound());
+    }
 
     @Test
     public void testResponseChunked() {


### PR DESCRIPTION
Related: #3445

Motivation:

HttpObjectDecoder.HeaderParser does not reset its counter (the size
field) when it failed to find the end of line.  If a header is split
into multiple fragments, the counter is increased as many times as the
number of fragments, resulting an unexpected TooLongFrameException.

Modifications:

- Add test cases that reproduces the problem
- Reset the HeaderParser.size field when no EOL is found.

Result:

One less bug