### PR TITLE
Add support for mutual auth when using OpenSslEngine.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -39,6 +39,7 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
+import javax.security.auth.x500.X500Principal;
 import java.io.File;
 import java.io.IOException;
 import java.security.InvalidAlgorithmParameterException;
@@ -52,6 +53,7 @@ import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.ArrayList;
@@ -399,8 +401,8 @@ public abstract class SslContext {
                     keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
         case OPENSSL:
             return new OpenSslServerContext(
-                    keyCertChainFile, keyFile, keyPassword, trustManagerFactory,
-                    ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
+                    trustCertChainFile, trustManagerFactory, keyCertChainFile, keyFile, keyPassword,
+                    keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
         default:
             throw new Error(provider.toString());
         }
@@ -729,8 +731,8 @@ public abstract class SslContext {
                         keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
             case OPENSSL:
                 return new OpenSslClientContext(
-                        trustCertChainFile, trustManagerFactory, ciphers, cipherFilter, apn,
-                        sessionCacheSize, sessionTimeout);
+                        trustCertChainFile, trustManagerFactory, keyCertChainFile, keyFile, keyPassword,
+                        keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
         }
         // Should never happen!!
         throw new Error();
@@ -924,5 +926,40 @@ public abstract class SslContext {
         ks.load(null, null);
         ks.setKeyEntry("key", key, keyPasswordChars, certChain.toArray(new Certificate[certChain.size()]));
         return ks;
+    }
+
+    /**
+     * Build a {@link TrustManagerFactory} from a certificate chain file.
+     * @param certChainFile The certificate file to build from.
+     * @param trustManagerFactory The existing {@link TrustManagerFactory} that will be used if not {@code null}.
+     * @return A {@link TrustManagerFactory} which contains the certificates in {@code certChainFile}
+     */
+    protected static TrustManagerFactory buildTrustManagerFactory(File certChainFile,
+                                                                  TrustManagerFactory trustManagerFactory)
+            throws NoSuchAlgorithmException, CertificateException, KeyStoreException, IOException {
+        KeyStore ks = KeyStore.getInstance("JKS");
+        ks.load(null, null);
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+
+        ByteBuf[] certs = PemReader.readCertificates(certChainFile);
+        try {
+            for (ByteBuf buf: certs) {
+                X509Certificate cert = (X509Certificate) cf.generateCertificate(new ByteBufInputStream(buf));
+                X500Principal principal = cert.getSubjectX500Principal();
+                ks.setCertificateEntry(principal.getName("RFC2253"), cert);
+            }
+        } finally {
+            for (ByteBuf buf: certs) {
+                buf.release();
+            }
+        }
+
+        // Set up trust manager factory to use our key store.
+        if (trustManagerFactory == null) {
+            trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        }
+        trustManagerFactory.init(ks);
+
+        return trustManagerFactory;
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+public class OpenSslEngineTest extends SSLEngineTest {
+    @Override
+    protected SslProvider sslProvider() {
+        return SslProvider.OPENSSL;
+    }
+}

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.NetUtil;
+import io.netty.util.concurrent.Future;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.verify;
+
+public abstract class SSLEngineTest {
+
+    @Mock
+    protected MessageReciever serverReceiver;
+    @Mock
+    protected MessageReciever clientReceiver;
+
+    protected Throwable serverException;
+    protected Throwable clientException;
+    protected SslContext serverSslCtx;
+    protected SslContext clientSslCtx;
+    protected ServerBootstrap sb;
+    protected Bootstrap cb;
+    protected Channel serverChannel;
+    protected Channel serverConnectedChannel;
+    protected Channel clientChannel;
+    protected CountDownLatch serverLatch;
+    protected CountDownLatch clientLatch;
+
+    interface MessageReciever {
+        void messageReceived(ByteBuf msg);
+    }
+
+    protected static final class MessageDelegatorChannelHandler extends SimpleChannelInboundHandler<ByteBuf> {
+        private final MessageReciever receiver;
+        private final CountDownLatch latch;
+
+        public MessageDelegatorChannelHandler(MessageReciever receiver, CountDownLatch latch) {
+            super(false);
+            this.receiver = receiver;
+            this.latch = latch;
+        }
+
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) throws Exception {
+            receiver.messageReceived(msg);
+            latch.countDown();
+        }
+    }
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        serverLatch = new CountDownLatch(1);
+        clientLatch = new CountDownLatch(1);
+    }
+
+    @After
+    public void tearDown() throws InterruptedException {
+        if (serverChannel != null) {
+            serverChannel.close().sync();
+            Future<?> serverGroup = sb.group().shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
+            Future<?> serverChildGroup = sb.childGroup().shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
+            Future<?> clientGroup = cb.group().shutdownGracefully(0, 0, TimeUnit.MILLISECONDS);
+            serverGroup.sync();
+            serverChildGroup.sync();
+            clientGroup.sync();
+        }
+        clientChannel = null;
+        serverChannel = null;
+        serverConnectedChannel = null;
+        serverException = null;
+    }
+
+    @Test
+    public void testMutualAuthSameCerts() throws Exception {
+        mySetupMutualAuth(new File(getClass().getResource("test_unencrypted.pem").getFile()),
+                          new File(getClass().getResource("test.crt").getFile()),
+                          null);
+        runTest(null);
+    }
+
+    @Test
+    public void testMutualAuthDiffCerts() throws Exception {
+        File serverKeyFile = new File(getClass().getResource("test_encrypted.pem").getFile());
+        File serverCrtFile = new File(getClass().getResource("test.crt").getFile());
+        String serverKeyPassword = "12345";
+        File clientKeyFile = new File(getClass().getResource("test2_encrypted.pem").getFile());
+        File clientCrtFile = new File(getClass().getResource("test2.crt").getFile());
+        String clientKeyPassword = "12345";
+        mySetupMutualAuth(clientCrtFile, serverKeyFile, serverCrtFile, serverKeyPassword,
+                          serverCrtFile, clientKeyFile, clientCrtFile, clientKeyPassword);
+        runTest(null);
+    }
+
+    @Test
+    public void testMutualAuthDiffCertsServerFailure() throws Exception {
+        File serverKeyFile = new File(getClass().getResource("test_encrypted.pem").getFile());
+        File serverCrtFile = new File(getClass().getResource("test.crt").getFile());
+        String serverKeyPassword = "12345";
+        File clientKeyFile = new File(getClass().getResource("test2_encrypted.pem").getFile());
+        File clientCrtFile = new File(getClass().getResource("test2.crt").getFile());
+        String clientKeyPassword = "12345";
+        // Client trusts server but server only trusts itself
+        mySetupMutualAuth(serverCrtFile, serverKeyFile, serverCrtFile, serverKeyPassword,
+                          serverCrtFile, clientKeyFile, clientCrtFile, clientKeyPassword);
+        assertTrue(serverLatch.await(2, TimeUnit.SECONDS));
+        assertTrue(serverException instanceof SSLHandshakeException);
+    }
+
+    @Test
+    public void testMutualAuthDiffCertsClientFailure() throws Exception {
+        File serverKeyFile = new File(getClass().getResource("test_unencrypted.pem").getFile());
+        File serverCrtFile = new File(getClass().getResource("test.crt").getFile());
+        String serverKeyPassword = null;
+        File clientKeyFile = new File(getClass().getResource("test2_unencrypted.pem").getFile());
+        File clientCrtFile = new File(getClass().getResource("test2.crt").getFile());
+        String clientKeyPassword = null;
+        // Server trusts client but client only trusts itself
+        mySetupMutualAuth(clientCrtFile, serverKeyFile, serverCrtFile, serverKeyPassword,
+                          clientCrtFile, clientKeyFile, clientCrtFile, clientKeyPassword);
+        assertTrue(clientLatch.await(2, TimeUnit.SECONDS));
+        assertTrue(clientException instanceof SSLHandshakeException);
+    }
+
+    private void mySetupMutualAuth(File keyFile, File crtFile, String keyPassword)
+            throws SSLException, InterruptedException {
+        mySetupMutualAuth(crtFile, keyFile, crtFile, keyPassword, crtFile, keyFile, crtFile, keyPassword);
+    }
+
+    private void mySetupMutualAuth(
+            File servertTrustCrtFile, File serverKeyFile, File serverCrtFile, String serverKeyPassword,
+            File clientTrustCrtFile, File clientKeyFile, File clientCrtFile, String clientKeyPassword)
+            throws InterruptedException, SSLException {
+        serverSslCtx = SslContext.newServerContext(sslProvider(), servertTrustCrtFile, null,
+                                                   serverCrtFile, serverKeyFile, serverKeyPassword, null,
+                                                   null, IdentityCipherSuiteFilter.INSTANCE, null, 0, 0);
+        clientSslCtx = SslContext.newClientContext(sslProvider(), clientTrustCrtFile, null,
+                                                   clientCrtFile, clientKeyFile, clientKeyPassword, null,
+                                                   null, IdentityCipherSuiteFilter.INSTANCE,
+                                                   null, 0, 0);
+
+        serverConnectedChannel = null;
+        sb = new ServerBootstrap();
+        cb = new Bootstrap();
+
+        sb.group(new NioEventLoopGroup(), new NioEventLoopGroup());
+        sb.channel(NioServerSocketChannel.class);
+        sb.childHandler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ChannelPipeline p = ch.pipeline();
+                SSLEngine engine = serverSslCtx.newEngine(ch.alloc());
+                engine.setUseClientMode(false);
+                engine.setNeedClientAuth(true);
+                p.addLast(new SslHandler(engine));
+                p.addLast(new MessageDelegatorChannelHandler(serverReceiver, serverLatch));
+                p.addLast(new ChannelHandlerAdapter() {
+                    @Override
+                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                        if (cause.getCause() instanceof SSLHandshakeException) {
+                            serverException = cause.getCause();
+                            serverLatch.countDown();
+                        } else {
+                            ctx.fireExceptionCaught(cause);
+                        }
+                    }
+                });
+                serverConnectedChannel = ch;
+            }
+        });
+
+        cb.group(new NioEventLoopGroup());
+        cb.channel(NioSocketChannel.class);
+        cb.handler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ChannelPipeline p = ch.pipeline();
+                p.addLast(clientSslCtx.newHandler(ch.alloc()));
+                p.addLast(new MessageDelegatorChannelHandler(clientReceiver, clientLatch));
+                p.addLast(new ChannelHandlerAdapter() {
+                    @Override
+                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                        cause.printStackTrace();
+                        if (cause.getCause() instanceof SSLHandshakeException) {
+                            clientException = cause.getCause();
+                            clientLatch.countDown();
+                        } else {
+                            ctx.fireExceptionCaught(cause);
+                        }
+                    }
+                });
+            }
+        });
+
+        serverChannel = sb.bind(new InetSocketAddress(0)).sync().channel();
+        int port = ((InetSocketAddress) serverChannel.localAddress()).getPort();
+
+        ChannelFuture ccf = cb.connect(new InetSocketAddress(NetUtil.LOCALHOST, port));
+        assertTrue(ccf.awaitUninterruptibly().isSuccess());
+        clientChannel = ccf.channel();
+    }
+
+    protected void runTest(String expectedApplicationProtocol) throws Exception {
+        final ByteBuf clientMessage = Unpooled.copiedBuffer("I am a client".getBytes());
+        final ByteBuf serverMessage = Unpooled.copiedBuffer("I am a server".getBytes());
+        try {
+            writeAndVerifyReceived(clientMessage.retain(), clientChannel, serverLatch, serverReceiver);
+            writeAndVerifyReceived(serverMessage.retain(), serverConnectedChannel, clientLatch, clientReceiver);
+            if (expectedApplicationProtocol != null) {
+                verifyApplicationLevelProtocol(clientChannel, expectedApplicationProtocol);
+                verifyApplicationLevelProtocol(serverConnectedChannel, expectedApplicationProtocol);
+            }
+        } finally {
+            clientMessage.release();
+            serverMessage.release();
+        }
+    }
+
+    private static void verifyApplicationLevelProtocol(Channel channel, String expectedApplicationProtocol) {
+        SslHandler handler = channel.pipeline().get(SslHandler.class);
+        assertNotNull(handler);
+        String[] protocol = handler.engine().getSession().getProtocol().split(":");
+        assertNotNull(protocol);
+        if (expectedApplicationProtocol != null && !expectedApplicationProtocol.isEmpty()) {
+            assertTrue("protocol.length must be greater than 1 but is " + protocol.length, protocol.length > 1);
+            assertEquals(expectedApplicationProtocol, protocol[1]);
+        } else {
+            assertEquals(1, protocol.length);
+        }
+    }
+
+    private static void writeAndVerifyReceived(ByteBuf message, Channel sendChannel, CountDownLatch receiverLatch,
+                                               MessageReciever receiver) throws Exception {
+        List<ByteBuf> dataCapture = null;
+        try {
+            sendChannel.writeAndFlush(message);
+            receiverLatch.await(5, TimeUnit.SECONDS);
+            message.resetReaderIndex();
+            ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
+            verify(receiver).messageReceived(captor.capture());
+            dataCapture = captor.getAllValues();
+            assertEquals(message, dataCapture.get(0));
+        } finally {
+            if (dataCapture != null) {
+                for (ByteBuf data : dataCapture) {
+                    data.release();
+                }
+            }
+        }
+    }
+
+    protected abstract SslProvider sslProvider();
+}


### PR DESCRIPTION
Motivation:

Currently mutual auth is not supported when using OpenSslEngine.

Modification:

- Add support to OpenSslClientContext
- Correctly throw SSLHandshakeException when an error during handshake is detected

Result:

Mutual auth can be used with OpenSslEngine