### PR TITLE
Always complete promise in GO_AWAY and allow multiple calls to writeRstStream

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -328,14 +328,13 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     public ChannelFuture writeRstStream(ChannelHandlerContext ctx, int streamId, long errorCode,
             ChannelPromise promise) {
         Http2Stream stream = connection().stream(streamId);
+        if (stream == null) {
+            return promise.setSuccess(null);
+        }
         ChannelFuture future = frameWriter().writeRstStream(ctx, streamId, errorCode, promise);
         ctx.flush();
-
-        if (stream != null) {
-            stream.resetSent();
-            closeStream(stream, promise);
-        }
-
+        stream.resetSent();
+        closeStream(stream, promise);
         return future;
     }
 
@@ -348,7 +347,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         Http2Connection connection = connection();
         if (connection.isGoAway()) {
             debugData.release();
-            return ctx.newSucceededFuture();
+            return promise.setSuccess(null);
         }
 
         ChannelFuture future = frameWriter().writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);


### PR DESCRIPTION
Hi guys,

so I was running into the issue today that my application might call `writeRstStream` multiple times. I would argue that it's a good idea if `writeRstStream` would only send the `RST_STREAM` frame on the first call and else just complete the promise (just like `writeGoAway` does at the moment).

There should also not be a need to send a `RST_STREAM` frame for a stream id that we don't recognize as in that case the spec requires a GOAWAY `"An endpoint that receives an unexpected stream identifier MUST respond with a connection error (Section 5.4.1) of type PROTOCOL_ERROR."`. 

While reading through that code I also found a bug in the `writeGoAway` method, where on multiple calls to `writeGoAway` the promise would not be completed.

If @nmittler and @Scottmitch agree with this change, I would add some comments and tests and update the commit message. Let me know!