### PR TITLE
Guard against race when calling SslHandler.handshakeFuture().sync()

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1528,5 +1528,19 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             }
             return ctx.executor();
         }
+
+        @Override
+        protected void checkDeadLock() {
+            if (ctx == null) {
+                // If ctx is null the handlerAdded(...) callback was not called, in this case the checkDeadLock()
+                // method was called from another Thread then the one that is used by ctx.executor(). We need to
+                // guard against this as a user can see a race if handshakeFuture().sync() is called but the
+                // handlerAdded(..) method was not yet as it is called from the EventExecutor of the
+                // ChannelHandlerContext. If we not guard against this super.checkDeadLock() would cause an
+                // IllegalStateException when trying to call executor().
+                return;
+            }
+            super.checkDeadLock();
+        }
     }
 }


### PR DESCRIPTION
Motivation:

If the handlerAdded(...) callback was not called, the checkDeadLock() of the handshakeFuture will produce an IllegalStateException.
This was first reported at https://github.com/impossibl/pgjdbc-ng/issues/168 .

Modifications:

Pass deadlock check if ctx is null

Result:

No more race and so IllegalStateException.