### PR TITLE
Fix typo in codec-memcache module

### DIFF
--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheEncoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheEncoder.java
@@ -22,7 +22,7 @@ import io.netty.handler.codec.memcache.AbstractMemcacheObjectEncoder;
 import io.netty.util.CharsetUtil;
 
 /**
- * A {@link MessageToByteEncoder} that encodes binary memache messages into bytes.
+ * A {@link MessageToByteEncoder} that encodes binary memcache messages into bytes.
  */
 public abstract class AbstractBinaryMemcacheEncoder<M extends BinaryMemcacheMessage>
     extends AbstractMemcacheObjectEncoder<M> {

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheMessage.java
@@ -137,7 +137,7 @@ public interface BinaryMemcacheMessage extends MemcacheMessage {
     /**
      * Sets the opaque value.
      *
-     * @param opaque the opqaue value to use.
+     * @param opaque the opaque value to use.
      */
     BinaryMemcacheMessage setOpaque(int opaque);
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheServerCodec.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheServerCodec.java
@@ -20,7 +20,7 @@ import io.netty.channel.ChannelHandlerAppender;
 /**
  * The full server codec that combines the correct encoder and decoder.
  * <p/>
- * Use this codec if you need to implement a server that speaks the memache binary protocol.
+ * Use this codec if you need to implement a server that speaks the memcache binary protocol.
  * Internally, it combines the {@link BinaryMemcacheRequestDecoder} and the
  * {@link BinaryMemcacheResponseEncoder} to request decoding and response encoding.
  */


### PR DESCRIPTION
Motivation:
For clean javadoc for codec-memcache module

Modifications:
Fix typos 

Result:
Clean javadoc