### PR TITLE
Fix invalid check arguments in 'OpenSslServerContext.setTicketKeys'

### DIFF
--- a/src/main/java/org/jboss/netty/handler/ssl/OpenSslServerContext.java
+++ b/src/main/java/org/jboss/netty/handler/ssl/OpenSslServerContext.java
@@ -331,7 +331,7 @@ public final class OpenSslServerContext extends SslContext {
      * Sets the SSL session ticket keys of this context.
      */
     public void setTicketKeys(byte[] keys) {
-        if (keys != null) {
+        if (keys == null) {
             throw new NullPointerException("keys");
         }
         SSLContext.setSessionTicketKeys(ctx, keys);


### PR DESCRIPTION
Motivation:

Invalid checking arguments causes the function not to work.

Modifications:

Modified checking arguments.

Result:

Fixes #3922