### PR TITLE
Better error when first HTTP/2 frame is not SETTINGS

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -14,13 +14,11 @@
  */
 package io.netty.handler.codec.http2;
 
-import static io.netty.buffer.ByteBufUtil.hexDump;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.STREAM_CLOSED;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static io.netty.handler.codec.http2.Http2Exception.streamError;
-import static io.netty.handler.codec.http2.Http2FrameTypes.SETTINGS;
 import static io.netty.handler.codec.http2.Http2PromisedRequestVerifier.ALWAYS_VERIFY;
 import static io.netty.handler.codec.http2.Http2Stream.State.CLOSED;
 import static io.netty.handler.codec.http2.Http2Stream.State.HALF_CLOSED_REMOTE;
@@ -48,7 +46,6 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
     private final Http2FrameReader frameReader;
     private final Http2FrameListener listener;
     private final Http2PromisedRequestVerifier requestVerifier;
-    private boolean firstFrame = true;
 
     public DefaultHttp2ConnectionDecoder(Http2Connection connection,
                                          Http2ConnectionEncoder encoder,
@@ -100,34 +97,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
 
     @Override
     public void decodeFrame(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Http2Exception {
-        // If it's the first frame we've decoded, make sure it's a SETTINGS frame.
-        if (firstFrame && verifyFrameIsSettings(in)) {
-            firstFrame = false;
-        }
-
         frameReader.readFrame(ctx, in, internalFrameListener);
-    }
-
-    /**
-     * Peeks at that the next frame in the buffer and verifies that it is a {@code SETTINGS} frame.
-     *
-     * @param in the inbound buffer.
-     * @return {@code} true if the next frame is a {@code SETTINGS} frame, {@code false} if more
-     * data is required before we can determine the next frame type.
-     * @throws Http2Exception thrown if the next frame is NOT a {@code SETTINGS} frame.
-     */
-    private boolean verifyFrameIsSettings(ByteBuf in) throws Http2Exception {
-        if (in.readableBytes() < 4) {
-            // Need more data before we can see the frame type for the first frame.
-            return false;
-        }
-
-        byte frameType = in.getByte(in.readerIndex() + 3);
-        if (frameType != SETTINGS) {
-            throw connectionError(PROTOCOL_ERROR, "First received frame was not SETTINGS. " +
-                    "Hex dump for first 4 bytes: %s", hexDump(in.slice(in.readerIndex(), 4)));
-        }
-        return true;
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -276,8 +276,8 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             // If the input so far doesn't match the preface, break the connection.
             if (bytesRead == 0 || !ByteBufUtil.equals(in, in.readerIndex(),
                     clientPrefaceString, clientPrefaceString.readerIndex(), bytesRead)) {
-                String receivedBytes = hexDump(in.slice(in.readerIndex(),
-                        min(in.readableBytes(), clientPrefaceString.readableBytes())));
+                String receivedBytes = hexDump(in, in.readerIndex(),
+                        min(in.readableBytes(), clientPrefaceString.readableBytes()));
                 throw connectionError(PROTOCOL_ERROR, "HTTP/2 client preface string missing or corrupt. " +
                         "Hex dump for received bytes: %s", receivedBytes);
             }
@@ -310,7 +310,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             byte frameType = in.getByte(in.readerIndex() + 3);
             if (frameType != SETTINGS) {
                 throw connectionError(PROTOCOL_ERROR, "First received frame was not SETTINGS. " +
-                        "Hex dump for first 4 bytes: %s", hexDump(in.slice(in.readerIndex(), 4)));
+                        "Hex dump for first 4 bytes: %s", hexDump(in, in.readerIndex(), 4));
             }
             return true;
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -30,12 +30,14 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
@@ -47,9 +49,6 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.GenericFutureListener;
-
-import java.util.List;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,6 +58,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
+import java.util.List;
 
 /**
  * Tests for {@link Http2ConnectionHandler}
@@ -205,19 +206,9 @@ public class Http2ConnectionHandlerTest {
     public void serverReceivingValidClientPrefaceStringShouldContinueReadingFrames() throws Exception {
         when(connection.isServer()).thenReturn(true);
         handler = newHandler();
-        ByteBuf preface = connectionPrefaceBuf();
-        ByteBuf prefacePlusSome = Unpooled.wrappedBuffer(new byte[preface.readableBytes() + 1]);
-        prefacePlusSome.resetWriterIndex().writeBytes(preface).writeByte(0);
+        ByteBuf prefacePlusSome = addSettingsHeader(Unpooled.buffer().writeBytes(connectionPrefaceBuf()));
         handler.channelRead(ctx, prefacePlusSome);
-        verify(decoder, times(2)).decodeFrame(eq(ctx), any(ByteBuf.class), Matchers.<List<Object>>any());
-    }
-
-    @Test
-    public void serverReceivingValidClientPrefaceStringShouldOnlyReadWholeFrame() throws Exception {
-        when(connection.isServer()).thenReturn(true);
-        handler = newHandler();
-        handler.channelRead(ctx, connectionPrefaceBuf());
-        verify(decoder).decodeFrame(any(ChannelHandlerContext.class),
+        verify(decoder, atLeastOnce()).decodeFrame(any(ChannelHandlerContext.class),
                 any(ByteBuf.class), Matchers.<List<Object>>any());
     }
 
@@ -228,6 +219,7 @@ public class Http2ConnectionHandlerTest {
         // Only read the connection preface...after preface is read internal state of Http2ConnectionHandler
         // is expected to change relative to the pipeline.
         ByteBuf preface = connectionPrefaceBuf();
+        handler.channelRead(ctx, preface);
         verify(decoder, never()).decodeFrame(any(ChannelHandlerContext.class),
                 any(ByteBuf.class), Matchers.<List<Object>>any());
 
@@ -236,10 +228,9 @@ public class Http2ConnectionHandlerTest {
         handler.handlerAdded(ctx);
 
         // Now verify we can continue as normal, reading connection preface plus more.
-        ByteBuf prefacePlusSome = Unpooled.wrappedBuffer(new byte[preface.readableBytes() + 1]);
-        prefacePlusSome.resetWriterIndex().writeBytes(preface).writeByte(0);
+        ByteBuf prefacePlusSome = addSettingsHeader(Unpooled.buffer().writeBytes(connectionPrefaceBuf()));
         handler.channelRead(ctx, prefacePlusSome);
-        verify(decoder, times(2)).decodeFrame(eq(ctx), any(ByteBuf.class), Matchers.<List<Object>>any());
+        verify(decoder, atLeastOnce()).decodeFrame(eq(ctx), any(ByteBuf.class), Matchers.<List<Object>>any());
     }
 
     @Test
@@ -276,7 +267,8 @@ public class Http2ConnectionHandlerTest {
         handler = newHandler();
         handler.resetStream(ctx, NON_EXISTANT_STREAM_ID, STREAM_CLOSED.code(), promise);
         verify(frameWriter, never())
-            .writeRstStream(any(ChannelHandlerContext.class), anyInt(), anyLong(), any(ChannelPromise.class));
+            .writeRstStream(any(ChannelHandlerContext.class), anyInt(), anyLong(),
+                    any(ChannelPromise.class));
         assertTrue(promise.isDone());
         assertTrue(promise.isSuccess());
         assertNull(promise.cause());
@@ -291,7 +283,8 @@ public class Http2ConnectionHandlerTest {
         // The stream is "closed" but is still known about by the connection (connection().stream(..)
         // will return the stream). We should still write a RST_STREAM frame in this scenario.
         handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code(), promise);
-        verify(frameWriter).writeRstStream(eq(ctx), eq(STREAM_ID), anyLong(), any(ChannelPromise.class));
+        verify(frameWriter).writeRstStream(eq(ctx), eq(STREAM_ID), anyLong(),
+                any(ChannelPromise.class));
     }
 
     @SuppressWarnings("unchecked")
@@ -346,7 +339,8 @@ public class Http2ConnectionHandlerTest {
         handler.goAway(ctx, STREAM_ID, errorCode, data, promise);
 
         verify(connection).goAwaySent(eq(STREAM_ID), eq(errorCode), eq(data));
-        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(errorCode), eq(data), eq(promise));
+        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID), eq(errorCode), eq(data),
+                eq(promise));
         verify(ctx).close();
         assertEquals(0, data.refCnt());
     }
@@ -358,7 +352,8 @@ public class Http2ConnectionHandlerTest {
         long errorCode = Http2Error.INTERNAL_ERROR.code();
 
         handler.goAway(ctx, STREAM_ID + 2, errorCode, data.retain(), promise);
-        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID + 2), eq(errorCode), eq(data), eq(promise));
+        verify(frameWriter).writeGoAway(eq(ctx), eq(STREAM_ID + 2), eq(errorCode), eq(data),
+                eq(promise));
         verify(connection).goAwaySent(eq(STREAM_ID + 2), eq(errorCode), eq(data));
         promise = new DefaultChannelPromise(channel);
         handler.goAway(ctx, STREAM_ID, errorCode, data, promise);
@@ -397,5 +392,13 @@ public class Http2ConnectionHandlerTest {
 
     private ByteBuf dummyData() {
         return Unpooled.buffer().writeBytes("abcdefgh".getBytes(CharsetUtil.UTF_8));
+    }
+
+    private ByteBuf addSettingsHeader(ByteBuf buf) {
+        buf.writeMedium(Http2CodecUtil.SETTING_ENTRY_LENGTH);
+        buf.writeByte(Http2FrameTypes.SETTINGS);
+        buf.writeByte(0);
+        buf.writeInt(0);
+        return buf;
     }
 }


### PR DESCRIPTION
Motivation:

Bootstrap of the HTTP/2 can take a lot of paths and a lot of things can go wrong in the initial handshakes leading up to establishment of HTTP/2 between client and server. There have been many times where handshakes have failed silently, leading to very cryptic errors that are hard to debug.

Modifications:

Changed the HTTP/2 handler to ensure that the very first data on the wire (WRT HTTP/2) are SETTINGS/preface+SETTINGS. When this is not the case, a connection error is thrown with the bytes that were found instead.

Result:

Fixes #3880