### PR TITLE
ByteString arrayOffset method

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -610,7 +610,7 @@ public final class ByteBufUtil {
                             + length + ") <= srcLen(" + thisLen + ')');
         }
 
-        checkNotNull(dst, "dst").setBytes(dstIdx, src.array(), srcIdx, length);
+        checkNotNull(dst, "dst").setBytes(dstIdx, src.array(), srcIdx + src.arrayOffset(), length);
     }
 
     /**
@@ -628,7 +628,7 @@ public final class ByteBufUtil {
                             + length + ") <= srcLen(" + thisLen + ')');
         }
 
-        checkNotNull(dst, "dst").writeBytes(src.array(), srcIdx, length);
+        checkNotNull(dst, "dst").writeBytes(src.array(), srcIdx + src.arrayOffset(), length);
     }
 
     static final class ThreadLocalUnsafeDirectByteBuf extends UnpooledUnsafeDirectByteBuf {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoder.java
@@ -109,7 +109,10 @@ public class DefaultHttp2HeadersEncoder implements Http2HeadersEncoder, Http2Hea
     }
 
     private void encodeHeader(ByteString key, ByteString value, OutputStream stream) throws IOException {
-        encoder.encodeHeader(stream, key.array(), value.array(), sensitivityDetector.isSensitive(key, value));
+        encoder.encodeHeader(stream,
+                key.isEntireArrayUsed() ? key.array() : new ByteString(key, true).array(),
+                value.isEntireArrayUsed() ? value.array() : new ByteString(value, true).array(),
+                sensitivityDetector.isSensitive(key, value));
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpUtil.java
@@ -377,7 +377,7 @@ public final class HttpUtil {
                     throw streamError(streamId, PROTOCOL_ERROR,
                             "Invalid HTTP/2 header '%s' encountered in translation to HTTP/1.x", translatedName);
                 } else {
-                    output.add(new AsciiString(translatedName.array(), false), new AsciiString(value.array(), false));
+                    output.add(new AsciiString(translatedName, false), new AsciiString(value, false));
                 }
             }
             return true;

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -863,8 +863,9 @@ public final class PlatformDependent {
         if (len1 != len2) {
             return false;
         }
-        for (int i = 0; i < len1; i++) {
-            if (bytes1[startPos1 + i] != bytes2[startPos2 + i]) {
+        final int end = startPos1 + len1;
+        for (int i = startPos1, j = startPos2; i < end; ++i, ++j) {
+            if (bytes1[i] != bytes2[j]) {
                 return false;
             }
         }

--- a/common/src/main/script/codegen.groovy
+++ b/common/src/main/script/codegen.groovy
@@ -23,7 +23,7 @@ void convertTemplates(String templateDir,
     def keyName = keyPrimitive.capitalize()
     def replaceFrom = "(^.*)K([^.]+)\\.template\$"
     def replaceTo = "\\1" + keyName + "\\2.java"
-    def hashCodeFn = keyPrimitive.equals("long") ? "(int)(key ^ (key >>> 32))" : "(int) key"
+    def hashCodeFn = keyPrimitive.equals("long") ? "(int) (key ^ (key >>> 32))" : "(int) key"
     ant.copy(todir: outputDir) {
         fileset(dir: templateDir) {
             include(name: "**/*.template")

--- a/common/src/test/java/io/netty/util/AsciiStringTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.util;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertArrayEquals;
 
 import java.nio.charset.Charset;
