### PR TITLE
Replace LinkedHashSet by ArrayList to avoid iterators.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -229,12 +229,13 @@ public interface Http2Connection {
     }
 
     /**
-     * Adds a listener of stream life-cycle events. Adding the same listener multiple times has no effect.
+     * Adds a listener of stream life-cycle events.
      */
     void addListener(Listener listener);
 
     /**
-     * Removes a listener of stream life-cycle events.
+     * Removes a listener of stream life-cycle events. If the same listener was added multiple times
+     * then only the first occurence gets removed.
      */
     void removeListener(Listener listener);
 


### PR DESCRIPTION
Motivation:

In a simple load test that creates and closes several 10k streams per second
I have seen Iterator objects using roughly 1.6% of the total committed heap.

Modifications:

Use an ArrayList instead of a LinkedHashSet to store the connection listeners.
That way we can iterate over the list without creating an iterator every time.

Result:

Zero Iterator allocations due to notifying connection listeners.