### PR TITLE
Add support for splice(...)

### DIFF
--- a/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.c
+++ b/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.c
@@ -46,6 +46,7 @@
 // optional
 extern int accept4(int sockFd, struct sockaddr* addr, socklen_t* addrlen, int flags) __attribute__((weak));
 extern int epoll_create1(int flags) __attribute__((weak));
+extern int pipe2(int pipefd[2], int flags) __attribute__((weak));
 
 #ifdef IO_NETTY_SENDMMSG_NOT_FOUND
 extern int sendmmsg(int sockfd, struct mmsghdr* msgvec, unsigned int vlen, unsigned int flags) __attribute__((weak));
@@ -1577,4 +1578,51 @@ JNIEXPORT jint JNICALL Java_io_netty_channel_epoll_Native_sizeofEpollEvent(JNIEn
 
 JNIEXPORT jint JNICALL Java_io_netty_channel_epoll_Native_offsetofEpollData(JNIEnv* env, jclass clazz) {
     return offsetof(struct epoll_event, data);
+}
+
+JNIEXPORT jlong JNICALL Java_io_netty_channel_epoll_Native_pipe0(JNIEnv* env, jclass clazz) {
+    int fd[2];
+    if (pipe2) {
+        // we can just use pipe2 and so save extra syscalls;
+        if (pipe2(fd, O_NONBLOCK) != 0) {
+            return -errno;
+        }
+    } else {
+         if (pipe(fd) == 0) {
+            if (fcntl(fd[0], F_SETFD, O_NONBLOCK) < 0) {
+                int err = errno;
+                close(fd[0]);
+                close(fd[1]);
+                return -err;
+            }
+            if (fcntl(fd[1], F_SETFD, O_NONBLOCK) < 0) {
+                int err = errno;
+                close(fd[0]);
+                close(fd[1]);
+                return -err;
+            }
+         } else {
+            return -errno;
+         }
+    }
+
+    // encode the fds into a long
+    return (((long) fd[0]) << 32) | (fd[1] & 0xffffffffL);
+}
+
+JNIEXPORT jint JNICALL Java_io_netty_channel_epoll_Native_splice0(JNIEnv* env, jclass clazz, jint fd, jint offIn, jint fdOut, jint offOut, jint len) {
+    ssize_t res;
+    int err;
+    loff_t off_in = offIn >= 0 ? (loff_t) offIn : NULL;
+    loff_t off_out = offOut >= 0 ? (loff_t) offOut : NULL;
+
+    do {
+       res = splice(fd, off_in, fdOut, off_out, (size_t) len, SPLICE_F_NONBLOCK | SPLICE_F_MOVE);
+       // keep on splicing if it was interrupted
+    } while (res == -1 && ((err = errno) == EINTR));
+
+    if (res < 0) {
+        return -err;
+    }
+    return (jint) res;
 }

--- a/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.h
+++ b/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.h
@@ -120,3 +120,6 @@ jint Java_io_netty_channel_epoll_Native_epollrdhup(JNIEnv* env, jclass clazz);
 jint Java_io_netty_channel_epoll_Native_epollet(JNIEnv* env, jclass clazz);
 jint Java_io_netty_channel_epoll_Native_sizeofEpollEvent(JNIEnv* env, jclass clazz);
 jint Java_io_netty_channel_epoll_Native_offsetofEpollData(JNIEnv* env, jclass clazz);
+
+jlong Java_io_netty_channel_epoll_Native_pipe0(JNIEnv* env, jclass clazz);
+jint Java_io_netty_channel_epoll_Native_splice0(JNIEnv* env, jclass clazz, jint fd, jint offIn, jint fdOut, jint offOut, jint len);

--- a/transport-native-epoll/src/main/c/io_netty_channel_unix_FileDescriptor.c
+++ b/transport-native-epoll/src/main/c/io_netty_channel_unix_FileDescriptor.c
@@ -16,6 +16,7 @@
 #include <jni.h>
 #include <unistd.h>
 #include <errno.h>
+#include <fcntl.h>
 #include "io_netty_channel_unix_FileDescriptor.h"
 
 JNIEXPORT int JNICALL Java_io_netty_channel_unix_FileDescriptor_close(JNIEnv* env, jclass clazz, jint fd) {
@@ -23,4 +24,17 @@ JNIEXPORT int JNICALL Java_io_netty_channel_unix_FileDescriptor_close(JNIEnv* en
        return -errno;
    }
    return 0;
+}
+
+JNIEXPORT int JNICALL Java_io_netty_channel_unix_FileDescriptor_open(JNIEnv* env, jclass clazz, jstring path) {
+
+    const char* f_path = (*env)->GetStringUTFChars(env, path, 0);
+
+    int res = open(f_path, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+    (*env)->ReleaseStringUTFChars(env, path, f_path);
+
+    if (res < 0) {
+        return -errno;
+    }
+    return res;
 }

--- a/transport-native-epoll/src/main/c/io_netty_channel_unix_FileDescriptor.h
+++ b/transport-native-epoll/src/main/c/io_netty_channel_unix_FileDescriptor.h
@@ -16,3 +16,4 @@
 #include <jni.h>
 
 int Java_io_netty_channel_unix_FileDescriptor_close(JNIEnv* env, jclass clazz, jint fd);
+int Java_io_netty_channel_unix_FileDescriptor_open(JNIEnv* env, jclass clazz, jstring path);

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -39,7 +39,7 @@ import java.util.Locale;
  *
  * <strong>Internal usage only!</strong>
  */
-final class Native {
+public final class Native {
 
     static {
         String name = SystemPropertyUtil.get("os.name").toLowerCase(Locale.UK).trim();
@@ -89,6 +89,7 @@ final class Native {
     private static final IOException CONNECTION_RESET_EXCEPTION_SENDTO;
     private static final IOException CONNECTION_RESET_EXCEPTION_SENDMSG;
     private static final IOException CONNECTION_RESET_EXCEPTION_SENDMMSG;
+    private static final IOException CONNECTION_RESET_EXCEPTION_SPLICE;
 
     static {
         for (int i = 0; i < ERRORS.length; i++) {
@@ -110,6 +111,8 @@ final class Native {
                 ERRNO_EPIPE_NEGATIVE);
         CONNECTION_RESET_EXCEPTION_SENDMMSG = newConnectionResetException("syscall:sendmmsg(...)",
                 ERRNO_EPIPE_NEGATIVE);
+        CONNECTION_RESET_EXCEPTION_SPLICE = newConnectionResetException("syscall:splice(...)",
+                ERRNO_EPIPE_NEGATIVE);
         CLOSED_CHANNEL_EXCEPTION = new ClosedChannelException();
         CLOSED_CHANNEL_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
     }
@@ -120,7 +123,7 @@ final class Native {
         return exception;
     }
 
-    private static IOException newIOException(String method, int err) {
+    public static IOException newIOException(String method, int err) {
         return new IOException(method + "() failed: " + ERRORS[-err]);
     }
 
@@ -176,6 +179,26 @@ final class Native {
     }
 
     private static native int close0(int fd);
+
+    public static int splice(int fd, int offIn, int fdOut, int offOut, int len) throws IOException {
+        int res = splice0(fd, offIn, fdOut, offOut, len);
+        if (res >= 0) {
+            return res;
+        }
+        return ioResult("splice", res, CONNECTION_RESET_EXCEPTION_SPLICE);
+    }
+
+    private static native int splice0(int fd, int offIn, int fdOut, int offOut, int len);
+
+    public static long pipe() throws IOException {
+        long res = pipe0();
+        if (res >= 0) {
+            return res;
+        }
+        throw newIOException("pipe", (int) res);
+    }
+
+    private static native long pipe0();
 
     public static int write(int fd, ByteBuffer buf, int pos, int limit) throws IOException {
         int res = write0(fd, buf, pos, limit);

--- a/transport-native-epoll/src/main/java/io/netty/channel/unix/FileDescriptor.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/unix/FileDescriptor.java
@@ -15,7 +15,12 @@
  */
 package io.netty.channel.unix;
 
+import io.netty.channel.epoll.Native;
+
+import java.io.File;
 import java.io.IOException;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * Native {@link FileDescriptor} implementation which allows to wrap an {@code int} and provide a
@@ -80,4 +85,25 @@ public class FileDescriptor {
     }
 
     private static native int close(int fd);
+
+    /**
+     * Open a new {@link FileDescriptor} for the given path.
+     */
+    public static FileDescriptor from(String path) throws IOException {
+        checkNotNull(path, "path");
+        int res = open(path);
+        if (res < 0) {
+            throw Native.newIOException("open", res);
+        }
+        return new FileDescriptor(res);
+    }
+
+    /**
+     * Open a new {@link FileDescriptor} for the given {@link File}.
+     */
+    public static FileDescriptor from(File file) throws IOException {
+        return from(checkNotNull(file, "file").getPath());
+    }
+
+    private static native int open(String path);
 }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.unix.FileDescriptor;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+
+public class EpollSpliceTest {
+
+    private static final int SPLICE_LEN = 32 * 1024;
+    private static final Random random = new Random();
+    private static final byte[] data = new byte[1048576];
+
+    static {
+        random.nextBytes(data);
+    }
+
+    @Test
+    public void spliceToSocket() throws Throwable {
+        final EchoHandler sh = new EchoHandler();
+        final EchoHandler ch = new EchoHandler();
+
+        EventLoopGroup group = new EpollEventLoopGroup(1);
+        ServerBootstrap bs = new ServerBootstrap();
+        bs.channel(EpollServerSocketChannel.class);
+        bs.group(group).childHandler(sh);
+        final Channel sc = bs.bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+
+        ServerBootstrap bs2 = new ServerBootstrap();
+        bs2.channel(EpollServerSocketChannel.class);
+        bs2.childOption(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED);
+        bs2.group(group).childHandler(new ChannelInboundHandlerAdapter() {
+            @Override
+            public void channelActive(final ChannelHandlerContext ctx) throws Exception {
+                ctx.channel().config().setAutoRead(false);
+                Bootstrap bs = new Bootstrap();
+                bs.option(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED);
+
+                bs.channel(EpollSocketChannel.class);
+                bs.group(ctx.channel().eventLoop()).handler(new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void channelActive(ChannelHandlerContext context) throws Exception {
+                        final EpollSocketChannel ch = (EpollSocketChannel) ctx.channel();
+                        final EpollSocketChannel ch2 = (EpollSocketChannel) context.channel();
+                        // We are splicing two channels together, at this point we have a tcp proxy which handles all
+                        // the data transfer only in kernel space!
+
+                        // Integer.MAX_VALUE will splice infinitly.
+                        ch.spliceTo(ch2, Integer.MAX_VALUE).addListener(new ChannelFutureListener() {
+                            @Override
+                            public void operationComplete(ChannelFuture future) throws Exception {
+                                if (!future.isSuccess()) {
+                                    future.channel().close();
+                                }
+                            }
+                        });
+                        // Trigger multiple splices to see if partial splicing works as well.
+                        ch2.spliceTo(ch, SPLICE_LEN).addListener(new ChannelFutureListener() {
+                            @Override
+                            public void operationComplete(ChannelFuture future) throws Exception {
+                                if (!future.isSuccess()) {
+                                    future.channel().close();
+                                } else {
+                                    ch2.spliceTo(ch, SPLICE_LEN).addListener(this);
+                                }
+                            }
+                        });
+                        ctx.channel().config().setAutoRead(true);
+                    }
+
+                    @Override
+                    public void channelInactive(ChannelHandlerContext context) throws Exception {
+                        context.close();
+                    }
+                });
+                bs.connect(sc.localAddress()).addListener(new ChannelFutureListener() {
+                    @Override
+                    public void operationComplete(ChannelFuture future) throws Exception {
+                        if (!future.isSuccess()) {
+                            ctx.close();
+                        } else {
+                            future.channel().closeFuture().addListener(new ChannelFutureListener() {
+                                @Override
+                                public void operationComplete(ChannelFuture future) throws Exception {
+                                    ctx.close();
+                                }
+                            });
+                        }
+                    }
+                });
+            }
+        });
+        Channel pc = bs2.bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+
+        Bootstrap cb = new Bootstrap();
+        cb.group(group);
+        cb.channel(EpollSocketChannel.class);
+        cb.handler(ch);
+        Channel cc = cb.connect(pc.localAddress()).syncUninterruptibly().channel();
+
+        for (int i = 0; i < data.length;) {
+            int length = Math.min(random.nextInt(1024 * 64), data.length - i);
+            ByteBuf buf = Unpooled.wrappedBuffer(data, i, length);
+            cc.writeAndFlush(buf);
+            i += length;
+        }
+
+        while (ch.counter < data.length) {
+            if (sh.exception.get() != null) {
+                break;
+            }
+            if (ch.exception.get() != null) {
+                break;
+            }
+
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                // Ignore.
+            }
+        }
+
+        while (sh.counter < data.length) {
+            if (sh.exception.get() != null) {
+                break;
+            }
+            if (ch.exception.get() != null) {
+                break;
+            }
+
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                // Ignore.
+            }
+        }
+
+        sh.channel.close().sync();
+        ch.channel.close().sync();
+        sc.close().sync();
+        pc.close().sync();
+        group.shutdownGracefully();
+
+        if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
+            throw sh.exception.get();
+        }
+        if (ch.exception.get() != null && !(ch.exception.get() instanceof IOException)) {
+            throw ch.exception.get();
+        }
+        if (sh.exception.get() != null) {
+            throw sh.exception.get();
+        }
+        if (ch.exception.get() != null) {
+            throw ch.exception.get();
+        }
+    }
+
+    @Test
+    public void spliceToFile() throws Throwable {
+        EventLoopGroup group = new EpollEventLoopGroup(1);
+        File file = File.createTempFile("netty-splice", null);
+        file.deleteOnExit();
+
+        SpliceHandler sh = new SpliceHandler(file);
+        ServerBootstrap bs = new ServerBootstrap();
+        bs.channel(EpollServerSocketChannel.class);
+        bs.group(group).childHandler(sh);
+        bs.childOption(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED);
+        Channel sc = bs.bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+
+        Bootstrap cb = new Bootstrap();
+        cb.group(group);
+        cb.channel(EpollSocketChannel.class);
+        cb.handler(new ChannelInboundHandlerAdapter());
+        Channel cc = cb.connect(sc.localAddress()).syncUninterruptibly().channel();
+
+        for (int i = 0; i < data.length;) {
+            int length = Math.min(random.nextInt(1024 * 64), data.length - i);
+            ByteBuf buf = Unpooled.wrappedBuffer(data, i, length);
+            cc.writeAndFlush(buf);
+            i += length;
+        }
+
+        while (sh.future == null || !sh.future.isDone()) {
+            if (sh.exception.get() != null) {
+                break;
+            }
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                // Ignore.
+            }
+        }
+
+        sc.close().sync();
+        cc.close().sync();
+
+        if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
+            throw sh.exception.get();
+        }
+
+        byte[] written = new byte[data.length];
+        FileInputStream in = new FileInputStream(file);
+
+        try {
+            Assert.assertEquals(written.length, in.read(written));
+            Assert.assertArrayEquals(data, written);
+        } finally {
+            in.close();
+            group.shutdownGracefully();
+        }
+    }
+
+    private static class EchoHandler extends SimpleChannelInboundHandler<ByteBuf> {
+        volatile Channel channel;
+        final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
+        volatile int counter;
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx)
+                throws Exception {
+            channel = ctx.channel();
+        }
+
+        @Override
+        public void channelRead0(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+            byte[] actual = new byte[in.readableBytes()];
+            in.readBytes(actual);
+
+            int lastIdx = counter;
+            for (int i = 0; i < actual.length; i ++) {
+                assertEquals(data[i + lastIdx], actual[i]);
+            }
+
+            if (channel.parent() != null) {
+                channel.write(Unpooled.wrappedBuffer(actual));
+            }
+
+            counter += actual.length;
+        }
+
+        @Override
+        public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+            ctx.flush();
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx,
+                                    Throwable cause) throws Exception {
+            if (exception.compareAndSet(null, cause)) {
+                cause.printStackTrace();
+                ctx.close();
+            }
+        }
+    }
+
+    private static class SpliceHandler extends ChannelInboundHandlerAdapter {
+        private final File file;
+
+        volatile Channel channel;
+        volatile ChannelFuture future;
+        final AtomicReference<Throwable> exception = new AtomicReference<Throwable>();
+
+        public SpliceHandler(File file) {
+            this.file = file;
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx)
+                throws Exception {
+            channel = ctx.channel();
+            final EpollSocketChannel ch = (EpollSocketChannel) ctx.channel();
+            final FileDescriptor fd = FileDescriptor.from(file);
+
+            future = ch.spliceTo(fd, 0, data.length);
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx,
+                                    Throwable cause) throws Exception {
+            if (exception.compareAndSet(null, cause)) {
+                cause.printStackTrace();
+                ctx.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Linux supports splice(...) to transfer data from one filedescriptor to another without
pass data through the user-space. This allows to write high-performant proxy code.

Modification:

Add AbstractEpollStreamChannel.spliceTo(...) to support splice(...) system call

Result:

Splice is now supported when using the native linux transport.