### PR TITLE
Allow to receive a ChannelGroupFuture that will be notified once all …

### DIFF
--- a/transport/src/main/java/io/netty/channel/group/ChannelGroup.java
+++ b/transport/src/main/java/io/netty/channel/group/ChannelGroup.java
@@ -241,4 +241,16 @@ public interface ChannelGroup extends Set<Channel>, Comparable<ChannelGroup> {
      */
     @Deprecated
     ChannelGroupFuture deregister(ChannelMatcher matcher);
+
+    /**
+     * Returns the {@link ChannelGroupFuture} which will be notified when all {@link Channel}s that are part of this
+     * {@link ChannelGroup}, at the time of calling, are closed.
+     */
+    ChannelGroupFuture newCloseFuture();
+
+    /**
+     * Returns the {@link ChannelGroupFuture} which will be notified when all {@link Channel}s that are part of this
+     * {@link ChannelGroup}, at the time of calling, are closed.
+     */
+    ChannelGroupFuture newCloseFuture(ChannelMatcher matcher);
 }

--- a/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
+++ b/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
@@ -350,6 +350,30 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
     }
 
     @Override
+    public ChannelGroupFuture newCloseFuture() {
+        return newCloseFuture(ChannelMatchers.all());
+    }
+
+    @Override
+    public ChannelGroupFuture newCloseFuture(ChannelMatcher matcher) {
+        Map<Channel, ChannelFuture> futures =
+                new LinkedHashMap<Channel, ChannelFuture>(size());
+
+        for (Channel c: serverChannels.values()) {
+            if (matcher.matches(c)) {
+                futures.put(c, c.closeFuture());
+            }
+        }
+        for (Channel c: nonServerChannels.values()) {
+            if (matcher.matches(c)) {
+                futures.put(c, c.closeFuture());
+            }
+        }
+
+        return new DefaultChannelGroupFuture(this, futures, executor);
+    }
+
+    @Override
     public int hashCode() {
         return System.identityHashCode(this);
     }


### PR DESCRIPTION
…Channels are closed.

Motivation:

It's useful to be able to be notified once all Channels that are part of the ChannelGroup are notified. This can for example be useful if you want to do a graceful shutdown.

Modifications:

- Add ChannelGroup.newCloseFuture(...) which will be notified once all Channels are notified that are part of the ChannelGroup at the time of calling.

Result:

Easier to be notified once all Channels within a ChannelGroup are closed.