### PR TITLE
HTTP/2 Warnings Cleanup

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -1177,13 +1177,12 @@ public class DefaultHttp2Connection implements Http2Connection {
     /**
      * A registry of all stream property keys known by this connection.
      */
-    private class PropertyKeyRegistry {
+    private final class PropertyKeyRegistry {
         final List<DefaultPropertyKey> keys = new ArrayList<DefaultPropertyKey>(4);
 
         /**
          * Registers a new property key.
          */
-        @SuppressWarnings("unchecked")
         DefaultPropertyKey newKey() {
             DefaultPropertyKey key = new DefaultPropertyKey(keys.size());
             keys.add(key);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
@@ -24,13 +24,11 @@ import static io.netty.handler.codec.http2.Http2FrameTypes.SETTINGS;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.base64.Base64;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
-import io.netty.util.ByteString;
 import io.netty.util.CharsetUtil;
 
 import java.nio.CharBuffer;


### PR DESCRIPTION
Motiviation:
There are a few spots in the HTTP/2 codec where warnings were generated and can be avoided.

Modifications:
Clean up the cause of the warnings.

Result:
Less warnings.