### PR TITLE
Fix GOAWAY logic in Http2Encoder and Http2Decoder.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -97,7 +97,7 @@ public interface Http2Connection {
          * Called when a {@code GOAWAY} was received from the remote endpoint. This event handler duplicates {@link
          * Http2FrameListener#onGoAwayRead(io.netty.channel.ChannelHandlerContext, int, long, io.netty.buffer.ByteBuf)}
          * but is added here in order to simplify application logic for handling {@code GOAWAY} in a uniform way. An
-         * application should generally not handle both events, but if it does this method is called first, before
+         * application should generally not handle both events, but if it does this method is called second, after
          * notifying the {@link Http2FrameListener}.
          *
          * @param lastStreamId the last known stream of the remote endpoint.
@@ -206,9 +206,8 @@ public interface Http2Connection {
         int lastStreamCreated();
 
         /**
-         * Gets the last stream created by this endpoint that is "known" by the opposite endpoint.
          * If a GOAWAY was received for this endpoint, this will be the last stream ID from the
-         * GOAWAY frame. Otherwise, this will be same as {@link #lastStreamCreated()}.
+         * GOAWAY frame. Otherwise, this will be {@code -1}.
          */
         int lastKnownStream();
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -23,6 +23,8 @@ import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static io.netty.handler.codec.http2.Http2Exception.isStreamError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static java.lang.String.format;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelFuture;
@@ -32,6 +34,9 @@ import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.http2.Http2Exception.CompositeStreamException;
 import io.netty.handler.codec.http2.Http2Exception.StreamException;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.Collection;
 import java.util.List;
@@ -50,6 +55,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     private final Http2ConnectionEncoder encoder;
     private ChannelFutureListener closeListener;
     private BaseDecoder byteDecoder;
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(Http2ConnectionHandler.class);
 
     public Http2ConnectionHandler(boolean server, Http2FrameListener listener) {
         this(new DefaultHttp2Connection(server), listener);
@@ -510,36 +516,47 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     }
 
     @Override
-    public ChannelFuture goAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
-            ByteBuf debugData, ChannelPromise promise) {
-        Http2Connection connection = connection();
-        if (connection.goAwayReceived() || connection.goAwaySent()) {
+    public ChannelFuture goAway(final ChannelHandlerContext ctx, final int lastStreamId, final long errorCode,
+                                final ByteBuf debugData, ChannelPromise promise) {
+        try {
+            final Http2Connection connection = connection();
+            if (connection.goAwaySent() && connection.remote().lastKnownStream() < lastStreamId) {
+                throw connectionError(PROTOCOL_ERROR, "Last stream identifier must not increase between " +
+                                                      "sending multiple GOAWAY frames (was '%d', is '%d').",
+                                                      connection.remote().lastKnownStream(),
+                                                      lastStreamId);
+            }
+            connection.goAwaySent(lastStreamId, errorCode, debugData);
+
+            ChannelFuture future = frameWriter().writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
+            ctx.flush();
+
+            future.addListener(new GenericFutureListener<ChannelFuture>() {
+                @Override
+                public void operationComplete(ChannelFuture future) throws Exception {
+                    if (!future.isSuccess()) {
+                        String msg = format("Sending GOAWAY failed: lastStreamId '%d', errorCode '%d', " +
+                                            "debugData '%s'.", lastStreamId, errorCode, debugData);
+                        logger.error(msg, future.cause());
+                        ctx.channel().close();
+                    }
+                }
+            });
+
+            return future;
+        } catch (Http2Exception e) {
             debugData.release();
-            return ctx.newSucceededFuture();
+            return promise.setFailure(e);
         }
-
-        connection.goAwaySent(lastStreamId, errorCode, debugData);
-
-        ChannelFuture future = frameWriter().writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
-        ctx.flush();
-
-        return future;
     }
 
     /**
      * Close the remote endpoint with with a {@code GO_AWAY} frame.
      */
     private ChannelFuture goAway(ChannelHandlerContext ctx, Http2Exception cause) {
-        Http2Connection connection = connection();
-        if (connection.goAwayReceived() || connection.goAwaySent()) {
-            return ctx.newSucceededFuture();
-        }
-
-        // The connection isn't alredy going away, send the GO_AWAY frame now to start
-        // the process.
         long errorCode = cause != null ? cause.error().code() : NO_ERROR.code();
         ByteBuf debugData = Http2CodecUtil.toByteBuf(ctx, cause);
-        int lastKnownStream = connection.remote().lastStreamCreated();
+        int lastKnownStream = connection().remote().lastStreamCreated();
         return goAway(ctx, lastKnownStream, errorCode, debugData, ctx.newPromise());
     }
 


### PR DESCRIPTION
Motivation:

1) The current implementation doesn't allow for HEADERS, DATA, PING, PRIORITY and SETTINGS
   frames to be sent after GOAWAY.

2) When receiving or sending a GOAWAY frame, all streams with ids greater than the lastStreamId
   of the GOAWAY frame should be closed. That's not happening.

Modifications:

1) Allow sending of HEADERS and DATA frames after GOAWAY for streams with ids < lastStreamId.
2) Always allow sending PING, PRIORITY AND SETTINGS frames.
3) Allow sending multiple GOAWAY frames with decreasing lastStreamIds.
4) After receiving or sending a GOAWAY frame, close all streams with ids > lastStreamId.

Result:

The GOAWAY handling is more correct.