### PR TITLE
Allow non-standard HTTP/2 settings

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -69,6 +69,7 @@ public final class Http2CodecUtil {
     public static final int SETTINGS_INITIAL_WINDOW_SIZE = 4;
     public static final int SETTINGS_MAX_FRAME_SIZE = 5;
     public static final int SETTINGS_MAX_HEADER_LIST_SIZE = 6;
+    public static final int NUM_STANDARD_SETTINGS = 6;
 
     public static final int MAX_HEADER_TABLE_SIZE = Integer.MAX_VALUE; // Size limited by HPACK library
     public static final long MAX_CONCURRENT_STREAMS = MAX_UNSIGNED_INT;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
@@ -183,6 +183,11 @@ public final class Http2Settings extends IntObjectHashMap<Long> {
         return this;
     }
 
+    /**
+     * A helper method that returns {@link Long#intValue()} on the value, if present. Note that
+     * if the range of the value exceeds {@link Integer#MAX_VALUE}, the {@link #get(int)} method should
+     * be used instead to avoid truncation of the value.
+     */
     public Integer getIntValue(int key) {
         Long value = get(key);
         if (value == null) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
@@ -184,7 +184,7 @@ public final class Http2Settings extends IntObjectHashMap<Long> {
     }
 
     /**
-     * A helper method that returns {@link Long#intValue()} on the value, if present. Note that
+     * A helper method that returns {@link Long#intValue()} on the return of {@link #get(int)}, if present. Note that
      * if the range of the value exceeds {@link Integer#MAX_VALUE}, the {@link #get(int)} method should
      * be used instead to avoid truncation of the value.
      */

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SettingsTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SettingsTest.java
@@ -61,4 +61,10 @@ public class Http2SettingsTest {
         assertEquals(MAX_FRAME_SIZE_UPPER_BOUND, (int) settings.maxFrameSize());
         assertEquals(4L, (long) settings.maxHeaderListSize());
     }
+
+    @Test
+    public void nonStandardSettingsShouldBeSet() {
+        settings.put(0, 123L);
+        assertEquals(123L, (long) settings.get(0));
+    }
 }

--- a/common/src/main/java/io/netty/util/collection/IntObjectHashMap.java
+++ b/common/src/main/java/io/netty/util/collection/IntObjectHashMap.java
@@ -33,10 +33,10 @@ import java.util.NoSuchElementException;
 public class IntObjectHashMap<V> implements IntObjectMap<V>, Iterable<IntObjectMap.Entry<V>> {
 
     /** Default initial capacity. Used if not specified in the constructor */
-    private static final int DEFAULT_CAPACITY = 11;
+    public static final int DEFAULT_CAPACITY = 11;
 
     /** Default load factor. Used if not specified in the constructor */
-    private static final float DEFAULT_LOAD_FACTOR = 0.5f;
+    public static final float DEFAULT_LOAD_FACTOR = 0.5f;
 
     /**
      * Placeholder for null values, so we can use the actual null to mean available.


### PR DESCRIPTION
Motivation:

The Http2Settings class currently disallows setting non-standard settings, which violates the spec.

Modifications:

Updated Http2Settings to permit arbitrary settings. Also adjusting the default initial capacity to allow setting all of the standard settings without reallocation.

Result:

Fixes #3560