### PR TITLE
Remove duplicated code in AcceptorChannel classes.

### DIFF
--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtAcceptorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtAcceptorChannel.java
@@ -17,10 +17,13 @@ package io.netty.channel.udt.nio;
 
 import com.barchart.udt.TypeUDT;
 import com.barchart.udt.nio.ServerSocketChannelUDT;
+import com.barchart.udt.nio.SocketChannelUDT;
 import io.netty.channel.ChannelException;
+import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.nio.AbstractNioMessageChannel;
 import io.netty.channel.udt.DefaultUdtServerChannelConfig;
+import io.netty.channel.udt.UdtChannel;
 import io.netty.channel.udt.UdtServerChannel;
 import io.netty.channel.udt.UdtServerChannelConfig;
 import io.netty.util.internal.logging.InternalLogger;
@@ -28,6 +31,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.List;
 
 import static java.nio.channels.SelectionKey.*;
 
@@ -38,6 +42,8 @@ public abstract class NioUdtAcceptorChannel extends AbstractNioMessageChannel im
 
     protected static final InternalLogger logger =
             InternalLoggerFactory.getInstance(NioUdtAcceptorChannel.class);
+
+    private static final ChannelMetadata METADATA = new ChannelMetadata(false);
 
     private final UdtServerChannelConfig config;
 
@@ -132,4 +138,21 @@ public abstract class NioUdtAcceptorChannel extends AbstractNioMessageChannel im
         return null;
     }
 
+    @Override
+    public ChannelMetadata metadata() {
+        return METADATA;
+    }
+
+    @Override
+    protected int doReadMessages(List<Object> buf) throws Exception {
+        final SocketChannelUDT channelUDT = javaChannel().accept();
+        if (channelUDT == null) {
+            return 0;
+        } else {
+            buf.add(newConnectorChannel(channelUDT));
+            return 1;
+        }
+    }
+
+    protected abstract UdtChannel newConnectorChannel(SocketChannelUDT channelUDT);
 }

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteAcceptorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteAcceptorChannel.java
@@ -17,34 +17,19 @@ package io.netty.channel.udt.nio;
 
 import com.barchart.udt.TypeUDT;
 import com.barchart.udt.nio.SocketChannelUDT;
-import io.netty.channel.ChannelMetadata;
-
-import java.util.List;
+import io.netty.channel.udt.UdtChannel;
 
 /**
  * Byte Channel Acceptor for UDT Streams.
  */
 public class NioUdtByteAcceptorChannel extends NioUdtAcceptorChannel {
 
-    private static final ChannelMetadata METADATA = new ChannelMetadata(false);
-
     public NioUdtByteAcceptorChannel() {
         super(TypeUDT.STREAM);
     }
 
     @Override
-    protected int doReadMessages(List<Object> buf) throws Exception {
-        final SocketChannelUDT channelUDT = javaChannel().accept();
-        if (channelUDT == null) {
-            return 0;
-        } else {
-            buf.add(new NioUdtByteConnectorChannel(this, channelUDT));
-            return 1;
-        }
-    }
-
-    @Override
-    public ChannelMetadata metadata() {
-        return METADATA;
+    protected UdtChannel newConnectorChannel(SocketChannelUDT channelUDT) {
+        return new NioUdtByteConnectorChannel(this, channelUDT);
     }
 }

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageAcceptorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageAcceptorChannel.java
@@ -17,35 +17,19 @@ package io.netty.channel.udt.nio;
 
 import com.barchart.udt.TypeUDT;
 import com.barchart.udt.nio.SocketChannelUDT;
-import io.netty.channel.ChannelMetadata;
-
-import java.util.List;
+import io.netty.channel.udt.UdtChannel;
 
 /**
  * Message Channel Acceptor for UDT Datagrams.
  */
 public class NioUdtMessageAcceptorChannel extends NioUdtAcceptorChannel {
 
-    private static final ChannelMetadata METADATA = new ChannelMetadata(false);
-
     public NioUdtMessageAcceptorChannel() {
         super(TypeUDT.DATAGRAM);
     }
 
     @Override
-    protected int doReadMessages(List<Object> buf) throws Exception {
-        final SocketChannelUDT channelUDT = javaChannel().accept();
-        if (channelUDT == null) {
-            return 0;
-        } else {
-            buf.add(new NioUdtMessageConnectorChannel(this, channelUDT));
-            return 1;
-        }
+    protected UdtChannel newConnectorChannel(SocketChannelUDT channelUDT) {
+        return new NioUdtMessageConnectorChannel(this, channelUDT);
     }
-
-    @Override
-    public ChannelMetadata metadata() {
-        return METADATA;
-    }
-
 }


### PR DESCRIPTION
Motivation:

NioUdtByteAcceptorChannel and NioUdtMessageAcceptorChannel have almost same code.
For maintainability, it's better to remove it.

Motification:

- Pulled a member(METADATA) and methods(doReadMessage(), metadata()) up.
- Added newConnectorChannel().

Result:

Cleaner code.