@@ -26,7 +27,6 @@ import org.junit.Test;
  * Test for the {@link AsciiString} class
  */
 public class AsciiStringTest {
-
     @Test
     public void testGetBytesStringBuilder() {
         final StringBuilder b = new StringBuilder();
@@ -77,5 +77,26 @@ public class AsciiStringTest {
         String string = "shouldn't fail";
         AsciiString ascii = new AsciiString(string.toCharArray());
         Assert.assertEquals(string, ascii.toString());
+    }
+
+    @Test
+    public void subSequenceTest() {
+        byte[] init = {'t', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 't', 'e', 's', 't' };
+        AsciiString ascii = new AsciiString(init);
+        final int start = 2;
+        final int end = init.length;
+        AsciiString sub1 = ascii.subSequence(start, end, false);
+        AsciiString sub2 = ascii.subSequence(start, end, true);
+        assertEquals(sub1, sub2);
+        for (int i = start; i < end; ++i) {
+            assertEquals(init[i], sub1.byteAt(i - start));
+        }
+    }
+
+    @Test
+    public void caseInsensativeHasher() {
+        String s1 = new String("TransfeR-EncodinG");
+        AsciiString s2 = new AsciiString("transfer-encoding");
+        assertEquals(AsciiString.caseInsensitiveHashCode(s1), AsciiString.caseInsensitiveHashCode(s2));
     }
 }

--- a/common/src/test/java/io/netty/util/ByteStringTest.java
+++ b/common/src/test/java/io/netty/util/ByteStringTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test for the {@link ByteString} class.
+ */
+public class ByteStringTest {
+    private byte[] a;
+    private byte[] b;
+    private int aOffset = 22;
+    private int bOffset = 53;
+    private int length = 100;
+    private ByteString aByteString;
+    private ByteString bByteString;
+    private ByteString greaterThanAByteString;
+    private ByteString lessThanAByteString;
+    private Random r = new Random();
+
+    @Before
+    public void setup() {
+        a = new byte[128];
+        b = new byte[256];
+        r.nextBytes(a);
+        r.nextBytes(b);
+        aOffset = 22;
+        bOffset = 53;
+        length = 100;
+        System.arraycopy(a, aOffset, b, bOffset, length);
+        aByteString = new ByteString(a, aOffset, length, false);
+        bByteString = new ByteString(b, bOffset, length, false);
+
+        int i;
+        // Find an element that can be decremented
+        for (i = 1; i < length; ++i) {
+            if (a[aOffset + 1] > Byte.MIN_VALUE) {
+                --a[aOffset + 1];
+                break;
+            }
+        }
+        lessThanAByteString = new ByteString(a, aOffset, length, true);
+        ++a[aOffset + i]; // Restore the a array to the original value
+
+        // Find an element that can be incremented
+        for (i = 1; i < length; ++i) {
+            if (a[aOffset + 1] < Byte.MAX_VALUE) {
+                ++a[aOffset + 1];
+                break;
+            }
+        }
+        greaterThanAByteString = new ByteString(a, aOffset, length, true);
+        --a[aOffset + i]; // Restore the a array to the original value
+    }
+
+    @Test
+    public void testEqualsComparareSelf() {
+        assertTrue(ByteString.DEFAULT_COMPARATOR.compare(aByteString, aByteString) == 0);
+        assertEquals(bByteString, bByteString);
+    }
+
+    @Test
+    public void testEqualsComparatorAgainstAnother1() {
+        assertTrue(ByteString.DEFAULT_COMPARATOR.compare(bByteString, aByteString) == 0);
+        assertEquals(bByteString, aByteString);
+        assertEquals(bByteString.hashCode(), aByteString.hashCode());
+    }
+
+    @Test
+    public void testEqualsComparatorAgainstAnother2() {
+        assertTrue(ByteString.DEFAULT_COMPARATOR.compare(aByteString, bByteString) == 0);
+        assertEquals(aByteString, bByteString);
+        assertEquals(aByteString.hashCode(), bByteString.hashCode());
+    }
+
+    @Test
+    public void testLessThan() {
+        assertTrue(ByteString.DEFAULT_COMPARATOR.compare(lessThanAByteString, aByteString) < 0);
+        assertTrue(ByteString.DEFAULT_COMPARATOR.compare(aByteString, lessThanAByteString) > 0);
+    }
+
+    @Test
+    public void testGreaterThan() {
+        assertTrue(ByteString.DEFAULT_COMPARATOR.compare(greaterThanAByteString, aByteString) > 0);
+        assertTrue(ByteString.DEFAULT_COMPARATOR.compare(aByteString, greaterThanAByteString) < 0);
+    }
+
+    @Test
+    public void testSharedMemory() {
+        ++a[aOffset];
+        ByteString aByteString1 = new ByteString(a, aOffset, length, true);
+        ByteString aByteString2 = new ByteString(a, aOffset, length, false);
+        assertEquals(aByteString, aByteString1);
+        assertEquals(aByteString, aByteString2);
+        for (int i = aOffset; i < length; ++i) {
+            assertEquals(a[i], aByteString.byteAt(i - aOffset));
+        }
+    }
+
+    @Test
+    public void testNotSharedMemory() {
+        ByteString aByteString1 = new ByteString(a, aOffset, length, true);
+        ++a[aOffset];
+        assertNotEquals(aByteString, aByteString1);
+        int i = aOffset;
+        assertNotEquals(a[i], aByteString1.byteAt(i - aOffset));
+        ++i;
+        for (; i < length; ++i) {
+            assertEquals(a[i], aByteString1.byteAt(i - aOffset));
+        }
+    }
+
+    @Test
+    public void forEachTest() throws Exception {
+        final AtomicReference<Integer> aCount = new AtomicReference<Integer>(0);
+        final AtomicReference<Integer> bCount = new AtomicReference<Integer>(0);
+        aByteString.forEachByte(new ByteProcessor() {
+            int i;
+            @Override
+            public boolean process(byte value) throws Exception {
+                assertEquals("failed at index: " + i, value, bByteString.byteAt(i++));
+                aCount.set(aCount.get() + 1);
+                return true;
+            }
+        });
+        bByteString.forEachByte(new ByteProcessor() {
+            int i;
+            @Override
+            public boolean process(byte value) throws Exception {
+                assertEquals("failed at index: " + i, value, aByteString.byteAt(i++));
+                bCount.set(bCount.get() + 1);
+                return true;
+            }
+        });
+        assertEquals(aByteString.length(), aCount.get().intValue());
+        assertEquals(bByteString.length(), bCount.get().intValue());
+    }
+
+    @Test
+    public void forEachDescTest() throws Exception {
+        final AtomicReference<Integer> aCount = new AtomicReference<Integer>(0);
+        final AtomicReference<Integer> bCount = new AtomicReference<Integer>(0);
+        aByteString.forEachByteDesc(new ByteProcessor() {
+            int i = 1;
+            @Override
+            public boolean process(byte value) throws Exception {
+                assertEquals("failed at index: " + i, value, bByteString.byteAt(bByteString.length() - (i++)));
+                aCount.set(aCount.get() + 1);
+                return true;
+            }
+        });
+        bByteString.forEachByteDesc(new ByteProcessor() {
+            int i = 1;
+            @Override
+            public boolean process(byte value) throws Exception {
+                assertEquals("failed at index: " + i, value, aByteString.byteAt(aByteString.length() - (i++)));
+                bCount.set(bCount.get() + 1);
+                return true;
+            }
+        });
+        assertEquals(aByteString.length(), aCount.get().intValue());
+        assertEquals(bByteString.length(), bCount.get().intValue());
+    }
+
+    @Test
+    public void subSequenceTest() {
+        final int start = 12;
+        final int end = aByteString.length();
+        ByteString aSubSequence = aByteString.subSequence(start, end, false);
+        ByteString bSubSequence = bByteString.subSequence(start, end, true);
+        assertEquals(aSubSequence, bSubSequence);
+        assertEquals(aSubSequence.hashCode(), bSubSequence.hashCode());
+    }
+
+    @Test
+    public void copyTest() {
+        byte[] aCopy = new byte[aByteString.length()];
+        aByteString.copy(0, aCopy, 0, aCopy.length);
+        ByteString aByteStringCopy = new ByteString(aCopy, false);
+        assertEquals(aByteString, aByteStringCopy);
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/internal/PlatformDependentBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/internal/PlatformDependentBenchmark.java
@@ -18,6 +18,8 @@ package io.netty.microbench.internal;
 import io.netty.microbench.util.AbstractMicrobenchmark;
 import io.netty.util.internal.PlatformDependent;
 
+import java.util.Arrays;
+
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Level;
@@ -28,25 +30,21 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
 
-import java.util.Arrays;
-
 @Threads(1)
 @State(Scope.Benchmark)
 public class PlatformDependentBenchmark extends AbstractMicrobenchmark {
 
     @Param({ "10", "50", "100", "1000", "10000", "100000" })
-    private String size;
+    private int size;
     private byte[] bytes1;
     private byte[] bytes2;
 
     @Setup(Level.Trial)
     public void setup() {
-        int size = Integer.parseInt(this.size);
         bytes1 = new byte[size];
         bytes2 = new byte[size];
         for (int i = 0; i < size; i++) {
-            bytes1[i] = (byte) i;
-            bytes2[i] = (byte) i;
+            bytes1[i] = bytes2[i] = (byte) i;
         }
     }
 


### PR DESCRIPTION
Motivation:
The ByteString class currently assumes the underlying array will be a complete representation of data. This is limiting as it does not allow a subsection of another array to be used. The forces copy operations to take place to compensate for the lack of API support.

Modifications:
- add arrayOffset method to ByteString
- modify all ByteString and AsciiString methods that loop over or index into the underlying array to use this offset
- update all code that uses ByteString.array to ensure it accounts for the offset
- add unit tests to test the implementation respects the offset

Result:
ByteString and AsciiString can represent a sub region of a byte[].