### PR TITLE
Normalize allocation sized to a power of cache line size to prevent f…

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -25,7 +25,7 @@ public class PoolArenaTest {
 
     @Test
     public void testNormalizeCapacity() throws Exception {
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, 0, 0, 9, 999999);
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, 0, 0, 9, 999999, false);
         int[] reqCapacities = {0, 15, 510, 1024, 1023, 1025};
         int[] expectedResult = {0, 16, 512, 1024, 1024, 2048};
         for (int i = 0; i < reqCapacities.length; i ++) {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -22,6 +22,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
@@ -29,6 +30,8 @@ import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.ByteBuffer;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Deque;
 import java.util.List;
 import java.util.Locale;
@@ -63,6 +66,7 @@ public final class PlatformDependent {
 
     private static final boolean IS_ANDROID = isAndroid0();
     private static final boolean IS_WINDOWS = isWindows0();
+
     private static volatile Boolean IS_ROOT;
 
     private static final int JAVA_VERSION = javaVersion0();
@@ -84,6 +88,9 @@ public final class PlatformDependent {
     private static final int BIT_MODE = bitMode0();
 
     private static final int ADDRESS_SIZE = addressSize0();
+
+    private static final int DEFAULT_CACHE_LINE_SIZE = 64;
+    private static final int CACHE_LINE_SIZE = cacheLineSize0();
 
     static {
         if (logger.isDebugEnabled()) {
@@ -444,6 +451,10 @@ public final class PlatformDependent {
         }
     }
 
+    public static int cacheLineSize() {
+        return CACHE_LINE_SIZE;
+    }
+
     private static boolean isAndroid0() {
         boolean android;
         try {
@@ -460,12 +471,113 @@ public final class PlatformDependent {
         return android;
     }
 
+    private static boolean isOs(String os) {
+        return SystemPropertyUtil.get("os.name", "").toLowerCase(Locale.US).contains(os);
+    }
+
     private static boolean isWindows0() {
-        boolean windows = SystemPropertyUtil.get("os.name", "").toLowerCase(Locale.US).contains("win");
+        boolean windows = isOs("win");
         if (windows) {
             logger.debug("Platform: Windows");
         }
         return windows;
+    }
+
+    private static boolean isLinux0() {
+        boolean linux = isOs("linux");
+        if (linux) {
+            logger.debug("Platform: Linux");
+        }
+        return linux;
+    }
+
+    private static boolean isOsx0() {
+        boolean osx = isOs("osx");
+        if (osx) {
+            logger.debug("Platform: OSX");
+        }
+        return osx;
+    }
+
+    private static int cacheLineSize0() {
+        return AccessController.doPrivileged(new PrivilegedAction<Integer>() {
+            @Override
+            public Integer run() {
+                if (isLinux0()) {
+                    BufferedReader in = null;
+                    try {
+                        in = new BufferedReader(new InputStreamReader(new FileInputStream("/proc/cpuinfo")));
+                        String line;
+                        while ((line = in.readLine()) != null) {
+                            if (line.startsWith("cache_alignment")) {
+                                String[] parts = StringUtil.split(line, ':');
+                                return Integer.parseInt(parts[1].trim());
+                            }
+                        }
+                    } catch (Throwable cause) {
+                        logger.debug(String.format("Failed to retrieve cache line size, using default: %db",
+                                                   DEFAULT_CACHE_LINE_SIZE), cause);
+                        return DEFAULT_CACHE_LINE_SIZE;
+                    } finally {
+                        if (in != null) {
+                            try {
+                                in.close();
+                            } catch (IOException ignore) {
+                                // ignore on close
+                            }
+                        }
+                    }
+                } else if (isOsx0()) {
+                    Process p = null;
+                    BufferedReader in = null;
+                    try {
+                        p = Runtime.getRuntime().exec(new String[] { "sysctl", "hw.cachelinesize" });
+                        in = new BufferedReader(new InputStreamReader(p.getInputStream(), CharsetUtil.US_ASCII));
+                        String line = in.readLine();
+                        in.close();
+
+                        for (;;) {
+                            try {
+                                int exitCode = p.waitFor();
+                                if (exitCode != 0) {
+                                    line = null;
+                                }
+                                break;
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                break;
+                            }
+                        }
+                        if (line != null) {
+                            String[] parts = StringUtil.split(line, ':');
+                            return Integer.parseInt(parts[1].trim());
+                        }
+                    } catch (Exception e) {
+                        // Failed to run the command.
+                        logger.debug(String.format("Failed to retrieve cache line size, using default: %db",
+                                                   DEFAULT_CACHE_LINE_SIZE), e);
+                        return DEFAULT_CACHE_LINE_SIZE;
+                    } finally {
+                        if (in != null) {
+                            try {
+                                in.close();
+                            } catch (IOException e) {
+                                // Ignore
+                            }
+                        }
+                        if (p != null) {
+                            try {
+                                p.destroy();
+                            } catch (Exception e) {
+                                // Android sometimes triggers an ErrnoException.
+                            }
+                        }
+                    }
+                }
+                logger.debug("Failed to retrieve cache line size, using default: %ib", DEFAULT_CACHE_LINE_SIZE);
+                return DEFAULT_CACHE_LINE_SIZE;
+            }
+        });
     }
 
     private static boolean isRoot0() {

--- a/microbench/src/test/java/io/netty/microbench/buffer/PooledByteBufAllocatorFalseSharingBenchmark.java
+++ b/microbench/src/test/java/io/netty/microbench/buffer/PooledByteBufAllocatorFalseSharingBenchmark.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.buffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+@Threads(16)
+public class PooledByteBufAllocatorFalseSharingBenchmark extends AbstractMicrobenchmark {
+    private static final byte BYTE = 'a';
+
+    private PooledByteBufAllocator allocator;
+    private PooledByteBufAllocator allocatorCacheLineSize;
+
+    @Setup
+    public void setup() {
+        allocator = new PooledByteBufAllocator(true, 4, 4, 8192, 11, 512, 256, 64, false);
+        allocatorCacheLineSize = new PooledByteBufAllocator(true, 4, 4, 8192, 11, 512, 256, 64, true);
+    }
+
+    @Param({ "00004", "00256", "01024", "04096", "16384" })
+    public int size;
+
+    @Benchmark
+    public void disablePowerofCacheLine(Blackhole hole) {
+        alloc(allocator, size, hole);
+    }
+
+    @Benchmark
+    public void enablePowerofCacheLine(Blackhole hole) {
+        alloc(allocatorCacheLineSize, size, hole);
+    }
+
+    private static void alloc(ByteBufAllocator allocator, int size, Blackhole hole) {
+        ByteBuf buffer = allocator.buffer(size);
+        for (int a = 0; a < size; a++) {
+            buffer.setByte(a, BYTE);
+            hole.consume(buffer.getByte(a));
+        }
+        buffer.release();
+    }
+}


### PR DESCRIPTION
…alse sharing.

Motivation:

Often we allocate and use buffers from different threads. This can lead to false sharing as memory is packed really tight and multiple buffers may share the same cache line.

Modification:

Allow to set a system property which will ensure that allocation sizes are normalized to a power of cache line size and so no false sharing takes place.

Result:

Improved performance.

Benchmark results:
```
Benchmark                                                                     (size)   Mode   Samples        Score  Score error    Units
i.n.m.b.PooledByteBufAllocatorFalseSharingBenchmark.disablePowerofCacheLine    00004  thrpt        20 27640305.250   380009.821    ops/s
i.n.m.b.PooledByteBufAllocatorFalseSharingBenchmark.disablePowerofCacheLine    00256  thrpt        20  3999993.921    91548.810    ops/s
i.n.m.b.PooledByteBufAllocatorFalseSharingBenchmark.disablePowerofCacheLine    01024  thrpt        20  1086446.388    39302.864    ops/s
i.n.m.b.PooledByteBufAllocatorFalseSharingBenchmark.disablePowerofCacheLine    04096  thrpt        20   288484.551     6109.254    ops/s
i.n.m.b.PooledByteBufAllocatorFalseSharingBenchmark.disablePowerofCacheLine    16384  thrpt        20    74683.288     1003.608    ops/s
i.n.m.b.PooledByteBufAllocatorFalseSharingBenchmark.enablePowerofCacheLine     00004  thrpt        20 29983907.618   655277.573    ops/s
i.n.m.b.PooledByteBufAllocatorFalseSharingBenchmark.enablePowerofCacheLine     00256  thrpt        20  4086304.947   104179.170    ops/s
i.n.m.b.PooledByteBufAllocatorFalseSharingBenchmark.enablePowerofCacheLine     01024  thrpt        20  1148571.578    19183.634    ops/s
i.n.m.b.PooledByteBufAllocatorFalseSharingBenchmark.enablePowerofCacheLine     04096  thrpt        20   297828.315     3971.846    ops/s
i.n.m.b.PooledByteBufAllocatorFalseSharingBenchmark.enablePowerofCacheLine     16384  thrpt        20    73727.950     2580.474    ops/s
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 516.717 sec - in io.netty.microbench.buffer.PooledByteBufAllocatorFalseSharingBenchmark

Results :

Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```