### PR TITLE
Cleaning up HTTP/2 method names for max_concurrent_streams

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -730,7 +730,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         @Override
-        public boolean acceptingNewStreams() {
+        public boolean canCreateStream() {
             return nextStreamId() > 0 && numActiveStreams + 1 <= maxStreams;
         }
 
@@ -808,18 +808,18 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         @Override
-        public int numActiveStreams() {
+        public int numConcurrentStreams() {
             return numActiveStreams;
         }
 
         @Override
-        public int maxStreams() {
+        public int maxConcurrentStreams() {
             return maxStreams;
         }
 
         @Override
-        public void maxStreams(int maxStreams) {
-            this.maxStreams = maxStreams;
+        public void maxConcurrentStreams(int maxConcurrentStreams) {
+            this.maxStreams = maxConcurrentStreams;
         }
 
         @Override
@@ -866,7 +866,7 @@ public class DefaultHttp2Connection implements Http2Connection {
                 throw connectionError(PROTOCOL_ERROR, "Cannot create a stream since the connection is going away");
             }
             verifyStreamId(streamId);
-            if (!acceptingNewStreams()) {
+            if (!canCreateStream()) {
                 throw connectionError(REFUSED_STREAM, "Maximum streams exceeded for this endpoint.");
             }
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -612,7 +612,8 @@ public class DefaultHttp2Connection implements Http2Connection {
      * @param events The events (top down order) which have changed
      */
     private void notifyParentChanged(List<ParentChangedEvent> events) {
-        for (ParentChangedEvent event : events) {
+        for (int i = 0; i < events.size(); ++i) {
+            ParentChangedEvent event = events.get(i);
             for (Listener l : listeners) {
                 event.notifyListener(l);
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -143,7 +143,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         Http2HeaderTable headerTable = config.headerTable();
         Http2FrameSizePolicy frameSizePolicy = config.frameSizePolicy();
         settings.initialWindowSize(flowController().initialWindowSize());
-        settings.maxConcurrentStreams(connection.remote().maxStreams());
+        settings.maxConcurrentStreams(connection.remote().maxConcurrentStreams());
         settings.headerTableSize(headerTable.maxHeaderTableSize());
         settings.maxFrameSize(frameSizePolicy.maxFrameSize());
         settings.maxHeaderListSize(headerTable.maxHeaderListSize());
@@ -170,7 +170,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         Long maxConcurrentStreams = settings.maxConcurrentStreams();
         if (maxConcurrentStreams != null) {
             int value = (int) Math.min(maxConcurrentStreams, Integer.MAX_VALUE);
-            connection.remote().maxStreams(value);
+            connection.remote().maxConcurrentStreams(value);
         }
 
         Long headerTableSize = settings.headerTableSize();
@@ -428,7 +428,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
             Long maxConcurrentStreams = settings.maxConcurrentStreams();
             if (maxConcurrentStreams != null) {
                 int value = (int) Math.min(maxConcurrentStreams, Integer.MAX_VALUE);
-                connection.remote().maxStreams(value);
+                connection.remote().maxConcurrentStreams(value);
             }
 
             Long headerTableSize = settings.headerTableSize();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -143,7 +143,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         Http2HeaderTable headerTable = config.headerTable();
         Http2FrameSizePolicy frameSizePolicy = config.frameSizePolicy();
         settings.initialWindowSize(flowController().initialWindowSize());
-        settings.maxConcurrentStreams(connection.remote().maxConcurrentStreams());
+        settings.maxConcurrentStreams(connection.remote().maxActiveStreams());
         settings.headerTableSize(headerTable.maxHeaderTableSize());
         settings.maxFrameSize(frameSizePolicy.maxFrameSize());
         settings.maxHeaderListSize(headerTable.maxHeaderListSize());
@@ -170,7 +170,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         Long maxConcurrentStreams = settings.maxConcurrentStreams();
         if (maxConcurrentStreams != null) {
             int value = (int) Math.min(maxConcurrentStreams, Integer.MAX_VALUE);
-            connection.remote().maxConcurrentStreams(value);
+            connection.remote().maxActiveStreams(value);
         }
 
         Long headerTableSize = settings.headerTableSize();
@@ -322,7 +322,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
             }
 
             if (stream == null) {
-                stream = connection.createRemoteStream(streamId).open(endOfStream);
+                stream = connection.remote().createStream(streamId).open(endOfStream);
             } else {
                 switch (stream.state()) {
                     case RESERVED_REMOTE:
@@ -371,7 +371,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
             if (stream == null) {
                 // PRIORITY frames always identify a stream. This means that if a PRIORITY frame is the
                 // first frame to be received for a stream that we must create the stream.
-                stream = connection.createRemoteStream(streamId);
+                stream = connection.remote().createStream(streamId);
             }
 
             // This call will create a stream for streamDependency if necessary.
@@ -428,7 +428,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
             Long maxConcurrentStreams = settings.maxConcurrentStreams();
             if (maxConcurrentStreams != null) {
                 int value = (int) Math.min(maxConcurrentStreams, Integer.MAX_VALUE);
-                connection.remote().maxConcurrentStreams(value);
+                connection.remote().maxActiveStreams(value);
             }
 
             Long headerTableSize = settings.headerTableSize();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -121,7 +121,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
 
         Long maxConcurrentStreams = settings.maxConcurrentStreams();
         if (maxConcurrentStreams != null) {
-            connection.local().maxConcurrentStreams((int) Math.min(maxConcurrentStreams, Integer.MAX_VALUE));
+            connection.local().maxActiveStreams((int) Math.min(maxConcurrentStreams, Integer.MAX_VALUE));
         }
 
         Long headerTableSize = settings.headerTableSize();
@@ -194,7 +194,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
             }
             Http2Stream stream = connection.stream(streamId);
             if (stream == null) {
-                stream = connection.createLocalStream(streamId);
+                stream = connection.local().createStream(streamId);
             }
 
             switch (stream.state()) {
@@ -235,7 +235,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
             // Update the priority on this stream.
             Http2Stream stream = connection.stream(streamId);
             if (stream == null) {
-                stream = connection.createLocalStream(streamId);
+                stream = connection.local().createStream(streamId);
             }
 
             stream.setPriority(streamDependency, weight, exclusive);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -121,7 +121,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
 
         Long maxConcurrentStreams = settings.maxConcurrentStreams();
         if (maxConcurrentStreams != null) {
-            connection.local().maxStreams((int) Math.min(maxConcurrentStreams, Integer.MAX_VALUE));
+            connection.local().maxConcurrentStreams((int) Math.min(maxConcurrentStreams, Integer.MAX_VALUE));
         }
 
         Long headerTableSize = settings.headerTableSize();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -73,7 +73,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
             }
 
             @Override
-            public void streamInactive(Http2Stream stream) {
+            public void streamClosed(Http2Stream stream) {
                 // Any pending frames can never be written, cancel and
                 // write errors for any pending frames.
                 state(stream).cancel();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -106,18 +106,18 @@ public interface Http2Connection {
         boolean createdStreamId(int streamId);
 
         /**
-         * Indicates whether or not this endpoint is currently accepting new streams. This will be
-         * be false if {@link #numActiveStreams()} + 1 >= {@link #maxStreams()} or if the stream IDs
+         * Indicates whether or not this endpoint is currently allowed to create new streams. This will be
+         * be false if {@link #numConcurrentStreams()} + 1 >= {@link #maxConcurrentStreams()} or if the stream IDs
          * for this endpoint have been exhausted (i.e. {@link #nextStreamId()} < 0).
          */
-        boolean acceptingNewStreams();
+        boolean canCreateStream();
 
         /**
          * Creates a stream initiated by this endpoint. This could fail for the following reasons:
          * <ul>
          * <li>The requested stream ID is not the next sequential ID for this endpoint.</li>
          * <li>The stream already exists.</li>
-         * <li>The number of concurrent streams is above the allowed threshold for this endpoint.</li>
+         * <li>{@link #canCreateStream()} is {@code false}.</li>
          * <li>The connection is marked as going away.</li>
          * </ul>
          * <p>
@@ -164,17 +164,21 @@ public interface Http2Connection {
         /**
          * Gets the number of currently active streams that were created by this endpoint.
          */
-        int numActiveStreams();
+        int numConcurrentStreams();
 
         /**
-         * Gets the maximum number of concurrent streams allowed by this endpoint.
+         * Gets the maximum number of streams (created by this endpoint) that are allowed to be active at once.
+         * This is the {@code SETTINGS_MAX_CONCURRENT_STREAMS} value sent from the opposite endpoint to
+         * restrict stream creation by this endpoint.
          */
-        int maxStreams();
+        int maxConcurrentStreams();
 
         /**
-         * Sets the maximum number of concurrent streams allowed by this endpoint.
+         * Sets the maximum number of streams (created by this endpoint) that are allowed to be active at once.
+         * This is the {@code SETTINGS_MAX_CONCURRENT_STREAMS} value sent from the opposite endpoint to
+         * restrict stream creation by this endpoint.
          */
-        void maxStreams(int maxStreams);
+        void maxConcurrentStreams(int maxConcurrentStreams);
 
         /**
          * Gets the ID of the stream last successfully created by this endpoint.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -28,24 +28,23 @@ public interface Http2Connection {
     interface Listener {
         /**
          * Notifies the listener that the given stream was added to the connection. This stream may
-         * not yet be active (i.e. open/half-closed).
+         * not yet be active (i.e. {@code OPEN} or {@code HALF CLOSED}).
          */
         void streamAdded(Http2Stream stream);
 
         /**
-         * Notifies the listener that the given stream was made active (i.e. open in at least one
-         * direction).
+         * Notifies the listener that the given stream was made active (i.e. {@code OPEN} or {@code HALF CLOSED}).
          */
         void streamActive(Http2Stream stream);
 
         /**
-         * Notifies the listener that the given stream is now half-closed. The stream can be
-         * inspected to determine which side is closed.
+         * Notifies the listener that the given stream is now {@code HALF CLOSED}. The stream can be
+         * inspected to determine which side is {@code CLOSED}.
          */
         void streamHalfClosed(Http2Stream stream);
 
         /**
-         * Notifies the listener that the given stream is now closed in both directions and will no longer
+         * Notifies the listener that the given stream is now {@code CLOSED} in both directions and will no longer
          * be returned by {@link #activeStreams()}.
          */
         void streamClosed(Http2Stream stream);
@@ -136,7 +135,7 @@ public interface Http2Connection {
          * <li>The requested stream ID is not the next sequential stream ID for this endpoint.</li>
          * <li>The number of concurrent streams is above the allowed threshold for this endpoint.</li>
          * <li>The connection is marked as going away.</li>
-         * <li>The parent stream ID does not exist or is not open from the side sending the push
+         * <li>The parent stream ID does not exist or is not {@code OPEN} from the side sending the push
          * promise.</li>
          * <li>Could not set a valid priority for the new stream.</li>
          * </ul>
@@ -163,7 +162,8 @@ public interface Http2Connection {
         boolean allowPushTo();
 
         /**
-         * Gets the number of active streams (i.e. open or half-closed) that were created by this endpoint.
+         * Gets the number of active streams (i.e. {@code OPEN} or {@code HALF CLOSED}) that were created by this
+         * endpoint.
          */
         int numActiveStreams();
 
@@ -236,12 +236,12 @@ public interface Http2Connection {
     Http2Stream connectionStream();
 
     /**
-     * Gets the number of streams that are actively in use (i.e. open or half-closed).
+     * Gets the number of streams that are actively in use (i.e. {@code OPEN} or {@code HALF CLOSED}).
      */
     int numActiveStreams();
 
     /**
-     * Gets all streams that are actively in use (i.e. open or half-closed). The returned collection is
+     * Gets all streams that are actively in use (i.e. {@code OPEN} or {@code HALF CLOSED}). The returned collection is
      * sorted by priority.
      */
     Collection<Http2Stream> activeStreams();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionAdapter.java
@@ -32,7 +32,7 @@ public class Http2ConnectionAdapter implements Http2Connection.Listener {
     }
 
     @Override
-    public void streamInactive(Http2Stream stream) {
+    public void streamClosed(Http2Stream stream) {
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -125,7 +125,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         }
 
         // Create a local stream used for the HTTP cleartext upgrade.
-        connection().createLocalStream(HTTP_UPGRADE_STREAM_ID).open(true);
+        connection().local().createStream(HTTP_UPGRADE_STREAM_ID).open(true);
     }
 
     /**
@@ -144,7 +144,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         encoder.remoteSettings(settings);
 
         // Create a stream in the half-closed state.
-        connection().createRemoteStream(HTTP_UPGRADE_STREAM_ID).open(true);
+        connection().remote().createStream(HTTP_UPGRADE_STREAM_ID).open(true);
     }
 
     @Override
@@ -262,9 +262,6 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         future.addListener(new ChannelFutureListener() {
           @Override
           public void operationComplete(ChannelFuture future) throws Exception {
-            // Deactivate this stream.
-            connection().deactivate(stream);
-
             // If this connection is closing and there are no longer any
             // active streams, close after the current operation completes.
             if (closeListener != null && connection().numActiveStreams() == 0) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
@@ -96,7 +96,7 @@ public class Http2EventAdapter implements Http2Connection.Listener, Http2FrameLi
     }
 
     @Override
-    public void streamInactive(Http2Stream stream) {
+    public void streamClosed(Http2Stream stream) {
     }
 
     @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -128,20 +128,6 @@ public class DefaultHttp2ConnectionDecoderTest {
         when(local.flowController()).thenReturn(localFlow);
         when(encoder.flowController()).thenReturn(remoteFlow);
         when(connection.remote()).thenReturn(remote);
-        doAnswer(new Answer<Http2Stream>() {
-            @Override
-            public Http2Stream answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                return local.createStream((Integer) args[0]);
-            }
-        }).when(connection).createLocalStream(anyInt());
-        doAnswer(new Answer<Http2Stream>() {
-            @Override
-            public Http2Stream answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                return remote.createStream((Integer) args[0]);
-            }
-        }).when(connection).createRemoteStream(anyInt());
         when(local.createStream(eq(STREAM_ID))).thenReturn(stream);
         when(local.reservePushStream(eq(PUSH_STREAM_ID), eq(stream))).thenReturn(pushStream);
         when(remote.createStream(eq(STREAM_ID))).thenReturn(stream);
@@ -389,7 +375,7 @@ public class DefaultHttp2ConnectionDecoderTest {
         decode().onPriorityRead(ctx, STREAM_ID, 0, (short) 255, true);
         verify(stream).setPriority(eq(0), eq((short) 255), eq(true));
         verify(listener).onPriorityRead(eq(ctx), eq(STREAM_ID), eq(0), eq((short) 255), eq(true));
-        verify(connection).createRemoteStream(STREAM_ID);
+        verify(remote).createStream(STREAM_ID);
         verify(stream, never()).open(anyBoolean());
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -163,7 +163,7 @@ public class DefaultHttp2ConnectionTest {
 
     @Test(expected = Http2Exception.class)
     public void maxAllowedStreamsExceededShouldThrow() throws Http2Exception {
-        server.local().maxConcurrentStreams(0);
+        server.local().maxActiveStreams(0);
         server.local().createStream(2).open(true);
     }
 
@@ -214,12 +214,12 @@ public class DefaultHttp2ConnectionTest {
 
     @Test(expected = Http2Exception.class)
     public void localStreamInvalidStreamIdShouldThrow() throws Http2Exception {
-        client.createLocalStream(Integer.MAX_VALUE + 2).open(false);
+        client.local().createStream(Integer.MAX_VALUE + 2).open(false);
     }
 
     @Test(expected = Http2Exception.class)
     public void remoteStreamInvalidStreamIdShouldThrow() throws Http2Exception {
-        client.createRemoteStream(Integer.MAX_VALUE + 1).open(false);
+        client.remote().createStream(Integer.MAX_VALUE + 1).open(false);
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -163,7 +163,7 @@ public class DefaultHttp2ConnectionTest {
 
     @Test(expected = Http2Exception.class)
     public void maxAllowedStreamsExceededShouldThrow() throws Http2Exception {
-        server.local().maxStreams(0);
+        server.local().maxConcurrentStreams(0);
         server.local().createStream(2).open(true);
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -111,20 +111,6 @@ public class Http2ConnectionHandlerTest {
         when(connection.local()).thenReturn(local);
         when(connection.activeStreams()).thenReturn(Collections.singletonList(stream));
         when(stream.open(anyBoolean())).thenReturn(stream);
-        doAnswer(new Answer<Http2Stream>() {
-            @Override
-            public Http2Stream answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                return local.createStream((Integer) args[0]);
-            }
-        }).when(connection).createLocalStream(anyInt());
-        doAnswer(new Answer<Http2Stream>() {
-            @Override
-            public Http2Stream answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                return remote.createStream((Integer) args[0]);
-            }
-        }).when(connection).createRemoteStream(anyInt());
         when(encoder.writeSettings(eq(ctx), any(Http2Settings.class), eq(promise))).thenReturn(future);
         when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
         when(ctx.channel()).thenReturn(channel);


### PR DESCRIPTION
Motivation:

The current documentation for Endpoint methods referring to concurrent streams and the SETTINGS_MAX_CONCURRENT_STREAMS setting are a bit confusing.

Modifications:

Renamed a few of the methods and added more clear documentation.

Result:

Fixes #3451