### PR TITLE
Fix race-condition in SocketSslEchoTest

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -300,14 +300,6 @@ public class SocketSslEchoTest extends AbstractSocketTest {
             }
         }
 
-        // Wait until renegotiation is done.
-        if (renegoFuture != null) {
-            renegoFuture.sync();
-        }
-        if (serverHandler.renegoFuture != null) {
-            serverHandler.renegoFuture.sync();
-        }
-
         // Ensure all data has been exchanged.
         while (clientRecvCounter.get() < data.length) {
             if (serverException.get() != null) {
@@ -337,6 +329,14 @@ public class SocketSslEchoTest extends AbstractSocketTest {
             } catch (InterruptedException e) {
                 // Ignore.
             }
+        }
+
+        // Wait until renegotiation is done.
+        if (renegoFuture != null) {
+            renegoFuture.sync();
+        }
+        if (serverHandler.renegoFuture != null) {
+            serverHandler.renegoFuture.sync();
         }
 
         serverChannel.close().awaitUninterruptibly();


### PR DESCRIPTION
Motivation:

Because we tried to grab the SSL renegotation future to early we could see test-failures.

Modifications:

Access the future at the correct time.

Result:

No more test-failures.