### PR TITLE
[#3784] Support hostname verification when using OpenSSLEngine

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -288,18 +288,18 @@ public abstract class OpenSslContext extends SslContext {
 
     @Override
     public final SSLEngine newEngine(ByteBufAllocator alloc, String peerHost, int peerPort) {
-        throw new UnsupportedOperationException();
+        final OpenSslEngine engine = new OpenSslEngine(ctx, alloc, isClient(), sessionContext(), apn, engineMap,
+                rejectRemoteInitiatedRenegotiation, peerHost, peerPort);
+        engineMap.add(engine);
+        return engine;
     }
 
     /**
-     * Returns a new server-side {@link javax.net.ssl.SSLEngine} with the current configuration.
+     * Returns a new server-side {@link SSLEngine} with the current configuration.
      */
     @Override
     public final SSLEngine newEngine(ByteBufAllocator alloc) {
-        final OpenSslEngine engine = new OpenSslEngine(
-                ctx, alloc, isClient(), sessionContext(), apn, engineMap, rejectRemoteInitiatedRenegotiation);
-        engineMap.add(engine);
-        return engine;
+        return newEngine(alloc, null, -1);
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/SslParametersUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslParametersUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import javax.net.ssl.SSLParameters;
+import java.security.AlgorithmConstraints;
+
+final class SslParametersUtils {
+
+    private SslParametersUtils() {
+        // Utility
+    }
+
+    /**
+     * Utility method that is used by {@link OpenSslEngine} and so allow use not not have any reference to
+     * {@link AlgorithmConstraints} in the code. This helps us to not get into trouble when using it in java
+     * version < 7 and especially when using on android.
+     */
+    static void setAlgorithmConstraints(SSLParameters sslParameters, Object algorithmConstraints) {
+        sslParameters.setAlgorithmConstraints((AlgorithmConstraints) algorithmConstraints);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -993,6 +993,8 @@
             <!-- SSLSession implementation -->
             <ignore>javax.net.ssl.SSLEngine</ignore>
             <ignore>javax.net.ssl.X509ExtendedTrustManager</ignore>
+            <ignore>javax.net.ssl.SSLParameters</ignore>
+            <ignore>java.security.AlgorithmConstraints</ignore>
             
             <ignore>java.util.concurrent.ConcurrentLinkedDeque</ignore>
           </ignores>


### PR DESCRIPTION
Motivation:

At the moment hostname verification is not supported with OpenSSLEngine.

Modifications:

Allow to create OpenSslEngine with peerHost and peerPort informations.

Result:

hostname verification is supported now.