### PR TITLE
Always consume bytes for closed HTTP/2 streams.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -1121,19 +1121,19 @@ public class DefaultHttp2Connection implements Http2Connection {
 
         void removeFromActiveStreams(DefaultStream stream) {
             if (streams.remove(stream)) {
-                try {
-                    // Update the number of active streams initiated by the endpoint.
-                    stream.createdBy().numActiveStreams--;
+                // Update the number of active streams initiated by the endpoint.
+                stream.createdBy().numActiveStreams--;
+            }
+            notifyClosed(stream);
+            removeStream(stream);
+        }
 
-                    for (int i = 0; i < listeners.size(); i++) {
-                        try {
-                            listeners.get(i).onStreamClosed(stream);
-                        } catch (RuntimeException e) {
-                            logger.error("Caught RuntimeException from listener onStreamClosed.", e);
-                        }
-                    }
-                } finally {
-                    removeStream(stream);
+        private void notifyClosed(DefaultStream stream) {
+            for (int i = 0; i < listeners.size(); i++) {
+                try {
+                    listeners.get(i).onStreamClosed(stream);
+                } catch (RuntimeException e) {
+                    logger.error("Caught RuntimeException from listener onStreamClosed.", e);
                 }
             }
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
@@ -28,6 +28,8 @@ public interface Http2LocalFlowController extends Http2FlowController {
      * policies to it for both the {@code stream} as well as the connection. If any flow control
      * policies have been violated, an exception is raised immediately, otherwise the frame is
      * considered to have "passed" flow control.
+     * <p/>
+     * If {@code stream} is closed, flow control should only be applied to the connection window.
      *
      * @param ctx the context from the handler where the frame was read.
      * @param stream the subject stream for the received frame. The connection stream object must
@@ -39,28 +41,28 @@ public interface Http2LocalFlowController extends Http2FlowController {
      * @throws Http2Exception if any flow control errors are encountered.
      */
     void receiveFlowControlledFrame(ChannelHandlerContext ctx, Http2Stream stream, ByteBuf data, int padding,
-            boolean endOfStream) throws Http2Exception;
+                                    boolean endOfStream) throws Http2Exception;
 
     /**
-     * Indicates that the application has consumed a number of bytes for the given stream and is
-     * therefore ready to receive more data from the remote endpoint. The application must consume
-     * any bytes that it receives or the flow control window will collapse. Consuming bytes enables
-     * the flow controller to send {@code WINDOW_UPDATE} to restore a portion of the flow control
-     * window for the stream.
+     * Indicates that the application has consumed a number of bytes for the given stream and is therefore ready to
+     * receive more data from the remote endpoint. The application must consume any bytes that it receives or the flow
+     * control window will collapse. Consuming bytes enables the flow controller to send {@code WINDOW_UPDATE} to
+     * restore a portion of the flow control window for the stream.
+     * <p/>
+     * If {@code stream} is closed, the consumed bytes are only restored to the connection window. When a stream is
+     * closed, the flow controller automatically restores any unconsumed bytes for that stream to the connection window.
+     * This is done to ensure that the connection window does not degrade over time as streams are closed/terminated.
      *
-     * @param ctx the channel handler context to use when sending a {@code WINDOW_UPDATE} if
-     *            appropriate
-     * @param stream the stream for which window space should be freed. The connection stream object
-     *            must not be used.
+     * @param ctx the channel handler context to use when sending a {@code WINDOW_UPDATE} if appropriate
+     * @param stream the stream for which window space should be freed. The connection stream object must not be used.
      * @param numBytes the number of bytes to be returned to the flow control window.
-     * @throws Http2Exception if the number of bytes returned exceeds the {@link #unconsumedBytes}
-     *             for the stream.
+     * @throws Http2Exception if the number of bytes returned exceeds the {@link #unconsumedBytes} for the stream.
      */
     void consumeBytes(ChannelHandlerContext ctx, Http2Stream stream, int numBytes) throws Http2Exception;
 
     /**
      * The number of bytes for the given stream that have been received but not yet consumed by the
-     * application.
+     * application. If {@code stream} is closed, returns {@code zero}.
      *
      * @param stream the stream for which window space should be freed.
      * @return the number of unconsumed bytes for the stream.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
@@ -49,11 +49,10 @@ public interface Http2LocalFlowController extends Http2FlowController {
      * control window will collapse. Consuming bytes enables the flow controller to send {@code WINDOW_UPDATE} to
      * restore a portion of the flow control window for the stream.
      * <p/>
-     * If {@code stream} is closed (i.e. {@link Http2Stream#state()} method returns {@link
-     * io.netty.handler.codec.http2.Http2Stream.State#CLOSED}), the consumed bytes are only restored to the connection
-     * window. When a stream is closed, the flow controller automatically restores any unconsumed bytes for that stream
-     * to the connection window. This is done to ensure that the connection window does not degrade over time as streams
-     * are closed.
+     * If {@code stream} is closed (i.e. {@link Http2Stream#state()} method returns {@link Http2Stream.State#CLOSED}),
+     * the consumed bytes are only restored to the connection window. When a stream is closed, the flow controller
+     * automatically restores any unconsumed bytes for that stream to the connection window. This is done to ensure that
+     * the connection window does not degrade over time as streams are closed.
      *
      * @param ctx the channel handler context to use when sending a {@code WINDOW_UPDATE} if appropriate
      * @param stream the stream for which window space should be freed. The connection stream object must not be used.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
@@ -49,20 +49,23 @@ public interface Http2LocalFlowController extends Http2FlowController {
      * control window will collapse. Consuming bytes enables the flow controller to send {@code WINDOW_UPDATE} to
      * restore a portion of the flow control window for the stream.
      * <p/>
-     * If {@code stream} is closed, the consumed bytes are only restored to the connection window. When a stream is
-     * closed, the flow controller automatically restores any unconsumed bytes for that stream to the connection window.
-     * This is done to ensure that the connection window does not degrade over time as streams are closed/terminated.
+     * If {@code stream} is closed (i.e. {@link Http2Stream#state()} method returns {@link
+     * io.netty.handler.codec.http2.Http2Stream.State#CLOSED}), the consumed bytes are only restored to the connection
+     * window. When a stream is closed, the flow controller automatically restores any unconsumed bytes for that stream
+     * to the connection window. This is done to ensure that the connection window does not degrade over time as streams
+     * are closed.
      *
      * @param ctx the channel handler context to use when sending a {@code WINDOW_UPDATE} if appropriate
      * @param stream the stream for which window space should be freed. The connection stream object must not be used.
      * @param numBytes the number of bytes to be returned to the flow control window.
-     * @throws Http2Exception if the number of bytes returned exceeds the {@link #unconsumedBytes} for the stream.
+     * @throws Http2Exception if the number of bytes returned exceeds the {@link #unconsumedBytes(Http2Stream)} for the
+     * stream.
      */
     void consumeBytes(ChannelHandlerContext ctx, Http2Stream stream, int numBytes) throws Http2Exception;
 
     /**
      * The number of bytes for the given stream that have been received but not yet consumed by the
-     * application. If {@code stream} is closed, returns {@code zero}.
+     * application.
      *
      * @param stream the stream for which window space should be freed.
      * @return the number of unconsumed bytes for the stream.

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -311,7 +311,7 @@ public class DefaultHttp2LocalFlowControllerTest {
         return controller.windowSize(stream(streamId));
     }
 
-    private Http2Stream stream(int streamId) {
-        return connection.stream(streamId);
+    private Http2Stream stream(int streamId) throws Http2Exception {
+        return connection.requireStream(streamId);
     }
 }


### PR DESCRIPTION
Motivation:

The current local flow controller does not guarantee that unconsumed bytes for a closed stream will be restored to the connection window.  This may lead to degradation of the connection window over time.

Modifications:

Modified DefaultHttp2LocalFlowController to guarantee that any unconsumed bytes are returned to the connection window as soon as the stream is closed. We also immediately consume any bytes when receiving DATA for a closed stream.

Result:

Fixes #3668