### PR TITLE
Concurrency problem with ByteString#hash

### DIFF
--- a/common/src/main/java/io/netty/util/ByteString.java
+++ b/common/src/main/java/io/netty/util/ByteString.java
@@ -393,15 +393,15 @@ public class ByteString {
 
     @Override
     public int hashCode() {
-        if (hash != 0) {
-            return hash;
+        int h = hash;
+        if (h == 0) {
+            for (int i = 0; i < value.length; ++i) {
+                h = h * HASH_CODE_PRIME ^ value[i] & HASH_CODE_PRIME;
+            }
+            
+            hash = h;
         }
-
-        for (int i = 0; i < value.length; ++i) {
-            hash = hash * HASH_CODE_PRIME ^ value[i] & HASH_CODE_PRIME;
-        }
-
-        return hash;
+        return h;
     }
 
     /**


### PR DESCRIPTION
* 4.1.0.Beta5-SNAPSHOT

There is a "race condition" with `ByteString#hash`. I noticed it through one of the headers defined in HttpHeaderNames. One of them was returning null values which wasn't possible. Here is a simple example:

```
HttpRequest request;
HttpHeaders headers = request.headers();

// Returns null
String value1 = headers.get(HttpHeaderNames.HOST);

// Returns non-null
String value2 = headers.get(HttpHeaderNames.HOST.toString());
String value3 = headers.get(new AsciiString("Host"));
String value4 = headers.get("Host");
```

I tracked it down to `ByteString#hash` getting trashed if the hash code is not initialized and multiple threads attempt to calculate it concurrently. A simple repro looks about like this (you may have to run it a few times).

```
public static void main(String[] args) throws Exception {
    
    final int concurrency = 10;
    
    final HttpHeaders headers = new DefaultHttpHeaders();
    headers.add(HttpHeaderNames.HOST, "netty.io");
    assertEquals("netty.io", headers.get(HttpHeaderNames.HOST));
    
    while (true) {
      
      // Reset the hash
      HttpHeaderNames.HOST.arrayChanged();
      
      final CountDownLatch latch = new CountDownLatch(concurrency);
      
      for (int i = 0; i < concurrency; i++) {
        (new Thread() {
          @Override
          public void run() {
            try {
              assertEquals("netty.io", headers.get(HttpHeaderNames.HOST));
            } finally {
              latch.countDown();
            }
          }
        }).start();
      }
      
      latch.await();
    }
  }
```
