### PR TITLE
HTTP/2 Headers Code Using String instead of AsciiString

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersEncoder.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.AsciiString;
 
 /**
  * Encodes {@link Http2Headers} into HPACK-encoded headers blocks.
@@ -32,6 +33,24 @@ public interface Http2HeadersEncoder {
     }
 
     /**
+     * Determine if a header name/value pair is treated as
+     * <a href="http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12#section-7.1.3">sensitive</a>.
+     * If the object can be dynamically modified and shared across multiple connections it may need to be thread safe.
+     */
+    interface SensitivityDetector {
+        /**
+         * Determine if a header {@code name}/{@code value} pair should be treated as
+         * <a href="http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12#section-7.1.3">sensitive</a>.
+         * @param name The name for the header.
+         * @param value The value of the header.
+         * @return {@code true} if a header {@code name}/{@code value} pair should be treated as
+         * <a href="http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12#section-7.1.3">sensitive</a>.
+         * {@code false} otherwise.
+         */
+        boolean isSensitive(AsciiString name, AsciiString value);
+    }
+
+    /**
      * Encodes the given headers and writes the output headers block to the given output buffer.
      *
      * @param headers the headers to be encoded.
@@ -43,4 +62,14 @@ public interface Http2HeadersEncoder {
      * Get the {@link Configuration} for this {@link Http2HeadersEncoder}
      */
     Configuration configuration();
+
+    /**
+     * Always return {@code false} for {@link SensitivityDetector#isSensitive(AsciiString, AsciiString)}.
+     */
+    SensitivityDetector NEVER_SENSITIVE = new SensitivityDetector() {
+        @Override
+        public boolean isSensitive(AsciiString name, AsciiString value) {
+            return false;
+        }
+    };
 }


### PR DESCRIPTION
Motivation:
The HTTP/2 headers code should be using binary string (currently AsciiString) objects instead of String objects. The DefaultHttp2HeadersEncoder was still using String for sensitiveHeaders.

Modifications:
- Remove the usage of String from DefaultHttp2HeadersEncoder.
- Introduce an interface to determine if a header name/value is sensitive or not to 1. prevent necessarily creating/copying sets. 2. Allow the name/value to be considered when checking if sensitive.

Result:
No more String in DefaultHttp2HeadersEncoder and less required set creation/operations.