### PR TITLE
HTTP/2 Flow Controller required memory reduction

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -271,7 +271,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
             Http2Stream stream = connection.stream(streamId);
             boolean allowHalfClosedRemote = false;
             if (stream == null && !connection.streamMayHaveExisted(streamId)) {
-                stream = connection.remote().createStream(streamId).open(endOfStream);
+                stream = connection.remote().createStream(streamId, endOfStream);
                 // Allow the state to be HALF_CLOSE_REMOTE if we're creating it in that state.
                 allowHalfClosedRemote = stream.state() == HALF_CLOSED_REMOTE;
             }
@@ -283,7 +283,6 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
 
             switch (stream.state()) {
                 case RESERVED_REMOTE:
-                case IDLE:
                     stream.open(endOfStream);
                     break;
                 case OPEN:
@@ -336,7 +335,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
 
                     // PRIORITY frames always identify a stream. This means that if a PRIORITY frame is the
                     // first frame to be received for a stream that we must create the stream.
-                    stream = connection.remote().createStream(streamId);
+                    stream = connection.remote().createIdleStream(streamId);
                 } else if (streamCreatedAfterGoAwaySent(streamId)) {
                     // Ignore this frame.
                     return;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -171,11 +171,31 @@ public interface Http2Connection {
          * <li>The connection is marked as going away.</li>
          * </ul>
          * <p>
-         * The caller is expected to {@link Http2Stream#open(boolean)} the stream.
+         * If the stream is intended to initialized to {@link Http2Stream.State#OPEN} then use
+         * {@link #createStream(int, boolean)} otherwise optimizations in {@link Listener}s may not work
+         * and memory may be thrashed. The caller is expected to {@link Http2Stream#open(boolean)} the stream.
          * @param streamId The ID of the stream
          * @see Http2Stream#open(boolean)
          */
-        Http2Stream createStream(int streamId) throws Http2Exception;
+        Http2Stream createIdleStream(int streamId) throws Http2Exception;
+
+        /**
+         * Creates a stream initiated by this endpoint. This could fail for the following reasons:
+         * <ul>
+         * <li>The requested stream ID is not the next sequential ID for this endpoint.</li>
+         * <li>The stream already exists.</li>
+         * <li>{@link #canCreateStream()} is {@code false}.</li>
+         * <li>The connection is marked as going away.</li>
+         * </ul>
+         * <p>
+         * This method differs from {@link #createdStreamId(int)} because the initial state of the stream will be
+         * Immediately set before notifying {@link Listener}s. The state transition is sensitive to {@code halfClosed}
+         * and is defined by {@link Http2Stream#open(boolean)}.
+         * @param streamId The ID of the stream
+         * @param halfClosed see {@link Http2Stream#open(boolean)}.
+         * @see Http2Stream#open(boolean)
+         */
+        Http2Stream createStream(int streamId, boolean halfClosed) throws Http2Exception;
 
         /**
          * Creates a push stream in the reserved state for this endpoint and notifies all listeners.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -115,7 +115,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         }
 
         // Create a local stream used for the HTTP cleartext upgrade.
-        connection().local().createStream(HTTP_UPGRADE_STREAM_ID).open(true);
+        connection().local().createStream(HTTP_UPGRADE_STREAM_ID, true);
     }
 
     /**
@@ -134,7 +134,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         encoder.remoteSettings(settings);
 
         // Create a stream in the half-closed state.
-        connection().remote().createStream(HTTP_UPGRADE_STREAM_ID).open(true);
+        connection().remote().createStream(HTTP_UPGRADE_STREAM_ID, true);
     }
 
     private abstract class BaseDecoder {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -81,9 +81,9 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void goAwayReceivedShouldCloseStreamsGreaterThanLastStream() throws Exception {
-        Http2Stream stream1 = client.local().createStream(3).open(false);
-        Http2Stream stream2 = client.local().createStream(5).open(false);
-        Http2Stream remoteStream = client.remote().createStream(4).open(false);
+        Http2Stream stream1 = client.local().createStream(3, false);
+        Http2Stream stream2 = client.local().createStream(5, false);
+        Http2Stream remoteStream = client.remote().createStream(4, false);
 
         assertEquals(State.OPEN, stream1.state());
         assertEquals(State.OPEN, stream2.state());
@@ -102,9 +102,9 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void goAwaySentShouldCloseStreamsGreaterThanLastStream() throws Exception {
-        Http2Stream stream1 = server.remote().createStream(3).open(false);
-        Http2Stream stream2 = server.remote().createStream(5).open(false);
-        Http2Stream localStream = server.local().createStream(4).open(false);
+        Http2Stream stream1 = server.remote().createStream(3, false);
+        Http2Stream stream2 = server.remote().createStream(5, false);
+        Http2Stream localStream = server.local().createStream(4, false);
 
         server.goAwaySent(3, 8, null);
 
@@ -120,25 +120,25 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void serverCreateStreamShouldSucceed() throws Http2Exception {
-        Http2Stream stream = server.local().createStream(2).open(false);
+        Http2Stream stream = server.local().createStream(2, false);
         assertEquals(2, stream.id());
         assertEquals(State.OPEN, stream.state());
         assertEquals(1, server.numActiveStreams());
         assertEquals(2, server.local().lastStreamCreated());
 
-        stream = server.local().createStream(4).open(true);
+        stream = server.local().createStream(4, true);
         assertEquals(4, stream.id());
         assertEquals(State.HALF_CLOSED_LOCAL, stream.state());
         assertEquals(2, server.numActiveStreams());
         assertEquals(4, server.local().lastStreamCreated());
 
-        stream = server.remote().createStream(3).open(true);
+        stream = server.remote().createStream(3, true);
         assertEquals(3, stream.id());
         assertEquals(State.HALF_CLOSED_REMOTE, stream.state());
         assertEquals(3, server.numActiveStreams());
         assertEquals(3, server.remote().lastStreamCreated());
 
-        stream = server.remote().createStream(5).open(false);
+        stream = server.remote().createStream(5, false);
         assertEquals(5, stream.id());
         assertEquals(State.OPEN, stream.state());
         assertEquals(4, server.numActiveStreams());
@@ -147,25 +147,25 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void clientCreateStreamShouldSucceed() throws Http2Exception {
-        Http2Stream stream = client.remote().createStream(2).open(false);
+        Http2Stream stream = client.remote().createStream(2, false);
         assertEquals(2, stream.id());
         assertEquals(State.OPEN, stream.state());
         assertEquals(1, client.numActiveStreams());
         assertEquals(2, client.remote().lastStreamCreated());
 
-        stream = client.remote().createStream(4).open(true);
+        stream = client.remote().createStream(4, true);
         assertEquals(4, stream.id());
         assertEquals(State.HALF_CLOSED_REMOTE, stream.state());
         assertEquals(2, client.numActiveStreams());
         assertEquals(4, client.remote().lastStreamCreated());
 
-        stream = client.local().createStream(3).open(true);
+        stream = client.local().createStream(3, true);
         assertEquals(3, stream.id());
         assertEquals(State.HALF_CLOSED_LOCAL, stream.state());
         assertEquals(3, client.numActiveStreams());
         assertEquals(3, client.local().lastStreamCreated());
 
-        stream = client.local().createStream(5).open(false);
+        stream = client.local().createStream(5, false);
         assertEquals(5, stream.id());
         assertEquals(State.OPEN, stream.state());
         assertEquals(4, client.numActiveStreams());
@@ -174,7 +174,7 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void serverReservePushStreamShouldSucceed() throws Http2Exception {
-        Http2Stream stream = server.remote().createStream(3).open(true);
+        Http2Stream stream = server.remote().createStream(3, true);
         Http2Stream pushStream = server.local().reservePushStream(2, stream);
         assertEquals(2, pushStream.id());
         assertEquals(State.RESERVED_LOCAL, pushStream.state());
@@ -184,7 +184,7 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void clientReservePushStreamShouldSucceed() throws Http2Exception {
-        Http2Stream stream = server.remote().createStream(3).open(true);
+        Http2Stream stream = server.remote().createStream(3, true);
         Http2Stream pushStream = server.local().reservePushStream(4, stream);
         assertEquals(4, pushStream.id());
         assertEquals(State.RESERVED_LOCAL, pushStream.state());
@@ -194,28 +194,28 @@ public class DefaultHttp2ConnectionTest {
 
     @Test(expected = Http2Exception.class)
     public void newStreamBehindExpectedShouldThrow() throws Http2Exception {
-        server.local().createStream(0).open(true);
+        server.local().createStream(0, true);
     }
 
     @Test(expected = Http2Exception.class)
     public void newStreamNotForServerShouldThrow() throws Http2Exception {
-        server.local().createStream(11).open(true);
+        server.local().createStream(11, true);
     }
 
     @Test(expected = Http2Exception.class)
     public void newStreamNotForClientShouldThrow() throws Http2Exception {
-        client.local().createStream(10).open(true);
+        client.local().createStream(10, true);
     }
 
     @Test(expected = Http2Exception.class)
     public void maxAllowedStreamsExceededShouldThrow() throws Http2Exception {
         server.local().maxActiveStreams(0);
-        server.local().createStream(2).open(true);
+        server.local().createStream(2, true);
     }
 
     @Test(expected = Http2Exception.class)
     public void reserveWithPushDisallowedShouldThrow() throws Http2Exception {
-        Http2Stream stream = server.remote().createStream(3).open(true);
+        Http2Stream stream = server.remote().createStream(3, true);
         server.remote().allowPushTo(false);
         server.local().reservePushStream(2, stream);
     }
@@ -223,12 +223,12 @@ public class DefaultHttp2ConnectionTest {
     @Test(expected = Http2Exception.class)
     public void goAwayReceivedShouldDisallowCreation() throws Http2Exception {
         server.goAwayReceived(0, 1L, Unpooled.EMPTY_BUFFER);
-        server.remote().createStream(3).open(true);
+        server.remote().createStream(3, true);
     }
 
     @Test
     public void closeShouldSucceed() throws Http2Exception {
-        Http2Stream stream = server.remote().createStream(3).open(true);
+        Http2Stream stream = server.remote().createStream(3, true);
         stream.close();
         assertEquals(State.CLOSED, stream.state());
         assertEquals(0, server.numActiveStreams());
@@ -236,7 +236,7 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void closeLocalWhenOpenShouldSucceed() throws Http2Exception {
-        Http2Stream stream = server.remote().createStream(3).open(false);
+        Http2Stream stream = server.remote().createStream(3, false);
         stream.closeLocalSide();
         assertEquals(State.HALF_CLOSED_LOCAL, stream.state());
         assertEquals(1, server.numActiveStreams());
@@ -244,7 +244,7 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void closeRemoteWhenOpenShouldSucceed() throws Http2Exception {
-        Http2Stream stream = server.remote().createStream(3).open(false);
+        Http2Stream stream = server.remote().createStream(3, false);
         stream.closeRemoteSide();
         assertEquals(State.HALF_CLOSED_REMOTE, stream.state());
         assertEquals(1, server.numActiveStreams());
@@ -252,7 +252,7 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void closeOnlyOpenSideShouldClose() throws Http2Exception {
-        Http2Stream stream = server.remote().createStream(3).open(true);
+        Http2Stream stream = server.remote().createStream(3, true);
         stream.closeLocalSide();
         assertEquals(State.CLOSED, stream.state());
         assertEquals(0, server.numActiveStreams());
@@ -261,32 +261,32 @@ public class DefaultHttp2ConnectionTest {
     @SuppressWarnings("NumericOverflow")
     @Test(expected = Http2Exception.class)
     public void localStreamInvalidStreamIdShouldThrow() throws Http2Exception {
-        client.local().createStream(Integer.MAX_VALUE + 2).open(false);
+        client.local().createStream(Integer.MAX_VALUE + 2, false);
     }
 
     @SuppressWarnings("NumericOverflow")
     @Test(expected = Http2Exception.class)
     public void remoteStreamInvalidStreamIdShouldThrow() throws Http2Exception {
-        client.remote().createStream(Integer.MAX_VALUE + 1).open(false);
+        client.remote().createStream(Integer.MAX_VALUE + 1, false);
     }
 
     @Test
     public void localStreamCanDependUponIdleStream() throws Http2Exception {
-        Http2Stream streamA = client.local().createStream(1).open(false);
+        Http2Stream streamA = client.local().createStream(1, false);
         streamA.setPriority(3, MIN_WEIGHT, true);
         verifyDependUponIdleStream(streamA, client.stream(3), client.local());
     }
 
     @Test
     public void remoteStreamCanDependUponIdleStream() throws Http2Exception {
-        Http2Stream streamA = client.remote().createStream(2).open(false);
+        Http2Stream streamA = client.remote().createStream(2, false);
         streamA.setPriority(4, MIN_WEIGHT, true);
         verifyDependUponIdleStream(streamA, client.stream(4), client.remote());
     }
 
     @Test
     public void prioritizeShouldUseDefaults() throws Exception {
-        Http2Stream stream = client.local().createStream(1).open(false);
+        Http2Stream stream = client.local().createStream(1, false);
         assertEquals(1, client.connectionStream().numChildren());
         assertEquals(2, client.connectionStream().prioritizableForTree());
         assertEquals(stream, child(client.connectionStream(), 1));
@@ -297,7 +297,7 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void reprioritizeWithNoChangeShouldDoNothing() throws Exception {
-        Http2Stream stream = client.local().createStream(1).open(false);
+        Http2Stream stream = client.local().createStream(1, false);
         stream.setPriority(0, DEFAULT_PRIORITY_WEIGHT, false);
         assertEquals(1, client.connectionStream().numChildren());
         assertEquals(2, client.connectionStream().prioritizableForTree());
@@ -309,10 +309,10 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void insertExclusiveShouldAddNewLevel() throws Exception {
-        Http2Stream streamA = client.local().createStream(1).open(false);
-        Http2Stream streamB = client.local().createStream(3).open(false);
-        Http2Stream streamC = client.local().createStream(5).open(false);
-        Http2Stream streamD = client.local().createStream(7).open(false);
+        Http2Stream streamA = client.local().createStream(1, false);
+        Http2Stream streamB = client.local().createStream(3, false);
+        Http2Stream streamC = client.local().createStream(5, false);
+        Http2Stream streamD = client.local().createStream(7, false);
 
         streamB.setPriority(streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
         streamC.setPriority(streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
@@ -359,10 +359,10 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void existingChildMadeExclusiveShouldNotCreateTreeCycle() throws Http2Exception {
-        Http2Stream streamA = client.local().createStream(1).open(false);
-        Http2Stream streamB = client.local().createStream(3).open(false);
-        Http2Stream streamC = client.local().createStream(5).open(false);
-        Http2Stream streamD = client.local().createStream(7).open(false);
+        Http2Stream streamA = client.local().createStream(1, false);
+        Http2Stream streamB = client.local().createStream(3, false);
+        Http2Stream streamC = client.local().createStream(5, false);
+        Http2Stream streamD = client.local().createStream(7, false);
 
         streamB.setPriority(streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
         streamC.setPriority(streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
@@ -412,12 +412,12 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void newExclusiveChildShouldUpdateOldParentCorrectly() throws Http2Exception {
-        Http2Stream streamA = client.local().createStream(1).open(false);
-        Http2Stream streamB = client.local().createStream(3).open(false);
-        Http2Stream streamC = client.local().createStream(5).open(false);
-        Http2Stream streamD = client.local().createStream(7).open(false);
-        Http2Stream streamE = client.local().createStream(9).open(false);
-        Http2Stream streamF = client.local().createStream(11).open(false);
+        Http2Stream streamA = client.local().createStream(1, false);
+        Http2Stream streamB = client.local().createStream(3, false);
+        Http2Stream streamC = client.local().createStream(5, false);
+        Http2Stream streamD = client.local().createStream(7, false);
+        Http2Stream streamE = client.local().createStream(9, false);
+        Http2Stream streamF = client.local().createStream(11, false);
 
         streamB.setPriority(streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
         streamC.setPriority(streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
@@ -483,10 +483,10 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void weightChangeWithNoTreeChangeShouldNotifyListeners() throws Http2Exception {
-        Http2Stream streamA = client.local().createStream(1).open(false);
-        Http2Stream streamB = client.local().createStream(3).open(false);
-        Http2Stream streamC = client.local().createStream(5).open(false);
-        Http2Stream streamD = client.local().createStream(7).open(false);
+        Http2Stream streamA = client.local().createStream(1, false);
+        Http2Stream streamB = client.local().createStream(3, false);
+        Http2Stream streamC = client.local().createStream(5, false);
+        Http2Stream streamD = client.local().createStream(7, false);
 
         streamB.setPriority(streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
         streamC.setPriority(streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
@@ -513,10 +513,10 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void sameNodeDependentShouldNotStackOverflowNorChangePrioritizableForTree() throws Http2Exception {
-        Http2Stream streamA = client.local().createStream(1).open(false);
-        Http2Stream streamB = client.local().createStream(3).open(false);
-        Http2Stream streamC = client.local().createStream(5).open(false);
-        Http2Stream streamD = client.local().createStream(7).open(false);
+        Http2Stream streamA = client.local().createStream(1, false);
+        Http2Stream streamB = client.local().createStream(3, false);
+        Http2Stream streamC = client.local().createStream(5, false);
+        Http2Stream streamD = client.local().createStream(7, false);
 
         streamB.setPriority(streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
         streamC.setPriority(streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
@@ -551,10 +551,10 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void multipleCircularDependencyShouldUpdatePrioritizable() throws Http2Exception {
-        Http2Stream streamA = client.local().createStream(1).open(false);
-        Http2Stream streamB = client.local().createStream(3).open(false);
-        Http2Stream streamC = client.local().createStream(5).open(false);
-        Http2Stream streamD = client.local().createStream(7).open(false);
+        Http2Stream streamA = client.local().createStream(1, false);
+        Http2Stream streamB = client.local().createStream(3, false);
+        Http2Stream streamC = client.local().createStream(5, false);
+        Http2Stream streamD = client.local().createStream(7, false);
 
         streamB.setPriority(streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
         streamC.setPriority(streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
@@ -606,10 +606,10 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void removeWithPrioritizableDependentsShouldNotRestructureTree() throws Exception {
-        Http2Stream streamA = client.local().createStream(1).open(false);
-        Http2Stream streamB = client.local().createStream(3).open(false);
-        Http2Stream streamC = client.local().createStream(5).open(false);
-        Http2Stream streamD = client.local().createStream(7).open(false);
+        Http2Stream streamA = client.local().createStream(1, false);
+        Http2Stream streamB = client.local().createStream(3, false);
+        Http2Stream streamC = client.local().createStream(5, false);
+        Http2Stream streamD = client.local().createStream(7, false);
 
         streamB.setPriority(streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
         streamC.setPriority(streamB.id(), DEFAULT_PRIORITY_WEIGHT, false);
@@ -657,12 +657,12 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void closeWithNoPrioritizableDependentsShouldRestructureTree() throws Exception {
-        Http2Stream streamA = client.local().createStream(1).open(false);
-        Http2Stream streamB = client.local().createStream(3).open(false);
-        Http2Stream streamC = client.local().createStream(5).open(false);
-        Http2Stream streamD = client.local().createStream(7).open(false);
-        Http2Stream streamE = client.local().createStream(9).open(false);
-        Http2Stream streamF = client.local().createStream(11).open(false);
+        Http2Stream streamA = client.local().createStream(1, false);
+        Http2Stream streamB = client.local().createStream(3, false);
+        Http2Stream streamC = client.local().createStream(5, false);
+        Http2Stream streamD = client.local().createStream(7, false);
+        Http2Stream streamE = client.local().createStream(9, false);
+        Http2Stream streamF = client.local().createStream(11, false);
 
         streamB.setPriority(streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
         streamC.setPriority(streamB.id(), DEFAULT_PRIORITY_WEIGHT, false);
@@ -717,12 +717,12 @@ public class DefaultHttp2ConnectionTest {
 
     @Test
     public void priorityChangeWithNoPrioritizableDependentsShouldRestructureTree() throws Exception {
-        Http2Stream streamA = client.local().createStream(1).open(false);
-        Http2Stream streamB = client.local().createStream(3).open(false);
-        Http2Stream streamC = client.local().createStream(5).open(false);
-        Http2Stream streamD = client.local().createStream(7).open(false);
-        Http2Stream streamE = client.local().createStream(9).open(false);
-        Http2Stream streamF = client.local().createStream(11).open(false);
+        Http2Stream streamA = client.local().createStream(1, false);
+        Http2Stream streamB = client.local().createStream(3, false);
+        Http2Stream streamC = client.local().createStream(5, false);
+        Http2Stream streamD = client.local().createStream(7, false);
+        Http2Stream streamE = client.local().createStream(9, false);
+        Http2Stream streamF = client.local().createStream(11, false);
 
         streamB.setPriority(streamA.id(), DEFAULT_PRIORITY_WEIGHT, false);
         streamC.setPriority(streamB.id(), DEFAULT_PRIORITY_WEIGHT, false);
@@ -786,17 +786,17 @@ public class DefaultHttp2ConnectionTest {
     public void circularDependencyShouldRestructureTree() throws Exception {
         // Using example from http://tools.ietf.org/html/draft-ietf-httpbis-http2-16#section-5.3.3
         // Initialize all the nodes
-        Http2Stream streamA = client.local().createStream(1).open(false);
+        Http2Stream streamA = client.local().createStream(1, false);
         verifyParentChanged(streamA, null);
-        Http2Stream streamB = client.local().createStream(3).open(false);
+        Http2Stream streamB = client.local().createStream(3, false);
         verifyParentChanged(streamB, null);
-        Http2Stream streamC = client.local().createStream(5).open(false);
+        Http2Stream streamC = client.local().createStream(5, false);
         verifyParentChanged(streamC, null);
-        Http2Stream streamD = client.local().createStream(7).open(false);
+        Http2Stream streamD = client.local().createStream(7, false);
         verifyParentChanged(streamD, null);
-        Http2Stream streamE = client.local().createStream(9).open(false);
+        Http2Stream streamE = client.local().createStream(9, false);
         verifyParentChanged(streamE, null);
-        Http2Stream streamF = client.local().createStream(11).open(false);
+        Http2Stream streamF = client.local().createStream(11, false);
         verifyParentChanged(streamF, null);
 
         // Build the tree
@@ -882,17 +882,17 @@ public class DefaultHttp2ConnectionTest {
     public void circularDependencyWithExclusiveShouldRestructureTree() throws Exception {
         // Using example from http://tools.ietf.org/html/draft-ietf-httpbis-http2-16#section-5.3.3
         // Initialize all the nodes
-        Http2Stream streamA = client.local().createStream(1).open(false);
+        Http2Stream streamA = client.local().createStream(1, false);
         verifyParentChanged(streamA, null);
-        Http2Stream streamB = client.local().createStream(3).open(false);
+        Http2Stream streamB = client.local().createStream(3, false);
         verifyParentChanged(streamB, null);
-        Http2Stream streamC = client.local().createStream(5).open(false);
+        Http2Stream streamC = client.local().createStream(5, false);
         verifyParentChanged(streamC, null);
-        Http2Stream streamD = client.local().createStream(7).open(false);
+        Http2Stream streamD = client.local().createStream(7, false);
         verifyParentChanged(streamD, null);
-        Http2Stream streamE = client.local().createStream(9).open(false);
+        Http2Stream streamE = client.local().createStream(9, false);
         verifyParentChanged(streamE, null);
-        Http2Stream streamF = client.local().createStream(11).open(false);
+        Http2Stream streamF = client.local().createStream(11, false);
         verifyParentChanged(streamF, null);
 
         // Build the tree
@@ -1050,9 +1050,11 @@ public class DefaultHttp2ConnectionTest {
         // Now we add clienListener2 and exercise all listener functionality
         try {
             client.addListener(clientListener2);
-            Http2Stream stream = client.local().createStream(3);
+            Http2Stream stream = client.local().createIdleStream(3);
             verify(clientListener).onStreamAdded(any(Http2Stream.class));
             verify(clientListener2).onStreamAdded(any(Http2Stream.class));
+            verify(clientListener, never()).onStreamActive(any(Http2Stream.class));
+            verify(clientListener2, never()).onStreamActive(any(Http2Stream.class));
 
             stream.open(false);
             verify(clientListener).onStreamActive(any(Http2Stream.class));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -68,7 +68,7 @@ public class DefaultHttp2LocalFlowControllerTest {
         connection = new DefaultHttp2Connection(false);
         controller = new DefaultHttp2LocalFlowController(connection, frameWriter, updateRatio);
 
-        connection.local().createStream(STREAM_ID).open(false);
+        connection.local().createStream(STREAM_ID, false);
     }
 
     @Test
@@ -156,7 +156,7 @@ public class DefaultHttp2LocalFlowControllerTest {
     @Test
     public void connectionWindowShouldAdjustWithMultipleStreams() throws Http2Exception {
         int newStreamId = 3;
-        connection.local().createStream(newStreamId).open(false);
+        connection.local().createStream(newStreamId, false);
 
         try {
             assertEquals(DEFAULT_WINDOW_SIZE, window(STREAM_ID));
@@ -246,7 +246,7 @@ public class DefaultHttp2LocalFlowControllerTest {
             throws Http2Exception {
         int delta = newDefaultWindowSize - DEFAULT_WINDOW_SIZE;
         controller.incrementWindowSize(ctx, stream(0), delta);
-        Http2Stream stream = connection.local().createStream(newStreamId).open(false);
+        Http2Stream stream = connection.local().createStream(newStreamId, false);
         if (setStreamRatio) {
             controller.windowUpdateRatio(ctx, stream, ratio);
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -87,10 +87,10 @@ public class DefaultHttp2RemoteFlowControllerTest {
         connection = new DefaultHttp2Connection(false);
         controller = new DefaultHttp2RemoteFlowController(connection);
 
-        connection.local().createStream(STREAM_A).open(false);
-        connection.local().createStream(STREAM_B).open(false);
-        Http2Stream streamC = connection.local().createStream(STREAM_C).open(false);
-        Http2Stream streamD = connection.local().createStream(STREAM_D).open(false);
+        connection.local().createStream(STREAM_A, false);
+        connection.local().createStream(STREAM_B, false);
+        Http2Stream streamC = connection.local().createStream(STREAM_C, false);
+        Http2Stream streamD = connection.local().createStream(STREAM_D, false);
         streamC.setPriority(STREAM_A, DEFAULT_PRIORITY_WEIGHT, false);
         streamD.setPriority(STREAM_A, DEFAULT_PRIORITY_WEIGHT, false);
     }
@@ -885,7 +885,7 @@ public class DefaultHttp2RemoteFlowControllerTest {
         Http2Stream streamC = connection.stream(STREAM_C);
         Http2Stream streamD = connection.stream(STREAM_D);
 
-        Http2Stream streamE = connection.local().createStream(STREAM_E).open(false);
+        Http2Stream streamE = connection.local().createStream(STREAM_E, false);
         streamE.setPriority(STREAM_A, DEFAULT_PRIORITY_WEIGHT, true);
 
         // Send a bunch of data on each stream.

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -117,9 +117,9 @@ final class Http2TestUtil {
                 Http2Stream stream = connection.stream(streamId);
                 if (stream == null) {
                     if (connection.isServer() && streamId % 2 == 0 || !connection.isServer() && streamId % 2 != 0) {
-                        stream = connection.local().createStream(streamId).open(halfClosed);
+                        stream = connection.local().createStream(streamId, halfClosed);
                     } else {
-                        stream = connection.remote().createStream(streamId).open(halfClosed);
+                        stream = connection.remote().createStream(streamId, halfClosed);
                     }
                 }
                 return stream;
@@ -266,6 +266,7 @@ final class Http2TestUtil {
         private final CountDownLatch settingsAckLatch;
         private final CountDownLatch dataLatch;
         private final CountDownLatch trailersLatch;
+        private final CountDownLatch goAwayLatch;
 
         FrameCountDown(Http2FrameListener listener, CountDownLatch settingsAckLatch, CountDownLatch messageLatch) {
             this(listener, settingsAckLatch, messageLatch, null, null);
@@ -273,11 +274,17 @@ final class Http2TestUtil {
 
         FrameCountDown(Http2FrameListener listener, CountDownLatch settingsAckLatch, CountDownLatch messageLatch,
                 CountDownLatch dataLatch, CountDownLatch trailersLatch) {
+            this(listener, settingsAckLatch, messageLatch, dataLatch, trailersLatch, messageLatch);
+        }
+
+        FrameCountDown(Http2FrameListener listener, CountDownLatch settingsAckLatch, CountDownLatch messageLatch,
+                CountDownLatch dataLatch, CountDownLatch trailersLatch, CountDownLatch goAwayLatch) {
             this.listener = listener;
             this.messageLatch = messageLatch;
             this.settingsAckLatch = settingsAckLatch;
             this.dataLatch = dataLatch;
             this.trailersLatch = trailersLatch;
+            this.goAwayLatch = goAwayLatch;
         }
 
         @Override
@@ -362,7 +369,7 @@ final class Http2TestUtil {
         public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData)
                 throws Http2Exception {
             listener.onGoAwayRead(ctx, lastStreamId, errorCode, debugData);
-            messageLatch.countDown();
+            goAwayLatch.countDown();
         }
 
         @Override


### PR DESCRIPTION
Motivation:
Currently we allocate the full amount of state for each stream as soon as the stream is created, and keep that state until the stream is GC. The full set of state is only needed when the stream can support flow controlled frames. There is an opportunity to reduce the required amount of memory, and make memory eligible for GC sooner by only allocating what is necessary for flow control stream state.

Modifications:
- Introduce objects which require 'less' state for local/remote flow control stream state.
- Use these new objects when streams have been created but will not transition out of idle AND when streams are no longer eligible for flow controlled frame transfer but still must persist in the priority tree.

Result:
Memory allocations are reduced to what is actually needed, and memory is made eligible for GC potentially sooner.