### PR TITLE
Fix broken constructor chaining for FixedChannelPool class.

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -96,12 +96,7 @@ public final class FixedChannelPool extends SimpleChannelPool {
      */
     public FixedChannelPool(Bootstrap bootstrap,
                             ChannelPoolHandler handler, int maxConnections, int maxPendingAcquires) {
-        super(bootstrap, handler);
-        executor = bootstrap.group().next();
-        timeoutTask = null;
-        acquireTimeoutNanos = -1;
-        this.maxConnections = maxConnections;
-        this.maxPendingAcquires = maxPendingAcquires;
+        this(bootstrap, handler, ChannelHealthChecker.ACTIVE, null, -1, maxConnections, maxPendingAcquires);
     }
 
     /**


### PR DESCRIPTION
Motivation:

Only one of the three FixedChannelPool constructors checks for illegal constructor
arguments. Therfore it was possible to create a pool, say with zero maxConnections.

This change chains all constructors together, so that the last one
in the chain always checks the validity of the arguments, regardless of the
constructor used.

Result:

It is no longer possible to create a FixedChannelPool instance with invalid
maxConnections or maxPendingAcquires parameters.