### PR TITLE
Update compression dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -709,17 +709,17 @@
       <dependency>
         <groupId>com.jcraft</groupId>
         <artifactId>jzlib</artifactId>
-        <version>1.1.2</version>
+        <version>1.1.3</version>
       </dependency>
       <dependency>
         <groupId>com.ning</groupId>
         <artifactId>compress-lzf</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.3</version>
       </dependency>
       <dependency>
         <groupId>net.jpountz.lz4</groupId>
         <artifactId>lz4</artifactId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
       </dependency>
       <dependency>
         <groupId>com.github.jponge</groupId>
@@ -863,7 +863,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.8.1</version>
+        <version>1.9</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
**NOTE**: we have to check that it works well with JDK 6, if we need to support this version.

For example, `lz4-java` hasn't officially support JDK 6 since 1.3.0, but its developer thinks that all should work well.
https://github.com/jpountz/lz4-java/commit/1ac84bbb5af5255985b905251a0e8c06e237ae61