### PR TITLE
Only call System.nanoTime() if no read batch is ongoing. Related to […

### DIFF
--- a/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutHandler.java
@@ -212,10 +212,9 @@ public class ReadTimeoutHandler extends ChannelInboundHandlerAdapter {
                 return;
             }
 
-            long currentTime = System.nanoTime();
             long nextDelay = timeoutNanos;
             if (!reading) {
-                nextDelay -= currentTime - lastReadTime;
+                nextDelay -= System.nanoTime() - lastReadTime;
             }
 
             if (nextDelay <= 0) {


### PR DESCRIPTION
…#3808]

Motivation:

[#3808] introduced some improvements to reduce the calls to System.nanoTime() but missed one possible optimization.

Modifications:

Only call System.nanoTime() if no reading patch is in process.

Result:

Less System.nanoTime() calls.