### PR TITLE
Search for native artifacts using new layout

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -53,6 +53,10 @@
       <artifactId>log4j</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>kr.motd.maven</groupId>
+      <artifactId>os-maven-plugin</artifactId>
+    </dependency>
   </dependencies>
 </project>
 

--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -41,9 +41,9 @@ public final class NativeLibraryLoader {
 
     static {
         OsDetector osDetector = new OsDetector();
-        OSNAME = osDetector.getOsName();
-        OSARCH = osDetector.getOsArch();
-        OSCLASSIFIER = osDetector.getOsClassifier();
+        OSNAME = osDetector.osName();
+        OSARCH = osDetector.osArch();
+        OSCLASSIFIER = osDetector.osClassifier();
 
         String workdir = SystemPropertyUtil.get("io.netty.native.workdir");
         if (workdir != null) {
@@ -159,11 +159,11 @@ public final class NativeLibraryLoader {
 
         // First, attempt to load the library based on the detected os/arch
         String detectedOsPath = NATIVE_RESOURCE_HOME + OSCLASSIFIER + "/" + libname;
-        URL url = getLibraryUrl(loader, detectedOsPath);
+        URL url = libraryUrl(loader, detectedOsPath);
         if (url == null) {
             // Fallback to the legacy path
             String legacyPath = NATIVE_RESOURCE_HOME + libname;
-            url = getLibraryUrl(loader, legacyPath);
+            url = libraryUrl(loader, legacyPath);
         }
 
         if (url == null) {
@@ -225,7 +225,7 @@ public final class NativeLibraryLoader {
         }
     }
 
-    private static URL getLibraryUrl(ClassLoader loader, String path) {
+    private static URL libraryUrl(ClassLoader loader, String path) {
         URL url = loader.getResource(path);
         if (url == null && isOSX()) {
             // OSX libraries may have a jnilib or a dylib suffix.

--- a/common/src/main/java/io/netty/util/internal/OsDetector.java
+++ b/common/src/main/java/io/netty/util/internal/OsDetector.java
@@ -23,9 +23,9 @@ import kr.motd.maven.os.Detector;
 
 
 /**
- * Use the same OS name and architecture detection and normalization logic as netty/tcnative
+ * Use the same OS name and architecture detection and normalization logic as netty/tcnative.
  */
-public class OsDetector extends Detector {
+public final class OsDetector extends Detector {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(OsDetector.class);
 
     private final String osName;
@@ -39,15 +39,15 @@ public class OsDetector extends Detector {
         osClassifier = System.getProperty("os.detected.classifier");
     }
 
-    public String getOsName() {
+    public String osName() {
         return osName;
     }
 
-    public String getOsArch() {
+    public String osArch() {
         return osArch;
     }
 
-    public String getOsClassifier() {
+    public String osClassifier() {
         return osClassifier;
     }
 

--- a/common/src/main/java/io/netty/util/internal/OsDetector.java
+++ b/common/src/main/java/io/netty/util/internal/OsDetector.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.util.internal;
+
+import io.netty.util.internal.logging.InternalLogLevel;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import kr.motd.maven.os.Detector;
+
+
+/**
+ * Use the same OS name and architecture detection and normalization logic as netty/tcnative
+ */
+public class OsDetector extends Detector {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(OsDetector.class);
+
+    private final String osName;
+    private final String osArch;
+    private final String osClassifier;
+
+    public OsDetector() {
+        super.detect(System.getProperties());
+        osName = System.getProperty("os.detected.name");
+        osArch = System.getProperty("os.detected.arch");
+        osClassifier = System.getProperty("os.detected.classifier");
+    }
+
+    public String getOsName() {
+        return osName;
+    }
+
+    public String getOsArch() {
+        return osArch;
+    }
+
+    public String getOsClassifier() {
+        return osClassifier;
+    }
+
+    @Override
+    protected void log(String s) {
+        logger.log(InternalLogLevel.INFO, s);
+    }
+
+    @Override
+    protected void logProperty(String s, String s1) {
+        logger.log(InternalLogLevel.INFO, String.format("%s: %s", s, s1));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -582,6 +582,12 @@
         <scope>compile</scope>
         <optional>true</optional>
       </dependency>
+      <!-- OS Detection for loading the native libraries -->
+      <dependency>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.2.3.Final</version>
+      </dependency>
 
       <!--
         Bouncy Castle - completely optional, only needed when:


### PR DESCRIPTION
Look under META-INF/native/${os.classifier} first to work with a shaded
tcnative.

Blocked on landing and release of companion tcnative PR: https://github.com/netty/netty-tcnative/pull/33