### PR TITLE
HTTP/2 Prevent modification of activeStreams while iterating

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -17,8 +17,6 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 
-import java.util.Collection;
-
 /**
  * Manager for the state of an HTTP/2 connection with the remote end-point.
  */
@@ -260,10 +258,25 @@ public interface Http2Connection {
     int numActiveStreams();
 
     /**
-     * Gets all streams that are actively in use (i.e. {@code OPEN} or {@code HALF CLOSED}). The returned collection is
-     * sorted by priority.
+     * Provide a means of iterating over the collection of active streams.
+     *
+     * @param visitor The visitor which will visit each active stream.
+     * @return The stream before iteration stopped or {@code null} if iteration went past the end.
      */
-    Collection<Http2Stream> activeStreams();
+    Http2Stream forEachActiveStream(StreamVisitor visitor) throws Http2Exception;
+
+    /**
+     * A visitor that allows iteration over a collection of streams.
+     */
+    interface StreamVisitor {
+        /**
+         * @return <ul>
+         *         <li>{@code true} if the processor wants to continue the loop and handle the entry.</li>
+         *         <li>{@code false} if the processor wants to stop handling headers and abort the loop.</li>
+         *         </ul>
+         */
+        boolean visit(Http2Stream stream) throws Http2Exception;
+    }
 
     /**
      * Indicates whether or not the local endpoint for this connection is the server.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -33,6 +33,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandler;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.codec.http2.Http2Connection.StreamVisitor;
 import io.netty.handler.codec.http2.Http2Exception.CompositeStreamException;
 import io.netty.handler.codec.http2.Http2Exception.StreamException;
 import io.netty.util.concurrent.GenericFutureListener;
@@ -40,7 +41,6 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.net.SocketAddress;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -145,10 +145,17 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
 
         public void channelInactive(ChannelHandlerContext ctx) throws Exception {
             try {
-                ChannelFuture future = ctx.newSucceededFuture();
-                final Collection<Http2Stream> streams = connection().activeStreams();
-                for (Http2Stream s : streams.toArray(new Http2Stream[streams.size()])) {
-                    closeStream(s, future);
+                final Http2Connection connection = connection();
+                // Check if there are streams to avoid the overhead of creating the ChannelFuture.
+                if (connection.numActiveStreams() > 0) {
+                    final ChannelFuture future = ctx.newSucceededFuture();
+                    connection.forEachActiveStream(new StreamVisitor() {
+                        @Override
+                        public boolean visit(Http2Stream stream) throws Http2Exception {
+                            closeStream(stream, future);
+                            return true;
+                        }
+                    });
                 }
             } finally {
                 try {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyShort;
 import static org.mockito.Matchers.eq;
@@ -30,7 +29,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http2.Http2Connection.Endpoint;
 import io.netty.handler.codec.http2.Http2Stream.State;
@@ -118,25 +116,25 @@ public class DefaultHttp2ConnectionTest {
         Http2Stream stream = server.local().createStream(2).open(false);
         assertEquals(2, stream.id());
         assertEquals(State.OPEN, stream.state());
-        assertEquals(1, server.activeStreams().size());
+        assertEquals(1, server.numActiveStreams());
         assertEquals(2, server.local().lastStreamCreated());
 
         stream = server.local().createStream(4).open(true);
         assertEquals(4, stream.id());
         assertEquals(State.HALF_CLOSED_LOCAL, stream.state());
-        assertEquals(2, server.activeStreams().size());
+        assertEquals(2, server.numActiveStreams());
         assertEquals(4, server.local().lastStreamCreated());
 
         stream = server.remote().createStream(3).open(true);
         assertEquals(3, stream.id());
         assertEquals(State.HALF_CLOSED_REMOTE, stream.state());
-        assertEquals(3, server.activeStreams().size());
+        assertEquals(3, server.numActiveStreams());
         assertEquals(3, server.remote().lastStreamCreated());
 
         stream = server.remote().createStream(5).open(false);
         assertEquals(5, stream.id());
         assertEquals(State.OPEN, stream.state());
-        assertEquals(4, server.activeStreams().size());
+        assertEquals(4, server.numActiveStreams());
         assertEquals(5, server.remote().lastStreamCreated());
     }
 
@@ -145,25 +143,25 @@ public class DefaultHttp2ConnectionTest {
         Http2Stream stream = client.remote().createStream(2).open(false);
         assertEquals(2, stream.id());
         assertEquals(State.OPEN, stream.state());
-        assertEquals(1, client.activeStreams().size());
+        assertEquals(1, client.numActiveStreams());
         assertEquals(2, client.remote().lastStreamCreated());
 
         stream = client.remote().createStream(4).open(true);
         assertEquals(4, stream.id());
         assertEquals(State.HALF_CLOSED_REMOTE, stream.state());
-        assertEquals(2, client.activeStreams().size());
+        assertEquals(2, client.numActiveStreams());
         assertEquals(4, client.remote().lastStreamCreated());
 
         stream = client.local().createStream(3).open(true);
         assertEquals(3, stream.id());
         assertEquals(State.HALF_CLOSED_LOCAL, stream.state());
-        assertEquals(3, client.activeStreams().size());
+        assertEquals(3, client.numActiveStreams());
         assertEquals(3, client.local().lastStreamCreated());
 
         stream = client.local().createStream(5).open(false);
         assertEquals(5, stream.id());
         assertEquals(State.OPEN, stream.state());
-        assertEquals(4, client.activeStreams().size());
+        assertEquals(4, client.numActiveStreams());
         assertEquals(5, client.local().lastStreamCreated());
     }
 
@@ -173,7 +171,7 @@ public class DefaultHttp2ConnectionTest {
         Http2Stream pushStream = server.local().reservePushStream(2, stream);
         assertEquals(2, pushStream.id());
         assertEquals(State.RESERVED_LOCAL, pushStream.state());
-        assertEquals(1, server.activeStreams().size());
+        assertEquals(1, server.numActiveStreams());
         assertEquals(2, server.local().lastStreamCreated());
     }
 
@@ -183,7 +181,7 @@ public class DefaultHttp2ConnectionTest {
         Http2Stream pushStream = server.local().reservePushStream(4, stream);
         assertEquals(4, pushStream.id());
         assertEquals(State.RESERVED_LOCAL, pushStream.state());
-        assertEquals(1, server.activeStreams().size());
+        assertEquals(1, server.numActiveStreams());
         assertEquals(4, server.local().lastStreamCreated());
     }
 
@@ -226,7 +224,7 @@ public class DefaultHttp2ConnectionTest {
         Http2Stream stream = server.remote().createStream(3).open(true);
         stream.close();
         assertEquals(State.CLOSED, stream.state());
-        assertTrue(server.activeStreams().isEmpty());
+        assertEquals(0, server.numActiveStreams());
     }
 
     @Test
@@ -234,7 +232,7 @@ public class DefaultHttp2ConnectionTest {
         Http2Stream stream = server.remote().createStream(3).open(false);
         stream.closeLocalSide();
         assertEquals(State.HALF_CLOSED_LOCAL, stream.state());
-        assertEquals(1, server.activeStreams().size());
+        assertEquals(1, server.numActiveStreams());
     }
 
     @Test
@@ -242,7 +240,7 @@ public class DefaultHttp2ConnectionTest {
         Http2Stream stream = server.remote().createStream(3).open(false);
         stream.closeRemoteSide();
         assertEquals(State.HALF_CLOSED_REMOTE, stream.state());
-        assertEquals(1, server.activeStreams().size());
+        assertEquals(1, server.numActiveStreams());
     }
 
     @Test
@@ -250,7 +248,7 @@ public class DefaultHttp2ConnectionTest {
         Http2Stream stream = server.remote().createStream(3).open(true);
         stream.closeLocalSide();
         assertEquals(State.CLOSED, stream.state());
-        assertTrue(server.activeStreams().isEmpty());
+        assertEquals(0, server.numActiveStreams());
     }
 
     @Test(expected = Http2Exception.class)


### PR DESCRIPTION
Motivation:
The Http2Connection interface exposes an activeStreams() method which allows direct iteration over the underlying collection. There are a few places that make copies of this collection to avoid modification while iterating, and a few places that do not make copies. The copy operation can be expensive on hot code paths and also we are not consistently iterating over the activeStreams collection.

Modifications:
- The Http2Connection interface should reduce the exposure of the underlying collection and just expose what is necessary for the interface to function.  This is just a means to iterate over the collection.
- The DefaultHttp2Connection should use this new interface and protect it's internal state while iteration is occurring.

Result:
Reduction in surface area of the Http2Connection interface.  Consistent iteration of the set of active streams.  Concurrent modification exceptions are handled in 1 encapsulated spot.