### PR TITLE
HTTP/2 Decoder reduce preface conditional checks

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -15,12 +15,74 @@
  */
 package io.netty.buffer;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
+
+import java.util.Random;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 public class ByteBufUtilTest {
+    @Test
+    public void equalsBufferSubsections() {
+        byte[] b1 = new byte[128];
+        byte[] b2 = new byte[256];
+        Random rand = new Random();
+        rand.nextBytes(b1);
+        rand.nextBytes(b2);
+        final int iB1 = b1.length / 2;
+        final int iB2 = iB1 + b1.length;
+        final int length = b1.length - iB1;
+        System.arraycopy(b1, iB1, b2, iB2, length);
+        assertTrue(ByteBufUtil.equals(Unpooled.wrappedBuffer(b1), iB1, Unpooled.wrappedBuffer(b2), iB2, length));
+    }
+
+    @Test
+    public void notEqualsBufferSubsections() {
+        byte[] b1 = new byte[50];
+        byte[] b2 = new byte[256];
+        Random rand = new Random();
+        rand.nextBytes(b1);
+        rand.nextBytes(b2);
+        final int iB1 = b1.length / 2;
+        final int iB2 = iB1 + b1.length;
+        final int length = b1.length - iB1;
+        System.arraycopy(b1, iB1, b2, iB2, length - 1);
+        assertFalse(ByteBufUtil.equals(Unpooled.wrappedBuffer(b1), iB1, Unpooled.wrappedBuffer(b2), iB2, length));
+    }
+
+    @Test
+    public void notEqualsBufferOverflow() {
+        byte[] b1 = new byte[8];
+        byte[] b2 = new byte[16];
+        Random rand = new Random();
+        rand.nextBytes(b1);
+        rand.nextBytes(b2);
+        final int iB1 = b1.length / 2;
+        final int iB2 = iB1 + b1.length;
+        final int length = b1.length - iB1;
+        System.arraycopy(b1, iB1, b2, iB2, length - 1);
+        assertFalse(ByteBufUtil.equals(Unpooled.wrappedBuffer(b1), iB1, Unpooled.wrappedBuffer(b2), iB2,
+                Math.max(b1.length, b2.length) * 2));
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void notEqualsBufferUnderflow() {
+        byte[] b1 = new byte[8];
+        byte[] b2 = new byte[16];
+        Random rand = new Random();
+        rand.nextBytes(b1);
+        rand.nextBytes(b2);
+        final int iB1 = b1.length / 2;
+        final int iB2 = iB1 + b1.length;
+        final int length = b1.length - iB1;
+        System.arraycopy(b1, iB1, b2, iB2, length - 1);
+        assertFalse(ByteBufUtil.equals(Unpooled.wrappedBuffer(b1), iB1, Unpooled.wrappedBuffer(b2), iB2,
+                -1));
+    }
 
     @Test
     public void testWriteUsAscii() {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -568,7 +568,8 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
                 listener);
     }
 
-    private void readUnknownFrame(ChannelHandlerContext ctx, ByteBuf payload, Http2FrameListener listener) {
+    private void readUnknownFrame(ChannelHandlerContext ctx, ByteBuf payload, Http2FrameListener listener)
+            throws Http2Exception {
         payload = payload.readSlice(payload.readableBytes());
         listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
@@ -211,5 +211,6 @@ public interface Http2FrameListener {
      * @param flags the flags in the frame header.
      * @param payload the payload of the frame.
      */
-    void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags, ByteBuf payload);
+    void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags, ByteBuf payload)
+            throws Http2Exception;
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListenerDecorator.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListenerDecorator.java
@@ -97,7 +97,7 @@ public class Http2FrameListenerDecorator implements Http2FrameListener {
 
     @Override
     public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
-            ByteBuf payload) {
+            ByteBuf payload) throws Http2Exception {
         listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
@@ -126,7 +126,7 @@ public class Http2InboundFrameLogger implements Http2FrameReader {
 
             @Override
             public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
-                    Http2Flags flags, ByteBuf payload) {
+                    Http2Flags flags, ByteBuf payload) throws Http2Exception {
                 logger.logUnknownFrame(INBOUND, frameType, streamId, flags, payload);
                 listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
             }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -247,7 +247,7 @@ final class Http2TestUtil {
 
                 @Override
                 public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
-                        ByteBuf payload) {
+                        ByteBuf payload) throws Http2Exception {
                     listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
                     latch.countDown();
                 }
@@ -373,7 +373,7 @@ final class Http2TestUtil {
 
         @Override
         public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
-                ByteBuf payload) {
+                ByteBuf payload) throws Http2Exception {
             listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
             messageLatch.countDown();
         }

--- a/example/src/main/java/io/netty/example/http2/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/server/HelloWorldHttp2Handler.java
@@ -20,7 +20,6 @@ import static io.netty.buffer.Unpooled.unreleasableBuffer;
 import static io.netty.example.http2.Http2ExampleUtil.UPGRADE_RESPONSE_HEADER;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.logging.LogLevel.INFO;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.AsciiString;
@@ -79,7 +78,8 @@ public class HelloWorldHttp2Handler extends Http2ConnectionHandler {
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        super.exceptionCaught(ctx, cause);
         cause.printStackTrace();
         ctx.close();
     }


### PR DESCRIPTION
Motivation:
The DefaultHttp2ConnectionDecoder class is calling verifyPrefaceReceived() for almost every frame event at all times.
The Http2ConnectionHandler class is calling readClientPrefaceString() on every decode event.

Modifications:
- DefaultHttp2ConnectionDecoder should not have to continuously call verifyPrefaceReceived() because it transitions boolean state 1 time for each connection.
- Http2ConnectionHandler should not have to continuously call readClientPrefaceString() because it transitions boolean state 1 time for each connection.

Result:
- Less conditional checks for the mainstream usage of the connection.