### PR TITLE
Make the flow-controllers more 'batchy'

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -161,6 +161,17 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         connection().remote().createStream(HTTP_UPGRADE_STREAM_ID, true);
     }
 
+    @Override
+    public void flush(ChannelHandlerContext ctx) throws Http2Exception {
+        // Trigger pending writes in the remote flow controller.
+        connection().remote().flowController().writePendingBytes();
+        try {
+            super.flush(ctx);
+        } catch (Throwable t) {
+            throw new Http2Exception(INTERNAL_ERROR, "Error flushing" , t);
+        }
+    }
+
     private abstract class BaseDecoder {
         public abstract void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception;
         public void handlerRemoved(ChannelHandlerContext ctx) throws Exception { }
@@ -382,7 +393,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
         // Trigger flush after read on the assumption that flush is cheap if there is nothing to write and that
         // for flow-control the read may release window that causes data to be written that can now be flushed.
-        ctx.flush();
+        flush(ctx);
     }
 
     /**

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -77,7 +77,13 @@ public class Http2ConnectionHandlerTest {
     private Http2Connection.Endpoint<Http2RemoteFlowController> remote;
 
     @Mock
+    private Http2RemoteFlowController remoteFlowController;
+
+    @Mock
     private Http2Connection.Endpoint<Http2LocalFlowController> local;
+
+    @Mock
+    private Http2LocalFlowController localFlowController;
 
     @Mock
     private ChannelHandlerContext ctx;
@@ -134,7 +140,9 @@ public class Http2ConnectionHandlerTest {
         when(future.channel()).thenReturn(channel);
         when(channel.isActive()).thenReturn(true);
         when(connection.remote()).thenReturn(remote);
+        when(remote.flowController()).thenReturn(remoteFlowController);
         when(connection.local()).thenReturn(local);
+        when(local.flowController()).thenReturn(localFlowController);
         doAnswer(new Answer<Http2Stream>() {
             @Override
             public Http2Stream answer(InvocationOnMock in) throws Throwable {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -120,10 +120,10 @@ public class Http2ConnectionRoundtripTest {
         final Http2Headers headers = dummyHeaders();
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
-            public void run() {
+            public void run() throws Http2Exception {
                 http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, weight, false, 0, true,
                         newPromise());
-                ctx().flush();
+                http2Client.flush(ctx());
             }
         });
 
@@ -157,10 +157,10 @@ public class Http2ConnectionRoundtripTest {
         final Http2Headers headers = dummyHeaders();
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
-            public void run() {
+            public void run() throws Http2Exception {
                 http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0, false,
                         newPromise());
-                ctx().flush();
+                http2Client.flush(ctx());
             }
         });
 
@@ -202,10 +202,10 @@ public class Http2ConnectionRoundtripTest {
         // Create a single stream by sending a HEADERS frame to the server.
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
-            public void run() {
+            public void run() throws Http2Exception {
                 http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0, false,
                         newPromise());
-                ctx().flush();
+                http2Client.flush(ctx());
             }
         });
 
@@ -235,10 +235,10 @@ public class Http2ConnectionRoundtripTest {
         final Http2Headers headers = dummyHeaders();
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
-            public void run() {
+            public void run() throws Http2Exception {
                 http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0, false,
                         newPromise());
-                ctx().flush();
+                http2Client.flush(ctx());
             }
         });
 
@@ -267,10 +267,10 @@ public class Http2ConnectionRoundtripTest {
         final Http2Headers headers = dummyHeaders();
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
-            public void run() {
+            public void run() throws Http2Exception {
                 http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0,
                         true, newPromise());
-                ctx().flush();
+                http2Client.flush(ctx());
             }
         });
 
@@ -278,10 +278,10 @@ public class Http2ConnectionRoundtripTest {
 
         runInChannel(clientChannel, new Http2Runnable() {
             @Override
-            public void run() {
+            public void run() throws Http2Exception {
                 http2Client.encoder().writeHeaders(ctx(), Integer.MAX_VALUE + 1, headers, 0, (short) 16, false, 0,
                         true, newPromise());
-                ctx().flush();
+                http2Client.flush(ctx());
             }
         });
 
@@ -319,7 +319,7 @@ public class Http2ConnectionRoundtripTest {
             // Create the stream and send all of the data at once.
             runInChannel(clientChannel, new Http2Runnable() {
                 @Override
-                public void run() {
+                public void run() throws Http2Exception {
                     http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0,
                             false, newPromise());
                     http2Client.encoder().writeData(ctx(), 3, data.retain(), 0, false, newPromise());
@@ -327,7 +327,7 @@ public class Http2ConnectionRoundtripTest {
                     // Write trailers.
                     http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0,
                             true, newPromise());
-                    ctx().flush();
+                    http2Client.flush(ctx());
                 }
             });
 
@@ -399,7 +399,7 @@ public class Http2ConnectionRoundtripTest {
             bootstrapEnv(numStreams * length, 1, numStreams * 4, numStreams);
             runInChannel(clientChannel, new Http2Runnable() {
                 @Override
-                public void run() {
+                public void run() throws Http2Exception {
                     int upperLimit = 3 + 2 * numStreams;
                     for (int streamId = 3; streamId < upperLimit; streamId += 2) {
                         // Send a bunch of data on each stream.
@@ -412,7 +412,7 @@ public class Http2ConnectionRoundtripTest {
                         // Write trailers.
                         http2Client.encoder().writeHeaders(ctx(), streamId, headers, 0, (short) 16,
                                 false, 0, true, newPromise());
-                        ctx().flush();
+                        http2Client.flush(ctx());
                     }
                 }
             });

--- a/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
@@ -51,7 +51,20 @@ public final class NoopHttp2RemoteFlowController implements Http2RemoteFlowContr
     }
 
     @Override
-    public void sendFlowControlled(ChannelHandlerContext ctx, Http2Stream stream, FlowControlled payload) {
+    public void writePendingBytes() throws Http2Exception {
+    }
+
+    @Override
+    public void listener(Listener listener) {
+    }
+
+    @Override
+    public Listener listener() {
+        return null;
+    }
+
+    @Override
+    public void addFlowControlled(ChannelHandlerContext ctx, Http2Stream stream, FlowControlled payload) {
         // Don't check size beforehand because Headers payload returns 0 all the time.
         do {
             payload.write(MAX_INITIAL_WINDOW_SIZE);


### PR DESCRIPTION
- Remote flow controller can merge small writes into a single DATA frame
- Add listener to remote flow-controller that notifies the number of bytes written for a stream.
- Local flow-controller defers writing WINDOW_UPDATE until asked to do so, this allows for a single WINDOW_UPDATE to be written per stream in a read-write cycle as opposed to one update each time the number of returned bytes triggers the threshold.

This will improve throughput in a number of ways
- Coalescing payloads into a single DATA frame causes fewer onDataRead calls on the remote side
- Applications can use the flow-controller listener to receive more granular notifications of written bytes rather than listening to each individual payload
- Deferring WINDOW_UPDATE allows more flow-control to be returned to the remote side as all consumed bytes are returned and not just the amount consumed when the threshold was crossed.

Fixes
https://github.com/netty/netty/issues/3852