### PR TITLE
Http2ConnectionHandler should propagate channelActive and channelInactive events.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -314,12 +314,14 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             byteDecoder = new PrefaceDecoder(ctx);
         }
         byteDecoder.channelActive(ctx);
+        super.channelActive(ctx);
     }
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         if (byteDecoder != null) {
             byteDecoder.channelInactive(ctx);
+            super.channelInactive(ctx);
             byteDecoder = null;
         }
     }
@@ -346,25 +348,6 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         } else {
             closeListener = new ClosingChannelFutureListener(ctx, promise);
         }
-    }
-
-    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
-        ctx.deregister(promise);
-    }
-
-    @Override
-    public void read(ChannelHandlerContext ctx) throws Exception {
-        ctx.read();
-    }
-
-    @Override
-    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-        ctx.write(msg, promise);
-    }
-
-    @Override
-    public void flush(ChannelHandlerContext ctx) throws Exception {
-        ctx.flush();
     }
 
     /**


### PR DESCRIPTION
Motivation:

The Http2ConnectionHandler incorrectly doesn't propagate channelActive and channelInactive events and thus breaks the pipeline for other ChannelHandler.

Modification:

- Add calls to super.channelActive() and super.channelInactive().
- Remove unused methods.

Result:

- Http2ConnectionHandler can be used with other ChannelHandlers.