### PR TITLE
Add unit to maxContentLength javadoc 

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -65,7 +65,7 @@ public class HttpObjectAggregator
      * Creates a new instance.
      *
      * @param maxContentLength
-     *        the maximum length of the aggregated content.
+     *        the maximum length of the aggregated content in bytes.
      *        If the length of the aggregated content exceeds this value,
      *        {@link #handleOversizedMessage(ChannelHandlerContext, HttpMessage)}
      *        will be called.

--- a/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
@@ -135,7 +135,7 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
     protected abstract boolean isAggregated(I msg) throws Exception;
 
     /**
-     * Returns the maximum allowed length of the aggregated message.
+     * Returns the maximum allowed length of the aggregated message in bytes.
      */
     public final int maxContentLength() {
         return maxContentLength;


### PR DESCRIPTION
Motivation:
Not knowing which unit is used for the maxContentLength of the HttpObjectAggregator and returned by the MessageAggregator when reading the Javadoc is annoying and can be a source of bugs.

Modifications:
Added the mention "in bytes"

Result:
Javadoc is clear.