### PR TITLE
[#3848] Respect EPOLLERR event

### DIFF
--- a/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.c
+++ b/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.c
@@ -1598,6 +1598,10 @@ JNIEXPORT jint JNICALL Java_io_netty_channel_epoll_Native_epollrdhup(JNIEnv* env
     return EPOLLRDHUP;
 }
 
+JNIEXPORT jint JNICALL Java_io_netty_channel_epoll_Native_epollerr(JNIEnv* env, jclass clazz) {
+    return EPOLLERR;
+}
+
 JNIEXPORT jint JNICALL Java_io_netty_channel_epoll_Native_sizeofEpollEvent(JNIEnv* env, jclass clazz) {
     return sizeof(struct epoll_event);
 }

--- a/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.h
+++ b/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.h
@@ -119,6 +119,7 @@ jint Java_io_netty_channel_epoll_Native_epollin(JNIEnv* env, jclass clazz);
 jint Java_io_netty_channel_epoll_Native_epollout(JNIEnv* env, jclass clazz);
 jint Java_io_netty_channel_epoll_Native_epollrdhup(JNIEnv* env, jclass clazz);
 jint Java_io_netty_channel_epoll_Native_epollet(JNIEnv* env, jclass clazz);
+jint Java_io_netty_channel_epoll_Native_epollerr(JNIEnv* env, jclass clazz);
 jint Java_io_netty_channel_epoll_Native_sizeofEpollEvent(JNIEnv* env, jclass clazz);
 jint Java_io_netty_channel_epoll_Native_offsetofEpollData(JNIEnv* env, jclass clazz);
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -55,6 +55,7 @@ public final class Native {
     public static final int EPOLLOUT = epollout();
     public static final int EPOLLRDHUP = epollrdhup();
     public static final int EPOLLET = epollet();
+    public static final int EPOLLERR = epollerr();
 
     public static final int IOV_MAX = iovMax();
     public static final int UIO_MAX_IOV = uioMaxIov();
@@ -699,6 +700,7 @@ public final class Native {
     private static native int epollout();
     private static native int epollrdhup();
     private static native int epollet();
+    private static native int epollerr();
 
     private static native long ssizeMax();
     private Native() {


### PR DESCRIPTION
Motivation:

Some glibc/kernel versions will trigger an EPOLLERR event to notify
about failed connect and not an EPOLLOUT. Also EPOLLERR may be triggered
when a connection is broke.

Modification:

React on EPOLLERR like if an EPOLLOUT / EPOLLIN was received, this will work in
all cases as we handle errors in EPOLLOUT / EPOLLIN anyway.

Result:

Correctly detect errors.