### PR TITLE
Update HTTP/2 to RFCs

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -37,8 +37,8 @@ public final class Http2CodecUtil {
     public static final int CONNECTION_STREAM_ID = 0;
     public static final int HTTP_UPGRADE_STREAM_ID = 1;
     public static final String HTTP_UPGRADE_SETTINGS_HEADER = "HTTP2-Settings";
-    public static final String HTTP_UPGRADE_PROTOCOL_NAME = "h2c-17";
-    public static final String TLS_UPGRADE_PROTOCOL_NAME = "h2-17";
+    public static final String HTTP_UPGRADE_PROTOCOL_NAME = "h2c";
+    public static final String TLS_UPGRADE_PROTOCOL_NAME = "h2";
 
     public static final int PING_FRAME_PAYLOAD_LENGTH = 8;
     public static final short MAX_UNSIGNED_BYTE = 0xFF;


### PR DESCRIPTION
Motivation:
HTTP/2 RFC 7540 has been released.

Modifications:
- Make changes RFC 7540 introduced since draft 17.

Result:
HTTP/2 RFC 7540 compliant code