### PR TITLE
Fix possible AttributeMap corruption on double removal

### DIFF
--- a/common/src/main/java/io/netty/util/DefaultAttributeMap.java
+++ b/common/src/main/java/io/netty/util/DefaultAttributeMap.java
@@ -172,6 +172,11 @@ public class DefaultAttributeMap implements AttributeMap {
                     if (next != null) {
                         next.prev = prev;
                     }
+
+                    // Null out prev and next - this will guard against multiple remove0() calls which may corrupt
+                    // the linked list for the bucket.
+                    prev = null;
+                    next = null;
                 }
             }
         }


### PR DESCRIPTION
Motivation:

When remove0() is called multiple times for an DefaultAttribute it can cause corruption of the internal linked-list structure.

Modifications:

- Ensure remove0() can not cause corruption by null out prev and next references.

Result:

No more corruption possible