### PR TITLE
fixing small leak on exception on the transport-epoll-native allocation

### DIFF
--- a/transport-native-epoll/src/main/c/exception_helper.h
+++ b/transport-native-epoll/src/main/c/exception_helper.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+void throwRuntimeException(JNIEnv* env, char* message);
+void throwRuntimeExceptionErrorNo(JNIEnv* env, char* message, int errorNumber);
+void throwIOException(JNIEnv* env, char* message);
+void throwIOExceptionErrorNo(JNIEnv* env, char* message, int errorNumber);
+void throwClosedChannelException(JNIEnv* env);
+void throwOutOfMemoryError(JNIEnv* env);
+char* exceptionMessage(char* msg, int error);


### PR DESCRIPTION
Motivation:

the JNI function ThrowNew won't release any allocated memory.
The method exceptionMessage is allocating a new string concatenating 2 constant strings
What is creating a small leak in case of these exceptions are happening.

Modifications:

Added new methods that will use exceptionMessage and free resources accordingly.
I am also removing the inline definition on these methods as they could be reused by
other added modules (e.g. libaio which should be coming soon)

Result:

No more leaks in case of failrues.