### PR TITLE
Add support for ALPN when using openssl + NPN client mode and support fo...

### DIFF
--- a/common/src/main/java/io/netty/util/internal/EmptyArrays.java
+++ b/common/src/main/java/io/netty/util/internal/EmptyArrays.java
@@ -17,6 +17,7 @@
 package io.netty.util.internal;
 
 import java.nio.ByteBuffer;
+import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 
 public final class EmptyArrays {
@@ -34,7 +35,10 @@ public final class EmptyArrays {
     public static final String[] EMPTY_STRINGS = new String[0];
     public static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
     public static final ByteBuffer[] EMPTY_BYTE_BUFFERS = new ByteBuffer[0];
+    public static final Certificate[] EMPTY_CERTIFICATES = new Certificate[0];
     public static final X509Certificate[] EMPTY_X509_CERTIFICATES = new X509Certificate[0];
+    public static final javax.security.cert.X509Certificate[] EMPTY_JAVAX_X509_CERTIFICATES =
+            new javax.security.cert.X509Certificate[0];
 
     private EmptyArrays() { }
 }

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -33,9 +33,9 @@ public final class StringUtil {
     public static final char COMMA = ',';
     public static final char LINE_FEED = '\n';
     public static final char CARRIAGE_RETURN = '\r';
+    public static final String EMPTY_STRING = "";
     private static final String[] BYTE2HEX_PAD = new String[256];
     private static final String[] BYTE2HEX_NOPAD = new String[256];
-    private static final String EMPTY_STRING = "";
     /**
      * 2 - Quote character at beginning and end.
      * 5 - Extra allowance for anticipated escape characters that may be added.

--- a/example/src/main/java/io/netty/example/http2/client/Http2Client.java
+++ b/example/src/main/java/io/netty/example/http2/client/Http2Client.java
@@ -31,6 +31,7 @@ import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
+import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
@@ -61,7 +62,8 @@ public final class Http2Client {
         // Configure SSL.
         final SslContext sslCtx;
         if (SSL) {
-            sslCtx = SslContext.newClientContext(SslProvider.JDK,
+            SslProvider provider = OpenSsl.isAlpnSupported() ? SslProvider.OPENSSL : SslProvider.JDK;
+            sslCtx = SslContext.newClientContext(provider,
                     null, InsecureTrustManagerFactory.INSTANCE,
                     Http2SecurityUtil.CIPHERS,
                     /* NOTE: the following filter may not include all ciphers required by the HTTP/2 specification
@@ -69,8 +71,8 @@ public final class Http2Client {
                     SupportedCipherSuiteFilter.INSTANCE,
                     new ApplicationProtocolConfig(
                             Protocol.ALPN,
-                            SelectorFailureBehavior.FATAL_ALERT,
-                            SelectedListenerFailureBehavior.FATAL_ALERT,
+                            SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
+                            SelectedListenerFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
                             SelectedProtocol.HTTP_2.protocolName(),
                             SelectedProtocol.HTTP_1_1.protocolName()),
                     0, 0);

--- a/example/src/main/java/io/netty/example/http2/server/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/server/Http2Server.java
@@ -30,6 +30,7 @@ import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
+import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
@@ -42,14 +43,16 @@ import io.netty.handler.ssl.util.SelfSignedCertificate;
 public final class Http2Server {
 
     static final boolean SSL = System.getProperty("ssl") != null;
+
     static final int PORT = Integer.parseInt(System.getProperty("port", SSL? "8443" : "8080"));
 
     public static void main(String[] args) throws Exception {
         // Configure SSL.
         final SslContext sslCtx;
         if (SSL) {
+            SslProvider provider = OpenSsl.isAlpnSupported() ? SslProvider.OPENSSL : SslProvider.JDK;
             SelfSignedCertificate ssc = new SelfSignedCertificate();
-            sslCtx = SslContext.newServerContext(SslProvider.JDK,
+            sslCtx = SslContext.newServerContext(provider,
                     ssc.certificate(), ssc.privateKey(), null,
                     Http2SecurityUtil.CIPHERS,
                     /* NOTE: the following filter may not include all ciphers required by the HTTP/2 specification
@@ -57,8 +60,8 @@ public final class Http2Server {
                     SupportedCipherSuiteFilter.INSTANCE,
                     new ApplicationProtocolConfig(
                             Protocol.ALPN,
-                            SelectorFailureBehavior.FATAL_ALERT,
-                            SelectedListenerFailureBehavior.FATAL_ALERT,
+                            SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
+                            SelectedListenerFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
                             SelectedProtocol.HTTP_2.protocolName(),
                             SelectedProtocol.HTTP_1_1.protocolName()),
                     0, 0);

--- a/example/src/main/java/io/netty/example/memcache/binary/MemcacheClient.java
+++ b/example/src/main/java/io/netty/example/memcache/binary/MemcacheClient.java
@@ -53,15 +53,15 @@ public final class MemcacheClient {
         // Configure SSL.
         final SslContext sslCtx;
         if (SSL) {
-            sslCtx = SslContext.newClientContext(SslProvider.JDK,
+            sslCtx = SslContext.newClientContext(null,
                     null, InsecureTrustManagerFactory.INSTANCE, Http2SecurityUtil.CIPHERS,
                     /* NOTE: the following filter may not include all ciphers required by the HTTP/2 specification
                      * Please refer to the HTTP/2 specification for cipher requirements. */
                     SupportedCipherSuiteFilter.INSTANCE,
                     new ApplicationProtocolConfig(
                             Protocol.ALPN,
-                            SelectorFailureBehavior.FATAL_ALERT,
-                            SelectedListenerFailureBehavior.FATAL_ALERT,
+                            SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
+                            SelectedListenerFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
                             SelectedProtocol.HTTP_2.protocolName(),
                             SelectedProtocol.HTTP_1_1.protocolName()),
                     0, 0);

--- a/example/src/main/java/io/netty/example/spdy/client/SpdyClient.java
+++ b/example/src/main/java/io/netty/example/spdy/client/SpdyClient.java
@@ -61,8 +61,8 @@ public final class SpdyClient {
                 null, InsecureTrustManagerFactory.INSTANCE, null, IdentityCipherSuiteFilter.INSTANCE,
                 new ApplicationProtocolConfig(
                         Protocol.NPN,
-                        SelectorFailureBehavior.FATAL_ALERT,
-                        SelectedListenerFailureBehavior.FATAL_ALERT,
+                        SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
+                        SelectedListenerFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
                         SelectedProtocol.SPDY_3_1.protocolName(),
                         SelectedProtocol.HTTP_1_1.protocolName()),
                 0, 0);

--- a/example/src/main/java/io/netty/example/spdy/server/SpdyServer.java
+++ b/example/src/main/java/io/netty/example/spdy/server/SpdyServer.java
@@ -61,8 +61,8 @@ public final class SpdyServer {
                 ssc.certificate(), ssc.privateKey(), null, null, IdentityCipherSuiteFilter.INSTANCE,
                 new ApplicationProtocolConfig(
                         Protocol.NPN,
-                        SelectorFailureBehavior.FATAL_ALERT,
-                        SelectedListenerFailureBehavior.FATAL_ALERT,
+                        SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
+                        SelectedListenerFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
                         SelectedProtocol.SPDY_3_1.protocolName(),
                         SelectedProtocol.HTTP_1_1.protocolName()),
                 0, 0);

--- a/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolConfig.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolConfig.java
@@ -79,6 +79,9 @@ public final class ApplicationProtocolConfig {
         if (protocol == Protocol.NONE) {
             throw new IllegalArgumentException("protocol (" + Protocol.NONE + ") must not be " + Protocol.NONE + '.');
         }
+        if (supportedProtocols.isEmpty()) {
+            throw new IllegalArgumentException("supportedProtocols must be not empty");
+        }
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -114,6 +114,14 @@ public final class OpenSsl {
     }
 
     /**
+     * Returns {@code true} if the used version of openssl supports
+     * <a href="https://tools.ietf.org/html/rfc7301">ALPN</a>.
+     */
+    public static boolean isAlpnSupported() {
+        return isAvailable() && SSL.version() >= 0x10002000L;
+    }
+
+    /**
      * Ensure that <a href="http://netty.io/wiki/forked-tomcat-native.html">{@code netty-tcnative}</a> and
      * its OpenSSL support are available.
      *

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslApplicationProtocolNegotiator.java
@@ -19,10 +19,19 @@ package io.netty.handler.ssl;
  * OpenSSL version of {@link ApplicationProtocolNegotiator}.
  */
 public interface OpenSslApplicationProtocolNegotiator extends ApplicationProtocolNegotiator {
-    // The current need for this interface is primarily for consistency with the JDK provider
-    // How the OpenSsl provider will provide extensibility to control the application selection
-    // and notification algorithms is not yet known (JNI, pure java, tcnative hooks, etc...).
-    // OpenSSL itself is currently not in compliance with the specification for the 2 supported
-    // protocols (ALPN, NPN) with respect to allowing the handshakes to fail during the application
-    // protocol negotiation process.  Issue https://github.com/openssl/openssl/issues/188 has been created for this.
+
+    /**
+     * Returns the {@link ApplicationProtocolConfig.Protocol} which should be used.
+     */
+    ApplicationProtocolConfig.Protocol protocol();
+
+    /**
+     * Get the desired behavior for the peer who selects the application protocol.
+     */
+    ApplicationProtocolConfig.SelectorFailureBehavior selectorFailureBehavior();
+
+    /**
+     * Get the desired behavior for the peer who is notified of the selected protocol.
+     */
+    ApplicationProtocolConfig.SelectedListenerFailureBehavior selectedListenerFailureBehavior();
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
@@ -45,7 +45,7 @@ public final class OpenSslClientContext extends OpenSslContext {
      * Creates a new instance.
      */
     public OpenSslClientContext() throws SSLException {
-        this(null, null, null, null, 0, 0);
+        this(null, null, null, IdentityCipherSuiteFilter.INSTANCE, null, 0, 0);
     }
 
     /**
@@ -79,10 +79,13 @@ public final class OpenSslClientContext extends OpenSslContext {
      *                            {@code null} to use the default.
      */
     public OpenSslClientContext(File certChainFile, TrustManagerFactory trustManagerFactory) throws SSLException {
-        this(certChainFile, trustManagerFactory, null, null, 0, 0);
+        this(certChainFile, trustManagerFactory, null, IdentityCipherSuiteFilter.INSTANCE, null, 0, 0);
     }
 
     /**
+     * @deprecated use {@link #OpenSslClientContext(File, TrustManagerFactory, Iterable,
+     *             CipherSuiteFilter, ApplicationProtocolConfig, long, long)}
+     *
      * Creates a new instance.
      *
      * @param certChainFile an X.509 certificate chain file in PEM format
@@ -97,10 +100,35 @@ public final class OpenSslClientContext extends OpenSslContext {
      * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
      *                       {@code 0} to use the default value.
      */
+    @Deprecated
     public OpenSslClientContext(File certChainFile, TrustManagerFactory trustManagerFactory, Iterable<String> ciphers,
                                 ApplicationProtocolConfig apn, long sessionCacheSize, long sessionTimeout)
             throws SSLException {
-        super(ciphers, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_CLIENT);
+        this(certChainFile, trustManagerFactory, ciphers, IdentityCipherSuiteFilter.INSTANCE,
+                apn, sessionCacheSize, sessionTimeout);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param certChainFile an X.509 certificate chain file in PEM format
+     * @param trustManagerFactory the {@link TrustManagerFactory} that provides the {@link TrustManager}s
+     *                            that verifies the certificates sent from servers.
+     *                            {@code null} to use the default..
+     * @param ciphers the cipher suites to enable, in the order of preference.
+     *                {@code null} to use the default cipher suites.
+     * @param cipherFilter a filter to apply over the supplied list of ciphers
+     * @param apn Provides a means to configure parameters related to application protocol negotiation.
+     * @param sessionCacheSize the size of the cache used for storing SSL session objects.
+     *                         {@code 0} to use the default value.
+     * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
+     *                       {@code 0} to use the default value.
+     */
+    public OpenSslClientContext(File certChainFile, TrustManagerFactory trustManagerFactory, Iterable<String> ciphers,
+                                CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
+                                long sessionCacheSize, long sessionTimeout)
+            throws SSLException {
+        super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_CLIENT);
         boolean success = false;
         try {
             if (certChainFile != null && !certChainFile.isFile()) {

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslDefaultApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslDefaultApplicationProtocolNegotiator.java
@@ -15,21 +15,36 @@
  */
 package io.netty.handler.ssl;
 
-import java.util.Collections;
 import java.util.List;
 
-/**
- * Provides no {@link ApplicationProtocolNegotiator} functionality for OpenSSL.
- */
-final class OpenSslDefaultApplicationProtocolNegotiator implements OpenSslApplicationProtocolNegotiator {
-    static final OpenSslDefaultApplicationProtocolNegotiator INSTANCE =
-            new OpenSslDefaultApplicationProtocolNegotiator();
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
-    private OpenSslDefaultApplicationProtocolNegotiator() {
+/**
+ * OpenSSL {@link ApplicationProtocolNegotiator} for ALPN and NPN.
+ */
+public final class OpenSslDefaultApplicationProtocolNegotiator implements OpenSslApplicationProtocolNegotiator {
+    private final ApplicationProtocolConfig config;
+    public OpenSslDefaultApplicationProtocolNegotiator(ApplicationProtocolConfig config) {
+        this.config = checkNotNull(config, "config");
     }
 
     @Override
     public List<String> protocols() {
-        return Collections.emptyList();
+        return config.supportedProtocols();
+    }
+
+    @Override
+    public ApplicationProtocolConfig.Protocol protocol() {
+        return config.protocol();
+    }
+
+    @Override
+    public ApplicationProtocolConfig.SelectorFailureBehavior selectorFailureBehavior() {
+        return config.selectorFailureBehavior();
+    }
+
+    @Override
+    public ApplicationProtocolConfig.SelectedListenerFailureBehavior selectedListenerFailureBehavior() {
+        return config.selectedListenerFailureBehavior();
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslNpnApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslNpnApplicationProtocolNegotiator.java
@@ -22,7 +22,10 @@ import java.util.List;
 
 /**
  * OpenSSL {@link ApplicationProtocolNegotiator} for NPN.
+ *
+ * @deprecated use {@link OpenSslDefaultApplicationProtocolNegotiator}
  */
+@Deprecated
 public final class OpenSslNpnApplicationProtocolNegotiator implements OpenSslApplicationProtocolNegotiator {
     private final List<String> protocols;
 
@@ -35,7 +38,22 @@ public final class OpenSslNpnApplicationProtocolNegotiator implements OpenSslApp
     }
 
     @Override
+    public ApplicationProtocolConfig.Protocol protocol() {
+        return ApplicationProtocolConfig.Protocol.NPN;
+    }
+
+    @Override
     public List<String> protocols() {
         return protocols;
+    }
+
+    @Override
+    public ApplicationProtocolConfig.SelectorFailureBehavior selectorFailureBehavior() {
+        return ApplicationProtocolConfig.SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL;
+    }
+
+    @Override
+    public ApplicationProtocolConfig.SelectedListenerFailureBehavior selectedListenerFailureBehavior() {
+        return ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT;
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -64,11 +64,14 @@ public final class OpenSslServerContext extends OpenSslContext {
      *                    {@code null} if it's not password-protected.
      */
     public OpenSslServerContext(File certChainFile, File keyFile, String keyPassword) throws SSLException {
-        this(certChainFile, keyFile, keyPassword, null, null,
-            OpenSslDefaultApplicationProtocolNegotiator.INSTANCE, 0, 0);
+        this(certChainFile, keyFile, keyPassword, null, null, IdentityCipherSuiteFilter.INSTANCE,
+            NONE_PROTOCOL_NEGOTIATOR, 0, 0);
     }
 
     /**
+     * @deprecated use {@link #OpenSslServerContext(
+     *             File, File, String, Iterable, CipherSuiteFilter, ApplicationProtocolConfig, long, long)}
+     *
      * Creates a new instance.
      *
      * @param certChainFile an X.509 certificate chain file in PEM format
@@ -83,12 +86,13 @@ public final class OpenSslServerContext extends OpenSslContext {
      * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
      *                       {@code 0} to use the default value.
      */
+    @Deprecated
     public OpenSslServerContext(
             File certChainFile, File keyFile, String keyPassword,
             Iterable<String> ciphers, ApplicationProtocolConfig apn,
             long sessionCacheSize, long sessionTimeout) throws SSLException {
         this(certChainFile, keyFile, keyPassword, null, ciphers,
-            toNegotiator(apn, false), sessionCacheSize, sessionTimeout);
+            toNegotiator(apn), sessionCacheSize, sessionTimeout);
     }
 
     /**
@@ -105,13 +109,17 @@ public final class OpenSslServerContext extends OpenSslContext {
      *                         {@code 0} to use the default value.
      * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
      *                       {@code 0} to use the default value.
+     * @deprecated use {@link #OpenSslServerContext(
+     *             File, File, String, TrustManagerFactory, Iterable,
+     *             CipherSuiteFilter, ApplicationProtocolConfig, long, long)}
      */
+    @Deprecated
     public OpenSslServerContext(
             File certChainFile, File keyFile, String keyPassword, TrustManagerFactory trustManagerFactory,
             Iterable<String> ciphers, ApplicationProtocolConfig config,
             long sessionCacheSize, long sessionTimeout) throws SSLException {
         this(certChainFile, keyFile, keyPassword, trustManagerFactory, ciphers,
-                toNegotiator(config, true), sessionCacheSize, sessionTimeout);
+                toNegotiator(config), sessionCacheSize, sessionTimeout);
     }
 
     /**
@@ -128,14 +136,89 @@ public final class OpenSslServerContext extends OpenSslContext {
      *                         {@code 0} to use the default value.
      * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
      *                       {@code 0} to use the default value.
+     * @deprecated use {@link #OpenSslServerContext(
+     *             File, File, String, TrustManagerFactory, Iterable,
+     *             CipherSuiteFilter, OpenSslApplicationProtocolNegotiator, long, long)}
      */
+    @Deprecated
     public OpenSslServerContext(
             File certChainFile, File keyFile, String keyPassword, TrustManagerFactory trustManagerFactory,
             Iterable<String> ciphers, OpenSslApplicationProtocolNegotiator apn,
             long sessionCacheSize, long sessionTimeout) throws SSLException {
+        this(certChainFile, keyFile, keyPassword, trustManagerFactory, ciphers,
+                IdentityCipherSuiteFilter.INSTANCE, apn, sessionCacheSize, sessionTimeout);
+    }
 
-         super(ciphers, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_SERVER);
-         OpenSsl.ensureAvailability();
+    /**
+     * Creates a new instance.
+     *
+     * @param certChainFile an X.509 certificate chain file in PEM format
+     * @param keyFile a PKCS#8 private key file in PEM format
+     * @param keyPassword the password of the {@code keyFile}.
+     *                    {@code null} if it's not password-protected.
+     * @param ciphers the cipher suites to enable, in the order of preference.
+     *                {@code null} to use the default cipher suites.
+     * @param cipherFilter a filter to apply over the supplied list of ciphers
+     * @param apn Provides a means to configure parameters related to application protocol negotiation.
+     * @param sessionCacheSize the size of the cache used for storing SSL session objects.
+     *                         {@code 0} to use the default value.
+     * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
+     *                       {@code 0} to use the default value.
+     */
+    public OpenSslServerContext(
+            File certChainFile, File keyFile, String keyPassword,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
+            long sessionCacheSize, long sessionTimeout) throws SSLException {
+        this(certChainFile, keyFile, keyPassword, null, ciphers, cipherFilter,
+                toNegotiator(apn), sessionCacheSize, sessionTimeout);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param certChainFile an X.509 certificate chain file in PEM format
+     * @param keyFile a PKCS#8 private key file in PEM format
+     * @param keyPassword the password of the {@code keyFile}.
+     *                    {@code null} if it's not password-protected.
+     * @param ciphers the cipher suites to enable, in the order of preference.
+     *                {@code null} to use the default cipher suites.
+     * @param cipherFilter a filter to apply over the supplied list of ciphers
+     * @param config Application protocol config.
+     * @param sessionCacheSize the size of the cache used for storing SSL session objects.
+     *                         {@code 0} to use the default value.
+     * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
+     *                       {@code 0} to use the default value.
+     */
+    public OpenSslServerContext(
+            File certChainFile, File keyFile, String keyPassword, TrustManagerFactory trustManagerFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig config,
+            long sessionCacheSize, long sessionTimeout) throws SSLException {
+        this(certChainFile, keyFile, keyPassword, trustManagerFactory, ciphers, cipherFilter,
+                toNegotiator(config), sessionCacheSize, sessionTimeout);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param certChainFile an X.509 certificate chain file in PEM format
+     * @param keyFile a PKCS#8 private key file in PEM format
+     * @param keyPassword the password of the {@code keyFile}.
+     *                    {@code null} if it's not password-protected.
+     * @param ciphers the cipher suites to enable, in the order of preference.
+     *                {@code null} to use the default cipher suites.
+     * @param cipherFilter a filter to apply over the supplied list of ciphers
+     * @param apn Application protocol negotiator.
+     * @param sessionCacheSize the size of the cache used for storing SSL session objects.
+     *                         {@code 0} to use the default value.
+     * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
+     *                       {@code 0} to use the default value.
+     */
+    public OpenSslServerContext(
+            File certChainFile, File keyFile, String keyPassword, TrustManagerFactory trustManagerFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, OpenSslApplicationProtocolNegotiator apn,
+            long sessionCacheSize, long sessionTimeout) throws SSLException {
+        super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_SERVER);
+        OpenSsl.ensureAvailability();
 
         checkNotNull(certChainFile, "certChainFile");
         if (!certChainFile.isFile()) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -262,7 +262,7 @@ public abstract class SslContext {
         case OPENSSL:
             return new OpenSslServerContext(
                     keyCertChainFile, keyFile, keyPassword, trustManagerFactory,
-                    ciphers, apn, sessionCacheSize, sessionTimeout);
+                    ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
         default:
             throw new Error(provider.toString());
         }
@@ -485,7 +485,8 @@ public abstract class SslContext {
                         keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
             case OPENSSL:
                 return new OpenSslClientContext(
-                        trustCertChainFile, trustManagerFactory, ciphers, apn, sessionCacheSize, sessionTimeout);
+                        trustCertChainFile, trustManagerFactory, ciphers, cipherFilter, apn,
+                        sessionCacheSize, sessionTimeout);
         }
         // Should never happen!!
         throw new Error();

--- a/pom.xml
+++ b/pom.xml
@@ -615,7 +615,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>1.1.32.Fork1</version>
+        <version>1.1.33.Fork1</version>
         <classifier>${os.detected.classifier}</classifier>
         <scope>compile</scope>
         <optional>true</optional>


### PR DESCRIPTION
...r CipherSuiteFilter

Motivation:

To support HTTP2 we need APLN support. This was not provided before when using OpenSslEngine, so SSLEngine (JDK one) was the only bet.
Beside this CipherSuiteFilter was not supported

Modifications:

- Upgrade netty-tcnative and make use of new features to support ALPN and NPN in server and client mode.
- Guard against segfaults after the ssl pointer is freed
- support correctly different failure behaviours
- add support for CipherSuiteFilter

Result:

Be able to use OpenSslEngine for ALPN / NPN for server and client.