### PR TITLE
Allow to minimize reference count checks

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -15,7 +15,7 @@
  */
 package io.netty.buffer;
 
-import io.netty.util.IllegalReferenceCountException;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
@@ -1174,8 +1174,8 @@ public abstract class AbstractByteBuf extends ByteBuf {
      * if the buffer was released before.
      */
     protected final void ensureAccessible() {
-        if (refCnt() == 0) {
-            throw new IllegalReferenceCountException(0);
+        if (ReferenceCountUtil.CHECK_REFERENCE_COUNT_VERBOSE) {
+            ReferenceCountUtil.ensureAccessible(this);
         }
     }
 

--- a/common/src/main/java/io/netty/util/ReferenceCountUtil.java
+++ b/common/src/main/java/io/netty/util/ReferenceCountUtil.java
@@ -16,6 +16,7 @@
 package io.netty.util;
 
 import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -25,6 +26,33 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 public final class ReferenceCountUtil {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(ReferenceCountUtil.class);
+
+    public static final boolean CHECK_REFERENCE_COUNT_VERBOSE;
+
+    static {
+        CHECK_REFERENCE_COUNT_VERBOSE = SystemPropertyUtil.getBoolean(
+                "io.netty.util.referenceCounted.checkVerbose", true);
+        logger.debug("-Dio.netty.util.referenceCounted.checkVerbose: {}", CHECK_REFERENCE_COUNT_VERBOSE);
+    }
+
+    /**
+     * Ensure the specified message is not released yet if its {@link ReferenceCounted}.
+     * If the specified message doesn't implement {@link ReferenceCounted}, this method does nothing.
+     */
+    public static void ensureAccessible(Object msg) {
+        if (msg instanceof ReferenceCounted) {
+            ensureAccessible((ReferenceCounted) msg);
+        }
+    }
+
+    /**
+     * Ensure the specified message is not released yet.
+     */
+    public static void ensureAccessible(ReferenceCounted msg) {
+        if (msg.refCnt() == 0) {
+            throw new IllegalReferenceCountException(0);
+        }
+    }
 
     /**
      * Try to call {@link ReferenceCounted#retain()} if the specified message implements {@link ReferenceCounted}.

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -276,6 +276,9 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
 
     private void invokeUserEventTriggered(Object event) {
         try {
+            if (!ReferenceCountUtil.CHECK_REFERENCE_COUNT_VERBOSE) {
+                ReferenceCountUtil.ensureAccessible(event);
+            }
             ((ChannelInboundHandler) handler()).userEventTriggered(this, event);
         } catch (Throwable t) {
             notifyHandlerException(t);
@@ -305,6 +308,9 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
 
     private void invokeChannelRead(Object msg) {
         try {
+            if (!ReferenceCountUtil.CHECK_REFERENCE_COUNT_VERBOSE) {
+                ReferenceCountUtil.ensureAccessible(msg);
+            }
             ((ChannelInboundHandler) handler()).channelRead(this, msg);
         } catch (Throwable t) {
             notifyHandlerException(t);
@@ -630,6 +636,9 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
 
     private void invokeWrite(Object msg, ChannelPromise promise) {
         try {
+            if (!ReferenceCountUtil.CHECK_REFERENCE_COUNT_VERBOSE) {
+                ReferenceCountUtil.ensureAccessible(msg);
+            }
             ((ChannelOutboundHandler) handler()).write(this, msg, promise);
         } catch (Throwable t) {
             notifyOutboundHandlerException(t, promise);


### PR DESCRIPTION
Motivation:

At the moment each operation on a ByteBuf will trigger a reference count check. This is quite some overhead and often not needed. Allow to specifiy via a system property that reference count checks should only be done when pass a ReferenceCounted object from one ChannelHandlerContext to the other.

Modifications:

- Add 'io.netty.util.referenceCounted.checkVerbose' system property which allows to disable frequently reference count checks (default is enabled).
- When 'io.netty.util.referenceCounted.checkVerbose' is false reference count checks will be done when a ReferenceCounted object is passed from one ChannelHandlerContext to another.

Result:

Less overhead when doing operations on a ByteBuf in a ChannelHandler.