### PR TITLE
Upgrade twitter hpack dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -581,7 +581,7 @@
       <dependency>
         <groupId>com.twitter</groupId>
         <artifactId>hpack</artifactId>
-        <version>0.10.1</version>
+        <version>0.11.0</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.npn</groupId>
@@ -966,7 +966,7 @@
             <!-- SSLSession implementation -->
             <ignore>javax.net.ssl.SSLEngine</ignore>
             <ignore>javax.net.ssl.X509ExtendedTrustManager</ignore>
-            
+
             <ignore>java.util.concurrent.ConcurrentLinkedDeque</ignore>
           </ignores>
         </configuration>
@@ -1461,4 +1461,3 @@
     </pluginManagement>
   </build>
 </project>
-

--- a/testsuite-osgi/src/test/java/io/netty/osgitests/OsgiBundleTest.java
+++ b/testsuite-osgi/src/test/java/io/netty/osgitests/OsgiBundleTest.java
@@ -90,7 +90,7 @@ public class OsgiBundleTest {
         options.addAll(Arrays.asList(junitBundles()));
 
         options.add(mavenBundle("com.barchart.udt", "barchart-udt-bundle").versionAsInProject());
-        options.add(wrappedBundle(mavenBundle("com.twitter", "hpack").versionAsInProject()));
+        options.add(mavenBundle("com.twitter", "hpack").versionAsInProject());
         options.add(wrappedBundle(mavenBundle("org.rxtx", "rxtx").versionAsInProject()));
 
         for (String name : BUNDLES) {
@@ -106,4 +106,3 @@ public class OsgiBundleTest {
         assertFalse("At least one bundle needs to be tested", BUNDLES.isEmpty());
     }
 }
-


### PR DESCRIPTION
Motivation:
Right now the used hpack dependency does not contain a valid osgi manifest.

Modifications:
Upgrade hpack from 0.10.1 to 0.11.0.

Result:
hpack dependency works in osgi containers without wrapping.