### PR TITLE
HTTP/2 Frame Writer Microbenchmark Fix

### DIFF
--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -73,12 +73,12 @@
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
-      <version>0.9</version>
+      <version>1.7.1</version>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
-      <version>0.9</version>
+      <version>1.7.1</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/microbench/src/test/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
+++ b/microbench/src/test/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
@@ -42,7 +42,7 @@ public abstract class AbstractMicrobenchmarkBase {
     protected static final int DEFAULT_MEASURE_ITERATIONS = 10;
     protected static final String[] BASE_JVM_ARGS = {
         "-server", "-dsa", "-da", "-ea:io.netty...", "-XX:+AggressiveOpts", "-XX:+UseBiasedLocking",
-        "-XX:+UseFastAccessorMethods", "-XX:+UseStringCache", "-XX:+OptimizeStringConcat",
+        "-XX:+UseFastAccessorMethods", "-XX:+OptimizeStringConcat",
         "-XX:+HeapDumpOnOutOfMemoryError", "-Dio.netty.noResourceLeakDetection"};
 
     static {

--- a/microbench/src/test/java/io/netty/microbench/util/AbstractSharedExecutorMicrobenchmark.java
+++ b/microbench/src/test/java/io/netty/microbench/util/AbstractSharedExecutorMicrobenchmark.java
@@ -33,13 +33,13 @@ import org.openjdk.jmh.annotations.Fork;
 @Fork(AbstractSharedExecutorMicrobenchmark.DEFAULT_FORKS)
 public class AbstractSharedExecutorMicrobenchmark extends AbstractMicrobenchmarkBase {
 
-    protected static final int DEFAULT_FORKS = 0; // Forks has to be 0 so tasks are run immediately by JMH
+    protected static final int DEFAULT_FORKS = 1;
     protected static final String[] JVM_ARGS;
 
     static {
         final String[] customArgs = {
         "-Xms2g", "-Xmx2g", "-XX:MaxDirectMemorySize=2g", "-Dharness.executor=CUSTOM",
-        "-Dharness.executor.class=io.netty.microbench.util.AbstractExecutorMicrobenchmark$DelegateHarnessExecutor" };
+    "-Dharness.executor.class=io.netty.microbench.util.AbstractSharedExecutorMicrobenchmark$DelegateHarnessExecutor" };
 
         JVM_ARGS = new String[BASE_JVM_ARGS.length + customArgs.length];
         System.arraycopy(BASE_JVM_ARGS, 0, JVM_ARGS, 0, BASE_JVM_ARGS.length);


### PR DESCRIPTION
Motivation:
The Http2FrameWriterBenchmark JMH harness class name was not updated for the JVM arguments. The number of forks is 0 which means the JHM will share a JVM with the benchmarks.  Sharing the JVM may lead to less reliable benchmarking results and as doesn't allow for the command line arguments to be applied for each benchmark.

Modifications:
- Update the JMH version from 0.9 to 1.7.1.  Benchmarks wouldn't run on old version.
- Increase the number of forks from 0 to 1.
- Remove allocation of environment from static and cleanup AfterClass to using the Setup and Teardown methods. The forked JVM would not shut down correctly otherwise (and wait for 30+ seconds before timeing out).

Result:
Benchmarks that run as intended.