### PR TITLE
HTTP/2 HEADERS stream dependency fix

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -307,10 +307,17 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                 }
             }
 
+            try {
+                // This call will create a stream for streamDependency if necessary.
+                // For this reason it must be done before notifying the listener.
+                stream.setPriority(streamDependency, weight, exclusive);
+            } catch (ClosedStreamCreationException ignored) {
+                // It is possible that either the stream for this frame or the parent stream is closed.
+                // In this case we should ignore the exception and allow the frame to be sent.
+            }
+
             listener.onHeadersRead(ctx, streamId, headers,
                     streamDependency, weight, exclusive, padding, endOfStream);
-
-            stream.setPriority(streamDependency, weight, exclusive);
 
             // If the headers completes this stream, close it.
             if (endOfStream) {


### PR DESCRIPTION
Motivation:
The DefaultHttp2ConnectionDecoder has the setPriority call after the Http2FrameListener is notified of the change. The setPriority call has additional verification logic and may even create the dependency stream and so it must be before the Http2FrameListener is notified.

Modifications:
The DefaultHttp2ConnectionDecoder should treat the setPriority call in the same for the HEADERS and PRIORITY frame (call it before notifying the listener).

Result:
Http2FrameListener should see correct state when a HEADERS frame has a stream dependency that has not yet been created yet.  Fixes https://github.com/netty/netty/issues/3572.