### PR TITLE
Allow to get version of available OpenSSL library

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -118,7 +118,29 @@ public final class OpenSsl {
      * <a href="https://tools.ietf.org/html/rfc7301">ALPN</a>.
      */
     public static boolean isAlpnSupported() {
-        return isAvailable() && SSL.version() >= 0x10002000L;
+        return version() >= 0x10002000L;
+    }
+
+    /**
+     * Returns the version of the used available OpenSSL library or {@code -1} if {@link #isAvailable()}
+     * returns {@code false}.
+     */
+    public static int version() {
+        if (isAvailable()) {
+            return SSL.version();
+        }
+        return -1;
+    }
+
+    /**
+     * Returns the version string of the used available OpenSSL library or {@code null} if {@link #isAvailable()}
+     * returns {@code false}.
+     */
+    public static String versionString() {
+        if (isAvailable()) {
+            return SSL.versionString();
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Motivation:

Sometimes it's useful to get informations about the available OpenSSL library that is used for the OpenSslEngine.

Modifications:

Add two new methods which allows to get the available OpenSSL version as either
an int or an String.

Result:

Easy to access details about OpenSSL version.