### PR TITLE
Not skip first cert when using OpenSslClientContext

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
@@ -184,8 +184,8 @@ public final class OpenSslClientContext extends OpenSslContext {
             }
             synchronized (OpenSslContext.class) {
                 if (trustCertChainFile != null) {
-                    /* Load the certificate chain. We must skip the first cert when server mode */
-                    if (!SSLContext.setCertificateChainFile(ctx, trustCertChainFile.getPath(), true)) {
+                    /* Load the certificate chain. We must NOT skip the first cert when client mode */
+                    if (!SSLContext.setCertificateChainFile(ctx, trustCertChainFile.getPath(), false)) {
                         long error = SSL.getLastErrorNumber();
                         if (OpenSsl.isError(error)) {
                             throw new SSLException(


### PR DESCRIPTION
Motivation:

Due a copy and paste error we incorrectly skipped the first cert in the keyCertChainFile when using OpenSslClientContext.

Modifications:

Correctly not skip the first cert.

Result:

The certificate chain is correctly setup when using OpenSslClientContext.