### PR TITLE
Add support for byte order to LengthFieldPrepender

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/frame/LengthFieldPrependerTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/frame/LengthFieldPrependerTest.java
@@ -24,6 +24,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static io.netty.buffer.Unpooled.*;
+import java.nio.ByteOrder;
+
 import static org.junit.Assert.*;
 
 public class LengthFieldPrependerTest {
@@ -87,4 +89,25 @@ public class LengthFieldPrependerTest {
             // Expected
         }
     }
+
+    @Test
+    public void testPrependLengthInLittleEndian() throws Exception {
+        final EmbeddedChannel ch = new EmbeddedChannel(new LengthFieldPrepender(ByteOrder.LITTLE_ENDIAN, 4, 0, false));
+        ch.writeOutbound(msg);
+        ByteBuf buf = ch.readOutbound();
+        assertEquals(4, buf.readableBytes());
+        byte[] writtenBytes = new byte[buf.readableBytes()];
+        buf.getBytes(0, writtenBytes);
+        assertEquals(1, writtenBytes[0]);
+        assertEquals(0, writtenBytes[1]);
+        assertEquals(0, writtenBytes[2]);
+        assertEquals(0, writtenBytes[3]);
+        buf.release();
+
+        buf = ch.readOutbound();
+        assertSame(buf, msg);
+        buf.release();
+        assertFalse("The channel must have been completely read", ch.finish());
+    }
+
 }


### PR DESCRIPTION
If this PR is accepted it would be great if it would be also cherry-picked to the 4.0 branch.

Motivation:

While the LengthFieldBasedFrameDecoder supports a byte order the LengthFieldPrepender does not.
That means that I can simply add a LengthFieldBasedFrameDecoder with ByteOrder.LITTLE_ENDIAN to my pipeline
but have to write my own Encoder to write length fields in little endian byte order.

Modifications:

Added a constructor that takes a byte order and all other parameters.
All other constructors delegate to this one with ByteOrder.nativeOrder().
LengthFieldPrepender.encode() uses this byte order to write the length field.

Result:

LengthFieldPrepender will write the length field in the defined byte order.