### PR TITLE
HTTP/2 Flow Controller interface updates

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -246,6 +246,8 @@ public class DefaultHttp2Connection implements Http2Connection {
         private int prioritizableForTree = 1;
         private boolean resetSent;
         private PropertyMap data;
+        private FlowControlState localFlowState;
+        private FlowControlState remoteFlowState;
 
         DefaultStream(int id) {
             this.id = id;
@@ -260,6 +262,26 @@ public class DefaultHttp2Connection implements Http2Connection {
         @Override
         public final State state() {
             return state;
+        }
+
+        @Override
+        public FlowControlState localFlowState() {
+            return localFlowState;
+        }
+
+        @Override
+        public void localFlowState(FlowControlState state) {
+            localFlowState = state;
+        }
+
+        @Override
+        public FlowControlState remoteFlowState() {
+            return remoteFlowState;
+        }
+
+        @Override
+        public void remoteFlowState(FlowControlState state) {
+            remoteFlowState = state;
         }
 
         @Override
@@ -917,6 +939,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         private void addStream(DefaultStream stream) {
             // Add the stream to the map and priority tree.
             streamMap.put(stream.id(), stream);
+
             List<ParentChangedEvent> events = new ArrayList<ParentChangedEvent>(1);
             connectionStream.takeChild(stream, false, events);
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
@@ -304,11 +304,6 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
         }
 
         @Override
-        public int windowSize(Http2Stream stream) {
-            return flowController.windowSize(stream);
-        }
-
-        @Override
         public void incrementWindowSize(ChannelHandlerContext ctx, Http2Stream stream, int delta)
                 throws Http2Exception {
             flowController.incrementWindowSize(ctx, stream, delta);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FlowController.java
@@ -40,16 +40,6 @@ public interface Http2FlowController {
     int initialWindowSize();
 
     /**
-     * Gets the number of bytes remaining in the flow control window size for the given stream.
-     *
-     * @param stream The subject stream. Use {@link Http2Connection#connectionStream()} for
-     *            requesting the size of the connection window.
-     * @return the current size of the flow control window.
-     * @throws IllegalArgumentException if the given stream does not exist.
-     */
-    int windowSize(Http2Stream stream);
-
-    /**
      * Increments the size of the stream's flow control window by the given delta.
      * <p>
      * In the case of a {@link Http2RemoteFlowController} this is called upon receipt of a

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -34,6 +34,24 @@ public interface Http2Stream {
     }
 
     /**
+     * Represents the state which flow controller implementations are expected to track.
+     */
+    interface FlowControlState {
+        /**
+         * Get the portion of the flow control window that is available for sending/receiving frames which are subject
+         * to flow control. This quantity is measured in number of bytes.
+         */
+        int windowSize();
+
+        /**
+         * Get the initial flow control window size. This quantity is measured in number of bytes.
+         * Note the unavailable window portion can be calculated by
+         * {@link #initialWindowSize()} - {@link #windowSize()}.
+         */
+        int initialWindowSize();
+    }
+
+    /**
      * Gets the unique identifier for this stream within the connection.
      */
     int id();
@@ -42,6 +60,26 @@ public interface Http2Stream {
      * Gets the state of this stream.
      */
     State state();
+
+    /**
+     * Get the state as related to the {@link Http2LocalFlowController}.
+     */
+    FlowControlState localFlowState();
+
+    /**
+     * Set the state as related to the {@link Http2LocalFlowController}.
+     */
+    void localFlowState(FlowControlState state);
+
+    /**
+     * Get the state as related to {@link Http2RemoteFlowController}.
+     */
+    FlowControlState remoteFlowState();
+
+    /**
+     * Set the state as related to {@link Http2RemoteFlowController}.
+     */
+    void remoteFlowState(FlowControlState state);
 
     /**
      * Opens this stream, making it available via {@link Http2Connection#forEachActiveStream(Http2StreamVisitor)} and

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -287,7 +287,7 @@ public class DefaultHttp2LocalFlowControllerTest {
     }
 
     private int window(int streamId) throws Http2Exception {
-        return controller.windowSize(stream(streamId));
+        return stream(streamId).localFlowState().windowSize();
     }
 
     private Http2Stream stream(int streamId) throws Http2Exception {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -256,7 +256,6 @@ public class DefaultHttp2RemoteFlowControllerTest {
         final int initWindow = 20;
         final int secondWindowSize = 10;
         controller.initialWindowSize(initWindow);
-        Http2Stream streamA = connection.stream(STREAM_A);
 
         FakeFlowControlled data1 = new FakeFlowControlled(initWindow);
         FakeFlowControlled data2 = new FakeFlowControlled(5);
@@ -267,7 +266,7 @@ public class DefaultHttp2RemoteFlowControllerTest {
 
         // Make the window size for stream A negative
         controller.initialWindowSize(initWindow - secondWindowSize);
-        assertEquals(-secondWindowSize, controller.windowSize(streamA));
+        assertEquals(-secondWindowSize, window(STREAM_A));
 
         // Queue up a write. It should not be written now because the window is negative
         sendData(STREAM_A, data2);
@@ -275,12 +274,12 @@ public class DefaultHttp2RemoteFlowControllerTest {
 
         // Open the window size back up a bit (no send should happen)
         incrementWindowSize(STREAM_A, 5);
-        assertEquals(-5, controller.windowSize(streamA));
+        assertEquals(-5, window(STREAM_A));
         data2.assertNotWritten();
 
         // Open the window size back up a bit (no send should happen)
         incrementWindowSize(STREAM_A, 5);
-        assertEquals(0, controller.windowSize(streamA));
+        assertEquals(0, window(STREAM_A));
         data2.assertNotWritten();
 
         // Open the window size back up and allow the write to happen
@@ -1223,7 +1222,7 @@ public class DefaultHttp2RemoteFlowControllerTest {
     }
 
     private int window(int streamId) throws Http2Exception {
-        return controller.windowSize(stream(streamId));
+        return stream(streamId).remoteFlowState().windowSize();
     }
 
     private void incrementWindowSize(int streamId, int delta) throws Http2Exception {

--- a/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2LocalFlowController.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2LocalFlowController.java
@@ -36,11 +36,6 @@ public final class NoopHttp2LocalFlowController implements Http2LocalFlowControl
     }
 
     @Override
-    public int windowSize(Http2Stream stream) {
-        return MAX_INITIAL_WINDOW_SIZE;
-    }
-
-    @Override
     public void incrementWindowSize(ChannelHandlerContext ctx, Http2Stream stream, int delta)
             throws Http2Exception {
     }

--- a/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
@@ -34,11 +34,6 @@ public final class NoopHttp2RemoteFlowController implements Http2RemoteFlowContr
     }
 
     @Override
-    public int windowSize(Http2Stream stream) {
-        return MAX_INITIAL_WINDOW_SIZE;
-    }
-
-    @Override
     public void incrementWindowSize(ChannelHandlerContext ctx, Http2Stream stream, int delta)
             throws Http2Exception {
     }


### PR DESCRIPTION
Motivation:
Flow control is a required part of the HTTP/2 specification but it is currently structured more like an optional item. It must be accessed through the property map which is time consuming and does not represent its required nature. This access pattern does not give any insight into flow control outside of the codec (or flow controller implementation).

Modifications:
1. Create a read only public interface for LocalFlowState and RemoteFlowState.
2. Add a LocalFlowState localFlowState(); and RemoteFlowState remoteFlowState(); to Http2Stream.

Result:
Flow control is not part of the Http2Stream interface. This clarifies its responsibility and logical relationship to other interfaces. The flow controller no longer must be acquired though a map lookup.