### PR TITLE
HTTP/2 codec missing from all/pom.xml

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -142,6 +142,13 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-http2</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-memcache</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>


### PR DESCRIPTION
Motivation:
The codec-http2 module was excluded from the all/pom.xml.

Modifications:
Include the codec-http2 dependency in the all/pom.xml.

Results:
Projects including the all dependency get codec-http2.