### PR TITLE
Get uploaded size while upload is in progress 3.10

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/AbstractHttpData.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/AbstractHttpData.java
@@ -87,4 +87,8 @@ public abstract class AbstractHttpData implements HttpData {
     public long length() {
         return size;
     }
+
+    public long definedLength() {
+        return definedSize;
+    }
 }

--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/DefaultHttpDataFactory.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/DefaultHttpDataFactory.java
@@ -120,6 +120,26 @@ public class DefaultHttpDataFactory implements HttpDataFactory {
         return attribute;
     }
 
+    public Attribute createAttribute(HttpRequest request, String name, long definedSize) {
+        if (useDisk) {
+            Attribute attribute = new DiskAttribute(name, definedSize);
+            attribute.setMaxSize(maxSize);
+            List<HttpData> fileToDelete = getList(request);
+            fileToDelete.add(attribute);
+            return attribute;
+        }
+        if (checkSize) {
+            Attribute attribute = new MixedAttribute(name, definedSize, minSize);
+            attribute.setMaxSize(maxSize);
+            List<HttpData> fileToDelete = getList(request);
+            fileToDelete.add(attribute);
+            return attribute;
+        }
+        MemoryAttribute attribute = new MemoryAttribute(name, definedSize);
+        attribute.setMaxSize(maxSize);
+        return attribute;
+    }
+
     /**
      * Utility method
      * @param data

--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/DiskAttribute.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/DiskAttribute.java
@@ -39,6 +39,11 @@ public class DiskAttribute extends AbstractDiskHttpData implements Attribute {
     public DiskAttribute(String name) {
         super(name, HttpConstants.DEFAULT_CHARSET, 0);
     }
+
+    public DiskAttribute(String name, long size) {
+        super(name, HttpConstants.DEFAULT_CHARSET, size);
+    }
+
     public DiskAttribute(String name, String value) throws IOException {
         super(name, HttpConstants.DEFAULT_CHARSET, 0); // Attribute have no default size
         setValue(value);

--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpData.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpData.java
@@ -95,6 +95,22 @@ public interface HttpData extends InterfaceHttpData {
     long length();
 
     /**
+     * Returns the defined length of the HttpData.
+     *
+     * If no Content-Length is provided in the request, the defined length is
+     * always 0 (whatever during decoding or in final state).
+     *
+     * If Content-Length is provided in the request, this is this given defined
+     * length. This value does not change, whatever during decoding or in the final state.
+     *
+     * This method could be used for instance to know the amount of bytes to be transmitted
+     * for one particular HttpData, for example one {@link FileUpload} or any known big {@link Attribute}.
+     *
+     * @return the defined length of the HttpData
+     */
+    long definedLength();
+
+    /**
      * Deletes the underlying storage for a file item, including deleting any
      * associated temporary disk file.
      */

--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpDataFactory.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpDataFactory.java
@@ -46,6 +46,14 @@ public interface HttpDataFactory {
 
     /**
      * @param request associated request
+     * @param name name of the attribute
+     * @param definedSize defined size from request for this attribute
+     * @return a new Attribute
+     */
+    Attribute createAttribute(HttpRequest request, String name, long definedSize);
+
+    /**
+     * @param request associated request
      * @param size the size of the Uploaded file
      * @return a new FileUpload
      */

--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -249,6 +249,14 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
         return null;
     }
 
+    public InterfaceHttpData currentPartialHttpData() {
+        if (currentFileUpload != null) {
+            return currentFileUpload;
+        } else {
+            return currentAttribute;
+        }
+    }
+
     /**
      * This method will parse as much as possible data and fill the list and map
      * @throws ErrorDataDecoderException if there is a problem with the charset decoding or
@@ -359,9 +367,25 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
             Attribute nameAttribute = currentFieldAttributes
                 .get(HttpPostBodyUtil.NAME);
             if (currentAttribute == null) {
+                Attribute lengthAttribute = currentFieldAttributes
+                        .get(HttpHeaders.Names.CONTENT_LENGTH);
+                long size;
                 try {
-                    currentAttribute = factory.createAttribute(request,
-                            cleanString(nameAttribute.getValue()));
+                    size = lengthAttribute != null? Long.parseLong(lengthAttribute
+                            .getValue()) : 0L;
+                } catch (IOException e) {
+                    throw new ErrorDataDecoderException(e);
+                } catch (NumberFormatException e) {
+                    size = 0;
+                }
+                try {
+                    if (size > 0) {
+                        currentAttribute = factory.createAttribute(request,
+                                cleanString(nameAttribute.getValue()), size);
+                    } else {
+                        currentAttribute = factory.createAttribute(request,
+                                cleanString(nameAttribute.getValue()));
+                    }
                 } catch (NullPointerException e) {
                     throw new ErrorDataDecoderException(e);
                 } catch (IllegalArgumentException e) {

--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestDecoder.java
@@ -279,6 +279,10 @@ public class HttpPostRequestDecoder implements InterfaceHttpPostRequestDecoder {
         return decoder.next();
     }
 
+    public InterfaceHttpData currentPartialHttpData() {
+        return decoder.currentPartialHttpData();
+    }
+
     /**
      * Clean all HttpDatas (on Disk) for the current request.
      */

