### PR TITLE
HTTP/2 ConnectionHandler close cleanup

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -481,20 +481,16 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     public void closeStream(final Http2Stream stream, ChannelFuture future) {
         stream.close();
 
-        future.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                // If this connection is closing and the graceful shutdown has completed, close the connection
-                // once this operation completes.
-                if (closeListener != null && isGracefulShutdownComplete()) {
-                    ChannelFutureListener closeListener = Http2ConnectionHandler.this.closeListener;
-                    // This method could be called multiple times
-                    // and we don't want to notify the closeListener multiple times.
-                    Http2ConnectionHandler.this.closeListener = null;
-                    closeListener.operationComplete(future);
+        if (future.isDone()) {
+            checkCloseConnection(future);
+        } else {
+            future.addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture future) throws Exception {
+                    checkCloseConnection(future);
                 }
-            }
-        });
+            });
+        }
     }
 
     /**
@@ -620,6 +616,26 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         } catch (Throwable cause) { // Make sure to catch Throwable because we are doing a retain() in this method.
             debugData.release();
             return promise.setFailure(cause);
+        }
+    }
+
+    /**
+     * Closes the connection if the graceful shutdown process has completed.
+     * @param future Represents the status that will be passed to the {@link #closeListener}.
+     */
+    private void checkCloseConnection(ChannelFuture future) {
+        // If this connection is closing and the graceful shutdown has completed, close the connection
+        // once this operation completes.
+        if (closeListener != null && isGracefulShutdownComplete()) {
+            ChannelFutureListener closeListener = Http2ConnectionHandler.this.closeListener;
+            // This method could be called multiple times
+            // and we don't want to notify the closeListener multiple times.
+            Http2ConnectionHandler.this.closeListener = null;
+            try {
+                closeListener.operationComplete(future);
+            } catch (Exception e) {
+                throw new IllegalStateException("Close listener threw an unexpected exception", e);
+            }
         }
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -319,6 +319,9 @@ public class Http2ConnectionHandlerTest {
             }
         }).when(future).addListener(any(GenericFutureListener.class));
         handler.close(ctx, promise);
+        if (future.isDone()) {
+            when(connection.numActiveStreams()).thenReturn(0);
+        }
         handler.closeStream(stream, future);
         // Simulate another stream close call being made after the context should already be closed.
         handler.closeStream(stream, future);


### PR DESCRIPTION
Motiviation:
The connection handler stream close operation is unconditionally adding a listener object to a future. We may not have to add a listener at all because the future has already been completed.

Modifications:
- If the future is done, directly invoke the logic without creating/adding a new listener.

Result:
No need to create/add listener if the future is already done in close logic.