### PR TITLE
Minor ClientCookieDecoder improvements

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ClientCookieDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ClientCookieDecoderTest.java
@@ -277,4 +277,11 @@ public class ClientCookieDecoderTest {
         Cookie cookie = ClientCookieDecoder.STRICT.decode(emptyDomain);
         assertNull(cookie.domain());
     }
+
+    @Test
+    public void testIgnoreEmptyPath() {
+        String emptyPath = "sessionid=OTY4ZDllNTgtYjU3OC00MWRjLTkzMWMtNGUwNzk4MTY0MTUw;Domain=;Path=";
+        Cookie cookie = ClientCookieDecoder.STRICT.decode(emptyPath);
+        assertNull(cookie.path());
+    }
 }


### PR DESCRIPTION
Motivation:

* Path attribute should be null, not empty String, if it's passed as "Path=".
* Only extract attribute value when the name is recognized.
* Only extract Expires attribute value String if MaxAge is undefined as it has precedence.

Modification:

Modify ClientCookieDecoder.
Add "testIgnoreEmptyPath" test in ClientCookieDecoderTest.

Result:

More idyomatic Path behavior (like Domain).
Minor performance improvement in some corner cases.