### PR TITLE
Remove explicit flushes from HTTP2 encoders, decoders & flow-controllers

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -443,7 +443,6 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
             // Send an ack back to the remote client.
             // Need to retain the buffer here since it will be released after the write completes.
             encoder.writePing(ctx, true, data.retain(), ctx.newPromise());
-            ctx.flush();
 
             listener.onPingRead(ctx, data);
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
@@ -413,7 +413,6 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
 
             // Send a window update for the stream/connection.
             frameWriter.writeWindowUpdate(ctx, stream.id(), deltaWindowSize, ctx.newPromise());
-            ctx.flush();
         }
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
@@ -27,8 +27,8 @@ public interface Http2RemoteFlowController extends Http2FlowController {
      * guarantee when the data will be written or whether it will be split into multiple frames
      * before sending.
      * <p>
-     * Manually flushing the {@link ChannelHandlerContext} is not required, since the flow
-     * controller will flush as appropriate.
+     * Manually flushing the {@link ChannelHandlerContext} is required for writes as the flow controller will
+     * <strong>not</strong> flush by itself.
      *
      * @param ctx the context from the handler.
      * @param stream the subject stream. Must not be the connection stream object.
@@ -75,15 +75,14 @@ public interface Http2RemoteFlowController extends Http2FlowController {
          * Writes up to {@code allowedBytes} of the encapsulated payload to the stream. Note that
          * a value of 0 may be passed which will allow payloads with flow-control size == 0 to be
          * written. The flow-controller may call this method multiple times with different values until
-         * the payload is fully written.
+         * the payload is fully written, i.e it's size after the write is 0.
          * <p>
          * When an exception is thrown the {@link Http2RemoteFlowController} will make a call to
          * {@link #error(Throwable)}.
          * </p>
          *
          * @param allowedBytes an upper bound on the number of bytes the payload can write at this time.
-         * @return {@code true} if a flush is required, {@code false} otherwise.
          */
-        boolean write(int allowedBytes);
+        void write(int allowedBytes);
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -48,6 +49,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.codec.http2.Http2Exception.ClosedStreamCreationException;
+import junit.framework.AssertionFailedError;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -161,6 +163,9 @@ public class DefaultHttp2ConnectionDecoderTest {
 
         // Simulate receiving the SETTINGS ACK for the initial settings.
         decode().onSettingsAckRead(ctx);
+
+        // Disallow any further flushes now that settings ACK has been sent
+        when(ctx.flush()).thenThrow(new AssertionFailedError("forbidden"));
     }
 
     @Test
@@ -605,7 +610,6 @@ public class DefaultHttp2ConnectionDecoderTest {
 
     @Test
     public void settingsReadShouldSetValues() throws Exception {
-        when(connection.isServer()).thenReturn(true);
         Http2Settings settings = new Http2Settings();
         settings.pushEnabled(true);
         settings.initialWindowSize(123);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -60,6 +60,7 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
 import java.util.ArrayList;
 import java.util.List;
 
+import junit.framework.AssertionFailedError;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -207,6 +208,7 @@ public class DefaultHttp2ConnectionEncoderTest {
         when(ctx.newSucceededFuture()).thenReturn(future);
         when(ctx.newPromise()).thenReturn(promise);
         when(ctx.write(any())).thenReturn(future);
+        when(ctx.flush()).thenThrow(new AssertionFailedError("forbidden"));
 
         encoder = new DefaultHttp2ConnectionEncoder(connection, writer);
         encoder.lifecycleManager(lifecycleManager);
@@ -217,7 +219,7 @@ public class DefaultHttp2ConnectionEncoderTest {
         final ByteBuf data = dummyData();
         encoder.writeData(ctx, STREAM_ID, data, 0, true, promise);
         assertEquals(payloadCaptor.getValue().size(), 8);
-        assertTrue(payloadCaptor.getValue().write(8));
+        payloadCaptor.getValue().write(8);
         assertEquals(0, payloadCaptor.getValue().size());
         assertEquals("abcdefgh", writtenData.get(0));
         assertEquals(0, data.refCnt());
@@ -229,7 +231,7 @@ public class DefaultHttp2ConnectionEncoderTest {
         final ByteBuf data = dummyData();
         encoder.writeData(ctx, STREAM_ID, data, 0, true, promise);
         assertEquals(payloadCaptor.getValue().size(), 8);
-        assertTrue(payloadCaptor.getValue().write(8));
+        payloadCaptor.getValue().write(8);
         // writer was called 3 times
         assertEquals(3, writtenData.size());
         assertEquals("abc", writtenData.get(0));
@@ -244,7 +246,7 @@ public class DefaultHttp2ConnectionEncoderTest {
         final ByteBuf data = dummyData();
         encoder.writeData(ctx, STREAM_ID, data, 5, true, promise);
         assertEquals(payloadCaptor.getValue().size(), 13);
-        assertTrue(payloadCaptor.getValue().write(13));
+        payloadCaptor.getValue().write(13);
         // writer was called 3 times
         assertEquals(3, writtenData.size());
         assertEquals("abcde", writtenData.get(0));
@@ -262,7 +264,7 @@ public class DefaultHttp2ConnectionEncoderTest {
         ByteBuf data = dummyData();
         encoder.writeData(ctx, STREAM_ID, data, 10, true, promise);
         assertEquals(payloadCaptor.getValue().size(), 18);
-        assertTrue(payloadCaptor.getValue().write(18));
+        payloadCaptor.getValue().write(18);
         // writer was called 4 times
         assertEquals(4, writtenData.size());
         assertEquals("abcde", writtenData.get(0));
@@ -292,7 +294,7 @@ public class DefaultHttp2ConnectionEncoderTest {
         when(frameSizePolicy.maxFrameSize()).thenReturn(5);
         encoder.writeData(ctx, STREAM_ID, data, 10, true, promise);
         assertEquals(payloadCaptor.getValue().size(), 10);
-        assertTrue(payloadCaptor.getValue().write(10));
+        payloadCaptor.getValue().write(10);
         // writer was called 2 times
         assertEquals(2, writtenData.size());
         assertEquals("", writtenData.get(0));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -30,6 +30,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 
+import junit.framework.AssertionFailedError;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -64,6 +65,7 @@ public class DefaultHttp2LocalFlowControllerTest {
         MockitoAnnotations.initMocks(this);
 
         when(ctx.newPromise()).thenReturn(promise);
+        when(ctx.flush()).thenThrow(new AssertionFailedError("forbidden"));
 
         connection = new DefaultHttp2Connection(false);
         controller = new DefaultHttp2LocalFlowController(connection, frameWriter, updateRatio);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -358,4 +358,11 @@ public class Http2ConnectionHandlerTest {
         verify(data).release();
         verifyNoMoreInteractions(frameWriter);
     }
+
+    @Test
+    public void channelReadCompleteTriggersFlush() throws Exception {
+        handler = newHandler();
+        handler.channelReadComplete(ctx);
+        verify(ctx, times(1)).flush();
+    }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -130,6 +130,7 @@ public class Http2ConnectionRoundtripTest {
             public void run() {
                 http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0, false,
                         newPromise());
+                ctx().flush();
             }
         });
 
@@ -174,6 +175,7 @@ public class Http2ConnectionRoundtripTest {
             public void run() {
                 http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0, false,
                         newPromise());
+                ctx().flush();
             }
         });
 
@@ -206,6 +208,7 @@ public class Http2ConnectionRoundtripTest {
             public void run() {
                 http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0, false,
                         newPromise());
+                ctx().flush();
             }
         });
 
@@ -237,6 +240,7 @@ public class Http2ConnectionRoundtripTest {
             public void run() {
                 http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0,
                         true, newPromise());
+                ctx().flush();
             }
         });
 
@@ -247,6 +251,7 @@ public class Http2ConnectionRoundtripTest {
             public void run() {
                 http2Client.encoder().writeHeaders(ctx(), Integer.MAX_VALUE + 1, headers, 0, (short) 16, false, 0,
                         true, newPromise());
+                ctx().flush();
             }
         });
 
@@ -292,6 +297,7 @@ public class Http2ConnectionRoundtripTest {
                     // Write trailers.
                     http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0,
                             true, newPromise());
+                    ctx().flush();
                 }
             });
 
@@ -376,6 +382,7 @@ public class Http2ConnectionRoundtripTest {
                         // Write trailers.
                         http2Client.encoder().writeHeaders(ctx(), streamId, headers, 0, (short) 16,
                                 false, 0, true, newPromise());
+                        ctx().flush();
                     }
                 }
             });


### PR DESCRIPTION
@Scottmitch 

Mostly fixes https://github.com/netty/netty/issues/3670