### PR TITLE
Skip http content compression for small or uncompressable content

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -146,7 +146,8 @@ public class HttpContentCompressor extends HttpContentEncoder {
      *                                 a response does not contain a content type will always be compressor. If the
      *                                 parameter is <tt>null</tt>, the content compressor is put into legacy mode,
      *                                 which will compress all responses independent of their length, content type
-     *                                 and response type.
+     *                                 and response type. By default all <tt>text/*</tt> and <tt>application/json</tt>
+     *                                 are compressed.
      * @return the compressor itself for fluent method calls
      */
     public HttpContentCompressor withCompressableContentTypes(Pattern compressableContentTypes) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -24,10 +24,15 @@ import java.util.regex.Pattern;
 
 /**
  * Compresses an {@link HttpMessage} and an {@link HttpContent} in {@code gzip} or
- * {@code deflate} encoding while respecting the {@code "Accept-Encoding"} header.
- * If there is no matching encoding, no compression is done.  For more
- * information on how this handler modifies the message, please refer to
- * {@link HttpContentEncoder}.
+ * {@code deflate} encoding while respecting the {@code "Accept-Encoding"} header. If there is no matching encoding,
+ * no compression is done.
+ *
+ * Note that only a {@link FullHttpResponse} or a response with {@code "Transfer-Encoding: chunked"}
+ * will be compressed. Also the {@code "Content-Length"} and {@code "Content-Type"} are checked against
+ * the given <tt>minCompressableContentLength</tt> and <tt>compressableContentTypes</tt> to determined if
+ * a compression would be effective at all.
+ *
+ * For more information on how this handler modifies the message, please refer to {@link HttpContentEncoder}.
  */
 public class HttpContentCompressor extends HttpContentEncoder {
 
@@ -91,17 +96,23 @@ public class HttpContentCompressor extends HttpContentEncoder {
      * Creates a new handler with the specified compression level, window size,
      * and memory level..
      *
-     * @param compressionLevel {@code 1} yields the fastest compression and {@code 9} yields the
-     *                         best compression.  {@code 0} means no compression.  The default
-     *                         compression level is {@code 6}.
-     * @param windowBits       The base two logarithm of the size of the history buffer.  The
-     *                         value should be in the range {@code 9} to {@code 15} inclusive.
-     *                         Larger values result in better compression at the expense of
-     *                         memory usage.  The default value is {@code 15}.
-     * @param memLevel         How much memory should be allocated for the internal compression
-     *                         state.  {@code 1} uses minimum memory and {@code 9} uses maximum
-     *                         memory.  Larger values result in better and faster compression
-     *                         at the expense of memory usage.  The default value is {@code 8}
+     * @param compressionLevel             {@code 1} yields the fastest compression and {@code 9} yields the
+     *                                     best compression.  {@code 0} means no compression.  The default
+     *                                     compression level is {@code 6}.
+     * @param windowBits                   The base two logarithm of the size of the history buffer.  The
+     *                                     value should be in the range {@code 9} to {@code 15} inclusive.
+     *                                     Larger values result in better compression at the expense of
+     *                                     memory usage.  The default value is {@code 15}.
+     * @param memLevel                     How much memory should be allocated for the internal compression
+     *                                     state.  {@code 1} uses minimum memory and {@code 9} uses maximum
+     *                                     memory.  Larger values result in better and faster compression
+     *                                     at the expense of memory usage.  The default value is {@code 8}
+     * @param minCompressableContentLength The minimum content size for the compressor to be enabled. If a given
+     *                                     request does not provide a content-length header, it will always
+     *                                     be compressed.
+     * @param compressableContentTypes     A regular expression that determines which content types to compress.
+     *                                     If a request does not contain a content-type header, it will always
+     *                                     be compressed.
      */
     public HttpContentCompressor(int compressionLevel,
                                  int windowBits,

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
  * <p/>
  * Note that only a {@link FullHttpResponse} or a response with {@code "Transfer-Encoding: chunked"}
  * will be compressed. Also the {@code "Content-Length"} and {@code "Content-Type"} are checked against
- * the given <tt>minCompressableContentLength</tt> and <tt>compressableContentTypes</tt> to determined if
+ * the given {@code minCompressableContentLength} and {@code compressableContentTypes} to determined if
  * a compression would be effective at all.
  * <p/>
  * Note that if one of the deprecated constructors is invoked, all requests independent of their request type,
@@ -39,6 +39,7 @@ import java.util.regex.Pattern;
  */
 public class HttpContentCompressor extends HttpContentEncoder {
 
+    private static final Pattern RECOMMENDED_COMPRESSABLE_CONTENT_TYPES = Pattern.compile("(text/.*|application/json.*)");
     private int compressionLevel;
     private int windowBits;
     private int memLevel;
@@ -48,7 +49,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
     /**
      * Creates a new content compressor with default settings.
      * <p/>
-     * Use the <tt>with...</tt> methods to further customize the settings.
+     * Use the {@code set...} methods to further customize the settings.
      * <p/>
      * A compressor created by this method will only compress FullHttpResponses or responses with {@code
      * "Transfer-Encoding: chunked"}.
@@ -56,7 +57,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
      * @return a new content compressor with sane default settings
      */
     public static HttpContentCompressor create() {
-        return new HttpContentCompressor(6, 15, 8, 1024, Pattern.compile("(text/.*|application/json.*)"));
+        return new HttpContentCompressor(6, 15, 8, 1024, RECOMMENDED_COMPRESSABLE_CONTENT_TYPES);
     }
 
     /*
@@ -83,10 +84,10 @@ public class HttpContentCompressor extends HttpContentEncoder {
      *                         compression level is {@code 6}.
      * @return the compressor itself for fluent method calls
      */
-    public HttpContentCompressor withCompressionLevel(int compressionLevel) {
+    public HttpContentCompressor setCompressionLevel(int compressionLevel) {
         if (compressionLevel < 0 || compressionLevel > 9) {
             throw new IllegalArgumentException("compressionLevel: " + compressionLevel +
-                                               " (expected: 0-9)");
+                    " (expected: 0-9)");
         }
         this.compressionLevel = compressionLevel;
         return this;
@@ -101,7 +102,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
      *                   memory usage.  The default value is {@code 15}.
      * @return the compressor itself for fluent method calls
      */
-    public HttpContentCompressor withWindowBits(int windowBits) {
+    public HttpContentCompressor setWindowBits(int windowBits) {
         if (windowBits < 9 || windowBits > 15) {
             throw new IllegalArgumentException("windowBits: " + windowBits + " (expected: 9-15)");
         }
@@ -118,7 +119,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
      *                 at the expense of memory usage.  The default value is {@code 8}
      * @return the compressor itself for fluent method calls
      */
-    public HttpContentCompressor withMemLevel(int memLevel) {
+    public HttpContentCompressor setMemLevel(int memLevel) {
         if (memLevel < 1 || memLevel > 9) {
             throw new IllegalArgumentException("memLevel: " + memLevel + " (expected: 1-9)");
         }
@@ -134,7 +135,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
      *                                     The default value is {@code 1024}
      * @return the compressor itself for fluent method calls
      */
-    public HttpContentCompressor withMinCompressableContentLength(int minCompressableContentLength) {
+    public HttpContentCompressor setMinCompressableContentLength(int minCompressableContentLength) {
         this.minCompressableContentLength = minCompressableContentLength;
         return this;
     }
@@ -144,24 +145,24 @@ public class HttpContentCompressor extends HttpContentEncoder {
      *
      * @param compressableContentTypes a regular expression matching all content types eligible for compression. If
      *                                 a response does not contain a content type will always be compressor. If the
-     *                                 parameter is <tt>null</tt>, the content compressor is put into legacy mode,
+     *                                 parameter is {@code null}, the content compressor is put into legacy mode,
      *                                 which will compress all responses independent of their length, content type
-     *                                 and response type. By default all <tt>text/*</tt> and <tt>application/json</tt>
+     *                                 and response type. By default all {@code text/*} and {@code application/json}
      *                                 are compressed.
      * @return the compressor itself for fluent method calls
      */
-    public HttpContentCompressor withCompressableContentTypes(Pattern compressableContentTypes) {
+    public HttpContentCompressor setCompressableContentTypes(Pattern compressableContentTypes) {
         this.compressableContentTypes = compressableContentTypes;
         return this;
     }
 
     /**
-     * Creates a new handler with the default compression level (<tt>6</tt>),
-     * default window size (<tt>15</tt>) and default memory level (<tt>8</tt>).
+     * Creates a new handler with the default compression level ({@code 6}),
+     * default window size ({@code 15}) and default memory level ({@code 8}).
      * <p/>
      *
-     * @deprecated Use the static factory method {@link #create()} and the <tt>with...</tt> methods to create
-     * and configure a new content compressor. Note: Creating a content compressor via <tt>create</tt> will
+     * @deprecated Use the static factory method {@link #create()} and the {@code set...} methods to create
+     * and configure a new content compressor. Note: Creating a content compressor via {@code create} will
      * apply a content length and content type filter, along with check which only compresses FullHttpResponses
      * or ones with {@code "Transfer-Encoding: chunked"}.
      */
@@ -172,13 +173,13 @@ public class HttpContentCompressor extends HttpContentEncoder {
 
     /**
      * Creates a new handler with the specified compression level, default
-     * window size (<tt>15</tt>) and default memory level (<tt>8</tt>).
+     * window size ({@code 15}) and default memory level ({@code 8}).
      *
      * @param compressionLevel {@code 1} yields the fastest compression and {@code 9} yields the
      *                         best compression.  {@code 0} means no compression.  The default
      *                         compression level is {@code 6}.
-     * @deprecated Use the static factory method {@link #create()} and the <tt>with...</tt> methods to create
-     * and configure a new content compressor. Note: Creating a content compressor via <tt>create</tt> will
+     * @deprecated Use the static factory method {@link #create()} and the {@code set...} methods to create
+     * and configure a new content compressor. Note: Creating a content compressor via {@code create} will
      * apply a content length and content type filter, along with check which only compresses FullHttpResponses
      * or ones with {@code "Transfer-Encoding: chunked"}.
      */
@@ -202,8 +203,8 @@ public class HttpContentCompressor extends HttpContentEncoder {
      *                         state.  {@code 1} uses minimum memory and {@code 9} uses maximum
      *                         memory.  Larger values result in better and faster compression
      *                         at the expense of memory usage.  The default value is {@code 8}
-     * @deprecated Use the static factory method {@link #create()} and the <tt>with...</tt> methods to create
-     * and configure a new content compressor. Note: Creating a content compressor via <tt>create</tt> will
+     * @deprecated Use the static factory method {@link #create()} and the {@code set...} methods to create
+     * and configure a new content compressor. Note: Creating a content compressor via {@code create} will
      * apply a content length and content type filter, along with check which only compresses FullHttpResponses
      * or ones with {@code "Transfer-Encoding: chunked"}.
      */
@@ -211,7 +212,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
     public HttpContentCompressor(int compressionLevel, int windowBits, int memLevel) {
         if (compressionLevel < 0 || compressionLevel > 9) {
             throw new IllegalArgumentException("compressionLevel: " + compressionLevel +
-                                               " (expected: 0-9)");
+                    " (expected: 0-9)");
         }
         if (windowBits < 9 || windowBits > 15) {
             throw new IllegalArgumentException("windowBits: " + windowBits + " (expected: 9-15)");
@@ -239,28 +240,29 @@ public class HttpContentCompressor extends HttpContentEncoder {
 
         String targetContentEncoding;
         switch (wrapper) {
-            case GZIP:
-                targetContentEncoding = "gzip";
-                break;
-            case ZLIB:
-                targetContentEncoding = "deflate";
-                break;
-            default:
-                throw new Error();
+        case GZIP:
+            targetContentEncoding = "gzip";
+            break;
+        case ZLIB:
+            targetContentEncoding = "deflate";
+            break;
+        default:
+            throw new Error();
         }
 
         return new Result(targetContentEncoding,
-                          new EmbeddedChannel(ZlibCodecFactory.newZlibEncoder(wrapper,
-                                                                              compressionLevel,
-                                                                              windowBits,
-                                                                              memLevel)));
+                new EmbeddedChannel(
+                        ZlibCodecFactory.newZlibEncoder(wrapper,
+                        compressionLevel,
+                        windowBits,
+                        memLevel)));
     }
 
     /**
      * Determines if the given response can and should be compressed.
      *
      * @param response the response to check.
-     * @return <tt>true</tt> if the response should be compressed, <tt>false</tt> otherwise.
+     * @return {@code true} if the response should be compressed, {@code false} otherwise.
      */
     protected boolean isCompressable(HttpResponse response) {
         CharSequence contentEncoding = response.headers().get(HttpHeaderNames.CONTENT_ENCODING);
@@ -294,17 +296,17 @@ public class HttpContentCompressor extends HttpContentEncoder {
      * <p/>
      * Only requests which are larger than a certain size and contain reasonable compressable content should
      * be compressed. If wouldn't make sense to compress a 100 byte JSON response or a JPEG image. The parameters
-     * for this decision are set by <tt>minCompressableContentLength</tt> and <tt>compressableContentTypes</tt>.
+     * for this decision are set by {@code minCompressableContentLength} and {@code compressableContentTypes}.
      * <p/>
      * This method is made public so that other handlers can decide which kind of response to generate. For example
      * when sending a file it might be better to send it via <code>new HttpChunkedInput(new ChunkedFile(..))</code>
      * which enables compression rather than via <code>new DefaultFileRegion(...)</code> which permits a zero
      * copy transfer - but without compression.
      *
-     * @param contentLength the expected length of the content in bytes or <tt>0</tt> if the length is unknown
-     * @param contentType   the expected type of the content as mime type (e.g. text/xml) or <tt>null</tt> if
+     * @param contentLength the expected length of the content in bytes or {@code 0} if the length is unknown
+     * @param contentType   the expected type of the content as mime type (e.g. text/xml) or {@code null} if
      *                      the type is not yet known
-     * @return <tt>true</tt> if it is considered effective to turn on compression, <tt>false</tt> otherwise
+     * @return {@code true} if it is considered effective to turn on compression, {@code false} otherwise
      */
     public boolean isCompressionEffective(int contentLength, CharSequence contentType) {
         if (minCompressableContentLength > 0) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -20,6 +20,8 @@ import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.util.internal.StringUtil;
 
+import java.util.regex.Pattern;
+
 /**
  * Compresses an {@link HttpMessage} and an {@link HttpContent} in {@code gzip} or
  * {@code deflate} encoding while respecting the {@code "Accept-Encoding"} header.
@@ -29,74 +31,106 @@ import io.netty.util.internal.StringUtil;
  */
 public class HttpContentCompressor extends HttpContentEncoder {
 
+    public static final int DEFAULT_COMPRESSION_LEVEL = 6;
+    public static final int DEFAULT_WINDOW_BITS = 15;
+    public static final int DEFAULT_MEM_LEVEL = 8;
+    public static final int DEFAULT_MIN_COMPRESSABLE_CONTENT_LENGTH = 1024;
+    public static final Pattern DEFAULT_COMPRESSABLE_CONTENT_TYPES = Pattern.compile("(text/.*|application/json.*)");
+
     private final int compressionLevel;
     private final int windowBits;
     private final int memLevel;
+    private final int minCompressableContentLength;
+    private final Pattern compressableContentTypes;
 
     /**
      * Creates a new handler with the default compression level (<tt>6</tt>),
      * default window size (<tt>15</tt>) and default memory level (<tt>8</tt>).
      */
     public HttpContentCompressor() {
-        this(6);
+        this(DEFAULT_COMPRESSION_LEVEL);
     }
 
     /**
      * Creates a new handler with the specified compression level, default
      * window size (<tt>15</tt>) and default memory level (<tt>8</tt>).
      *
-     * @param compressionLevel
-     *        {@code 1} yields the fastest compression and {@code 9} yields the
-     *        best compression.  {@code 0} means no compression.  The default
-     *        compression level is {@code 6}.
+     * @param compressionLevel {@code 1} yields the fastest compression and {@code 9} yields the
+     *                         best compression.  {@code 0} means no compression.  The default
+     *                         compression level is {@code 6}.
      */
     public HttpContentCompressor(int compressionLevel) {
-        this(compressionLevel, 15, 8);
+        this(compressionLevel, DEFAULT_WINDOW_BITS, DEFAULT_MEM_LEVEL);
     }
 
     /**
      * Creates a new handler with the specified compression level, window size,
      * and memory level..
      *
-     * @param compressionLevel
-     *        {@code 1} yields the fastest compression and {@code 9} yields the
-     *        best compression.  {@code 0} means no compression.  The default
-     *        compression level is {@code 6}.
-     * @param windowBits
-     *        The base two logarithm of the size of the history buffer.  The
-     *        value should be in the range {@code 9} to {@code 15} inclusive.
-     *        Larger values result in better compression at the expense of
-     *        memory usage.  The default value is {@code 15}.
-     * @param memLevel
-     *        How much memory should be allocated for the internal compression
-     *        state.  {@code 1} uses minimum memory and {@code 9} uses maximum
-     *        memory.  Larger values result in better and faster compression
-     *        at the expense of memory usage.  The default value is {@code 8}
+     * @param compressionLevel {@code 1} yields the fastest compression and {@code 9} yields the
+     *                         best compression.  {@code 0} means no compression.  The default
+     *                         compression level is {@code 6}.
+     * @param windowBits       The base two logarithm of the size of the history buffer.  The
+     *                         value should be in the range {@code 9} to {@code 15} inclusive.
+     *                         Larger values result in better compression at the expense of
+     *                         memory usage.  The default value is {@code 15}.
+     * @param memLevel         How much memory should be allocated for the internal compression
+     *                         state.  {@code 1} uses minimum memory and {@code 9} uses maximum
+     *                         memory.  Larger values result in better and faster compression
+     *                         at the expense of memory usage.  The default value is {@code 8}
      */
     public HttpContentCompressor(int compressionLevel, int windowBits, int memLevel) {
+        this(compressionLevel,
+             windowBits,
+             memLevel,
+             DEFAULT_MIN_COMPRESSABLE_CONTENT_LENGTH,
+             DEFAULT_COMPRESSABLE_CONTENT_TYPES);
+    }
+
+    /**
+     * Creates a new handler with the specified compression level, window size,
+     * and memory level..
+     *
+     * @param compressionLevel {@code 1} yields the fastest compression and {@code 9} yields the
+     *                         best compression.  {@code 0} means no compression.  The default
+     *                         compression level is {@code 6}.
+     * @param windowBits       The base two logarithm of the size of the history buffer.  The
+     *                         value should be in the range {@code 9} to {@code 15} inclusive.
+     *                         Larger values result in better compression at the expense of
+     *                         memory usage.  The default value is {@code 15}.
+     * @param memLevel         How much memory should be allocated for the internal compression
+     *                         state.  {@code 1} uses minimum memory and {@code 9} uses maximum
+     *                         memory.  Larger values result in better and faster compression
+     *                         at the expense of memory usage.  The default value is {@code 8}
+     */
+    public HttpContentCompressor(int compressionLevel,
+                                 int windowBits,
+                                 int memLevel,
+                                 int minCompressableContentLength,
+                                 Pattern compressableContentTypes) {
         if (compressionLevel < 0 || compressionLevel > 9) {
-            throw new IllegalArgumentException(
-                    "compressionLevel: " + compressionLevel +
-                    " (expected: 0-9)");
+            throw new IllegalArgumentException("compressionLevel: " + compressionLevel +
+                                                       " (expected: 0-9)");
         }
         if (windowBits < 9 || windowBits > 15) {
-            throw new IllegalArgumentException(
-                    "windowBits: " + windowBits + " (expected: 9-15)");
+            throw new IllegalArgumentException("windowBits: " + windowBits + " (expected: 9-15)");
         }
         if (memLevel < 1 || memLevel > 9) {
-            throw new IllegalArgumentException(
-                    "memLevel: " + memLevel + " (expected: 1-9)");
+            throw new IllegalArgumentException("memLevel: " + memLevel + " (expected: 1-9)");
+        }
+        if (compressableContentTypes == null) {
+            throw new IllegalArgumentException("compressableContentTypes: must not be null");
         }
         this.compressionLevel = compressionLevel;
         this.windowBits = windowBits;
         this.memLevel = memLevel;
+        this.minCompressableContentLength = minCompressableContentLength;
+        this.compressableContentTypes = compressableContentTypes;
     }
 
     @Override
-    protected Result beginEncode(HttpResponse headers, CharSequence acceptEncoding) throws Exception {
-        CharSequence contentEncoding = headers.headers().get(HttpHeaderNames.CONTENT_ENCODING);
-        if (contentEncoding != null &&
-            !HttpHeaderValues.IDENTITY.equalsIgnoreCase(contentEncoding)) {
+    protected Result beginEncode(HttpResponse response, CharSequence acceptEncoding) throws Exception {
+        if (!isCompressable(response)) {
             return null;
         }
 
@@ -107,20 +141,80 @@ public class HttpContentCompressor extends HttpContentEncoder {
 
         String targetContentEncoding;
         switch (wrapper) {
-        case GZIP:
-            targetContentEncoding = "gzip";
-            break;
-        case ZLIB:
-            targetContentEncoding = "deflate";
-            break;
-        default:
-            throw new Error();
+            case GZIP:
+                targetContentEncoding = "gzip";
+                break;
+            case ZLIB:
+                targetContentEncoding = "deflate";
+                break;
+            default:
+                throw new Error();
         }
 
-        return new Result(
-                targetContentEncoding,
-                new EmbeddedChannel(ZlibCodecFactory.newZlibEncoder(
-                        wrapper, compressionLevel, windowBits, memLevel)));
+        return new Result(targetContentEncoding,
+                          new EmbeddedChannel(ZlibCodecFactory.newZlibEncoder(wrapper,
+                                                                              compressionLevel,
+                                                                              windowBits,
+                                                                              memLevel)));
+    }
+
+    /**
+     * Determines if the given response can and should be compressed.
+     *
+     * @param response the response to check.
+     * @return <tt>true</tt> if the response should be compressed, <tt>false</tt> otherwise.
+     */
+    protected boolean isCompressable(HttpResponse response) {
+        CharSequence contentEncoding = response.headers().get(HttpHeaderNames.CONTENT_ENCODING);
+        if (contentEncoding != null && !HttpHeaderValues.IDENTITY.equalsIgnoreCase(contentEncoding)) {
+            // Another encoding is already being applied -> no compression
+            return false;
+        }
+
+        if (!(response instanceof FullHttpResponse)) {
+            if (!HttpHeaderValues.CHUNKED.equals(response.headers().get(HttpHeaderNames.TRANSFER_ENCODING))) {
+                // We either need a full response or a chunked transfer to turn on compression. If neither of both is
+                // present, we risk that the caller sends a i.e. DefaultFileReqion which would bypass our
+                // encoder completely resulting in an invalid response.
+                return false;
+            }
+        }
+
+        // Check if it is effective to compress the given content (compressing JPEG images wouldn't be a good idea)
+        int contentLength = response.headers().getInt(HttpHeaderNames.CONTENT_LENGTH, 0);
+        CharSequence contentType = response.headers().get(HttpHeaderNames.CONTENT_TYPE);
+        return isCompressionEffective(contentLength, contentType);
+    }
+
+    /**
+     * Determines if it is effective to compress a request with the given content-length and content-type.
+     * <p/>
+     * Only requests which are larger than a certain size and contain reasonable compressable content should
+     * be compressed. If wouldn't make sense to compress a 100 byte JSON response or a JPEG image. The parameters
+     * for this decision are set by <tt>minCompressableContentLength</tt> and <tt>compressableContentTypes</tt>.
+     * <p/>
+     * This method is made public so that other handlers can decide which kind of response to generate. For example
+     * when sending a file it might be better to send it via <code>new HttpChunkedInput(new ChunkedFile(..))</code>
+     * which enables compression rather than via <code>new DefaultFileRegion(...)</code> which permits a zero
+     * copy transfer - but without compression.
+     *
+     * @param contentLength the expected length of the content in bytes or <tt>0</tt> if the length is unknown
+     * @param contentType   the expected type of the content as mime type (e.g. text/xml) or <tt>null</tt> if
+     *                      the type is not yet known
+     * @return <tt>true</tt> if it is considered effective to turn on compression, <tt>false</tt> otherwise
+     */
+    public boolean isCompressionEffective(int contentLength, CharSequence contentType) {
+        if (minCompressableContentLength > 0) {
+            if (contentLength > 0 && contentLength < minCompressableContentLength) {
+                // Content is too small to effectively compress -> no compression
+                return false;
+            }
+        }
+        if (contentType != null && !compressableContentTypes.matcher(contentType).matches()) {
+            // Content is not compressable -> no compression
+            return false;
+        }
+        return true;
     }
 
     @SuppressWarnings("FloatingPointEquality")
@@ -128,7 +222,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
         float starQ = -1.0f;
         float gzipQ = -1.0f;
         float deflateQ = -1.0f;
-        for (String encoding: StringUtil.split(acceptEncoding.toString(), ',')) {
+        for (String encoding : StringUtil.split(acceptEncoding.toString(), ',')) {
             float q = 1.0f;
             int equalsPos = encoding.indexOf('=');
             if (equalsPos != -1) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -39,7 +39,8 @@ import java.util.regex.Pattern;
  */
 public class HttpContentCompressor extends HttpContentEncoder {
 
-    private static final Pattern RECOMMENDED_COMPRESSABLE_CONTENT_TYPES = Pattern.compile("(text/.*|application/json.*)");
+    private static final Pattern RECOMMENDED_COMPRESSABLE_CONTENT_TYPES =
+            Pattern.compile("(text/.*|application/json.*)");
     private int compressionLevel;
     private int windowBits;
     private int memLevel;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
@@ -50,7 +50,7 @@ public class HttpContentCompressorTest {
                 "gzip; q=0, deflate",
                 "deflate",
                 " deflate ; q=0 , *;q=0.5",
-                "gzip",};
+                "gzip", };
         for (int i = 0; i < tests.length; i += 2) {
             String acceptEncoding = tests[i];
             String contentEncoding = tests[i + 1];
@@ -204,7 +204,7 @@ public class HttpContentCompressorTest {
     public void testFullContent() throws Exception {
         // Lower the required content size for compression to 5 bytes, so that our "hello world"
         // content gets compressed....
-        EmbeddedChannel ch = new EmbeddedChannel(HttpContentCompressor.create().withMinCompressableContentLength(5));
+        EmbeddedChannel ch = new EmbeddedChannel(HttpContentCompressor.create().setMinCompressableContentLength(5));
         ch.writeInbound(newRequest());
 
         FullHttpResponse res = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
@@ -50,7 +50,7 @@ public class HttpContentCompressorTest {
                 "gzip; q=0, deflate",
                 "deflate",
                 " deflate ; q=0 , *;q=0.5",
-                "gzip", };
+                "gzip",};
         for (int i = 0; i < tests.length; i += 2) {
             String acceptEncoding = tests[i];
             String contentEncoding = tests[i + 1];
@@ -58,14 +58,14 @@ public class HttpContentCompressorTest {
             String targetEncoding = null;
             if (targetWrapper != null) {
                 switch (targetWrapper) {
-                    case GZIP:
-                        targetEncoding = "gzip";
-                        break;
-                    case ZLIB:
-                        targetEncoding = "deflate";
-                        break;
-                    default:
-                        fail();
+                case GZIP:
+                    targetEncoding = "gzip";
+                    break;
+                case ZLIB:
+                    targetEncoding = "deflate";
+                    break;
+                default:
+                    fail();
                 }
             }
             assertEquals(contentEncoding, targetEncoding);
@@ -208,8 +208,8 @@ public class HttpContentCompressorTest {
         ch.writeInbound(newRequest());
 
         FullHttpResponse res = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
-                                                           HttpResponseStatus.OK,
-                                                           Unpooled.copiedBuffer("Hello, World", CharsetUtil.US_ASCII));
+                HttpResponseStatus.OK,
+                Unpooled.copiedBuffer("Hello, World", CharsetUtil.US_ASCII));
         res.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, res.content().readableBytes());
         ch.writeOutbound(res);
 
@@ -239,8 +239,8 @@ public class HttpContentCompressorTest {
         ch.writeInbound(newRequest());
 
         FullHttpResponse res = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
-                                                           HttpResponseStatus.OK,
-                                                           Unpooled.copiedBuffer("Hello, World", CharsetUtil.US_ASCII));
+                HttpResponseStatus.OK,
+                Unpooled.copiedBuffer("Hello, World", CharsetUtil.US_ASCII));
         res.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, res.content().readableBytes());
         ch.writeOutbound(res);
 
@@ -268,8 +268,8 @@ public class HttpContentCompressorTest {
         ch.writeInbound(newRequest());
 
         FullHttpResponse res = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
-                                                           HttpResponseStatus.OK,
-                                                           Unpooled.copiedBuffer("Hello, World", CharsetUtil.US_ASCII));
+                HttpResponseStatus.OK,
+                Unpooled.copiedBuffer("Hello, World", CharsetUtil.US_ASCII));
         // This is a lie, but ensures that our response would be compressed and not skipped
         // because it is too small
         res.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 4096);


### PR DESCRIPTION
Motivation:

Content compression is not very effective for small results (default y 1024 bytes) or for already compresst content like JPEG images. Also the content compressor must be skipped for certain types of responses (like when sending a DefaultFileRegion). Therefore only FullResponses or chunked responses should be considered for content compression as otherwise an invalid result (Content-Encoding: gzip with uncompressed data) can be created.

Modification:

Introduced 2 new parameters for the content compressor: minCompressableContentLength (default: 1024) and compressableContentTypes (default: text/* and application/json) to better control when compression is turned on.
Also added a filter to only compress FullHttpResponses or ones with Transfer-Encoding: chunked.

Result:
Then content compressor now skips small or uncompressable results