### PR TITLE
[#3654] No need to hold lock while destroy a chunk

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -127,11 +127,9 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator {
     private final int tinyCacheSize;
     private final int smallCacheSize;
     private final int normalCacheSize;
-
     private final List<PoolArenaMetric> heapArenaMetrics;
     private final List<PoolArenaMetric> directArenaMetrics;
-
-    final PoolThreadLocalCache threadCache;
+    private final PoolThreadLocalCache threadCache;
 
     public PooledByteBufAllocator() {
         this(false);
@@ -386,6 +384,10 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator {
      */
     public int normalCacheSize() {
         return normalCacheSize;
+    }
+
+    final PoolThreadCache threadCache() {
+        return threadCache.get();
     }
 
     // Too noisy at the moment.


### PR DESCRIPTION
Motiviation:

At the moment we sometimes hold the lock on the PoolArena during destroy a PoolChunk. This is not needed.

Modification:

- Ensure we not hold the lock during destroy a PoolChunk
- Move all synchronized usage in PoolArena
- Cleanup

Result:

Less condition.