### PR TITLE
Correctly respect readerIndex of buffer when dumping.

### DIFF
--- a/handler/src/main/java/io/netty/handler/logging/LoggingHandler.java
+++ b/handler/src/main/java/io/netty/handler/logging/LoggingHandler.java
@@ -419,7 +419,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
 
         // Dump the rows which have 16 bytes.
         for (int row = 0; row < fullRows; row ++) {
-            int rowStartIndex = row << 4;
+            int rowStartIndex = (row << 4) + startIndex;
 
             // Per-row prefix.
             appendHexDumpRowPrefix(dump, row, rowStartIndex);
@@ -440,7 +440,7 @@ public class LoggingHandler extends ChannelDuplexHandler {
 
         // Dump the last row which has less than 16 bytes.
         if (remainder != 0) {
-            int rowStartIndex = fullRows << 4;
+            int rowStartIndex = (fullRows << 4) + startIndex;
             appendHexDumpRowPrefix(dump, fullRows, rowStartIndex);
 
             // Hex dump


### PR DESCRIPTION
Motivation:

The current dumping code does not respect the readerIndex and so logs incorrect.

Modifications:

Respect readerIndex of ByteBuf

Result:

Correctly log content of buffer.