### PR TITLE
ByteString and AsciiString equals/hashCode updates

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
@@ -116,9 +116,9 @@ public class DefaultLastHttpContent extends DefaultHttpContent implements LastHt
             public CharSequence convertName(CharSequence name) {
                 name = super.convertName(name);
                 if (validate) {
-                    if (HttpHeaderNames.CONTENT_LENGTH.equalsIgnoreCase(name)
-                                    || HttpHeaderNames.TRANSFER_ENCODING.equalsIgnoreCase(name)
-                                    || HttpHeaderNames.TRAILER.equalsIgnoreCase(name)) {
+                    if (HttpHeaderNames.CONTENT_LENGTH.contentEqualsIgnoreCase(name)
+                                    || HttpHeaderNames.TRANSFER_ENCODING.contentEqualsIgnoreCase(name)
+                                    || HttpHeaderNames.TRAILER.contentEqualsIgnoreCase(name)) {
                         throw new IllegalArgumentException("prohibited trailing header: " + name);
                     }
                 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
@@ -220,7 +220,7 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator implements Ch
                 throw new IllegalStateException(
                         "Switching Protocols response missing UPGRADE header");
             }
-            if (!AsciiString.equalsIgnoreCase(upgradeCodec.protocol(), upgradeHeader)) {
+            if (!AsciiString.contentEqualsIgnoreCase(upgradeCodec.protocol(), upgradeHeader)) {
                 throw new IllegalStateException(
                         "Switching Protocols response with unexpected UPGRADE protocol: "
                                 + upgradeHeader);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -96,7 +96,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
     protected Result beginEncode(HttpResponse headers, String acceptEncoding) throws Exception {
         String contentEncoding = headers.headers().get(HttpHeaderNames.CONTENT_ENCODING);
         if (contentEncoding != null &&
-            !HttpHeaderValues.IDENTITY.equalsIgnoreCase(contentEncoding)) {
+            !HttpHeaderValues.IDENTITY.contentEqualsIgnoreCase(contentEncoding)) {
             return null;
         }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderUtil.java
@@ -31,14 +31,14 @@ public final class HttpHeaderUtil {
      */
     public static boolean isKeepAlive(HttpMessage message) {
         CharSequence connection = message.headers().get(HttpHeaderNames.CONNECTION);
-        if (connection != null && HttpHeaderValues.CLOSE.equalsIgnoreCase(connection)) {
+        if (connection != null && HttpHeaderValues.CLOSE.contentEqualsIgnoreCase(connection)) {
             return false;
         }
 
         if (message.protocolVersion().isKeepAliveDefault()) {
-            return !HttpHeaderValues.CLOSE.equalsIgnoreCase(connection);
+            return !HttpHeaderValues.CLOSE.contentEqualsIgnoreCase(connection);
         } else {
-            return HttpHeaderValues.KEEP_ALIVE.equalsIgnoreCase(connection);
+            return HttpHeaderValues.KEEP_ALIVE.contentEqualsIgnoreCase(connection);
         }
     }
 
@@ -192,7 +192,7 @@ public final class HttpHeaderUtil {
         if (value == null) {
             return false;
         }
-        if (HttpHeaderValues.CONTINUE.equalsIgnoreCase(value)) {
+        if (HttpHeaderValues.CONTINUE.contentEqualsIgnoreCase(value)) {
             return true;
         }
 
@@ -237,7 +237,7 @@ public final class HttpHeaderUtil {
             Iterator<String> valuesIt = values.iterator();
             while (valuesIt.hasNext()) {
                 CharSequence value = valuesIt.next();
-                if (HttpHeaderValues.CHUNKED.equalsIgnoreCase(value)) {
+                if (HttpHeaderValues.CHUNKED.contentEqualsIgnoreCase(value)) {
                     valuesIt.remove();
                 }
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -1256,11 +1256,11 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     }
 
     /**
-     * @deprecated Use {@link AsciiString#equalsIgnoreCase(CharSequence, CharSequence)} instead.
+     * @deprecated Use {@link AsciiString#contentEqualsIgnoreCase(CharSequence, CharSequence)} instead.
      */
     @Deprecated
     public static boolean equalsIgnoreCase(CharSequence name1, CharSequence name2) {
-        return AsciiString.equalsIgnoreCase(name1, name2);
+        return AsciiString.contentEqualsIgnoreCase(name1, name2);
     }
 
     static void encode(HttpHeaders headers, ByteBuf buf) throws Exception {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -607,9 +607,9 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 } else {
                     splitHeader(line);
                     CharSequence headerName = name;
-                    if (!HttpHeaderNames.CONTENT_LENGTH.equalsIgnoreCase(headerName) &&
-                        !HttpHeaderNames.TRANSFER_ENCODING.equalsIgnoreCase(headerName) &&
-                        !HttpHeaderNames.TRAILER.equalsIgnoreCase(headerName)) {
+                    if (!HttpHeaderNames.CONTENT_LENGTH.contentEqualsIgnoreCase(headerName) &&
+                        !HttpHeaderNames.TRANSFER_ENCODING.contentEqualsIgnoreCase(headerName) &&
+                        !HttpHeaderNames.TRAILER.contentEqualsIgnoreCase(headerName)) {
                         trailer.trailingHeaders().add(headerName, value);
                     }
                     lastHeader = name;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -663,13 +663,13 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
                 return null;
             }
             String[] contents = splitMultipartHeader(newline);
-            if (HttpHeaderNames.CONTENT_DISPOSITION.equalsIgnoreCase(contents[0])) {
+            if (HttpHeaderNames.CONTENT_DISPOSITION.contentEqualsIgnoreCase(contents[0])) {
                 boolean checkSecondArg;
                 if (currentStatus == MultiPartStatus.DISPOSITION) {
-                    checkSecondArg = HttpHeaderValues.FORM_DATA.equalsIgnoreCase(contents[1]);
+                    checkSecondArg = HttpHeaderValues.FORM_DATA.contentEqualsIgnoreCase(contents[1]);
                 } else {
-                    checkSecondArg = HttpHeaderValues.ATTACHMENT.equalsIgnoreCase(contents[1])
-                            || HttpHeaderValues.FILE.equalsIgnoreCase(contents[1]);
+                    checkSecondArg = HttpHeaderValues.ATTACHMENT.contentEqualsIgnoreCase(contents[1])
+                            || HttpHeaderValues.FILE.contentEqualsIgnoreCase(contents[1]);
                 }
                 if (checkSecondArg) {
                     // read next values and store them in the map as Attribute
@@ -697,7 +697,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
                         currentFieldAttributes.put(attribute.getName(), attribute);
                     }
                 }
-            } else if (HttpHeaderNames.CONTENT_TRANSFER_ENCODING.equalsIgnoreCase(contents[0])) {
+            } else if (HttpHeaderNames.CONTENT_TRANSFER_ENCODING.contentEqualsIgnoreCase(contents[0])) {
                 Attribute attribute;
                 try {
                     attribute = factory.createAttribute(request, HttpHeaderNames.CONTENT_TRANSFER_ENCODING.toString(),
@@ -708,7 +708,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
                     throw new ErrorDataDecoderException(e);
                 }
                 currentFieldAttributes.put(HttpHeaderNames.CONTENT_TRANSFER_ENCODING, attribute);
-            } else if (HttpHeaderNames.CONTENT_LENGTH.equalsIgnoreCase(contents[0])) {
+            } else if (HttpHeaderNames.CONTENT_LENGTH.contentEqualsIgnoreCase(contents[0])) {
                 Attribute attribute;
                 try {
                     attribute = factory.createAttribute(request, HttpHeaderNames.CONTENT_LENGTH.toString(),
@@ -719,9 +719,9 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
                     throw new ErrorDataDecoderException(e);
                 }
                 currentFieldAttributes.put(HttpHeaderNames.CONTENT_LENGTH, attribute);
-            } else if (HttpHeaderNames.CONTENT_TYPE.equalsIgnoreCase(contents[0])) {
+            } else if (HttpHeaderNames.CONTENT_TYPE.contentEqualsIgnoreCase(contents[0])) {
                 // Take care of possible "multipart/mixed"
-                if (HttpHeaderValues.MULTIPART_MIXED.equalsIgnoreCase(contents[1])) {
+                if (HttpHeaderValues.MULTIPART_MIXED.contentEqualsIgnoreCase(contents[1])) {
                     if (currentStatus == MultiPartStatus.DISPOSITION) {
                         String values = StringUtil.substringAfter(contents[2], '=');
                         multipartMixedBoundary = "--" + values;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -747,7 +747,7 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
             if (transferEncoding != null) {
                 headers.remove(HttpHeaderNames.TRANSFER_ENCODING);
                 for (CharSequence v : transferEncoding) {
-                    if (HttpHeaderValues.CHUNKED.equalsIgnoreCase(v)) {
+                    if (HttpHeaderValues.CHUNKED.contentEqualsIgnoreCase(v)) {
                         // ignore
                     } else {
                         headers.add(HttpHeaderNames.TRANSFER_ENCODING, v);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker00.java
@@ -201,13 +201,13 @@ public class WebSocketClientHandshaker00 extends WebSocketClientHandshaker {
         HttpHeaders headers = response.headers();
 
         CharSequence upgrade = headers.get(HttpHeaderNames.UPGRADE);
-        if (!WEBSOCKET.equalsIgnoreCase(upgrade)) {
+        if (!WEBSOCKET.contentEqualsIgnoreCase(upgrade)) {
             throw new WebSocketHandshakeException("Invalid handshake response upgrade: "
                     + upgrade);
         }
 
         CharSequence connection = headers.get(HttpHeaderNames.CONNECTION);
-        if (!HttpHeaderValues.UPGRADE.equalsIgnoreCase(connection)) {
+        if (!HttpHeaderValues.UPGRADE.contentEqualsIgnoreCase(connection)) {
             throw new WebSocketHandshakeException("Invalid handshake response connection: "
                     + connection);
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker07.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker07.java
@@ -206,12 +206,12 @@ public class WebSocketClientHandshaker07 extends WebSocketClientHandshaker {
         }
 
         CharSequence upgrade = headers.get(HttpHeaderNames.UPGRADE);
-        if (!HttpHeaderValues.WEBSOCKET.equalsIgnoreCase(upgrade)) {
+        if (!HttpHeaderValues.WEBSOCKET.contentEqualsIgnoreCase(upgrade)) {
             throw new WebSocketHandshakeException("Invalid handshake response upgrade: " + upgrade);
         }
 
         CharSequence connection = headers.get(HttpHeaderNames.CONNECTION);
-        if (!HttpHeaderValues.UPGRADE.equalsIgnoreCase(connection)) {
+        if (!HttpHeaderValues.UPGRADE.contentEqualsIgnoreCase(connection)) {
             throw new WebSocketHandshakeException("Invalid handshake response connection: " + connection);
         }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker08.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker08.java
@@ -207,12 +207,12 @@ public class WebSocketClientHandshaker08 extends WebSocketClientHandshaker {
         }
 
         CharSequence upgrade = headers.get(HttpHeaderNames.UPGRADE);
-        if (!HttpHeaderValues.WEBSOCKET.equalsIgnoreCase(upgrade)) {
+        if (!HttpHeaderValues.WEBSOCKET.contentEqualsIgnoreCase(upgrade)) {
             throw new WebSocketHandshakeException("Invalid handshake response upgrade: " + upgrade);
         }
 
         CharSequence connection = headers.get(HttpHeaderNames.CONNECTION);
-        if (!HttpHeaderValues.UPGRADE.equalsIgnoreCase(connection)) {
+        if (!HttpHeaderValues.UPGRADE.contentEqualsIgnoreCase(connection)) {
             throw new WebSocketHandshakeException("Invalid handshake response connection: " + connection);
         }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
@@ -217,12 +217,12 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
         }
 
         CharSequence upgrade = headers.get(HttpHeaderNames.UPGRADE);
-        if (!HttpHeaderValues.WEBSOCKET.equalsIgnoreCase(upgrade)) {
+        if (!HttpHeaderValues.WEBSOCKET.contentEqualsIgnoreCase(upgrade)) {
             throw new WebSocketHandshakeException("Invalid handshake response upgrade: " + upgrade);
         }
 
         CharSequence connection = headers.get(HttpHeaderNames.CONNECTION);
-        if (!HttpHeaderValues.UPGRADE.equalsIgnoreCase(connection)) {
+        if (!HttpHeaderValues.UPGRADE.contentEqualsIgnoreCase(connection)) {
             throw new WebSocketHandshakeException("Invalid handshake response connection: " + connection);
         }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
@@ -107,8 +107,8 @@ public class WebSocketServerHandshaker00 extends WebSocketServerHandshaker {
     protected FullHttpResponse newHandshakeResponse(FullHttpRequest req, HttpHeaders headers) {
 
         // Serve the WebSocket handshake request.
-        if (!HttpHeaderValues.UPGRADE.equalsIgnoreCase(req.headers().get(HttpHeaderNames.CONNECTION))
-                || !HttpHeaderValues.WEBSOCKET.equalsIgnoreCase(req.headers().get(HttpHeaderNames.UPGRADE))) {
+        if (!HttpHeaderValues.UPGRADE.contentEqualsIgnoreCase(req.headers().get(HttpHeaderNames.CONNECTION))
+                || !HttpHeaderValues.WEBSOCKET.contentEqualsIgnoreCase(req.headers().get(HttpHeaderNames.UPGRADE))) {
             throw new WebSocketHandshakeException("not a WebSocket handshake request: missing upgrade");
         }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
@@ -52,9 +52,9 @@ public class HttpHeadersTest {
 
     @Test
     public void testEquansIgnoreCase() {
-        assertThat(AsciiString.equalsIgnoreCase(null, null), is(true));
-        assertThat(AsciiString.equalsIgnoreCase(null, "foo"), is(false));
-        assertThat(AsciiString.equalsIgnoreCase("bar", null), is(false));
-        assertThat(AsciiString.equalsIgnoreCase("FoO", "fOo"), is(true));
+        assertThat(AsciiString.contentEqualsIgnoreCase(null, null), is(true));
+        assertThat(AsciiString.contentEqualsIgnoreCase(null, "foo"), is(false));
+        assertThat(AsciiString.contentEqualsIgnoreCase("bar", null), is(false));
+        assertThat(AsciiString.contentEqualsIgnoreCase("FoO", "fOo"), is(true));
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -14,7 +14,7 @@
  */
 package io.netty.handler.codec.http2;
 
-import static io.netty.util.internal.StringUtil.UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET;
+import static io.netty.util.internal.StringUtil.asciiToLowerCase;
 import io.netty.handler.codec.BinaryHeaders;
 import io.netty.handler.codec.DefaultBinaryHeaders;
 import io.netty.util.AsciiString;
@@ -40,8 +40,7 @@ public class DefaultHttp2Headers extends DefaultBinaryHeaders implements Http2He
 
         @Override
         public boolean process(byte value) throws Exception {
-            result[i++] = (value >= 'A' && value <= 'Z')
-                    ? (byte) (value + UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET) : value;
+            result[i++] = asciiToLowerCase(value);
             return true;
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpUtil.java
@@ -312,8 +312,8 @@ public final class HttpUtil {
                     AsciiString aValue = AsciiString.of(entry.getValue());
                     // https://tools.ietf.org/html/draft-ietf-httpbis-http2-16#section-8.1.2.2
                     // makes a special exception for TE
-                    if (!aName.equalsIgnoreCase(HttpHeaderNames.TE) ||
-                        aValue.equalsIgnoreCase(HttpHeaderValues.TRAILERS)) {
+                    if (!aName.contentEqualsIgnoreCase(HttpHeaderNames.TE) ||
+                        aValue.contentEqualsIgnoreCase(HttpHeaderValues.TRAILERS)) {
                         out.add(aName, aValue);
                     }
                 }

--- a/common/src/main/java/io/netty/util/ByteString.java
+++ b/common/src/main/java/io/netty/util/ByteString.java
@@ -15,7 +15,7 @@
 package io.netty.util;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
-
+import io.netty.util.internal.HashCodeGenerator;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 
@@ -33,6 +33,9 @@ import java.util.Comparator;
  * this object is immutable.
  */
 public class ByteString {
+    protected static final HashCodeGenerator HASHER = PlatformDependent.hashCodeGenerator();
+    public static final ByteString EMPTY_STRING = new ByteString(0);
+
     /**
      * A byte wise comparator between two {@link ByteString} objects.
      */
@@ -76,9 +79,6 @@ public class ByteString {
         }
     };
 
-    public static final ByteString EMPTY_STRING = new ByteString(0);
-    protected static final int HASH_CODE_PRIME = 31;;
-
     /**
      * If this value is modified outside the constructor then call {@link #arrayChanged()}.
      */
@@ -95,7 +95,7 @@ public class ByteString {
     /**
      * The hash code is cached after it is first computed. It can be reset with {@link #arrayChanged()}.
      */
-    private int hash;
+    private int hash = HASHER.emptyHashValue();
 
     /**
      * Used for classes which extend this class and want to initialize the {@link #value} array by them selves.
@@ -342,7 +342,7 @@ public class ByteString {
     }
 
     public final boolean isEmpty() {
-        return length == 0;
+        return length() == 0;
     }
 
     public final int length() {
@@ -382,7 +382,7 @@ public class ByteString {
      * @see #array()
      */
     public final boolean isEntireArrayUsed() {
-        return offset == 0 && length == value.length;
+        return offset == 0 && length() == value.length;
     }
 
     /**
@@ -419,15 +419,10 @@ public class ByteString {
 
     @Override
     public int hashCode() {
-        int h = hash;
-        if (h == 0) {
-            final int end = offset + length;
-            for (int i = offset; i < end; ++i) {
-                h = h * HASH_CODE_PRIME ^ value[i] & HASH_CODE_PRIME;
-            }
-
-            hash = h;
+        if (hash == HASHER.emptyHashValue() && length() > 0) {
+            hash = HASHER.hashCode(value, offset, offset + length());
         }
+
         return hash;
     }
 
@@ -666,9 +661,12 @@ public class ByteString {
         }
 
         ByteString other = (ByteString) obj;
+        final int otherLen = other.length();
+        if (otherLen != length()) {
+            return false;
+        }
         return hashCode() == other.hashCode() &&
-               PlatformDependent.equals(array(), arrayOffset(), arrayOffset() + length(),
-                                        other.array(), other.arrayOffset(), other.arrayOffset() + other.length());
+               HASHER.equals(array(), arrayOffset(), other.array(), other.arrayOffset(), otherLen);
     }
 
     /**

--- a/common/src/main/java/io/netty/util/internal/AbstractHashCodeGenerator.java
+++ b/common/src/main/java/io/netty/util/internal/AbstractHashCodeGenerator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+/**
+ * Provides methods which don't take start/end positions from {@link HashCodeGenerator} and delegates to methods
+ * that do.
+ */
+public abstract class AbstractHashCodeGenerator implements HashCodeGenerator {
+    protected static final int HASH_PRIME = 31;
+
+    @Override
+    public final int hashCode(byte[] bytes) {
+        return hashCode(bytes, 0, bytes.length);
+    }
+
+    @Override
+    public final boolean equals(byte[] bytes1, byte[] bytes2) {
+        if (bytes1.length != bytes2.length) {
+            return false;
+        }
+        return equals(bytes1, 0, bytes2, 0, bytes2.length);
+    }
+
+    @Override
+    public final int hashCode(CharSequence data) {
+        return hashCode(data, 0, data.length());
+    }
+
+    @Override
+    public boolean equals(CharSequence bytes1, CharSequence bytes2) {
+        if (bytes1.length() != bytes2.length()) {
+            return false;
+        }
+        return equals(bytes1, 0, bytes2, 0, bytes2.length());
+    }
+
+    @Override
+    public boolean equals(byte[] bytes1, CharSequence bytes2) {
+        if (bytes1.length != bytes2.length()) {
+            return false;
+        }
+        return equals(bytes1, 0, bytes2, 0, bytes1.length);
+    }
+
+    @Override
+    public int emptyHashValue() {
+        return 1;
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/DefaultHashCodeGenerator.java
+++ b/common/src/main/java/io/netty/util/internal/DefaultHashCodeGenerator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+/**
+ * Default implementation of {@link HashCodeGenerator}. This will use a similar mechanism as
+ * {@link Arrays#hashCode(byte[])} for the hash code and a direct byte by byte comparison for equals.
+ * <p>
+ * Note that the hashCode methods must be compatible with {@link DefaultHashCodeGeneratorCaseInsensitive}.
+ */
+class DefaultHashCodeGenerator extends AbstractHashCodeGenerator {
+    @Override
+    public int hashCode(byte[] bytes, int startPos, int endPos) {
+        int h = emptyHashValue();
+        for (int i = startPos; i < endPos; ++i) {
+            h = HASH_PRIME * h + (char) (bytes[i] & 0xFF);
+        }
+        return h;
+    }
+
+    @Override
+    public boolean equals(byte[] bytes1, int startPos1, byte[] bytes2, int startPos2, int len) {
+        final int end = startPos1 + len;
+        for (int i = startPos1, j = startPos2; i < end; ++i, ++j) {
+            if (bytes1[i] != bytes2[j]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode(CharSequence data, int startPos, int endPos) {
+        int h = emptyHashValue();
+        for (int i = startPos; i < endPos; ++i) {
+            h = HASH_PRIME * h + data.charAt(i);
+        }
+        return h;
+    }
+
+    @Override
+    public boolean equals(CharSequence bytes1, CharSequence bytes2) {
+        // Take advantage of HotSpot intrinsics for String
+        if (bytes1.getClass() == String.class && bytes2.getClass() == String.class) {
+            return bytes1.equals(bytes2);
+        }
+        if (bytes1.length() != bytes2.length()) {
+            return false;
+        }
+        return equals(bytes1, 0, bytes2, 0, bytes2.length());
+    }
+
+    @Override
+    public boolean equals(CharSequence bytes1, int startPos1, CharSequence bytes2, int startPos2, int len) {
+        final int end = startPos1 + len;
+        for (int i = startPos1, j = startPos2; i < end; ++i, ++j) {
+            if (bytes1.charAt(i) != bytes2.charAt(j)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(byte[] bytes1, int startPos1, CharSequence bytes2, int startPos2, int len) {
+        final int end = startPos1 + len;
+        for (int i = startPos1, j = startPos2; i < end; ++i, ++j) {
+            if ((char) (bytes1[i] & 0xFF) != bytes2.charAt(j)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/DefaultHashCodeGeneratorCaseInsensitive.java
+++ b/common/src/main/java/io/netty/util/internal/DefaultHashCodeGeneratorCaseInsensitive.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+import static io.netty.util.internal.StringUtil.asciiToLowerCase;
+
+/**
+ * Default implementation of {@link HashCodeGenerator} which will ignore case during hash code generation and
+ * equality comparison operations.
+ * <p>
+ * Note that the hashCode methods must be compatible with {@link DefaultHashCodeGenerator}.
+ */
+class DefaultHashCodeGeneratorCaseInsensitive extends AbstractHashCodeGenerator {
+    @Override
+    public int hashCode(byte[] bytes, int startPos, int endPos) {
+        int h = emptyHashValue();
+        for (int i = startPos; i < endPos; ++i) {
+            h = HASH_PRIME * h + (char) (asciiToLowerCase(bytes[i]) & 0xFF);
+        }
+        return h;
+    }
+
+    @Override
+    public boolean equals(byte[] bytes1, int startPos1, byte[] bytes2, int startPos2, int len) {
+        final int end = startPos1 + len;
+        for (int i = startPos1, j = startPos2; i < end; ++i, ++j) {
+            byte b1 = bytes1[i];
+            byte b2 = bytes2[j];
+            if (b1 != b2 && asciiToLowerCase(b1) != asciiToLowerCase(b2)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode(CharSequence data, int startPos, int endPos) {
+        int h = emptyHashValue();
+        for (int i = startPos; i < endPos; ++i) {
+            h = HASH_PRIME * h + asciiToLowerCase(data.charAt(i));
+        }
+        return h;
+    }
+
+    @Override
+    public boolean equals(CharSequence bytes1, int startPos1, CharSequence bytes2, int startPos2, int len) {
+        final int end = startPos1 + len;
+        for (int i = startPos1, j = startPos2; i < end; ++i, ++j) {
+            char c1 = bytes1.charAt(i);
+            char c2 = bytes2.charAt(j);
+            if (c1 != c2 && asciiToLowerCase(c1) != asciiToLowerCase(c2)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(byte[] bytes1, int startPos1, CharSequence bytes2, int startPos2, int len) {
+        final int end = startPos1 + len;
+        for (int i = startPos1, j = startPos2; i < end; ++i, ++j) {
+            char c1 = (char) (bytes1[i] & 0xFF);
+            char c2 = bytes2.charAt(j);
+            if (c1 != c2 && asciiToLowerCase(c1) != asciiToLowerCase(c2)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/HashCodeGenerator.java
+++ b/common/src/main/java/io/netty/util/internal/HashCodeGenerator.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+/**
+ * Provides the ability to generate a hash code for array based objects.
+ */
+public interface HashCodeGenerator {
+    /**
+     * Same as calling {@link #hashCode(byte[], int, int)} as {@code hashCode(bytes, 0, bytes.length)}.
+     */
+    int hashCode(byte[] bytes);
+
+    /**
+     * Generate a hash code from the [{@code startPos}, {@code endPos}) subsection of {@code bytes}.
+     */
+    int hashCode(byte[] bytes, int startPos, int endPos);
+
+    /**
+     * Same as calling {@link #equals(byte[], int, byte[], int, int)} as
+     * {@code equals(bytes1, 0, bytes2, 0, bytes2.length)}.
+     */
+    boolean equals(byte[] bytes1, byte[] bytes2);
+
+    /**
+     * Determine if {@code bytes1} from range {@code [startPos1, startPos1 + len)} with {@code bytes2} from range
+     * {@code [startPos2, startPos2 + len)} are equal.
+     */
+    boolean equals(byte[] bytes1, int startPos1, byte[] bytes2, int startPos2, int len);
+
+    /**
+     * Same as calling {@link #hashCode(CharSequence, int, int)} as {@code hashCode(data, 0, data.length())}.
+     */
+    int hashCode(CharSequence data);
+
+    /**
+     * Generate a hash code from the [{@code startPos}, {@code endPos}) subsection of {@code bytes}.
+     */
+    int hashCode(CharSequence data, int startPos, int endPos);
+
+    /**
+     * Same as calling {@link #equals(CharSequence, int, int, CharSequence, int, int)} as
+     * {@code equals(bytes1, 0, bytes1.length(), bytes2, 0, bytes2.length())}.
+     */
+    boolean equals(CharSequence bytes1, CharSequence bytes2);
+
+    /**
+     * Determine if {@code bytes1} from range {@code [startPos1, startPos1 + len)} with {@code bytes2} from range
+     * {@code [startPos2, startPos2 + len)} are equal.
+     */
+    boolean equals(CharSequence bytes1, int startPos1, CharSequence bytes2, int startPos2, int len);
+
+    /**
+     * Same as calling {@link #equals(byte[], int, CharSequence, int, int)} as
+     * {@code equals(bytes1, 0, bytes2, 0, bytes2.length())}.
+     */
+    boolean equals(byte[] bytes1, CharSequence bytes2);
+
+    /**
+     * Determine if {@code bytes1} from range {@code [startPos1, startPos1 + len)} with {@code bytes2} from range
+     * {@code [startPos2, startPos2 + len)} are equal.
+     */
+    boolean equals(byte[] bytes1, int startPos1, CharSequence bytes2, int startPos2, int len);
+
+    /**
+     * Get the value that is returned when there is nothing to hash.
+     */
+    int emptyHashValue();
+}

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -16,12 +16,12 @@
 package io.netty.util.internal;
 
 
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Formatter;
 import java.util.List;
-
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * String utility class.
@@ -37,7 +37,7 @@ public final class StringUtil {
     public static final char CARRIAGE_RETURN = '\r';
     public static final char TAB = '\t';
 
-    public static final byte UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET = 'a' - 'A';
+    private static final byte UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET = 'a' - 'A';
     private static final String[] BYTE2HEX_PAD = new String[256];
     private static final String[] BYTE2HEX_NOPAD = new String[256];
 
@@ -373,6 +373,18 @@ public final class StringUtil {
         }
         return escapedDoubleQuote || foundSpecialCharacter && !quoted ?
                 escaped.append(DOUBLE_QUOTE) : value;
+    }
+
+    public static byte asciiToLowerCase(byte b) {
+        return ('A' <= b && b <= 'Z') ? (byte) (b + UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET) : b;
+    }
+
+    public static char asciiToLowerCase(char c) {
+        return ('A' <= c && c <= 'Z') ? (char) (c + UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET) : c;
+    }
+
+    public static byte asciiToUpperCase(byte b) {
+        return ('a' <= b && b <= 'z') ? (byte) (b - UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET) : b;
     }
 
     private static boolean isDoubleQuote(char c) {

--- a/common/src/test/java/io/netty/util/AsciiStringTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringTest.java
@@ -15,10 +15,13 @@
  */
 package io.netty.util;
 
-import static org.junit.Assert.assertEquals;
+import static io.netty.util.AsciiString.caseInsensitiveHashCode;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
+import java.nio.CharBuffer;
 import java.nio.charset.Charset;
+import java.util.Random;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -87,6 +90,8 @@ public class AsciiStringTest {
         final int end = init.length;
         AsciiString sub1 = ascii.subSequence(start, end, false);
         AsciiString sub2 = ascii.subSequence(start, end, true);
+        assertEquals(sub1.hashCode(), sub2.hashCode());
+        assertEquals(sub1.hashCodeCaseInsensitive(), sub2.hashCode());
         assertEquals(sub1, sub2);
         for (int i = start; i < end; ++i) {
             assertEquals(init[i], sub1.byteAt(i - start));
@@ -95,8 +100,48 @@ public class AsciiStringTest {
 
     @Test
     public void caseInsensativeHasher() {
-        String s1 = new String("TransfeR-EncodinG");
-        AsciiString s2 = new AsciiString("transfer-encoding");
-        assertEquals(AsciiString.caseInsensitiveHashCode(s1), AsciiString.caseInsensitiveHashCode(s2));
+        Random r = new Random();
+        int i = 0;
+        for (; i < 32; i++) {
+            doCaseInsensative(r, i);
+        }
+        final int min = i;
+        final int max = 4000;
+        final int len = r.nextInt((max - min) + 1) + min;
+        doCaseInsensative(r, len);
+    }
+
+    private static void doCaseInsensative(Random r, int len) {
+        final int upperA = 'A';
+        final int upperZ = 'Z';
+        final int upperToLower = (int) 'a' - upperA;
+        byte[] bytes = new byte[len];
+        StringBuilder b = new StringBuilder(len);
+        for (int i = 0; i < len; ++i) {
+            char upper = (char) (r.nextInt((upperZ - upperA) + 1) + upperA);
+            b.append(upper);
+            bytes[i] = (byte) (upper + upperToLower);
+        }
+        String s1 = b.toString();
+        AsciiString s2 = new AsciiString(bytes, false);
+        AsciiString s3 = new AsciiString(s1);
+        final String errorString = "len: " + len;
+        final int expected = s2.hashCode();
+        assertEquals(errorString, expected, caseInsensitiveHashCode(s1));
+        assertEquals(errorString, expected, caseInsensitiveHashCode(s2));
+        assertEquals(errorString, expected, s2.hashCodeCaseInsensitive());
+        assertEquals(errorString, expected, s3.hashCodeCaseInsensitive());
+    }
+
+    @Test
+    public void caseInsensativeHasherCharBuffer() {
+        String s1 = new String("TRANSFER-ENCODING");
+        char[] array = new char[128];
+        final int offset = 100;
+        for (int i = 0; i < s1.length(); ++i) {
+            array[offset + i] = s1.charAt(i);
+        }
+        CharBuffer buffer = CharBuffer.wrap(array, offset, s1.length());
+        assertEquals(caseInsensitiveHashCode(s1), caseInsensitiveHashCode(buffer));
     }
 }

--- a/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
+++ b/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
@@ -15,42 +15,75 @@
  */
 package io.netty.util.internal;
 
-import org.junit.Test;
-
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
+import io.netty.util.CharsetUtil;
+
+import java.util.Random;
+
+import org.junit.Test;
 
 public class PlatformDependentTest {
 
     @Test
-    public void testEquals() {
+    public void testEqualsBytes() {
+        final HashCodeGenerator hasher = PlatformDependent.hashCodeGenerator();
         byte[] bytes1 = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd'};
         byte[] bytes2 = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd'};
+        String string1 = new String(bytes1, CharsetUtil.US_ASCII);
+        String string2 = new String(bytes2, CharsetUtil.US_ASCII);
         assertNotSame(bytes1, bytes2);
-        assertTrue(PlatformDependent.equals(bytes1, 0, bytes1.length, bytes2, 0, bytes2.length));
-        assertTrue(PlatformDependent.equals(bytes1, 2, bytes1.length, bytes2, 2, bytes2.length));
+        assertTrue(hasher.equals(bytes1, bytes2));
+        assertTrue(hasher.equals(bytes1, string2));
+        assertTrue(hasher.equals(string1, string2));
+        assertTrue(hasher.equals(bytes1, 2, bytes2, 2, bytes2.length - 2));
+        assertTrue(hasher.equals(bytes1, 2, string2, 2, string2.length() - 2));
+        assertTrue(hasher.equals(string1, 2, string2, 2, string2.length() - 2));
 
         bytes1 = new byte[] {1, 2, 3, 4, 5, 6};
         bytes2 = new byte[] {1, 2, 3, 4, 5, 6, 7};
+        string1 = new String(bytes1, CharsetUtil.US_ASCII);
+        string2 = new String(bytes2, CharsetUtil.US_ASCII);
         assertNotSame(bytes1, bytes2);
-        assertFalse(PlatformDependent.equals(bytes1, 0, bytes1.length, bytes2, 0, bytes2.length));
-        assertTrue(PlatformDependent.equals(bytes2, 0, 6, bytes1, 0, 6));
+        assertFalse(hasher.equals(bytes1, bytes2));
+        assertFalse(hasher.equals(bytes1, string2));
+        assertFalse(hasher.equals(string1, string2));
+        assertTrue(hasher.equals(bytes2, 0, bytes1, 0, bytes1.length));
+        assertTrue(hasher.equals(bytes1, 0, string2, 0, bytes1.length));
+        assertTrue(hasher.equals(string1, 0, string2, 0, bytes1.length));
 
         bytes1 = new byte[] {1, 2, 3, 4};
         bytes2 = new byte[] {1, 2, 3, 5};
-        assertFalse(PlatformDependent.equals(bytes1, 0, bytes1.length, bytes2, 0, bytes2.length));
-        assertTrue(PlatformDependent.equals(bytes1, 0, 3, bytes2, 0, 3));
+        string1 = new String(bytes1, CharsetUtil.US_ASCII);
+        string2 = new String(bytes2, CharsetUtil.US_ASCII);
+        assertFalse(hasher.equals(bytes1, bytes2));
+        assertFalse(hasher.equals(bytes1, string2));
+        assertFalse(hasher.equals(string1, string2));
+        assertTrue(hasher.equals(bytes1, 0, bytes2, 0, 3));
+        assertTrue(hasher.equals(bytes1, 0, string2, 0, 3));
+        assertTrue(hasher.equals(string1, 0, string2, 0, 3));
 
         bytes1 = new byte[] {1, 2, 3, 4};
         bytes2 = new byte[] {1, 3, 3, 4};
-        assertFalse(PlatformDependent.equals(bytes1, 0, bytes1.length, bytes2, 0, bytes2.length));
-        assertTrue(PlatformDependent.equals(bytes1, 2, bytes1.length, bytes2, 2, bytes2.length));
+        string1 = new String(bytes1, CharsetUtil.US_ASCII);
+        string2 = new String(bytes2, CharsetUtil.US_ASCII);
+        assertFalse(hasher.equals(bytes1, bytes2));
+        assertFalse(hasher.equals(bytes1, string2));
+        assertFalse(hasher.equals(string1, string2));
+        assertTrue(hasher.equals(bytes1, 2, bytes2, 2, bytes1.length - 2));
+        assertTrue(hasher.equals(bytes1, 2, string2, 2, bytes1.length - 2));
+        assertTrue(hasher.equals(string1, 2, string2, 2, bytes1.length - 2));
 
         bytes1 = new byte[0];
         bytes2 = new byte[0];
+        string1 = new String(bytes1, CharsetUtil.US_ASCII);
+        string2 = new String(bytes2, CharsetUtil.US_ASCII);
         assertNotSame(bytes1, bytes2);
-        assertTrue(PlatformDependent.equals(bytes1, 0, 0, bytes2, 0, 0));
+        assertTrue(hasher.equals(bytes1, 0, bytes2, 0, 0));
+        assertTrue(hasher.equals(bytes1, 0, string2, 0, 0));
+        assertTrue(hasher.equals(string1, 0, string2, 0, 0));
 
         bytes1 = new byte[100];
         bytes2 = new byte[100];
@@ -58,16 +91,132 @@ public class PlatformDependentTest {
             bytes1[i] = (byte) i;
             bytes2[i] = (byte) i;
         }
-        assertTrue(PlatformDependent.equals(bytes1, 0, bytes1.length, bytes2, 0, bytes2.length));
+        assertTrue(hasher.equals(bytes1, bytes2));
         bytes1[50] = 0;
-        assertFalse(PlatformDependent.equals(bytes1, 0, bytes1.length, bytes2, 0, bytes2.length));
-        assertTrue(PlatformDependent.equals(bytes1, 51, bytes1.length, bytes2, 51, bytes2.length));
-        assertTrue(PlatformDependent.equals(bytes1, 0, 50, bytes2, 0, 50));
+        string1 = new String(bytes1, CharsetUtil.US_ASCII);
+        string2 = new String(bytes2, CharsetUtil.US_ASCII);
+        assertFalse(hasher.equals(bytes1, bytes2));
+        assertFalse(hasher.equals(bytes1, string2));
+        assertFalse(hasher.equals(string1, string2));
+        assertTrue(hasher.equals(bytes1, 51, bytes2, 51, bytes2.length - 51));
+        assertTrue(hasher.equals(bytes1, 51, string2, 51, bytes2.length - 51));
+        assertTrue(hasher.equals(string1, 51, string2, 51, bytes2.length - 51));
+        assertTrue(hasher.equals(bytes1, 0, bytes2, 0, 49));
+        assertTrue(hasher.equals(bytes1, 0, string2, 0, 49));
+        assertTrue(hasher.equals(string1, 0, string2, 0, 49));
 
         bytes1 = new byte[]{1, 2, 3, 4, 5};
         bytes2 = new byte[]{3, 4, 5};
-        assertFalse(PlatformDependent.equals(bytes1, 0, bytes1.length, bytes2, 0, bytes2.length));
-        assertTrue(PlatformDependent.equals(bytes1, 2, bytes1.length, bytes2, 0, bytes2.length));
-        assertTrue(PlatformDependent.equals(bytes2, 0, bytes2.length, bytes1, 2, bytes1.length));
+        string1 = new String(bytes1, CharsetUtil.US_ASCII);
+        string2 = new String(bytes2, CharsetUtil.US_ASCII);
+        assertFalse(hasher.equals(bytes1, bytes2));
+        assertFalse(hasher.equals(bytes1, string2));
+        assertFalse(hasher.equals(string1, string2));
+        assertTrue(hasher.equals(bytes1, 2, bytes2, 0, bytes2.length));
+        assertTrue(hasher.equals(bytes1, 2, string2, 0, bytes2.length));
+        assertTrue(hasher.equals(string1, 2, string2, 0, bytes2.length));
+        assertTrue(hasher.equals(bytes2, 0, bytes1, 2, bytes2.length));
+        assertTrue(hasher.equals(bytes2, 0, string1, 2, bytes2.length));
+        assertTrue(hasher.equals(string2, 0, string1, 2, bytes2.length));
+    }
+
+    @Test
+    public void testHashCode() {
+        HashCodeGenerator hasher = PlatformDependent.hashCodeGenerator();
+        final int bytes1Len = 256;
+        final int bytes2Len = bytes1Len >> 1;
+        final int bytes1Start = bytes2Len;
+        final int bytes2Start = bytes2Len >> 1;
+        int subSequenceLen = bytes2Len - bytes2Start;
+        // We want to have a number that is divisible by 7 to ensure we hit all the
+        // getlong/getint/getchar/direct lookup branches.
+        while (subSequenceLen % 7 != 0) {
+            --subSequenceLen;
+        }
+        byte[] bytes1 = new byte[bytes1Len];
+        byte[] bytes2 = new byte[bytes2Len];
+        Random r = new Random();
+        r.nextBytes(bytes1);
+        System.arraycopy(bytes1, bytes1Start, bytes2, bytes2Start, subSequenceLen);
+        assertNotSame(bytes1, bytes2);
+
+        final int expected = hasher.hashCode(bytes2, bytes2Start, subSequenceLen);
+        // Test that two separate arrays with the same value for a given range yield the same hash code.
+        assertEquals(expected, hasher.hashCode(bytes1, bytes1Start, subSequenceLen));
+    }
+
+    @Test
+    public void testHashDifferntTypesSameResults() {
+        HashCodeGenerator hasher = PlatformDependent.hashCodeGenerator();
+
+        Random r = new Random();
+        int i = 0;
+        for (; i < 32; ++i) {
+            runHasherEqualityTest(hasher, i, r);
+        }
+        final int min = i;
+        final int max = 20000;
+        int len = r.nextInt((max - min) + 1) + min;
+        // We now want to test a "random" length array but differnt permutations to test
+        // interesting boundary conditions.
+        while (len % 8 != 0) {
+            ++len;
+        }
+        for (i = len - 8; i < len; ++i) {
+            runHasherEqualityTest(hasher, i, r);
+        }
+    }
+
+    @Test
+    public void testHashTypeOptimizations() {
+        HashCodeGenerator hasher = PlatformDependent.hashCodeGenerator();
+
+        int i = 0;
+        for (; i < 32; ++i) {
+            runTypeOptimizations(hasher, i);
+        }
+        Random r = new Random();
+        final int min = i;
+        final int max = 20000;
+        int len = r.nextInt((max - min) + 1) + min;
+        // We now want to test a "random" length array but differnt permutations to test
+        // interesting boundary conditions.
+        while (len % 8 != 0) {
+            ++len;
+        }
+        for (i = len - 8; i < len; ++i) {
+            runTypeOptimizations(hasher, i);
+        }
+    }
+
+    private void runTypeOptimizations(HashCodeGenerator hasher, int len) {
+        StringBuilder b = new StringBuilder(len);
+        for (int i = 0; i < len; ++i) {
+            b.append((byte) i);
+        }
+        String s = b.toString();
+        byte[] bytes = s.getBytes(CharsetUtil.US_ASCII);
+
+        assertEquals(s.length(), bytes.length);
+
+        final int expected =  hasher.hashCode(bytes);
+        final String errorMsg = "len: " + len;
+        assertEquals(errorMsg, expected, hasher.hashCode(s));
+        assertEquals(errorMsg, expected, hasher.hashCode(b));
+    }
+
+    private static void runHasherEqualityTest(HashCodeGenerator hasher, int len, Random r) {
+        byte[] bytes = new byte[len];
+        char[] charsAsBytes = new char[bytes.length];
+        r.nextBytes(bytes);
+
+        for (int i = 0; i < bytes.length; ++i) {
+            charsAsBytes[i] = (char) (bytes[i] & 0xFF);
+        }
+
+        String a = new String(charsAsBytes);
+        final int expected =  hasher.hashCode(bytes);
+        final String errorMsg = "len: " + len;
+        assertEquals(errorMsg, expected, hasher.hashCode(a));
     }
 }

--- a/microbench/src/main/java/io/netty/microbench/internal/PlatformDependentBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/internal/PlatformDependentBenchmark.java
@@ -15,48 +15,158 @@
  */
 package io.netty.microbench.internal;
 
+import static io.netty.util.internal.StringUtil.asciiToLowerCase;
 import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.internal.HashCodeGenerator;
 import io.netty.util.internal.PlatformDependent;
 
 import java.util.Arrays;
 
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
 
 @Threads(1)
+@Fork(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
 @State(Scope.Benchmark)
 public class PlatformDependentBenchmark extends AbstractMicrobenchmark {
 
-    @Param({ "10", "50", "100", "1000", "10000", "100000" })
+    @Param({ "5", "10", "30", "50", "100", "1000", "10000", "100000" })
     private int size;
     private byte[] bytes1;
     private byte[] bytes2;
+    private char[] chars1;
+    private char[] chars2;
+    private String string1;
+    private String string2;
+    private StringBuilder sb2;
+    private HashCodeGenerator hasher = PlatformDependent.hashCodeGenerator();
+    private HashCodeGenerator caseHasher = PlatformDependent.hashCodeGeneratorAsciiCaseInsensitive();
 
     @Setup(Level.Trial)
     public void setup() {
         bytes1 = new byte[size];
         bytes2 = new byte[size];
+        chars1 = new char[size];
+        chars2 = new char[size];
         for (int i = 0; i < size; i++) {
             bytes1[i] = bytes2[i] = (byte) i;
+            chars1[i] = chars2[i] = (char) i;
         }
+        string1 = new String(chars1);
+        string2 = new String(chars2);
+        sb2 = new StringBuilder(string2);
     }
 
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
-    public boolean unsafeBytesEqual() {
-        return PlatformDependent.equals(bytes1, 0, bytes1.length, bytes2, 0, bytes2.length);
+    public boolean unsafeEqualsBytes() {
+        return hasher.equals(bytes1, 0, bytes2, 0, bytes2.length);
     }
 
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
-    public boolean arraysBytesEqual() {
+    public boolean arraysEqualsBytes() {
         return Arrays.equals(bytes1, bytes2);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public boolean unsafeStringEquals() {
+        return hasher.equals(string1, string2);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public boolean jdkStringEquals() {
+        return string1.contentEquals(string2);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public boolean unsafeStringBuilderEquals() {
+        return hasher.equals(string1, sb2);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public boolean jdkStringBuilderEquals() {
+        return string1.contentEquals(sb2);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public int unsafeHashBytes() {
+        return hasher.hashCode(bytes1);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public int oldHashBytes() {
+        int h = 0;
+        for (int i = 0; i < bytes1.length; ++i) {
+            h = h * 31 ^ bytes1[i] & 31;
+        }
+        return h;
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public int unsafeHashString() {
+        return hasher.hashCode(string1, 0, string1.length());
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public int oldHashString() {
+        int h = 0;
+        for (int i = 0; i < string1.length(); ++i) {
+            h = h * 31 ^ (byte) string1.charAt(i) & 31;
+        }
+        return h;
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public int unsafeHashCaseInsensitiveBytes() {
+        return caseHasher.hashCode(bytes1, 0, bytes1.length);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public int oldHashCaseInsensitiveBytes() {
+        int h = 0;
+        for (int i = 0; i < bytes1.length; ++i) {
+            h = h * 31 ^ asciiToLowerCase(bytes1[i]) & 31;
+        }
+        return h;
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public int unsafeHashCaseInsensitiveString() {
+        return caseHasher.hashCode(string1, 0, string1.length());
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public int oldHashCaseInsensitiveString() {
+        int hash = 0;
+        final int end = string1.length();
+        for (int i = 0; i < end; i++) {
+            hash = hash * 31 ^ asciiToLowerCase(string1.charAt(i)) & 31;
+        }
+        return hash;
     }
 }

--- a/microbench/src/main/java/io/netty/microbenchmark/common/AsciiStringBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbenchmark/common/AsciiStringBenchmark.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbenchmark.common;
+
+import static io.netty.util.internal.StringUtil.asciiToLowerCase;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.AsciiString;
+import io.netty.util.ByteProcessor;
+import io.netty.util.ByteString;
+
+import java.util.Random;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Threads(1)
+@Fork(1)
+@Warmup(iterations = 5)
+@State(Scope.Benchmark)
+public class AsciiStringBenchmark extends AbstractMicrobenchmark {
+
+    public enum InputType {
+        UPPER_CASE, LOWER_CASE, MIXED_CASE_SAME, MIXED_CASE_ALT, RANDOM, NOT_EQUAL;
+    }
+
+    @Param({ "5", "10", "20", "50", "100", "1000" })
+    private int size;
+
+    @Param
+    public InputType inputType;
+
+    private AsciiString a1;
+    private AsciiString a2;
+    private OldAsciiString a1Old;
+    private OldAsciiString a2Old;
+    private String string1;
+    private String string2;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        final int max = 255;
+        final int min = 0;
+        final int upperA = 'A';
+        final int upperZ = 'Z';
+        final int upperToLower = (int) 'a' - upperA;
+        Random r = new Random();
+        byte[] bytes = new byte[size];
+        char[] chars = new char[size];
+
+        switch (inputType) {
+        case UPPER_CASE:
+            for (int i = 0; i < size; i++) {
+                bytes[i] = (byte) (r.nextInt((upperZ - upperA) + 1) + upperA);
+            }
+            break;
+        case LOWER_CASE:
+            for (int i = 0; i < size; i++) {
+                bytes[i] = (byte) ((r.nextInt((upperZ - upperA) + 1) + upperA) + upperToLower);
+            }
+            break;
+        case MIXED_CASE_SAME:
+            for (int i = 0; i < size; i++) {
+                bytes[i] = (byte) (r.nextInt((upperZ - upperA) + 1) + upperA);
+                if ((i & 1) == 0) {
+                    bytes[i] += upperToLower;
+                }
+            }
+            break;
+        case NOT_EQUAL:
+        case RANDOM:
+            for (int i = 0; i < size; i++) {
+                bytes[i] = (byte) (r.nextInt((max - min) + 1) + min);
+            }
+            break;
+        case MIXED_CASE_ALT:
+            for (int i = 0; i < size; i++) {
+                bytes[i] = (byte) (r.nextInt((upperZ - upperA) + 1) + upperA);
+            }
+            break;
+        default:
+            throw new Error();
+        }
+
+        System.err.println();
+        for (int i = 0; i < bytes.length; ++i) {
+            chars[i] = (char) (bytes[i] & 0xFF);
+        }
+        a1 = new AsciiString(bytes, true);
+        a1Old = new OldAsciiString(bytes, true);
+        string1 = new String(chars);
+        if (inputType == InputType.MIXED_CASE_ALT || inputType == InputType.NOT_EQUAL) {
+            for (int i = 0; i < size; i++) {
+                if (upperA <= bytes[i] && bytes[i] <= upperZ) {
+                    bytes[i] += upperToLower;
+                } else {
+                    bytes[i] -= upperToLower;
+                }
+            }
+            for (int i = 0; i < bytes.length; ++i) {
+                chars[i] = (char) (bytes[i] & 0xFF);
+            }
+        }
+        a2 = new AsciiString(bytes, false);
+        a2Old = new OldAsciiString(bytes, false);
+        string2 = new String(chars);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public int unsafeHashCodeCaseInsensitive() {
+        return a1.hashCodeCaseInsensitive();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public int oldHashCodeCaseInsensitive() throws Exception {
+        ByteProcessor processor = new ByteProcessor() {
+            private int hash;
+            @Override
+            public boolean process(byte value) throws Exception {
+                hash = hash * 31 ^ asciiToLowerCase(value) & 31;
+                return true;
+            }
+
+            @Override
+            public int hashCode() {
+                return hash;
+            }
+        };
+        a1.forEachByte(processor);
+        return processor.hashCode();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public boolean unsafeContentEqualsAsciiString() {
+        return a1.contentEquals(a2);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public boolean oldContentEqualsAsciiString() {
+        return a1Old.contentEquals(a2Old);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public boolean unsafeContentEqualsString() {
+        return a1.contentEquals(string2);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public boolean oldContentEqualsString() {
+        return a1Old.contentEquals(string2);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public boolean unsafeEqualsCaseInsensitiveString() {
+        return a1.contentEqualsIgnoreCase(string2);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public boolean oldEqualsCaseInsensitiveString() {
+        return a1Old.equalsIgnoreCase(string2);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public boolean unsafeEqualsCaseInsensitiveAsciiString() {
+        return a1.contentEqualsIgnoreCase(a2);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public boolean oldEqualsCaseInsensitiveAsciiString() {
+        return a1Old.equalsIgnoreCase(a2Old);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public boolean unsafeEqualsCaseInsensitive2Strings() {
+        return AsciiString.contentEqualsIgnoreCase(string1, string2);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    public boolean oldEqualsCaseInsensitive2Strings() {
+        return OldAsciiString.equalsIgnoreCase(string1, string2);
+    }
+
+    private static final class OldAsciiString extends ByteString implements CharSequence {
+        public OldAsciiString(byte[] bytes, boolean cpy) {
+            super(bytes, cpy);
+        }
+
+        @Override
+        public OldAsciiString subSequence(int start, int end) {
+           return null;
+        }
+
+        @Override
+        public char charAt(int index) {
+            return (char) (byteAt(index) & 0xFF);
+        }
+
+        public boolean contentEquals(CharSequence cs) {
+            if (cs == null) {
+                throw new NullPointerException();
+            }
+
+            int length1 = length();
+            int length2 = cs.length();
+            if (length1 != length2) {
+                return false;
+            } else if (length1 == 0) {
+                return true; // since both are empty strings
+            }
+
+            return regionMatches(0, cs, 0, length2);
+        }
+
+        public boolean regionMatches(int thisStart, CharSequence string, int start, int length) {
+            if (string == null) {
+                throw new NullPointerException("string");
+            }
+
+            if (start < 0 || string.length() - start < length) {
+                return false;
+            }
+
+            final int thisLen = length();
+            if (thisStart < 0 || thisLen - thisStart < length) {
+                return false;
+            }
+
+            if (length <= 0) {
+                return true;
+            }
+
+            final int thatEnd = start + length;
+            for (int i = start, j = thisStart + arrayOffset(); i < thatEnd; i++, j++) {
+                if ((char) (value[j] & 0xFF) != string.charAt(i)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public static boolean equalsIgnoreCase(CharSequence a, CharSequence b) {
+            if (a == b) {
+                return true;
+            }
+
+            if (a instanceof OldAsciiString) {
+                OldAsciiString aa = (OldAsciiString) a;
+                return aa.equalsIgnoreCase(b);
+            }
+
+            if (b instanceof OldAsciiString) {
+                OldAsciiString ab = (OldAsciiString) b;
+                return ab.equalsIgnoreCase(a);
+            }
+
+            if (a == null || b == null) {
+                return false;
+            }
+
+            return a.toString().equalsIgnoreCase(b.toString());
+        }
+
+        public boolean equalsIgnoreCase(CharSequence string) {
+            if (string == this) {
+                return true;
+            }
+
+            if (string == null) {
+                return false;
+            }
+
+            final int thisLen = length();
+            final int thatLen = string.length();
+            if (thisLen != thatLen) {
+                return false;
+            }
+
+            for (int i = 0, j = arrayOffset(); i < thatLen; i++, j++) {
+                char c1 = (char) (value[j] & 0xFF);
+                char c2 = string.charAt(i);
+                if (c1 != c2 && asciiToLowerCase(c1) != asciiToLowerCase(c2)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
The ByteString class is often used in equality and hashCode operations. ByteString caches the hashCode after computed but case insensitive AsciiString hashCode operations are not cached.  The hash code algorithm we currently have is home grown and applies a mask of 31 onto every byte or character while generating the hash code which reduces the amount of bits each character contributes to the hash code from 8 down to 5. There is also an opportunity for improvement if two CharSequence objects are being used for equals/hashCode by using the underlying char[] (currently a toString() operation is being done).

Modifications:
- Use a hash code algorithm which takes all the bits of each character into account.
- Update ByteString and AsciiString to take advantage of the new equals/hashCode implementations.
- Improve string equality algorithm for case sensitive and insensitive.
- Consolidate equals/hashCode into an interface which can be easily upgraded or supplimented with UNSAFE in the future.
- Correct bug in AsciiString static equals method which takes a CharSequence parameter.

Result:
ByteString and AsciiString hashCode algorithm uses all bits from each character. AsciiString caches the case insensitive hashCode result. Equals operation has performance improvment when char[] is in use.