### PR TITLE
Bugfix in channelUDT().

### DIFF
--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtProvider.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtProvider.java
@@ -106,22 +106,24 @@ public final class NioUdtProvider<T extends UdtChannel> implements ChannelFactor
         if (channel instanceof NioUdtByteAcceptorChannel) {
             return ((NioUdtByteAcceptorChannel) channel).javaChannel();
         }
-        if (channel instanceof NioUdtByteConnectorChannel) {
-            return ((NioUdtByteConnectorChannel) channel).javaChannel();
-        }
         if (channel instanceof NioUdtByteRendezvousChannel) {
             return ((NioUdtByteRendezvousChannel) channel).javaChannel();
         }
+        if (channel instanceof NioUdtByteConnectorChannel) {
+            return ((NioUdtByteConnectorChannel) channel).javaChannel();
+        }
+
         // message
         if (channel instanceof NioUdtMessageAcceptorChannel) {
             return ((NioUdtMessageAcceptorChannel) channel).javaChannel();
         }
-        if (channel instanceof NioUdtMessageConnectorChannel) {
-            return ((NioUdtMessageConnectorChannel) channel).javaChannel();
-        }
         if (channel instanceof NioUdtMessageRendezvousChannel) {
             return ((NioUdtMessageRendezvousChannel) channel).javaChannel();
         }
+        if (channel instanceof NioUdtMessageConnectorChannel) {
+            return ((NioUdtMessageConnectorChannel) channel).javaChannel();
+        }
+
         return null;
     }
 

--- a/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtProviderTest.java
+++ b/transport-udt/src/test/java/io/netty/test/udt/nio/NioUdtProviderTest.java
@@ -17,7 +17,14 @@
 package io.netty.test.udt.nio;
 
 import io.netty.channel.udt.UdtServerChannel;
+import io.netty.channel.udt.nio.NioUdtByteAcceptorChannel;
+import io.netty.channel.udt.nio.NioUdtByteConnectorChannel;
+import io.netty.channel.udt.nio.NioUdtByteRendezvousChannel;
 import io.netty.channel.udt.nio.NioUdtProvider;
+import io.netty.channel.udt.nio.NioUdtMessageAcceptorChannel;
+import io.netty.channel.udt.nio.NioUdtMessageConnectorChannel;
+import io.netty.channel.udt.nio.NioUdtMessageRendezvousChannel;
+
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -29,15 +36,36 @@ public class NioUdtProviderTest extends AbstractUdtTest {
      */
     @Test
     public void provideFactory() {
+        NioUdtByteAcceptorChannel nioUdtByteAcceptorChannel
+                = (NioUdtByteAcceptorChannel) NioUdtProvider.BYTE_ACCEPTOR.newChannel();
+        NioUdtByteConnectorChannel nioUdtByteConnectorChannel
+                = (NioUdtByteConnectorChannel) NioUdtProvider.BYTE_CONNECTOR.newChannel();
+        NioUdtByteRendezvousChannel nioUdtByteRendezvousChannel
+                = (NioUdtByteRendezvousChannel) NioUdtProvider.BYTE_RENDEZVOUS.newChannel();
+        NioUdtMessageAcceptorChannel nioUdtMessageAcceptorChannel
+                = (NioUdtMessageAcceptorChannel) NioUdtProvider.MESSAGE_ACCEPTOR.newChannel();
+        NioUdtMessageConnectorChannel nioUdtMessageConnectorChannel
+                = (NioUdtMessageConnectorChannel) NioUdtProvider.MESSAGE_CONNECTOR.newChannel();
+        NioUdtMessageRendezvousChannel nioUdtMessageRendezvousChannel
+                = (NioUdtMessageRendezvousChannel) NioUdtProvider.MESSAGE_RENDEZVOUS.newChannel();
+
         // bytes
-        assertNotNull(NioUdtProvider.BYTE_ACCEPTOR.newChannel());
-        assertNotNull(NioUdtProvider.BYTE_CONNECTOR.newChannel());
-        assertNotNull(NioUdtProvider.BYTE_RENDEZVOUS.newChannel());
+        assertNotNull(nioUdtByteAcceptorChannel);
+        assertNotNull(nioUdtByteConnectorChannel);
+        assertNotNull(nioUdtByteRendezvousChannel);
 
         // message
-        assertNotNull(NioUdtProvider.MESSAGE_ACCEPTOR.newChannel());
-        assertNotNull(NioUdtProvider.MESSAGE_CONNECTOR.newChannel());
-        assertNotNull(NioUdtProvider.MESSAGE_RENDEZVOUS.newChannel());
+        assertNotNull(nioUdtMessageAcceptorChannel);
+        assertNotNull(nioUdtMessageConnectorChannel);
+        assertNotNull(nioUdtMessageRendezvousChannel);
+
+        // channel
+        assertNotNull(NioUdtProvider.channelUDT(nioUdtByteAcceptorChannel));
+        assertNotNull(NioUdtProvider.channelUDT(nioUdtByteConnectorChannel));
+        assertNotNull(NioUdtProvider.channelUDT(nioUdtByteRendezvousChannel));
+        assertNotNull(NioUdtProvider.channelUDT(nioUdtMessageAcceptorChannel));
+        assertNotNull(NioUdtProvider.channelUDT(nioUdtMessageConnectorChannel));
+        assertNotNull(NioUdtProvider.channelUDT(nioUdtMessageRendezvousChannel));
 
         // acceptor types
         assertTrue(NioUdtProvider.BYTE_ACCEPTOR.newChannel() instanceof UdtServerChannel);


### PR DESCRIPTION
Motivation:

channelUDT() can't handle NioUdtByteRendezvousChannel and NioUdtMessageRendezvousChannel because those are handled by the checking condition of their parent.

Motification:

Reorder checking conditions.

Result:

Bugfixed.