### PR TITLE
[#3881] FixedChannelPool creates 1 more channel than maxConnections

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -264,7 +264,7 @@ public final class FixedChannelPool extends SimpleChannelPool {
     }
 
     private void runTaskQueue() {
-        while (acquiredChannelCount <= maxConnections) {
+        while (acquiredChannelCount < maxConnections) {
             AcquireTask task = pendingAcquireQueue.poll();
             if (task == null) {
                 break;


### PR DESCRIPTION
Motivation:

FixedChannelPool should enforce a number of maximal used channels, but due a bug we fail to correctly enforce this.

Modifications:

Change check to correctly only acquire channel if we not hit the limit yet.

Result:

Correct limiting.