### PR TITLE
TCP_NOTSENT_LOWAT socket option support

### DIFF
--- a/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.h
+++ b/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.h
@@ -80,6 +80,7 @@ void Java_io_netty_channel_epoll_Native_setReceiveBufferSize(JNIEnv* env, jclass
 void Java_io_netty_channel_epoll_Native_setSendBufferSize(JNIEnv* env, jclass clazz, jint fd, jint optval);
 void Java_io_netty_channel_epoll_Native_setKeepAlive(JNIEnv* env, jclass clazz, jint fd, jint optval);
 void Java_io_netty_channel_epoll_Native_setTcpCork(JNIEnv* env, jclass clazz, jint fd, jint optval);
+void Java_io_netty_channel_epoll_Native_setTcpNotSentLowAt(JNIEnv* env, jclass clazz, jint fd, jint optval);
 void Java_io_netty_channel_epoll_Native_setSoLinger(JNIEnv* env, jclass clazz, jint fd, jint optval);
 void Java_io_netty_channel_epoll_Native_setTrafficClass(JNIEnv* env, jclass clazz, jint fd, jint optval);
 void Java_io_netty_channel_epoll_Native_setBroadcast(JNIEnv* env, jclass clazz, jint fd, jint optval);
@@ -93,6 +94,7 @@ jint Java_io_netty_channel_epoll_Native_isTcpNoDelay(JNIEnv* env, jclass clazz, 
 jint Java_io_netty_channel_epoll_Native_getReceiveBufferSize(JNIEnv* env, jclass clazz, jint fd);
 jint Java_io_netty_channel_epoll_Native_getSendBufferSize(JNIEnv* env, jclass clazz, jint fd);
 jint Java_io_netty_channel_epoll_Native_isTcpCork(JNIEnv* env, jclass clazz, jint fd);
+jint Java_io_netty_channel_epoll_Native_getTcpNotSentLowAt(JNIEnv* env, jclass clazz, jint fd);
 jint Java_io_netty_channel_epoll_Native_getSoLinger(JNIEnv* env, jclass clazz, jint fd);
 jint Java_io_netty_channel_epoll_Native_getTrafficClass(JNIEnv* env, jclass clazz, jint fd);
 jint Java_io_netty_channel_epoll_Native_isBroadcast(JNIEnv* env, jclass clazz, jint fd);

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelOption.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelOption.java
@@ -24,6 +24,7 @@ public final class EpollChannelOption<T> extends ChannelOption<T> {
 
     public static final ChannelOption<Boolean> TCP_CORK = ChannelOption.valueOf(T, "TCP_CORK");
     public static final ChannelOption<Boolean> SO_REUSEPORT = ChannelOption.valueOf(T, "SO_REUSEPORT");
+    public static final ChannelOption<Long> TCP_NOTSENT_LOWAT = ChannelOption.valueOf(T, "TCP_NOTSENT_LOWAT");
     public static final ChannelOption<Integer> TCP_KEEPIDLE = ChannelOption.valueOf(T, "TCP_KEEPIDLE");
     public static final ChannelOption<Integer> TCP_KEEPINTVL = ChannelOption.valueOf(T, "TCP_KEEPINTVL");
     public static final ChannelOption<Integer> TCP_KEEPCNT = ChannelOption.valueOf(T, "TCP_KEEPCNT");

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
@@ -16,9 +16,7 @@
 package io.netty.channel.epoll;
 
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.ChannelPipeline;
 import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.unix.DomainSocketChannelConfig;
@@ -28,8 +26,7 @@ import java.util.Map;
 
 public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
         implements DomainSocketChannelConfig {
-    private volatile DomainSocketReadMode mode =
-            DomainSocketReadMode.BYTES;
+    private volatile DomainSocketReadMode mode = DomainSocketReadMode.BYTES;
 
     EpollDomainSocketChannelConfig(AbstractEpollChannel channel) {
         super(channel);

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -626,6 +626,7 @@ public final class Native {
     public static native int isReusePort(int fd);
     public static native int isTcpNoDelay(int fd);
     public static native int isTcpCork(int fd);
+    public static native int getTcpNotSentLowAt(int fd);
     public static native int getSoLinger(int fd);
     public static native int getTrafficClass(int fd);
     public static native int isBroadcast(int fd);
@@ -641,6 +642,7 @@ public final class Native {
     public static native void setSendBufferSize(int fd, int sendBufferSize);
     public static native void setTcpNoDelay(int fd, int tcpNoDelay);
     public static native void setTcpCork(int fd, int tcpCork);
+    public static native void setTcpNotSentLowAt(int fd, int tcpNotSentLowAt);
     public static native void setSoLinger(int fd, int soLinger);
     public static native void setTrafficClass(int fd, int tcpNoDelay);
     public static native void setBroadcast(int fd, int broadcast);

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import static org.junit.Assert.*;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.EventLoopGroup;
+
+import java.net.InetSocketAddress;
+import java.util.Random;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class EpollSocketChannelConfigTest {
+
+    private static EventLoopGroup group;
+    private static EpollSocketChannel ch;
+    private static Random rand;
+
+    @BeforeClass
+    public static void before() {
+        rand = new Random();
+        group = new EpollEventLoopGroup(1);
+        Bootstrap bootstrap = new Bootstrap();
+        ch = (EpollSocketChannel) bootstrap.group(group)
+                .channel(EpollSocketChannel.class)
+                .handler(new ChannelInboundHandlerAdapter())
+                .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+    }
+
+    @AfterClass
+    public static void after() {
+        group.shutdownGracefully();
+    }
+
+    private long randLong(long min, long max) {
+        return min + nextLong(max - min + 1);
+    }
+
+    private long nextLong(long n) {
+        long bits, val;
+        do {
+           bits = (rand.nextLong() << 1) >>> 1;
+           val = bits % n;
+        } while (bits - val + (n - 1) < 0L);
+        return val;
+     }
+
+    @Test
+    public void testRandomTcpNotSentLowAt() {
+        final long value = randLong(0, 0xFFFFFFFFL);
+        ch.config().setTcpNotSentLowAt(value);
+        assertEquals(value, ch.config().getTcpNotSentLowAt());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidHighTcpNotSentLowAt() {
+        final long value = 0xFFFFFFFFL + 1;
+        ch.config().setTcpNotSentLowAt(value);
+        fail();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidLowTcpNotSentLowAt() {
+        final long value = -1;
+        ch.config().setTcpNotSentLowAt(value);
+        fail();
+    }
+
+    @Test
+    public void testTcpCork() {
+        ch.config().setTcpCork(false);
+        assertFalse(ch.config().isTcpCork());
+        ch.config().setTcpCork(true);
+        assertTrue(ch.config().isTcpCork());
+    }
+}

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTestPermutation.java
@@ -56,6 +56,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
         return list;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public List<BootstrapFactory<ServerBootstrap>> serverSocket() {
         return Arrays.asList(
@@ -76,6 +77,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
         );
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public List<BootstrapFactory<Bootstrap>> clientSocket() {
         return Arrays.asList(
@@ -97,6 +99,7 @@ class EpollSocketTestPermutation extends SocketTestPermutation {
     @Override
     public List<TestsuitePermutation.BootstrapComboFactory<Bootstrap, Bootstrap>> datagram() {
         // Make the list of Bootstrap factories.
+        @SuppressWarnings("unchecked")
         List<BootstrapFactory<Bootstrap>> bfs = Arrays.asList(
                 new BootstrapFactory<Bootstrap>() {
                     @Override


### PR DESCRIPTION
Motiviation:
Linux provides the TCP_NOTSENT_LOWAT socket option. This can be used to control how much unsent data is queued in the tcp kernel buffers. This can be important when application level protocols (SPDY, HTTP/2) have their own priority mechanism and don't want data queued in the kernel.

Modifications:
- The epoll module will have an additional socket option TCP_NOTSENT_LOWAT
- There will be JNI methods to control the underlying linux socket option mechanism

Result:
Linux EPOLL module exposes the TCP_NOTSENT_LOWAT socket option.