### PR TITLE
Add supported for X509ExtendedTrustManager when using OpenSslEngine

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngineMap.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngineMap.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+interface OpenSslEngineMap {
+
+    OpenSslEngineMap EMPTY = new OpenSslEngineMap() {
+        @Override
+        public OpenSslEngine remove(long ssl) {
+            return null;
+        }
+
+        @Override
+        public void add(OpenSslEngine engine) {
+            // NOOP
+        }
+    };
+
+    /**
+     * Remove the {@link OpenSslEngine} with the given {@code ssl} address and
+     * return it.
+     */
+    OpenSslEngine remove(long ssl);
+
+    /**
+     * Add a {@link OpenSslEngine} to this {@link OpenSslEngineMap}.
+     */
+    void add(OpenSslEngine engine);
+}

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -17,14 +17,12 @@ package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.apache.tomcat.jni.CertificateVerifier;
 import org.apache.tomcat.jni.SSL;
 import org.apache.tomcat.jni.SSLContext;
 
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509ExtendedTrustManager;
 import javax.net.ssl.X509TrustManager;
 import java.io.File;
 import java.security.KeyFactory;
@@ -44,9 +42,8 @@ import static io.netty.util.internal.ObjectUtil.*;
  * A server-side {@link SslContext} which uses OpenSSL's SSL/TLS implementation.
  */
 public final class OpenSslServerContext extends OpenSslContext {
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(OpenSslServerContext.class);
-
     private final OpenSslServerSessionContext sessionContext;
+    private final OpenSslEngineMap engineMap;
 
     /**
      * Creates a new instance.
@@ -258,19 +255,26 @@ public final class OpenSslServerContext extends OpenSslContext {
                     }
 
                     final X509TrustManager manager = chooseTrustManager(trustManagerFactory.getTrustManagers());
-                    SSLContext.setCertVerifyCallback(ctx, new CertificateVerifier() {
-                        @Override
-                        public boolean verify(long ssl, byte[][] chain, String auth) {
-                            X509Certificate[] peerCerts = certificates(chain);
-                            try {
-                                manager.checkClientTrusted(peerCerts, auth);
-                                return true;
-                            } catch (Exception e) {
-                                logger.debug("verification of certificate failed", e);
+
+                    engineMap = newEngineMap(manager);
+                    // Use this to prevent an error when running on java < 7
+                    if (useExtendedTrustManager(manager)) {
+                        final X509ExtendedTrustManager extendedManager = (X509ExtendedTrustManager) manager;
+                        SSLContext.setCertVerifyCallback(ctx, new AbstractCertificateVerifier() {
+                            @Override
+                            void verify(long ssl, X509Certificate[] peerCerts, String auth) throws Exception {
+                                OpenSslEngine engine = engineMap.remove(ssl);
+                                extendedManager.checkClientTrusted(peerCerts, auth, engine);
                             }
-                            return false;
-                        }
-                    });
+                        });
+                    } else {
+                        SSLContext.setCertVerifyCallback(ctx, new AbstractCertificateVerifier() {
+                            @Override
+                            void verify(long ssl, X509Certificate[] peerCerts, String auth) throws Exception {
+                                manager.checkClientTrusted(peerCerts, auth);
+                            }
+                        });
+                    }
                 } catch (Exception e) {
                     throw new SSLException("unable to setup trustmanager", e);
                 }
@@ -287,5 +291,10 @@ public final class OpenSslServerContext extends OpenSslContext {
     @Override
     public OpenSslServerSessionContext sessionContext() {
         return sessionContext;
+    }
+
+    @Override
+    OpenSslEngineMap engineMap() {
+        return engineMap;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -879,8 +879,9 @@
             <ignore>sun.security.x509.X509CertInfo</ignore>
             <ignore>sun.security.x509.X509CertImpl</ignore>
 
-            <!-- SSLSession implelementation -->
+            <!-- SSLSession implementation -->
             <ignore>javax.net.ssl.SSLEngine</ignore>
+            <ignore>javax.net.ssl.X509ExtendedTrustManager</ignore>
           </ignores>
         </configuration>
         <executions>


### PR DESCRIPTION
Motivation:

For some use cases X509ExtendedTrustManager is needed as it allows to also access the SslEngine during validation.

Modifications:

Add support for X509ExtendedTrustManager on java >= 7

Result:

It's now possible to use X509ExtendedTrustManager with OpenSslEngine