### PR TITLE
Updates the javadoc of Unpooled to remove mention to methods it does not provide

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -34,7 +34,8 @@ import java.nio.charset.CoderResult;
 import java.util.Locale;
 
 /**
- * A collection of utility methods that is related with handling {@link ByteBuf}.
+ * A collection of utility methods that is related with handling {@link ByteBuf},
+ * such as the generation of hex dump and swapping an integer's byte order.
  */
 public final class ByteBufUtil {
 

--- a/buffer/src/main/java/io/netty/buffer/Unpooled.java
+++ b/buffer/src/main/java/io/netty/buffer/Unpooled.java
@@ -67,12 +67,6 @@ import java.util.List;
  * between the original data and the copied buffer.  Various copy methods are
  * provided and their name is all {@code copiedBuffer()}.  It is also convenient
  * to use this operation to merge multiple buffers into one buffer.
- *
- * <h3>Miscellaneous utility methods</h3>
- *
- * This class also provides various utility methods to help implementation
- * of a new buffer type, generation of hex dump and swapping an integer's
- * byte order.
  */
 public final class Unpooled {
 


### PR DESCRIPTION
Motivation:

`Unpooled` javadoc's mentioned the generation of hex dump and swapping an integer's byte order,
which are actually provided by `ByteBufUtil`.

Modifications:

 Sentence moved to `ByteBufUtil` javadoc.

Result:

`Unpooled` javadoc is correct.