### PR TITLE
Upgrading Jetty alpn-api version

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
@@ -63,7 +63,7 @@ final class JdkAlpnSslEngine extends JdkSslEngine {
                 public String select(List<String> protocols) throws SSLException {
                     try {
                         return protocolSelector.select(protocols);
-                    } catch(SSLException e) {
+                    } catch (SSLException e) {
                         throw e;
                     } catch (Throwable t) {
                         // Ensure that all exceptions are propagated as SSLExceptions
@@ -91,7 +91,7 @@ final class JdkAlpnSslEngine extends JdkSslEngine {
                 public void selected(String protocol) throws SSLException {
                     try {
                         protocolListener.selected(protocol);
-                    } catch(SSLException e) {
+                    } catch (SSLException e) {
                         throw e;
                     } catch (Throwable t) {
                         // Ensure that all exceptions are propagated as SSLExceptions

--- a/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
@@ -71,7 +71,7 @@ final class JdkAlpnSslEngine extends JdkSslEngine {
                     } catch (Throwable t) {
                         // Ensure that all exceptions are propagated as SSLExceptions
                         // so that the SslHandler properly fails the handshake.
-                        throw new SSLException(t.getMessage());
+                        throw new SSLException(t);
                     }
                 }
 
@@ -99,7 +99,7 @@ final class JdkAlpnSslEngine extends JdkSslEngine {
                     } catch (Throwable t) {
                         // Ensure that all exceptions are propagated as SSLExceptions
                         // so that the SslHandler properly fails the handshake.
-                        throw new SSLException(t.getMessage());
+                        throw new SSLException(t);
                     }
                 }
 

--- a/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
 
 import org.eclipse.jetty.alpn.ALPN;
 import org.eclipse.jetty.alpn.ALPN.ClientProvider;
@@ -68,8 +69,9 @@ final class JdkAlpnSslEngine extends JdkSslEngine {
                     } catch(SSLException e) {
                         throw e;
                     } catch (Throwable t) {
-                        PlatformDependent.throwException(t);
-                        return null;
+                        // Ensure that all exceptions are propagated as SSLExceptions
+                        // so that the SslHandler properly fails the handshake.
+                        throw new SSLException(t.getMessage());
                     }
                 }
 
@@ -95,7 +97,9 @@ final class JdkAlpnSslEngine extends JdkSslEngine {
                     } catch(SSLException e) {
                         throw e;
                     } catch (Throwable t) {
-                        PlatformDependent.throwException(t);
+                        // Ensure that all exceptions are propagated as SSLExceptions
+                        // so that the SslHandler properly fails the handshake.
+                        throw new SSLException(t.getMessage());
                     }
                 }
 

--- a/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
@@ -62,9 +62,11 @@ final class JdkAlpnSslEngine extends JdkSslEngine {
                     "protocolSelector");
             ALPN.put(engine, new ServerProvider() {
                 @Override
-                public String select(List<String> protocols) {
+                public String select(List<String> protocols) throws SSLException {
                     try {
                         return protocolSelector.select(protocols);
+                    } catch(SSLException e) {
+                        throw e;
                     } catch (Throwable t) {
                         PlatformDependent.throwException(t);
                         return null;
@@ -87,9 +89,11 @@ final class JdkAlpnSslEngine extends JdkSslEngine {
                 }
 
                 @Override
-                public void selected(String protocol) {
+                public void selected(String protocol) throws SSLException {
                     try {
                         protocolListener.selected(protocol);
+                    } catch(SSLException e) {
+                        throw e;
                     } catch (Throwable t) {
                         PlatformDependent.throwException(t);
                     }

--- a/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
@@ -16,20 +16,17 @@
 package io.netty.handler.ssl;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
 import io.netty.handler.ssl.JdkApplicationProtocolNegotiator.ProtocolSelectionListener;
 import io.netty.handler.ssl.JdkApplicationProtocolNegotiator.ProtocolSelector;
-import io.netty.util.internal.PlatformDependent;
-
-import java.util.LinkedHashSet;
-import java.util.List;
-
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLHandshakeException;
-
 import org.eclipse.jetty.alpn.ALPN;
 import org.eclipse.jetty.alpn.ALPN.ClientProvider;
 import org.eclipse.jetty.alpn.ALPN.ServerProvider;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import java.util.LinkedHashSet;
+import java.util.List;
 
 final class JdkAlpnSslEngine extends JdkSslEngine {
     private static boolean available;

--- a/pom.xml
+++ b/pom.xml
@@ -662,7 +662,7 @@
       <dependency>
         <groupId>org.eclipse.jetty.alpn</groupId>
         <artifactId>alpn-api</artifactId>
-        <version>1.1.0.v20141014</version>
+        <version>1.1.2.v20150522</version>
       </dependency>
       <dependency>
         <groupId>org.mortbay.jetty.alpn</groupId>


### PR DESCRIPTION
Motivation:

Discussion is in https://github.com/jetty-project/jetty-alpn/issues/8. The new API allows protocol negotiation to properly throw SSLHandshakeException.

Modifications:

Updated the parent pom.xml with the new version.

Result:

Upgraded alpn-api now allows throwing SSLHandshakeException.