### PR TITLE
Ensure no null values are used when add/set headers.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -29,6 +29,8 @@ import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
 public class DefaultHttpHeaders extends HttpHeaders {
 
     private static final int BUCKET_SIZE = 17;
@@ -382,9 +384,7 @@ public class DefaultHttpHeaders extends HttpHeaders {
     }
 
     private static CharSequence toCharSequence(Object value) {
-        if (value == null) {
-            return null;
-        }
+        checkNotNull(value, "value");
         if (value instanceof CharSequence) {
             return (CharSequence) value;
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
@@ -55,4 +55,16 @@ public class HttpHeadersTest {
         assertThat(HttpHeaders.equalsIgnoreCase("bar", null), is(false));
         assertThat(HttpHeaders.equalsIgnoreCase("FoO", "fOo"), is(true));
     }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetNullHeaderValueValidate() {
+        HttpHeaders headers = new DefaultHttpHeaders(true);
+        headers.set("test", (CharSequence) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetNullHeaderValueNotValidate() {
+        HttpHeaders headers = new DefaultHttpHeaders(false);
+        headers.set("test", (CharSequence) null);
+    }
 }


### PR DESCRIPTION
Motivation:

We need to ensure we never allow to have null values set on headers, otherwise we will see a NPE during encoding them.

Modifications:

Add null check.

Result:

Correctly throw exception when a null header value is added/set