### PR TITLE
Remove the unreachable checking code In AsciiString

### DIFF
--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -959,9 +959,7 @@ public final class AsciiString extends ByteString implements CharSequence, Compa
         int length2 = cs.length();
         if (length1 != length2) {
             return false;
-        }
-
-        if (length1 == 0 && length2 == 0) {
+        } else if (length1 == 0) {
             return true; // since both are empty strings
         }
 


### PR DESCRIPTION
Motivation:
```'length2 == 0'``` is not reachable because length1 and length2 are same at this point.

Motification:
Removed ```'length2 == 0'```.

Result:
Cleaner code.