### PR TITLE
Proposal to fix issue #3768 (3.10)

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/DiskFileUpload.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/DiskFileUpload.java
@@ -118,7 +118,7 @@ public class DiskFileUpload extends AbstractDiskHttpData implements FileUpload {
             HttpPostBodyUtil.FORM_DATA + "; " + HttpPostBodyUtil.NAME + "=\"" + getName() +
                 "\"; " + HttpPostBodyUtil.FILENAME + "=\"" + filename + "\"\r\n" +
                 HttpHeaders.Names.CONTENT_TYPE + ": " + contentType +
-                (charset != null? "; " + HttpHeaders.Values.CHARSET + '=' + charset + "\r\n" : "\r\n") +
+                (charset != null? "; " + HttpHeaders.Values.CHARSET + '=' + charset.name() + "\r\n" : "\r\n") +
                 HttpHeaders.Names.CONTENT_LENGTH + ": " + length() + "\r\n" +
                 "Completed: " + isCompleted() +
                 "\r\nIsInMemory: " + isInMemory() + "\r\nRealFile: " +

--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -474,7 +474,7 @@ public class HttpPostRequestEncoder implements ChunkedInput {
                 // Content-Type: charset=charset
                 internal.addValue(HttpHeaders.Names.CONTENT_TYPE + ": " +
                         HttpPostBodyUtil.DEFAULT_TEXT_CONTENT_TYPE + "; " +
-                        HttpHeaders.Values.CHARSET + '=' + localcharset + "\r\n");
+                        HttpHeaders.Values.CHARSET + '=' + localcharset.name() + "\r\n");
             }
             // CRLF between body header and data
             internal.addValue("\r\n");
@@ -629,7 +629,7 @@ public class HttpPostRequestEncoder implements ChunkedInput {
                         "\r\n\r\n");
             } else if (fileUpload.getCharset() != null) {
                 internal.addValue("; " + HttpHeaders.Values.CHARSET + '=' +
-                        fileUpload.getCharset() + "\r\n\r\n");
+                        fileUpload.getCharset().name() + "\r\n\r\n");
             } else {
                 internal.addValue("\r\n\r\n");
             }

--- a/src/main/java/org/jboss/netty/handler/codec/http/multipart/MemoryFileUpload.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/multipart/MemoryFileUpload.java
@@ -112,7 +112,7 @@ public class MemoryFileUpload extends AbstractMemoryHttpData implements FileUplo
             HttpPostBodyUtil.FORM_DATA + "; " + HttpPostBodyUtil.NAME + "=\"" + getName() +
             "\"; " + HttpPostBodyUtil.FILENAME + "=\"" + filename + "\"\r\n" +
             HttpHeaders.Names.CONTENT_TYPE + ": " + contentType +
-            (charset != null? "; " + HttpHeaders.Values.CHARSET + '=' + charset + "\r\n" : "\r\n") +
+            (charset != null? "; " + HttpHeaders.Values.CHARSET + '=' + charset.name() + "\r\n" : "\r\n") +
             HttpHeaders.Names.CONTENT_LENGTH + ": " + length() + "\r\n" +
             "Completed: " + isCompleted() +
             "\r\nIsInMemory: " + isInMemory();


### PR DESCRIPTION
Motivations:
When using HttpPostRequestEncoder and trying to set an attribute if a
charset is defined, currenlty implicit Charset.toStrng() is used, given
wrong format.
As in Android for UTF-16 = "com.ibm.icu4jni.charset.CharsetICU[UTF-16]".

Modifications:
Each time charset is used to be printed as its name, charset.name() is
used to get the canonical name.

Result:
Now get "UTF-16" instead.
(3.10 version)