### PR TITLE
Optimizations for Http2FrameLogger

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
@@ -152,8 +152,7 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
 
         // Otherwise just log the first 64 bytes.
         int length = Math.min(buf.readableBytes(), BUFFER_LENGTH_THRESHOLD);
-        ByteBuf slice = buf.slice(0, length);
-        return ByteBufUtil.hexDump(slice) + "...";
+        return ByteBufUtil.hexDump(buf, buf.readerIndex(), length) + "...";
     }
 
     private void log(Direction direction, String format, Object... args) {


### PR DESCRIPTION
Motivation:

The logger was always performing a hex dump of the ByteBufs regarless whether or not the log would take place.

Modifications:

Fixed the logger to avoid serializing the ByteBufs and calling the varargs method if logging is not enabled.

Result:

The loggers should run MUCH faster when disabled.