### PR TITLE
[#3883] OpenSSL SSLSession returns incorrect peer principal

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -1446,7 +1446,7 @@ public final class OpenSslEngine extends SSLEngine {
             if (peer == null || peer.length == 0) {
                 return null;
             }
-            return principal(peer);
+            return ((java.security.cert.X509Certificate) peer[0]).getSubjectX500Principal();
         }
 
         @Override
@@ -1455,11 +1455,7 @@ public final class OpenSslEngine extends SSLEngine {
             if (local == null || local.length == 0) {
                 return null;
             }
-            return principal(local);
-        }
-
-        private Principal principal(Certificate[] certs) {
-            return ((java.security.cert.X509Certificate) certs[0]).getIssuerX500Principal();
+            return ((java.security.cert.X509Certificate) local[0]).getIssuerX500Principal();
         }
 
         @Override


### PR DESCRIPTION
Motivation:

According to the javadocs of SSLSession.getPeerPrincipal should be returning the identity of the peer, while we return the identity of the issuer.

Modifications:

Return the correct indentity.

Result:

Behavior match the documentation.