### PR TITLE
Ensure backward-compability with 4.0

### DIFF
--- a/common/src/main/java/io/netty/util/ConstantPool.java
+++ b/common/src/main/java/io/netty/util/ConstantPool.java
@@ -113,4 +113,13 @@ public abstract class ConstantPool<T extends Constant<T>> {
     }
 
     protected abstract T newConstant(int id, String name);
+
+    @Deprecated
+    public final int nextId() {
+        synchronized (constants) {
+            int id = nextId;
+            nextId++;
+            return id;
+        }
+    }
 }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelOption.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelOption.java
@@ -18,7 +18,8 @@ package io.netty.channel.epoll;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.unix.DomainSocketReadMode;
 
-public final class EpollChannelOption {
+public final class EpollChannelOption<T> extends ChannelOption<T> {
+    @SuppressWarnings("rawtypes")
     private static final Class<EpollChannelOption> T = EpollChannelOption.class;
 
     public static final ChannelOption<Boolean> TCP_CORK = ChannelOption.valueOf(T, "TCP_CORK");
@@ -30,5 +31,9 @@ public final class EpollChannelOption {
             ChannelOption.valueOf(T, "DOMAIN_SOCKET_READ_MODE");
     public static final ChannelOption<EpollMode> EPOLL_MODE =
             ChannelOption.valueOf(T, "EPOLL_MODE");
-    private EpollChannelOption() { }
+
+    @SuppressWarnings({ "unused", "deprecation" })
+    private EpollChannelOption() {
+        super(null);
+    }
 }

--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannelOption.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannelOption.java
@@ -20,13 +20,12 @@ import io.netty.channel.rxtx.RxtxChannelConfig.Databits;
 import io.netty.channel.rxtx.RxtxChannelConfig.Paritybit;
 import io.netty.channel.rxtx.RxtxChannelConfig.Stopbits;
 
-import static io.netty.channel.ChannelOption.*;
-
 /**
  * Option for configuring a serial port connection
  */
-public final class RxtxChannelOption {
+public final class RxtxChannelOption<T> extends ChannelOption<T> {
 
+    @SuppressWarnings("rawtypes")
     private static final Class<RxtxChannelOption> T = RxtxChannelOption.class;
 
     public static final ChannelOption<Integer> BAUD_RATE = valueOf(T, "BAUD_RATE");
@@ -38,5 +37,8 @@ public final class RxtxChannelOption {
     public static final ChannelOption<Integer> WAIT_TIME = valueOf(T, "WAIT_TIME");
     public static final ChannelOption<Integer> READ_TIMEOUT = valueOf(T, "READ_TIMEOUT");
 
-    private RxtxChannelOption() { }
+    @SuppressWarnings({ "unused", "deprecation" })
+    private RxtxChannelOption() {
+        super(null);
+    }
 }

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpChannelOption.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpChannelOption.java
@@ -25,8 +25,9 @@ import static io.netty.channel.ChannelOption.*;
 /**
  * Option for configuring the SCTP transport
  */
-public final class SctpChannelOption {
+public final class SctpChannelOption<T> extends ChannelOption<T> {
 
+    @SuppressWarnings("rawtypes")
     private static final Class<SctpChannelOption> T = SctpChannelOption.class;
 
     public static final ChannelOption<Boolean> SCTP_DISABLE_FRAGMENTS = valueOf(T, "SCTP_DISABLE_FRAGMENTS");
@@ -39,5 +40,8 @@ public final class SctpChannelOption {
     public static final ChannelOption<SocketAddress> SCTP_SET_PEER_PRIMARY_ADDR =
             valueOf(T, "SCTP_SET_PEER_PRIMARY_ADDR");
 
-    private SctpChannelOption() { }
+    @SuppressWarnings({ "unused", "deprecation" })
+    private SctpChannelOption() {
+        super(null);
+    }
 }

--- a/transport-udt/src/main/java/io/netty/channel/udt/UdtChannelOption.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/UdtChannelOption.java
@@ -23,8 +23,9 @@ import static io.netty.channel.ChannelOption.*;
 /**
  * Options for the UDT transport
  */
-public final class UdtChannelOption {
+public final class UdtChannelOption<T> extends ChannelOption<T> {
 
+    @SuppressWarnings("rawtypes")
     private static final Class<UdtChannelOption> T = UdtChannelOption.class;
 
     /**
@@ -48,5 +49,8 @@ public final class UdtChannelOption {
      */
     public static final ChannelOption<Integer> SYSTEM_SEND_BUFFER_SIZE = valueOf(T, "SYSTEM_SEND_BUFFER_SIZE");
 
-    private UdtChannelOption() { }
+    @SuppressWarnings({ "unused", "deprecation" })
+    private UdtChannelOption() {
+        super(null);
+    }
 }

--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -30,9 +30,10 @@ import java.net.NetworkInterface;
  *
  * @param <T>   the type of the value which is valid for the {@link ChannelOption}
  */
-public final class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
+public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
 
     private static final ConstantPool<ChannelOption<Object>> pool = new ConstantPool<ChannelOption<Object>>() {
+        @SuppressWarnings("deprecation")
         @Override
         protected ChannelOption<Object> newConstant(int id, String name) {
             return new ChannelOption<Object>(id, name);
@@ -119,6 +120,11 @@ public final class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
      */
     private ChannelOption(int id, String name) {
         super(id, name);
+    }
+
+    @Deprecated
+    protected ChannelOption(String name) {
+        this(pool.nextId(), name);
     }
 
     /**


### PR DESCRIPTION
Motivation:

Each different *ChannelOption did extend ChannelOption in 4.0, which we changed in 4.1. This is a breaking change in terms of the API so we need to ensure we keep the old hierarchy.

Modifications:

- Let all *ChannelOption extend ChannelOption
- Add back constructor and mark it as @deprecated

Result:

No API breakage between 4.0 and 4.1