### PR TITLE
Simple file transfer example for transport-udt

### DIFF
--- a/example/src/main/java/io/netty/example/udt/file/LastUdtFileMessage.java
+++ b/example/src/main/java/io/netty/example/udt/file/LastUdtFileMessage.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.udt.file;
+
+/**
+ * The {@link UdtFileMessage} which signals the end of the content batch.
+ */
+public class LastUdtFileMessage extends UdtFileMessage {
+    @Override
+    public byte magic() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setMagic(byte magic) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte opcode() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setOpcode(byte opcode) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int fileLength() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setFileLength(int fileSize) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int messageLength() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setMessageLength(int messageLength) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String message() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setMessage(String message) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/example/src/main/java/io/netty/example/udt/file/UdtFileClient.java
+++ b/example/src/main/java/io/netty/example/udt/file/UdtFileClient.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.udt.file;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.udt.nio.NioUdtProvider;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.util.concurrent.DefaultExecutorServiceFactory;
+import io.netty.util.concurrent.ExecutorServiceFactory;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+/**
+ * Sends the path of a file to a {@link UdtFileServer} to download it.
+ */
+public class UdtFileClient {
+    static final boolean SSL = System.getProperty("ssl") != null;
+    static final String HOST = System.getProperty("host", "127.0.0.1");
+    static final int PORT = Integer.parseInt(System.getProperty("port", SSL? "8992" : "8023"));
+
+    public static void main(String[] args) throws Exception {
+        // Configures SSL.
+        final SslContext sslCtx;
+        if (SSL) {
+            sslCtx = SslContext.newClientContext(SslProvider.JDK, InsecureTrustManagerFactory.INSTANCE);
+        } else {
+            sslCtx = null;
+        }
+        final ExecutorServiceFactory connectFactory = new DefaultExecutorServiceFactory("connect");
+        final NioEventLoopGroup connectGroup =
+                new NioEventLoopGroup(1, connectFactory, NioUdtProvider.BYTE_PROVIDER);
+
+        try {
+            Bootstrap b = new Bootstrap();
+            b.group(connectGroup)
+                    .channelFactory(NioUdtProvider.BYTE_CONNECTOR)
+                    .handler(new UdtFileClientInitializer(sslCtx));
+
+            // Starts the connection attempt.
+            Channel ch = b.connect(HOST, PORT).sync().channel();
+
+            // Reads the name of a file from the stdin.
+            ChannelFuture lastWriteFuture = null;
+            BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
+            for (;;) {
+                String line = in.readLine();
+                if (line == null) {
+                    break;
+                }
+
+                // Sends the received line to the server.
+                lastWriteFuture = ch.writeAndFlush(line + "\r\n");
+
+                // If user typed the 'bye', waits until the server closes
+                // the connection.
+                if ("bye".equals(line.toLowerCase())) {
+                    ch.closeFuture().sync();
+                    break;
+                }
+            }
+
+            // Waits until all messages are flushed before closing the channel.
+            if (lastWriteFuture != null) {
+                lastWriteFuture.sync();
+            }
+        } finally {
+            connectGroup.shutdownGracefully();
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/udt/file/UdtFileClientHandler.java
+++ b/example/src/main/java/io/netty/example/udt/file/UdtFileClientHandler.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.udt.file;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+/**
+ * A simple handler that receives a file or a message from a server.
+ */
+public class UdtFileClientHandler extends SimpleChannelInboundHandler<Object> {
+
+    FileOutputStream fos;
+    FileChannel fch;
+    String copiedFileName;
+
+    @Override
+    protected void messageReceived(ChannelHandlerContext ctx, Object msg) throws Exception {
+        // Creates a file.
+        if (msg instanceof File) {
+            copiedFileName = "copy_of_" + ((File) msg).getName();
+            fos = new FileOutputStream(copiedFileName);
+            fch = fos.getChannel();
+            return;
+        }
+
+        // File writing.
+        if (msg instanceof ByteBuf) {
+            ByteBuf in = (ByteBuf) msg;
+            ByteBuffer nioBuffer = in.nioBuffer();
+            while (nioBuffer.hasRemaining()) {
+                fch.write(nioBuffer);
+            }
+            return;
+        }
+
+        // Closing the file.
+        if (msg instanceof LastUdtFileMessage) {
+            fch.close();
+            fos.close();
+            System.out.println(">> " + copiedFileName + " is created.");
+            return;
+        }
+
+        // Prints out a message from a server.
+        if (msg instanceof String) {
+            System.out.println(msg);
+            return;
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/udt/file/UdtFileClientInitializer.java
+++ b/example/src/main/java/io/netty/example/udt/file/UdtFileClientInitializer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.udt.file;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.udt.UdtChannel;
+import io.netty.handler.codec.string.StringEncoder;
+import io.netty.handler.ssl.SslContext;
+import io.netty.util.CharsetUtil;
+
+/**
+ * Creates a newly configured {@link ChannelPipeline} for a client-side channel.
+ */
+public class UdtFileClientInitializer extends ChannelInitializer<UdtChannel> {
+
+    private final SslContext sslCtx;
+
+    public UdtFileClientInitializer(SslContext sslCtx) {
+        this.sslCtx = sslCtx;
+    }
+
+    @Override
+    protected void initChannel(UdtChannel ch) throws Exception {
+        ChannelPipeline pipeline = ch.pipeline();
+        if (sslCtx != null) {
+            pipeline.addLast(sslCtx.newHandler(ch.alloc(), UdtFileClient.HOST, UdtFileClient.PORT));
+        }
+
+        // Add an encoder for encoding the name of a file name to download.
+        pipeline.addLast(new StringEncoder(CharsetUtil.UTF_8));
+
+        // Add a decoder for decoding the response from a server.
+        pipeline.addLast(new UdtFileResponseDecoder());
+
+        // Add the business logic.
+        pipeline.addLast(new UdtFileClientHandler());
+    }
+}

--- a/example/src/main/java/io/netty/example/udt/file/UdtFileMessage.java
+++ b/example/src/main/java/io/netty/example/udt/file/UdtFileMessage.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.udt.file;
+
+import io.netty.util.ReferenceCounted;
+
+/**
+ * Represents a response message from a server to a client.
+ */
+public class UdtFileMessage implements ReferenceCounted {
+    public static final byte MAGIC_BYTE = (byte) 0x80;
+    private byte magic;
+    private byte opcode;
+    private int messageLength;
+    private int fileLength;
+    private String message;
+
+    public UdtFileMessage() {
+        this.magic = MAGIC_BYTE;
+    }
+
+    public byte magic() {
+        return magic;
+    }
+
+    public void setMagic(byte magic) {
+        this.magic = magic;
+    }
+
+    public byte opcode() {
+        return opcode;
+    }
+
+    public void setOpcode(byte opcode) {
+        this.opcode = opcode;
+    }
+
+    public int messageLength() {
+        return messageLength;
+    }
+
+    public void setMessageLength(int messageLength) {
+        this.messageLength = messageLength;
+    }
+
+    public int fileLength() {
+        return fileLength;
+    }
+
+    public void setFileLength(int fileLength) {
+        this.fileLength = fileLength;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public int refCnt() {
+        return 1;
+    }
+
+    @Override
+    public ReferenceCounted retain() {
+        return this;
+    }
+
+    @Override
+    public ReferenceCounted retain(int increment) {
+        return this;
+    }
+
+    @Override
+    public ReferenceCounted touch() {
+        return this;
+    }
+
+    @Override
+    public ReferenceCounted touch(Object hint) {
+        return this;
+    }
+
+    @Override
+    public boolean release() {
+        return false;
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        return false;
+    }
+}

--- a/example/src/main/java/io/netty/example/udt/file/UdtFileOpcodes.java
+++ b/example/src/main/java/io/netty/example/udt/file/UdtFileOpcodes.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.udt.file;
+
+public final class UdtFileOpcodes {
+
+    private UdtFileOpcodes() {}
+
+    public static final byte SND_FILE = 0x01;
+    public static final byte SND_MSG = 0x02;
+}

--- a/example/src/main/java/io/netty/example/udt/file/UdtFileResponseDecoder.java
+++ b/example/src/main/java/io/netty/example/udt/file/UdtFileResponseDecoder.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.udt.file;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.codec.CorruptedFrameException;
+import io.netty.util.CharsetUtil;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Decodes the binary representation of a {@link UdtFileMessage}.
+ */
+public class UdtFileResponseDecoder extends ByteToMessageDecoder {
+
+    public static final int DEFAULT_MAX_CHUNK_SIZE = 8192;
+    private State state = State.READ_HEADER;
+    private UdtFileMessage header;
+    private int alreadyReadBytes;
+    private final int chunkSize;
+    private boolean isSendFileOperation = false;
+
+    public UdtFileResponseDecoder() {
+        this(DEFAULT_MAX_CHUNK_SIZE);
+    }
+
+    public UdtFileResponseDecoder(int chunkSize) {
+        if (chunkSize > 0) {
+            this.chunkSize = chunkSize;
+        } else {
+            this.chunkSize = DEFAULT_MAX_CHUNK_SIZE;
+        }
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+        switch (state) {
+            case READ_HEADER:
+                if (in.readableBytes() < 10) {
+                    return;
+                }
+                in.markReaderIndex();
+
+                alreadyReadBytes = 0;
+                header = decodeHeader(in);
+                if (header.magic() != UdtFileMessage.MAGIC_BYTE) {
+                    in.resetReaderIndex();
+                    throw new CorruptedFrameException("Invalid magic number: " + header.magic());
+                }
+
+                if (header.opcode() == UdtFileOpcodes.SND_FILE) {
+                    isSendFileOperation = true;
+                } else {
+                    isSendFileOperation = false;
+                }
+
+                state = State.READ_MESSAGE;
+                return;
+            case READ_MESSAGE:
+                int messageLength = header.messageLength();
+                if (messageLength > 0) {
+                    if (in.readableBytes() < messageLength) {
+                        return;
+                    }
+                    if (isSendFileOperation) {
+                        String fileName = in.toString(in.readerIndex(), messageLength, CharsetUtil.UTF_8);
+                        in.skipBytes(messageLength);
+                        out.add(new File(fileName));
+                        state = State.READ_FILE;
+                    } else {
+                        byte[] message = new byte[messageLength];
+                        in.readBytes(message);
+                        out.add(new String(message));
+                        state = State.READ_HEADER;
+                    }
+                } else {
+                    state = State.READ_HEADER;
+                }
+                return;
+            case READ_FILE:
+                int fileSize = header.fileLength();
+                if (fileSize > 0) {
+                    int toRead = in.readableBytes();
+                    if (toRead == 0) {
+                        return;
+                    }
+
+                    if (toRead > chunkSize) {
+                        toRead = chunkSize;
+                    }
+
+                    int remainingBytes = fileSize - alreadyReadBytes;
+                    if (toRead > remainingBytes) {
+                        toRead = remainingBytes;
+                    }
+
+                    ByteBuf chunkBuf = ByteBufUtil.readBytes(ctx.alloc(), in, toRead);
+                    alreadyReadBytes += toRead;
+                    out.add(chunkBuf);
+
+                    if (alreadyReadBytes >= fileSize) {
+                        out.add(new LastUdtFileMessage());
+                    }
+
+                    if (alreadyReadBytes < fileSize) {
+                        return;
+                    }
+                } else {
+                    out.add(new LastUdtFileMessage());
+                }
+                state = State.READ_HEADER;
+                return;
+            default:
+                break;
+        }
+    }
+
+    private UdtFileMessage decodeHeader(ByteBuf in) {
+        UdtFileMessage header = new UdtFileMessage();
+        header.setMagic(in.readByte());
+        header.setOpcode(in.readByte());
+        header.setMessageLength(in.readInt());
+        header.setFileLength(in.readInt());
+        return header;
+    }
+
+    private enum State {
+        READ_HEADER,
+        READ_MESSAGE,
+        READ_FILE
+    }
+}

--- a/example/src/main/java/io/netty/example/udt/file/UdtFileResponseEncoder.java
+++ b/example/src/main/java/io/netty/example/udt/file/UdtFileResponseEncoder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.udt.file;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.util.CharsetUtil;
+
+import java.util.List;
+
+/**
+ * Encodes a {@link UdtFileMessage} into {@link ByteBuf}.
+ */
+public class UdtFileResponseEncoder extends MessageToMessageEncoder<Object> {
+    @Override
+    protected void encode(ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
+        if (msg instanceof ByteBuf) {
+            if (((ByteBuf) msg).readableBytes() > 0) {
+                out.add(((ByteBuf) msg).retain());
+            } else {
+                out.add(Unpooled.EMPTY_BUFFER);
+            }
+            return;
+        }
+
+        if (msg instanceof UdtFileMessage) {
+            out.add(encodeHeader(ctx, (UdtFileMessage) msg));
+            return;
+        }
+    }
+
+    private ByteBuf encodeHeader(ChannelHandlerContext ctx, UdtFileMessage msg) {
+        ByteBuf buf = ctx.alloc().buffer(10);
+        buf.writeByte(msg.magic());
+        buf.writeByte(msg.opcode());
+        buf.writeInt(msg.messageLength());
+        buf.writeInt(msg.fileLength());
+        buf.writeBytes((msg.message()).getBytes(CharsetUtil.UTF_8));
+        return buf;
+    }
+}

--- a/example/src/main/java/io/netty/example/udt/file/UdtFileServer.java
+++ b/example/src/main/java/io/netty/example/udt/file/UdtFileServer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.udt.file;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.udt.nio.NioUdtProvider;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.concurrent.DefaultExecutorServiceFactory;
+import io.netty.util.concurrent.ExecutorServiceFactory;
+
+/**
+ * Server that accepts the name of a file and sends back its content.
+ */
+public class UdtFileServer {
+    static final boolean SSL = System.getProperty("ssl") != null;
+    static final int PORT = Integer.parseInt(System.getProperty("port", SSL? "8992" : "8023"));
+
+    public static void main(String[] args) throws Exception {
+        // Configures SSL.
+        final SslContext sslCtx;
+        if (SSL) {
+            SelfSignedCertificate ssc = new SelfSignedCertificate();
+            sslCtx = SslContext.newServerContext(ssc.certificate(), ssc.privateKey());
+        } else {
+            sslCtx = null;
+        }
+
+        ExecutorServiceFactory acceptFactory = new DefaultExecutorServiceFactory("accept");
+        ExecutorServiceFactory connectFactory = new DefaultExecutorServiceFactory("connect");
+        NioEventLoopGroup acceptGroup = new NioEventLoopGroup(1, acceptFactory, NioUdtProvider.BYTE_PROVIDER);
+        NioEventLoopGroup connectGroup = new NioEventLoopGroup(1, connectFactory, NioUdtProvider.BYTE_PROVIDER);
+
+        try {
+            // Configures the server.
+            ServerBootstrap b = new ServerBootstrap();
+            b.group(acceptGroup, connectGroup)
+                    .channelFactory(NioUdtProvider.BYTE_ACCEPTOR)
+                    .option(ChannelOption.SO_BACKLOG, 100)
+                    .handler(new LoggingHandler(LogLevel.INFO))
+                    .childHandler(new UdtFileServerInitializer(sslCtx));
+
+            // Starts the server.
+            ChannelFuture f = b.bind(PORT).sync();
+
+            // Waits until the server socket is closed.
+            f.channel().closeFuture().sync();
+        } finally {
+            // Shuts down all event loops to terminate all threads.
+            acceptGroup.shutdownGracefully();
+            connectGroup.shutdownGracefully();
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/udt/file/UdtFileServerHandler.java
+++ b/example/src/main/java/io/netty/example/udt/file/UdtFileServerHandler.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.udt.file;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.stream.ChunkedFile;
+
+import java.io.RandomAccessFile;
+
+/**
+ * A simple handler that serves incoming the String which is a name of a file
+ * and sends its contents back.
+ */
+public class UdtFileServerHandler extends SimpleChannelInboundHandler<String> {
+
+    private UdtFileMessage response;
+    private static final String welcomeMsg = "[HELLO]: Type the name of a file to download.";
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        response = createMsgResponse(welcomeMsg);
+        ctx.writeAndFlush(response);
+    }
+
+    @Override
+    protected void messageReceived(ChannelHandlerContext ctx, String msg) throws Exception {
+
+        // Close the connection if the client has sent 'bye'.
+        if ("bye".equals(msg.toLowerCase())) {
+            ctx.close();
+            return;
+        }
+
+        RandomAccessFile raf = null;
+        long length = -1;
+        try {
+            raf = new RandomAccessFile(msg, "r");
+            length = raf.length();
+        } catch (Exception e) {
+            String errorMsg = "[ERROR]: " + e.getClass().getSimpleName() + ": " + e.getMessage();
+            response = createMsgResponse(errorMsg);
+            ctx.writeAndFlush(response);
+            return;
+        } finally {
+            if (length < 0 && raf != null) {
+                raf.close();
+            }
+        }
+
+        // Builds a response message and write to the ctx.
+        response = createFileResponse(msg, (int) length);
+        ctx.write(response);
+
+        // Writes the file to the ctx
+        ctx.write(new ChunkedFile(raf));
+        ctx.flush();
+    }
+
+    private UdtFileMessage createMsgResponse(String msg) {
+        UdtFileMessage response = new UdtFileMessage();
+        response.setOpcode(UdtFileOpcodes.SND_MSG);
+        response.setMessageLength(msg.length());
+        response.setMessage(msg);
+        return response;
+    }
+
+    private UdtFileMessage createFileResponse(String fileName, int fileLength) {
+        UdtFileMessage response = new UdtFileMessage();
+        response.setOpcode(UdtFileOpcodes.SND_FILE);
+        response.setMessageLength(fileName.length());
+        response.setFileLength(fileLength);
+        response.setMessage(fileName);
+        return response;
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        cause.printStackTrace();
+        ctx.close();
+    }
+}

--- a/example/src/main/java/io/netty/example/udt/file/UdtFileServerInitializer.java
+++ b/example/src/main/java/io/netty/example/udt/file/UdtFileServerInitializer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.udt.file;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.udt.UdtChannel;
+import io.netty.handler.codec.LineBasedFrameDecoder;
+import io.netty.handler.codec.string.StringDecoder;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.stream.ChunkedWriteHandler;
+import io.netty.util.CharsetUtil;
+
+/**
+ * Creates a newly configured {@link ChannelPipeline} for a server-side channel.
+ */
+public class UdtFileServerInitializer extends ChannelInitializer<UdtChannel> {
+
+    private final SslContext sslCtx;
+
+    public UdtFileServerInitializer(SslContext sslCtx) {
+        this.sslCtx = sslCtx;
+    }
+
+    @Override
+    protected void initChannel(UdtChannel ch) throws Exception {
+        ChannelPipeline pipeline = ch.pipeline();
+        if (sslCtx != null) {
+            pipeline.addLast(sslCtx.newHandler(ch.alloc()));
+        }
+
+        // Add decoders for decoding a string from a client.
+        pipeline.addLast(new LineBasedFrameDecoder(8192));
+        pipeline.addLast(new StringDecoder(CharsetUtil.UTF_8));
+
+        // Add the file response encoder.
+        pipeline.addLast(new UdtFileResponseEncoder());
+
+        // Add the file writing handler for ChunkedFile.
+        pipeline.addLast(new ChunkedWriteHandler());
+
+        // Add the business logic.
+        pipeline.addLast(new UdtFileServerHandler());
+    }
+}


### PR DESCRIPTION
Motivation:
There are only echo examples for transport-udt.
I think it's better if we have a simple file transfer server/client example because it's more practical.
This example works as follows.
1. The client sends the name of a file to the server.
2. The server checks if it exists in the path.
2.a. If it exists, sends back a response message and file content.
2.b. if it does not exists, sends back an error message.
3. The client decodes a response from the server and save it as a file if it has content.

Modification:
Added server/client example codes under io.netty.example.udt.

Result:
We can have one more practical example for transport-udt.