### PR TITLE
Ensure server preference order in ALPN

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
@@ -20,7 +20,7 @@ import io.netty.handler.ssl.JdkApplicationProtocolNegotiator.ProtocolSelectionLi
 import io.netty.handler.ssl.JdkApplicationProtocolNegotiator.ProtocolSelector;
 import io.netty.util.internal.PlatformDependent;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import javax.net.ssl.SSLEngine;
@@ -64,7 +64,8 @@ final class JdkAlpnSslEngine extends JdkSslEngine {
 
         if (server) {
             final ProtocolSelector protocolSelector = checkNotNull(applicationNegotiator.protocolSelectorFactory()
-                    .newSelector(this, new HashSet<String>(applicationNegotiator.protocols())), "protocolSelector");
+                    .newSelector(this, new LinkedHashSet<String>(applicationNegotiator.protocols())),
+                    "protocolSelector");
             ALPN.put(engine, new ServerProvider() {
                 @Override
                 public String select(List<String> protocols) {

--- a/handler/src/main/java/io/netty/handler/ssl/JdkApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkApplicationProtocolNegotiator.java
@@ -15,9 +15,10 @@
  */
 package io.netty.handler.ssl;
 
-import javax.net.ssl.SSLEngine;
 import java.util.List;
 import java.util.Set;
+
+import javax.net.ssl.SSLEngine;
 
 /**
  * JDK extension methods to support {@link ApplicationProtocolNegotiator}

--- a/handler/src/main/java/io/netty/handler/ssl/JdkBaseApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkBaseApplicationProtocolNegotiator.java
@@ -142,9 +142,8 @@ class JdkBaseApplicationProtocolNegotiator implements JdkApplicationProtocolNego
 
         @Override
         public String select(List<String> protocols) throws Exception {
-            for (int i = 0; i < protocols.size(); ++i) {
-                String p = protocols.get(i);
-                if (supportedProtocols.contains(p)) {
+            for (String p : supportedProtocols) {
+                if (protocols.contains(p)) {
                     jettyWrapper.getSession().setApplicationProtocol(p);
                     return p;
                 }

--- a/handler/src/main/java/io/netty/handler/ssl/JdkNpnSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkNpnSslEngine.java
@@ -21,7 +21,7 @@ import io.netty.handler.ssl.JdkApplicationProtocolNegotiator.ProtocolSelectionLi
 import io.netty.handler.ssl.JdkApplicationProtocolNegotiator.ProtocolSelector;
 import io.netty.util.internal.PlatformDependent;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import javax.net.ssl.SSLEngine;
@@ -88,7 +88,8 @@ final class JdkNpnSslEngine extends JdkSslEngine {
             });
         } else {
             final ProtocolSelector protocolSelector = checkNotNull(applicationNegotiator.protocolSelectorFactory()
-                    .newSelector(this, new HashSet<String>(applicationNegotiator.protocols())), "protocolSelector");
+                    .newSelector(this, new LinkedHashSet<String>(applicationNegotiator.protocols())),
+                    "protocolSelector");
             NextProtoNego.put(engine, new ClientProvider() {
                 @Override
                 public boolean supports() {


### PR DESCRIPTION
Motivation:
With the current implementation the client protocol preference list
takes precedence over the one of the server, since the select method
will return the first item, in the client list, that matches any of the
protocols supported by the server. This violates the recommendation of
http://tools.ietf.org/html/rfc7301#section-3.2.

It will also fail with the current implementation of Chrome, which
sends back Extension application_layer_protocol_negotiation, protocols:
[http/1.1, spdy/3.1, h2-14]

Modifications:
Changed the protocol negotiator to prefer server’s list. Added a test
case that demonstrates the issue and that is fixed with the
modifications of this commit.

Result:
Server’s preference list is used.