### PR TITLE
ByteString and AsciiString hashCode updates

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -203,3 +203,10 @@ non-blocking XML processor, which can be obtained at:
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
+This product contains a modified version of Fowler/Noll/Vo's Public Domain
+FNV1-a Hash Code Algorithm, which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.fnv1a.txt (Public Domain)
+  * HOMEPAGE:
+    * http://www.isthe.com/chongo/tech/comp/fnv/index.html

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -14,7 +14,7 @@
  */
 package io.netty.handler.codec.http2;
 
-import static io.netty.util.internal.StringUtil.UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET;
+import static io.netty.util.internal.StringUtil.asciiToLowerCase;
 import io.netty.handler.codec.BinaryHeaders;
 import io.netty.handler.codec.DefaultBinaryHeaders;
 import io.netty.util.AsciiString;
@@ -40,8 +40,7 @@ public class DefaultHttp2Headers extends DefaultBinaryHeaders implements Http2He
 
         @Override
         public boolean process(byte value) throws Exception {
-            result[i++] = (value >= 'A' && value <= 'Z')
-                    ? (byte) (value + UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET) : value;
+            result[i++] = asciiToLowerCase(value);
             return true;
         }
 

--- a/common/src/main/java/io/netty/util/ByteString.java
+++ b/common/src/main/java/io/netty/util/ByteString.java
@@ -15,7 +15,7 @@
 package io.netty.util;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
-
+import io.netty.util.internal.HashCodeGenerator;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 
@@ -33,6 +33,9 @@ import java.util.Comparator;
  * this object is immutable.
  */
 public class ByteString {
+    private static final HashCodeGenerator HASHER = PlatformDependent.hashCodeGenerator();
+    public static final ByteString EMPTY_STRING = new ByteString(0);
+
     /**
      * A byte wise comparator between two {@link ByteString} objects.
      */
@@ -76,9 +79,6 @@ public class ByteString {
         }
     };
 
-    public static final ByteString EMPTY_STRING = new ByteString(0);
-    protected static final int HASH_CODE_PRIME = 31;;
-
     /**
      * If this value is modified outside the constructor then call {@link #arrayChanged()}.
      */
