### PR TITLE
HTTP/2 Closed Streams Conditional Priority Tree Removal

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -158,6 +158,13 @@ public interface Http2Stream {
     Http2Stream parent();
 
     /**
+     * Get the number of streams in the priority tree rooted at this node that are OK to exist in the priority
+     * tree on their own right. Some streams may be in the priority tree because their dependents require them to
+     * remain.
+     */
+    int prioritizableForTree();
+
+    /**
      * Indicates whether or not this stream is a descendant in the priority tree from the given stream.
      */
     boolean isDescendantOf(Http2Stream stream);


### PR DESCRIPTION
Motivation:
The HTTP/2 specification allows for closed (and streams in any state) to exist in the priority tree. The current code removes streams from the priority tree as soon as they are closed (subject to the removal policy). This may lead to undesired distribution of resources from the peer's perspective.

Modifications:
- We should only remove streams from the priority tree when they have no descendant streams in a viable state.
- We should track when tree edges change or nodes are removed if inviable nodes can then be removed.

Result:
Fixes #3518