--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -469,6 +469,9 @@ public class HttpPostRequestEncoder implements ChunkedInput {
             internal.addValue(HttpPostBodyUtil.CONTENT_DISPOSITION + ": " +
                     HttpPostBodyUtil.FORM_DATA + "; " +
                     HttpPostBodyUtil.NAME + "=\"" + attribute.getName() + "\"\r\n");
+            // Add Content-Length: xxx
+            internal.addValue(HttpHeaders.Names.CONTENT_LENGTH + ": " +
+                    attribute.length() + "\r\n");
             Charset localcharset = attribute.getCharset();
             if (localcharset != null) {
                 // Content-Type: charset=charset
@@ -615,6 +618,9 @@ public class HttpPostRequestEncoder implements ChunkedInput {
                         fileUpload.getFilename() +
                         "\"\r\n");
             }
+            // Add Content-Length: xxx
+            internal.addValue(HttpHeaders.Names.CONTENT_LENGTH + ": " +
+                    fileUpload.length() + "\r\n");
             // Content-Type: image/gif
             // Content-Type: text/plain; charset=ISO-8859-1
             // Content-Transfer-Encoding: binary

--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -225,6 +225,10 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
         parseBodyAttributes();
     }
 
+    public InterfaceHttpData currentPartialHttpData() {
+        return currentAttribute;
+    }
+
     /**
      * Utility function to add a new decoded data
      */

--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/InterfaceHttpPostRequestDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/InterfaceHttpPostRequestDecoder.java
@@ -93,6 +93,16 @@ public interface InterfaceHttpPostRequestDecoder {
     InterfaceHttpData next() throws EndOfDataDecoderException;
 
     /**
+     * Returns the current InterfaceHttpData if currently in decoding status,
+     * meaning all data are not yet within, or null if there is no InterfaceHttpData
+     * currently in decoding status (either because none yet decoded or none currently partially
+     * decoded). Full decoded ones are accessible through hasNext() and next() methods.
+     *
+     * @return the current InterfaceHttpData if currently in decoding status or null if none.
+     */
+    InterfaceHttpData currentPartialHttpData();
+
+    /**
      * Clean all HttpDatas (on Disk) for the current request.
      */
     void cleanFiles();

--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/MemoryAttribute.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/MemoryAttribute.java
@@ -30,6 +30,10 @@ public class MemoryAttribute extends AbstractMemoryHttpData implements Attribute
         super(name, HttpConstants.DEFAULT_CHARSET, 0);
     }
 
