### PR TITLE
Update jUnit version to 4.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -687,7 +687,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.12</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Motivation:

Too many new features in the new release of jUnit.
https://github.com/junit-team/junit/blob/master/doc/ReleaseNotes4.12.md

Modifications:

- Changed version of jUnit from 4.11 to 4.12 in the parent pom.

Result:

Allows using new testing features.


For example, it has improved `Theories` which will allow to simplify and improve tests for compression codecs #2791. 