### PR TITLE
Optimizing user-defined stream properties.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
@@ -45,6 +45,7 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
 
     private final Http2Connection connection;
     private final Http2FrameWriter frameWriter;
+    private final Http2Connection.PropertyKey stateKey;
     private ChannelHandlerContext ctx;
     private volatile float windowUpdateRatio;
     private volatile int initialWindowSize = DEFAULT_WINDOW_SIZE;
@@ -60,14 +61,15 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
         windowUpdateRatio(windowUpdateRatio);
 
         // Add a flow state for the connection.
-        connection.connectionStream().localFlowState(
-                new DefaultFlowState(connection.connectionStream(), initialWindowSize));
+        stateKey = connection.newKey();
+        connection.connectionStream()
+                .setProperty(stateKey, new DefaultFlowState(connection.connectionStream(), initialWindowSize));
 
         // Register for notification of new streams.
         connection.addListener(new Http2ConnectionAdapter() {
             @Override
             public void onStreamAdded(Http2Stream stream) {
-                stream.localFlowState(new DefaultFlowState(stream, 0));
+                stream.setProperty(stateKey, new DefaultFlowState(stream, 0));
             }
 
             @Override
@@ -93,6 +95,11 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
                 }
             }
         });
+    }
+
+    @Override
+    public Http2Connection.PropertyKey stateKey() {
+        return stateKey;
     }
 
     @Override
@@ -224,11 +231,12 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
     }
 
     private DefaultFlowState connectionState() {
-        return (DefaultFlowState) connection.connectionStream().localFlowState();
+        return (DefaultFlowState) connection.connectionStream().getProperty(stateKey);
     }
 
