### PR TITLE
Adding reject task handler (#3449)

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -15,6 +15,8 @@
  */
 package io.netty.util.concurrent;
 
+import io.netty.util.internal.ObjectUtil;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -36,6 +38,8 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
 
     private final EventExecutorGroup parent;
     private final Collection<AbstractEventExecutor> selfCollection = Collections.singleton(this);
+
+    private volatile RejectedTaskHandler rejectedTaskHandler = DefaultRejectedTaskHandler.INSTANCE;
 
     protected AbstractEventExecutor() {
         this(null);
@@ -179,5 +183,16 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
         public void remove() {
             throw new UnsupportedOperationException("read-only");
         }
+    }
+    
+    @Override
+    public void setRejectedTaskHandler(RejectedTaskHandler rejectedTaskHandler) {
+        ObjectUtil.checkNotNull(rejectedTaskHandler, "rejectedTaskHandler");
+        this.rejectedTaskHandler = rejectedTaskHandler;
+    }
+
+    @Override
+    public RejectedTaskHandler rejectedTaskHandler() {
+        return rejectedTaskHandler;
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutorGroup.java
@@ -15,6 +15,8 @@
  */
 package io.netty.util.concurrent;
 
+import io.netty.util.internal.ObjectUtil;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -30,6 +32,9 @@ import static io.netty.util.concurrent.AbstractEventExecutor.*;
  * Abstract base class for {@link EventExecutorGroup} implementations.
  */
 public abstract class AbstractEventExecutorGroup implements EventExecutorGroup {
+
+    private volatile RejectedTaskHandler rejectedTaskHandler = DefaultRejectedTaskHandler.INSTANCE;
+
     @Override
     public Future<?> submit(Runnable task) {
         return next().submit(task);
@@ -113,5 +118,16 @@ public abstract class AbstractEventExecutorGroup implements EventExecutorGroup {
     @Override
     public void execute(Runnable command) {
         next().execute(command);
+    }
+    
+    @Override
+    public void setRejectedTaskHandler(RejectedTaskHandler rejectedTaskHandler) {
+        ObjectUtil.checkNotNull(rejectedTaskHandler, "rejectedTaskHandler");
+        this.rejectedTaskHandler = rejectedTaskHandler;
+    }
+    
+    @Override
+    public RejectedTaskHandler rejectedTaskHandler() {
+        return rejectedTaskHandler;
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -32,8 +32,6 @@ import static java.util.concurrent.TimeUnit.*;
 public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultPromise.class);
-    private static final InternalLogger rejectedExecutionLogger =
-            InternalLoggerFactory.getInstance(DefaultPromise.class.getName() + ".rejectedExecution");
 
     private static final int MAX_LISTENER_STACK_DEPTH = 8;
     private static final Signal SUCCESS = Signal.valueOf(DefaultPromise.class, "SUCCESS");
@@ -670,7 +668,7 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
         try {
             executor.execute(task);
         } catch (Throwable t) {
-            rejectedExecutionLogger.error("Failed to submit a listener notification task. Event loop shut down?", t);
+            executor.rejectedTaskHandler().taskRejected(task, t);
         }
     }
 

--- a/common/src/main/java/io/netty/util/concurrent/DefaultRejectedTaskHandler.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultRejectedTaskHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+/**
+ * The default implementation that just logs the rejection of a rejected task.
+ */
+public final class DefaultRejectedTaskHandler implements RejectedTaskHandler {
+    
+    public static final RejectedTaskHandler INSTANCE = new DefaultRejectedTaskHandler();
+    
+    private static final InternalLogger rejectedExecutionLogger = 
+            InternalLoggerFactory.getInstance(DefaultRejectedTaskHandler.class.getName() + ".rejectedExecution");
+
+    private DefaultRejectedTaskHandler() {}
+
+    @Override
+    public void taskRejected(Runnable task, Throwable cause) {
+        rejectedExecutionLogger.error("Failed to submit a listener notification task. Event loop shut down?", cause);
+    }
+}

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java
@@ -116,4 +116,16 @@ public interface EventExecutorGroup extends ScheduledExecutorService, Iterable<E
 
     @Override
     ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit);
+    
+    /**
+     * Set the {@link RejectTaskHandler} that will be called if the execution of a task is rejected. 
+     * 
+     * @param rejectTaskHandler the handler that handles rejected tasks
+     */
+    void setRejectedTaskHandler(RejectedTaskHandler rejectedTaskHandler);
+    
+    /**
+     * Returns the {@link RejectTaskHandler} that will be used for rejected tasks.
+     */
+    RejectedTaskHandler rejectedTaskHandler();
 }

--- a/common/src/main/java/io/netty/util/concurrent/RejectedTaskHandler.java
+++ b/common/src/main/java/io/netty/util/concurrent/RejectedTaskHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+/**
+ * The default implementation for rejected tasks is
+ * {@link DefaultRejectedTaskHandler}, which logs the failure of executing a task. To change
+ * this default behavior, a custom
+ * {@link RejectedTaskHandler} can be set in
+ * {@link AbstractEventExecutor#setRejectedTaskHandler(RejectedTaskHandler)} or
+ * {@link AbstractEventExecutorGroup#setRejectedTaskHandler(RejectedTaskHandler)}.
+ */
+public interface RejectedTaskHandler {
+    /**
+     * This method is called if the task was rejected for execution.
+     * 
+     * @param task the rejected task
+     * @param cause the cause of rejection
+     */
+    void taskRejected(Runnable task, Throwable cause);
+}


### PR DESCRIPTION
Discussion in #3449: operationComplete() silently fails if EventLoop is closed. Added rejection handler that can be set by the user to get notified for such an event