### PR TITLE
Fix possible IllegalStateException caused by closeNotifyTimeout when usi...

### DIFF
--- a/common/src/test/java/io/netty/util/concurrent/PromiseNotifierTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/PromiseNotifierTest.java
@@ -55,8 +55,8 @@ public class PromiseNotifierTest {
         Future<Void> future = createStrictMock(Future.class);
         expect(future.isSuccess()).andReturn(true);
         expect(future.get()).andReturn(null);
-        expect(p1.setSuccess(null)).andReturn(p1);
-        expect(p2.setSuccess(null)).andReturn(p2);
+        expect(p1.trySuccess(null)).andReturn(true);
+        expect(p2.trySuccess(null)).andReturn(true);
         replay(p1, p2, future);
 
         notifier.operationComplete(future);
@@ -79,8 +79,8 @@ public class PromiseNotifierTest {
         Throwable t = createStrictMock(Throwable.class);
         expect(future.isSuccess()).andReturn(false);
         expect(future.cause()).andReturn(t);
-        expect(p1.setFailure(t)).andReturn(p1);
-        expect(p2.setFailure(t)).andReturn(p2);
+        expect(p1.tryFailure(t)).andReturn(true);
+        expect(p2.tryFailure(t)).andReturn(true);
         replay(p1, p2, future);
 
         notifier.operationComplete(future);

--- a/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
@@ -32,5 +32,4 @@ public final class ChannelPromiseNotifier
     public ChannelPromiseNotifier(ChannelPromise... promises) {
         super(promises);
     }
-
 }


### PR DESCRIPTION
...ng SslHandler

Motivation:

In the SslHandler we schedule a timeout at which we close the Channel if a timeout was detected during close_notify. Because this can race with notify the flushFuture we can see an IllegalStateException when the Channel is closed.

Modifications:

- Use a trySuccess() and tryFailure(...) to guard against race.

Result:

No more race.