### PR TITLE
[#3539] Correctly handle EPOLLRDHUP

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -569,11 +569,11 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel {
 
         @Override
         void epollRdHupReady() {
-            if (isActive()) {
-                epollInReady();
-            } else {
-                closeOnRead(pipeline());
-            }
+            // Just call closeOnRead(). There is no need to trigger a read as this
+            // will result in a IOException anyway.
+            //
+            // See https://github.com/netty/netty/issues/3539
+            closeOnRead(pipeline());
         }
 
         @Override

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -570,7 +570,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel {
         @Override
         void epollRdHupReady() {
             // Just call closeOnRead(). There is no need to trigger a read as this
-            // will result in a IOException anyway.
+            // will result in an IOException anyway.
             //
             // See https://github.com/netty/netty/issues/3539
             closeOnRead(pipeline());

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -305,26 +305,22 @@ final class EpollEventLoop extends SingleThreadEventLoop {
 
                 AbstractEpollChannel ch = channels.get(fd);
                 if (ch != null && ch.isOpen()) {
-                    boolean close = (ev & Native.EPOLLRDHUP) != 0;
-                    boolean read = (ev & Native.EPOLLIN) != 0;
-                    boolean write = (ev & Native.EPOLLOUT) != 0;
 
                     AbstractEpollUnsafe unsafe = (AbstractEpollUnsafe) ch.unsafe();
 
                     // We need to check if the channel is still open before try to trigger the
                     // callbacks.
-                    //
                     // See https://github.com/netty/netty/issues/3443
-                    if (close && ch.isOpen()) {
+                    if ((ev & Native.EPOLLRDHUP) != 0 && ch.isOpen()) {
                         unsafe.epollRdHupReady();
                     }
 
-                    if (write && ch.isOpen()) {
+                    if ((ev & Native.EPOLLOUT) != 0 && ch.isOpen()) {
                         // force flush of data as the epoll is writable again
                         unsafe.epollOutReady();
                     }
 
-                    if (read && ch.isOpen()) {
+                    if ((ev & Native.EPOLLIN) != 0 && ch.isOpen()) {
                         // Something is ready to read, so consume it now
                         unsafe.epollInReady();
                     }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -311,19 +311,19 @@ final class EpollEventLoop extends SingleThreadEventLoop {
 
                     AbstractEpollUnsafe unsafe = (AbstractEpollUnsafe) ch.unsafe();
 
-                    if (close) {
+                    // We need to check if the channel is still open before try to trigger the
+                    // callbacks.
+                    //
+                    // See https://github.com/netty/netty/issues/3443
+                    if (close && ch.isOpen()) {
                         unsafe.epollRdHupReady();
                     }
 
-                    // We need to check if the channel is still open before try to trigger the
-                    // callbacks as otherwise we may trigger an IllegalStateException when try
-                    // to access the file descriptor.
-                    //
-                    // See https://github.com/netty/netty/issues/3443
                     if (write && ch.isOpen()) {
                         // force flush of data as the epoll is writable again
                         unsafe.epollOutReady();
                     }
+
                     if (read && ch.isOpen()) {
                         // Something is ready to read, so consume it now
                         unsafe.epollInReady();


### PR DESCRIPTION
Motivation:

As we missed to correctly handle EPOLLRDHUP we produce an IOException which is unnessary. This leads
to have exceptionCaught(...) methods called.

Modifications:

When EPOLLRDHUP was received just close the socket and fail all pending writes.

Result:

Correctly handle of EPOLLRDHUP and so not miss-leading exceptions.