### PR TITLE
DefaultChannelPipeline needs to release objects

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -1023,13 +1023,22 @@ final class DefaultChannelPipeline implements ChannelPipeline {
         public void handlerRemoved(ChannelHandlerContext ctx) throws Exception { }
 
         @Override
-        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception { }
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            // This may not be a configuration error and so don't log anything.
+            // The event may be superfluous for the current pipeline configuration.
+            ReferenceCountUtil.release(evt);
+        }
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-            logger.warn(
-                    "An exceptionCaught() event was fired, and it reached at the tail of the pipeline. " +
-                            "It usually means the last handler in the pipeline did not handle the exception.", cause);
+            try {
+                logger.warn(
+                        "An exceptionCaught() event was fired, and it reached at the tail of the pipeline. " +
+                                "It usually means the last handler in the pipeline did not handle the exception.",
+                                cause);
+            } finally {
+                ReferenceCountUtil.release(cause);
+            }
         }
 
         @Override


### PR DESCRIPTION
Motiviation:
If user events or excpetions reach the tail end of the pipeline they are not released. This could result in buffer leaks.

Motivation:
- Use the ReferenceCountUtil.release to release objects for the userEventTriggered and exceptionCaught methods on DefaultChannelPipeline

Result:
2 less areas where buffer leaks can occur.