@@ -95,7 +95,7 @@ public class ByteString {
     /**
      * The hash code is cached after it is first computed. It can be reset with {@link #arrayChanged()}.
      */
-    private int hash;
+    private int hash = HASHER.emptyHashValue();
 
     /**
      * Used for classes which extend this class and want to initialize the {@link #value} array by them selves.
@@ -342,7 +342,7 @@ public class ByteString {
     }
 
     public final boolean isEmpty() {
-        return length == 0;
+        return length() == 0;
     }
 
     public final int length() {
@@ -382,7 +382,7 @@ public class ByteString {
      * @see #array()
      */
     public final boolean isEntireArrayUsed() {
-        return offset == 0 && length == value.length;
+        return offset == 0 && length() == value.length;
     }
 
     /**
@@ -419,15 +419,10 @@ public class ByteString {
 
     @Override
     public int hashCode() {
-        int h = hash;
-        if (h == 0) {
-            final int end = offset + length;
-            for (int i = offset; i < end; ++i) {
-                h = h * HASH_CODE_PRIME ^ value[i] & HASH_CODE_PRIME;
-            }
-
-            hash = h;
+        if (hash == HASHER.emptyHashValue() && length() > 0) {
+            hash = HASHER.hashCode(value, offset, offset + length());
         }
+
         return hash;
     }
 

--- a/common/src/main/java/io/netty/util/internal/AbstractHashCodeGenerator.java
+++ b/common/src/main/java/io/netty/util/internal/AbstractHashCodeGenerator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+/**
+ * Provides methods which don't take start/end positions from {@link HashCodeGenerator} and delegates to methods
+ * that do.
+ */
+public abstract class AbstractHashCodeGenerator implements HashCodeGenerator {
+    @Override
+    public final int hashCode(byte[] bytes) {
+        return hashCode(bytes, 0, bytes.length);
+    }
+
+    @Override
+    public final int hashCodeAsBytes(char[] bytes) {
+        return hashCodeAsBytes(bytes, 0, bytes.length);
+    }
+
+    @Override
+    public final int hashCodeAsBytes(CharSequence data) {
+        return hashCodeAsBytes(data, 0, data.length());
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/HashCodeGenerator.java
+++ b/common/src/main/java/io/netty/util/internal/HashCodeGenerator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+/**
+ * Provides the ability to generate a hash code for array based objects.
+ */
+public interface HashCodeGenerator {
+    /**
+     * Same as calling {@link #hashCode(byte[], int, int)} as {@code hashCode(bytes, 0, bytes.length)}.
+     */
+    int hashCode(byte[] bytes);
+
+    /**
+     * Generate a hash code from the [{@code startPos}, {@code endPos}) subsection of {@code bytes}.
+     */
+    int hashCode(byte[] bytes, int startPos, int endPos);
+
+    /**
+     * Same as calling {@link #hashCodeAsBytes(char[], int, int)} as {@code hashCode(bytes, 0, bytes.length)}.
+     */
+    int hashCodeAsBytes(char[] bytes);
+
+    /**
+     * Generate a hash code from the [{@code startPos}, {@code endPos}) subsection of {@code bytes}.
+     * <p>
+     * This method will treat the {@code byte[]} as though it was a {@code byte[]}. This means that the
+     * Most Significant Byte of each {@code char} will be ignored. This is useful when a {@code char[]} is used to
+     * represent a {@code byte[]} and the results need to be equivalent when hashing the two different types.
+     * <p>
+     * This method is preferred over {@link #hashCodeAsBytes(CharSequence, int, int, int)} because arrays have more
+     * unsafe support for optimizations.
+     */
+    int hashCodeAsBytes(char[] bytes, int startPos, int endPos);
+
+    /**
+     * Same as calling {@link #hashCodeAsBytes(CharSequence, int, int)} as {@code hashCode(data, 0, data.length())}.
+     */
+    int hashCodeAsBytes(CharSequence data);
+
+    /**
+     * Generate a hash code from the [{@code startPos}, {@code endPos}) subsection of {@code bytes}.
+     * <p>
+     * This method will treat the {@code byte[]} as though it was a {@code byte[]}. This means that the
+     * Most Significant Byte of each {@code char} will be ignored. This is useful when a {@code char[]} is used to
+     * represent a {@code byte[]} and the results need to be equivalent when hashing the two different types.
+     */
+    int hashCodeAsBytes(CharSequence data, int startPos, int endPos);
+
+    /**
+     * Get the value that is returned when there is nothing to hash.
+     */
+    int emptyHashValue();
+}

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -16,12 +16,12 @@
 package io.netty.util.internal;
 
 
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Formatter;
 import java.util.List;
-
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * String utility class.
@@ -37,7 +37,7 @@ public final class StringUtil {
     public static final char CARRIAGE_RETURN = '\r';
     public static final char TAB = '\t';
 
-    public static final byte UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET = 'a' - 'A';
+    private static final byte UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET = 'a' - 'A';
     private static final String[] BYTE2HEX_PAD = new String[256];
     private static final String[] BYTE2HEX_NOPAD = new String[256];
 
@@ -373,6 +373,18 @@ public final class StringUtil {
         }
         return escapedDoubleQuote || foundSpecialCharacter && !quoted ?
                 escaped.append(DOUBLE_QUOTE) : value;
+    }
+
+    public static byte asciiToLowerCase(byte b) {
+        return ('A' <= b && b <= 'Z') ? (byte) (b + UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET) : b;
+    }
+
+    public static char asciiToLowerCase(char c) {
+        return ('A' <= c && c <= 'Z') ? (char) (c + UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET) : c;
+    }
+
+    public static byte asciiToUpperCase(byte b) {
+        return ('a' <= b && b <= 'z') ? (byte) (b - UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET) : b;
     }
 
     private static boolean isDoubleQuote(char c) {

--- a/common/src/test/java/io/netty/util/AsciiStringTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringTest.java
@@ -15,10 +15,13 @@
  */
 package io.netty.util;
 
-import static org.junit.Assert.assertEquals;
+import static io.netty.util.AsciiString.caseInsensitiveHashCode;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
+import java.nio.CharBuffer;
 import java.nio.charset.Charset;
+import java.util.Random;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -87,6 +90,8 @@ public class AsciiStringTest {
         final int end = init.length;
         AsciiString sub1 = ascii.subSequence(start, end, false);
         AsciiString sub2 = ascii.subSequence(start, end, true);
+        assertEquals(sub1.hashCode(), sub2.hashCode());
+        assertEquals(sub1.hashCodeCaseInsensitive(), sub2.hashCode());
         assertEquals(sub1, sub2);
         for (int i = start; i < end; ++i) {
             assertEquals(init[i], sub1.byteAt(i - start));
@@ -95,8 +100,48 @@ public class AsciiStringTest {
 
     @Test
     public void caseInsensativeHasher() {
-        String s1 = new String("TransfeR-EncodinG");
-        AsciiString s2 = new AsciiString("transfer-encoding");
-        assertEquals(AsciiString.caseInsensitiveHashCode(s1), AsciiString.caseInsensitiveHashCode(s2));
+        Random r = new Random();
+        int i = 0;
+        for (; i < 32; i++) {
+            doCaseInsensative(r, i);
+        }
+        final int min = i;
+        final int max = 4000;
+        final int len = r.nextInt((max - min) + 1) + min;
+        doCaseInsensative(r, len);
+    }
+
+    private static void doCaseInsensative(Random r, int len) {
+        final int upperA = 'A';
+        final int upperZ = 'Z';
+        final int upperToLower = (int) 'a' - upperA;
+        byte[] bytes = new byte[len];
+        StringBuilder b = new StringBuilder(len);
+        for (int i = 0; i < len; ++i) {
+            char upper = (char) (r.nextInt((upperZ - upperA) + 1) + upperA);
+            b.append(upper);
+            bytes[i] = (byte) (upper + upperToLower);
+        }
+        String s1 = b.toString();
+        AsciiString s2 = new AsciiString(bytes, false);
+        AsciiString s3 = new AsciiString(s1);
+        final String errorString = "len: " + len;
+        final int expected = s2.hashCode();
+        assertEquals(errorString, expected, caseInsensitiveHashCode(s1));
+        assertEquals(errorString, expected, caseInsensitiveHashCode(s2));
+        assertEquals(errorString, expected, s2.hashCodeCaseInsensitive());
+        assertEquals(errorString, expected, s3.hashCodeCaseInsensitive());
+    }
+
+    @Test
+    public void caseInsensativeHasherCharBuffer() {
+        String s1 = new String("TRANSFER-ENCODING");
+        char[] array = new char[128];
+        final int offset = 100;
+        for (int i = 0; i < s1.length(); ++i) {
+            array[offset + i] = s1.charAt(i);
+        }
+        CharBuffer buffer = CharBuffer.wrap(array, offset, s1.length());
+        assertEquals(caseInsensitiveHashCode(s1), caseInsensitiveHashCode(buffer));
     }
 }

--- a/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
+++ b/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
@@ -15,11 +15,15 @@
  */
 package io.netty.util.internal;
 
-import org.junit.Test;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
+import io.netty.util.CharsetUtil;
+
+import java.util.Random;
+
+import org.junit.Test;
 
 public class PlatformDependentTest {
 
@@ -69,5 +73,106 @@ public class PlatformDependentTest {
         assertFalse(PlatformDependent.equals(bytes1, 0, bytes1.length, bytes2, 0, bytes2.length));
         assertTrue(PlatformDependent.equals(bytes1, 2, bytes1.length, bytes2, 0, bytes2.length));
         assertTrue(PlatformDependent.equals(bytes2, 0, bytes2.length, bytes1, 2, bytes1.length));
+    }
+
+    @Test
+    public void testHashCode() {
+        HashCodeGenerator hasher = PlatformDependent.hashCodeGenerator();
+        final int bytes1Len = 256;
+        final int bytes2Len = bytes1Len >> 1;
+        final int bytes1Start = bytes2Len;
+        final int bytes2Start = bytes2Len >> 1;
+        int subSequenceLen = bytes2Len - bytes2Start;
+        // We want to have a number that is divisible by 7 to ensure we hit all the
+        // getlong/getint/getchar/direct lookup branches.
+        while (subSequenceLen % 7 != 0) {
+            --subSequenceLen;
+        }
+        byte[] bytes1 = new byte[bytes1Len];
+        byte[] bytes2 = new byte[bytes2Len];
+        Random r = new Random();
+        r.nextBytes(bytes1);
+        System.arraycopy(bytes1, bytes1Start, bytes2, bytes2Start, subSequenceLen);
+        assertNotSame(bytes1, bytes2);
+
+        final int expected = hasher.hashCode(bytes2, bytes2Start, subSequenceLen);
+        // Test that two separate arrays with the same value for a given range yield the same hash code.
+        assertEquals(expected, hasher.hashCode(bytes1, bytes1Start, subSequenceLen));
+    }
+
+    @Test
+    public void testHashDifferntTypesSameResults() {
+        HashCodeGenerator hasher = PlatformDependent.hashCodeGenerator();
+
+        Random r = new Random();
+        int i = 0;
+        for (; i < 32; ++i) {
+            runHasherEqualityTest(hasher, i, r);
+        }
+        final int min = i;
+        final int max = 20000;
+        int len = r.nextInt((max - min) + 1) + min;
+        // We now want to test a "random" length array but differnt permutations to test
+        // interesting boundary conditions.
+        while (len % 8 != 0) {
+            ++len;
+        }
+        for (i = len - 8; i < len; ++i) {
+            runHasherEqualityTest(hasher, i, r);
+        }
+    }
+
+    @Test
+    public void testHashTypeOptimizations() {
+        HashCodeGenerator hasher = PlatformDependent.hashCodeGenerator();
+
+        int i = 0;
+        for (; i < 32; ++i) {
+            runTypeOptimizations(hasher, i);
+        }
+        Random r = new Random();
+        final int min = i;
+        final int max = 20000;
+        int len = r.nextInt((max - min) + 1) + min;
+        // We now want to test a "random" length array but differnt permutations to test
+        // interesting boundary conditions.
+        while (len % 8 != 0) {
+            ++len;
+        }
+        for (i = len - 8; i < len; ++i) {
+            runTypeOptimizations(hasher, i);
+        }
+    }
+
+    private void runTypeOptimizations(HashCodeGenerator hasher, int len) {
+        StringBuilder b = new StringBuilder(len);
+        for (int i = 0; i < len; ++i) {
+            b.append((byte) i);
+        }
+        String s = b.toString();
+        byte[] bytes = s.getBytes(CharsetUtil.US_ASCII);
+
+        assertEquals(s.length(), bytes.length);
+
+        final int expected =  hasher.hashCode(bytes);
+        final String errorMsg = "len: " + len;
+        assertEquals(errorMsg, expected, hasher.hashCodeAsBytes(s));
+        assertEquals(errorMsg, expected, hasher.hashCodeAsBytes(b));
+    }
+
+    private static void runHasherEqualityTest(HashCodeGenerator hasher, int len, Random r) {
+        byte[] bytes = new byte[len];
+        char[] charsAsBytes = new char[bytes.length];
+        r.nextBytes(bytes);
+
+        for (int i = 0; i < bytes.length; ++i) {
+            charsAsBytes[i] = (char) (bytes[i] & 0xFF);
+        }
+
+        String a = new String(charsAsBytes);
+        final int expected =  hasher.hashCode(bytes);
+        final String errorMsg = "len: " + len;
+        assertEquals(errorMsg, expected, hasher.hashCodeAsBytes(a));
+        assertEquals(errorMsg, expected, hasher.hashCodeAsBytes(charsAsBytes));
     }
 }

--- a/license/LICENSE.fnv1a.txt
+++ b/license/LICENSE.fnv1a.txt
@@ -1,0 +1,26 @@
+The person or persons who have associated work with this document (the
+"Dedicator" or "Certifier") hereby either (a) certifies that, to the best of
+his knowledge, the work of authorship identified is in the public domain of
+the country from which the work is published, or (b) hereby dedicates whatever
+copyright the dedicators holds in the work of authorship identified below (the
+"Work") to the public domain. A certifier, moreover, dedicates any copyright
+interest he may have in the associated work, and for these purposes, is
+described as a "dedicator" below.
+
+A certifier has taken reasonable steps to verify the copyright status of this
+work. Certifier recognizes that his good faith efforts may not shield him from
+liability if in fact the work certified is not in the public domain.
+
+Dedicator makes this dedication for the benefit of the public at large and to
+the detriment of the Dedicator's heirs and successors. Dedicator intends this
+dedication to be an overt act of relinquishment in perpetuate of all present
+and future rights under copyright law, whether vested or contingent, in the
+Work. Dedicator understands that such relinquishment of all rights includes
+the relinquishment of all rights to enforce (by lawsuit or otherwise) those
+copyrights in the Work.
+
+Dedicator recognizes that, once placed in the public domain, the Work may be
+freely reproduced, distributed, transmitted, used, modified, built upon, or
+otherwise exploited by anyone for any purpose, commercial or non-commercial,
+and in any way, including by methods that have not yet been invented or
+conceived.

--- a/microbench/src/main/java/io/netty/microbenchmark/common/AsciiStringBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbenchmark/common/AsciiStringBenchmark.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbenchmark.common;
+
+import static io.netty.util.internal.StringUtil.asciiToLowerCase;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.AsciiString;
+import io.netty.util.ByteProcessor;
+
+import java.util.Random;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+
+@Threads(1)
+@State(Scope.Benchmark)
+public class AsciiStringBenchmark extends AbstractMicrobenchmark {
+
+    public enum InputType {
+        UPPER_CASE, LOWER_CASE, MIXED_CASE, RANDOM;
+    }
+
+    @Param({ "5", "10", "20", "50", "100" })
+    private int size;
+
+    @Param
+    public InputType inputType;
+
+    private AsciiString a;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        final int max = 255;
+        final int min = 0;
+        final int upperA = 'A';
+        final int upperZ = 'Z';
+        final int upperToLower = (int) 'a' - upperA;
+        Random r = new Random();
+        byte[] bytes = new byte[size];
+
+        switch (inputType) {
+        case UPPER_CASE:
+            for (int i = 0; i < size; i++) {
+                bytes[i] = (byte) (r.nextInt((upperZ - upperA) + 1) + upperA);
+            }
+            break;
+        case LOWER_CASE:
+            for (int i = 0; i < size; i++) {
+                bytes[i] = (byte) ((r.nextInt((upperZ - upperA) + 1) + upperA) + upperToLower);
+            }
+            break;
+        case MIXED_CASE:
+            for (int i = 0; i < size; i++) {
+                bytes[i] = (byte) (r.nextInt((upperZ - upperA) + 1) + upperA);
+                if ((i & 1) == 0) {
+                    bytes[i] += upperToLower;
+                }
+            }
+            break;
+        case RANDOM:
+            for (int i = 0; i < size; i++) {
+                bytes[i] = (byte) (r.nextInt((max - min) + 1) + min);
+            }
+            break;
+        default:
+            throw new Error();
+        }
+
+        a = new AsciiString(bytes, false);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public int hashCodeCaseInsensitiveAscii() {
+        return a.hashCodeCaseInsensitive();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public int hashCodeCaseInsensitiveOldNettyAscii() throws Exception {
+        ByteProcessor processor = new ByteProcessor() {
+            private int hash;
+            @Override
+            public boolean process(byte value) throws Exception {
+                hash = hash * 31 ^ asciiToLowerCase(value) & 31;
+                return true;
+            }
+
+            @Override
+            public int hashCode() {
+                return hash;
+            }
+        };
+        a.forEachByte(processor);
+        return processor.hashCode();
+    }
+}


### PR DESCRIPTION
Motivation:
The ByteString class is often used in equality and hashCode operations. ByteString caches the hashCode after computed but case insensitive AsciiString hashCode operations are not cached.  The hash code algorithm we currently have is home grown and applies a mask of 31 onto every byte or character while generating the hash code which reduces the amount of bits each character contributes to the hash code from 8 down to 5. The JDK Arrays.hashCode(..) method does not support generating a hash code over a sub-section of an array which is required by ByteString and AsciiString.

Modifications:
- Use a hash code algorithm which takes all the bits of each character into account.
- Provide an optimized UNSAFE version of this algorithm which can work for case sensitive and insensitive.
- Update ByteString and AsciiString to take advantage of the new hashCode implementations.

Result:
ByteString and AsciiString hashCode algorithm uses all bits from each character. AsciiString caches the case insensitive hashCode result.