### PR TITLE
Let CompositeByteBuf implement Iterable

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -37,7 +37,7 @@ import java.util.ListIterator;
  * {@link ByteBufAllocator#compositeBuffer()} or {@link Unpooled#wrappedBuffer(ByteBuf...)} instead of calling the
  * constructor explicitly.
  */
-public class CompositeByteBuf extends AbstractReferenceCountedByteBuf {
+public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements Iterable<ByteBuf> {
 
     private static final ByteBuffer EMPTY_NIO_BUFFER = Unpooled.EMPTY_BUFFER.nioBuffer();
 
@@ -371,6 +371,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf {
         return this;
     }
 
+    @Override
     public Iterator<ByteBuf> iterator() {
         ensureAccessible();
         List<ByteBuf> list = new ArrayList<ByteBuf>(components.size());


### PR DESCRIPTION
Motivation:

CompositeByteBuf has an iterator() method but fails to implement Iterable

Modifications:

Let CompositeByteBuf implement Iterable<ByteBuf>

Result:

Easier usage