### PR TITLE
Allowing inbound HTTP/2 frames after sending GOAWAY

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -147,12 +147,12 @@ public class DefaultHttp2Connection implements Http2Connection {
 
     @Override
     public boolean goAwayReceived() {
-        return localEndpoint.lastKnownStream >= 0;
+        return localEndpoint.lastStreamKnownByPeer >= 0;
     }
 
     @Override
     public void goAwayReceived(final int lastKnownStream, long errorCode, ByteBuf debugData) {
-        localEndpoint.lastKnownStream(lastKnownStream);
+        localEndpoint.lastStreamKnownByPeer(lastKnownStream);
         for (int i = 0; i < listeners.size(); ++i) {
             try {
                 listeners.get(i).onGoAwayReceived(lastKnownStream, errorCode, debugData);
@@ -178,12 +178,12 @@ public class DefaultHttp2Connection implements Http2Connection {
 
     @Override
     public boolean goAwaySent() {
-        return remoteEndpoint.lastKnownStream >= 0;
+        return remoteEndpoint.lastStreamKnownByPeer >= 0;
     }
 
     @Override
     public void goAwaySent(final int lastKnownStream, long errorCode, ByteBuf debugData) {
-        remoteEndpoint.lastKnownStream(lastKnownStream);
+        remoteEndpoint.lastStreamKnownByPeer(lastKnownStream);
         for (int i = 0; i < listeners.size(); ++i) {
             try {
                 listeners.get(i).onGoAwaySent(lastKnownStream, errorCode, debugData);
@@ -834,7 +834,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         private final boolean server;
         private int nextStreamId;
         private int lastStreamCreated;
-        private int lastKnownStream = -1;
+        private int lastStreamKnownByPeer = -1;
         private boolean pushToAllowed = true;
         private F flowController;
         private int maxActiveStreams;
@@ -989,12 +989,12 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         @Override
-        public int lastKnownStream() {
-            return lastKnownStream;
+        public int lastStreamKnownByPeer() {
+            return lastStreamKnownByPeer;
         }
 
-        private void lastKnownStream(int lastKnownStream) {
-            this.lastKnownStream = lastKnownStream;
+        private void lastStreamKnownByPeer(int lastKnownStream) {
+            this.lastStreamKnownByPeer = lastKnownStream;
         }
 
         @Override
@@ -1013,10 +1013,10 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         private void checkNewStreamAllowed(int streamId) throws Http2Exception {
-            if (goAwayReceived() && streamId > localEndpoint.lastKnownStream()) {
+            if (goAwayReceived() && streamId > localEndpoint.lastStreamKnownByPeer()) {
                 throw connectionError(PROTOCOL_ERROR, "Cannot create stream %d since this endpoint has received a " +
                                                       "GOAWAY frame with last stream id %d.", streamId,
-                                                      localEndpoint.lastKnownStream());
+                                                      localEndpoint.lastStreamKnownByPeer());
             }
             if (streamId < 0) {
                 throw new Http2NoMoreStreamIdsException();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -528,13 +528,16 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         }
 
         /**
-         * Helper method for determining whether or not to ignore inbound frames. This is done after a {@code GOAWAY}
-         * frame was sent by this endpoint and the stream: <br/> <ol> <li>was created remotely and </li> <li>is known by
-         * this endpoint.</li> </ol> <br/> Returns {@code true} if all of these conditions are met and the frame should
-         * be ignored.
+         * Helper method for determining whether or not to ignore inbound frames. A stream is considered to be created
+         * after a go away is sent if the following conditions hold:
          * <p/>
-         * This only applies to streams created by the remote endpoint.  Received frames for streams created locally
-         * should not be ignored as this endpoint may be awaiting their completion.
+         * <ul>
+         *     <li>A {@code GOAWAY} must have been sent by this endpoint</li>
+         *     <li>The {@code streamId} must identify a legitimate stream id for the remote peer to be creating</li>
+         *     <li>{@code streamId} is greater than the Last Known Stream ID which was sent by this endpoint in the
+         *     last {@code GOAWAY} frame</li>
+         * </ul>
+         * <p/>
          */
         private boolean streamCreatedAfterGoAwaySent(int streamId) {
             Http2Connection.Endpoint<?> remote = connection.remote();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -188,7 +188,7 @@ public interface Http2Connection {
          * <li>The connection is marked as going away.</li>
          * </ul>
          * <p>
-         * This method differs from {@link #createdStreamId(int)} because the initial state of the stream will be
+         * This method differs from {@link #createIdleStream(int)} because the initial state of the stream will be
          * Immediately set before notifying {@link Listener}s. The state transition is sensitive to {@code halfClosed}
          * and is defined by {@link Http2Stream#open(boolean)}.
          * @param streamId The ID of the stream
@@ -260,7 +260,7 @@ public interface Http2Connection {
          * If a GOAWAY was received for this endpoint, this will be the last stream ID from the
          * GOAWAY frame. Otherwise, this will be {@code -1}.
          */
-        int lastKnownStream();
+        int lastStreamKnownByPeer();
 
         /**
          * Gets the flow controller for this endpoint.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -517,10 +517,10 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
                                 final ByteBuf debugData, ChannelPromise promise) {
         try {
             final Http2Connection connection = connection();
-            if (connection.goAwaySent() && connection.remote().lastKnownStream() < lastStreamId) {
+            if (connection.goAwaySent() && lastStreamId > connection.remote().lastStreamKnownByPeer()) {
                 throw connectionError(PROTOCOL_ERROR, "Last stream identifier must not increase between " +
                                                       "sending multiple GOAWAY frames (was '%d', is '%d').",
-                                                      connection.remote().lastKnownStream(),
+                                                      connection.remote().lastStreamKnownByPeer(),
                                                       lastStreamId);
             }
             connection.goAwaySent(lastStreamId, errorCode, debugData);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -699,12 +699,12 @@ public class DefaultHttp2ConnectionDecoderTest {
     private void mockGoAwaySent() {
         when(connection.goAwaySent()).thenReturn(true);
         when(remote.isValidStreamId(STREAM_ID)).thenReturn(true);
-        when(remote.lastStreamKnownByPeer()).thenReturn(1);
+        when(remote.lastStreamKnownByPeer()).thenReturn(0);
     }
 
     private void mockGoAwaySentShouldAllowFramesForStreamCreatedByLocalEndpoint() {
         when(connection.goAwaySent()).thenReturn(true);
         when(remote.isValidStreamId(STREAM_ID)).thenReturn(false);
-        when(remote.lastStreamKnownByPeer()).thenReturn(1);
+        when(remote.lastStreamKnownByPeer()).thenReturn(0);
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -517,7 +517,7 @@ public class DefaultHttp2ConnectionEncoderTest {
     @Test
     public void canWriteDataFrameAfterGoAwaySent() {
         when(connection.goAwaySent()).thenReturn(true);
-        when(remote.lastKnownStream()).thenReturn(0);
+        when(remote.lastStreamKnownByPeer()).thenReturn(0);
         ByteBuf data = mock(ByteBuf.class);
         encoder.writeData(ctx, STREAM_ID, data, 0, false, promise);
         verify(remoteFlow).sendFlowControlled(eq(ctx), eq(stream), any(FlowControlled.class));
@@ -526,7 +526,7 @@ public class DefaultHttp2ConnectionEncoderTest {
     @Test
     public void canWriteHeaderFrameAfterGoAwaySent() {
         when(connection.goAwaySent()).thenReturn(true);
-        when(remote.lastKnownStream()).thenReturn(0);
+        when(remote.lastStreamKnownByPeer()).thenReturn(0);
         encoder.writeHeaders(ctx, STREAM_ID, EmptyHttp2Headers.INSTANCE, 0, false, promise);
         verify(remoteFlow).sendFlowControlled(eq(ctx), eq(stream), any(FlowControlled.class));
     }
@@ -534,7 +534,7 @@ public class DefaultHttp2ConnectionEncoderTest {
     @Test
     public void canWriteDataFrameAfterGoAwayReceived() {
         when(connection.goAwayReceived()).thenReturn(true);
-        when(local.lastKnownStream()).thenReturn(STREAM_ID);
+        when(local.lastStreamKnownByPeer()).thenReturn(STREAM_ID);
         ByteBuf data = mock(ByteBuf.class);
         encoder.writeData(ctx, STREAM_ID, data, 0, false, promise);
         verify(remoteFlow).sendFlowControlled(eq(ctx), eq(stream), any(FlowControlled.class));
@@ -543,7 +543,7 @@ public class DefaultHttp2ConnectionEncoderTest {
     @Test
     public void canWriteHeaderFrameAfterGoAwayReceived() {
         when(connection.goAwayReceived()).thenReturn(true);
-        when(local.lastKnownStream()).thenReturn(STREAM_ID);
+        when(local.lastStreamKnownByPeer()).thenReturn(STREAM_ID);
         encoder.writeHeaders(ctx, STREAM_ID, EmptyHttp2Headers.INSTANCE, 0, false, promise);
         verify(remoteFlow).sendFlowControlled(eq(ctx), eq(stream), any(FlowControlled.class));
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -93,10 +93,10 @@ public class DefaultHttp2ConnectionTest {
         assertEquals(State.OPEN, stream1.state());
         assertEquals(State.CLOSED, stream2.state());
         assertEquals(State.OPEN, remoteStream.state());
-        assertEquals(3, client.local().lastKnownStream());
+        assertEquals(3, client.local().lastStreamKnownByPeer());
         assertEquals(5, client.local().lastStreamCreated());
         // The remote endpoint must not be affected by a received GOAWAY frame.
-        assertEquals(-1, client.remote().lastKnownStream());
+        assertEquals(-1, client.remote().lastStreamKnownByPeer());
         assertEquals(State.OPEN, remoteStream.state());
     }
 
@@ -111,10 +111,10 @@ public class DefaultHttp2ConnectionTest {
         assertEquals(State.OPEN, stream1.state());
         assertEquals(State.CLOSED, stream2.state());
 
-        assertEquals(3, server.remote().lastKnownStream());
+        assertEquals(3, server.remote().lastStreamKnownByPeer());
         assertEquals(5, server.remote().lastStreamCreated());
         // The local endpoint must not be affected by a sent GOAWAY frame.
-        assertEquals(-1, server.local().lastKnownStream());
+        assertEquals(-1, server.local().lastStreamKnownByPeer());
         assertEquals(State.OPEN, localStream.state());
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -351,7 +351,7 @@ public class Http2ConnectionHandlerTest {
         assertFalse(promise.isDone());
 
         when(connection.goAwaySent()).thenReturn(true);
-        when(remote.lastKnownStream()).thenReturn(STREAM_ID);
+        when(remote.lastStreamKnownByPeer()).thenReturn(STREAM_ID);
         handler.goAway(ctx, STREAM_ID + 2, errorCode, data, promise);
         assertTrue(promise.isDone());
         assertFalse(promise.isSuccess());


### PR DESCRIPTION
Motivation:

If the client closes, a GOWAY is sent with a lastKnownStream of zero (since the remote side never created a stream). If there is still an exchange in progress, inbound frames for streams created by the client will be ignored because our ignore logic doesn't check to see if the stream was created by the remote endpoint. Frames for streams created by the local endpoint should continue to come through after sending GOAWAY.

Modifications:

Changed the decoder's streamCreatedAfterGoAwaySent logic to properly ensure that the stream was created remotely.

Result:

We now propertly process frames received after sending GOAWAY.