### PR TITLE
Fixing logging of ping acks in Http2OutboundFrameLogger

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
@@ -89,7 +89,11 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
     @Override
     public ChannelFuture writePing(ChannelHandlerContext ctx, boolean ack,
             ByteBuf data, ChannelPromise promise) {
-        logger.logPing(OUTBOUND, data);
+        if (ack) {
+            logger.logPingAck(OUTBOUND, data);
+        } else {
+            logger.logPing(OUTBOUND, data);
+        }
         return writer.writePing(ctx, ack, data, promise);
     }
 


### PR DESCRIPTION
Motivation:

The Http2OutboundFrameLogger logs all PING frames as not acks.

Modifications:

Changed the logger to correctly log PING acks.

Result:

PING acks are logged correctly.