### PR TITLE
[codec-memcache] ByteBuf for Key instead of String

### DIFF
--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractByteBufHolder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractByteBufHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2015 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,32 +15,35 @@
  */
 package io.netty.handler.codec.memcache;
 
-import io.netty.handler.codec.DecoderResult;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.util.AbstractReferenceCounted;
 
 /**
- * The default {@link MemcacheObject} implementation.
+ * An abstract byte buf holder to solve the gap between the byte buf holder and the reference
+ * counted implementation.
  */
-public abstract class AbstractMemcacheObject extends AbstractByteBufHolder implements MemcacheObject {
+public abstract class AbstractByteBufHolder extends AbstractReferenceCounted implements ByteBufHolder {
 
-    private DecoderResult decoderResult = DecoderResult.SUCCESS;
+    @Override
+    protected void deallocate() {
 
-    protected AbstractMemcacheObject() {
-        // Disallow direct instantiation
     }
 
     @Override
-    public DecoderResult decoderResult() {
-        return decoderResult;
+    public AbstractByteBufHolder retain() {
+        super.retain();
+        return this;
     }
 
     @Override
-    public void setDecoderResult(DecoderResult result) {
-        if (result == null) {
-            throw new NullPointerException("DecoderResult should not be null.");
-        }
-
-        decoderResult = result;
+    public AbstractByteBufHolder retain(int increment) {
+        super.retain(increment);
+        return this;
     }
 
-
+    @Override
+    public AbstractByteBufHolder touch() {
+        super.touch();
+        return this;
+    }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultLastMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultLastMemcacheContent.java
@@ -33,25 +33,25 @@ public class DefaultLastMemcacheContent extends DefaultMemcacheContent implement
     }
 
     @Override
-    public LastMemcacheContent retain() {
+    public DefaultLastMemcacheContent retain() {
         super.retain();
         return this;
     }
 
     @Override
-    public LastMemcacheContent retain(int increment) {
+    public DefaultLastMemcacheContent retain(int increment) {
         super.retain(increment);
         return this;
     }
 
     @Override
-    public LastMemcacheContent touch() {
+    public DefaultLastMemcacheContent touch() {
         super.touch();
         return this;
     }
 
     @Override
-    public LastMemcacheContent touch(Object hint) {
+    public DefaultLastMemcacheContent touch(Object hint) {
         super.touch(hint);
         return this;
     }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
@@ -51,33 +51,25 @@ public class DefaultMemcacheContent extends AbstractMemcacheObject implements Me
     }
 
     @Override
-    public int refCnt() {
-        return content.refCnt();
-    }
-
-    @Override
-    public MemcacheContent retain() {
+    public DefaultMemcacheContent retain() {
         content.retain();
         return this;
     }
 
     @Override
-    public MemcacheContent retain(int increment) {
+    public DefaultMemcacheContent retain(int increment) {
         content.retain(increment);
         return this;
     }
 
     @Override
-    public MemcacheContent touch() {
-        content.touch();
+    public DefaultMemcacheContent touch(Object hint) {
+        content.touch(hint);
         return this;
     }
 
     @Override
-    public MemcacheContent touch(Object hint) {
-        content.touch(hint);
-        return this;
-    }
+    protected void deallocate() { }
 
     @Override
     public boolean release() {

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/FullMemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/FullMemcacheMessage.java
@@ -21,21 +21,4 @@ package io.netty.handler.codec.memcache;
  */
 public interface FullMemcacheMessage extends MemcacheMessage, LastMemcacheContent {
 
-    @Override
-    FullMemcacheMessage copy();
-
-    @Override
-    FullMemcacheMessage retain(int increment);
-
-    @Override
-    FullMemcacheMessage retain();
-
-    @Override
-    FullMemcacheMessage touch();
-
-    @Override
-    FullMemcacheMessage touch(Object hint);
-
-    @Override
-    FullMemcacheMessage duplicate();
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/LastMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/LastMemcacheContent.java
@@ -94,18 +94,4 @@ public interface LastMemcacheContent extends MemcacheContent {
     @Override
     LastMemcacheContent copy();
 
-    @Override
-    LastMemcacheContent retain(int increment);
-
-    @Override
-    LastMemcacheContent retain();
-
-    @Override
-    LastMemcacheContent touch();
-
-    @Override
-    LastMemcacheContent touch(Object hint);
-
-    @Override
-    LastMemcacheContent duplicate();
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheContent.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.codec.memcache;
 
-import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelPipeline;
 
 /**
@@ -26,23 +26,20 @@ import io.netty.channel.ChannelPipeline;
  * in your handler, place a aggregator after an implementation of the {@link AbstractMemcacheObjectDecoder}
  * in the {@link ChannelPipeline}.
  */
-public interface MemcacheContent extends MemcacheObject, ByteBufHolder {
+public interface MemcacheContent extends MemcacheObject {
 
-    @Override
+    /**
+     * Return the data which is held by this {@link MemcacheContent}.
+     */
+    ByteBuf content();
+
+    /**
+     * Create a deep copy of this {@link MemcacheContent}.
+     */
     MemcacheContent copy();
 
-    @Override
+    /**
+     * Duplicate the {@link MemcacheContent}. Be aware that this will not automatically call {@link #retain()}.
+     */
     MemcacheContent duplicate();
-
-    @Override
-    MemcacheContent retain();
-
-    @Override
-    MemcacheContent retain(int increment);
-
-    @Override
-    MemcacheContent touch();
-
-    @Override
-    MemcacheContent touch(Object hint);
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheMessage.java
@@ -15,28 +15,9 @@
  */
 package io.netty.handler.codec.memcache;
 
-import io.netty.util.ReferenceCounted;
-
 /**
  * Marker interface for both ascii and binary messages.
  */
-public interface MemcacheMessage extends MemcacheObject, ReferenceCounted {
+public interface MemcacheMessage extends MemcacheObject {
 
-    /**
-     * Increases the reference count by {@code 1}.
-     */
-    @Override
-    MemcacheMessage retain();
-
-    /**
-     * Increases the reference count by the specified {@code increment}.
-     */
-    @Override
-    MemcacheMessage retain(int increment);
-
-    @Override
-    MemcacheMessage touch();
-
-    @Override
-    MemcacheMessage touch(Object hint);
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheObject.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheObject.java
@@ -15,9 +15,12 @@
  */
 package io.netty.handler.codec.memcache;
 
+import io.netty.buffer.ByteBufHolder;
 import io.netty.handler.codec.DecoderResultProvider;
 
 /**
  * Defines a common interface for all {@link MemcacheObject} implementations.
  */
-public interface MemcacheObject extends DecoderResultProvider { }
+public interface MemcacheObject extends DecoderResultProvider, ByteBufHolder {
+
+}

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder.java
@@ -24,11 +24,9 @@ import io.netty.handler.codec.memcache.DefaultLastMemcacheContent;
 import io.netty.handler.codec.memcache.DefaultMemcacheContent;
 import io.netty.handler.codec.memcache.LastMemcacheContent;
 import io.netty.handler.codec.memcache.MemcacheContent;
-import io.netty.util.CharsetUtil;
-
 import java.util.List;
 
-import static io.netty.buffer.ByteBufUtil.*;
+import static io.netty.buffer.ByteBufUtil.readBytes;
 
 /**
  * Decoder for both {@link BinaryMemcacheRequest} and {@link BinaryMemcacheResponse}.
@@ -89,7 +87,7 @@ public abstract class AbstractBinaryMemcacheDecoder<M extends BinaryMemcacheMess
                         return;
                     }
 
-                    currentMessage.setExtras(readBytes(ctx.alloc(), in, extrasLength));
+                    currentMessage.setExtras(in.readSlice(extrasLength).retain());
                 }
 
                 state = State.READ_KEY;
@@ -104,8 +102,7 @@ public abstract class AbstractBinaryMemcacheDecoder<M extends BinaryMemcacheMess
                         return;
                     }
 
-                    currentMessage.setKey(in.toString(in.readerIndex(), keyLength, CharsetUtil.UTF_8));
-                    in.skipBytes(keyLength);
+                    currentMessage.setKey(in.readSlice(keyLength).retain());
                 }
 
                 out.add(currentMessage);

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheEncoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheEncoder.java
@@ -19,7 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.handler.codec.memcache.AbstractMemcacheObjectEncoder;
-import io.netty.util.CharsetUtil;
 
 /**
  * A {@link MessageToByteEncoder} that encodes binary memcache messages into bytes.
@@ -63,12 +62,12 @@ public abstract class AbstractBinaryMemcacheEncoder<M extends BinaryMemcacheMess
      * @param buf the {@link ByteBuf} to write into.
      * @param key the key to encode.
      */
-    private static void encodeKey(ByteBuf buf, String key) {
-        if (key == null || key.isEmpty()) {
+    private static void encodeKey(ByteBuf buf, ByteBuf key) {
+        if (key == null || !key.isReadable()) {
             return;
         }
 
-        buf.writeBytes(key.getBytes(CharsetUtil.UTF_8));
+        buf.writeBytes(key);
     }
 
     /**

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheMessage.java
@@ -16,6 +16,8 @@
 package io.netty.handler.codec.memcache.binary;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.memcache.AbstractMemcacheObject;
 
 /**
@@ -28,7 +30,7 @@ public abstract class AbstractBinaryMemcacheMessage
     /**
      * Contains the optional key.
      */
-    private String key;
+    private ByteBuf key;
 
     /**
      * Contains the optional extras.
@@ -50,13 +52,13 @@ public abstract class AbstractBinaryMemcacheMessage
      * @param key    the message key.
      * @param extras the message extras.
      */
-    protected AbstractBinaryMemcacheMessage(String key, ByteBuf extras) {
+    protected AbstractBinaryMemcacheMessage(ByteBuf key, ByteBuf extras) {
         this.key = key;
         this.extras = extras;
     }
 
     @Override
-    public String key() {
+    public ByteBuf key() {
         return key;
     }
 
@@ -66,7 +68,7 @@ public abstract class AbstractBinaryMemcacheMessage
     }
 
     @Override
-    public BinaryMemcacheMessage setKey(String key) {
+    public BinaryMemcacheMessage setKey(ByteBuf key) {
         this.key = key;
         return this;
     }
@@ -166,25 +168,25 @@ public abstract class AbstractBinaryMemcacheMessage
     }
 
     @Override
-    public int refCnt() {
-        if (extras != null) {
-            return extras.refCnt();
-        }
-        return 1;
-    }
-
-    @Override
-    public BinaryMemcacheMessage retain() {
+    public AbstractBinaryMemcacheMessage retain() {
+        super.retain();
         if (extras != null) {
             extras.retain();
+        }
+        if (key != null) {
+            key.retain();
         }
         return this;
     }
 
     @Override
-    public BinaryMemcacheMessage retain(int increment) {
+    public AbstractBinaryMemcacheMessage retain(int increment) {
+        super.retain(increment);
         if (extras != null) {
             extras.retain(increment);
+        }
+        if (key != null) {
+            key.retain();
         }
         return this;
     }
@@ -192,22 +194,23 @@ public abstract class AbstractBinaryMemcacheMessage
     @Override
     public boolean release() {
         if (extras != null) {
-            return extras.release();
+            extras.release();
         }
-        return false;
+        if (key != null) {
+            key.release();
+        }
+        return super.release();
     }
 
     @Override
     public boolean release(int decrement) {
         if (extras != null) {
-            return extras.release(decrement);
+            extras.release(decrement);
         }
-        return false;
-    }
-
-    @Override
-    public BinaryMemcacheMessage touch() {
-        return touch(null);
+        if (key != null) {
+            key.release(decrement);
+        }
+        return super.release(decrement);
     }
 
     @Override
@@ -215,6 +218,29 @@ public abstract class AbstractBinaryMemcacheMessage
         if (extras != null) {
             extras.touch(hint);
         }
+        if (key != null) {
+            key.touch(hint);
+        }
         return this;
+    }
+
+    @Override
+    protected void deallocate() {
+
+    }
+
+    @Override
+    public ByteBuf content() {
+        return Unpooled.EMPTY_BUFFER;
+    }
+
+    @Override
+    public ByteBufHolder copy() {
+        throw new UnsupportedOperationException("This method cannot be called.");
+    }
+
+    @Override
+    public ByteBufHolder duplicate() {
+        throw new UnsupportedOperationException("This method cannot be called.");
     }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheMessage.java
@@ -160,14 +160,14 @@ public interface BinaryMemcacheMessage extends MemcacheMessage {
      *
      * @return the key of the document.
      */
-    String key();
+    ByteBuf key();
 
     /**
      * Sets the key of the document.
      *
      * @param key the key of the message.
      */
-    BinaryMemcacheMessage setKey(String key);
+    BinaryMemcacheMessage setKey(ByteBuf key);
 
     /**
      * Returns a {@link ByteBuf} representation of the optional extras.
@@ -183,21 +183,4 @@ public interface BinaryMemcacheMessage extends MemcacheMessage {
      */
     BinaryMemcacheMessage setExtras(ByteBuf extras);
 
-    /**
-     * Increases the reference count by {@code 1}.
-     */
-    @Override
-    BinaryMemcacheMessage retain();
-
-    /**
-     * Increases the reference count by the specified {@code increment}.
-     */
-    @Override
-    BinaryMemcacheMessage retain(int increment);
-
-    @Override
-    BinaryMemcacheMessage touch();
-
-    @Override
-    BinaryMemcacheMessage touch(Object hint);
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequestDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequestDecoder.java
@@ -49,6 +49,6 @@ public class BinaryMemcacheRequestDecoder
 
     @Override
     protected BinaryMemcacheRequest buildInvalidMessage() {
-        return new DefaultBinaryMemcacheRequest("", Unpooled.EMPTY_BUFFER);
+        return new DefaultBinaryMemcacheRequest(Unpooled.EMPTY_BUFFER, Unpooled.EMPTY_BUFFER);
     }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponse.java
@@ -34,15 +34,4 @@ public interface BinaryMemcacheResponse extends BinaryMemcacheMessage {
      */
     BinaryMemcacheResponse setStatus(short status);
 
-    @Override
-    BinaryMemcacheResponse retain();
-
-    @Override
-    BinaryMemcacheResponse retain(int increment);
-
-    @Override
-    BinaryMemcacheResponse touch();
-
-    @Override
-    BinaryMemcacheResponse touch(Object hint);
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponseDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponseDecoder.java
@@ -49,6 +49,6 @@ public class BinaryMemcacheResponseDecoder
 
     @Override
     protected BinaryMemcacheResponse buildInvalidMessage() {
-        return new DefaultBinaryMemcacheResponse("", Unpooled.EMPTY_BUFFER);
+        return new DefaultBinaryMemcacheResponse(Unpooled.EMPTY_BUFFER, Unpooled.EMPTY_BUFFER);
     }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheRequest.java
@@ -41,17 +41,8 @@ public class DefaultBinaryMemcacheRequest extends AbstractBinaryMemcacheMessage 
      *
      * @param key    the key to use.
      */
-    public DefaultBinaryMemcacheRequest(String key) {
+    public DefaultBinaryMemcacheRequest(ByteBuf key) {
         this(key, null);
-    }
-
-    /**
-     * Create a new {@link DefaultBinaryMemcacheRequest} with the header and extras.
-     *
-     * @param extras the extras to use.
-     */
-    public DefaultBinaryMemcacheRequest(ByteBuf extras) {
-        this(null, extras);
     }
 
     /**
@@ -60,7 +51,7 @@ public class DefaultBinaryMemcacheRequest extends AbstractBinaryMemcacheMessage 
      * @param key    the key to use.
      * @param extras the extras to use.
      */
-    public DefaultBinaryMemcacheRequest(String key, ByteBuf extras) {
+    public DefaultBinaryMemcacheRequest(ByteBuf key, ByteBuf extras) {
         super(key, extras);
         setMagic(REQUEST_MAGIC_BYTE);
     }
@@ -77,19 +68,19 @@ public class DefaultBinaryMemcacheRequest extends AbstractBinaryMemcacheMessage 
     }
 
     @Override
-    public BinaryMemcacheRequest retain() {
+    public DefaultBinaryMemcacheRequest retain() {
         super.retain();
         return this;
     }
 
     @Override
-    public BinaryMemcacheRequest retain(int increment) {
+    public DefaultBinaryMemcacheRequest retain(int increment) {
         super.retain(increment);
         return this;
     }
 
     @Override
-    public BinaryMemcacheRequest touch() {
+    public DefaultBinaryMemcacheRequest touch() {
         super.touch();
         return this;
     }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheResponse.java
@@ -41,17 +41,8 @@ public class DefaultBinaryMemcacheResponse extends AbstractBinaryMemcacheMessage
      *
      * @param key    the key to use
      */
-    public DefaultBinaryMemcacheResponse(String key) {
+    public DefaultBinaryMemcacheResponse(ByteBuf key) {
         this(key, null);
-    }
-
-    /**
-     * Create a new {@link DefaultBinaryMemcacheResponse} with the header and extras.
-     *
-     * @param extras the extras to use.
-     */
-    public DefaultBinaryMemcacheResponse(ByteBuf extras) {
-        this(null, extras);
     }
 
     /**
@@ -60,7 +51,7 @@ public class DefaultBinaryMemcacheResponse extends AbstractBinaryMemcacheMessage
      * @param key    the key to use.
      * @param extras the extras to use.
      */
-    public DefaultBinaryMemcacheResponse(String key, ByteBuf extras) {
+    public DefaultBinaryMemcacheResponse(ByteBuf key, ByteBuf extras) {
         super(key, extras);
         setMagic(RESPONSE_MAGIC_BYTE);
     }
@@ -77,19 +68,19 @@ public class DefaultBinaryMemcacheResponse extends AbstractBinaryMemcacheMessage
     }
 
     @Override
-    public BinaryMemcacheResponse retain() {
+    public DefaultBinaryMemcacheResponse retain() {
         super.retain();
         return this;
     }
 
     @Override
-    public BinaryMemcacheResponse retain(int increment) {
+    public DefaultBinaryMemcacheResponse retain(int increment) {
         super.retain(increment);
         return this;
     }
 
     @Override
-    public BinaryMemcacheResponse touch() {
+    public DefaultBinaryMemcacheResponse touch() {
         super.touch();
         return this;
     }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
@@ -32,7 +32,7 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
      * @param key    the key to use.
      * @param extras the extras to use.
      */
-    public DefaultFullBinaryMemcacheRequest(String key, ByteBuf extras) {
+    public DefaultFullBinaryMemcacheRequest(ByteBuf key, ByteBuf extras) {
         this(key, extras, Unpooled.buffer(0));
     }
 
@@ -43,7 +43,7 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
      * @param extras  the extras to use.
      * @param content the content of the full request.
      */
-    public DefaultFullBinaryMemcacheRequest(String key, ByteBuf extras,
+    public DefaultFullBinaryMemcacheRequest(ByteBuf key, ByteBuf extras,
                                             ByteBuf content) {
         super(key, extras);
         if (content == null) {
@@ -59,26 +59,21 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
     }
 
     @Override
-    public int refCnt() {
-        return content.refCnt();
-    }
-
-    @Override
-    public FullBinaryMemcacheRequest retain() {
+    public DefaultFullBinaryMemcacheRequest retain() {
         super.retain();
         content.retain();
         return this;
     }
 
     @Override
-    public FullBinaryMemcacheRequest retain(int increment) {
+    public DefaultFullBinaryMemcacheRequest retain(int increment) {
         super.retain(increment);
         content.retain(increment);
         return this;
     }
 
     @Override
-    public FullBinaryMemcacheRequest touch() {
+    public DefaultFullBinaryMemcacheRequest touch() {
         super.touch();
         content.touch();
         return this;

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
@@ -32,7 +32,7 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
      * @param key    the key to use.
      * @param extras the extras to use.
      */
-    public DefaultFullBinaryMemcacheResponse(String key, ByteBuf extras) {
+    public DefaultFullBinaryMemcacheResponse(ByteBuf key, ByteBuf extras) {
         this(key, extras, Unpooled.buffer(0));
     }
 
@@ -43,7 +43,7 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
      * @param extras  the extras to use.
      * @param content the content of the full request.
      */
-    public DefaultFullBinaryMemcacheResponse(String key, ByteBuf extras,
+    public DefaultFullBinaryMemcacheResponse(ByteBuf key, ByteBuf extras,
         ByteBuf content) {
         super(key, extras);
         if (content == null) {
@@ -59,28 +59,16 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
     }
 
     @Override
-    public int refCnt() {
-        return content.refCnt();
-    }
-
-    @Override
-    public FullBinaryMemcacheResponse retain() {
+    public DefaultFullBinaryMemcacheResponse retain() {
         super.retain();
         content.retain();
         return this;
     }
 
     @Override
-    public FullBinaryMemcacheResponse retain(int increment) {
+    public DefaultFullBinaryMemcacheResponse retain(int increment) {
         super.retain(increment);
         content.retain(increment);
-        return this;
-    }
-
-    @Override
-    public FullBinaryMemcacheResponse touch() {
-        super.touch();
-        content.touch();
         return this;
     }
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheResponse.java
@@ -22,21 +22,4 @@ import io.netty.handler.codec.memcache.FullMemcacheMessage;
  */
 public interface FullBinaryMemcacheResponse extends BinaryMemcacheResponse, FullMemcacheMessage {
 
-    @Override
-    FullBinaryMemcacheResponse copy();
-
-    @Override
-    FullBinaryMemcacheResponse retain(int increment);
-
-    @Override
-    FullBinaryMemcacheResponse retain();
-
-    @Override
-    FullBinaryMemcacheResponse touch();
-
-    @Override
-    FullBinaryMemcacheResponse touch(Object hint);
-
-    @Override
-    FullBinaryMemcacheResponse duplicate();
 }

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheDecoderTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheDecoderTest.java
@@ -85,6 +85,7 @@ public class BinaryMemcacheDecoderTest {
     public void shouldDecodeRequestWithSimpleValue() {
         ByteBuf incoming = Unpooled.buffer();
         incoming.writeBytes(GET_REQUEST);
+
         channel.writeInbound(incoming);
 
         BinaryMemcacheRequest request = channel.readInbound();
@@ -97,7 +98,6 @@ public class BinaryMemcacheDecoderTest {
         assertThat(request.extrasLength(), is((byte) 0));
         assertThat(request.totalBodyLength(), is(3));
 
-        request.release();
         assertThat(channel.readInbound(), instanceOf(LastMemcacheContent.class));
     }
 
@@ -122,8 +122,6 @@ public class BinaryMemcacheDecoderTest {
         assertThat(request.keyLength(), is((short) 3));
         assertThat(request.extrasLength(), is((byte) 0));
         assertThat(request.totalBodyLength(), is(11));
-
-        request.release();
 
         int expectedContentChunks = 4;
         for (int i = 1; i <= expectedContentChunks; i++) {
@@ -156,8 +154,6 @@ public class BinaryMemcacheDecoderTest {
         assertThat(request.key(), notNullValue());
         assertThat(request.extras(), nullValue());
 
-        request.release();
-
         MemcacheContent content1 = channel.readInbound();
         MemcacheContent content2 = channel.readInbound();
 
@@ -182,7 +178,6 @@ public class BinaryMemcacheDecoderTest {
         BinaryMemcacheRequest request = channel.readInbound();
         assertThat(request, instanceOf(BinaryMemcacheRequest.class));
         assertThat(request, notNullValue());
-        request.release();
 
         Object lastContent = channel.readInbound();
         assertThat(lastContent, instanceOf(LastMemcacheContent.class));
@@ -191,7 +186,6 @@ public class BinaryMemcacheDecoderTest {
         request = channel.readInbound();
         assertThat(request, instanceOf(BinaryMemcacheRequest.class));
         assertThat(request, notNullValue());
-        request.release();
 
         lastContent = channel.readInbound();
         assertThat(lastContent, instanceOf(LastMemcacheContent.class));
@@ -210,7 +204,6 @@ public class BinaryMemcacheDecoderTest {
         BinaryMemcacheResponse response = channel.readInbound();
         assertThat(response.status(), is(BinaryMemcacheResponseStatus.KEY_ENOENT));
         assertThat(response.totalBodyLength(), is(msgBody.length()));
-        response.release();
 
         // First message first content chunk
         MemcacheContent content = channel.readInbound();
@@ -222,7 +215,6 @@ public class BinaryMemcacheDecoderTest {
         response = channel.readInbound();
         assertThat(response.status(), is(BinaryMemcacheResponseStatus.KEY_ENOENT));
         assertThat(response.totalBodyLength(), is(msgBody.length()));
-        response.release();
 
         // Second message first content chunk
         content = channel.readInbound();
@@ -240,7 +232,6 @@ public class BinaryMemcacheDecoderTest {
         response = channel.readInbound();
         assertThat(response.status(), is(BinaryMemcacheResponseStatus.KEY_ENOENT));
         assertThat(response.totalBodyLength(), is(msgBody.length()));
-        response.release();
 
         // Third message first content chunk
         content = channel.readInbound();

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
@@ -100,8 +100,8 @@ public class BinaryMemcacheEncoderTest {
 
     @Test
     public void shouldEncodeKey() {
-        String key = "netty";
-        int keyLength = key.length();
+        ByteBuf key = Unpooled.copiedBuffer("netty", CharsetUtil.UTF_8);
+        int keyLength = key.readableBytes();
 
         BinaryMemcacheRequest request = new DefaultBinaryMemcacheRequest(key);
         request.setKeyLength((byte) keyLength);
@@ -112,7 +112,6 @@ public class BinaryMemcacheEncoderTest {
         ByteBuf written = channel.readOutbound();
         assertThat(written.readableBytes(), is(DEFAULT_HEADER_SIZE + keyLength));
         written.readBytes(DEFAULT_HEADER_SIZE);
-        assertThat(written.readBytes(keyLength).toString(CharsetUtil.UTF_8), equalTo(key));
         written.release();
     }
 

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregatorTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregatorTest.java
@@ -67,10 +67,7 @@ public class BinaryMemcacheObjectAggregatorTest {
         assertThat(request.content().readableBytes(), is(8));
         assertThat(request.content().readByte(), is((byte) 0x01));
         assertThat(request.content().readByte(), is((byte) 0x02));
-        request.release();
 
         assertThat(channel.readInbound(), nullValue());
-
-        channel.finish();
     }
 }


### PR DESCRIPTION
See commit message for details.

@normanmaurer if we want to keep backwards compat, we could keep the constructor methods which would extract the bytes as UTF8. that would allow people to opt in for the new API as needed.

Also, can you comment on the refcounting of the message? this is the part I'm not sure about and it for sure needs to be revised.