### PR TITLE
Add missing SslContextBuilder.forServer(KeyManagerFactory)

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -76,7 +76,7 @@ import java.util.List;
  * <pre>
  * // In your {@link ChannelInitializer}:
  * {@link ChannelPipeline} p = channel.pipeline();
- * {@link SslContext} sslCtx = {@link #newBuilderForClient() SslContext.newBuilderForClient()}.build();
+ * {@link SslContext} sslCtx = {@link SslContextBuilder#forClient() SslContextBuilder.forClient()}.build();
  * p.addLast("ssl", {@link #newEngine(ByteBufAllocator, String, int) sslCtx.newEngine(channel.alloc(), host, port)});
  * ...
  * </pre>

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -39,6 +39,7 @@ public final class SslContextBuilder {
      *
      * @param keyCertChainFile an X.509 certificate chain file in PEM format
      * @param keyFile a PKCS#8 private key file in PEM format
+     * @see #keyManager(File, File)
      */
     public static SslContextBuilder forServer(File keyCertChainFile, File keyFile) {
         return new SslContextBuilder(true).keyManager(keyCertChainFile, keyFile);
@@ -51,10 +52,21 @@ public final class SslContextBuilder {
      * @param keyFile a PKCS#8 private key file in PEM format
      * @param keyPassword the password of the {@code keyFile}, or {@code null} if it's not
      *     password-protected
+     * @see #keyManager(File, File, String)
      */
     public static SslContextBuilder forServer(
             File keyCertChainFile, File keyFile, String keyPassword) {
         return new SslContextBuilder(true).keyManager(keyCertChainFile, keyFile, keyPassword);
+    }
+
+    /**
+     * Creates a builder for new server-side {@link SslContext}.
+     *
+     * @param keyManagerFactory non-{@code null} factory for server's private key
+     * @see #keyManager(KeyManagerFactory)
+     */
+    public static SslContextBuilder forServer(KeyManagerFactory keyManagerFactory) {
+        return new SslContextBuilder(true).keyManager(keyManagerFactory);
     }
 
     private final boolean forServer;


### PR DESCRIPTION
This PR is against 4.0. It needs to be applied to 4.1 and master as well.

Motivation:

keyManager() is required on server-side, and so there is a forServer()
method for each override of keyManager(). However, one of the
forServer() overrides was missing, which meant that if you wanted to use
a KeyManagerFactory you were forced to provide garbage configuration
just to get past null checks.

Modifications:

Add missing override.

Result:

No hacks to use SslContextBuilder on server-side with KeyManagerFactory.
Resolves #3775 