### PR TITLE
[#3218] Add ChannelPool abstraction and implementations

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -29,13 +29,16 @@ import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.ByteBuffer;
+import java.util.Deque;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
@@ -428,6 +431,17 @@ public final class PlatformDependent {
      */
     public static ClassLoader getSystemClassLoader() {
         return PlatformDependent0.getSystemClassLoader();
+    }
+
+    /**
+     * Returns a new concurrent {@link Deque}.
+     */
+    public static <C> Deque<C> newConcurrentDeque() {
+        if (javaVersion() < 7) {
+            return new LinkedBlockingDeque<C>();
+        } else {
+            return new ConcurrentLinkedDeque<C>();
+        }
     }
 
     private static boolean isAndroid0() {

--- a/pom.xml
+++ b/pom.xml
@@ -927,6 +927,8 @@
             <!-- SSLSession implementation -->
             <ignore>javax.net.ssl.SSLEngine</ignore>
             <ignore>javax.net.ssl.X509ExtendedTrustManager</ignore>
+            
+            <ignore>java.util.concurrent.ConcurrentLinkedDeque</ignore>
           </ignores>
         </configuration>
         <executions>

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -46,8 +46,8 @@ import java.util.Map;
  */
 public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C extends Channel> implements Cloneable {
 
-    private volatile EventLoopGroup group;
-    private volatile ChannelFactory<? extends C> channelFactory;
+    volatile EventLoopGroup group;
+    volatile ChannelFactory<? extends C> channelFactory;
     private volatile SocketAddress localAddress;
     private final Map<ChannelOption<?>, Object> options = new LinkedHashMap<ChannelOption<?>, Object>();
     private final Map<AttributeKey<?>, Object> attrs = new LinkedHashMap<AttributeKey<?>, Object>();
@@ -369,7 +369,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
         return localAddress;
     }
 
-    final ChannelFactory<? extends C> channelFactory() {
+    public final ChannelFactory<? extends C> channelFactory() {
         return channelFactory;
     }
 

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.EventLoopGroup;
 import io.netty.util.AttributeKey;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -214,6 +215,18 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
     @SuppressWarnings("CloneDoesntCallSuperClone")
     public Bootstrap clone() {
         return new Bootstrap(this);
+    }
+
+    /**
+     * Returns a deep clone of this bootstrap which has the identical configuration except that it uses
+     * the given {@link EventLoopGroup}. This method is useful when making multiple {@link Channel}s with similar
+     * settings.
+     */
+    public Bootstrap clone(EventLoopGroup group, ChannelFactory<? extends Channel> channelFactory) {
+        Bootstrap bs = new Bootstrap(this);
+        bs.group = group;
+        bs.channelFactory = channelFactory;
+        return bs;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -16,6 +16,7 @@
 package io.netty.channel;
 
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.pool.PooledChannel;
 import io.netty.util.DefaultAttributeMap;
 import io.netty.util.Recycler;
 import io.netty.util.ReferenceCountUtil;
@@ -869,7 +870,8 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
             throw new IllegalArgumentException("promise already done: " + promise);
         }
 
-        if (promise.channel() != channel()) {
+        Channel ch = promise.channel();
+        if (ch != channel() && (!(ch instanceof PooledChannel) && ((PooledChannel<?, ?>) ch).unwrap() != ch)) {
             throw new IllegalArgumentException(String.format(
                     "promise.channel does not match: %s (expected: %s)", promise.channel(), channel()));
         }

--- a/transport/src/main/java/io/netty/channel/FailedChannelFuture.java
+++ b/transport/src/main/java/io/netty/channel/FailedChannelFuture.java
@@ -23,7 +23,7 @@ import io.netty.util.internal.PlatformDependent;
  * recommended to use {@link Channel#newFailedFuture(Throwable)}
  * instead of calling the constructor of this future.
  */
-final class FailedChannelFuture extends CompleteChannelFuture {
+public final class FailedChannelFuture extends CompleteChannelFuture {
 
     private final Throwable cause;
 
@@ -33,7 +33,7 @@ final class FailedChannelFuture extends CompleteChannelFuture {
      * @param channel the {@link Channel} associated with this future
      * @param cause   the cause of failure
      */
-    FailedChannelFuture(Channel channel, EventExecutor executor, Throwable cause) {
+    public FailedChannelFuture(Channel channel, EventExecutor executor, Throwable cause) {
         super(channel, executor);
         if (cause == null) {
             throw new NullPointerException("cause");

--- a/transport/src/main/java/io/netty/channel/SucceededChannelFuture.java
+++ b/transport/src/main/java/io/netty/channel/SucceededChannelFuture.java
@@ -22,14 +22,14 @@ import io.netty.util.concurrent.EventExecutor;
  * recommended to use {@link Channel#newSucceededFuture()} instead of
  * calling the constructor of this future.
  */
-final class SucceededChannelFuture extends CompleteChannelFuture {
+public final class SucceededChannelFuture extends CompleteChannelFuture {
 
     /**
      * Creates a new instance.
      *
      * @param channel the {@link Channel} associated with this future
      */
-    SucceededChannelFuture(Channel channel, EventExecutor executor) {
+    public SucceededChannelFuture(Channel channel, EventExecutor executor) {
         super(channel, executor);
     }
 

--- a/transport/src/main/java/io/netty/channel/pool/AbstractChannelPoolHandler.java
+++ b/transport/src/main/java/io/netty/channel/pool/AbstractChannelPoolHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+import io.netty.channel.Channel;
+
+/**
+ * Base class for {@link ChannelPoolHandler} implementations.
+ *
+ * @param <C>   the {@link Channel} type to pool.
+ * @param <K>   the {@link ChannelPoolKey} that is used to store and lookup the {@link Channel}s.
+ */
+public abstract class AbstractChannelPoolHandler<C extends Channel, K extends ChannelPoolKey>
+        implements ChannelPoolHandler<C, K> {
+
+    /**
+     * NOOP implementation, sub-classes may override this.
+     */
+    @Override
+    public void channelAcquired(@SuppressWarnings("unused") PooledChannel<C, K> ch) throws Exception {
+        // NOOP
+    }
+
+    /**
+     * NOOP implementation, sub-classes may override this.
+     */
+    @Override
+    public void channelReleased(@SuppressWarnings("unused") PooledChannel<C, K> ch) throws Exception {
+        // NOOP
+    }
+}

--- a/transport/src/main/java/io/netty/channel/pool/AbstractChannelPoolHandler.java
+++ b/transport/src/main/java/io/netty/channel/pool/AbstractChannelPoolHandler.java
@@ -18,7 +18,7 @@ package io.netty.channel.pool;
 import io.netty.channel.Channel;
 
 /**
- * Base class for {@link ChannelPoolHandler} implementations.
+ * A skeletal {@link ChannelPoolHandler} implementation.
  *
  * @param <C>   the {@link Channel} type to pool.
  * @param <K>   the {@link ChannelPoolKey} that is used to store and lookup the {@link Channel}s.
@@ -28,6 +28,8 @@ public abstract class AbstractChannelPoolHandler<C extends Channel, K extends Ch
 
     /**
      * NOOP implementation, sub-classes may override this.
+     *
+     * {@inheritDoc}
      */
     @Override
     public void channelAcquired(@SuppressWarnings("unused") PooledChannel<C, K> ch) throws Exception {
@@ -36,6 +38,8 @@ public abstract class AbstractChannelPoolHandler<C extends Channel, K extends Ch
 
     /**
      * NOOP implementation, sub-classes may override this.
+     *
+     * {@inheritDoc}
      */
     @Override
     public void channelReleased(@SuppressWarnings("unused") PooledChannel<C, K> ch) throws Exception {

--- a/transport/src/main/java/io/netty/channel/pool/AbstractPooledChannel.java
+++ b/transport/src/main/java/io/netty/channel/pool/AbstractPooledChannel.java
@@ -1,0 +1,1316 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelMetadata;
+import io.netty.channel.ChannelOutboundHandler;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelProgressivePromise;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelProgressivePromise;
+import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.EventLoop;
+import io.netty.channel.FailedChannelFuture;
+import io.netty.channel.SucceededChannelFuture;
+import io.netty.util.Attribute;
+import io.netty.util.AttributeKey;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.ThreadLocalRandom;
+
+import java.net.SocketAddress;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+public abstract class AbstractPooledChannel<C extends Channel, K extends ChannelPoolKey>
+        implements PooledChannel<C, K>  {
+    private final long hashCode = ThreadLocalRandom.current().nextLong();
+    private final C channel;
+    private final K key;
+    private final ChannelPool<C, K> pool;
+    private final PooledChannelPipeline pipeline;
+    private final ChannelFuture succeededFuture = new SucceededChannelFuture(this, null);
+    private final CloseFuture closeFuture = new CloseFuture(this);
+    private final AtomicBoolean acquired = new AtomicBoolean(false);
+
+    protected AbstractPooledChannel(C channel, K key, ChannelPool<C, K> pool) {
+        this.channel = checkNotNull(channel, "channel");
+        this.key = checkNotNull(key, "key");
+        this.pool = checkNotNull(pool, "pool");
+        pipeline = new PooledChannelPipeline(this, channel.pipeline());
+        channel.closeFuture().addListener(closeFuture);
+    }
+
+    /**
+     * Mark the {@link AbstractPooledChannel} as acquired. This methods needs to be called by the
+     * {@link ChannelPool} implementation before return this {@link PooledChannel}.
+     */
+    public void acquired() {
+        if (!acquired.compareAndSet(false, true)) {
+            throw new IllegalStateException("PooledChannel already in use");
+        }
+    }
+
+    @Override
+    public final C unwrap() {
+        return channel;
+    }
+
+    @Override
+    public final ChannelPool<C, K> pool() {
+        return pool;
+    }
+
+    @Override
+    public final K key() {
+        return key;
+    }
+
+    @Override
+    public final Future<Void> release() {
+        return release(newPromise());
+    }
+
+    @Override
+    public final Future<Void> release(Promise<Void> promise) {
+        if (!acquired.compareAndSet(true, false)) {
+            return promise.setFailure(new IllegalStateException("PooledChannel was already released"));
+        }
+        return releaseToPool(promise);
+    }
+
+    /**
+     * Release this {@link PooledChannel} back to the pool from which it was acquired.
+     */
+    protected abstract Future<Void> releaseToPool(Promise<Void> promise);
+
+    @Override
+    public final EventLoop eventLoop() {
+        return channel.eventLoop();
+    }
+
+    @Override
+    public final Channel parent() {
+        return channel.parent();
+    }
+
+    @Override
+    public final ChannelConfig config() {
+        return channel.config();
+    }
+
+    @Override
+    public final boolean isOpen() {
+        return channel.isOpen();
+    }
+
+    @Override
+    public final boolean isRegistered() {
+        return channel.isRegistered();
+    }
+
+    @Override
+    public final boolean isActive() {
+        return channel.isActive();
+    }
+
+    @Override
+    public final ChannelMetadata metadata() {
+        return channel.metadata();
+    }
+
+    @Override
+    public final SocketAddress localAddress() {
+        return channel.localAddress();
+    }
+
+    @Override
+    public final SocketAddress remoteAddress() {
+        return channel.remoteAddress();
+    }
+
+    @Override
+    public final ChannelFuture closeFuture() {
+        return closeFuture;
+    }
+
+    @Override
+    public final boolean isWritable() {
+        return channel.isWritable();
+    }
+
+    @Override
+    public final Unsafe unsafe() {
+        return channel.unsafe();
+    }
+
+    @Override
+    public final ChannelPipeline pipeline() {
+        return pipeline;
+    }
+
+    @Override
+    public final ByteBufAllocator alloc() {
+        return channel.alloc();
+    }
+
+    @Override
+    public final ChannelPromise newPromise() {
+        return new DefaultChannelPromise(this, eventLoop());
+    }
+
+    @Override
+    public final ChannelProgressivePromise newProgressivePromise() {
+        return new DefaultChannelProgressivePromise(this, eventLoop());
+    }
+
+    @Override
+    public final ChannelFuture newSucceededFuture() {
+        return succeededFuture;
+    }
+
+    @Override
+    public final ChannelFuture newFailedFuture(Throwable cause) {
+        return new FailedChannelFuture(this, eventLoop(), cause);
+    }
+
+    @Override
+    public final ChannelPromise voidPromise() {
+        return newPromise();
+    }
+
+    @Override
+    public final ChannelFuture bind(SocketAddress localAddress) {
+        ChannelPromise promise = newPromise();
+        channel.bind(localAddress, promise);
+        return promise;
+    }
+
+    @Override
+    public final ChannelFuture connect(SocketAddress remoteAddress) {
+        ChannelPromise promise = newPromise();
+        channel.connect(remoteAddress, promise);
+        return promise;
+    }
+
+    @Override
+    public final ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
+        ChannelPromise promise = newPromise();
+        channel.connect(remoteAddress, localAddress, promise);
+        return promise;
+    }
+
+    @Override
+    public final ChannelFuture disconnect() {
+        ChannelPromise promise = newPromise();
+        channel.disconnect(promise);
+        return promise;
+    }
+
+    @Override
+    public final ChannelFuture close() {
+        ChannelPromise promise = newPromise();
+        channel.close(promise);
+        return promise;
+    }
+
+    @Override
+    public final ChannelFuture deregister() {
+        ChannelPromise promise = newPromise();
+        channel.deregister(promise);
+        return promise;
+    }
+
+    private void validatePromise(ChannelPromise promise) {
+        if (promise.channel() != this) {
+            throw new IllegalArgumentException(String.format(
+                    "promise.channel does not match: %s (expected: %s)", promise.channel(), this));
+        }
+    }
+
+    @Override
+    public final ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
+        validatePromise(promise);
+        channel.bind(localAddress, promise);
+        return promise;
+    }
+
+    @Override
+    public final ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
+        validatePromise(promise);
+        channel.connect(remoteAddress, promise);
+        return promise;
+    }
+
+    @Override
+    public final ChannelFuture connect(
+            SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+        validatePromise(promise);
+        channel.connect(remoteAddress, localAddress, promise);
+        return promise;
+    }
+
+    @Override
+    public final ChannelFuture disconnect(ChannelPromise promise) {
+        validatePromise(promise);
+        channel.disconnect(promise);
+        return promise;
+    }
+
+    @Override
+    public final ChannelFuture close(ChannelPromise promise) {
+        validatePromise(promise);
+        channel.close(promise);
+        return promise;
+    }
+
+    @Override
+    public final ChannelFuture deregister(ChannelPromise promise) {
+        validatePromise(promise);
+        channel.deregister(promise);
+        return promise;
+    }
+
+    @Override
+    public final Channel read() {
+        return channel.read();
+    }
+
+    @Override
+    public final ChannelFuture write(Object msg) {
+        ChannelPromise promise = newPromise();
+        channel.write(msg, promise);
+        return promise;
+    }
+
+    @Override
+    public final ChannelFuture write(Object msg, ChannelPromise promise) {
+        validatePromise(promise);
+        channel.write(msg, promise);
+        return promise;
+    }
+
+    @Override
+    public final Channel flush() {
+        return channel.flush();
+    }
+
+    @Override
+    public final ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+        validatePromise(promise);
+        channel.writeAndFlush(msg, promise);
+        return promise;
+    }
+
+    @Override
+    public final ChannelFuture writeAndFlush(Object msg) {
+        ChannelPromise promise = newPromise();
+        channel.writeAndFlush(msg, promise);
+        return promise;
+    }
+
+    @Override
+    public final <T> Attribute<T> attr(AttributeKey<T> key) {
+        return channel.attr(key);
+    }
+
+    /**
+     * Returns {@code true} if and only if the specified object is identical
+     * with this channel (i.e: {@code this == o}).
+     */
+    @Override
+    public final boolean equals(Object o) {
+        return this == o;
+    }
+
+    @Override
+    public final int compareTo(Channel o) {
+        if (this == o) {
+            return 0;
+        }
+
+        long ret = hashCode - o.hashCode();
+        if (ret > 0) {
+            return 1;
+        }
+        if (ret < 0) {
+            return -1;
+        }
+
+        ret = System.identityHashCode(this) - System.identityHashCode(o);
+        if (ret != 0) {
+            return (int) ret;
+        }
+
+        // Jackpot! - different objects with same hashes
+        throw new Error();
+    }
+
+    @Override
+    public final int hashCode() {
+        return (int) hashCode;
+    }
+
+    // We need to wrap the existing Channel and ChannelPipeline to ensure that we always return the PooledChannel.
+    private final class PooledChannelPipeline implements ChannelPipeline {
+        private final Channel channel;
+        private final ChannelPipeline pipeline;
+
+        PooledChannelPipeline(Channel channel, ChannelPipeline pipeline) {
+            this.channel = channel;
+            this.pipeline = pipeline;
+        }
+
+        // Wrap the ChannelHandler so we can pass in our own PooledChannelHandlerContext and PooledChannel.
+        private ChannelHandler wrap(ChannelHandler handler) {
+            boolean inbound = handler instanceof ChannelInboundHandler;
+            boolean outbound = handler instanceof ChannelOutboundHandler;
+
+            if (inbound) {
+                if (outbound) {
+                    return new PooledChannelDuplexHandler(channel, (ChannelOutboundHandler) handler);
+                }
+                return new PooledChannelInboundHandler(channel, (ChannelInboundHandler) handler);
+            }
+            if (outbound) {
+                return new PooledChannelOutboundHandler(channel, (ChannelOutboundHandler) handler);
+            }
+            return new PooledChannelHandler(channel, handler);
+        }
+
+        private ChannelHandler[] wrap(ChannelHandler[] handlers) {
+            ChannelHandler[] wrapped = new ChannelHandler[handlers.length];
+            for (int i = 0; i < wrapped.length; i++) {
+                wrapped[i] = wrap(handlers[i]);
+            }
+            return wrapped;
+        }
+
+        @Override
+        public ChannelPipeline addFirst(String name, ChannelHandler handler) {
+            pipeline.addFirst(name, wrap(handler));
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline addFirst(EventExecutorGroup group, String name, ChannelHandler handler) {
+            pipeline.addFirst(group, name, wrap(handler));
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline addLast(String name, ChannelHandler handler) {
+            pipeline.addLast(name, wrap(handler));
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline addLast(EventExecutorGroup group, String name, ChannelHandler handler) {
+            pipeline.addLast(group, name, wrap(handler));
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline addBefore(String baseName, String name, ChannelHandler handler) {
+            pipeline.addBefore(baseName, name, wrap(handler));
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline addBefore(EventExecutorGroup group, String baseName, String name,
+                                         ChannelHandler handler) {
+            pipeline.addBefore(group, baseName, name, wrap(handler));
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline addAfter(String baseName, String name, ChannelHandler handler) {
+            pipeline.addAfter(baseName, name, wrap(handler));
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline addAfter(EventExecutorGroup group, String baseName, String name,
+                                        ChannelHandler handler) {
+            pipeline.addAfter(group, baseName, name, wrap(handler));
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline addFirst(ChannelHandler... handlers) {
+            pipeline.addFirst(wrap(handlers));
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline addFirst(EventExecutorGroup group, ChannelHandler... handlers) {
+            pipeline.addFirst(group, wrap(handlers));
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline addLast(ChannelHandler... handlers) {
+            pipeline.addLast(wrap(handlers));
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline addLast(EventExecutorGroup group, ChannelHandler... handlers) {
+            pipeline.addLast(group, wrap(handlers));
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline remove(ChannelHandler handler) {
+            ChannelHandlerContext ctx = context(handler);
+            if (ctx == null) {
+                throw new NoSuchElementException();
+            }
+            pipeline.remove(ctx.handler());
+            return this;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public ChannelHandler remove(String name) {
+            ChannelHandler handler = pipeline.remove(name);
+            return ((PooledChannelHandler) handler).handler;
+        }
+
+        @Override
+        public <T extends ChannelHandler> T remove(Class<T> handlerType) {
+            T handler = get(handlerType);
+            if (handler == null) {
+                throw new NoSuchElementException();
+            }
+            remove(handler);
+            return handler;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public ChannelHandler removeFirst() {
+            ChannelHandler handler = pipeline.removeFirst();
+            if (handler == null) {
+                throw new NoSuchElementException();
+            }
+            return ((PooledChannelHandler) handler).handler;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public ChannelHandler removeLast() {
+            ChannelHandler handler = pipeline.removeLast();
+            if (handler == null) {
+                throw new NoSuchElementException();
+            }
+            return ((PooledChannelHandler) handler).handler;
+        }
+
+        @Override
+        public ChannelPipeline replace(ChannelHandler oldHandler, String newName, ChannelHandler newHandler) {
+            ChannelHandlerContext context = context(oldHandler);
+            if (context == null) {
+                throw new NoSuchElementException();
+            }
+            replace(context.name(), newName, newHandler);
+
+            return this;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public ChannelHandler replace(String oldName, String newName, ChannelHandler newHandler) {
+            ChannelHandler handler = pipeline.replace(oldName, newName, newHandler);
+            if (handler == null) {
+                throw new NoSuchElementException();
+            }
+            return ((PooledChannelHandler) handler).handler;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T extends ChannelHandler> T replace(Class<T> oldHandlerType, String newName,
+                                                    ChannelHandler newHandler) {
+            ChannelHandlerContext context = context(oldHandlerType);
+            if (context == null) {
+                throw new NoSuchElementException();
+            }
+            return (T) replace(context.name(), newName, newHandler);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public ChannelHandler first() {
+            ChannelHandler handler = pipeline.first();
+            if (handler != null) {
+                return ((PooledChannelHandler) handler).handler;
+            }
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public ChannelHandlerContext firstContext() {
+            ChannelHandler handler = pipeline.first();
+            if (handler != null) {
+                return ((PooledChannelHandler) handler).context;
+            }
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public ChannelHandler last() {
+            ChannelHandler handler = pipeline.last();
+            if (handler != null) {
+                return ((PooledChannelHandler) handler).handler;
+            }
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public ChannelHandlerContext lastContext() {
+            ChannelHandler handler = pipeline.last();
+            if (handler != null) {
+                return ((PooledChannelHandler) handler).context;
+            }
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public ChannelHandler get(String name) {
+            ChannelHandler handler = pipeline.get(name);
+            if (handler != null) {
+                return ((PooledChannelHandler) handler).handler;
+            }
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T extends ChannelHandler> T get(Class<T> handlerType) {
+            for (Entry<String, ChannelHandler> entry: pipeline) {
+                PooledChannelHandler handler = (PooledChannelHandler) entry.getValue();
+                if (handlerType.isAssignableFrom(handler.handler.getClass())) {
+                    return (T) handler.handler;
+                }
+            }
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public ChannelHandlerContext context(ChannelHandler h) {
+            for (Entry<String, ChannelHandler> entry: pipeline) {
+                PooledChannelHandler handler = (PooledChannelHandler) entry.getValue();
+                if (h == handler.handler) {
+                    return handler.context;
+                }
+            }
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public ChannelHandlerContext context(String name) {
+            ChannelHandler handler = pipeline.get(name);
+            if (handler != null) {
+                return ((PooledChannelHandler) handler).context;
+            }
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public ChannelHandlerContext context(Class<? extends ChannelHandler> handlerType) {
+            for (Entry<String, ChannelHandler> entry: pipeline) {
+                PooledChannelHandler handler = (PooledChannelHandler) entry.getValue();
+                if (handlerType.isAssignableFrom(handler.handler.getClass())) {
+                    return handler.context;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public Channel channel() {
+            return channel;
+        }
+
+        @Override
+        public List<String> names() {
+            return pipeline.names();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Map<String, ChannelHandler> toMap() {
+            Map<String, ChannelHandler> map = pipeline.toMap();
+            int size = map.size();
+            if (size == 0) {
+                return map;
+            }
+            Map<String, ChannelHandler> unwrapped = new HashMap<String, ChannelHandler>(size);
+            for (Entry<String, ChannelHandler> entries: map.entrySet()) {
+                unwrapped.put(entries.getKey(), ((PooledChannelHandler) entries.getValue()).handler);
+            }
+            return unwrapped;
+        }
+
+        @Override
+        public ChannelPipeline fireChannelRegistered() {
+            pipeline.fireChannelRegistered();
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline fireChannelUnregistered() {
+            pipeline.fireChannelUnregistered();
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline fireChannelActive() {
+            pipeline.fireChannelActive();
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline fireChannelInactive() {
+            pipeline.fireChannelInactive();
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline fireExceptionCaught(Throwable cause) {
+            pipeline.fireExceptionCaught(cause);
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline fireUserEventTriggered(Object event) {
+            pipeline.fireUserEventTriggered(event);
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline fireChannelRead(Object msg) {
+            pipeline.fireChannelRead(msg);
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline fireChannelReadComplete() {
+            pipeline.fireChannelReadComplete();
+            return this;
+        }
+
+        @Override
+        public ChannelPipeline fireChannelWritabilityChanged() {
+            pipeline.fireChannelWritabilityChanged();
+            return this;
+        }
+
+        @Override
+        public ChannelFuture bind(SocketAddress localAddress) {
+            return bind(localAddress, newPromise());
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress) {
+            return connect(remoteAddress, newPromise());
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
+            return connect(remoteAddress, localAddress, newPromise());
+        }
+
+        @Override
+        public ChannelFuture disconnect() {
+            return disconnect(newPromise());
+        }
+
+        @Override
+        public ChannelFuture close() {
+            return close(newPromise());
+        }
+
+        @Override
+        public ChannelFuture deregister() {
+            return deregister(newPromise());
+        }
+
+        @Override
+        public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
+            validatePromise(promise);
+            pipeline.bind(localAddress, promise);
+            return promise;
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
+            validatePromise(promise);
+            pipeline.connect(remoteAddress, promise);
+            return promise;
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+            validatePromise(promise);
+            pipeline.connect(remoteAddress, localAddress, promise);
+            return promise;
+        }
+
+        @Override
+        public ChannelFuture disconnect(ChannelPromise promise) {
+            validatePromise(promise);
+            pipeline.disconnect(promise);
+            return promise;
+        }
+
+        @Override
+        public ChannelFuture close(ChannelPromise promise) {
+            validatePromise(promise);
+            pipeline.close(promise);
+            return promise;
+        }
+
+        @Override
+        public ChannelFuture deregister(ChannelPromise promise) {
+            validatePromise(promise);
+            pipeline.deregister(promise);
+            return promise;
+        }
+
+        @Override
+        public ChannelPipeline read() {
+            pipeline.read();
+            return this;
+        }
+
+        @Override
+        public ChannelFuture write(Object msg) {
+           return  write(msg, newPromise());
+        }
+
+        @Override
+        public ChannelFuture write(Object msg, ChannelPromise promise) {
+            validatePromise(promise);
+            pipeline.write(msg, promise);
+            return promise;
+        }
+
+        @Override
+        public ChannelPipeline flush() {
+            pipeline.flush();
+            return this;
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+            validatePromise(promise);
+            pipeline.writeAndFlush(msg, promise);
+            return promise;
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object msg) {
+            return writeAndFlush(msg, newPromise());
+        }
+
+        @Override
+        public Iterator<Entry<String, ChannelHandler>> iterator() {
+            return toMap().entrySet().iterator();
+        }
+    }
+
+    private class PooledChannelHandler implements ChannelHandler, ChannelHandlerContext {
+        protected ChannelHandlerContext context;
+        private final Channel channel;
+        final ChannelHandler handler;
+
+        PooledChannelHandler(Channel channel, ChannelHandler handler) {
+            this.channel = channel;
+            this.handler = handler;
+        }
+
+        @Override
+        public final void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+            context = ctx;
+            handler.handlerAdded(this);
+        }
+
+        @Override
+        public final void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+            assert ctx == context;
+            handler.handlerRemoved(this);
+        }
+
+        @Override
+        public final void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            assert ctx == context;
+            handler.exceptionCaught(this, cause);
+        }
+
+        @Override
+        public Channel channel() {
+            return channel;
+        }
+
+        @Override
+        public EventExecutor executor() {
+            return context.executor();
+        }
+
+        @Override
+        public String name() {
+            return context.name();
+        }
+
+        @Override
+        public ChannelHandler handler() {
+            return context.handler();
+        }
+
+        @Override
+        public boolean isRemoved() {
+            return context.isRemoved();
+        }
+
+        @Override
+        public ChannelHandlerContext fireChannelRegistered() {
+            context.fireChannelRegistered();
+            return this;
+        }
+
+        @Override
+        public ChannelHandlerContext fireChannelUnregistered() {
+            context.fireChannelUnregistered();
+            return this;
+        }
+
+        @Override
+        public ChannelHandlerContext fireChannelActive() {
+            context.fireChannelActive();
+            return this;
+        }
+
+        @Override
+        public ChannelHandlerContext fireChannelInactive() {
+            context.fireChannelInactive();
+            return this;
+        }
+
+        @Override
+        public ChannelHandlerContext fireExceptionCaught(Throwable cause) {
+            context.fireExceptionCaught(cause);
+            return this;
+        }
+
+        @Override
+        public ChannelHandlerContext fireUserEventTriggered(Object event) {
+            context.fireUserEventTriggered(event);
+            return this;
+        }
+
+        @Override
+        public ChannelHandlerContext fireChannelRead(Object msg) {
+            context.fireChannelRead(msg);
+            return this;
+        }
+
+        @Override
+        public ChannelHandlerContext fireChannelReadComplete() {
+            context.fireChannelReadComplete();
+            return this;
+        }
+
+        @Override
+        public ChannelHandlerContext fireChannelWritabilityChanged() {
+            context.fireChannelWritabilityChanged();
+            return this;
+        }
+
+        @Override
+        public ChannelFuture bind(SocketAddress localAddress) {
+            return bind(localAddress, newPromise());
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress) {
+            return connect(remoteAddress, newPromise());
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
+            return connect(remoteAddress, localAddress, newPromise());
+        }
+
+        @Override
+        public ChannelFuture disconnect() {
+            return disconnect(newPromise());
+        }
+
+        @Override
+        public ChannelFuture close() {
+            return close(newPromise());
+        }
+
+        @Override
+        public ChannelFuture deregister() {
+            return deregister(newPromise());
+        }
+
+        @Override
+        public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
+            validatePromise(promise);
+            context.bind(localAddress, promise);
+            return promise;
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress, ChannelPromise promise) {
+            validatePromise(promise);
+            context.connect(remoteAddress, promise);
+            return promise;
+        }
+
+        @Override
+        public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+            validatePromise(promise);
+            context.connect(remoteAddress, localAddress, promise);
+            return promise;
+        }
+
+        @Override
+        public ChannelFuture disconnect(ChannelPromise promise) {
+            validatePromise(promise);
+            context.disconnect(promise);
+            return promise;
+        }
+
+        @Override
+        public ChannelFuture close(ChannelPromise promise) {
+            validatePromise(promise);
+            context.close(promise);
+            return promise;
+        }
+
+        @Override
+        public ChannelFuture deregister(ChannelPromise promise) {
+            return context.deregister(promise);
+        }
+
+        @Override
+        public ChannelHandlerContext read() {
+            context.read();
+            return this;
+        }
+
+        @Override
+        public ChannelFuture write(Object msg) {
+            return write(msg, newPromise());
+        }
+
+        @Override
+        public ChannelFuture write(Object msg, ChannelPromise promise) {
+            validatePromise(promise);
+            context.write(msg, promise);
+            return promise;
+        }
+
+        @Override
+        public ChannelHandlerContext flush() {
+            context.flush();
+            return this;
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+            validatePromise(promise);
+            context.writeAndFlush(msg, promise);
+            return promise;
+        }
+
+        @Override
+        public ChannelFuture writeAndFlush(Object msg) {
+            return writeAndFlush(msg, newPromise());
+        }
+
+        @Override
+        public ChannelPipeline pipeline() {
+            return channel.pipeline();
+        }
+
+        @Override
+        public ByteBufAllocator alloc() {
+            return context.alloc();
+        }
+
+        @Override
+        public ChannelPromise newPromise() {
+            return new DefaultChannelPromise(channel, executor());
+        }
+
+        @Override
+        public ChannelProgressivePromise newProgressivePromise() {
+            return new DefaultChannelProgressivePromise(channel, executor());
+        }
+
+        @Override
+        public ChannelFuture newSucceededFuture() {
+            return succeededFuture;
+        }
+
+        @Override
+        public ChannelFuture newFailedFuture(Throwable cause) {
+            return new FailedChannelFuture(channel, executor(), cause);
+        }
+
+        @Override
+        public ChannelPromise voidPromise() {
+            return newPromise();
+        }
+
+        @Override
+        public <T> Attribute<T> attr(AttributeKey<T> key) {
+            return context.attr(key);
+        }
+    }
+
+    private class PooledChannelInboundHandler extends PooledChannelHandler implements ChannelInboundHandler {
+
+        public PooledChannelInboundHandler(Channel channel, ChannelInboundHandler handler) {
+            super(channel, handler);
+        }
+
+        @Override
+        public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).channelRegistered(this);
+        }
+
+        @Override
+        public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).channelUnregistered(this);
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).channelActive(this);
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).channelInactive(this);
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).channelRead(this, msg);
+        }
+
+        @Override
+        public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).channelReadComplete(this);
+        }
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).userEventTriggered(this, evt);
+        }
+
+        @Override
+        public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).channelWritabilityChanged(this);
+        }
+    }
+
+    private class PooledChannelOutboundHandler extends PooledChannelHandler implements ChannelOutboundHandler {
+        public PooledChannelOutboundHandler(Channel channel, ChannelOutboundHandler handler) {
+            super(channel, handler);
+        }
+
+        @Override
+        public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise)
+                throws Exception {
+            assert ctx == context;
+            ((ChannelOutboundHandler) handler).bind(this, localAddress, promise);
+        }
+
+        @Override
+        public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
+                            ChannelPromise promise) throws Exception {
+            assert ctx == context;
+            ((ChannelOutboundHandler) handler).connect(this, remoteAddress, localAddress, promise);
+        }
+
+        @Override
+        public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+            assert ctx == context;
+            ((ChannelOutboundHandler) handler).disconnect(this, promise);
+        }
+
+        @Override
+        public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+            assert ctx == context;
+            ((ChannelOutboundHandler) handler).close(this, promise);
+        }
+
+        @Override
+        public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+            assert ctx == context;
+            ((ChannelOutboundHandler) handler).deregister(context, promise);
+        }
+
+        @Override
+        public void read(ChannelHandlerContext ctx) throws Exception {
+            assert ctx == context;
+            ((ChannelOutboundHandler) handler).read(this);
+        }
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            assert ctx == context;
+            ((ChannelOutboundHandler) handler).write(this, msg, promise);
+        }
+
+        @Override
+        public void flush(ChannelHandlerContext ctx) throws Exception {
+            assert ctx == context;
+            ((ChannelOutboundHandler) handler).flush(this);
+        }
+    }
+
+    private final class PooledChannelDuplexHandler extends PooledChannelOutboundHandler
+            implements ChannelInboundHandler {
+        public PooledChannelDuplexHandler(Channel channel, ChannelOutboundHandler handler) {
+            super(channel, handler);
+        }
+
+        @Override
+        public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).channelRegistered(this);
+        }
+
+        @Override
+        public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).channelUnregistered(this);
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).channelActive(this);
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).channelInactive(this);
+        }
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).channelRead(this, msg);
+        }
+
+        @Override
+        public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).channelReadComplete(this);
+        }
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).userEventTriggered(this, evt);
+        }
+
+        @Override
+        public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+            assert ctx == context;
+            ((ChannelInboundHandler) handler).channelWritabilityChanged(this);
+        }
+    }
+
+    private static final class CloseFuture extends DefaultChannelPromise implements ChannelFutureListener {
+
+        CloseFuture(Channel ch) {
+            super(ch);
+        }
+
+        @Override
+        public ChannelPromise setSuccess() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public ChannelPromise setFailure(Throwable cause) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public boolean trySuccess() {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public boolean tryFailure(Throwable cause) {
+            throw new IllegalStateException();
+        }
+
+        boolean setClosed() {
+            return super.trySuccess();
+        }
+
+        @Override
+        public void operationComplete(ChannelFuture future) throws Exception {
+            setClosed();
+        }
+    }
+}

--- a/transport/src/main/java/io/netty/channel/pool/ActiveChannelHealthChecker.java
+++ b/transport/src/main/java/io/netty/channel/pool/ActiveChannelHealthChecker.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+import io.netty.channel.Channel;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+
+/**
+ * {@link ChannelHealthChecker} implementation that checks if {@link Channel#isActive()} returns {@code true}.
+ *
+ * @param <C>   the {@link Channel} type to pool.
+ * @param <K>   the {@link ChannelPoolKey} that is used to store and lookup the {@link Channel}s.
+ */
+public final class ActiveChannelHealthChecker<C extends Channel, K extends ChannelPoolKey>
+        implements ChannelHealthChecker<C, K> {
+
+    private static final Future<Boolean> ACTIVE = ImmediateEventExecutor.INSTANCE.newSucceededFuture(Boolean.TRUE);
+    private static final Future<Boolean> NOT_ACTIVE = ImmediateEventExecutor.INSTANCE.newSucceededFuture(Boolean.FALSE);
+
+    private ActiveChannelHealthChecker() { }
+
+    @SuppressWarnings("rawtypes")
+    private static final ChannelHealthChecker
+            INSTANCE = new ActiveChannelHealthChecker<Channel, ChannelPoolKey>();
+
+    @SuppressWarnings("unchecked")
+    public static <C extends Channel, K extends ChannelPoolKey> ChannelHealthChecker<C, K> instance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Future<Boolean> isHealthy(PooledChannel<C, K> channel) {
+        if (channel.isActive()) {
+            return ACTIVE;
+        }
+        return NOT_ACTIVE;
+    }
+}

--- a/transport/src/main/java/io/netty/channel/pool/ActiveChannelHealthChecker.java
+++ b/transport/src/main/java/io/netty/channel/pool/ActiveChannelHealthChecker.java
@@ -34,8 +34,7 @@ public final class ActiveChannelHealthChecker<C extends Channel, K extends Chann
     private ActiveChannelHealthChecker() { }
 
     @SuppressWarnings("rawtypes")
-    private static final ChannelHealthChecker
-            INSTANCE = new ActiveChannelHealthChecker<Channel, ChannelPoolKey>();
+    private static final ChannelHealthChecker INSTANCE = new ActiveChannelHealthChecker<Channel, ChannelPoolKey>();
 
     @SuppressWarnings("unchecked")
     public static <C extends Channel, K extends ChannelPoolKey> ChannelHealthChecker<C, K> instance() {
@@ -44,9 +43,6 @@ public final class ActiveChannelHealthChecker<C extends Channel, K extends Chann
 
     @Override
     public Future<Boolean> isHealthy(PooledChannel<C, K> channel) {
-        if (channel.isActive()) {
-            return ACTIVE;
-        }
-        return NOT_ACTIVE;
+        return channel.isActive()? ACTIVE: NOT_ACTIVE;
     }
 }

--- a/transport/src/main/java/io/netty/channel/pool/ActiveChannelHealthChecker.java
+++ b/transport/src/main/java/io/netty/channel/pool/ActiveChannelHealthChecker.java
@@ -16,8 +16,8 @@
 package io.netty.channel.pool;
 
 import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.ImmediateEventExecutor;
 
 /**
  * {@link ChannelHealthChecker} implementation that checks if {@link Channel#isActive()} returns {@code true}.
@@ -27,9 +27,6 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
  */
 public final class ActiveChannelHealthChecker<C extends Channel, K extends ChannelPoolKey>
         implements ChannelHealthChecker<C, K> {
-
-    private static final Future<Boolean> ACTIVE = ImmediateEventExecutor.INSTANCE.newSucceededFuture(Boolean.TRUE);
-    private static final Future<Boolean> NOT_ACTIVE = ImmediateEventExecutor.INSTANCE.newSucceededFuture(Boolean.FALSE);
 
     private ActiveChannelHealthChecker() { }
 
@@ -43,6 +40,7 @@ public final class ActiveChannelHealthChecker<C extends Channel, K extends Chann
 
     @Override
     public Future<Boolean> isHealthy(PooledChannel<C, K> channel) {
-        return channel.isActive()? ACTIVE: NOT_ACTIVE;
+        EventLoop loop = channel.eventLoop();
+        return channel.isActive()? loop.newSucceededFuture(Boolean.TRUE) : loop.newSucceededFuture(Boolean.FALSE);
     }
 }

--- a/transport/src/main/java/io/netty/channel/pool/ChannelHealthChecker.java
+++ b/transport/src/main/java/io/netty/channel/pool/ChannelHealthChecker.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+
+/**
+ * Called before a {@link Channel} will be returned via {@link ChannelPool#acquire(ChannelPoolKey)} or
+ * {@link ChannelPool#acquire(ChannelPoolKey, Promise)}.
+ *
+ * @param <C>   the {@link Channel} type to pool.
+ * @param <K>   the {@link ChannelPoolKey} that is used to store and lookup the {@link Channel}s.
+ */
+public interface ChannelHealthChecker<C extends Channel, K extends ChannelPoolKey> {
+
+    /**
+     * Check if the given channel is healthy which means it can be used. The returned {@link Future} is notified once
+     * the check is complete. If notified with {@link Boolean#TRUE} it can be used {@link Boolean#FALSE} otherwise.
+     *
+     * This method will be called by the {@link EventLoop} of the {@link Channel}.
+     */
+    Future<Boolean> isHealthy(PooledChannel<C, K> channel);
+}

--- a/transport/src/main/java/io/netty/channel/pool/ChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/ChannelPool.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+import io.netty.channel.Channel;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+
+/**
+ * Allows to acquire and release {@link Channel} and so act as a pool of these.
+ *
+ * @param <C>   the {@link Channel} type to pool.
+ * @param <K>   the {@link ChannelPoolKey} that is used to store and lookup the {@link Channel}s.
+ */
+public interface ChannelPool<C extends Channel, K extends ChannelPoolKey> {
+
+    /**
+     * Acquire a {@link Channel} for the given {@link ChannelPoolKey}. The returned {@link Future} is notified once
+     * the acquire is successful and failed otherwise.
+     */
+    Future<PooledChannel<C, K>> acquire(K key);
+
+    /**
+     * Acquire a {@link Channel} for the given {@link ChannelPoolKey}. The given {@link Promise} is notified once
+     * the acquire is successful and failed otherwise.
+     */
+    Future<PooledChannel<C, K>> acquire(K key, Promise<PooledChannel<C, K>> promise);
+}

--- a/transport/src/main/java/io/netty/channel/pool/ChannelPoolHandler.java
+++ b/transport/src/main/java/io/netty/channel/pool/ChannelPoolHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.Promise;
+
+/**
+ * Handler which is called for various actions done by the {@link ChannelPool}.
+ *
+ * @param <C>   the {@link Channel} type to pool.
+ * @param <K>   the {@link ChannelPoolKey} that is used to store and lookup the {@link Channel}s.
+ */
+public interface ChannelPoolHandler<C extends Channel, K extends ChannelPoolKey> {
+    /**
+     * Called once a {@link PooledChannel} was released by calling {@link PooledChannel#release()} or
+     * {@link PooledChannel#release(Promise)}.
+     *
+     * This method will be called by the {@link EventLoop} of the {@link PooledChannel}.
+     *
+     * @param ch        the {@link PooledChannel}
+     */
+    void channelReleased(PooledChannel<C, K> ch) throws Exception;
+
+    /**
+     * Called once a {@link PooledChannel} was acquired by calling {@link ChannelPool#acquire(ChannelPoolKey)} or
+     * {@link ChannelPool#acquire(ChannelPoolKey, Promise)}.
+     *
+     * This method will be called by the {@link EventLoop} of the {@link PooledChannel}.
+     *
+     * @param ch       the {@link PooledChannel}
+     */
+    void channelAcquired(PooledChannel<C, K> ch) throws Exception;
+
+    /**
+     * Called once a new {@link PooledChannel} is created in the {@link ChannelPool}.
+     *
+     * This method will be called by the {@link EventLoop} of the {@link PooledChannel}.
+     *
+     * @param ch        the {@link PooledChannel}
+     */
+    void channelCreated(PooledChannel<C, K> ch) throws Exception;
+}

--- a/transport/src/main/java/io/netty/channel/pool/ChannelPoolKey.java
+++ b/transport/src/main/java/io/netty/channel/pool/ChannelPoolKey.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
+
+import java.net.SocketAddress;
+
+/**
+ * A key that can be used to acquire and release {@link Channel}s from a {@link ChannelPool}.
+ *
+ * Please note that implementations <strong>MUST</strong> implement proper {@link #hashCode()} and
+ * {@link #equals(Object)} methods.
+ */
+public interface ChannelPoolKey {
+
+    /**
+     * The {@link SocketAddress} of the remote peer.
+     */
+    SocketAddress remoteAddress();
+
+    /**
+     * The {@link EventLoop} that should be used or {@code null} if not specified.
+     */
+    EventLoop eventLoop();
+}

--- a/transport/src/main/java/io/netty/channel/pool/ChannelPoolSegmentFactories.java
+++ b/transport/src/main/java/io/netty/channel/pool/ChannelPoolSegmentFactories.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+import io.netty.channel.Channel;
+import io.netty.channel.pool.ChannelPoolSegmentFactory.ChannelPoolSegment;
+import io.netty.util.internal.PlatformDependent;
+
+import java.util.Deque;
+import java.util.Queue;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * Utilites for {@link ChannelPoolSegmentFactories}.
+ */
+public final class ChannelPoolSegmentFactories {
+
+    private ChannelPoolSegmentFactories() {
+        // Use static methods.
+    }
+
+    /**
+     * Creates a new {@link ChannelPoolSegmentFactory} that creates {@link ChannelPoolSegment} that use LIFO order.
+     *
+     * @param <C>   the {@link Channel} type
+     */
+    public static <C extends Channel, K extends ChannelPoolKey> ChannelPoolSegmentFactory<C, K> newLifoFactory() {
+        return new ChannelPoolSegmentFactory<C, K>() {
+            @Override
+            public ChannelPoolSegment<C, K> newSegment() {
+                return newLifoSegment(PlatformDependent.<PooledChannel<C, K>>newConcurrentDeque());
+            }
+        };
+    }
+
+    /**
+     * Creates a new {@link ChannelPoolSegmentFactory} that creates {@link ChannelPoolSegment} that use FIFO order.
+     *
+     * @param <C>   the {@link Channel} type
+     */
+    public static <C extends Channel, K extends ChannelPoolKey> ChannelPoolSegmentFactory<C, K> newFifoFactory() {
+        return new ChannelPoolSegmentFactory<C, K>() {
+            @Override
+            public ChannelPoolSegment<C, K> newSegment() {
+                return newFifoSegment(PlatformDependent.<PooledChannel<C, K>>newConcurrentDeque());
+            }
+        };
+    }
+
+    /**
+     * Wraps a {@link Queue} and creates a new {@link ChannelPoolSegment} out of it that will use FIFO order.
+     * The given {@link Queue} needs to be thread-safe!
+     */
+    public static <C extends Channel, K extends ChannelPoolKey> ChannelPoolSegment<C, K> newFifoSegment(
+            final Queue<PooledChannel<C, K>> queue) {
+        checkNotNull(queue, "queue");
+        return new ChannelPoolSegment<C, K>() {
+            @Override
+            public PooledChannel<C, K> poll() {
+                return queue.poll();
+            }
+
+            @Override
+            public boolean offer(PooledChannel<C, K> ch) {
+                return queue.offer(ch);
+            }
+        };
+    }
+
+    /**
+     * Wraps a {@link Queue} and creates a new {@link ChannelPoolSegment} out of it that will use LIFO order.
+     * The given {@link Deque} needs to be thread-safe!
+     */
+    public static <C extends Channel, K extends ChannelPoolKey> ChannelPoolSegment<C, K> newLifoSegment(
+            final Deque<PooledChannel<C, K>> deque) {
+        checkNotNull(deque, "deque");
+        return new ChannelPoolSegment<C, K>() {
+            @Override
+            public PooledChannel<C, K> poll() {
+                return deque.pollLast();
+            }
+
+            @Override
+            public boolean offer(PooledChannel<C, K> ch) {
+                return deque.offer(ch);
+            }
+        };
+    }
+}

--- a/transport/src/main/java/io/netty/channel/pool/ChannelPoolSegmentFactory.java
+++ b/transport/src/main/java/io/netty/channel/pool/ChannelPoolSegmentFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+import io.netty.channel.Channel;
+
+/**
+ * Creates new {@link ChannelPoolSegment}s that are used to store {@link Channel}s for a {@link ChannelPoolKey}.
+ *
+ * @param <C>   the type of the {@link Channel}.
+ * @param <K>   the type of the {@link ChannelPoolKey}
+ */
+public interface ChannelPoolSegmentFactory<C extends Channel, K extends ChannelPoolKey> {
+
+    /**
+     * Create a new {@link ChannelPoolSegment}.
+     */
+    ChannelPoolSegment<C, K> newSegment();
+
+    /**
+     * Segment of a poll which contains {@link Channel}s. Implementations must be thread-safe!
+     *
+     * @param <C> the {@link Channel} type
+     * @param <K>   the type of the {@link ChannelPoolKey}
+     */
+    interface ChannelPoolSegment<C extends Channel, K extends ChannelPoolKey> {
+        /**
+         * Remove the next {@link Channel} from the {@link ChannelPoolSegment} and return it. This will return
+         * {@code null} if the {@link ChannelPoolSegment} is empty.
+         */
+        PooledChannel<C, K> poll();
+
+        /**
+         * Add the given {@link Channel} to the {@link ChannelPoolSegment} and return {@code true} if successful,
+         * {@code false} otherwise.
+         */
+        boolean offer(PooledChannel<C, K> ch);
+    }
+}

--- a/transport/src/main/java/io/netty/channel/pool/DefaultChannelPoolKey.java
+++ b/transport/src/main/java/io/netty/channel/pool/DefaultChannelPoolKey.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+import io.netty.channel.EventLoop;
+
+import java.net.SocketAddress;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * Default implementation of a {@link ChannelPoolKey}.
+ */
+public final class DefaultChannelPoolKey implements ChannelPoolKey {
+
+    private final SocketAddress remoteAddress;
+    private final EventLoop loop;
+    private final int hash;
+
+    /**
+     * @see {@link #DefaultChannelPoolKey(SocketAddress, EventLoop)}
+     */
+    public DefaultChannelPoolKey(SocketAddress remoteAddress) {
+        this(remoteAddress, null);
+    }
+
+    /**
+     * Create a new instance.
+     *
+     * @param remoteAddress     The {@link SocketAddress} of the remote peer.
+     * @param loop              The {@link EventLoop} that should be used or {@code null} if not specified.
+     */
+    public DefaultChannelPoolKey(SocketAddress remoteAddress, EventLoop loop) {
+        this.remoteAddress = checkNotNull(remoteAddress, "address");
+        this.loop = loop;
+        hash = (loop == null) ? remoteAddress.hashCode() : (37 * remoteAddress.hashCode() + loop.hashCode());
+    }
+
+    @Override
+    public SocketAddress remoteAddress() {
+        return remoteAddress;
+    }
+
+    @Override
+    public EventLoop eventLoop() {
+        return loop;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof ChannelPoolKey)) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        ChannelPoolKey key = (ChannelPoolKey) obj;
+        if (!remoteAddress.equals(key.remoteAddress()) ||
+            (loop != null && (!loop.equals(key.eventLoop()))) &&
+            key.eventLoop() != null || key.eventLoop() == null && loop != null) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+}

--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -1,0 +1,368 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.OneTimeTask;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * {@link ChannelPool} implementation that takes another {@link ChannelPool} implementation and enfore a maximum
+ * number of concurrent connections.
+ *
+ * @param <C>   the {@link Channel} type to pool.
+ * @param <K>   the {@link ChannelPoolKey} that is used to store and lookup the {@link Channel}s.
+ */
+public final class FixedChannelPool<C extends Channel, K extends ChannelPoolKey> extends SimpleChannelPool<C, K> {
+    private static final TimeoutException TIMEOUT_EXCEPTION =
+            new TimeoutException("Acquire operation took longer then configured maximum time");
+    static {
+        TIMEOUT_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
+    }
+
+    enum AcquireTimeoutAction {
+        /**
+         * Create a new connection when the timeout is detected.
+         */
+        NewConnection,
+
+        /**
+         * Fail the {@link Future} of the acquire call with a {@link TimeoutException}.
+         */
+        Fail
+    }
+
+    private final EventExecutor executor;
+    private final long acquireTimeoutNanos;
+    private final Runnable timeoutTask;
+
+    // There is no need to worry about synchronization as everything that modified the queue or counts is done
+    // by the above EventExecutor.
+    private final Queue<AcquireTask> pendingAcquireQueue = new ArrayDeque<AcquireTask>();
+    private final int maxConnections;
+    private final int maxPendingAcquires;
+    private int acquiredChannelCount;
+    private int pendingAcquireCount;
+
+    /**
+     * Creates a new instance using the {@link ActiveChannelHealthChecker} and a {@link ChannelPoolSegmentFactory} that
+     * process things in LIFO order.
+     *
+     * @param bootstrap         the {@link Bootstrap} that is used for connections
+     * @param handler           the {@link ChannelPoolHandler} that will be notified for the different pool actions
+     * @param maxConnections    the numnber of maximal active connections, once this is reached new tries to acquire
+     *                          a {@link Channel} will be delayed until a connection is returned to the pool again.
+     */
+    public FixedChannelPool(Bootstrap bootstrap,
+                            ChannelPoolHandler<C, K> handler, int maxConnections) {
+        this(bootstrap, handler, maxConnections, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Creates a new instance using the {@link ActiveChannelHealthChecker} and a {@link ChannelPoolSegmentFactory} that
+     * process things in LIFO order.
+     *
+     * @param bootstrap             the {@link Bootstrap} that is used for connections
+     * @param handler               the {@link ChannelPoolHandler} that will be notified for the different pool actions
+     * @param maxConnections        the numnber of maximal active connections, once this is reached new tries to
+     *                              acquire a {@link Channel} will be delayed until a connection is returned to the
+     *                              pool again.
+     * @param maxPendingAcquires    the maximum number of pending acquires. Once this is exceed acquire tries will
+     *                              be failed.
+     */
+    public FixedChannelPool(Bootstrap bootstrap,
+                            ChannelPoolHandler<C, K> handler, int maxConnections, int maxPendingAcquires) {
+        super(bootstrap, handler);
+        executor = bootstrap.group().next();
+        timeoutTask = null;
+        acquireTimeoutNanos = -1;
+        this.maxConnections = maxConnections;
+        this.maxPendingAcquires = maxPendingAcquires;
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param bootstrap             the {@link Bootstrap} that is used for connections
+     * @param handler               the {@link ChannelPoolHandler} that will be notified for the different pool actions
+     * @param healthCheck           the {@link ChannelHealthChecker} that will be used to check if a {@link Channel} is
+     *                              still healty when obtain from the {@link ChannelPool}
+     * @param segmentFactory        the {@link ChannelPoolSegmentFactory} that will be used to create new
+     *                              {@link ChannelPoolSegmentFactory.ChannelPoolSegment}s when needed
+     * @param action                the {@link AcquireTimeoutAction} to use or {@code null} if non should be used.
+     *                              In this case {@param acquireTimeoutMillis} must be {@code -1}.
+     * @param acquireTimeoutMillis  the time (in milliseconds) after which an pending acquire must complete or
+     *                              the {@link AcquireTimeoutAction} takes place.
+     * @param maxConnections        the numnber of maximal active connections, once this is reached new tries to
+     *                              acquire a {@link Channel} will be delayed until a connection is returned to the
+     *                              pool again.
+     * @param maxPendingAcquires    the maximum number of pending acquires. Once this is exceed acquire tries will
+     *                              be failed.
+     */
+    public FixedChannelPool(Bootstrap bootstrap,
+                            ChannelPoolHandler<C, K> handler,
+                            ChannelHealthChecker<C, K> healthCheck,
+                            ChannelPoolSegmentFactory<C, K> segmentFactory, AcquireTimeoutAction action,
+                            final long acquireTimeoutMillis,
+                            int maxConnections, int maxPendingAcquires) {
+        super(bootstrap, handler, healthCheck, segmentFactory);
+        if (maxConnections < 1) {
+            throw new IllegalArgumentException("maxConnections: " + maxConnections + " (expected: >= 1)");
+        }
+        if (maxPendingAcquires < 1) {
+            throw new IllegalArgumentException("maxPendingAcquires: " + maxPendingAcquires + " (expected: >= 1)");
+        }
+        if (action == null && acquireTimeoutMillis == -1) {
+            timeoutTask = null;
+            acquireTimeoutNanos = -1;
+        } else if (action == null && acquireTimeoutMillis != -1) {
+            throw new NullPointerException("action");
+        } else if (action != null && acquireTimeoutMillis < 0) {
+            throw new IllegalArgumentException("acquireTimeoutMillis: " + acquireTimeoutMillis
+                                               + " (acquireTimeoutMillis: >= 1)");
+        } else {
+            acquireTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(acquireTimeoutMillis);
+            switch (action) {
+            case Fail:
+                timeoutTask = new TimeoutTask() {
+                    @Override
+                    public void onTimeout(AcquireTask task) {
+                        // Fail the promise as we timed out.
+                        task.promise.setFailure(TIMEOUT_EXCEPTION);
+                    }
+                };
+                break;
+            case NewConnection:
+                timeoutTask = new TimeoutTask() {
+                    @Override
+                    public void onTimeout(AcquireTask task) {
+                        // Increment the acquire count and delegate to super to actually acquire a Channel which will
+                        // create a new connetion.
+                        ++acquiredChannelCount;
+
+                        FixedChannelPool.super.acquire(task.key, task.promise);
+                    }
+                };
+                break;
+            default:
+                throw new Error();
+            }
+        }
+        executor = bootstrap.group().next();
+        this.maxConnections = maxConnections;
+        this.maxPendingAcquires = maxPendingAcquires;
+    }
+
+    @Override
+    public Future<PooledChannel<C, K>> acquire(final K key, final Promise<PooledChannel<C, K>> promise) {
+        try {
+            if (executor.inEventLoop()) {
+                acquire0(key, promise);
+            } else {
+                executor.execute(new OneTimeTask() {
+                    @Override
+                    public void run() {
+                        acquire0(key, promise);
+                    }
+                });
+            }
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+        }
+        return promise;
+    }
+
+    private void acquire0(K key, final Promise<PooledChannel<C, K>> promise) {
+        assert executor.inEventLoop();
+
+        if (acquiredChannelCount < maxConnections) {
+            ++acquiredChannelCount;
+
+            assert acquiredChannelCount > 0;
+
+            // We need to create a new promise as we need to ensure the AcquireListener runs in the correct
+            // EventLoop
+            Promise<PooledChannel<C, K>> p = executor.newPromise();
+            p.addListener(new AcquireListener(promise));
+            super.acquire(key, p);
+        } else {
+            if (pendingAcquireCount >= maxPendingAcquires) {
+                promise.setFailure(FULL_EXCEPTION);
+            } else {
+                AcquireTask task = new AcquireTask(key, promise);
+                if (pendingAcquireQueue.offer(task)) {
+                    ++pendingAcquireCount;
+
+                    if (timeoutTask != null) {
+                        task.timeoutFuture = executor.schedule(timeoutTask, acquireTimeoutNanos, TimeUnit.NANOSECONDS);
+                    }
+                } else {
+                    promise.setFailure(FULL_EXCEPTION);
+                }
+            }
+
+            assert pendingAcquireCount > 0;
+        }
+    }
+
+    @Override
+    SimplePooledChannel newPooledChannel(C channel, K key) {
+        return new FixedPooledChannel(channel, key, this);
+    }
+
+    private void runTaskQueue() {
+        while (acquiredChannelCount <= maxConnections) {
+            AcquireTask  task = pendingAcquireQueue.poll();
+            if (task == null) {
+                break;
+            }
+
+            // Cancel the timeout if one was scheduled
+            ScheduledFuture<?> timeoutFuture = task.timeoutFuture;
+            if (timeoutFuture != null) {
+                timeoutFuture.cancel(false);
+            }
+
+            --pendingAcquireCount;
+            ++acquiredChannelCount;
+
+            super.acquire(task.key, task.promise);
+        }
+
+        // We should never have a negative value.
+        assert pendingAcquireCount >= 0;
+        assert acquiredChannelCount >= 0;
+    }
+
+    // AcquireTask extends AcquireListener to reduce object creations and so GC pressure
+    private final class AcquireTask extends AcquireListener {
+        final K key;
+        final Promise<PooledChannel<C, K>> promise;
+        final long creationTime = System.nanoTime();
+        ScheduledFuture<?> timeoutFuture;
+
+        public AcquireTask(final K key, Promise<PooledChannel<C, K>> promise) {
+            super(promise);
+            this.key = key;
+            // We need to create a new promise as we need to ensure the AcquireListener runs in the correct
+            // EventLoop.
+            this.promise = executor.<PooledChannel<C, K>>newPromise().addListener(this);
+        }
+    }
+
+    private abstract class TimeoutTask implements Runnable {
+        @Override
+        public final void run() {
+            assert executor.inEventLoop();
+
+            long expiredThresholdTime = System.nanoTime() - acquireTimeoutNanos;
+            for (;;) {
+                AcquireTask task = pendingAcquireQueue.peek();
+                if (task == null || task.creationTime >= expiredThresholdTime) {
+                    break;
+                }
+                pendingAcquireQueue.remove();
+
+                --pendingAcquireCount;
+                onTimeout(task);
+            }
+        }
+
+        public abstract void onTimeout(AcquireTask task);
+    }
+
+    private class AcquireListener implements FutureListener<PooledChannel<C, K>> {
+        private final Promise<PooledChannel<C, K>> originalPromise;
+
+        AcquireListener(Promise<PooledChannel<C, K>> originalPromise) {
+            this.originalPromise = originalPromise;
+        }
+
+        @Override
+        public void operationComplete(Future<PooledChannel<C, K>> future) throws Exception {
+            assert executor.inEventLoop();
+
+            if (future.isSuccess()) {
+                originalPromise.setSuccess(future.getNow());
+            } else {
+                // Something went wrong try to run pending acquire tasks.
+                --acquiredChannelCount;
+
+                // We should never have a negative value.
+                assert acquiredChannelCount >= 0;
+
+                // Run the pending acquire tasks before notify the original promise so if the user would
+                // try to acquire again from the ChannelFutureListener and the pendingAcquireCount is >=
+                // maxPendingAcquires we may be able to run some pending tasks first and so allow to add
+                // more.
+                runTaskQueue();
+                originalPromise.setFailure(future.cause());
+            }
+        }
+    }
+
+    private final class FixedPooledChannel extends SimplePooledChannel {
+        public FixedPooledChannel(C channel, K key, SimpleChannelPool<C, K> pool) {
+            super(channel, key, pool);
+        }
+
+        @Override
+        public Future<Void> releaseToPool(final Promise<Void> promise) {
+            try {
+                final Promise<Void> p = executor.newPromise();
+
+                super.releaseToPool(p.addListener(new FutureListener<Void>() {
+
+                    @Override
+                    public void operationComplete(Future<Void> future) throws Exception {
+                        assert executor.inEventLoop();
+                        --acquiredChannelCount;
+
+                        // We should never have a negative value.
+                        assert acquiredChannelCount >= 0;
+
+                        // Run the pending acquire tasks before notify the original promise so if the user would
+                        // try to acquire again from the ChannelFutureListener and the pendingAcquireCount is >=
+                        // maxPendingAcquires we may be able to run some pending tasks first and so allow to add
+                        // more.
+                        runTaskQueue();
+
+                        if (future.isSuccess()) {
+                            promise.setSuccess(null);
+                        } else {
+                            promise.setFailure(future.cause());
+                        }
+                    }
+                }));
+                return p;
+            } catch (Throwable cause) {
+                promise.setFailure(cause);
+            }
+            return promise;
+        }
+    }
+}

--- a/transport/src/main/java/io/netty/channel/pool/PooledChannel.java
+++ b/transport/src/main/java/io/netty/channel/pool/PooledChannel.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+import io.netty.channel.Channel;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+
+/**
+ * Channel which is acquired from a {@link ChannelPool} and wrap an actual {@link Channel} implementaton.
+ *
+ * @param <C>   the {@link Channel} type to pool.
+ * @param <K>   the {@link ChannelPoolKey} that is used to store and lookup the {@link Channel}s.
+ */
+public interface PooledChannel<C extends Channel, K extends ChannelPoolKey> extends Channel {
+
+    /**
+     * Returns the real {@link Channel} that is pooled.
+     */
+    C unwrap();
+
+    /**
+     * Returns the {@link ChannelPool} from which this {@link PooledChannel} was acquired.
+     */
+    ChannelPool<C, K> pool();
+
+    /**
+     * Returns the {@link ChannelPoolKey} which was used to acquire this {@link PooledChannel}.
+     */
+    K key();
+
+    /**
+     * Release a {@link Channel} back to this {@link ChannelPool}. The returned {@link Future} is notified once
+     * the release is successful and failed otherwise. When failed the {@link Channel} will automatically closed.
+     */
+    Future<Void> release();
+
+    /**
+     * Release a {@link Channel} back to this {@link ChannelPool}.  The given {@link Promise} is notified once
+     * the release is successful and failed otherwise. When failed the {@link Channel} will automatically closed.
+     */
+    Future<Void> release(Promise<Void> promise);
+}

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ChannelFactory;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoop;
+import io.netty.channel.pool.ChannelPoolSegmentFactory.ChannelPoolSegment;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.OneTimeTask;
+import io.netty.util.internal.PlatformDependent;
+
+import java.util.concurrent.ConcurrentMap;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * Simple {@link ChannelPool} implementation which will create new {@link Channel}s if someone tries to acquire
+ * a {@link Channel} but none is in the pool atm. No limit on the maximal concurrent {@link Channel}s is enforced.
+ *
+ * @param <C>   the {@link Channel} type to pool.
+ * @param <K>   the {@link ChannelPoolKey} that is used to store and lookup the {@link Channel}s.
+ */
+public class SimpleChannelPool<C extends Channel, K extends ChannelPoolKey> implements ChannelPool<C, K> {
+    static final IllegalStateException FULL_EXCEPTION =
+            new IllegalStateException("Too many outstanding acquire operations");
+    static {
+        FULL_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
+    }
+
+    private final ConcurrentMap<ChannelPoolKey, ChannelPoolSegment<C, K>> pool =
+            PlatformDependent.newConcurrentHashMap();
+    private final ChannelPoolHandler<C, K> handler;
+    private final ChannelHealthChecker<C, K> healthCheck;
+    private final ChannelPoolSegmentFactory<C, K> segmentFactory;
+    private final ChannelFactory<?> channelFactory;
+    private final Bootstrap bootstrap;
+
+    /**
+     * Creates a new instance using the {@link ActiveChannelHealthChecker} and a {@link ChannelPoolSegmentFactory} that
+     * process things in LIFO order.
+     *
+     * @param bootstrap         the {@link Bootstrap} that is used for connections
+     * @param handler           the {@link ChannelPoolHandler} that will be notified for the different pool actions
+     */
+    public SimpleChannelPool(Bootstrap bootstrap, final ChannelPoolHandler<C, K> handler) {
+        this(bootstrap, handler,
+             ActiveChannelHealthChecker.<C, K>instance(), ChannelPoolSegmentFactories.<C, K>newLifoFactory());
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param bootstrap         the {@link Bootstrap} that is used for connections
+     * @param handler           the {@link ChannelPoolHandler} that will be notified for the different pool actions
+     * @param healthCheck       the {@link ChannelHealthChecker} that will be used to check if a {@link Channel} is
+     *                          still healty when obtain from the {@link ChannelPool}
+     * @param segmentFactory    the {@link ChannelPoolSegmentFactory} that will be used to create new
+     *                          {@link ChannelPoolSegment}s when needed
+     */
+    public SimpleChannelPool(Bootstrap bootstrap, final ChannelPoolHandler<C, K> handler,
+                             final ChannelHealthChecker<C, K> healthCheck,
+                             final ChannelPoolSegmentFactory<C, K> segmentFactory) {
+        this.handler = checkNotNull(handler, "handler");
+        this.healthCheck = checkNotNull(healthCheck, "healthCheck");
+        this.segmentFactory = checkNotNull(segmentFactory, "segmentFactory");
+        channelFactory = bootstrap.channelFactory();
+        this.bootstrap = checkNotNull(bootstrap, "bootstrap").clone();
+        this.bootstrap.handler(new ChannelInitializer<PooledChannel<C, K>>() {
+            @SuppressWarnings("unchecked")
+            @Override
+            protected void initChannel(PooledChannel<C, K> ch) throws Exception {
+                assert ch.eventLoop().inEventLoop();
+                handler.channelCreated(ch);
+            }
+        });
+    }
+
+    private EventLoop loop(K key) {
+        EventLoop loop = key.eventLoop();
+        if (loop == null) {
+            loop = bootstrap.group().next();
+        }
+        return loop;
+    }
+
+    @Override
+    public final Future<PooledChannel<C, K>> acquire(K key) {
+        return acquire(key, loop(key).<PooledChannel<C, K>>newPromise());
+    }
+
+    @Override
+    public Future<PooledChannel<C, K>> acquire(final K key, final Promise<PooledChannel<C, K>> promise) {
+        checkNotNull(key, "key");
+        checkNotNull(promise, "promise");
+        try {
+            ChannelPoolSegment<C, K> channels = pool.get(key);
+            if (channels == null) {
+                newChannel(key, promise);
+                return promise;
+            }
+
+            final SimplePooledChannel ch = (SimplePooledChannel) channels.poll();
+            if (ch == null) {
+                newChannel(key, promise);
+                return promise;
+            }
+            EventLoop loop = ch.eventLoop();
+            if (loop.inEventLoop()) {
+                doHealthCheck(ch, promise);
+            } else {
+                loop.execute(new OneTimeTask() {
+                    @Override
+                    public void run() {
+                        doHealthCheck(ch, promise);
+                    }
+                });
+            }
+        } catch (Throwable cause) {
+            promise.setFailure(cause);
+        }
+        return promise;
+    }
+
+    private void doHealthCheck(final SimplePooledChannel ch, final Promise<PooledChannel<C, K>> promise) {
+        assert ch.eventLoop().inEventLoop();
+
+        Future<Boolean> f = healthCheck.isHealthy(ch);
+        if (f.isDone()) {
+            notifyHealthCheck(f, ch, promise);
+        } else {
+            f.addListener(new FutureListener<Boolean>() {
+                @Override
+                public void operationComplete(Future<Boolean> future) throws Exception {
+                    notifyHealthCheck(future, ch, promise);
+                }
+            });
+        }
+    }
+
+    private void notifyHealthCheck(Future<? super Boolean> future,
+                                   SimplePooledChannel ch, Promise<PooledChannel<C, K>> promise) {
+        assert ch.eventLoop().inEventLoop();
+
+        if (future.isSuccess()) {
+            try {
+                ch.acquired();
+                handler.channelAcquired(ch);
+                promise.setSuccess(ch);
+            } catch (Throwable cause) {
+                closeAndFail(ch, promise, cause);
+            }
+        } else {
+            ch.close();
+            acquire(ch.key(), promise);
+        }
+    }
+
+    private void newChannel(
+            final K key, final Promise<PooledChannel<C, K>> promise) {
+        Bootstrap bs = bootstrap.clone(loop(key), new ChannelFactory<Channel>() {
+            @SuppressWarnings("unchecked")
+            @Override
+            public Channel newChannel() {
+                SimplePooledChannel ch = newPooledChannel((C) channelFactory.newChannel(), key);
+                ch.acquired();
+                return ch;
+            }
+        });
+
+        ChannelFuture f = bs.connect(key.remoteAddress());
+        if (f.isDone()) {
+            notifyConnect(f, promise);
+        } else {
+            f.addListener(new ChannelFutureListener() {
+                @SuppressWarnings("unchecked")
+                @Override
+                public void operationComplete(ChannelFuture future) throws Exception {
+                    notifyConnect(future, promise);
+                }
+            });
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void notifyConnect(ChannelFuture future, Promise<PooledChannel<C, K>> promise) {
+        if (future.isSuccess()) {
+            PooledChannel<C, K> ch = (PooledChannel<C, K>) future.channel();
+            promise.setSuccess(ch);
+        } else {
+            promise.setFailure(future.cause());
+        }
+    }
+
+    SimplePooledChannel newPooledChannel(C channel, K key) {
+        return new SimplePooledChannel(channel, key, this);
+    }
+
+    class SimplePooledChannel extends AbstractPooledChannel<C, K> {
+        public SimplePooledChannel(C channel, K key, SimpleChannelPool<C, K> pool) {
+            super(channel, key, pool);
+        }
+
+        @Override
+        public Future<Void> releaseToPool(final Promise<Void> promise) {
+            checkNotNull(promise, "promise");
+            try {
+                final K key = key();
+                ChannelPoolSegment<C, K> channels = pool.get(key);
+                if (channels == null) {
+                    channels = segmentFactory.newSegment();
+                    ChannelPoolSegment<C, K> old = pool.putIfAbsent(key, channels);
+                    if (old != null) {
+                        channels = old;
+                    }
+                }
+                final ChannelPoolSegment<C, K> channelQueue = channels;
+
+                EventLoop loop = eventLoop();
+                if (loop.inEventLoop()) {
+                    doReleaseChannel(channelQueue, promise);
+                } else {
+                    loop.execute(new OneTimeTask() {
+                        @Override
+                        public void run() {
+                            doReleaseChannel(channelQueue, promise);
+                        }
+                    });
+                }
+            } catch (Throwable cause) {
+                closeAndFail(this, promise, cause);
+            }
+            return promise;
+        }
+
+        private void doReleaseChannel(ChannelPoolSegment<C, K> channels, Promise<Void> promise) {
+            assert eventLoop().inEventLoop();
+
+            try {
+                if (channels.offer(this)) {
+                    handler.channelReleased(this);
+                    promise.setSuccess(null);
+                } else {
+                    closeAndFail(this, promise, FULL_EXCEPTION);
+                }
+            } catch (Throwable cause) {
+                closeAndFail(this, promise, cause);
+            }
+        }
+    }
+
+    private static void closeAndFail(Channel ch, Promise<?> promise, Throwable cause) {
+        ch.close();
+        promise.setFailure(cause);
+    }
+}

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -87,7 +87,6 @@ public class SimpleChannelPool<C extends Channel, K extends ChannelPoolKey> impl
         channelFactory = bootstrap.channelFactory();
         this.bootstrap = checkNotNull(bootstrap, "bootstrap").clone();
         this.bootstrap.handler(new ChannelInitializer<PooledChannel<C, K>>() {
-            @SuppressWarnings("unchecked")
             @Override
             protected void initChannel(PooledChannel<C, K> ch) throws Exception {
                 assert ch.eventLoop().inEventLoop();
@@ -179,9 +178,9 @@ public class SimpleChannelPool<C extends Channel, K extends ChannelPoolKey> impl
     private void newChannel(
             final K key, final Promise<PooledChannel<C, K>> promise) {
         Bootstrap bs = bootstrap.clone(loop(key), new ChannelFactory<Channel>() {
-            @SuppressWarnings("unchecked")
             @Override
             public Channel newChannel() {
+                @SuppressWarnings("unchecked")
                 SimplePooledChannel ch = newPooledChannel((C) channelFactory.newChannel(), key);
                 ch.acquired();
                 return ch;
@@ -193,7 +192,6 @@ public class SimpleChannelPool<C extends Channel, K extends ChannelPoolKey> impl
             notifyConnect(f, promise);
         } else {
             f.addListener(new ChannelFutureListener() {
-                @SuppressWarnings("unchecked")
                 @Override
                 public void operationComplete(ChannelFuture future) throws Exception {
                     notifyConnect(future, promise);
@@ -202,9 +200,9 @@ public class SimpleChannelPool<C extends Channel, K extends ChannelPoolKey> impl
         }
     }
 
-    @SuppressWarnings("unchecked")
     private void notifyConnect(ChannelFuture future, Promise<PooledChannel<C, K>> promise) {
         if (future.isSuccess()) {
+            @SuppressWarnings("unchecked")
             PooledChannel<C, K> ch = (PooledChannel<C, K>) future.channel();
             promise.setSuccess(ch);
         } else {

--- a/transport/src/main/java/io/netty/channel/pool/package-info.java
+++ b/transport/src/main/java/io/netty/channel/pool/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Implementations and API for {@link io.netty.channel.Channel} pools.
+ */
+package io.netty.channel.pool;

--- a/transport/src/test/java/io/netty/channel/pool/CountingChannelPoolHandler.java
+++ b/transport/src/test/java/io/netty/channel/pool/CountingChannelPoolHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+import io.netty.channel.Channel;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+final class CountingChannelPoolHandler implements ChannelPoolHandler<Channel, ChannelPoolKey> {
+    private final AtomicInteger channelCount = new AtomicInteger(0);
+    private final AtomicInteger acquiredCount = new AtomicInteger(0);
+    private final AtomicInteger releasedCount = new AtomicInteger(0);
+
+    @Override
+    public void channelCreated(@SuppressWarnings("unused")  PooledChannel<Channel, ChannelPoolKey> ch) {
+        channelCount.incrementAndGet();
+    }
+
+    @Override
+    public void channelReleased(@SuppressWarnings("unused") PooledChannel<Channel, ChannelPoolKey> ch) {
+        releasedCount.incrementAndGet();
+    }
+
+    @Override
+    public void channelAcquired(@SuppressWarnings("unused") PooledChannel<Channel, ChannelPoolKey> ch) {
+        acquiredCount.incrementAndGet();
+    }
+
+    public int channelCount() {
+        return channelCount.get();
+    }
+
+    public int acquiredCount() {
+        return acquiredCount.get();
+    }
+
+    public int releasedCount() {
+        return releasedCount.get();
+    }
+}

--- a/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.local.LocalAddress;
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalEventLoopGroup;
+import io.netty.channel.local.LocalServerChannel;
+import io.netty.channel.pool.FixedChannelPool.AcquireTimeoutAction;
+import io.netty.util.concurrent.Future;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.*;
+
+public class FixedChannelPoolTest {
+    private static final String LOCAL_ADDR_ID = "test.id";
+
+    @Test
+    public void testAcquire() throws Exception {
+        EventLoopGroup group = new LocalEventLoopGroup();
+        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        Bootstrap cb = new Bootstrap();
+        ServerBootstrap sb = new ServerBootstrap();
+
+        cb.group(group)
+          .channel(LocalChannel.class);
+
+        sb.group(group)
+          .channel(LocalServerChannel.class)
+          .childHandler(new ChannelInitializer<LocalChannel>() {
+              @Override
+              public void initChannel(LocalChannel ch) throws Exception {
+                  ch.pipeline().addLast(new ChannelInboundHandlerAdapter());
+              }
+          });
+
+        // Start server
+        Channel sc = sb.bind(addr).sync().channel();
+        ChannelPoolKey key = new DefaultChannelPoolKey(addr);
+        CountingChannelPoolHandler handler = new CountingChannelPoolHandler();
+
+        ChannelPool<Channel, ChannelPoolKey> pool  = new FixedChannelPool<Channel, ChannelPoolKey>(
+                cb, handler, 1, Integer.MAX_VALUE);
+
+        PooledChannel<Channel, ChannelPoolKey> channel = pool.acquire(key).sync().getNow();
+        Future<PooledChannel<Channel, ChannelPoolKey>> future = pool.acquire(key);
+        assertFalse(future.isDone());
+
+        channel.release().syncUninterruptibly();
+        assertTrue(future.await(1, TimeUnit.SECONDS));
+
+        Channel channel2 = future.getNow();
+        assertSame(channel, channel2);
+        assertEquals(1, handler.channelCount());
+
+        assertEquals(1, handler.acquiredCount());
+        assertEquals(1, handler.releasedCount());
+
+        sc.close().sync();
+        channel2.close().sync();
+        group.shutdownGracefully();
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void testAcquireTimeout() throws Exception {
+        EventLoopGroup group = new LocalEventLoopGroup();
+        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        Bootstrap cb = new Bootstrap();
+        ServerBootstrap sb = new ServerBootstrap();
+
+        cb.group(group)
+          .channel(LocalChannel.class);
+
+        sb.group(group)
+          .channel(LocalServerChannel.class)
+          .childHandler(new ChannelInitializer<LocalChannel>() {
+              @Override
+              public void initChannel(LocalChannel ch) throws Exception {
+                  ch.pipeline().addLast(new ChannelInboundHandlerAdapter());
+              }
+          });
+
+        // Start server
+        Channel sc = sb.bind(addr).sync().channel();
+        ChannelPoolHandler<Channel, ChannelPoolKey> handler = new TestChannelPoolHandler();
+        ChannelPool<Channel, ChannelPoolKey> pool  = new FixedChannelPool<Channel, ChannelPoolKey>(
+                cb, handler, ActiveChannelHealthChecker.instance(),
+                ChannelPoolSegmentFactories.newLifoFactory(), AcquireTimeoutAction.Fail, 500,
+                1, Integer.MAX_VALUE);
+
+        ChannelPoolKey key = new DefaultChannelPoolKey(addr);
+        Channel channel = pool.acquire(key).sync().getNow();
+        Future<PooledChannel<Channel, ChannelPoolKey>> future = pool.acquire(key);
+        try {
+            future.sync();
+        } finally {
+            sc.close().sync();
+            channel.close().sync();
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testAcquireNewConnection() throws Exception {
+        EventLoopGroup group = new LocalEventLoopGroup();
+        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        Bootstrap cb = new Bootstrap();
+        ServerBootstrap sb = new ServerBootstrap();
+
+        cb.group(group)
+          .channel(LocalChannel.class);
+
+        sb.group(group)
+          .channel(LocalServerChannel.class)
+          .childHandler(new ChannelInitializer<LocalChannel>() {
+              @Override
+              public void initChannel(LocalChannel ch) throws Exception {
+                  ch.pipeline().addLast(new ChannelInboundHandlerAdapter());
+              }
+          });
+
+        // Start server
+        Channel sc = sb.bind(addr).sync().channel();
+        ChannelPoolHandler<Channel, ChannelPoolKey> handler = new TestChannelPoolHandler();
+        ChannelPool<Channel, ChannelPoolKey> pool  = new FixedChannelPool<Channel, ChannelPoolKey>(
+                cb, handler, ActiveChannelHealthChecker.instance(),
+                ChannelPoolSegmentFactories.newLifoFactory(), AcquireTimeoutAction.NewConnection, 500,
+                1, Integer.MAX_VALUE);
+
+        ChannelPoolKey key = new DefaultChannelPoolKey(addr);
+        Channel channel = pool.acquire(key).sync().getNow();
+        Channel channel2 = pool.acquire(key).sync().getNow();
+        assertNotSame(channel, channel2);
+        sc.close().sync();
+        channel.close().sync();
+        channel2.close().sync();
+        group.shutdownGracefully();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testAcquireBoundQueue() throws Exception {
+        EventLoopGroup group = new LocalEventLoopGroup();
+        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        Bootstrap cb = new Bootstrap();
+        ServerBootstrap sb = new ServerBootstrap();
+
+        cb.group(group)
+          .channel(LocalChannel.class);
+
+        sb.group(group)
+          .channel(LocalServerChannel.class)
+          .childHandler(new ChannelInitializer<LocalChannel>() {
+              @Override
+              public void initChannel(LocalChannel ch) throws Exception {
+                  ch.pipeline().addLast(new ChannelInboundHandlerAdapter());
+              }
+          });
+
+        // Start server
+        Channel sc = sb.bind(addr).sync().channel();
+        ChannelPoolHandler<Channel, ChannelPoolKey> handler = new TestChannelPoolHandler();
+        ChannelPool<Channel, ChannelPoolKey> pool  = new FixedChannelPool<Channel, ChannelPoolKey>(
+                cb, handler,
+                1, 1);
+
+        ChannelPoolKey key = new DefaultChannelPoolKey(addr);
+        Channel channel = pool.acquire(key).sync().getNow();
+        Future<PooledChannel<Channel, ChannelPoolKey>> future = pool.acquire(key);
+        assertFalse(future.isDone());
+
+        try {
+            pool.acquire(key).sync();
+        } finally {
+            sc.close().sync();
+            channel.close().sync();
+            group.shutdownGracefully();
+        }
+    }
+
+    private static final class TestChannelPoolHandler extends AbstractChannelPoolHandler<Channel, ChannelPoolKey> {
+        @Override
+        public void channelCreated(@SuppressWarnings("unused") PooledChannel<Channel, ChannelPoolKey> ch)
+                throws Exception {
+            // NOOP
+        }
+    }
+}

--- a/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/SimpleChannelPoolTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.pool;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.local.LocalAddress;
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalEventLoopGroup;
+import io.netty.channel.local.LocalServerChannel;
+import org.junit.Test;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.junit.Assert.*;
+
+public class SimpleChannelPoolTest {
+    private static final String LOCAL_ADDR_ID = "test.id";
+
+    @Test
+    public void testAcquire() throws Exception {
+        EventLoopGroup group = new LocalEventLoopGroup();
+        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        Bootstrap cb = new Bootstrap();
+        ServerBootstrap sb = new ServerBootstrap();
+
+        cb.group(group)
+          .channel(LocalChannel.class);
+
+        sb.group(group)
+          .channel(LocalServerChannel.class)
+          .childHandler(new ChannelInitializer<LocalChannel>() {
+              @Override
+              public void initChannel(LocalChannel ch) throws Exception {
+                  ch.pipeline().addLast(new ChannelInboundHandlerAdapter());
+              }
+          });
+
+        // Start server
+        Channel sc = sb.bind(addr).sync().channel();
+        CountingChannelPoolHandler handler = new CountingChannelPoolHandler();
+
+        ChannelPool<Channel, ChannelPoolKey> pool =
+                new SimpleChannelPool<Channel, ChannelPoolKey>(cb, handler);
+
+        ChannelPoolKey key = new DefaultChannelPoolKey(addr);
+        ChannelPoolKey key2 = new DefaultChannelPoolKey(addr, group.next());
+
+        PooledChannel<Channel, ChannelPoolKey> channel = pool.acquire(key).sync().getNow();
+
+        channel.release().syncUninterruptibly();
+
+        Channel channel2 = pool.acquire(key).sync().getNow();
+        assertSame(channel, channel2);
+        assertEquals(1, handler.channelCount());
+
+        PooledChannel<Channel, ChannelPoolKey> channel3 = pool.acquire(key2).sync().getNow();
+        assertNotSame(channel, channel3);
+        assertEquals(2, handler.channelCount());
+        channel3.release().syncUninterruptibly();
+
+        // Should fail on multiple release calls.
+        try {
+            channel3.release().syncUninterruptibly();
+            fail();
+        } catch (IllegalStateException e) {
+            // Should fail
+        }
+
+        assertEquals(1, handler.acquiredCount());
+        assertEquals(2, handler.releasedCount());
+
+        sc.close().sync();
+        channel2.close().sync();
+        channel3.close().sync();
+        group.shutdownGracefully();
+    }
+
+    @Test
+    public void testBoundedChannelPoolSegment() throws Exception {
+        EventLoopGroup group = new LocalEventLoopGroup();
+        LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
+        Bootstrap cb = new Bootstrap();
+        ServerBootstrap sb = new ServerBootstrap();
+
+        cb.group(group)
+          .channel(LocalChannel.class);
+
+        sb.group(group)
+          .channel(LocalServerChannel.class)
+          .childHandler(new ChannelInitializer<LocalChannel>() {
+              @Override
+              public void initChannel(LocalChannel ch) throws Exception {
+                  ch.pipeline().addLast(new ChannelInboundHandlerAdapter());
+              }
+          });
+
+        // Start server
+        Channel sc = sb.bind(addr).sync().channel();
+        CountingChannelPoolHandler handler = new CountingChannelPoolHandler();
+
+        ChannelPool<Channel, ChannelPoolKey> pool = new SimpleChannelPool<Channel, ChannelPoolKey>(cb, handler,
+                ActiveChannelHealthChecker.instance(), new ChannelPoolSegmentFactory<Channel, ChannelPoolKey>() {
+                    @Override
+                    public ChannelPoolSegment<Channel, ChannelPoolKey> newSegment() {
+                        // Bounded queue with a maximal capacity of 1
+                        return ChannelPoolSegmentFactories.newFifoSegment(
+                                new LinkedBlockingQueue<PooledChannel<Channel, ChannelPoolKey>>(1));
+                    }
+                });
+
+        ChannelPoolKey key = new DefaultChannelPoolKey(addr);
+
+        PooledChannel<Channel, ChannelPoolKey> channel = pool.acquire(key).sync().getNow();
+        PooledChannel<Channel, ChannelPoolKey> channel2 = pool.acquire(key).sync().getNow();
+
+        channel.release().syncUninterruptibly();
+        try {
+            channel2.release().syncUninterruptibly();
+            fail();
+        } catch (IllegalStateException e) {
+            // Should fail
+        }
+
+        channel2.close().sync();
+
+        assertEquals(2, handler.channelCount());
+        assertEquals(0, handler.acquiredCount());
+        assertEquals(1, handler.releasedCount());
+        sc.close().sync();
+        channel.close().sync();
+        channel2.close().sync();
+        group.shutdownGracefully();
+    }
+}


### PR DESCRIPTION
Motivation:

Many projects need some kind a Channel/Connection pool implementation. While the protocols are different many things can be shared, so we should provide a generic API and implementation.

Modifications:

Add ChannelPool API and implementations.

Result:

Reusable / Generic pool implementation that users can use.