### PR TITLE
[#3709] Ensure all data is read from socket when EPOLLRDUP is received

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -99,12 +99,14 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     @Override
     protected void doClose() throws Exception {
         active = false;
-
-        // deregister from epoll now
-        doDeregister();
-
-        FileDescriptor fd = fileDescriptor;
-        fd.close();
+        try {
+            // deregister from epoll now
+            doDeregister();
+        } finally {
+            // Ensure the file descriptor is closed in all cases.
+            FileDescriptor fd = fileDescriptor;
+            fd.close();
+        }
     }
 
     @Override

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -765,11 +765,14 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel {
 
         @Override
         void epollRdHupReady() {
-            // Just call closeOnRead(). There is no need to trigger a read as this
-            // will result in an IOException anyway.
-            //
-            // See https://github.com/netty/netty/issues/3539
-            closeOnRead(pipeline());
+            if (isActive()) {
+                // If it is still active, we need to call epollInReady as otherwise we may miss to
+                // read pending data from the underyling file descriptor.
+                // See https://github.com/netty/netty/issues/3709
+                epollInReady();
+            } else {
+                closeOnRead(pipeline());
+            }
         }
 
         @Override


### PR DESCRIPTION
Motivation:

When EPOLLRDHUP is received we need to try to read at least one time to ensure
that we read all pending data from the socket. Otherwise we may loose data.

Modifications:

- Ensure we read all data from socket
- Ensure file descriptor is closed on doClose() even if doDeregister() throws an Exception.
- Only handle either EPOLLRDHUP or EPOLLIN as only one is needed to detect connection reset.

Result:

No more data loss on connection reset.