### PR TITLE
[#3798] Extract dump method to ByteBufUtil

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -18,7 +18,9 @@ package io.netty.buffer;
 import io.netty.util.CharsetUtil;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -42,6 +44,12 @@ public final class ByteBufUtil {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(ByteBufUtil.class);
 
     private static final char[] HEXDUMP_TABLE = new char[256 * 4];
+    private static final String NEWLINE = StringUtil.NEWLINE;
+    private static final String[] BYTE2HEX = new String[256];
+    private static final String[] HEXPADDING = new String[16];
+    private static final String[] BYTEPADDING = new String[16];
+    private static final char[] BYTE2CHAR = new char[256];
+    private static final String[] HEXDUMP_ROWPREFIXES = new String[65536 >>> 4];
 
     static final ByteBufAllocator DEFAULT_ALLOCATOR;
 
@@ -52,6 +60,52 @@ public final class ByteBufUtil {
         for (int i = 0; i < 256; i ++) {
             HEXDUMP_TABLE[ i << 1     ] = DIGITS[i >>> 4 & 0x0F];
             HEXDUMP_TABLE[(i << 1) + 1] = DIGITS[i       & 0x0F];
+        }
+
+        int i;
+
+        // Generate the lookup table for byte-to-hex-dump conversion
+        for (i = 0; i < BYTE2HEX.length; i ++) {
+            BYTE2HEX[i] = ' ' + StringUtil.byteToHexStringPadded(i);
+        }
+
+        // Generate the lookup table for hex dump paddings
+        for (i = 0; i < HEXPADDING.length; i ++) {
+            int padding = HEXPADDING.length - i;
+            StringBuilder buf = new StringBuilder(padding * 3);
+            for (int j = 0; j < padding; j ++) {
+                buf.append("   ");
+            }
+            HEXPADDING[i] = buf.toString();
+        }
+
+        // Generate the lookup table for byte dump paddings
+        for (i = 0; i < BYTEPADDING.length; i ++) {
+            int padding = BYTEPADDING.length - i;
+            StringBuilder buf = new StringBuilder(padding);
+            for (int j = 0; j < padding; j ++) {
+                buf.append(' ');
+            }
+            BYTEPADDING[i] = buf.toString();
+        }
+
+        // Generate the lookup table for byte-to-char conversion
+        for (i = 0; i < BYTE2CHAR.length; i ++) {
+            if (i <= 0x1f || i >= 0x7f) {
+                BYTE2CHAR[i] = '.';
+            } else {
+                BYTE2CHAR[i] = (char) i;
+            }
+        }
+
+        // Generate the lookup table for the start-offset header in each row (up to 64KiB).
+        for (i = 0; i < HEXDUMP_ROWPREFIXES.length; i ++) {
+            StringBuilder buf = new StringBuilder(12);
+            buf.append(NEWLINE);
+            buf.append(Long.toHexString(i << 4 & 0xFFFFFFFFL | 0x100000000L));
+            buf.setCharAt(buf.length() - 9, '|');
+            buf.append('|');
+            HEXDUMP_ROWPREFIXES[i] = buf.toString();
         }
 
         String allocType = SystemPropertyUtil.get("io.netty.allocator.type", "unpooled").toLowerCase(Locale.US).trim();
@@ -468,6 +522,118 @@ public final class ByteBufUtil {
             throw new IllegalStateException(x);
         }
         return dst.flip().toString();
+    }
+
+    /**
+     * Returns a multi-line hexadecimal dump of the specified {@link ByteBuf} that is easy to read by humans.
+     */
+    public static String prettyHexDump(ByteBuf buffer) {
+        return prettyHexDump(buffer, buffer.readerIndex(), buffer.readableBytes());
+    }
+
+    /**
+     * Returns a multi-line hexadecimal dump of the specified {@link ByteBuf} that is easy to read by humans,
+     * starting at the given {@code offset} using the given {@code length}.
+     */
+    public static String prettyHexDump(ByteBuf buffer, int offset, int length) {
+        if (length == 0) {
+            return StringUtil.EMPTY_STRING;
+        } else {
+            int rows = length / 16 + (length % 15 == 0? 0 : 1) + 4;
+            StringBuilder buf = new StringBuilder(rows * 80);
+            appendPrettyHexDump(buf, buffer, offset, length);
+            return buf.toString();
+        }
+    }
+
+    /**
+     * Appends the prettified multi-line hexadecimal dump of the specified {@link ByteBuf} to the specified
+     * {@link StringBuilder} that is easy to read by humans.
+     */
+    public static void appendPrettyHexDump(StringBuilder dump, ByteBuf buf) {
+        appendPrettyHexDump(dump, buf, buf.readerIndex(), buf.readableBytes());
+    }
+
+    /**
+     * Appends the prettified multi-line hexadecimal dump of the specified {@link ByteBuf} to the specified
+     * {@link StringBuilder} that is easy to read by humans, starting at the given {@code offset} using
+     * the given {@code length}.
+     */
+    public static void appendPrettyHexDump(StringBuilder dump, ByteBuf buf, int offset, int length) {
+        if (offset < 0 || length  > ObjectUtil.checkNotNull(buf, "buf").capacity() - offset) {
+            throw new IndexOutOfBoundsException(
+                    "expected: " + "0 <= offset(" + offset + ") <= offset + length(" + length
+                    + ") <= " + "buf.capacity(" + buf.capacity() + ')');
+        }
+        if (length == 0) {
+            return;
+        }
+        dump.append(
+                "         +-------------------------------------------------+" +
+                NEWLINE + "         |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |" +
+                NEWLINE + "+--------+-------------------------------------------------+----------------+");
+
+        final int startIndex = offset;
+        final int fullRows = length >>> 4;
+        final int remainder = length & 0xF;
+
+        // Dump the rows which have 16 bytes.
+        for (int row = 0; row < fullRows; row ++) {
+            int rowStartIndex = (row << 4) + startIndex;
+
+            // Per-row prefix.
+            appendHexDumpRowPrefix(dump, row, rowStartIndex);
+
+            // Hex dump
+            int rowEndIndex = rowStartIndex + 16;
+            for (int j = rowStartIndex; j < rowEndIndex; j ++) {
+                dump.append(BYTE2HEX[buf.getUnsignedByte(j)]);
+            }
+            dump.append(" |");
+
+            // ASCII dump
+            for (int j = rowStartIndex; j < rowEndIndex; j ++) {
+                dump.append(BYTE2CHAR[buf.getUnsignedByte(j)]);
+            }
+            dump.append('|');
+        }
+
+        // Dump the last row which has less than 16 bytes.
+        if (remainder != 0) {
+            int rowStartIndex = (fullRows << 4) + startIndex;
+            appendHexDumpRowPrefix(dump, fullRows, rowStartIndex);
+
+            // Hex dump
+            int rowEndIndex = rowStartIndex + remainder;
+            for (int j = rowStartIndex; j < rowEndIndex; j ++) {
+                dump.append(BYTE2HEX[buf.getUnsignedByte(j)]);
+            }
+            dump.append(HEXPADDING[remainder]);
+            dump.append(" |");
+
+            // Ascii dump
+            for (int j = rowStartIndex; j < rowEndIndex; j ++) {
+                dump.append(BYTE2CHAR[buf.getUnsignedByte(j)]);
+            }
+            dump.append(BYTEPADDING[remainder]);
+            dump.append('|');
+        }
+
+        dump.append(NEWLINE + "+--------+-------------------------------------------------+----------------+");
+    }
+
+    /**
+     * Appends the prefix of each hex dump row.  Uses the look-up table for the buffer <= 64 KiB.
+     */
+    private static void appendHexDumpRowPrefix(StringBuilder dump, int row, int rowStartIndex) {
+        if (row < HEXDUMP_ROWPREFIXES.length) {
+            dump.append(HEXDUMP_ROWPREFIXES[row]);
+        } else {
+            dump.append(NEWLINE);
+            dump.append(Long.toHexString(rowStartIndex & 0xFFFFFFFFL | 0x100000000L));
+            dump.setCharAt(dump.length() - 9, '|');
+            dump.append('|');
+        }
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/logging/LoggingHandler.java
+++ b/handler/src/main/java/io/netty/handler/logging/LoggingHandler.java
@@ -22,12 +22,14 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogLevel;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.net.SocketAddress;
+
+import static io.netty.buffer.ByteBufUtil.appendPrettyHexDump;
+import static io.netty.util.internal.StringUtil.NEWLINE;
 
 /**
  * A {@link ChannelHandler} that logs all events using a logging framework.
@@ -37,51 +39,6 @@ import java.net.SocketAddress;
 public class LoggingHandler extends ChannelDuplexHandler {
 
     private static final LogLevel DEFAULT_LEVEL = LogLevel.DEBUG;
-
-    private static final String NEWLINE = StringUtil.NEWLINE;
-
-    private static final String[] BYTE2HEX = new String[256];
-    private static final String[] HEXPADDING = new String[16];
-    private static final String[] BYTEPADDING = new String[16];
-    private static final char[] BYTE2CHAR = new char[256];
-
-    static {
-        int i;
-
-        // Generate the lookup table for byte-to-hex-dump conversion
-        for (i = 0; i < BYTE2HEX.length; i ++) {
-            BYTE2HEX[i] = ' ' + StringUtil.byteToHexStringPadded(i);
-        }
-
-        // Generate the lookup table for hex dump paddings
-        for (i = 0; i < HEXPADDING.length; i ++) {
-            int padding = HEXPADDING.length - i;
-            StringBuilder buf = new StringBuilder(padding * 3);
-            for (int j = 0; j < padding; j ++) {
-                buf.append("   ");
-            }
-            HEXPADDING[i] = buf.toString();
-        }
-
-        // Generate the lookup table for byte dump paddings
-        for (i = 0; i < BYTEPADDING.length; i ++) {
-            int padding = BYTEPADDING.length - i;
-            StringBuilder buf = new StringBuilder(padding);
-            for (int j = 0; j < padding; j ++) {
-                buf.append(' ');
-            }
-            BYTEPADDING[i] = buf.toString();
-        }
-
-        // Generate the lookup table for byte-to-char conversion
-        for (i = 0; i < BYTE2CHAR.length; i ++) {
-            if (i <= 0x1f || i >= 0x7f) {
-                BYTE2CHAR[i] = '.';
-            } else {
-                BYTE2CHAR[i] = (char) i;
-            }
-        }
-    }
 
     protected final InternalLogger logger;
     protected final InternalLogLevel internalLevel;
@@ -316,55 +273,21 @@ public class LoggingHandler extends ChannelDuplexHandler {
     /**
      * Returns a String which contains all details to log the {@link ByteBuf}
      */
-    protected String formatByteBuf(String eventName, ByteBuf buf) {
-        int length = buf.readableBytes();
-        int rows = length / 16 + (length % 15 == 0? 0 : 1) + 4;
-        StringBuilder dump = new StringBuilder(rows * 80 + eventName.length() + 16)
+    protected String formatByteBuf(String eventName, ByteBuf msg) {
+        int length = msg.readableBytes();
+        if (length == 0) {
+            StringBuilder buf = new StringBuilder(eventName.length() + 4);
+            buf.append(eventName).append(": 0B");
+            return buf.toString();
+        } else {
+            int rows = length / 16 + (length % 15 == 0? 0 : 1) + 4;
+            StringBuilder buf = new StringBuilder(eventName.length() + 2 + 10 + 1 + 2 + rows * 80);
 
-        .append(eventName).append('(').append(length).append('B').append(')')
-        .append(
-                NEWLINE + "         +-------------------------------------------------+" +
-                        NEWLINE + "         |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |" +
-                        NEWLINE + "+--------+-------------------------------------------------+----------------+");
+            buf.append(eventName).append(": ").append(length).append('B').append(NEWLINE);
+            appendPrettyHexDump(buf, msg);
 
-        final int startIndex = buf.readerIndex();
-        final int endIndex = buf.writerIndex();
-
-        int i;
-        for (i = startIndex; i < endIndex; i ++) {
-            int relIdx = i - startIndex;
-            int relIdxMod16 = relIdx & 15;
-            if (relIdxMod16 == 0) {
-                dump.append(NEWLINE)
-                .append(Long.toHexString(relIdx & 0xFFFFFFFFL | 0x100000000L))
-                .setCharAt(dump.length() - 9, '|');
-                dump.append('|');
-            }
-            dump.append(BYTE2HEX[buf.getUnsignedByte(i)]);
-            if (relIdxMod16 == 15) {
-                dump.append(" |");
-                for (int j = i - 15; j <= i; j ++) {
-                    dump.append(BYTE2CHAR[buf.getUnsignedByte(j)]);
-                }
-                dump.append('|');
-            }
+            return buf.toString();
         }
-
-        if ((i - startIndex & 15) != 0) {
-            int remainder = length & 15;
-            dump.append(HEXPADDING[remainder])
-            .append(" |");
-            for (int j = i - remainder; j < i; j ++) {
-                dump.append(BYTE2CHAR[buf.getUnsignedByte(j)]);
-            }
-            dump.append(BYTEPADDING[remainder])
-            .append('|');
-        }
-
-        dump.append(
-                NEWLINE + "+--------+-------------------------------------------------+----------------+");
-
-        return dump.toString();
     }
 
     /**
@@ -381,7 +304,24 @@ public class LoggingHandler extends ChannelDuplexHandler {
      * using the content of the {@link ByteBufHolder}. Sub-classes may override this.
      */
     protected String formatByteBufHolder(String eventName, ByteBufHolder msg) {
-        return formatByteBuf(eventName, msg.content());
+        String msgStr = msg.toString();
+        ByteBuf content = msg.content();
+        int length = content.readableBytes();
+        if (length == 0) {
+            StringBuilder buf = new StringBuilder(eventName.length() + 2 + msgStr.length() + 4);
+            buf.append(eventName).append(", ").append(msgStr).append(", 0B");
+            return buf.toString();
+        } else {
+            int rows = length / 16 + (length % 15 == 0? 0 : 1) + 4;
+            StringBuilder buf = new StringBuilder(
+                    eventName.length() + 2 + msgStr.length() + 2 + 10 + 1 + 2 + rows * 80);
+
+            buf.append(eventName).append(": ")
+               .append(msgStr).append(", ").append(length).append('B').append(NEWLINE);
+            appendPrettyHexDump(buf, content);
+
+            return buf.toString();
+        }
     }
 }
 


### PR DESCRIPTION
Motivation:

Dumping the content of a ByteBuf in a hex format is very useful.

Modifications:

Move code into ByteBufUtil so its easy to reuse.

Result:

Easy to reuse dumping code.