### PR TITLE
Composite byte buf in data frame coalescing

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -15,14 +15,11 @@
 package io.netty.handler.codec.http2;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
-import static io.netty.handler.codec.http2.Http2CodecUtil.connectionPrefaceBuf;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
-import io.netty.buffer.SlicedByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -31,7 +28,6 @@ import io.netty.handler.codec.http2.Http2Exception.ClosedStreamCreationException
 import io.netty.util.ReferenceCountUtil;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 
 /**
  * Default implementation of {@link Http2ConnectionEncoder}.


### PR DESCRIPTION
By releasing the read components of the CompositeByteBuffer on completion of the write future it causes any outstanding slices of the underlying composite buffer to have incorrect indices.

Fixes https://github.com/netty/netty/issues/3914