### PR TITLE
[#3373] Rename class to match naming scheme

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
@@ -269,7 +269,7 @@ public abstract class ReplayingDecoder<S> extends ByteToMessageDecoder {
 
     static final Signal REPLAY = Signal.valueOf(ReplayingDecoder.class.getName() + ".REPLAY");
 
-    private final ReplayingDecoderBuffer replayable = new ReplayingDecoderBuffer();
+    private final ReplayingDecoderByteBuf replayable = new ReplayingDecoderByteBuf();
     private S state;
     private int checkpoint = -1;
 

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
@@ -34,7 +34,7 @@ import java.nio.charset.Charset;
 /**
  * Special {@link ByteBuf} implementation which is used by the {@link ReplayingDecoder}
  */
-final class ReplayingDecoderBuffer extends ByteBuf {
+final class ReplayingDecoderByteBuf extends ByteBuf {
 
     private static final Signal REPLAY = ReplayingDecoder.REPLAY;
 
@@ -42,15 +42,15 @@ final class ReplayingDecoderBuffer extends ByteBuf {
     private boolean terminated;
     private SwappedByteBuf swapped;
 
-    static final ReplayingDecoderBuffer EMPTY_BUFFER = new ReplayingDecoderBuffer(Unpooled.EMPTY_BUFFER);
+    static final ReplayingDecoderByteBuf EMPTY_BUFFER = new ReplayingDecoderByteBuf(Unpooled.EMPTY_BUFFER);
 
     static {
         EMPTY_BUFFER.terminate();
     }
 
-    ReplayingDecoderBuffer() { }
+    ReplayingDecoderByteBuf() { }
 
-    ReplayingDecoderBuffer(ByteBuf buffer) {
+    ReplayingDecoderByteBuf(ByteBuf buffer) {
         setCumulation(buffer);
     }
 

--- a/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderByteBufTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderByteBufTest.java
@@ -24,14 +24,14 @@ import org.junit.Test;
 import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.junit.Assert.*;
 
-public class ReplayingDecoderBufferTest {
+public class ReplayingDecoderByteBufTest {
 
     /**
      * See https://github.com/netty/netty/issues/445
      */
     @Test
     public void testGetUnsignedByte() {
-        ReplayingDecoderBuffer buffer = new ReplayingDecoderBuffer(releaseLater(Unpooled.copiedBuffer("TestBuffer",
+        ReplayingDecoderByteBuf buffer = new ReplayingDecoderByteBuf(releaseLater(Unpooled.copiedBuffer("TestBuffer",
                 CharsetUtil.ISO_8859_1)));
 
         boolean error;
@@ -54,7 +54,7 @@ public class ReplayingDecoderBufferTest {
      */
     @Test
     public void testGetByte() {
-        ReplayingDecoderBuffer buffer = new ReplayingDecoderBuffer(releaseLater(Unpooled.copiedBuffer("TestBuffer",
+        ReplayingDecoderByteBuf buffer = new ReplayingDecoderByteBuf(releaseLater(Unpooled.copiedBuffer("TestBuffer",
                 CharsetUtil.ISO_8859_1)));
 
         boolean error;
@@ -81,7 +81,7 @@ public class ReplayingDecoderBufferTest {
         while (buf.isWritable()) {
             buf.writeBoolean(true);
         }
-        ReplayingDecoderBuffer buffer = new ReplayingDecoderBuffer(buf);
+        ReplayingDecoderByteBuf buffer = new ReplayingDecoderByteBuf(buf);
 
         boolean error;
         int i = 0;


### PR DESCRIPTION
Motivation:

The ReplayingDecoderBuffer does not match the naming scheme we use for ByteBuf types.

Modifications:

Rename to ReplayingDecoderByteBuf to match naming scheme

Result:

Consistent naming