### PR TITLE
maxAge my overflow while encoding in ServerCookieEncoder.java

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
@@ -93,7 +93,7 @@ public final class ServerCookieEncoder extends CookieEncoder {
 
         if (cookie.maxAge() != Long.MIN_VALUE) {
             add(buf, CookieHeaderNames.MAX_AGE, cookie.maxAge());
-            Date expires = new Date(cookie.maxAge() * 1000 + System.currentTimeMillis());
+            Date expires = new Date(cookie.maxAge() *1L * 1000 + System.currentTimeMillis());
             add(buf, CookieHeaderNames.EXPIRES, HttpHeaderDateFormat.get().format(expires));
         }
 


### PR DESCRIPTION
maxAge may overflow while encoding.
if a cookie's maxAge is a month, which is 30 * 24 * 60 * 60 = 2592000 seconds, then
cookie.maxAge() * 1000 = -1702967296.

change this expression to "cookie.maxAge() *1L * 1000"