### PR TITLE
[#3699] Nio|EpollEventLoopGroup.shutdownGracefully() needs to gracefully...

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -257,11 +257,9 @@ final class EpollEventLoop extends SingleThreadEventLoop {
                     //increase the size of the array as we needed the whole space for the events
                     events.increase();
                 }
-                if (isShuttingDown()) {
+                if (isShuttingDown() && confirmShutdown()) {
                     closeAll();
-                    if (confirmShutdown()) {
-                        break;
-                    }
+                    break;
                 }
             } catch (Throwable t) {
                 logger.warn("Unexpected exception in the selector loop.", t);

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -357,11 +357,9 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                     runAllTasks(ioTime * (100 - ioRatio) / ioRatio);
                 }
 
-                if (isShuttingDown()) {
+                if (isShuttingDown() && confirmShutdown()) {
                     closeAll();
-                    if (confirmShutdown()) {
-                        break;
-                    }
+                    break;
                 }
             } catch (Throwable t) {
                 logger.warn("Unexpected exception in the selector loop.", t);


### PR DESCRIPTION
... close connections.

Motivation:

Currently when calling Nio|EpollEventLoopGroup.shutdownGracefully() all active Channels will be closed right away. This is not what should happen for a graceful shutdown.

Modifications:

Only close Channels after quite period is complete.

Result:

Correct behavior when call shutdownGracefully()