### PR TITLE
Avoid object allocations for HTTP2 child streams.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -38,6 +38,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http2.Http2StreamRemovalPolicy.Action;
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
+import io.netty.util.collection.PrimitiveCollections;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -212,7 +213,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         private State state = IDLE;
         private short weight = DEFAULT_PRIORITY_WEIGHT;
         private DefaultStream parent;
-        private IntObjectMap<DefaultStream> children = newChildMap();
+        private IntObjectMap<DefaultStream> children = PrimitiveCollections.emptyIntObjectMap();
         private int totalChildWeights;
         private int prioritizableForTree = 1;
         private boolean resetSent;
@@ -499,6 +500,12 @@ public class DefaultHttp2Connection implements Http2Connection {
             }
         }
 
+        private void initChildrenIfEmpty() {
+            if (children == PrimitiveCollections.<DefaultStream>emptyIntObjectMap()) {
+                children = new IntObjectHashMap<DefaultStream>(4);
+            }
+        }
+
         @Override
         public final boolean remoteSideOpen() {
             return state == HALF_CLOSED_LOCAL || state == OPEN || state == RESERVED_REMOTE;
@@ -535,7 +542,7 @@ public class DefaultHttp2Connection implements Http2Connection {
             totalChildWeights = 0;
             prioritizableForTree = isPrioritizable() ? 1 : 0;
             IntObjectMap<DefaultStream> prevChildren = children;
-            children = newChildMap();
+            children = PrimitiveCollections.emptyIntObjectMap();
             return prevChildren;
         }
 
@@ -556,6 +563,9 @@ public class DefaultHttp2Connection implements Http2Connection {
                     child.takeChild(grandchild, false, events);
                 }
             }
+
+            // Lazily initialize the children to save object allocations.
+            initChildrenIfEmpty();
 
             if (children.put(child.id(), child) == null) {
                 totalChildWeights += child.weight();
@@ -667,10 +677,6 @@ public class DefaultHttp2Connection implements Http2Connection {
             stream.data = new DefaultProperyMap(DEFAULT_INITIAL_SIZE);
             return stream.data.remove(key);
         }
-    }
-
-    private static IntObjectMap<DefaultStream> newChildMap() {
-        return new IntObjectHashMap<DefaultStream>(4);
     }
 
     /**

--- a/common/src/main/java/io/netty/util/collection/PrimitiveCollections.java
+++ b/common/src/main/java/io/netty/util/collection/PrimitiveCollections.java
@@ -68,7 +68,7 @@ public final class PrimitiveCollections {
 
         @Override
         public Object remove(int key) {
-            throw new UnsupportedOperationException("remove");
+            return null;
         }
 
         @Override


### PR DESCRIPTION
Motivation:

We are allocating a hash map for every HTTP2 Stream to store it's children.
Most streams are leafs in the priority tree and don't have children.

Modification:

 - Only allocate children when we actually use them.
 - Make EmptyIntObjectMap not throw a UnsupportedOperationException on remove, but return null instead (as is stated in it's javadoc).

Result:

Fewer unnecessary allocations.