### PR TITLE
Safely encode Strings to ASCII

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/HttpMessageEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/HttpMessageEncoder.java
@@ -171,8 +171,15 @@ public abstract class HttpMessageEncoder extends OneToOneEncoder {
 
     protected static void encodeAscii(String s, ChannelBuffer buf) {
         for (int i = 0; i < s.length(); i++) {
-            buf.writeByte(s.charAt(i));
+            buf.writeByte(c2b(s.charAt(i)));
         }
+    }
+
+    private static byte c2b(char c) {
+        if (c > 255) {
+            return '?';
+        }
+        return (byte) c;
     }
 
     protected abstract void encodeInitialLine(ChannelBuffer buf, HttpMessage message) throws Exception;


### PR DESCRIPTION
Motivation:

The current implementation of the encoder writes each character of the
String as a single byte to the buffer, however not all characters are
mappable to a single byte.

Modifications:

If a character is outside the ASCII range, it's converted to '?'.

Result:

A safer encoder for String to ASCII, which substitutes unmappable
characters with'?'.