### PR TITLE
Fix incorrect null value check in TrafficCounter

### DIFF
--- a/handler/src/main/java/io/netty/handler/traffic/TrafficCounter.java
+++ b/handler/src/main/java/io/netty/handler/traffic/TrafficCounter.java
@@ -251,9 +251,6 @@ public class TrafficCounter {
      *            the checkInterval in millisecond between two computations.
      */
     public TrafficCounter(ScheduledExecutorService executor, String name, long checkInterval) {
-        if (executor == null) {
-            throw new NullPointerException("executor");
-        }
         if (name == null) {
             throw new NullPointerException("name");
         }
@@ -285,9 +282,6 @@ public class TrafficCounter {
 
         if (trafficShapingHandler == null) {
             throw new IllegalArgumentException("trafficShapingHandler");
-        }
-        if (executor == null) {
-            throw new NullPointerException("executor");
         }
         if (name == null) {
             throw new NullPointerException("name");


### PR DESCRIPTION
In TrafficCounter, a recent change makes the contract of the API (the
constructor) wrong and lead to issue with GlobalChannelTrafficCounter
where executor must be null.

Motivation:
TrafficCounter executor argument in constructor might be null, as
explained in the API, for some particular cases where no executor are
needed (relevant tasks being taken by the caller as in
GlobalChannelTrafficCounter).
A null pointer exception is raised while it should not since it is
legal.

Modifications:
Remove the 2 null checking for this particular attribute.
Note that when null, the attribute is not reached nor used (a null
checking condition later on is applied).

Result:
No more null exception raized while it should not.

This shall be made also to 4.0, 4.1 (present) and master. 3.10 is not
concerned.