### PR TITLE
Http2 draft 17

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
@@ -86,7 +86,7 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
             // Default handler for any other types of errors that may have occurred. For example,
             // the the Header builder throws IllegalArgumentException if the key or value was invalid
             // for any reason (e.g. the key was an invalid pseudo-header).
-            throw connectionError(PROTOCOL_ERROR, e, e.getMessage());
+            throw connectionError(COMPRESSION_ERROR, e, e.getMessage());
         } finally {
             try {
                 in.close();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -37,8 +37,8 @@ public final class Http2CodecUtil {
     public static final int CONNECTION_STREAM_ID = 0;
     public static final int HTTP_UPGRADE_STREAM_ID = 1;
     public static final String HTTP_UPGRADE_SETTINGS_HEADER = "HTTP2-Settings";
-    public static final String HTTP_UPGRADE_PROTOCOL_NAME = "h2c-16";
-    public static final String TLS_UPGRADE_PROTOCOL_NAME = "h2-16";
+    public static final String HTTP_UPGRADE_PROTOCOL_NAME = "h2c-17";
+    public static final String TLS_UPGRADE_PROTOCOL_NAME = "h2-17";
 
     public static final int PING_FRAME_PAYLOAD_LENGTH = 8;
     public static final short MAX_UNSIGNED_BYTE = 0xFF;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
@@ -32,7 +32,6 @@ public interface Http2ConnectionDecoder extends Closeable {
      * Builder for new instances of {@link Http2ConnectionDecoder}.
      */
     interface Builder {
-
         /**
          * Sets the {@link Http2Connection} to be used when building the decoder.
          */
@@ -62,6 +61,11 @@ public interface Http2ConnectionDecoder extends Closeable {
          * Sets the {@link Http2ConnectionEncoder} used when building the decoder.
          */
         Builder encoder(Http2ConnectionEncoder encoder);
+
+        /**
+         * Sets the {@link Http2PromisedRequestVerifier} used when building the decoder.
+         */
+        Builder requestVerifier(Http2PromisedRequestVerifier requestVerifier);
 
         /**
          * Creates a new decoder instance.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
@@ -22,7 +22,6 @@ import io.netty.channel.ChannelHandlerContext;
  * An listener of HTTP/2 frames.
  */
 public interface Http2FrameListener {
-
     /**
      * Handles an inbound {@code DATA} frame.
      *
@@ -157,11 +156,8 @@ public interface Http2FrameListener {
     /**
      * Handles an inbound PUSH_PROMISE frame. Only called if END_HEADERS encountered.
      * <p>
-     * Promised requests MUST be cacheable
-     * (see <a href="https://tools.ietf.org/html/rfc7231#section-4.2.3">[RFC7231], Section 4.2.3</a>) and
-     * MUST be safe (see <a href="https://tools.ietf.org/html/rfc7231#section-4.2.1">[RFC7231], Section 4.2.1</a>).
-     * If these conditions do not hold the application MUST throw a {@link Http2Exception.StreamException} with
-     * error type {@link Http2Error#PROTOCOL_ERROR}.
+     * Promised requests MUST be authoritative, cacheable, and safe.
+     * See <a href="https://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-8.2">[RFC http2], Seciton 8.2</a>.
      * <p>
      * Only one of the following methods will be called for each HEADERS frame sequence.
      * One will be called when the END_HEADERS flag has been received.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2PromisedRequestVerifier.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2PromisedRequestVerifier.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.channel.ChannelHandlerContext;
+
+/**
+ * Provides an extensibility point for users to define the validity of push requests.
+ * @see <a href="https://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-8.2">[RFC http2], Section 8.2</a>.
+ */
+public interface Http2PromisedRequestVerifier {
+    /**
+     * Determine if a {@link Http2Headers} are authoritative for a particular {@link ChannelHandlerContext}.
+     * @param ctx The context on which the {@code headers} where received on.
+     * @param headers The headers to be verified.
+     * @return {@code true} if the {@code ctx} is authoritative for the {@code headers}, {@code false} otherwise.
+     * @see
+     * <a href="https://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-10.1">[RFC http2], Section 10.1</a>.
+     */
+    boolean isAuthoritative(ChannelHandlerContext ctx, Http2Headers headers);
+
+    /**
+     * Determine if a request is cacheable.
+     * @param headers The headers for a push request.
+     * @return {@code true} if the request associated with {@code headers} is known to be cacheable,
+     * {@code false} otherwise.
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-4.2.3">[RFC 7231], Section 4.2.3</a>.
+     */
+    boolean isCacheable(Http2Headers headers);
+
+    /**
+     * Determine if a request is safe.
+     * @param headers The headers for a push request.
+     * @return {@code true} if the request associated with {@code headers} is known to be safe,
+     * {@code false} otherwise.
+     * @see <a href="https://tools.ietf.org/html/rfc7231#section-4.2.1">[RFC 7231], Section 4.2.1</a>.
+     */
+    boolean isSafe(Http2Headers headers);
+
+    /**
+     * A default implementation of {@link Http2PromisedRequestVerifier} which always returns positive responses for
+     * all verification challenges.
+     */
+    Http2PromisedRequestVerifier ALWAYS_VERIFY = new Http2PromisedRequestVerifier() {
+        @Override
+        public boolean isAuthoritative(ChannelHandlerContext ctx, Http2Headers headers) {
+            return true;
+        }
+
+        @Override
+        public boolean isCacheable(Http2Headers headers) {
+            return true;
+        }
+
+        @Override
+        public boolean isSafe(Http2Headers headers) {
+            return true;
+        }
+    };
+}


### PR DESCRIPTION
Motivation:
There was a new draft for HTTP/2.  We should support the new draft.

Modifications:
- Review the HTTP/2 draft 17 specification, and update code to reflect changes.

Result:
Support for HTTP/2 draft 17.