### PR TITLE
Removing direct access to HTTP/2 child streams.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -335,15 +335,13 @@ public class DefaultHttp2Connection implements Http2Connection {
 
         @Override
         public Http2Stream forEachChild(Http2StreamVisitor visitor) throws Http2Exception {
-            Http2Stream resultStream = null;
             for (IntObjectHashMap.Entry<DefaultStream> entry : children.entries()) {
                 Http2Stream stream = entry.value();
                 if (!visitor.visit(stream)) {
-                    resultStream = stream;
-                    break;
+                    return stream;
                 }
             }
-            return resultStream;
+            return null;
         }
 
         @Override
@@ -1020,15 +1018,13 @@ public class DefaultHttp2Connection implements Http2Connection {
 
         public Http2Stream forEachActiveStream(Http2StreamVisitor visitor) throws Http2Exception {
             ++pendingIterations;
-            Http2Stream resultStream = null;
             try {
                 for (Http2Stream stream : streams) {
                     if (!visitor.visit(stream)) {
-                        resultStream = stream;
-                        break;
+                        return stream;
                     }
                 }
-                return resultStream;
+                return null;
             } finally {
                 --pendingIterations;
                 if (allowModifications()) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -239,7 +239,6 @@ public class DefaultHttp2Connection implements Http2Connection {
         private State state = IDLE;
         private short weight = DEFAULT_PRIORITY_WEIGHT;
         private DefaultStream parent;
-        // TODO(nathanmittler): We no longer need a map. LinkedList?
         private IntObjectMap<DefaultStream> children = PrimitiveCollections.emptyIntObjectMap();
         private int totalChildWeights;
         private int prioritizableForTree = 1;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
@@ -28,7 +28,6 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http2.Http2Connection.StreamVisitor;
 import io.netty.handler.codec.http2.Http2Exception.CompositeStreamException;
 import io.netty.handler.codec.http2.Http2Exception.StreamException;
 
@@ -381,7 +380,7 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
     /**
      * Provides a means to iterate over all active streams and increment the flow control windows.
      */
-    private static final class WindowUpdateVisitor implements StreamVisitor {
+    private static final class WindowUpdateVisitor implements Http2StreamVisitor {
         private CompositeStreamException compositeException;
         private final int delta;
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -251,7 +251,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
      * @param connectionWindow The connection window this is available for use at this point in the tree.
      * @return An object summarizing the write and allocation results.
      */
-    private static int allocateBytesForTree(Http2Stream parent, int connectionWindow) throws Http2Exception {
+    static int allocateBytesForTree(Http2Stream parent, int connectionWindow) throws Http2Exception {
         FlowState state = state(parent);
         if (state.streamableBytesForTree() <= 0) {
             return 0;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -348,8 +348,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
 
                 // Iterate over the children that are currently still hungry.
                 for (int head = 0; head < tail && nextConnectionWindow > 0; ++head) {
-                    Http2Stream child = stillHungry[head];
-                    if (!visit(child)) {
+                    if (!visit(stillHungry[head])) {
                         // The connection window has collapsed, break out of the loop.
                         break;
                     }
@@ -375,11 +374,8 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
         void allocateSpace(int index) {
             if (stillHungry == null) {
                 // Initial size is 1/4 the number of children.
-                int minSize = max(index + 1, 4);
-                int desiredSize = maxSize / 4;
-                int initialSize = min(max(minSize, desiredSize), maxSize);
-                stillHungry = new Http2Stream[initialSize];
-            } else if (index >= stillHungry.length) {
+                stillHungry = new Http2Stream[max(2, maxSize / 4)];
+            } else if (index == stillHungry.length) {
                 // Grow the array by a factor of 2.
                 stillHungry = Arrays.copyOf(stillHungry, min(maxSize, stillHungry.length * 2));
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -364,14 +364,14 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
          * fit within the current connection window).
          */
         void stillHungry(Http2Stream child) {
-            allocateSpace(nextTail);
+            ensureSpaceIsAllocated(nextTail);
             stillHungry[nextTail++] = child;
         }
 
         /**
          * Ensures that the {@link #stillHungry} array is properly sized to hold the given index.
          */
-        void allocateSpace(int index) {
+        void ensureSpaceIsAllocated(int index) {
             if (stillHungry == null) {
                 // Initial size is 1/4 the number of children.
                 stillHungry = new Http2Stream[max(2, maxSize / 4)];

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -45,7 +45,7 @@ public interface Http2Connection {
 
         /**
          * Notifies the listener that the given stream is now {@code CLOSED} in both directions and will no longer
-         * be returned by {@link #activeStreams()}.
+         * be accessible via {@link #forEachActiveStream(Http2StreamVisitor)}.
          */
         void onStreamClosed(Http2Stream stream);
 
@@ -263,20 +263,7 @@ public interface Http2Connection {
      * @param visitor The visitor which will visit each active stream.
      * @return The stream before iteration stopped or {@code null} if iteration went past the end.
      */
-    Http2Stream forEachActiveStream(StreamVisitor visitor) throws Http2Exception;
-
-    /**
-     * A visitor that allows iteration over a collection of streams.
-     */
-    interface StreamVisitor {
-        /**
-         * @return <ul>
-         *         <li>{@code true} if the processor wants to continue the loop and handle the entry.</li>
-         *         <li>{@code false} if the processor wants to stop handling headers and abort the loop.</li>
-         *         </ul>
-         */
-        boolean visit(Http2Stream stream) throws Http2Exception;
-    }
+    Http2Stream forEachActiveStream(Http2StreamVisitor visitor) throws Http2Exception;
 
     /**
      * Indicates whether or not the local endpoint for this connection is the server.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -32,7 +32,6 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.ByteToMessageDecoder;
-import io.netty.handler.codec.http2.Http2Connection.StreamVisitor;
 import io.netty.handler.codec.http2.Http2Exception.CompositeStreamException;
 import io.netty.handler.codec.http2.Http2Exception.StreamException;
 import io.netty.util.concurrent.GenericFutureListener;
@@ -146,7 +145,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
                 // Check if there are streams to avoid the overhead of creating the ChannelFuture.
                 if (connection.numActiveStreams() > 0) {
                     final ChannelFuture future = ctx.newSucceededFuture();
-                    connection.forEachActiveStream(new StreamVisitor() {
+                    connection.forEachActiveStream(new Http2StreamVisitor() {
                         @Override
                         public boolean visit(Http2Stream stream) throws Http2Exception {
                             closeStream(stream, future);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -15,8 +15,6 @@
 
 package io.netty.handler.codec.http2;
 
-import java.util.Collection;
-
 /**
  * A single stream within an HTTP2 connection. Streams are compared to each other by priority.
  */
@@ -46,7 +44,8 @@ public interface Http2Stream {
     State state();
 
     /**
-     * Add this stream to {@link Http2Connection#activeStreams()} and transition state to:
+     * Opens this stream, making it available via {@link Http2Connection#forEachActiveStream(Http2StreamVisitor)} and
+     * transition state to:
      * <ul>
      * <li>{@link State#OPEN} if {@link #state()} is {@link State#IDLE} and {@code halfClosed} is {@code false}.</li>
      * <li>{@link State#HALF_CLOSED_LOCAL} if {@link #state()} is {@link State#IDLE} and {@code halfClosed}
@@ -175,18 +174,10 @@ public interface Http2Stream {
     int numChildren();
 
     /**
-     * Indicates whether the given stream is a direct child of this stream.
+     * Provide a means of iterating over the children of this stream.
+     *
+     * @param visitor The visitor which will visit each child stream.
+     * @return The stream before iteration stopped or {@code null} if iteration went past the end.
      */
-    boolean hasChild(int streamId);
-
-    /**
-     * Attempts to find a child of this stream with the given ID. If not found, returns
-     * {@code null}.
-     */
-    Http2Stream child(int streamId);
-
-    /**
-     * Gets all streams that are direct dependents on this stream.
-     */
-    Collection<? extends Http2Stream> children();
+    Http2Stream forEachChild(Http2StreamVisitor visitor) throws Http2Exception;
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamVisitor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamVisitor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+/**
+ * A visitor that allows iteration over a collection of streams.
+ */
+public interface Http2StreamVisitor {
+    /**
+     * @return <ul>
+     *         <li>{@code true} if the processor wants to continue the loop and handle the entry.</li>
+     *         <li>{@code false} if the processor wants to stop handling headers and abort the loop.</li>
+     *         </ul>
+     */
+    boolean visit(Http2Stream stream) throws Http2Exception;
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamVisitor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamVisitor.java
@@ -20,8 +20,8 @@ package io.netty.handler.codec.http2;
 public interface Http2StreamVisitor {
     /**
      * @return <ul>
-     *         <li>{@code true} if the processor wants to continue the loop and handle the entry.</li>
-     *         <li>{@code false} if the processor wants to stop handling headers and abort the loop.</li>
+     *         <li>{@code true} if the visitor wants to continue the loop and handle the entry.</li>
+     *         <li>{@code false} if the visitor wants to stop handling headers and abort the loop.</li>
      *         </ul>
      */
     boolean visit(Http2Stream stream) throws Http2Exception;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -46,7 +46,6 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
-import io.netty.handler.codec.http2.Http2Connection.StreamVisitor;
 import io.netty.handler.codec.http2.Http2Exception.ClosedStreamCreationException;
 
 import java.util.Collections;
@@ -128,13 +127,13 @@ public class DefaultHttp2ConnectionDecoderTest {
         doAnswer(new Answer<Http2Stream>() {
             @Override
             public Http2Stream answer(InvocationOnMock in) throws Throwable {
-                StreamVisitor visitor = in.getArgumentAt(0, StreamVisitor.class);
+                Http2StreamVisitor visitor = in.getArgumentAt(0, Http2StreamVisitor.class);
                 if (!visitor.visit(stream)) {
                     return stream;
                 }
                 return null;
             }
-        }).when(connection).forEachActiveStream(any(StreamVisitor.class));
+        }).when(connection).forEachActiveStream(any(Http2StreamVisitor.class));
         when(connection.stream(STREAM_ID)).thenReturn(stream);
         when(connection.requireStream(STREAM_ID)).thenReturn(stream);
         when(connection.local()).thenReturn(local);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -53,7 +53,6 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
-import io.netty.handler.codec.http2.Http2Connection.StreamVisitor;
 import io.netty.handler.codec.http2.Http2Exception.ClosedStreamCreationException;
 import io.netty.handler.codec.http2.Http2RemoteFlowController.FlowControlled;
 import io.netty.util.concurrent.ImmediateEventExecutor;
@@ -141,13 +140,13 @@ public class DefaultHttp2ConnectionEncoderTest {
         doAnswer(new Answer<Http2Stream>() {
             @Override
             public Http2Stream answer(InvocationOnMock in) throws Throwable {
-                StreamVisitor visitor = in.getArgumentAt(0, StreamVisitor.class);
+                Http2StreamVisitor visitor = in.getArgumentAt(0, Http2StreamVisitor.class);
                 if (!visitor.visit(stream)) {
                     return stream;
                 }
                 return null;
             }
-        }).when(connection).forEachActiveStream(any(StreamVisitor.class));
+        }).when(connection).forEachActiveStream(any(Http2StreamVisitor.class));
         when(connection.stream(STREAM_ID)).thenReturn(stream);
         when(connection.requireStream(STREAM_ID)).thenReturn(stream);
         when(connection.local()).thenReturn(local);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.verify;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http2.Http2Connection.Endpoint;
 import io.netty.handler.codec.http2.Http2Stream.State;
+import io.netty.util.internal.PlatformDependent;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -924,7 +925,8 @@ public class DefaultHttp2ConnectionTest {
             });
             return streamHolder.value;
         } catch (Http2Exception e) {
-            throw new RuntimeException(e);
+            PlatformDependent.throwException(e);
+            return null;
         }
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -44,7 +44,6 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
-import io.netty.handler.codec.http2.Http2Connection.StreamVisitor;
 import io.netty.util.concurrent.GenericFutureListener;
 
 import java.util.List;
@@ -115,13 +114,13 @@ public class Http2ConnectionHandlerTest {
         doAnswer(new Answer<Http2Stream>() {
             @Override
             public Http2Stream answer(InvocationOnMock in) throws Throwable {
-                StreamVisitor visitor = in.getArgumentAt(0, StreamVisitor.class);
+                Http2StreamVisitor visitor = in.getArgumentAt(0, Http2StreamVisitor.class);
                 if (!visitor.visit(stream)) {
                     return stream;
                 }
                 return null;
             }
-        }).when(connection).forEachActiveStream(any(StreamVisitor.class));
+        }).when(connection).forEachActiveStream(any(Http2StreamVisitor.class));
         when(connection.stream(NON_EXISTANT_STREAM_ID)).thenReturn(null);
         when(connection.numActiveStreams()).thenReturn(1);
         when(connection.stream(STREAM_ID)).thenReturn(stream);
@@ -288,7 +287,7 @@ public class Http2ConnectionHandlerTest {
                     public Http2Stream answer(InvocationOnMock in) throws Throwable {
                         return null;
                     }
-                }).when(connection).forEachActiveStream(any(StreamVisitor.class));
+                }).when(connection).forEachActiveStream(any(Http2StreamVisitor.class));
                 when(connection.numActiveStreams()).thenReturn(0);
                 // Simulate the future being completed.
                 listener.operationComplete(future);


### PR DESCRIPTION
Motivation:

We've removed access to the activeStreams collection, we should do the same for the children of a stream to provide a consistent interface.

Modifications:

Moved Http2StreamVisitor to a top-level interface. Removed unnecessary child operations from the Http2Stream interface so that we no longer require a map structure.

Result:

Cleaner and more consistent interface for iterating over child streams.