### PR TITLE
Fix handling of non-auto read for ByteToMessageDecoder and SslHandler

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -252,6 +252,17 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
 
     @Override
     public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        discardSomeReadBytes();
+        if (decodeWasNull) {
+            decodeWasNull = false;
+            if (!ctx.channel().config().isAutoRead()) {
+                ctx.read();
+            }
+        }
+        ctx.fireChannelReadComplete();
+    }
+
+    protected final void discardSomeReadBytes() {
         if (cumulation != null && !first && cumulation.refCnt() == 1) {
             // discard some bytes if possible to make more room in the
             // buffer but only if the refCnt == 1  as otherwise the user may have
@@ -262,13 +273,6 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
             // - https://github.com/netty/netty/issues/1764
             cumulation.discardSomeReadBytes();
         }
-        if (decodeWasNull) {
-            decodeWasNull = false;
-            if (!ctx.channel().config().isAutoRead()) {
-                ctx.read();
-            }
-        }
-        ctx.fireChannelReadComplete();
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -133,6 +133,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
     ByteBuf cumulation;
     private Cumulator cumulator = MERGE_CUMULATOR;
     private boolean singleDecode;
+    private boolean decodeWasNull;
     private boolean first;
 
     protected ByteToMessageDecoder() {
@@ -237,6 +238,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                     cumulation = null;
                 }
                 int size = out.size();
+                decodeWasNull = size == 0;
 
                 for (int i = 0; i < size; i ++) {
                     ctx.fireChannelRead(out.get(i));
@@ -259,6 +261,12 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
             // - https://github.com/netty/netty/issues/2327
             // - https://github.com/netty/netty/issues/1764
             cumulation.discardSomeReadBytes();
+        }
+        if (decodeWasNull) {
+            decodeWasNull = false;
+            if (!ctx.channel().config().isAutoRead()) {
+                ctx.read();
+            }
         }
         ctx.fireChannelReadComplete();
     }

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -200,11 +200,11 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
             ByteBuf bytes = buf.readBytes(readable);
             buf.release();
             ctx.fireChannelRead(bytes);
-            ctx.fireChannelReadComplete();
         } else {
             buf.release();
         }
         cumulation = null;
+        ctx.fireChannelReadComplete();
         handlerRemoved0(ctx);
     }
 

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -20,7 +20,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.Assert;
 import org.junit.Test;
@@ -28,7 +27,6 @@ import org.junit.Test;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class ByteToMessageDecoderTest {
 
@@ -161,62 +159,5 @@ public class ByteToMessageDecoderTest {
         Assert.assertEquals(2, (int) queue.take());
         Assert.assertEquals(3, (int) queue.take());
         Assert.assertTrue(queue.isEmpty());
-    }
-
-    // See https://github.com/netty/netty/pull/3263
-    @Test
-    public void testFireChannelReadCompleteOnlyWhenDecoded() {
-        final AtomicInteger readComplete = new AtomicInteger();
-        EmbeddedChannel ch = new EmbeddedChannel(new ByteToMessageDecoder() {
-            @Override
-            protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
-                // Do nothing
-            }
-        }, new ChannelInboundHandlerAdapter() {
-            @Override
-            public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-                readComplete.incrementAndGet();
-            }
-        });
-        Assert.assertFalse(ch.writeInbound(Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII)));
-        Assert.assertFalse(ch.finish());
-        Assert.assertEquals(0, readComplete.get());
-    }
-
-    // See https://github.com/netty/netty/pull/3263
-    @Test
-    public void testFireChannelReadCompleteWhenDecodeOnce() {
-        final AtomicInteger readComplete = new AtomicInteger();
-        EmbeddedChannel ch = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
-            @Override
-            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                ctx.fireChannelRead(msg);
-                ctx.fireChannelRead(Unpooled.EMPTY_BUFFER);
-            }
-        }, new ByteToMessageDecoder() {
-            private boolean first = true;
-            @Override
-            protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
-                if (first) {
-                    first = false;
-                    out.add(in.readSlice(in.readableBytes()).retain());
-                }
-            }
-        }, new ChannelInboundHandlerAdapter() {
-            @Override
-            public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-                readComplete.incrementAndGet();
-            }
-        });
-        Assert.assertTrue(ch.writeInbound(Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII)));
-        Assert.assertTrue(ch.finish());
-        Assert.assertEquals(1, readComplete.get());
-        for (;;) {
-            ByteBuf buf = (ByteBuf) ch.readInbound();
-            if (buf == null) {
-                break;
-            }
-            buf.release();
-        }
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
@@ -23,6 +23,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.EventExecutorGroup;
@@ -150,6 +151,8 @@ public class SocketEchoTest extends AbstractSocketTest {
             });
             cb.handler(ch);
         }
