### PR TITLE
Scoring loopback addresses as 0 in DefaultChannelId

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelId.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelId.java
@@ -280,7 +280,7 @@ final class DefaultChannelId implements ChannelId {
     }
 
     private static int scoreAddress(InetAddress addr) {
-        if (addr.isAnyLocalAddress()) {
+        if (addr.isAnyLocalAddress() || addr.isLoopbackAddress()) {
             return 0;
         }
         if (addr.isMulticastAddress()) {


### PR DESCRIPTION
Motivation:

As described in #3490, [compareAddresses](https://github.com/netty/netty/blob/master/transport/src/main/java/io/netty/channel/DefaultChannelId.java#L182)  seems to allow loopback addresses to score high, disallowing replacing the loopback address.

Modifications:

Changed [scoreAddress](https://github.com/netty/netty/blob/master/transport/src/main/java/io/netty/channel/DefaultChannelId.java#L283) to score loopback addresses as 0.

Result:

Fixes #3490