### PR TITLE
HTTP/2 Connection Listener Unchecked Exceptions

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -21,7 +21,6 @@ import io.netty.buffer.ByteBuf;
  * Manager for the state of an HTTP/2 connection with the remote end-point.
  */
 public interface Http2Connection {
-
     /**
      * Listener for life-cycle events for streams in this connection.
      */
@@ -29,23 +28,35 @@ public interface Http2Connection {
         /**
          * Notifies the listener that the given stream was added to the connection. This stream may
          * not yet be active (i.e. {@code OPEN} or {@code HALF CLOSED}).
+         * <p>
+         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
+         * Throwing from this method is not supported and is considered a programming error.
          */
         void onStreamAdded(Http2Stream stream);
 
         /**
          * Notifies the listener that the given stream was made active (i.e. {@code OPEN} or {@code HALF CLOSED}).
+         * <p>
+         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
+         * Throwing from this method is not supported and is considered a programming error.
          */
         void onStreamActive(Http2Stream stream);
 
         /**
          * Notifies the listener that the given stream is now {@code HALF CLOSED}. The stream can be
          * inspected to determine which side is {@code CLOSED}.
+         * <p>
+         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
+         * Throwing from this method is not supported and is considered a programming error.
          */
         void onStreamHalfClosed(Http2Stream stream);
 
         /**
          * Notifies the listener that the given stream is now {@code CLOSED} in both directions and will no longer
          * be accessible via {@link #forEachActiveStream(Http2StreamVisitor)}.
+         * <p>
+         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
+         * Throwing from this method is not supported and is considered a programming error.
          */
         void onStreamClosed(Http2Stream stream);
 
@@ -53,6 +64,9 @@ public interface Http2Connection {
          * Notifies the listener that the given stream has now been removed from the connection and
          * will no longer be returned via {@link Http2Connection#stream(int)}. The connection may
          * maintain inactive streams for some time before removing them.
+         * <p>
+         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
+         * Throwing from this method is not supported and is considered a programming error.
          */
         void onStreamRemoved(Http2Stream stream);
 
@@ -61,6 +75,9 @@ public interface Http2Connection {
          * in a top down order relative to the priority tree. This method will also be invoked after all tree
          * structure changes have been made and the tree is in steady state relative to the priority change
          * which caused the tree structure to change.
+         * <p>
+         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
+         * Throwing from this method is not supported and is considered a programming error.
          * @param stream The stream which had a parent change (new parent and children will be steady state)
          * @param oldParent The old parent which {@code stream} used to be a child of (may be {@code null})
          */
@@ -70,13 +87,19 @@ public interface Http2Connection {
          * Notifies the listener that a parent dependency is about to change
          * This is called while the tree is being restructured and so the tree
          * structure is not necessarily steady state.
+         * <p>
+         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
+         * Throwing from this method is not supported and is considered a programming error.
          * @param stream The stream which the parent is about to change to {@code newParent}
          * @param newParent The stream which will be the parent of {@code stream}
          */
         void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent);
 
         /**
-         * Notifies the listener that the weight has changed for {@code stream}
+         * Notifies the listener that the weight has changed for {@code stream}.
+         * <p>
+         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
+         * Throwing from this method is not supported and is considered a programming error.
          * @param stream The stream which the weight has changed
          * @param oldWeight The old weight for {@code stream}
          */
@@ -84,7 +107,9 @@ public interface Http2Connection {
 
         /**
          * Called when a {@code GOAWAY} frame was sent for the connection.
-         *
+         * <p>
+         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
+         * Throwing from this method is not supported and is considered a programming error.
          * @param lastStreamId the last known stream of the remote endpoint.
          * @param errorCode    the error code, if abnormal closure.
          * @param debugData    application-defined debug data.
@@ -97,7 +122,9 @@ public interface Http2Connection {
          * but is added here in order to simplify application logic for handling {@code GOAWAY} in a uniform way. An
          * application should generally not handle both events, but if it does this method is called second, after
          * notifying the {@link Http2FrameListener}.
-         *
+         * <p>
+         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
+         * Throwing from this method is not supported and is considered a programming error.
          * @param lastStreamId the last known stream of the remote endpoint.
          * @param errorCode    the error code, if abnormal closure.
          * @param debugData    application-defined debug data.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -53,11 +53,11 @@ import java.util.List;
  */
 public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http2LifecycleManager,
         ChannelOutboundHandler {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(Http2ConnectionHandler.class);
     private final Http2ConnectionDecoder decoder;
     private final Http2ConnectionEncoder encoder;
     private ChannelFutureListener closeListener;
     private BaseDecoder byteDecoder;
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(Http2ConnectionHandler.class);
 
     public Http2ConnectionHandler(boolean server, Http2FrameListener listener) {
         this(new DefaultHttp2Connection(server), listener);


### PR DESCRIPTION
Motivation:
The DefaultHttp2Connection is not checking for RuntimeExceptions when invoking Http2Connection.Listener methods. This is a problem for a few reasons: 1. The state of DefaultHttp2Connection will be corrupted if a listener throws a RuntimeException. 2. If the first listener throws then no other listeners will be notified, which may further corrupt state that is updated as a result of listeners being notified.

Modifications:
- Document that RuntimeExceptions are not supported for Http2Connection.Listener methods, and will be logged as an error.
- Update DefaultHttp2Connection to handle and exception for each listener that is notified, and be sure that 1 listener throwing an exception does not prevent others from being notified.

Result:
More robust DefaultHttp2Connection.