-    private static DefaultFlowState state(Http2Stream stream) {
-        return (DefaultFlowState) checkNotNull(stream, "stream").localFlowState();
+    private DefaultFlowState state(Http2Stream stream) {
+        checkNotNull(stream, "stream");
+        return stream.getProperty(stateKey);
     }
 
     private static boolean isClosed(Http2Stream stream) {
@@ -411,7 +419,7 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
     /**
      * Provides a means to iterate over all active streams and increment the flow control windows.
      */
-    private static final class WindowUpdateVisitor implements Http2StreamVisitor {
+    private final class WindowUpdateVisitor implements Http2StreamVisitor {
         private CompositeStreamException compositeException;
         private final int delta;
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
@@ -26,11 +26,11 @@ import static io.netty.handler.codec.http2.Http2Exception.streamError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2Exception.CompositeStreamException;
 import io.netty.handler.codec.http2.Http2Exception.StreamException;
-import io.netty.handler.codec.http2.Http2Stream.FlowControlState;
 import io.netty.util.internal.PlatformDependent;
 
 /**
@@ -98,11 +98,6 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
     }
 
     @Override
-    public Http2Connection.PropertyKey stateKey() {
-        return stateKey;
-    }
-
-    @Override
     public void initialWindowSize(int newWindowSize) throws Http2Exception {
         int delta = newWindowSize - initialWindowSize;
         initialWindowSize = newWindowSize;
@@ -115,6 +110,16 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
     @Override
     public int initialWindowSize() {
         return initialWindowSize;
+    }
+
+    @Override
+    public int windowSize(Http2Stream stream) {
+        return state(stream).windowSize();
+    }
+
+    @Override
+    public int initialWindowSize(Http2Stream stream) {
+        return state(stream).initialWindowSize();
     }
 
     @Override
@@ -246,7 +251,7 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
     /**
      * Flow control window state for an individual stream.
      */
-    private final class DefaultFlowState implements FlowControlState {
+    private final class DefaultFlowState {
         private final Http2Stream stream;
 
         /**
@@ -284,13 +289,11 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
             streamWindowUpdateRatio = windowUpdateRatio;
         }
 
-        @Override
-        public int windowSize() {
+        int windowSize() {
             return window;
         }
 
-        @Override
-        public int initialWindowSize() {
+        int initialWindowSize() {
             return initialStreamWindowSize;
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -22,8 +22,8 @@ import static io.netty.handler.codec.http2.Http2Exception.streamError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
+
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http2.Http2Stream.FlowControlState;
 import io.netty.handler.codec.http2.Http2Stream.State;
 
 import java.util.ArrayDeque;
@@ -120,11 +120,6 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
     }
 
     @Override
-    public Http2Connection.PropertyKey stateKey() {
-        return stateKey;
-    }
-
-    @Override
     public void initialWindowSize(int newWindowSize) throws Http2Exception {
         if (newWindowSize < 0) {
             throw new IllegalArgumentException("Invalid initial window size: " + newWindowSize);
@@ -150,6 +145,16 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
     @Override
     public int initialWindowSize() {
         return initialWindowSize;
+    }
+
+    @Override
+    public int windowSize(Http2Stream stream) {
+        return state(stream).windowSize();
+    }
+
+    @Override
+    public int initialWindowSize(Http2Stream stream) {
+        return state(stream).initialWindowSize();
     }
 
     @Override
@@ -418,7 +423,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
     /**
      * The remote flow control state for a single stream.
      */
-    private final class DefaultFlowState implements FlowControlState {
+    private final class DefaultFlowState {
         private final Deque<FlowControlled> pendingWriteQueue;
         private final Http2Stream stream;
         private int window;
@@ -436,13 +441,11 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
             pendingWriteQueue = new ArrayDeque<FlowControlled>(2);
         }
 
-        @Override
-        public int windowSize() {
+        int windowSize() {
             return window;
         }
 
-        @Override
-        public int initialWindowSize() {
+        int initialWindowSize() {
             return initialWindowSize;
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
@@ -296,11 +296,6 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
         }
 
         @Override
-        public Http2Connection.PropertyKey stateKey() {
-            return flowController.stateKey();
-        }
-
-        @Override
         public void initialWindowSize(int newWindowSize) throws Http2Exception {
             flowController.initialWindowSize(newWindowSize);
         }
@@ -308,6 +303,16 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
         @Override
         public int initialWindowSize() {
             return flowController.initialWindowSize();
+        }
+
+        @Override
+        public int windowSize(Http2Stream stream) {
+            return flowController.windowSize(stream);
+        }
+
+        @Override
+        public int initialWindowSize(Http2Stream stream) {
+            return flowController.initialWindowSize(stream);
         }
 
         @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -253,6 +253,17 @@ public interface Http2Connection {
     }
 
     /**
+     * A key to be used for associating application-defined properties with streams within this connection.
+     */
+    interface PropertyKey {
+    }
+
+    /**
+     * Creates a new key that is unique within this {@link Http2Connection}.
+     */
+    PropertyKey newKey();
+
+    /**
      * Adds a listener of stream life-cycle events.
      */
     void addListener(Listener listener);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FlowController.java
@@ -22,14 +22,8 @@ import io.netty.channel.ChannelHandlerContext;
 public interface Http2FlowController {
 
     /**
-     * Gets the {@link Http2Connection.PropertyKey} used for accessing the {@link Http2Stream.FlowControlState} property
-     * that this controller associates with each {@link Http2Stream}.
-     */
-    Http2Connection.PropertyKey stateKey();
-
-    /**
-     * Sets the initial flow control window and updates all stream windows (but not the connection
-     * window) by the delta.
+     * Sets the connection-wide initial flow control window and updates all stream windows (but not the connection
+     * stream window) by the delta.
      * <p>
      * This method is used to apply the {@code SETTINGS_INITIAL_WINDOW_SIZE} value for an
      * {@code SETTINGS} frame.
@@ -40,10 +34,23 @@ public interface Http2FlowController {
     void initialWindowSize(int newWindowSize) throws Http2Exception;
 
     /**
-     * Gets the initial flow control window size that is used as the basis for new stream flow
+     * Gets the connection-wide initial flow control window size that is used as the basis for new stream flow
      * control windows.
      */
     int initialWindowSize();
+
+    /**
+     * Get the portion of the flow control window for the given stream that is currently available for sending/receiving
+     * frames which are subject to flow control. This quantity is measured in number of bytes.
+     */
+    int windowSize(Http2Stream stream);
+
+    /**
+     * Get the initial flow control window size for the given stream. This quantity is measured in number of bytes. Note
+     * the unavailable window portion can be calculated by {@link #initialWindowSize()} - {@link
+     * #windowSize(Http2Stream)}.
+     */
+    int initialWindowSize(Http2Stream stream);
 
     /**
      * Increments the size of the stream's flow control window by the given delta.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FlowController.java
@@ -22,6 +22,12 @@ import io.netty.channel.ChannelHandlerContext;
 public interface Http2FlowController {
 
     /**
+     * Gets the {@link Http2Connection.PropertyKey} used for accessing the {@link Http2Stream.FlowControlState} property
+     * that this controller associates with each {@link Http2Stream}.
+     */
+    Http2Connection.PropertyKey stateKey();
+
+    /**
      * Sets the initial flow control window and updates all stream windows (but not the connection
      * window) by the delta.
      * <p>

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -34,24 +34,6 @@ public interface Http2Stream {
     }
 
     /**
-     * Represents the state which flow controller implementations are expected to track.
-     */
-    interface FlowControlState {
-        /**
-         * Get the portion of the flow control window that is available for sending/receiving frames which are subject
-         * to flow control. This quantity is measured in number of bytes.
-         */
-        int windowSize();
-
-        /**
-         * Get the initial flow control window size. This quantity is measured in number of bytes.
-         * Note the unavailable window portion can be calculated by
-         * {@link #initialWindowSize()} - {@link #windowSize()}.
-         */
-        int initialWindowSize();
-    }
-
-    /**
      * Gets the unique identifier for this stream within the connection.
      */
     int id();
@@ -60,20 +42,6 @@ public interface Http2Stream {
      * Gets the state of this stream.
      */
     State state();
-
-    /**
-     * Get the state as related to the {@link Http2LocalFlowController}. This is equivalent to calling {@link
-     * Http2Stream#getProperty(Http2Connection.PropertyKey)} with the {@link Http2FlowController#stateKey()} for the
-     * local flow controller.
-     */
-    FlowControlState localFlowState();
-
-    /**
-     * Get the state as related to {@link Http2RemoteFlowController}. This is equivalent to calling {@link
-     * Http2Stream#getProperty(Http2Connection.PropertyKey)} with the {@link Http2FlowController#stateKey()} for the
-     * remote flow controller.
-     */
-    FlowControlState remoteFlowState();
 
     /**
      * Opens this stream, making it available via {@link Http2Connection#forEachActiveStream(Http2StreamVisitor)} and

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -62,24 +62,18 @@ public interface Http2Stream {
     State state();
 
     /**
-     * Get the state as related to the {@link Http2LocalFlowController}.
+     * Get the state as related to the {@link Http2LocalFlowController}. This is equivalent to calling {@link
+     * Http2Stream#getProperty(Http2Connection.PropertyKey)} with the {@link Http2FlowController#stateKey()} for the
+     * local flow controller.
      */
     FlowControlState localFlowState();
 
     /**
-     * Set the state as related to the {@link Http2LocalFlowController}.
-     */
-    void localFlowState(FlowControlState state);
-
-    /**
-     * Get the state as related to {@link Http2RemoteFlowController}.
+     * Get the state as related to {@link Http2RemoteFlowController}. This is equivalent to calling {@link
+     * Http2Stream#getProperty(Http2Connection.PropertyKey)} with the {@link Http2FlowController#stateKey()} for the
+     * remote flow controller.
      */
     FlowControlState remoteFlowState();
-
-    /**
-     * Set the state as related to {@link Http2RemoteFlowController}.
-     */
-    void remoteFlowState(FlowControlState state);
 
     /**
      * Opens this stream, making it available via {@link Http2Connection#forEachActiveStream(Http2StreamVisitor)} and
@@ -140,17 +134,17 @@ public interface Http2Stream {
      * Associates the application-defined data with this stream.
      * @return The value that was previously associated with {@code key}, or {@code null} if there was none.
      */
-    Object setProperty(Object key, Object value);
+    <V> V setProperty(Http2Connection.PropertyKey key, V value);
 
     /**
      * Returns application-defined data if any was associated with this stream.
      */
-    <V> V getProperty(Object key);
+    <V> V getProperty(Http2Connection.PropertyKey key);
 
     /**
      * Returns and removes application-defined data if any was associated with this stream.
      */
-    <V> V removeProperty(Object key);
+    <V> V removeProperty(Http2Connection.PropertyKey key);
 
     /**
      * Updates an priority for this stream. Calling this method may affect the straucture of the

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -67,6 +67,7 @@ public class DefaultHttp2LocalFlowControllerTest {
 
         connection = new DefaultHttp2Connection(false);
         controller = new DefaultHttp2LocalFlowController(connection, frameWriter, updateRatio);
+        connection.local().flowController(controller);
 
         connection.local().createStream(STREAM_ID).open(false);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -309,7 +309,7 @@ public class DefaultHttp2LocalFlowControllerTest {
     }
 
     private int window(int streamId) throws Http2Exception {
-        return stream(streamId).localFlowState().windowSize();
+        return controller.windowSize(stream(streamId));
     }
 
     private Http2Stream stream(int streamId) throws Http2Exception {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -1223,7 +1223,7 @@ public class DefaultHttp2RemoteFlowControllerTest {
     }
 
     private int window(int streamId) throws Http2Exception {
-        return stream(streamId).remoteFlowState().windowSize();
+        return controller.windowSize(stream(streamId));
     }
 
     private void incrementWindowSize(int streamId, int delta) throws Http2Exception {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -86,6 +86,7 @@ public class DefaultHttp2RemoteFlowControllerTest {
 
         connection = new DefaultHttp2Connection(false);
         controller = new DefaultHttp2RemoteFlowController(connection);
+        connection.remote().flowController(controller);
 
         connection.local().createStream(STREAM_A).open(false);
         connection.local().createStream(STREAM_B).open(false);

--- a/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2LocalFlowController.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2LocalFlowController.java
@@ -15,9 +15,9 @@
 package io.netty.microbench.http2;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_INITIAL_WINDOW_SIZE;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2LocalFlowController;
 import io.netty.handler.codec.http2.Http2Stream;
@@ -28,16 +28,21 @@ public final class NoopHttp2LocalFlowController implements Http2LocalFlowControl
     private NoopHttp2LocalFlowController() { }
 
     @Override
-    public Http2Connection.PropertyKey stateKey() {
-        return null;
-    }
-
-    @Override
     public void initialWindowSize(int newWindowSize) throws Http2Exception {
     }
 
     @Override
     public int initialWindowSize() {
+        return MAX_INITIAL_WINDOW_SIZE;
+    }
+
+    @Override
+    public int windowSize(Http2Stream stream) {
+        return MAX_INITIAL_WINDOW_SIZE;
+    }
+
+    @Override
+    public int initialWindowSize(Http2Stream stream) {
         return MAX_INITIAL_WINDOW_SIZE;
     }
 

--- a/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2LocalFlowController.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2LocalFlowController.java
@@ -17,6 +17,7 @@ package io.netty.microbench.http2;
 import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_INITIAL_WINDOW_SIZE;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2LocalFlowController;
 import io.netty.handler.codec.http2.Http2Stream;
@@ -25,6 +26,11 @@ public final class NoopHttp2LocalFlowController implements Http2LocalFlowControl
     public static final NoopHttp2LocalFlowController INSTANCE = new NoopHttp2LocalFlowController();
 
     private NoopHttp2LocalFlowController() { }
+
+    @Override
+    public Http2Connection.PropertyKey stateKey() {
+        return null;
+    }
 
     @Override
     public void initialWindowSize(int newWindowSize) throws Http2Exception {

--- a/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
@@ -16,6 +16,7 @@ package io.netty.microbench.http2;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_INITIAL_WINDOW_SIZE;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2RemoteFlowController;
 import io.netty.handler.codec.http2.Http2Stream;
@@ -24,6 +25,12 @@ public final class NoopHttp2RemoteFlowController implements Http2RemoteFlowContr
     public static final NoopHttp2RemoteFlowController INSTANCE = new NoopHttp2RemoteFlowController();
 
     private NoopHttp2RemoteFlowController() { }
+
+    @Override
+    public Http2Connection.PropertyKey stateKey() {
+        return null;
+    }
+
     @Override
     public void initialWindowSize(int newWindowSize) throws Http2Exception {
     }

--- a/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
@@ -15,8 +15,8 @@
 package io.netty.microbench.http2;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_INITIAL_WINDOW_SIZE;
+
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2RemoteFlowController;
 import io.netty.handler.codec.http2.Http2Stream;
@@ -27,16 +27,21 @@ public final class NoopHttp2RemoteFlowController implements Http2RemoteFlowContr
     private NoopHttp2RemoteFlowController() { }
 
     @Override
-    public Http2Connection.PropertyKey stateKey() {
-        return null;
-    }
-
-    @Override
     public void initialWindowSize(int newWindowSize) throws Http2Exception {
     }
 
     @Override
     public int initialWindowSize() {
+        return MAX_INITIAL_WINDOW_SIZE;
+    }
+
+    @Override
+    public int windowSize(Http2Stream stream) {
+        return MAX_INITIAL_WINDOW_SIZE;
+    }
+
+    @Override
+    public int initialWindowSize(Http2Stream stream) {
         return MAX_INITIAL_WINDOW_SIZE;
     }
 


### PR DESCRIPTION
Motivation:

Streams currently maintain a hash map of user-defined properties, which has been shown to add significant memory overhead as well as being a performance bottleneck for lookup of frequently used properties.

Modifications:

Modifying the connection/stream to use an array as the storage of user-defined properties, indexed by a Key object that identifies the index into the array where the property is stored.

Result:

Stream processing performance should be improved.