### PR TITLE
Respect -Djava.net.preferIPv4Stack when using epoll transport

### DIFF
--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -115,6 +115,11 @@ public final class NetUtil {
     private static final int IPV4_SEPARATORS = 3;
 
     /**
+     * {@code true} if ipv4 should be used on a system that supports ipv4 and ipv6.
+     */
+    private static final boolean IPV4_PREFERRED = Boolean.getBoolean("java.net.preferIPv4Stack");
+
+    /**
      * The logger being used by this class
      */
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(NetUtil.class);
@@ -257,6 +262,13 @@ public final class NetUtil {
         }
 
         SOMAXCONN = somaxconn;
+    }
+
+    /**
+     * Returns {@code true} if ipv4 should be prefered on a system that supports ipv4 and ipv6.
+     */
+    public static boolean isIpV4StackPreferred() {
+        return IPV4_PREFERRED;
     }
 
     /**


### PR DESCRIPTION
Motivation:

On a system where ipv4 and ipv6 are supported a user may want to use -Djava.net.preferIPv4Stack=true to restrict it to use ipv4 only.
This is currently ignored with the epoll transport.

Modifications:

Respect java.net.preferIPv4Stack system property.

Result:

-Djava.net.preferIPv4Stack=true will have the effect the user is looking for.