### PR TITLE
Fix cookie encoding when maxAge is greater than 24 days

### DIFF
--- a/src/main/java/org/jboss/netty/handler/codec/http/cookie/ServerCookieEncoder.java
+++ b/src/main/java/org/jboss/netty/handler/codec/http/cookie/ServerCookieEncoder.java
@@ -95,7 +95,7 @@ public final class ServerCookieEncoder extends CookieEncoder {
 
         if (cookie.maxAge() != Integer.MIN_VALUE) {
             add(buf, CookieHeaderNames.MAX_AGE, cookie.maxAge());
-            Date expires = new Date(cookie.maxAge() * 1000 + System.currentTimeMillis());
+            Date expires = new Date((long) cookie.maxAge() * 1000 + System.currentTimeMillis());
             add(buf, CookieHeaderNames.EXPIRES, HttpHeaderDateFormat.get().format(expires));
         }
 

--- a/src/test/java/org/jboss/netty/handler/codec/http/cookie/ServerCookieEncoderTest.java
+++ b/src/test/java/org/jboss/netty/handler/codec/http/cookie/ServerCookieEncoderTest.java
@@ -60,4 +60,24 @@ public class ServerCookieEncoderTest {
         assertNotNull(encodedCookie2);
         assertTrue(encodedCookie2.isEmpty());
     }
+
+    @Test
+    public void testEncodingLargeMaxValue() throws ParseException {
+        int maxAge = Integer.MAX_VALUE / 1000 + 84600;
+
+        String result =
+                "myCookie=myValue; Max-Age=" + maxAge + "; Expires=(.+)";
+        Cookie cookie = new DefaultCookie("myCookie", "myValue");
+        cookie.setMaxAge(maxAge);
+
+        String encodedCookie = ServerCookieEncoder.STRICT.encode(cookie);
+        Matcher matcher = Pattern.compile(result).matcher(encodedCookie);
+        System.out.println(encodedCookie);
+        assertTrue(matcher.find());
+        Date expiresDate = HttpHeaderDateFormat.get().parse(matcher.group(1));
+        long diff = (expiresDate.getTime() - System.currentTimeMillis()) / 1000;
+        // 2 secs should be fine
+        assertTrue(Math.abs(diff - maxAge) <= 2);
+
+    }
 }


### PR DESCRIPTION
Unfortunately, this was missed when making `maxAge` an `int` again. I've added a test to protect against this in future.