### PR TITLE
Avoid ConcurrentModificationException when iterating over Http2Connectio...

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -241,8 +241,8 @@ public interface Http2Connection {
     int numActiveStreams();
 
     /**
-     * Gets all streams that are actively in use (i.e. {@code OPEN} or {@code HALF CLOSED}). The returned collection is
-     * sorted by priority.
+     * Gets all streams that are actively in use (i.e. {@code OPEN} or {@code HALF CLOSED}).
+     * The returned collection must be safe to be modified while iterating.
      */
     Collection<Http2Stream> activeStreams();
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -195,8 +195,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         try {
             ChannelFuture future = ctx.newSucceededFuture();
-            final Collection<Http2Stream> streams = connection().activeStreams();
-            for (Http2Stream s : streams.toArray(new Http2Stream[streams.size()])) {
+            for (Http2Stream s : connection().activeStreams()) {
                 closeStream(s, future);
             }
         } finally {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -548,6 +548,20 @@ public class DefaultHttp2ConnectionTest {
         assertEquals(p.numChildren() * DEFAULT_PRIORITY_WEIGHT, p.totalChildWeights());
     }
 
+    /**
+     * Ensure that the collection used for {@link DefaultHttp2Connection#activeStreams()} can be
+     * modified while being iterated over.
+     */
+    @Test
+    public void activeStreamsMayBeClosedWhileIterating() throws Http2Exception {
+        server.local().createStream(2).open(false);
+        server.local().createStream(4).open(false);
+
+        for (Http2Stream stream : server.activeStreams()) {
+            stream.close();
+        }
+    }
+
     private void verifyParentChanging(List<Http2Stream> expectedArg1, List<Http2Stream> expectedArg2) {
         assertSame(expectedArg1.size(), expectedArg2.size());
         ArgumentCaptor<Http2Stream> arg1Captor = ArgumentCaptor.forClass(Http2Stream.class);


### PR DESCRIPTION
...n.activeStreams().

Motivation:

We have seen `ConcurrentModificationExceptions` being thrown in `DefaultHttp2RemoteFlowController.writePendingBytes()`
while iterating over all active streams and trying to flush their frames buffered in the flow controller.

The issue can be reproduced 100% of the time, when we receive a `WINDOW_UPDATE` for the connection and we
subsequently write a frame with the `END_STREAM` flag set of a stream that is already state `HALF_CLOSED_REMOTE`,
then the frame gets closed and removed from the set of active streams - thus a `ConcurrentModificationException`
is raised.

Modifications:

- Replace the `LinkedHashSet` with a `ConcurrentSkipListSet`, which allows for being modified while being iterated over.
- Require `Http2Connection.activeStreams()` to return a collection that allows for concurrent modifications.

Result:

The HTTP2 codec no longer crashes in the before mentioned scenario.