### PR TITLE
Dereference when calling PooledByteBuf.deallocate()

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -141,10 +141,14 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
         if (handle >= 0) {
             final long handle = this.handle;
             this.handle = -1;
-            memory = null;
             boolean sameThread = initThread == Thread.currentThread();
-            initThread = null;
             chunk.arena.free(chunk, handle, maxLength, sameThread);
+            // Dereference everything so GC can do it's work.
+            chunk = null;
+            tmpNioBuf = null;
+            initThread = null;
+            memory = null;
+
             recycle();
         }
     }


### PR DESCRIPTION
Motivation:

We missed to dereference the chunk and tmpNioBuf when calling deallocate(). This means the GC can not collect these as we still hold a reference while have the PooledByteBuf in the recycler stack.

Modifications:

Dereference chunk and tmpNioBuf.

Result:

GC can collect things.