### PR TITLE
Removing unnecessary use of Math.ceil in HTTP/2 priority algorithm.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -236,9 +236,9 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
 
     /**
      * This will allocate bytes by stream weight and priority for the entire tree rooted at {@code parent}, but does not
-     * write any bytes. Priority is generally distributed proportionally to siblings in the priority tree, however we
-     * need to ensure that the entire connection window is used (assuming streams have >= connection window bytes to
-     * send) and we may need some sort of rounding to accomplish this.
+     * write any bytes. The connection window is generally distributed amongst siblings according to their weight,
+     * however we need to ensure that the entire connection window is used (assuming streams have >= connection window
+     * bytes to send) and we may need some sort of rounding to accomplish this.
      *
      * @param parent           The parent of the tree.
      * @param connectionWindow The connection window this is available for use at this point in the tree.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -282,7 +282,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
                 int weight = child.weight();
                 double weightRatio = weight / (double) totalWeight;
 
-                int bytesForTree = Math.min(nextConnectionWindow, (int) Math.ceil(connectionWindow * weightRatio));
+                int bytesForTree = Math.min(nextConnectionWindow, Math.max(1, (int) (connectionWindow * weightRatio)));
                 int bytesForChild = Math.min(state.streamableBytes(), bytesForTree);
 
                 if (bytesForChild > 0) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -238,7 +238,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
      * This will allocate bytes by stream weight and priority for the entire tree rooted at {@code parent}, but does not
      * write any bytes. Priority is generally distributed proportionally to siblings in the priority tree, however we
      * need to ensure that the entire connection window is used (assuming streams have >= connection window bytes to
-     * send) and we may need some sort of rounding to accomplish this..
+     * send) and we may need some sort of rounding to accomplish this.
      *
      * @param parent           The parent of the tree.
      * @param connectionWindow The connection window this is available for use at this point in the tree.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -236,7 +236,8 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
 
     /**
      * This will allocate bytes by stream weight and priority for the entire tree rooted at {@code parent}, but does
-     * not write any bytes.
+     * not write any bytes. Priority is generally distributed proportionally to siblings in the priority tree, however
+     * we ensure that at least 1 byte is assigned to each stream in order to make progress.
      *
      * @param parent The parent of the tree.
      * @param connectionWindow The connection window this is available for use at this point in the tree.
@@ -282,6 +283,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
                 int weight = child.weight();
                 double weightRatio = weight / (double) totalWeight;
 
+                // Ensure that at least one byte is allocated to this stream (if it has streamableBytes).
                 int bytesForTree = Math.min(nextConnectionWindow, Math.max(1, (int) (connectionWindow * weightRatio)));
                 int bytesForChild = Math.min(state.streamableBytes(), bytesForTree);
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -283,8 +283,10 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
                 int weight = child.weight();
                 double weightRatio = weight / (double) totalWeight;
 
-                // Ensure that at least one byte is allocated to this stream (if it has streamableBytes).
-                int bytesForTree = Math.min(nextConnectionWindow, Math.max(1, (int) (connectionWindow * weightRatio)));
+                // To make progress toward the connection window due to possible rounding errors, we make sure that each
+                // stream (with data to send) is given at least 1 byte toward the connection window.
+                int connectionWindowChunk = Math.max(1, (int) (connectionWindow * weightRatio));
+                int bytesForTree = Math.min(nextConnectionWindow, connectionWindowChunk);
                 int bytesForChild = Math.min(state.streamableBytes(), bytesForTree);
 
                 if (bytesForChild > 0) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -283,7 +283,9 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
                 int weight = child.weight();
                 double weightRatio = weight / (double) totalWeight;
 
-                // To make progress toward the connection window due to possible rounding errors, we make sure that each
+                // We need to ensure that the entire connection window is used (assuming streams have >= connection
+                // window bytes to send) and we may need some sort of rounding to accomplish this. In order to make
+                // progress toward the connection window due to possible rounding errors, we make sure that each
                 // stream (with data to send) is given at least 1 byte toward the connection window.
                 int connectionWindowChunk = Math.max(1, (int) (connectionWindow * weightRatio));
                 int bytesForTree = Math.min(nextConnectionWindow, connectionWindowChunk);


### PR DESCRIPTION
Motivation:

We're currently using Math.ceil which isn't necessary. We should exchange for a lighter weight operation.

Modifications:

Changing the logic to just ensure that we allocate at least one byte to the child rather than always performing a ceil.

Result:

Slight performance improvement in the priority algorithm.