### PR TITLE
ALPN/NPN Examples Not using failure behavior compatible with all SslP…

### DIFF
--- a/example/src/main/java/io/netty/example/http2/client/Http2Client.java
+++ b/example/src/main/java/io/netty/example/http2/client/Http2Client.java
@@ -73,8 +73,10 @@ public final class Http2Client {
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .applicationProtocolConfig(new ApplicationProtocolConfig(
                     Protocol.ALPN,
-                    SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
-                    SelectedListenerFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
+                    // NO_ADVERTISE is currently the only mode supported by both OpenSsl and JDK providers.
+                    SelectorFailureBehavior.NO_ADVERTISE,
+                    // ACCEPT is currently the only mode supported by both OpenSsl and JDK providers.
+                    SelectedListenerFailureBehavior.ACCEPT,
                     SelectedProtocol.HTTP_2.protocolName(),
                     SelectedProtocol.HTTP_1_1.protocolName()))
                 .build();

--- a/example/src/main/java/io/netty/example/http2/server/Http2Server.java
+++ b/example/src/main/java/io/netty/example/http2/server/Http2Server.java
@@ -60,8 +60,10 @@ public final class Http2Server {
                 .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
                 .applicationProtocolConfig(new ApplicationProtocolConfig(
                     Protocol.ALPN,
-                    SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
-                    SelectedListenerFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
+                    // NO_ADVERTISE is currently the only mode supported by both OpenSsl and JDK providers.
+                    SelectorFailureBehavior.NO_ADVERTISE,
+                    // ACCEPT is currently the only mode supported by both OpenSsl and JDK providers.
+                    SelectedListenerFailureBehavior.ACCEPT,
                     SelectedProtocol.HTTP_2.protocolName(),
                     SelectedProtocol.HTTP_1_1.protocolName()))
                 .build();

--- a/example/src/main/java/io/netty/example/spdy/client/SpdyClient.java
+++ b/example/src/main/java/io/netty/example/spdy/client/SpdyClient.java
@@ -32,7 +32,6 @@ import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
-import io.netty.handler.ssl.IdentityCipherSuiteFilter;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -62,8 +61,10 @@ public final class SpdyClient {
             .trustManager(InsecureTrustManagerFactory.INSTANCE)
             .applicationProtocolConfig(new ApplicationProtocolConfig(
                         Protocol.NPN,
-                        SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
-                        SelectedListenerFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
+                        // NO_ADVERTISE is currently the only mode supported by both OpenSsl and JDK providers.
+                        SelectorFailureBehavior.NO_ADVERTISE,
+                        // ACCEPT is currently the only mode supported by both OpenSsl and JDK providers.
+                        SelectedListenerFailureBehavior.ACCEPT,
                         SelectedProtocol.SPDY_3_1.protocolName(),
                         SelectedProtocol.HTTP_1_1.protocolName()))
             .build();

--- a/example/src/main/java/io/netty/example/spdy/server/SpdyServer.java
+++ b/example/src/main/java/io/netty/example/spdy/server/SpdyServer.java
@@ -28,7 +28,6 @@ import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
-import io.netty.handler.ssl.IdentityCipherSuiteFilter;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -61,8 +60,10 @@ public final class SpdyServer {
         SslContext sslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
             .applicationProtocolConfig(new ApplicationProtocolConfig(
                         Protocol.NPN,
-                        SelectorFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
-                        SelectedListenerFailureBehavior.CHOOSE_MY_LAST_PROTOCOL,
+                        // NO_ADVERTISE is currently the only mode supported by both OpenSsl and JDK providers.
+                        SelectorFailureBehavior.NO_ADVERTISE,
+                        // ACCEPT is currently the only mode supported by both OpenSsl and JDK providers.
+                        SelectedListenerFailureBehavior.ACCEPT,
                         SelectedProtocol.SPDY_3_1.protocolName(),
                         SelectedProtocol.HTTP_1_1.protocolName()))
             .build();


### PR DESCRIPTION
…roviders

Motivation:
Examples that are using ALPN/NPN are using a failure mode which is not supported by the JDK SslProvider. The examples fail to run and throw an exception if the JDK SslProvider is used.

Modifications:
- Use SelectorFailureBehavior.NO_ADVERTISE
- Use SelectedListenerFailureBehavior.ACCEPT

Result:
Examples can be run with both OpenSsl and JDK SslProviders.