+        sb.childOption(ChannelOption.AUTO_READ, autoRead);
+        cb.option(ChannelOption.AUTO_READ, autoRead);
 
         Channel sc = sb.bind().sync().channel();
         Channel cc = cb.connect().sync().channel();
@@ -227,6 +230,9 @@ public class SocketEchoTest extends AbstractSocketTest {
         public void channelActive(ChannelHandlerContext ctx)
                 throws Exception {
             channel = ctx.channel();
+            if (!autoRead) {
+                ctx.read();
+            }
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
@@ -22,6 +22,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.FileRegion;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -84,6 +85,9 @@ public class SocketFileRegionTest extends AbstractSocketTest {
 
     private static void testFileRegion0(
             ServerBootstrap sb, Bootstrap cb, boolean voidPromise, final boolean autoRead) throws Throwable {
+        sb.childOption(ChannelOption.AUTO_READ, autoRead);
+        cb.option(ChannelOption.AUTO_READ, autoRead);
+
         final int bufferSize = 1024;
         final File file = File.createTempFile("netty-", ".tmp");
         file.deleteOnExit();
@@ -193,6 +197,9 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         public void channelActive(ChannelHandlerContext ctx)
                 throws Exception {
             channel = ctx.channel();
+            if (!autoRead) {
+                ctx.read();
+            }
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -22,6 +22,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.FixedLengthFrameDecoder;
 import org.junit.Test;
@@ -63,6 +64,7 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
         final EchoHandler sh = new EchoHandler(autoRead);
         final EchoHandler ch = new EchoHandler(autoRead);
 
+        sb.childOption(ChannelOption.AUTO_READ, autoRead);
         sb.childHandler(new ChannelInitializer<Channel>() {
             @Override
             public void initChannel(Channel sch) throws Exception {
@@ -71,6 +73,7 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
             }
         });
 
+        cb.option(ChannelOption.AUTO_READ, autoRead);
         cb.handler(new ChannelInitializer<Channel>() {
             @Override
             public void initChannel(Channel sch) throws Exception {
@@ -148,6 +151,9 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
             channel = ctx.channel();
+            if (!autoRead) {
+                ctx.read();
+            }
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -23,6 +23,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.testsuite.util.TestUtils;
 import io.netty.util.internal.StringUtil;
@@ -104,6 +105,9 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
 
     private void testGatheringWrite0(
             ServerBootstrap sb, Bootstrap cb, byte[] data, boolean composite, boolean autoRead) throws Throwable {
+        sb.childOption(ChannelOption.AUTO_READ, autoRead);
+        cb.option(ChannelOption.AUTO_READ, autoRead);
+
         final TestHandler sh = new TestHandler(autoRead);
         final TestHandler ch = new TestHandler(autoRead);
 
@@ -190,6 +194,9 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
         public void channelActive(ChannelHandlerContext ctx)
                 throws Exception {
             channel = ctx.channel();
+            if (!autoRead) {
+                ctx.read();
+            }
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketObjectEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketObjectEchoTest.java
@@ -21,6 +21,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.handler.codec.serialization.ClassResolvers;
 import io.netty.handler.codec.serialization.ObjectDecoder;
 import io.netty.handler.codec.serialization.ObjectEncoder;
@@ -68,6 +69,9 @@ public class SocketObjectEchoTest extends AbstractSocketTest {
     }
 
     private static void testObjectEcho(ServerBootstrap sb, Bootstrap cb, boolean autoRead) throws Throwable {
+        sb.childOption(ChannelOption.AUTO_READ, autoRead);
+        cb.option(ChannelOption.AUTO_READ, autoRead);
+
         final EchoHandler sh = new EchoHandler(autoRead);
         final EchoHandler ch = new EchoHandler(autoRead);
 
@@ -159,6 +163,9 @@ public class SocketObjectEchoTest extends AbstractSocketTest {
         public void channelActive(ChannelHandlerContext ctx)
                 throws Exception {
             channel = ctx.channel();
+            if (!autoRead) {
+                ctx.read();
+            }
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSpdyEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSpdyEchoTest.java
@@ -23,6 +23,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.spdy.SpdyFrameCodec;
@@ -176,6 +177,9 @@ public class SocketSpdyEchoTest extends AbstractSocketTest {
             throw new IllegalArgumentException("unknown version");
         }
 
+        sb.childOption(ChannelOption.AUTO_READ, autoRead);
+        cb.option(ChannelOption.AUTO_READ, autoRead);
+
         final SpdyEchoTestServerHandler sh = new SpdyEchoTestServerHandler(autoRead);
         final SpdyEchoTestClientHandler ch = new SpdyEchoTestClientHandler(frames.copy(), autoRead);
 
@@ -234,6 +238,13 @@ public class SocketSpdyEchoTest extends AbstractSocketTest {
         }
 
         @Override
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            if (!autoRead) {
+                ctx.read();
+            }
+        }
+
+        @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
             ctx.write(msg);
         }
@@ -266,6 +277,12 @@ public class SocketSpdyEchoTest extends AbstractSocketTest {
         SpdyEchoTestClientHandler(ByteBuf frames, boolean autoRead) {
             this.frames = frames;
             this.autoRead = autoRead;
+        }
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            if (!autoRead) {
+                ctx.read();
+            }
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.ssl.JdkSslClientContext;
 import io.netty.handler.ssl.JdkSslServerContext;
@@ -221,6 +222,9 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         final ExecutorService delegatedTaskExecutor = Executors.newCachedThreadPool();
         reset();
 
+        sb.childOption(ChannelOption.AUTO_READ, autoRead);
+        cb.option(ChannelOption.AUTO_READ, autoRead);
+
         sb.childHandler(new ChannelInitializer<Channel>() {
             @Override
             @SuppressWarnings("deprecation")
@@ -417,6 +421,13 @@ public class SocketSslEchoTest extends AbstractSocketTest {
             this.recvCounter = recvCounter;
             this.negoCounter = negoCounter;
             this.exception = exception;
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            if (!autoRead) {
+                ctx.read();
+            }
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStartTlsTest.java
@@ -21,6 +21,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.LineBasedFrameDecoder;
@@ -142,6 +143,9 @@ public class SocketStartTlsTest extends AbstractSocketTest {
     }
 
     private void testStartTls(ServerBootstrap sb, Bootstrap cb, boolean autoRead) throws Throwable {
+        sb.childOption(ChannelOption.AUTO_READ, autoRead);
+        cb.option(ChannelOption.AUTO_READ, autoRead);
+
         final EventExecutorGroup executor = SocketStartTlsTest.executor;
         SSLEngine sse = serverCtx.newEngine(PooledByteBufAllocator.DEFAULT);
         SSLEngine cse = clientCtx.newEngine(PooledByteBufAllocator.DEFAULT);
@@ -235,6 +239,9 @@ public class SocketStartTlsTest extends AbstractSocketTest {
         @Override
         public void channelActive(ChannelHandlerContext ctx)
                 throws Exception {
+            if (!autoRead) {
+                ctx.read();
+            }
             ctx.writeAndFlush("StartTlsRequest\n");
         }
 
@@ -287,6 +294,9 @@ public class SocketStartTlsTest extends AbstractSocketTest {
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
             channel = ctx.channel();
+            if (!autoRead) {
+                ctx.read();
+            }
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStringEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStringEchoTest.java
@@ -20,6 +20,7 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.DelimiterBasedFrameDecoder;
 import io.netty.handler.codec.Delimiters;
@@ -70,6 +71,9 @@ public class SocketStringEchoTest extends AbstractSocketTest {
     }
 
     private static void testStringEcho(ServerBootstrap sb, Bootstrap cb, boolean autoRead) throws Throwable {
+        sb.childOption(ChannelOption.AUTO_READ, autoRead);
+        cb.option(ChannelOption.AUTO_READ, autoRead);
+
         final StringEchoHandler sh = new StringEchoHandler(autoRead);
         final StringEchoHandler ch = new StringEchoHandler(autoRead);
 
@@ -160,6 +164,9 @@ public class SocketStringEchoTest extends AbstractSocketTest {
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
             channel = ctx.channel();
+            if (!autoRead) {
+                ctx.read();
+            }
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -41,21 +41,12 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
     private final String name;
 
     /**
-     * Set when the {@link ChannelInboundHandler#channelRead(ChannelHandlerContext, Object)} of
-     * this context's handler is invoked.
-     * Cleared when a user calls {@link #fireChannelReadComplete()} on this context.
-     *
-     * See {@link #fireChannelReadComplete()} to understand how this flag is used.
-     */
-    boolean invokedThisChannelRead;
-
-    /**
      * Set when a user calls {@link #fireChannelRead(Object)} on this context.
      * Cleared when a user calls {@link #fireChannelReadComplete()} on this context.
      *
      * See {@link #fireChannelReadComplete()} to understand how this flag is used.
      */
-    private volatile boolean invokedNextChannelRead;
+    private volatile boolean firedChannelRead;
 
     /**
      * Set when a user calls {@link #read()} on this context.
@@ -63,7 +54,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
      *
      * See {@link #fireChannelReadComplete()} to understand how this flag is used.
      */
-    private volatile boolean invokedPrevRead;
+    private volatile boolean invokedRead;
 
     /**
      * {@code true} if and only if this context has been removed from the pipeline.
@@ -317,7 +308,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
             throw new NullPointerException("msg");
         }
 
-        invokedNextChannelRead = true;
+        firedChannelRead = true;
         final AbstractChannelHandlerContext next = findContextInbound();
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
@@ -334,7 +325,6 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
     }
 
     private void invokeChannelRead(Object msg) {
-        invokedThisChannelRead = true;
         try {
             ((ChannelInboundHandler) handler()).channelRead(this, msg);
         } catch (Throwable t) {
@@ -350,15 +340,11 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
          *
          * This is pretty common for the handlers that transform multiple messages into one message,
          * such as byte-to-message decoder and message aggregators.
-         *
-         * Only one exception is when nobody invoked the channelRead() method of this context's handler.
-         * It means the handler has been added later dynamically.
          */
-        if (invokedNextChannelRead ||  // The handler of this context produced a message, or
-            !invokedThisChannelRead) { // it is not required to produce a message to trigger the event.
-
-            invokedNextChannelRead = false;
-            invokedPrevRead = false;
+        if (firedChannelRead) {
+            // The handler of this context produced a message, so we are OK to trigger this event.
+            firedChannelRead = false;
+            invokedRead = false;
 
             final AbstractChannelHandlerContext next = findContextInbound();
             EventExecutor executor = next.executor();
@@ -390,7 +376,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
          * Why? Because otherwise the next handler will not receive {@code channelRead()} nor
          * {@code channelReadComplete()} event at all for the {@link #read()} operation it issued.
          */
-        if (invokedPrevRead && !channel().config().isAutoRead()) {
+        if (invokedRead && !channel().config().isAutoRead()) {
             /**
              * The next (or upstream) handler invoked {@link #read()}, but it didn't get any
              * {@code channelRead()} event. We should read once more, so that the handler of the current
@@ -398,7 +384,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
              */
             read();
         } else {
-            invokedPrevRead = false;
+            invokedRead = false;
         }
 
         return this;
@@ -651,7 +637,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
 
     @Override
     public ChannelHandlerContext read() {
-        invokedPrevRead = true;
+        invokedRead = true;
         final AbstractChannelHandlerContext next = findContextOutbound();
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -40,12 +40,6 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
     private final DefaultChannelPipeline pipeline;
     private final String name;
     private boolean removed;
-    // This does not need to be volatile as we always check and set this flag from EventExecutor thread. This means
-    // that at worse we will submit a task for channelReadComplete() that may do nothing if nextChannelReadInvoked
-    // is false. This is prefered to introduce another volatile flag because often fireChannelRead(...) and
-    // fireChannelReadComplete() are triggered from the EventExecutor thread anyway.
-    private boolean nextChannelReadInvoked;
-    private boolean readInvoked;
 
     // Will be set to null if no child executor should be used, otherwise it will be set to the
     // child executor.
@@ -297,12 +291,12 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
         final AbstractChannelHandlerContext next = findContextInbound();
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
-            invokeNextChannelRead(next, msg);
+            next.invokeChannelRead(msg);
         } else {
             executor.execute(new OneTimeTask() {
                 @Override
                 public void run() {
-                    invokeNextChannelRead(next, msg);
+                    next.invokeChannelRead(msg);
                 }
             });
         }
@@ -317,24 +311,19 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
         }
     }
 
-    private void invokeNextChannelRead(AbstractChannelHandlerContext next, Object msg) {
-        nextChannelReadInvoked = true;
-        next.invokeChannelRead(msg);
-    }
-
     @Override
     public ChannelHandlerContext fireChannelReadComplete() {
         final AbstractChannelHandlerContext next = findContextInbound();
         EventExecutor executor = next.executor();
         if (executor.inEventLoop()) {
-            invokeNextChannelReadComplete(next);
+            next.invokeChannelReadComplete();
         } else {
             Runnable task = next.invokeChannelReadCompleteTask;
             if (task == null) {
                 next.invokeChannelReadCompleteTask = task = new Runnable() {
                     @Override
                     public void run() {
-                        invokeNextChannelReadComplete(next);
+                        next.invokeChannelReadComplete();
                     }
                 };
             }
@@ -348,24 +337,6 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
             ((ChannelInboundHandler) handler()).channelReadComplete(this);
         } catch (Throwable t) {
             notifyHandlerException(t);
-        }
-    }
-
-    private void invokeNextChannelReadComplete(AbstractChannelHandlerContext next) {
-        if (nextChannelReadInvoked) {
-            nextChannelReadInvoked = false;
-            readInvoked = false;
-
-            next.invokeChannelReadComplete();
-        } else if (readInvoked && !channel().config().isAutoRead()) {
-            // As this context not belongs to the last handler in the pipeline and autoRead is false we need to
-            // trigger read again as otherwise we may stop reading before a full message was passed on to the
-            // pipeline. This is especially true for all kind of decoders that usually buffer bytes/messages until
-            // they are able to compose a full message that is passed via fireChannelRead(...) and so be consumed
-            // be the rest of the handlers in the pipeline.
-            read();
-        } else {
-            readInvoked = false;
         }
     }
 
@@ -630,7 +601,6 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
 
     private void invokeRead() {
         try {
-            readInvoked = true;
             ((ChannelOutboundHandler) handler()).read(this);
         } catch (Throwable t) {
             notifyHandlerException(t);

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -67,7 +67,7 @@ final class DefaultChannelPipeline implements ChannelPipeline {
     final Map<EventExecutorGroup, EventExecutor> childExecutors =
             new IdentityHashMap<EventExecutorGroup, EventExecutor>();
 
-    DefaultChannelPipeline(AbstractChannel channel) {
+    public DefaultChannelPipeline(AbstractChannel channel) {
         if (channel == null) {
             throw new NullPointerException("channel");
         }
@@ -469,7 +469,7 @@ final class DefaultChannelPipeline implements ChannelPipeline {
         }
     }
 
-    private void callHandlerAdded(final AbstractChannelHandlerContext ctx) {
+    private void callHandlerAdded(final ChannelHandlerContext ctx) {
         if (ctx.channel().isRegistered() && !ctx.executor().inEventLoop()) {
             ctx.executor().execute(new Runnable() {
                 @Override
@@ -482,14 +482,13 @@ final class DefaultChannelPipeline implements ChannelPipeline {
         callHandlerAdded0(ctx);
     }
 
-    private void callHandlerAdded0(final AbstractChannelHandlerContext ctx) {
+    private void callHandlerAdded0(final ChannelHandlerContext ctx) {
         try {
-            ctx.invokedThisChannelRead = false;
             ctx.handler().handlerAdded(ctx);
         } catch (Throwable t) {
             boolean removed = false;
             try {
-                remove(ctx);
+                remove((AbstractChannelHandlerContext) ctx);
                 removed = true;
             } catch (Throwable t2) {
                 if (logger.isWarnEnabled()) {
@@ -1030,7 +1029,7 @@ final class DefaultChannelPipeline implements ChannelPipeline {
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             logger.warn(
                     "An exceptionCaught() event was fired, and it reached at the tail of the pipeline. " +
-                    "It usually means the last handler in the pipeline did not handle the exception.", cause);
+                            "It usually means the last handler in the pipeline did not handle the exception.", cause);
         }
 
         @Override
@@ -1052,7 +1051,7 @@ final class DefaultChannelPipeline implements ChannelPipeline {
 
         private static final String HEAD_NAME = generateName0(HeadContext.class);
 
-        final Unsafe unsafe;
+        protected final Unsafe unsafe;
 
         HeadContext(DefaultChannelPipeline pipeline) {
             super(pipeline, null, HEAD_NAME, false, true);

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -621,44 +621,6 @@ public class DefaultChannelPipelineTest {
         }
     }
 
-    /**
-     * {@link ChannelInboundHandler#channelReadComplete(ChannelHandlerContext)} should not be suppressed
-     * when a handler has just been added and thus had no chance to get the previous
-     * {@link ChannelInboundHandler#channelRead(ChannelHandlerContext, Object)}.
-     */
-    @Test
-    public void testProhibitChannelReadCompleteSuppression() throws Exception {
-        final AtomicInteger readComplete = new AtomicInteger();
-
-        EmbeddedChannel ch = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
-            @Override
-            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                ctx.fireChannelRead(msg);
-
-                // Add a new handler *after* channelRead() is triggered, so that
-                // the new handler does not handle channelRead() at all.
-                ctx.pipeline().addAfter(ctx.name(), "newHandler", new ChannelInboundHandlerAdapter() {
-                    @Override
-                    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-                        readComplete.incrementAndGet();
-                    }
-                });
-            }
-
-            @Override
-            public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-                ctx.fireChannelReadComplete();
-            }
-        });
-
-        ChannelPipeline p = ch.pipeline();
-        p.fireChannelRead(Boolean.TRUE);
-        p.fireChannelReadComplete();
-        ch.finish();
-
-        assertEquals(1, readComplete.get());
-    }
-
     @Test
     public void testChannelReadTriggered() {
         final AtomicInteger read1 = new AtomicInteger();

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -21,7 +21,6 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler.Sharable;
-import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalEventLoopGroup;
@@ -29,8 +28,6 @@ import io.netty.channel.local.LocalServerChannel;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
-import io.netty.util.concurrent.DefaultEventExecutorGroup;
-import io.netty.util.concurrent.EventExecutorGroup;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
@@ -42,7 +39,6 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.*;
@@ -537,249 +533,6 @@ public class DefaultChannelPipelineTest {
     public void testLastHandlerEmptyPipeline() throws Exception {
         ChannelPipeline pipeline = new LocalChannel().pipeline();
         assertNull(pipeline.last());
-    }
-
-    @Test
-    public void testSurpressChannelReadComplete() throws Exception {
-        testSurpressChannelReadComplete0(false);
-    }
-
-    @Test
-    public void testSurpressChannelReadCompleteDifferentExecutors() throws Exception {
-        testSurpressChannelReadComplete0(true);
-    }
-
-    // See:
-    //  https://github.com/netty/netty/pull/3263
-    //  https://github.com/netty/netty/pull/3272
-    private static void testSurpressChannelReadComplete0(boolean executors) throws Exception {
-        final AtomicInteger read1 = new AtomicInteger();
-        final AtomicInteger read2 = new AtomicInteger();
-        final AtomicInteger readComplete1 = new AtomicInteger();
-        final AtomicInteger readComplete2 = new AtomicInteger();
-
-        final CountDownLatch latch = new CountDownLatch(1);
-
-        final EventExecutorGroup group = executors ? new DefaultEventExecutorGroup(2) : null;
-
-        EmbeddedChannel ch = new EmbeddedChannel(new ChannelInitializer<Channel>() {
-            @Override
-            protected void initChannel(Channel ch) throws Exception {
-                ch.pipeline().addLast(group, new ChannelInboundHandlerAdapter() {
-                    @Override
-                    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                        if (read1.incrementAndGet() == 1) {
-                            return;
-                        }
-                        ctx.fireChannelRead(msg);
-                    }
-
-                    @Override
-                    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-                        readComplete1.incrementAndGet();
-                        ctx.fireChannelReadComplete();
-                    }
-                });
-                ch.pipeline().addLast(group, new ChannelInboundHandlerAdapter() {
-                    @Override
-                    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                        read2.incrementAndGet();
-                        ctx.fireChannelRead(msg);
-                    }
-
-                    @Override
-                    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-                        readComplete2.incrementAndGet();
-                        ctx.fireChannelReadComplete();
-                    }
-
-                    @Override
-                    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-                        latch.countDown();
-                    }
-                });
-            }
-        });
-
-        ch.writeInbound(1);
-        ch.writeInbound(2);
-        ch.writeInbound(3);
-        ch.finish();
-        latch.await();
-        assertEquals(3, read1.get());
-        assertEquals(3, readComplete1.get());
-
-        assertEquals(2, read2.get());
-        assertEquals(2, readComplete2.get());
-
-        assertEquals(2, ch.readInbound());
-        assertEquals(3, ch.readInbound());
-        assertNull(ch.readInbound());
-
-        if (group != null) {
-            group.shutdownGracefully();
-        }
-    }
-
-    @Test
-    public void testChannelReadTriggered() {
-        final AtomicInteger read1 = new AtomicInteger();
-        final AtomicInteger channelRead1 = new AtomicInteger();
-        final AtomicInteger channelReadComplete1 = new AtomicInteger();
-        final AtomicInteger read2 = new AtomicInteger();
-        final AtomicInteger channelRead2 = new AtomicInteger();
-        final AtomicInteger channelReadComplete2 = new AtomicInteger();
-        final AtomicInteger read3 = new AtomicInteger();
-        final AtomicInteger channelRead3 = new AtomicInteger();
-        final AtomicInteger channelReadComplete3 = new AtomicInteger();
-
-        EmbeddedChannel ch = new EmbeddedChannel(new ChannelDuplexHandler() {
-            @Override
-            public void read(ChannelHandlerContext ctx) throws Exception {
-                read1.incrementAndGet();
-                ctx.read();
-            }
-
-            @Override
-            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                channelRead1.incrementAndGet();
-                ctx.fireChannelRead(msg);
-            }
-
-            @Override
-            public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-                channelReadComplete1.incrementAndGet();
-                ctx.fireChannelReadComplete();
-            }
-        }, new ChannelDuplexHandler() {
-            @Override
-            public void read(ChannelHandlerContext ctx) throws Exception {
-                read2.incrementAndGet();
-                ctx.read();
-            }
-
-            @Override
-            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                // Consume
-                channelRead2.incrementAndGet();
-            }
-
-            @Override
-            public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-                channelReadComplete2.incrementAndGet();
-                ctx.fireChannelReadComplete();
-            }
-        }, new ChannelDuplexHandler() {
-            @Override
-            public void read(ChannelHandlerContext ctx) throws Exception {
-                read3.incrementAndGet();
-                ctx.read();
-            }
-
-            @Override
-            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                channelRead3.incrementAndGet();
-                ctx.fireChannelRead(msg);
-            }
-
-            @Override
-            public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-                channelReadComplete3.incrementAndGet();
-                ctx.fireChannelReadComplete();
-            }
-        });
-
-        ch.config().setAutoRead(false);
-
-        ch.writeInbound(1);
-        ch.writeInbound(2);
-        ch.writeInbound(3);
-        ch.finish();
-        assertEquals(4, read1.get());
-        assertEquals(3, channelRead1.get());
-        assertEquals(3, channelReadComplete1.get());
-
-        assertEquals(1, read2.get());
-        assertEquals(3, channelRead2.get());
-        assertEquals(3, channelReadComplete1.get());
-
-        assertEquals(1, read3.get());
-        assertEquals(0, channelRead3.get());
-        assertEquals(0, channelReadComplete3.get());
-
-        assertNull(ch.readInbound());
-    }
-
-    @Test
-    public void testChannelReadNotTriggeredWhenLast() throws Exception {
-        final AtomicInteger read1 = new AtomicInteger();
-        final AtomicInteger channelRead1 = new AtomicInteger();
-        final AtomicInteger channelReadComplete1 = new AtomicInteger();
-        final AtomicInteger read2 = new AtomicInteger();
-        final AtomicInteger channelRead2 = new AtomicInteger();
-        final AtomicInteger channelReadComplete2 = new AtomicInteger();
-
-        EmbeddedChannel ch = new EmbeddedChannel(new ChannelInboundHandlerAdapter());
-
-        // Ensure pipeline is really empty
-        ChannelPipeline pipeline = ch.pipeline();
-        while (pipeline.first() != null) {
-            pipeline.removeFirst();
-        }
-
-        pipeline.addLast(new ChannelDuplexHandler() {
-            @Override
-            public void read(ChannelHandlerContext ctx) throws Exception {
-                read1.incrementAndGet();
-                ctx.read();
-            }
-
-            @Override
-            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                channelRead1.incrementAndGet();
-                ctx.fireChannelRead(msg);
-            }
-
-            @Override
-            public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-                channelReadComplete1.incrementAndGet();
-                ctx.fireChannelReadComplete();
-            }
-        }, new ChannelDuplexHandler() {
-            @Override
-            public void read(ChannelHandlerContext ctx) throws Exception {
-                read2.incrementAndGet();
-                ctx.read();
-            }
-
-            @Override
-            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                // Consume
-                channelRead2.incrementAndGet();
-            }
-
-            @Override
-            public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-                channelReadComplete2.incrementAndGet();
-                ctx.fireChannelReadComplete();
-            }
-        });
-
-        ch.config().setAutoRead(false);
-
-        ch.writeInbound(1);
-        ch.writeInbound(2);
-        ch.writeInbound(3);
-        ch.finish();
-        assertEquals(0, read1.get());
-        assertEquals(3, channelRead1.get());
-        assertEquals(3, channelReadComplete1.get());
-
-        assertEquals(0, read2.get());
-        assertEquals(3, channelRead2.get());
-        assertEquals(3, channelReadComplete1.get());
-
-        assertNull(ch.readInbound());
     }
 
     private static int next(AbstractChannelHandlerContext ctx) {

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -540,19 +540,19 @@ public class DefaultChannelPipelineTest {
     }
 
     @Test
-    public void testSupressChannelReadComplete() throws Exception {
-        testSupressChannelReadComplete0(false);
+    public void testSurpressChannelReadComplete() throws Exception {
+        testSurpressChannelReadComplete0(false);
     }
 
     @Test
-    public void testSupressChannelReadCompleteDifferentExecutors() throws Exception {
-        testSupressChannelReadComplete0(true);
+    public void testSurpressChannelReadCompleteDifferentExecutors() throws Exception {
+        testSurpressChannelReadComplete0(true);
     }
 
     // See:
     //  https://github.com/netty/netty/pull/3263
     //  https://github.com/netty/netty/pull/3272
-    private static void testSupressChannelReadComplete0(boolean executors) throws Exception {
+    private static void testSurpressChannelReadComplete0(boolean executors) throws Exception {
         final AtomicInteger read1 = new AtomicInteger();
         final AtomicInteger read2 = new AtomicInteger();
         final AtomicInteger readComplete1 = new AtomicInteger();


### PR DESCRIPTION
Motivation:

Our automatically handling of non-auto-read failed because it not detected the need of calling read again by itself if nothing was decoded. Beside this handling of non-auto-read never worked for SslHandler as it always triggered a read even if it decoded a message and auto-read was false.

This fixes [#3529] and [#3587].

Modifications:

- Implement handling of calling read when nothing was decoded (with non-auto-read) to ByteToMessageDecoder again
- Correctly respect non-auto-read by SslHandler

Result:

No more stales and correctly respecting of non-auto-read by SslHandler.