### PR TITLE
Swap to SslContextBuilder in examples

### DIFF
--- a/example/src/main/java/io/netty/example/http2/server/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/server/Http2Server.java
@@ -32,6 +32,7 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBeh
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -52,19 +53,18 @@ public final class Http2Server {
         if (SSL) {
             SslProvider provider = OpenSsl.isAlpnSupported() ? SslProvider.OPENSSL : SslProvider.JDK;
             SelfSignedCertificate ssc = new SelfSignedCertificate();
-            sslCtx = SslContext.newServerContext(provider,
-                    ssc.certificate(), ssc.privateKey(), null,
-                    Http2SecurityUtil.CIPHERS,
-                    /* NOTE: the following filter may not include all ciphers required by the HTTP/2 specification
-                     * Please refer to the HTTP/2 specification for cipher requirements. */
-                    SupportedCipherSuiteFilter.INSTANCE,
-                    new ApplicationProtocolConfig(
-                            Protocol.ALPN,
-                            SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
-                            SelectedListenerFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
-                            SelectedProtocol.HTTP_2.protocolName(),
-                            SelectedProtocol.HTTP_1_1.protocolName()),
-                    0, 0);
+            sslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
+                .sslProvider(provider)
+                /* NOTE: the cipher filter may not include all ciphers required by the HTTP/2 specification.
+                 * Please refer to the HTTP/2 specification for cipher requirements. */
+                .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+                .applicationProtocolConfig(new ApplicationProtocolConfig(
+                    Protocol.ALPN,
+                    SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
+                    SelectedListenerFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
+                    SelectedProtocol.HTTP_2.protocolName(),
+                    SelectedProtocol.HTTP_1_1.protocolName()))
+                .build();
         } else {
             sslCtx = null;
         }

--- a/example/src/main/java/io/netty/example/memcache/binary/MemcacheClient.java
+++ b/example/src/main/java/io/netty/example/memcache/binary/MemcacheClient.java
@@ -26,13 +26,8 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.memcache.binary.BinaryMemcacheClientCodec;
 import io.netty.handler.codec.memcache.binary.BinaryMemcacheObjectAggregator;
-import io.netty.handler.codec.spdy.SpdyOrHttpChooser.SelectedProtocol;
-import io.netty.handler.ssl.ApplicationProtocolConfig;
-import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
-import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
-import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
-import io.netty.handler.ssl.IdentityCipherSuiteFilter;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 
 import java.io.BufferedReader;
@@ -51,15 +46,8 @@ public final class MemcacheClient {
         // Configure SSL.
         final SslContext sslCtx;
         if (SSL) {
-            sslCtx = SslContext.newClientContext(
-                    null, InsecureTrustManagerFactory.INSTANCE, null,
-                    IdentityCipherSuiteFilter.INSTANCE,
-                    new ApplicationProtocolConfig(
-                            Protocol.ALPN,
-                            SelectorFailureBehavior.FATAL_ALERT,
-                            SelectedListenerFailureBehavior.FATAL_ALERT,
-                            SelectedProtocol.HTTP_1_1.protocolName()),
-                    0, 0);
+            sslCtx = SslContextBuilder.forClient()
+                .trustManager(InsecureTrustManagerFactory.INSTANCE).build();
         } else {
             sslCtx = null;
         }


### PR DESCRIPTION
Motivation:

Using factory methods of SslContext is deprecated. Code should be using
SslContextBuilder instead. This would have been done when the old
methods were deprecated, but memcache and http2 examples didn't exist in
the 4.0 branch which the PR was against.

Modifications:

Swap to the new construction pattern.

Result:

No more deprecated warnings during build of examples. Users are
instructed to use the new pattern.


This is the non-testing part of #3686.

I've tested this PR has same behavior as before, but it is impacted by #3758.