### PR TITLE
The "null" ClassLoader is the bootstrap ClassLoader

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
@@ -44,14 +44,8 @@ final class JdkAlpnSslEngine extends JdkSslEngine {
         }
 
         try {
-            // Try to get the bootstrap class loader.
-            ClassLoader bootloader = ClassLoader.getSystemClassLoader().getParent();
-            if (bootloader == null) {
-                // If failed, use the system class loader,
-                // although it's not perfect to tell if APLN extension has been loaded.
-                bootloader = ClassLoader.getSystemClassLoader();
-            }
-            Class.forName("sun.security.ssl.ALPNExtension", true, bootloader);
+            // Always use bootstrap class loader.
+            Class.forName("sun.security.ssl.ALPNExtension", true, null);
             available = true;
         } catch (Exception ignore) {
             // alpn-boot was not loaded.

--- a/handler/src/main/java/io/netty/handler/ssl/JdkNpnSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkNpnSslEngine.java
@@ -44,14 +44,8 @@ final class JdkNpnSslEngine extends JdkSslEngine {
             return;
         }
         try {
-            // Try to get the bootstrap class loader.
-            ClassLoader bootloader = ClassLoader.getSystemClassLoader().getParent();
-            if (bootloader == null) {
-                // If failed, use the system class loader,
-                // although it's not perfect to tell if NPN extension has been loaded.
-                bootloader = ClassLoader.getSystemClassLoader();
-            }
-            Class.forName("sun.security.ssl.NextProtoNegoExtension", true, bootloader);
+            // Always use bootstrap class loader.
+            Class.forName("sun.security.ssl.NextProtoNegoExtension", true, null);
             available = true;
         } catch (Exception ignore) {
             // npn-boot was not loaded.


### PR DESCRIPTION
Motivation:
Class.forName() documents that null will use bootstrap loader:
http://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#forName-java.lang.String-boolean-java.lang.ClassLoader-

But the link between "null" and bootstrap loader is even more explicit
in ClassLoader's documentation:
http://docs.oracle.com/javase/8/docs/api/java/lang/ClassLoader.html#getParent--

The current code is trying to use the bootstrap loader but seems to have
not been aware of the meaning of null.

Modifications:
Use "null" as the class loader when we want to load classes in the
bootstrap loader.

Result:
More reliable ALPN/NPN loading and simpler code.