### PR TITLE
Fix compile errors introduced by cherry picking of 3440eadb3843676e993cf from master.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -369,6 +369,26 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         }
     }
 
+    @Override
+    public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        ctx.deregister(promise);
+    }
+
+    @Override
+    public void read(ChannelHandlerContext ctx) throws Exception {
+        ctx.read();
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        ctx.write(msg, promise);
+    }
+
+    @Override
+    public void flush(ChannelHandlerContext ctx) throws Exception {
+        ctx.flush();
+    }
+
     /**
      * Handles {@link Http2Exception} objects that were thrown from other handlers. Ignores all other exceptions.
      */


### PR DESCRIPTION
Fix compile errors introduced by cherry picking of 3440eadb3843676e993cf from master.

@normanmaurer that should fix the compile errors of 4.1