### PR TITLE
Returns after encoding message

### DIFF
--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObjectEncoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObjectEncoder.java
@@ -45,6 +45,7 @@ public abstract class AbstractMemcacheObjectEncoder<M extends MemcacheMessage> e
             @SuppressWarnings({ "unchecked", "CastConflictsWithInstanceof" })
             final M m = (M) msg;
             out.add(encodeMessage(ctx, m));
+            return;
         }
 
         if (msg instanceof MemcacheContent || msg instanceof ByteBuf || msg instanceof FileRegion) {


### PR DESCRIPTION
Motivation:
Current AbstractMemcacheObjectEncoder does unnecessary message type checking if the message is MemcacheMessage type.   

Modifications:
Returns after encoding MemcacheMessage message.

Result:
Small performance improvement for this encoder.