### PR TITLE
HTTP/2 GOAWAY Reference Count Issue

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.http2;
 import static io.netty.util.CharsetUtil.UTF_8;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -135,10 +136,9 @@ public final class Http2CodecUtil {
             return Unpooled.EMPTY_BUFFER;
         }
 
-        // Create the debug message.
-        byte[] msg = cause.getMessage().getBytes(UTF_8);
-        ByteBuf debugData = ctx.alloc().buffer(msg.length);
-        debugData.writeBytes(msg);
+        // Create the debug message. `* 3` because UTF-8 max character consumes 3 bytes.
+        ByteBuf debugData = ctx.alloc().buffer(cause.getMessage().length() * 3);
+        ByteBufUtil.writeUtf8(debugData, cause.getMessage());
         return debugData;
     }
 


### PR DESCRIPTION
Motiviation:
The Http2ConnectionHandler is incrementing the reference count in the goAway method for the debugData buffer after it has already been sent and maybe consumed. This may result in an IllegalRefCountException to be thrown. The unit tests also encounter buffer leaks because they have not been updated to invoke the listener which releases the buffer in the goAway method.

Modifications:
- The retain() call should be before the frameWriter().writeGoAway(...) call
- The unit tests which call goAway must also invoke the operationComplete(..) method for the listener.

Result:
No IllegalRefCountException. Less buffer leaks in tests.