+    public MemoryAttribute(String name, long size) {
+        super(name, HttpConstants.DEFAULT_CHARSET, size);
+    }
+
     public MemoryAttribute(String name, String value) throws IOException {
         super(name, HttpConstants.DEFAULT_CHARSET, 0); // Attribute have no default size
         setValue(value);

--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/MixedAttribute.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/MixedAttribute.java
@@ -36,6 +36,11 @@ public class MixedAttribute implements Attribute {
         attribute = new MemoryAttribute(name);
     }
 
+    public MixedAttribute(String name, long size, long limitSize) {
+        this.limitSize = limitSize;
+        attribute = new MemoryAttribute(name, size);
+    }
+
     public MixedAttribute(String name, String value, long limitSize) {
         this.limitSize = limitSize;
         if (value.length() > this.limitSize) {
@@ -74,7 +79,7 @@ public class MixedAttribute implements Attribute {
             checkSize(attribute.length() + buffer.readableBytes());
             if (attribute.length() + buffer.readableBytes() > limitSize) {
                 DiskAttribute diskAttribute = new DiskAttribute(attribute
-                        .getName());
+                        .getName(), attribute.definedLength());
                 diskAttribute.setMaxSize(maxSize);
                 if (((MemoryAttribute) attribute).getChannelBuffer() != null) {
                     diskAttribute.addContent(((MemoryAttribute) attribute)
@@ -122,6 +127,10 @@ public class MixedAttribute implements Attribute {
         return attribute.length();
     }
 
+    public long definedLength() {
+        return attribute.definedLength();
+    }
+
     public boolean renameTo(File dest) throws IOException {
         return attribute.renameTo(dest);
     }
@@ -135,7 +144,7 @@ public class MixedAttribute implements Attribute {
         if (buffer.readableBytes() > limitSize) {
             if (attribute instanceof MemoryAttribute) {
                 // change to Disk
-                attribute = new DiskAttribute(attribute.getName());
+                attribute = new DiskAttribute(attribute.getName(), attribute.definedLength());
                 attribute.setMaxSize(maxSize);
             }
         }
@@ -147,7 +156,7 @@ public class MixedAttribute implements Attribute {
         if (file.length() > limitSize) {
             if (attribute instanceof MemoryAttribute) {
                 // change to Disk
-                attribute = new DiskAttribute(attribute.getName());
+                attribute = new DiskAttribute(attribute.getName(), attribute.definedLength());
                 attribute.setMaxSize(maxSize);
             }
         }
@@ -157,7 +166,7 @@ public class MixedAttribute implements Attribute {
     public void setContent(InputStream inputStream) throws IOException {
         if (attribute instanceof MemoryAttribute) {
             // change to Disk even if we don't know the size
-            attribute = new DiskAttribute(attribute.getName());
+            attribute = new DiskAttribute(attribute.getName(), attribute.definedLength());
             attribute.setMaxSize(maxSize);
         }
         attribute.setContent(inputStream);

--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/MixedFileUpload.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/MixedFileUpload.java
@@ -127,6 +127,10 @@ public class MixedFileUpload implements FileUpload {
         return fileUpload.length();
     }
 
+    public long definedLength() {
+        return fileUpload.definedLength();
+    }
+
     public boolean renameTo(File dest) throws IOException {
         return fileUpload.renameTo(dest);
     }

--- a/src/test/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
+++ b/src/test/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
@@ -47,12 +47,14 @@ public class HttpPostRequestEncoderTest {
 
         String expected = "--" + multipartDataBoundary + "\r\n" +
                 "Content-Disposition: form-data; name=\"foo\"" + "\r\n" +
+                "Content-Length: 3" + "\r\n" +
                 "Content-Type: text/plain; charset=UTF-8" + "\r\n" +
                 "\r\n" +
                 "bar" +
                 "\r\n" +
                 "--" + multipartDataBoundary + "\r\n" +
                 "Content-Disposition: form-data; name=\"quux\"; filename=\"file-01.txt\"" + "\r\n" +
+                "Content-Length: " + file1.length() + "\r\n" +
                 "Content-Type: text/plain" + "\r\n" +
                 "Content-Transfer-Encoding: binary" + "\r\n" +
                 "\r\n" +
@@ -83,6 +85,7 @@ public class HttpPostRequestEncoderTest {
 
         String expected = "--" + multipartDataBoundary + "\r\n" +
                 "Content-Disposition: form-data; name=\"foo\"" + "\r\n" +
+                "Content-Length: 3" + "\r\n" +
                 "Content-Type: text/plain; charset=UTF-8" + "\r\n" +
                 "\r\n" +
                 "bar" + "\r\n" +
@@ -92,6 +95,7 @@ public class HttpPostRequestEncoderTest {
                 "\r\n" +
                 "--" + multipartMixedBoundary + "\r\n" +
                 "Content-Disposition: attachment; filename=\"file-02.txt\"" + "\r\n" +
+                "Content-Length: " + file1.length() + "\r\n" +
                 "Content-Type: text/plain" + "\r\n" +
                 "Content-Transfer-Encoding: binary" + "\r\n" +
                 "\r\n" +
@@ -99,6 +103,7 @@ public class HttpPostRequestEncoderTest {
                 "\r\n" +
                 "--" + multipartMixedBoundary + "\r\n" +
                 "Content-Disposition: attachment; filename=\"file-02.txt\"" + "\r\n" +
+                "Content-Length: " + file1.length() + "\r\n" +
                 "Content-Type: text/plain" + "\r\n" +
                 "Content-Transfer-Encoding: binary" + "\r\n" +
                 "\r\n" +


### PR DESCRIPTION
Proposal to fix issue #3636 (this has to be fix in all versions: version 3.10)

Motivations:
Currently, while adding the next buffers to the decoder (`decoder.offer()`), there is no way to access to the current HTTP object being decoded since it can only be available currently once fully decoded by `decoder.hasNext()`.

Some could want to know the progression on the overall transfer but also per HTTP object.
While overall progression could be done using (if available) the global Content-Length of the request and taking into account each HttpContent size, the per HttpData object progression is unknown.

In addition, currently, the Content-Length is not provided by the client and not taken into account for Attribute.

Modifications:
1) For HTTP object, `AbstractHttpData` has 2 protected properties named `definedSize` and `size`, respectively the supposely final size and the current (decoded until now) size.
This provides a new method `definedSize()` to get the current value for `definedSize`. The `size` attribute is reachable by the `length()` method.

Note however `definedSize` is only defined if Content-Length is provided (not mandatory). So `definedSize` might be 0.

2) In the InterfaceHttpPostRequestDecoder (and the derived classes), I add a new method: `decoder.currentPartialHttpData()` which will return a `InterfaceHttpData` (if any) as the current `Attribute` or `FileUpload` (the 2 generic types), which will allow then the programmer to check
according to the real type (instance of) the 2 methods `definedSize()` and `length()`.

This method check if currentFileUpload or currentAttribute are null and returns the one (only one could be not null) that is not null.

Note that if this method returns null, it might mean 2 situations:
a) the last `HttpData` (whatever attribute or file upload) is already finished and therefore accessible through `next()`
b) there is not yet any `HttpData` in decoding (body not yet parsed for instance)

3) Add Content-Length in default behavior in Multipart Encoder and handling in Multipart Decoder for Attribute (missing parts).

4) Add constructor for Attribute and Factory to create Attribute if possible with `definedSize`.

Result:
The developper has more access and therefore control on the current upload.
The coding from developper side could looks like in the example in HttpUloadServerHandler.


Master piece for #3661 (complete version for 3.10, master version will need to be redone once this 3.10 version could be accepted).