### PR TITLE
Ignore frames for streams that may have previously existed.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -113,17 +113,13 @@ public class DefaultHttp2Connection implements Http2Connection {
     }
 
     @Override
-    public Http2Stream requireStream(int streamId) throws Http2Exception {
-        Http2Stream stream = stream(streamId);
-        if (stream == null) {
-            throw connectionError(PROTOCOL_ERROR, "Stream does not exist %d", streamId);
-        }
-        return stream;
+    public Http2Stream stream(int streamId) {
+        return streamMap.get(streamId);
     }
 
     @Override
-    public Http2Stream stream(int streamId) {
-        return streamMap.get(streamId);
+    public boolean streamMayHaveExisted(int streamId) {
+        return remoteEndpoint.mayHaveCreatedStream(streamId) || localEndpoint.mayHaveCreatedStream(streamId);
     }
 
     @Override
@@ -166,7 +162,7 @@ public class DefaultHttp2Connection implements Http2Connection {
             forEachActiveStream(new Http2StreamVisitor() {
                 @Override
                 public boolean visit(Http2Stream stream) {
-                    if (stream.id() > lastKnownStream && localEndpoint.createdStreamId(stream.id())) {
+                    if (stream.id() > lastKnownStream && localEndpoint.isStreamForEndpoint(stream.id())) {
                         stream.close();
                     }
                     return true;
@@ -197,7 +193,7 @@ public class DefaultHttp2Connection implements Http2Connection {
             forEachActiveStream(new Http2StreamVisitor() {
                 @Override
                 public boolean visit(Http2Stream stream) {
-                    if (stream.id() > lastKnownStream && remoteEndpoint.createdStreamId(stream.id())) {
+                    if (stream.id() > lastKnownStream && remoteEndpoint.isStreamForEndpoint(stream.id())) {
                         stream.close();
                     }
                     return true;
@@ -551,11 +547,11 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         final DefaultEndpoint<? extends Http2FlowController> createdBy() {
-            return localEndpoint.createdStreamId(id) ? localEndpoint : remoteEndpoint;
+            return localEndpoint.isStreamForEndpoint(id) ? localEndpoint : remoteEndpoint;
         }
 
         final boolean isLocal() {
-            return localEndpoint.createdStreamId(id);
+            return localEndpoint.isStreamForEndpoint(id);
         }
 
         final void weight(short weight) {
@@ -880,9 +876,14 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         @Override
-        public boolean createdStreamId(int streamId) {
+        public boolean isStreamForEndpoint(int streamId) {
             boolean even = (streamId & 1) == 0;
             return server == even;
+        }
+
+        @Override
+        public boolean mayHaveCreatedStream(int streamId) {
+            return isStreamForEndpoint(streamId) && streamId <= lastStreamCreated;
         }
 
         @Override
@@ -1021,7 +1022,7 @@ public class DefaultHttp2Connection implements Http2Connection {
             if (streamId < 0) {
                 throw new Http2NoMoreStreamIdsException();
             }
-            if (!createdStreamId(streamId)) {
+            if (!isStreamForEndpoint(streamId)) {
                 throw connectionError(PROTOCOL_ERROR, "Request stream %d is not correct for %s connection", streamId,
                         server ? "server" : "client");
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -184,16 +184,20 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         @Override
         public int onDataRead(final ChannelHandlerContext ctx, int streamId, ByteBuf data,
                 int padding, boolean endOfStream) throws Http2Exception {
-            Http2Stream stream = connection.requireStream(streamId);
+            Http2Stream stream = connection.stream(streamId);
             Http2LocalFlowController flowController = flowController();
             int bytesToReturn = data.readableBytes() + padding;
 
-            if (stream.isResetSent() || streamCreatedAfterGoAwaySent(stream)) {
-                // Count the frame towards the connection flow control window and don't process it further.
+            if (stream == null || stream.isResetSent() || streamCreatedAfterGoAwaySent(streamId)) {
+                // Ignoring this frame. We still need to count the frame towards the connection flow control
+                // window, but we immediately mark all bytes as consumed.
                 flowController.receiveFlowControlledFrame(ctx, stream, data, padding, endOfStream);
                 flowController.consumeBytes(ctx, stream, bytesToReturn);
 
-                // Since no bytes are consumed, return them all.
+                // Verify that the stream may have existed after we apply flow control.
+                verifyStreamMayHaveExisted(streamId);
+
+                // All bytes have been consumed.
                 return bytesToReturn;
             }
 
@@ -264,31 +268,40 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency,
                 short weight, boolean exclusive, int padding, boolean endOfStream) throws Http2Exception {
             Http2Stream stream = connection.stream(streamId);
-
-            if (stream == null) {
+            boolean allowHalfClosedRemote = false;
+            if (stream == null && !connection().streamMayHaveExisted(streamId)) {
                 stream = connection.remote().createStream(streamId).open(endOfStream);
-            } else if (stream.isResetSent() || streamCreatedAfterGoAwaySent(stream)) {
+                // Allow the state to be HALF_CLOSE_REMOTE if we're creating it in that state.
+                allowHalfClosedRemote = endOfStream;
+            }
+
+            if (stream == null || stream.isResetSent() || streamCreatedAfterGoAwaySent(streamId)) {
                 // Ignore this frame.
                 return;
-            } else {
-                switch (stream.state()) {
-                    case RESERVED_REMOTE:
-                    case IDLE:
-                        stream.open(endOfStream);
-                        break;
-                    case OPEN:
-                    case HALF_CLOSED_LOCAL:
-                        // Allowed to receive headers in these states.
-                        break;
-                    case HALF_CLOSED_REMOTE:
-                    case CLOSED:
+            }
+
+            switch (stream.state()) {
+                case RESERVED_REMOTE:
+                case IDLE:
+                    stream.open(endOfStream);
+                    break;
+                case OPEN:
+                case HALF_CLOSED_LOCAL:
+                    // Allowed to receive headers in these states.
+                    break;
+                case HALF_CLOSED_REMOTE:
+                    if (!allowHalfClosedRemote) {
                         throw streamError(stream.id(), STREAM_CLOSED, "Stream %d in unexpected state: %s",
-                                          stream.id(), stream.state());
-                    default:
-                        // Connection error.
-                        throw connectionError(PROTOCOL_ERROR, "Stream %d in unexpected state: %s", stream.id(),
-                                stream.state());
-                }
+                                stream.id(), stream.state());
+                    }
+                    break;
+                case CLOSED:
+                    throw streamError(stream.id(), STREAM_CLOSED, "Stream %d in unexpected state: %s",
+                            stream.id(), stream.state());
+                default:
+                    // Connection error.
+                    throw connectionError(PROTOCOL_ERROR, "Stream %d in unexpected state: %s", stream.id(),
+                            stream.state());
             }
 
             try {
@@ -314,11 +327,13 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
             Http2Stream stream = connection.stream(streamId);
 
             try {
-                if (stream == null) {
+                if (stream == null && !connection.streamMayHaveExisted(streamId)) {
                     // PRIORITY frames always identify a stream. This means that if a PRIORITY frame is the
                     // first frame to be received for a stream that we must create the stream.
                     stream = connection.remote().createStream(streamId);
-                } else if (streamCreatedAfterGoAwaySent(stream)) {
+                }
+
+                if (stream == null || streamCreatedAfterGoAwaySent(streamId)) {
                     // Ignore this frame.
                     return;
                 }
@@ -336,7 +351,11 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
 
         @Override
         public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception {
-            Http2Stream stream = connection.requireStream(streamId);
+            Http2Stream stream = connection.stream(streamId);
+            if (stream == null) {
+                verifyStreamMayHaveExisted(streamId);
+                return;
+            }
 
             switch(stream.state()) {
             case IDLE:
@@ -434,9 +453,10 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         @Override
         public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
                 Http2Headers headers, int padding) throws Http2Exception {
-            Http2Stream parentStream = connection.requireStream(streamId);
+            Http2Stream parentStream = connection.stream(streamId);
 
-            if (streamCreatedAfterGoAwaySent(parentStream)) {
+            if (parentStream == null || streamCreatedAfterGoAwaySent(streamId)) {
+                verifyStreamMayHaveExisted(streamId);
                 return;
             }
 
@@ -483,9 +503,10 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         @Override
         public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
                 throws Http2Exception {
-            Http2Stream stream = connection.requireStream(streamId);
-
-            if (stream.state() == CLOSED || streamCreatedAfterGoAwaySent(stream)) {
+            Http2Stream stream = connection.stream(streamId);
+            if (stream == null || stream.state() == CLOSED || streamCreatedAfterGoAwaySent(streamId)) {
+                // Ignore this frame.
+                verifyStreamMayHaveExisted(streamId);
                 return;
             }
 
@@ -501,10 +522,16 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
             onUnknownFrame0(ctx, frameType, streamId, flags, payload);
         }
 
-        private boolean streamCreatedAfterGoAwaySent(Http2Stream stream) {
+        private boolean streamCreatedAfterGoAwaySent(int streamId) {
             // Ignore inbound frames after a GOAWAY was sent and the stream id is greater than
             // the last stream id set in the GOAWAY frame.
-            return connection().goAwaySent() && stream.id() > connection().remote().lastKnownStream();
+            return connection().goAwaySent() && streamId > connection().remote().lastKnownStream();
+        }
+
+        private void verifyStreamMayHaveExisted(int streamId) throws Http2Exception {
+            if (!connection().streamMayHaveExisted(streamId)) {
+                throw connectionError(PROTOCOL_ERROR, "Stream does not exist %d", streamId);
+            }
         }
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -300,7 +300,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
     private Http2Stream requireStream(int streamId) {
         Http2Stream stream = connection.stream(streamId);
         if (stream == null) {
-            String message;
+            final String message;
             if (connection.streamMayHaveExisted(streamId)) {
                 message = "Stream no longer exists: " + streamId;
             } else {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -147,7 +147,13 @@ public interface Http2Connection {
          * Indicates whether the given streamId is from the set of IDs used by this endpoint to
          * create new streams.
          */
-        boolean createdStreamId(int streamId);
+        boolean isStreamForEndpoint(int streamId);
+
+        /**
+         * Indicates whether or not this endpoint may have created the given stream. This is {@code true} if
+         * {@link #isStreamForEndpoint(int)} and {@code streamId} <= {@link #lastStreamCreated()}.
+         */
+        boolean mayHaveCreatedStream(int streamId);
 
         /**
          * Indicates whether or not this endpoint is currently allowed to create new streams. This will be
@@ -264,14 +270,15 @@ public interface Http2Connection {
     void removeListener(Listener listener);
 
     /**
-     * Attempts to get the stream for the given ID. If it doesn't exist, throws.
-     */
-    Http2Stream requireStream(int streamId) throws Http2Exception;
-
-    /**
      * Gets the stream if it exists. If not, returns {@code null}.
      */
     Http2Stream stream(int streamId);
+
+    /**
+     * Indicates whether or not the given stream may have existed within this connection. This is a short form
+     * for calling {@link Endpoint#mayHaveCreatedStream(int)} on both endpoints.
+     */
+    boolean streamMayHaveExisted(int streamId);
 
     /**
      * Gets the stream object representing the connection, itself (i.e. stream zero). This object

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -147,11 +147,11 @@ public interface Http2Connection {
          * Indicates whether the given streamId is from the set of IDs used by this endpoint to
          * create new streams.
          */
-        boolean isStreamForEndpoint(int streamId);
+        boolean isValidStreamId(int streamId);
 
         /**
          * Indicates whether or not this endpoint may have created the given stream. This is {@code true} if
-         * {@link #isStreamForEndpoint(int)} and {@code streamId} <= {@link #lastStreamCreated()}.
+         * {@link #isValidStreamId(int)} and {@code streamId} <= {@link #lastStreamCreated()}.
          */
         boolean mayHaveCreatedStream(int streamId);
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
@@ -29,21 +29,17 @@ public interface Http2FrameListener {
      * @param streamId the subject stream for the frame.
      * @param data payload buffer for the frame. This buffer will be released by the codec.
      * @param padding the number of padding bytes found at the end of the frame.
-     * @param endOfStream Indicates whether this is the last frame to be sent from the remote
-     *            endpoint for this stream.
-     * @return the number of bytes that have been processed by the application. The returned bytes
-     *         are used by the inbound flow controller to determine the appropriate time to expand
-     *         the inbound flow control window (i.e. send {@code WINDOW_UPDATE}). Returning a value
-     *         equal to the length of {@code data} + {@code padding} will effectively opt-out of
-     *         application-level flow control for this frame. Returning a value less than the length
-     *         of {@code data} + {@code padding} will defer the returning of the processed bytes,
-     *         which the application must later return via
-     *         {@link Http2InboundFlowState#returnProcessedBytes(ChannelHandlerContext, int)}. The
-     *         returned value must be >= {@code 0} and <= {@code data.readableBytes()} +
-     *         {@code padding}.
+     * @param endOfStream Indicates whether this is the last frame to be sent from the remote endpoint for this stream.
+     * @return the number of bytes that have been processed by the application. The returned bytes are used by the
+     * inbound flow controller to determine the appropriate time to expand the inbound flow control window (i.e. send
+     * {@code WINDOW_UPDATE}). Returning a value equal to the length of {@code data} + {@code padding} will effectively
+     * opt-out of application-level flow control for this frame. Returning a value less than the length of {@code data}
+     * + {@code padding} will defer the returning of the processed bytes, which the application must later return via
+     * {@link Http2LocalFlowController#consumeBytes(io.netty.channel.ChannelHandlerContext, Http2Stream, int)}. The
+     * returned value must be >= {@code 0} and <= {@code data.readableBytes()} + {@code padding}.
      */
     int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
-            boolean endOfStream) throws Http2Exception;
+                   boolean endOfStream) throws Http2Exception;
 
     /**
      * Handles an inbound {@code HEADERS} frame.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
@@ -35,8 +35,8 @@ public interface Http2FrameListener {
      * {@code WINDOW_UPDATE}). Returning a value equal to the length of {@code data} + {@code padding} will effectively
      * opt-out of application-level flow control for this frame. Returning a value less than the length of {@code data}
      * + {@code padding} will defer the returning of the processed bytes, which the application must later return via
-     * {@link Http2LocalFlowController#consumeBytes(io.netty.channel.ChannelHandlerContext, Http2Stream, int)}. The
-     * returned value must be >= {@code 0} and <= {@code data.readableBytes()} + {@code padding}.
+     * {@link Http2LocalFlowController#consumeBytes(ChannelHandlerContext, Http2Stream, int)}. The returned value must
+     * be >= {@code 0} and <= {@code data.readableBytes()} + {@code padding}.
      */
     int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
                    boolean endOfStream) throws Http2Exception;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
@@ -33,7 +33,8 @@ public interface Http2LocalFlowController extends Http2FlowController {
      *
      * @param ctx the context from the handler where the frame was read.
      * @param stream the subject stream for the received frame. The connection stream object must not be used. If {@code
-     * null} or closed, only the connection window is impacted.
+     * stream} is {@code null} or closed, flow control should only be applied to the connection window and the bytes are
+     * immediately consumed.
      * @param data payload buffer for the frame.
      * @param padding the number of padding bytes found at the end of the frame.
      * @param endOfStream Indicates whether this is the last frame to be sent from the remote endpoint for this stream.
@@ -53,7 +54,8 @@ public interface Http2LocalFlowController extends Http2FlowController {
      *
      * @param ctx the channel handler context to use when sending a {@code WINDOW_UPDATE} if appropriate
      * @param stream the stream for which window space should be freed. The connection stream object must not be used.
-     * If {@code null} or closed, does nothing.
+     * If {@code stream} is {@code null} or closed (i.e. {@link Http2Stream#state()} method returns {@link
+     * Http2Stream.State#CLOSED}), calling this method has no effect.
      * @param numBytes the number of bytes to be returned to the flow control window.
      * @throws Http2Exception if the number of bytes returned exceeds the {@link #unconsumedBytes(Http2Stream)} for the
      * stream.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
@@ -24,20 +24,19 @@ import io.netty.channel.ChannelHandlerContext;
 public interface Http2LocalFlowController extends Http2FlowController {
 
     /**
-     * Receives an inbound {@code DATA} frame from the remote endpoint and applies flow control
-     * policies to it for both the {@code stream} as well as the connection. If any flow control
-     * policies have been violated, an exception is raised immediately, otherwise the frame is
-     * considered to have "passed" flow control.
+     * Receives an inbound {@code DATA} frame from the remote endpoint and applies flow control policies to it for both
+     * the {@code stream} as well as the connection. If any flow control policies have been violated, an exception is
+     * raised immediately, otherwise the frame is considered to have "passed" flow control.
      * <p/>
-     * If {@code stream} is closed, flow control should only be applied to the connection window.
+     * If {@code stream} is {@code null} or closed, flow control should only be applied to the connection window and the
+     * bytes are immediately consumed.
      *
      * @param ctx the context from the handler where the frame was read.
-     * @param stream the subject stream for the received frame. The connection stream object must
-     *            not be used.
+     * @param stream the subject stream for the received frame. The connection stream object must not be used. If {@code
+     * null} or closed, only the connection window is impacted.
      * @param data payload buffer for the frame.
      * @param padding the number of padding bytes found at the end of the frame.
-     * @param endOfStream Indicates whether this is the last frame to be sent from the remote
-     *            endpoint for this stream.
+     * @param endOfStream Indicates whether this is the last frame to be sent from the remote endpoint for this stream.
      * @throws Http2Exception if any flow control errors are encountered.
      */
     void receiveFlowControlledFrame(ChannelHandlerContext ctx, Http2Stream stream, ByteBuf data, int padding,
@@ -49,13 +48,12 @@ public interface Http2LocalFlowController extends Http2FlowController {
      * control window will collapse. Consuming bytes enables the flow controller to send {@code WINDOW_UPDATE} to
      * restore a portion of the flow control window for the stream.
      * <p/>
-     * If {@code stream} is closed (i.e. {@link Http2Stream#state()} method returns {@link Http2Stream.State#CLOSED}),
-     * the consumed bytes are only restored to the connection window. When a stream is closed, the flow controller
-     * automatically restores any unconsumed bytes for that stream to the connection window. This is done to ensure that
-     * the connection window does not degrade over time as streams are closed.
+     * If {@code stream} is {@code null} or closed (i.e. {@link Http2Stream#state()} method returns {@link
+     * Http2Stream.State#CLOSED}), calling this method has no effect.
      *
      * @param ctx the channel handler context to use when sending a {@code WINDOW_UPDATE} if appropriate
      * @param stream the stream for which window space should be freed. The connection stream object must not be used.
+     * If {@code null} or closed, does nothing.
      * @param numBytes the number of bytes to be returned to the flow control window.
      * @throws Http2Exception if the number of bytes returned exceeds the {@link #unconsumedBytes(Http2Stream)} for the
      * stream.

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -148,7 +148,6 @@ public class DefaultHttp2ConnectionEncoderTest {
             }
         }).when(connection).forEachActiveStream(any(Http2StreamVisitor.class));
         when(connection.stream(STREAM_ID)).thenReturn(stream);
-        when(connection.requireStream(STREAM_ID)).thenReturn(stream);
         when(connection.local()).thenReturn(local);
         when(connection.remote()).thenReturn(remote);
         when(remote.flowController()).thenReturn(remoteFlow);
@@ -357,7 +356,6 @@ public class DefaultHttp2ConnectionEncoderTest {
     @Test
     public void priorityWriteShouldSetPriorityForStream() throws Exception {
         when(connection.stream(STREAM_ID)).thenReturn(null);
-        when(connection.requireStream(STREAM_ID)).thenReturn(null);
         encoder.writePriority(ctx, STREAM_ID, 0, (short) 255, true, promise);
         verify(stream).setPriority(eq(0), eq((short) 255), eq(true));
         verify(writer).writePriority(eq(ctx), eq(STREAM_ID), eq(0), eq((short) 255), eq(true), eq(promise));
@@ -374,10 +372,8 @@ public class DefaultHttp2ConnectionEncoderTest {
             }
         }).when(local).createStream(eq(STREAM_ID));
         when(connection.stream(STREAM_ID)).thenReturn(null);
-        when(connection.requireStream(STREAM_ID)).thenReturn(null);
         // Just return the stream object as the connection stream to ensure the dependent stream "exists"
         when(connection.stream(0)).thenReturn(stream);
-        when(connection.requireStream(0)).thenReturn(stream);
         encoder.writePriority(ctx, STREAM_ID, 0, (short) 255, true, promise);
         verify(stream, never()).setPriority(anyInt(), anyShort(), anyBoolean());
         verify(writer).writePriority(eq(ctx), eq(STREAM_ID), eq(0), eq((short) 255), eq(true), eq(promise));
@@ -393,7 +389,6 @@ public class DefaultHttp2ConnectionEncoderTest {
             }
         }).when(stream).setPriority(eq(0), eq((short) 255), eq(true));
         when(connection.stream(STREAM_ID)).thenReturn(stream);
-        when(connection.requireStream(STREAM_ID)).thenReturn(stream);
         encoder.writePriority(ctx, STREAM_ID, 0, (short) 255, true, promise);
         verify(stream).setPriority(eq(0), eq((short) 255), eq(true));
         verify(writer).writePriority(eq(ctx), eq(STREAM_ID), eq(0), eq((short) 255), eq(true), eq(promise));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -74,11 +74,6 @@ public class DefaultHttp2ConnectionTest {
         client.addListener(clientListener);
     }
 
-    @Test(expected = Http2Exception.class)
-    public void getStreamOrFailWithoutStreamShouldFail() throws Http2Exception {
-        server.requireStream(100);
-    }
-
     @Test
     public void getStreamWithoutStreamShouldReturnNull() {
         assertNull(server.stream(100));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -218,6 +218,18 @@ public class DefaultHttp2LocalFlowControllerTest {
     }
 
     @Test
+    public void dataReceivedForNullStreamShouldImmediatelyConsumeBytes() throws Http2Exception {
+        receiveFlowControlledFrame(null, 10, 0, false);
+        assertEquals(0, controller.unconsumedBytes(connection.connectionStream()));
+    }
+
+    @Test
+    public void consumeBytesForNullStreamShouldIgnore() throws Http2Exception {
+        controller.consumeBytes(ctx, null, 10);
+        assertEquals(0, controller.unconsumedBytes(connection.connectionStream()));
+    }
+
+    @Test
     public void globalRatioShouldImpactStreams() throws Http2Exception {
         float ratio = 0.6f;
         controller.windowUpdateRatio(ratio);
@@ -312,6 +324,6 @@ public class DefaultHttp2LocalFlowControllerTest {
     }
 
     private Http2Stream stream(int streamId) throws Http2Exception {
-        return connection.requireStream(streamId);
+        return connection.stream(streamId);
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -1234,7 +1234,7 @@ public class DefaultHttp2RemoteFlowControllerTest {
     }
 
     private Http2Stream stream(int streamId) throws Http2Exception {
-        return connection.requireStream(streamId);
+        return connection.stream(streamId);
     }
 
     private static final class FakeFlowControlled implements Http2RemoteFlowController.FlowControlled {


### PR DESCRIPTION
Motivation:

The recent PR that discarded the Http2StreamRemovalPolicy causes connection errors when receiving a frame for a stream that no longer exists. We should ignore these frames if we think there's a chance that the stream has existed previously

Modifications:

Modified the Http2Connection interface to provide a `streamMayHaveExisted` method. Also removed the requireStream() method to identify all of the places in the code that need to be updated.

Modified the encoder and decoder to properly handle cases where a stream may have existed but no longer does.

Result:

Fixes #3643