### PR TITLE
Include error code and message in GOAWAY events.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -40,7 +40,7 @@ import io.netty.handler.codec.compression.ZlibWrapper;
 public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionEncoder {
     private static final Http2ConnectionAdapter CLEAN_UP_LISTENER = new Http2ConnectionAdapter() {
         @Override
-        public void streamRemoved(Http2Stream stream) {
+        public void onStreamRemoved(Http2Stream stream) {
             final EmbeddedChannel compressor = stream.getProperty(CompressorHttp2ConnectionEncoder.class);
             if (compressor != null) {
                 cleanup(stream, compressor);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -163,7 +163,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         localEndpoint.lastKnownStream(lastKnownStream);
         if (!alreadyNotified) {
             for (Listener listener : listeners) {
-                listener.onGoAwayReceived(errorCode, debugData);
+                listener.onGoAwayReceived(lastKnownStream, errorCode, debugData);
             }
         }
     }
@@ -179,7 +179,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         remoteEndpoint.lastKnownStream(lastKnownStream);
         if (!alreadyNotified) {
             for (Listener listener : listeners) {
-                listener.onGoAwaySent(errorCode, debugData);
+                listener.onGoAwaySent(lastKnownStream, errorCode, debugData);
             }
         }
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -169,7 +169,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
     void onGoAwayRead0(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData)
             throws Http2Exception {
         // Don't allow any more connections to be created.
-        connection.goAwayReceived(lastStreamId);
+        connection.goAwayReceived(lastStreamId, errorCode, debugData);
 
         listener.onGoAwayRead(ctx, lastStreamId, errorCode, debugData);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -112,7 +112,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
             final boolean endOfStream, ChannelPromise promise) {
         final Http2Stream stream;
         try {
-            if (connection.isGoAway()) {
+            if (connection.goAwayReceived() || connection.goAwaySent()) {
                 throw new IllegalStateException("Sending data after connection going away.");
             }
 
@@ -151,7 +151,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
             final boolean exclusive, final int padding, final boolean endOfStream,
             final ChannelPromise promise) {
         try {
-            if (connection.isGoAway()) {
+            if (connection.goAwayReceived() || connection.goAwaySent()) {
                 throw connectionError(PROTOCOL_ERROR, "Sending headers after connection going away.");
             }
             Http2Stream stream = connection.stream(streamId);
@@ -190,7 +190,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
     public ChannelFuture writePriority(ChannelHandlerContext ctx, int streamId, int streamDependency, short weight,
             boolean exclusive, ChannelPromise promise) {
         try {
-            if (connection.isGoAway()) {
+            if (connection.goAwayReceived() || connection.goAwaySent()) {
                 throw connectionError(PROTOCOL_ERROR, "Sending priority after connection going away.");
             }
 
@@ -227,7 +227,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
             ChannelPromise promise) {
         outstandingLocalSettingsQueue.add(settings);
         try {
-            if (connection.isGoAway()) {
+            if (connection.goAwayReceived() || connection.goAwaySent()) {
                 throw connectionError(PROTOCOL_ERROR, "Sending settings after connection going away.");
             }
 
@@ -254,7 +254,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
     @Override
     public ChannelFuture writePing(ChannelHandlerContext ctx, boolean ack, ByteBuf data,
             ChannelPromise promise) {
-        if (connection.isGoAway()) {
+        if (connection.goAwayReceived() || connection.goAwaySent()) {
             data.release();
             return promise.setFailure(connectionError(PROTOCOL_ERROR, "Sending ping after connection going away."));
         }
@@ -268,7 +268,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
     public ChannelFuture writePushPromise(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
             Http2Headers headers, int padding, ChannelPromise promise) {
         try {
-            if (connection.isGoAway()) {
+            if (connection.goAwayReceived() || connection.goAwaySent()) {
                 throw connectionError(PROTOCOL_ERROR, "Sending push promise after connection going away.");
             }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
@@ -64,12 +64,12 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
         // Register for notification of new streams.
         connection.addListener(new Http2ConnectionAdapter() {
             @Override
-            public void streamAdded(Http2Stream stream) {
+            public void onStreamAdded(Http2Stream stream) {
                 stream.setProperty(FlowState.class, new FlowState(stream, 0));
             }
 
             @Override
-            public void streamActive(Http2Stream stream) {
+            public void onStreamActive(Http2Stream stream) {
                 // Need to be sure the stream's initial window is adjusted for SETTINGS
                 // frames which may have been exchanged while it was in IDLE
                 state(stream).window(initialWindowSize);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -48,27 +48,27 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
         // Register for notification of new streams.
         connection.addListener(new Http2ConnectionAdapter() {
             @Override
-            public void streamAdded(Http2Stream stream) {
+            public void onStreamAdded(Http2Stream stream) {
                 // Just add a new flow state to the stream.
                 stream.setProperty(FlowState.class, new FlowState(stream, 0));
             }
 
             @Override
-            public void streamActive(Http2Stream stream) {
+            public void onStreamActive(Http2Stream stream) {
                 // Need to be sure the stream's initial window is adjusted for SETTINGS
                 // frames which may have been exchanged while it was in IDLE
                 state(stream).window(initialWindowSize);
             }
 
             @Override
-            public void streamClosed(Http2Stream stream) {
+            public void onStreamClosed(Http2Stream stream) {
                 // Any pending frames can never be written, cancel and
                 // write errors for any pending frames.
                 state(stream).cancel();
             }
 
             @Override
-            public void streamHalfClosed(Http2Stream stream) {
+            public void onStreamHalfClosed(Http2Stream stream) {
                 if (State.HALF_CLOSED_LOCAL.equals(stream.state())) {
                     /**
                      * When this method is called there should not be any
@@ -86,7 +86,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
             }
 
             @Override
-            public void priorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) {
+            public void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) {
                 Http2Stream parent = stream.parent();
                 if (parent != null) {
                     int delta = state(stream).streamableBytesForTree();
@@ -97,7 +97,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
             }
 
             @Override
-            public void priorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) {
+            public void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) {
                 Http2Stream parent = stream.parent();
                 if (parent != null) {
                     int delta = -state(stream).streamableBytesForTree();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
@@ -40,7 +40,7 @@ import io.netty.handler.codec.compression.ZlibWrapper;
 public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecorator {
     private static final Http2ConnectionAdapter CLEAN_UP_LISTENER = new Http2ConnectionAdapter() {
         @Override
-        public void streamRemoved(Http2Stream stream) {
+        public void onStreamRemoved(Http2Stream stream) {
             final Http2Decompressor decompressor = decompressor(stream);
             if (decompressor != null) {
                 cleanup(stream, decompressor);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -86,17 +86,25 @@ public interface Http2Connection {
 
         /**
          * Called when a {@code GOAWAY} frame was sent for the connection.
+         *
+         * @param lastStreamId the last known stream of the remote endpoint.
+         * @param errorCode    the error code, if abnormal closure.
+         * @param debugData    application-defined debug data.
          */
-        void onGoAwaySent(long errorCode, ByteBuf debugData);
+        void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData);
 
         /**
-         * Called when a {@code GOAWAY} was received from the remote endpoint. This
-         * event handler duplicates {@link Http2FrameListener#onGoAwayRead(io.netty.channel.ChannelHandlerContext,
-         * int, long, io.netty.buffer.ByteBuf)} but is added here in order to simplify application logic
-         * for handling {@code GOAWAY} in a uniform way. An application should generally not handle both events, but if
-         * it does this method is called first, before notifying the {@link Http2FrameListener}.
+         * Called when a {@code GOAWAY} was received from the remote endpoint. This event handler duplicates {@link
+         * Http2FrameListener#onGoAwayRead(io.netty.channel.ChannelHandlerContext, int, long, io.netty.buffer.ByteBuf)}
+         * but is added here in order to simplify application logic for handling {@code GOAWAY} in a uniform way. An
+         * application should generally not handle both events, but if it does this method is called first, before
+         * notifying the {@link Http2FrameListener}.
+         *
+         * @param lastStreamId the last known stream of the remote endpoint.
+         * @param errorCode    the error code, if abnormal closure.
+         * @param debugData    application-defined debug data.
          */
-        void onGoAwayReceived(long errorCode, ByteBuf debugData);
+        void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData);
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionAdapter.java
@@ -14,41 +14,47 @@
  */
 package io.netty.handler.codec.http2;
 
+import io.netty.buffer.ByteBuf;
+
 /**
  * Provides empty implementations of all {@link Http2Connection.Listener} methods.
  */
 public class Http2ConnectionAdapter implements Http2Connection.Listener {
 
     @Override
-    public void streamAdded(Http2Stream stream) {
+    public void onStreamAdded(Http2Stream stream) {
     }
 
     @Override
-    public void streamActive(Http2Stream stream) {
+    public void onStreamActive(Http2Stream stream) {
     }
 
     @Override
-    public void streamHalfClosed(Http2Stream stream) {
+    public void onStreamHalfClosed(Http2Stream stream) {
     }
 
     @Override
-    public void streamClosed(Http2Stream stream) {
+    public void onStreamClosed(Http2Stream stream) {
     }
 
     @Override
-    public void streamRemoved(Http2Stream stream) {
+    public void onStreamRemoved(Http2Stream stream) {
     }
 
     @Override
-    public void goingAway() {
+    public void onGoAwaySent(long errorCode, ByteBuf debugData) {
     }
 
     @Override
-    public void priorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) {
+    public void onGoAwayReceived(long errorCode, ByteBuf debugData) {
     }
 
     @Override
-    public void priorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) {
+    public void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) {
+    }
+
+    @Override
+    public void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) {
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionAdapter.java
@@ -42,11 +42,11 @@ public class Http2ConnectionAdapter implements Http2Connection.Listener {
     }
 
     @Override
-    public void onGoAwaySent(long errorCode, ByteBuf debugData) {
+    public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) {
     }
 
     @Override
-    public void onGoAwayReceived(long errorCode, ByteBuf debugData) {
+    public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -526,15 +526,16 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     public ChannelFuture writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData,
             ChannelPromise promise) {
         Http2Connection connection = connection();
-        if (connection.isGoAway()) {
+        if (connection.goAwayReceived() || connection.goAwaySent()) {
             debugData.release();
             return ctx.newSucceededFuture();
         }
 
+        connection.goAwaySent(lastStreamId, errorCode, debugData);
+
         ChannelFuture future = frameWriter().writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
         ctx.flush();
 
-        connection.goAwaySent(lastStreamId);
         return future;
     }
 
@@ -543,7 +544,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
      */
     private ChannelFuture writeGoAway(ChannelHandlerContext ctx, Http2Exception cause) {
         Http2Connection connection = connection();
-        if (connection.isGoAway()) {
+        if (connection.goAwayReceived() || connection.goAwaySent()) {
             return ctx.newSucceededFuture();
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
@@ -84,31 +84,31 @@ public class Http2EventAdapter implements Http2Connection.Listener, Http2FrameLi
     }
 
     @Override
-    public void streamAdded(Http2Stream stream) {
+    public void onStreamAdded(Http2Stream stream) {
     }
 
     @Override
-    public void streamActive(Http2Stream stream) {
+    public void onStreamActive(Http2Stream stream) {
     }
 
     @Override
-    public void streamHalfClosed(Http2Stream stream) {
+    public void onStreamHalfClosed(Http2Stream stream) {
     }
 
     @Override
-    public void streamClosed(Http2Stream stream) {
+    public void onStreamClosed(Http2Stream stream) {
     }
 
     @Override
-    public void streamRemoved(Http2Stream stream) {
+    public void onStreamRemoved(Http2Stream stream) {
     }
 
     @Override
-    public void priorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) {
+    public void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) {
     }
 
     @Override
-    public void priorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) {
+    public void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) {
     }
 
     @Override
@@ -116,6 +116,10 @@ public class Http2EventAdapter implements Http2Connection.Listener, Http2FrameLi
     }
 
     @Override
-    public void goingAway() {
+    public void onGoAwaySent(long errorCode, ByteBuf debugData) {
+    }
+
+    @Override
+    public void onGoAwayReceived(long errorCode, ByteBuf debugData) {
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
@@ -116,10 +116,10 @@ public class Http2EventAdapter implements Http2Connection.Listener, Http2FrameLi
     }
 
     @Override
-    public void onGoAwaySent(long errorCode, ByteBuf debugData) {
+    public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) {
     }
 
     @Override
-    public void onGoAwayReceived(long errorCode, ByteBuf debugData) {
+    public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -155,7 +155,7 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
     }
 
     @Override
-    public void streamRemoved(Http2Stream stream) {
+    public void onStreamRemoved(Http2Stream stream) {
         removeMessage(stream.id());
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpPriorityAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpPriorityAdapter.java
@@ -166,7 +166,7 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
     }
 
     @Override
-    public void priorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) {
+    public void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) {
         Http2Stream parent = stream.parent();
         FullHttpMessage msg = messageMap.get(stream.id());
         if (msg == null) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -271,7 +271,7 @@ public class DataCompressionHttp2Test {
 
         serverConnection.addListener(new Http2ConnectionAdapter() {
             @Override
-            public void streamHalfClosed(Http2Stream stream) {
+            public void onStreamHalfClosed(Http2Stream stream) {
                 serverLatch.countDown();
             }
         });

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -491,7 +491,7 @@ public class DefaultHttp2ConnectionDecoderTest {
     @Test
     public void goAwayShouldReadShouldUpdateConnectionState() throws Exception {
         decode().onGoAwayRead(ctx, 1, 2L, EMPTY_BUFFER);
-        verify(connection).goAwayReceived(1);
+        verify(connection).goAwayReceived(eq(1), eq(2L), eq(EMPTY_BUFFER));
         verify(listener).onGoAwayRead(eq(ctx), eq(1), eq(2L), eq(EMPTY_BUFFER));
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -201,7 +201,7 @@ public class DefaultHttp2ConnectionEncoderTest {
 
     @Test
     public void dataWriteAfterGoAwayShouldFail() throws Exception {
-        when(connection.isGoAway()).thenReturn(true);
+        when(connection.goAwayReceived()).thenReturn(true);
         final ByteBuf data = dummyData();
         try {
             ChannelFuture future = encoder.writeData(ctx, STREAM_ID, data, 0, true, promise);
@@ -304,7 +304,7 @@ public class DefaultHttp2ConnectionEncoderTest {
 
     @Test
     public void headersWriteAfterGoAwayShouldFail() throws Exception {
-        when(connection.isGoAway()).thenReturn(true);
+        when(connection.goAwayReceived()).thenReturn(true);
         ChannelFuture future = encoder.writeHeaders(
                 ctx, 5, EmptyHttp2Headers.INSTANCE, 0, (short) 255, false, 0, false, promise);
         verify(local, never()).createStream(anyInt());
@@ -345,7 +345,7 @@ public class DefaultHttp2ConnectionEncoderTest {
 
     @Test
     public void pushPromiseWriteAfterGoAwayShouldFail() throws Exception {
-        when(connection.isGoAway()).thenReturn(true);
+        when(connection.goAwayReceived()).thenReturn(true);
         ChannelFuture future =
                 encoder.writePushPromise(ctx, STREAM_ID, PUSH_STREAM_ID,
                                          EmptyHttp2Headers.INSTANCE, 0, promise);
@@ -362,7 +362,7 @@ public class DefaultHttp2ConnectionEncoderTest {
 
     @Test
     public void priorityWriteAfterGoAwayShouldFail() throws Exception {
-        when(connection.isGoAway()).thenReturn(true);
+        when(connection.goAwayReceived()).thenReturn(true);
         ChannelFuture future = encoder.writePriority(ctx, STREAM_ID, 0, (short) 255, true, promise);
         assertTrue(future.awaitUninterruptibly().cause() instanceof Http2Exception);
     }
@@ -426,7 +426,7 @@ public class DefaultHttp2ConnectionEncoderTest {
 
     @Test
     public void pingWriteAfterGoAwayShouldFail() throws Exception {
-        when(connection.isGoAway()).thenReturn(true);
+        when(connection.goAwayReceived()).thenReturn(true);
         ChannelFuture future = encoder.writePing(ctx, false, emptyPingBuf(), promise);
         assertTrue(future.awaitUninterruptibly().cause() instanceof Http2Exception);
     }
@@ -439,7 +439,7 @@ public class DefaultHttp2ConnectionEncoderTest {
 
     @Test
     public void settingsWriteAfterGoAwayShouldFail() throws Exception {
-        when(connection.isGoAway()).thenReturn(true);
+        when(connection.goAwayReceived()).thenReturn(true);
         ChannelFuture future = encoder.writeSettings(ctx, new Http2Settings(), promise);
         assertTrue(future.awaitUninterruptibly().cause() instanceof Http2Exception);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http2.Http2Connection.Endpoint;
 import io.netty.handler.codec.http2.Http2Stream.State;
 
@@ -176,7 +178,7 @@ public class DefaultHttp2ConnectionTest {
 
     @Test(expected = Http2Exception.class)
     public void goAwayReceivedShouldDisallowCreation() throws Http2Exception {
-        server.goAwayReceived(0);
+        server.goAwayReceived(0, 1L, Unpooled.EMPTY_BUFFER);
         server.remote().createStream(3).open(true);
     }
 
@@ -321,10 +323,10 @@ public class DefaultHttp2ConnectionTest {
         streamD.setPriority(streamD.parent().id(), newWeight, false);
         verify(clientListener).onWeightChanged(eq(streamD), eq(oldWeight));
         assertEquals(streamD.weight(), newWeight);
-        verify(clientListener, never()).priorityTreeParentChanging(any(Http2Stream.class),
-                        any(Http2Stream.class));
-        verify(clientListener, never()).priorityTreeParentChanged(any(Http2Stream.class),
-                        any(Http2Stream.class));
+        verify(clientListener, never()).onPriorityTreeParentChanging(any(Http2Stream.class),
+                any(Http2Stream.class));
+        verify(clientListener, never()).onPriorityTreeParentChanged(any(Http2Stream.class),
+                any(Http2Stream.class));
     }
 
     @Test
@@ -552,8 +554,8 @@ public class DefaultHttp2ConnectionTest {
         assertSame(expectedArg1.size(), expectedArg2.size());
         ArgumentCaptor<Http2Stream> arg1Captor = ArgumentCaptor.forClass(Http2Stream.class);
         ArgumentCaptor<Http2Stream> arg2Captor = ArgumentCaptor.forClass(Http2Stream.class);
-        verify(clientListener, times(expectedArg1.size())).priorityTreeParentChanging(arg1Captor.capture(),
-                        arg2Captor.capture());
+        verify(clientListener, times(expectedArg1.size())).onPriorityTreeParentChanging(arg1Captor.capture(),
+                arg2Captor.capture());
         List<Http2Stream> capturedArg1 = arg1Captor.getAllValues();
         List<Http2Stream> capturedArg2 = arg2Captor.getAllValues();
         assertSame(capturedArg1.size(), capturedArg2.size());
@@ -568,8 +570,8 @@ public class DefaultHttp2ConnectionTest {
         assertSame(expectedArg1.size(), expectedArg2.size());
         ArgumentCaptor<Http2Stream> arg1Captor = ArgumentCaptor.forClass(Http2Stream.class);
         ArgumentCaptor<Http2Stream> arg2Captor = ArgumentCaptor.forClass(Http2Stream.class);
-        verify(clientListener, times(expectedArg1.size())).priorityTreeParentChanged(arg1Captor.capture(),
-                        arg2Captor.capture());
+        verify(clientListener, times(expectedArg1.size())).onPriorityTreeParentChanged(arg1Captor.capture(),
+                arg2Captor.capture());
         List<Http2Stream> capturedArg1 = arg1Captor.getAllValues();
         List<Http2Stream> capturedArg2 = arg2Captor.getAllValues();
         assertSame(capturedArg1.size(), capturedArg2.size());
@@ -597,10 +599,10 @@ public class DefaultHttp2ConnectionTest {
     }
 
     private void verifyParentChanging(Http2Stream stream, Http2Stream newParent) {
-        verify(clientListener).priorityTreeParentChanging(streamEq(stream), streamEq(newParent));
+        verify(clientListener).onPriorityTreeParentChanging(streamEq(stream), streamEq(newParent));
     }
 
     private void verifyParentChanged(Http2Stream stream, Http2Stream oldParent) {
-        verify(clientListener).priorityTreeParentChanged(streamEq(stream), streamEq(oldParent));
+        verify(clientListener).onPriorityTreeParentChanged(streamEq(stream), streamEq(oldParent));
     }
 }


### PR DESCRIPTION
Motivation:

The Connection.Listener GOAWAY event handler currently provides no additional information, requiring applications to hack in other ways to get at the error code and debug message.

Modifications:

Modified the Connection.Listener interface to pass on the error code and message that triggered the GOAWAY.

Result:

Application can now use Connection.Listener for all GOAWAY processing.