### PR TITLE
Disable flushing on frame write in flow-controller

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -206,12 +206,9 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
             frame.error(t);
             return;
         }
+        // Write data to channel but don't flush as more writes may be coming and we want to
+        // allow a flush to coalesce them
         state.writeBytes(state.writableWindow());
-        try {
-            flush();
-        } catch (Throwable t) {
-            frame.error(t);
-        }
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
@@ -27,8 +27,8 @@ public interface Http2RemoteFlowController extends Http2FlowController {
      * guarantee when the data will be written or whether it will be split into multiple frames
      * before sending.
      * <p>
-     * Manually flushing the {@link ChannelHandlerContext} is not required, since the flow
-     * controller will flush as appropriate.
+     * Manually flushing the {@link ChannelHandlerContext} is required for writes as the flow controller will
+     * not flush by itself except in response to window update events.
      *
      * @param ctx the context from the handler.
      * @param stream the subject stream. Must not be the connection stream object.

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -127,19 +127,19 @@ public class DefaultHttp2RemoteFlowControllerTest {
     }
 
     @Test
-    public void payloadSmallerThanWindowShouldBeSentImmediately() throws Http2Exception {
+    public void payloadSmallerThanWindowShouldBeWrittenImmediately() throws Http2Exception {
         FakeFlowControlled data = new FakeFlowControlled(5);
         sendData(STREAM_A, data);
         data.assertFullyWritten();
-        verify(ctx, times(1)).flush();
+        verify(ctx, times(0)).flush();
     }
 
     @Test
-    public void emptyPayloadShouldBeSentImmediately() throws Http2Exception {
+    public void emptyPayloadShouldBeWrittenImmediately() throws Http2Exception {
         FakeFlowControlled data = new FakeFlowControlled(0);
         sendData(STREAM_A, data);
         data.assertFullyWritten();
-        verify(ctx, times(1)).flush();
+        verify(ctx, times(0)).flush();
     }
 
     @Test
@@ -180,7 +180,7 @@ public class DefaultHttp2RemoteFlowControllerTest {
         sendData(STREAM_A, data);
         // Verify that a partial frame of 5 remains to be sent
         data.assertPartiallyWritten(5);
-        verify(ctx, times(1)).flush();
+        verify(ctx, times(0)).flush();
     }
 
     @Test
@@ -193,7 +193,7 @@ public class DefaultHttp2RemoteFlowControllerTest {
         sendData(STREAM_A, moreData);
         data.assertPartiallyWritten(10);
         moreData.assertNotWritten();
-        verify(ctx, times(1)).flush();
+        verify(ctx, times(0)).flush();
         reset(ctx);
 
         // Update the window and verify that the rest of data and some of moreData are written


### PR DESCRIPTION
Don't flush in sendFrame so Http2ConenctionEncoder maintains its guarantee to not call flush. This allows for a write of HEADERS followed by DATA to be flushed together.

Fixes https://github.com/netty/netty/issues/3688
Partially fixes https://github.com/netty/netty/issues/3670
