### PR TITLE
Http/2 Priority on CLOSED stream

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
@@ -73,6 +73,18 @@ public class Http2Exception extends Exception {
     }
 
     /**
+     * Use if an error has occurred which can not be isolated to a single stream, but instead applies
+     * to the entire connection.
+     * @param error The type of error as defined by the HTTP/2 specification.
+     * @param fmt String with the content and format for the additional debug data.
+     * @param args Objects which fit into the format defined by {@code fmt}.
+     * @return An exception which can be translated into a HTTP/2 error.
+     */
+    public static Http2Exception closedStreamError(Http2Error error, String fmt, Object... args) {
+        return new ClosedStreamCreationException(error, String.format(fmt, args));
+    }
+
+    /**
      * Use if an error which can be isolated to a single stream has occurred.  If the {@code id} is not
      * {@link Http2CodecUtil#CONNECTION_STREAM_ID} then a {@link Http2Exception.StreamException} will be returned.
      * Otherwise the error is considered a connection error and a {@link Http2Exception} is returned.
@@ -128,6 +140,25 @@ public class Http2Exception extends Exception {
      */
     public static int streamId(Http2Exception e) {
         return isStreamError(e) ? ((StreamException) e).streamId() : CONNECTION_STREAM_ID;
+    }
+
+    /**
+     * Used when a stream creation attempt fails but may be because the stream was previously closed.
+     */
+    public static final class ClosedStreamCreationException extends Http2Exception {
+        private static final long serialVersionUID = -1911637707391622439L;
+
+        public ClosedStreamCreationException(Http2Error error) {
+            super(error);
+        }
+
+        public ClosedStreamCreationException(Http2Error error, String message) {
+            super(error, message);
+        }
+
+        public ClosedStreamCreationException(Http2Error error, String message, Throwable cause) {
+            super(error, message, cause);
+        }
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
@@ -46,10 +46,10 @@ public interface Http2FrameListener {
             boolean endOfStream) throws Http2Exception;
 
     /**
-     * Handles an inbound HEADERS frame.
+     * Handles an inbound {@code HEADERS} frame.
      * <p>
-     * Only one of the following methods will be called for each HEADERS frame sequence.
-     * One will be called when the END_HEADERS flag has been received.
+     * Only one of the following methods will be called for each {@code HEADERS} frame sequence.
+     * One will be called when the {@code END_HEADERS} flag has been received.
      * <ul>
      * <li>{@link #onHeadersRead(ChannelHandlerContext, int, Http2Headers, int, boolean)}</li>
      * <li>{@link #onHeadersRead(ChannelHandlerContext, int, Http2Headers, int, short, boolean, int, boolean)}</li>
@@ -70,11 +70,11 @@ public interface Http2FrameListener {
             boolean endOfStream) throws Http2Exception;
 
     /**
-     * Handles an inbound HEADERS frame with priority information specified. Only called if END_HEADERS encountered.
-     *
+     * Handles an inbound {@code HEADERS} frame with priority information specified.
+     * Only called if {@code END_HEADERS} encountered.
      * <p>
-     * Only one of the following methods will be called for each HEADERS frame sequence.
-     * One will be called when the END_HEADERS flag has been received.
+     * Only one of the following methods will be called for each {@code HEADERS} frame sequence.
+     * One will be called when the {@code END_HEADERS} flag has been received.
      * <ul>
      * <li>{@link #onHeadersRead(ChannelHandlerContext, int, Http2Headers, int, boolean)}</li>
      * <li>{@link #onHeadersRead(ChannelHandlerContext, int, Http2Headers, int, short, boolean, int, boolean)}</li>
@@ -100,7 +100,11 @@ public interface Http2FrameListener {
             throws Http2Exception;
 
     /**
-     * Handles an inbound PRIORITY frame.
+     * Handles an inbound {@code PRIORITY} frame.
+     * <p>
+     * Note that is it possible to have this method called and no stream object exist for either
+     * {@code streamId}, {@code streamDependency}, or both. This is because the {@code PRIORITY} frame can be
+     * sent/received when streams are in the {@code CLOSED} state.
      *
      * @param ctx the context from the handler where the frame was read.
      * @param streamId the subject stream for the frame.
@@ -113,7 +117,7 @@ public interface Http2FrameListener {
             short weight, boolean exclusive) throws Http2Exception;
 
     /**
-     * Handles an inbound RST_STREAM frame.
+     * Handles an inbound {@code RST_STREAM} frame.
      *
      * @param ctx the context from the handler where the frame was read.
      * @param streamId the stream that is terminating.
@@ -122,13 +126,13 @@ public interface Http2FrameListener {
     void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception;
 
     /**
-     * Handles an inbound SETTINGS acknowledgment frame.
+     * Handles an inbound {@code SETTINGS} acknowledgment frame.
      * @param ctx the context from the handler where the frame was read.
      */
     void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception;
 
     /**
-     * Handles an inbound SETTINGS frame.
+     * Handles an inbound {@code SETTINGS} frame.
      *
      * @param ctx the context from the handler where the frame was read.
      * @param settings the settings received from the remote endpoint.
@@ -136,7 +140,7 @@ public interface Http2FrameListener {
     void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings) throws Http2Exception;
 
     /**
-     * Handles an inbound PING frame.
+     * Handles an inbound {@code PING} frame.
      *
      * @param ctx the context from the handler where the frame was read.
      * @param data the payload of the frame. If this buffer needs to be retained by the listener
@@ -145,7 +149,7 @@ public interface Http2FrameListener {
     void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception;
 
     /**
-     * Handles an inbound PING acknowledgment.
+     * Handles an inbound {@code PING} acknowledgment.
      *
      * @param ctx the context from the handler where the frame was read.
      * @param data the payload of the frame. If this buffer needs to be retained by the listener
@@ -154,13 +158,13 @@ public interface Http2FrameListener {
     void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception;
 
     /**
-     * Handles an inbound PUSH_PROMISE frame. Only called if END_HEADERS encountered.
+     * Handles an inbound {@code PUSH_PROMISE} frame. Only called if {@code END_HEADERS} encountered.
      * <p>
      * Promised requests MUST be authoritative, cacheable, and safe.
      * See <a href="https://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-8.2">[RFC http2], Seciton 8.2</a>.
      * <p>
-     * Only one of the following methods will be called for each HEADERS frame sequence.
-     * One will be called when the END_HEADERS flag has been received.
+     * Only one of the following methods will be called for each {@code HEADERS} frame sequence.
+     * One will be called when the {@code END_HEADERS} flag has been received.
      * <ul>
      * <li>{@link #onHeadersRead(ChannelHandlerContext, int, Http2Headers, int, boolean)}</li>
      * <li>{@link #onHeadersRead(ChannelHandlerContext, int, Http2Headers, int, short, boolean, int, boolean)}</li>
@@ -180,7 +184,7 @@ public interface Http2FrameListener {
             Http2Headers headers, int padding) throws Http2Exception;
 
     /**
-     * Handles an inbound GO_AWAY frame.
+     * Handles an inbound {@code GO_AWAY} frame.
      *
      * @param ctx the context from the handler where the frame was read.
      * @param lastStreamId the last known stream of the remote endpoint.
@@ -192,7 +196,7 @@ public interface Http2FrameListener {
             throws Http2Exception;
 
     /**
-     * Handles an inbound WINDOW_UPDATE frame.
+     * Handles an inbound {@code WINDOW_UPDATE} frame.
      *
      * @param ctx the context from the handler where the frame was read.
      * @param streamId the stream the frame was sent on.


### PR DESCRIPTION
Motivation:
The encoder/decoder currently do not handle streams which have previously existed but no longer exist because they were closed. The specification requires supporting this.

Modifications:
- encoder/decoder should tolerate the frame or the dependent frame not existing in the streams map due to the fact that it may have previously existed.

Result:
encoder/decoder are more compliant with the specification.