### PR TITLE
[#3785] Correctly handle connection refused with native transport

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/AbstractTestsuiteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/AbstractTestsuiteTest.java
@@ -57,7 +57,7 @@ public abstract class AbstractTestsuiteTest<T extends AbstractBootstrap<?, ?>> {
                         "Running: %s %d of %d with %s",
                         testName.getMethodName(), ++ i, combos.size(), StringUtil.simpleClassName(allocator)));
                 try {
-                    Method m = getClass().getDeclaredMethod(
+                    Method m = getClass().getMethod(
                             TestUtils.testMethodName(testName), clazz);
                     m.invoke(this, cb);
                 } catch (InvocationTargetException ex) {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -25,6 +25,7 @@ import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
 
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -471,7 +472,7 @@ public final class Native {
                 // connect not complete yet need to wait for EPOLLOUT event
                 return false;
             }
-            throw newIOException("connect", res);
+            throw newConnectException("connect", res);
         }
         return true;
     }
@@ -486,12 +487,16 @@ public final class Native {
                 // connect still in progress
                 return false;
             }
-            throw newIOException("finishConnect", res);
+            throw newConnectException("finishConnect", res);
         }
         return true;
     }
 
     private static native int finishConnect0(int fd);
+
+    private static ConnectException newConnectException(String method, int err) {
+        return new ConnectException(method + "() failed: " + ERRORS[-err]);
+    }
 
     public static InetSocketAddress remoteAddress(int fd) {
         byte[] addr = remoteAddress0(fd);

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketConnectionAttemptTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketConnectionAttemptTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketConnectionAttemptTest;
+
+import java.util.List;
+
+public class EpollSocketConnectionAttemptTest extends SocketConnectionAttemptTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
+        return EpollSocketTestPermutation.INSTANCE.clientSocket();
+    }
+}


### PR DESCRIPTION
Motivation:

Due a bug we not correctly handled connection refused errors and so failed the connect promise with the wrong exception.
Beside this we some times even triggered fireChannelActive() which is not correct.

Modifications:

- Add testcase
- correctly detect connect errors

Result:

Correct and consistent handling.