### PR TITLE
Fix binary compatibility

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/Cookie.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/Cookie.java
@@ -20,7 +20,7 @@ import java.util.Set;
 /**
  * An interface defining an
  * <a href="http://en.wikipedia.org/wiki/HTTP_cookie">HTTP cookie</a>.
- * @deprecated Use {@link io.netty.handler.codec.http.cookie.Cookie} instead.
+ * @deprecated Use {@link org.jboss.netty.handler.codec.http.cookie.Cookie} instead.
  */
 @Deprecated
 public interface Cookie extends org.jboss.netty.handler.codec.http.cookie.Cookie {
@@ -79,23 +79,23 @@ public interface Cookie extends org.jboss.netty.handler.codec.http.cookie.Cookie
      * @deprecated Use {@link #maxAge()} instead.
      */
     @Deprecated
-    long getMaxAge();
+    int getMaxAge();
 
     /**
-     * Returns the maximum age of this {@link Cookie} in seconds or {@link Long#MIN_VALUE} if unspecified
+     * Returns the maximum age of this {@link Cookie} in seconds or {@link Integer#MIN_VALUE} if unspecified
      *
      * @return The maximum age of this {@link Cookie}
      *
      * @deprecated Not part of RFC6265
      */
     @Deprecated
-    long maxAge();
+    int maxAge();
 
     /**
      * Sets the maximum age of this {@link Cookie} in seconds.
      * If an age of {@code 0} is specified, this {@link Cookie} will be
      * automatically removed by browser because it will expire immediately.
-     * If {@link Long#MIN_VALUE} is specified, this {@link Cookie} will be removed when the
+     * If {@link Integer#MIN_VALUE} is specified, this {@link Cookie} will be removed when the
      * browser is closed.
      *
      * @param maxAge The maximum age of this {@link Cookie} in seconds
@@ -103,7 +103,7 @@ public interface Cookie extends org.jboss.netty.handler.codec.http.cookie.Cookie
      * @deprecated Not part of RFC6265
      */
     @Deprecated
-    void setMaxAge(long maxAge);
+    void setMaxAge(int maxAge);
 
     /**
      * @deprecated Use {@link #version()} instead.

--- a/src/main/java/org/jboss/netty/handler/codec/http/CookieDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/CookieDecoder.java
@@ -138,7 +138,7 @@ public final class CookieDecoder {
             String commentURL = null;
             String domain = null;
             String path = null;
-            long maxAge = Long.MIN_VALUE;
+            int maxAge = Integer.MIN_VALUE;
             List<Integer> ports = new ArrayList<Integer>(2);
 
             for (int j = i + 1; j < names.size(); j++, i++) {
@@ -165,7 +165,7 @@ public final class CookieDecoder {
                             HttpHeaderDateFormat.get().parse(value).getTime() -
                             System.currentTimeMillis();
 
-                        maxAge = maxAgeMillis / 1000 + (maxAgeMillis % 1000 != 0? 1 : 0);
+                        maxAge = (int) (maxAgeMillis / 1000 + (maxAgeMillis % 1000 != 0? 1 : 0));
                     } catch (ParseException e) {
                         // Ignore.
                     }

--- a/src/main/java/org/jboss/netty/handler/codec/http/DefaultCookie.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/DefaultCookie.java
@@ -154,7 +154,7 @@ public class DefaultCookie extends org.jboss.netty.handler.codec.http.cookie.Def
     }
 
     @Deprecated
-    public long getMaxAge() {
+    public int getMaxAge() {
         return maxAge();
     }
 

--- a/src/main/java/org/jboss/netty/handler/codec/http/cookie/ClientCookieDecoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/cookie/ClientCookieDecoder.java
@@ -154,7 +154,7 @@ public final class ClientCookieDecoder extends CookieDecoder {
         private final DefaultCookie cookie;
         private String domain;
         private String path;
-        private long maxAge = Long.MIN_VALUE;
+        private int maxAge = Integer.MIN_VALUE;
         private String expires;
         private boolean secure;
         private boolean httpOnly;
@@ -163,18 +163,18 @@ public final class ClientCookieDecoder extends CookieDecoder {
             this.cookie = cookie;
         }
 
-        private long mergeMaxAgeAndExpire(long maxAge, String expires) {
+        private int mergeMaxAgeAndExpire(int maxAge, String expires) {
             // max age has precedence over expires
-            if (maxAge != Long.MIN_VALUE) {
+            if (maxAge != Integer.MIN_VALUE) {
                 return maxAge;
             } else if (expires != null) {
                 Date expiresDate = HttpHeaderDateFormat.get().parse(expires, new ParsePosition(0));
                 if (expiresDate != null) {
                     long maxAgeMillis = expiresDate.getTime() - System.currentTimeMillis();
-                    return maxAgeMillis / 1000 + (maxAgeMillis % 1000 != 0 ? 1 : 0);
+                    return (int) (maxAgeMillis / 1000 + (maxAgeMillis % 1000 != 0 ? 1 : 0));
                 }
             }
-            return Long.MIN_VALUE;
+            return Integer.MIN_VALUE;
         }
 
         public Cookie cookie() {
@@ -239,7 +239,7 @@ public final class ClientCookieDecoder extends CookieDecoder {
 
         private void setMaxAge(String value) {
             try {
-                maxAge = Math.max(Long.valueOf(value), 0L);
+                maxAge = Math.max(Integer.valueOf(value), 0);
             } catch (NumberFormatException e1) {
                 // ignore failure to parse -> treat as session cookie
             }

--- a/src/main/java/org/jboss/netty/handler/codec/http/cookie/Cookie.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/cookie/Cookie.java
@@ -87,22 +87,22 @@ public interface Cookie extends Comparable<Cookie> {
     void setPath(String path);
 
     /**
-     * Returns the maximum age of this {@link Cookie} in seconds or {@link Long#MIN_VALUE} if unspecified
+     * Returns the maximum age of this {@link Cookie} in seconds or {@link Integer#MIN_VALUE} if unspecified
      *
      * @return The maximum age of this {@link Cookie}
      */
-    long maxAge();
+    int maxAge();
 
     /**
      * Sets the maximum age of this {@link Cookie} in seconds.
      * If an age of {@code 0} is specified, this {@link Cookie} will be
      * automatically removed by browser because it will expire immediately.
-     * If {@link Long#MIN_VALUE} is specified, this {@link Cookie} will be removed when the
+     * If {@link Integer#MIN_VALUE} is specified, this {@link Cookie} will be removed when the
      * browser is closed.
      *
      * @param maxAge The maximum age of this {@link Cookie} in seconds
      */
-    void setMaxAge(long maxAge);
+    void setMaxAge(int maxAge);
 
     /**
      * Checks to see if this {@link Cookie} is secure

--- a/src/main/java/org/jboss/netty/handler/codec/http/cookie/DefaultCookie.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/cookie/DefaultCookie.java
@@ -25,7 +25,7 @@ public class DefaultCookie implements Cookie {
     private boolean wrap;
     private String domain;
     private String path;
-    private long maxAge = Long.MIN_VALUE;
+    private int maxAge = Integer.MIN_VALUE;
     private boolean secure;
     private boolean httpOnly;
 
@@ -105,11 +105,11 @@ public class DefaultCookie implements Cookie {
         this.path = validateValue("path", path);
     }
 
-    public long maxAge() {
+    public int maxAge() {
         return maxAge;
     }
 
-    public void setMaxAge(long maxAge) {
+    public void setMaxAge(int maxAge) {
         this.maxAge = maxAge;
     }
 

--- a/src/main/java/org/jboss/netty/handler/codec/http/cookie/ServerCookieEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/cookie/ServerCookieEncoder.java
@@ -93,7 +93,7 @@ public final class ServerCookieEncoder extends CookieEncoder {
             add(buf, name, value);
         }
 
-        if (cookie.maxAge() != Long.MIN_VALUE) {
+        if (cookie.maxAge() != Integer.MIN_VALUE) {
             add(buf, CookieHeaderNames.MAX_AGE, cookie.maxAge());
             Date expires = new Date(cookie.maxAge() * 1000 + System.currentTimeMillis());
             add(buf, CookieHeaderNames.EXPIRES, HttpHeaderDateFormat.get().format(expires));

--- a/src/test/java/org/jboss/netty/handler/codec/http/CookieDecoderTest.java
+++ b/src/test/java/org/jboss/netty/handler/codec/http/CookieDecoderTest.java
@@ -207,7 +207,7 @@ public class CookieDecoderTest {
         assertNull(c.getCommentUrl());
         assertNull(c.getDomain());
         assertTrue(c.getPorts().isEmpty());
-        assertEquals(Long.MIN_VALUE, c.getMaxAge());
+        assertEquals(Integer.MIN_VALUE, c.getMaxAge());
 
         c = it.next();
         assertEquals(1, c.getVersion());
@@ -218,7 +218,7 @@ public class CookieDecoderTest {
         assertNull(c.getCommentUrl());
         assertNull(c.getDomain());
         assertTrue(c.getPorts().isEmpty());
-        assertEquals(Long.MIN_VALUE, c.getMaxAge());
+        assertEquals(Integer.MIN_VALUE, c.getMaxAge());
 
         assertFalse(it.hasNext());
     }
@@ -243,7 +243,7 @@ public class CookieDecoderTest {
         assertNull(c.getCommentUrl());
         assertNull(c.getDomain());
         assertTrue(c.getPorts().isEmpty());
-        assertEquals(Long.MIN_VALUE, c.getMaxAge());
+        assertEquals(Integer.MIN_VALUE, c.getMaxAge());
 
         assertTrue(it.hasNext());
         c = it.next();
@@ -255,7 +255,7 @@ public class CookieDecoderTest {
         assertNull(c.getComment());
         assertNull(c.getCommentUrl());
         assertTrue(c.getPorts().isEmpty());
-        assertEquals(Long.MIN_VALUE, c.getMaxAge());
+        assertEquals(Integer.MIN_VALUE, c.getMaxAge());
 
         assertFalse(it.hasNext());
     }

--- a/src/test/java/org/jboss/netty/handler/codec/http/cookie/ClientCookieDecoderTest.java
+++ b/src/test/java/org/jboss/netty/handler/codec/http/cookie/ClientCookieDecoderTest.java
@@ -172,11 +172,11 @@ public class ClientCookieDecoderTest {
     @Test
     public void testDecodingLongDates() {
         Calendar cookieDate = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-        cookieDate.set(9999, Calendar.DECEMBER, 31, 23, 59, 59);
-        long expectedMaxAge = (cookieDate.getTimeInMillis() - System
-                .currentTimeMillis()) / 1000;
+        cookieDate.set(2080, Calendar.DECEMBER, 31, 23, 59, 59);
+        int expectedMaxAge = (int)((cookieDate.getTimeInMillis() - System
+                .currentTimeMillis()) / 1000);
 
-        String source = "Format=EU; expires=Fri, 31-Dec-9999 23:59:59 GMT; path=/";
+        String source = "Format=EU; expires=Fri, 31-Dec-2080 23:59:59 GMT; path=/";
 
         Cookie cookie = ClientCookieDecoder.STRICT.decode(source);
 


### PR DESCRIPTION
Change type of Cookie.maxAge back to int to maintain binary compatibility for drop in fixes.