### PR TITLE
Make sure bytesToReturn > 0 before calling flowController.consumeByte…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -249,9 +249,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                 throw e;
             } finally {
                 // If appropriate, return the processed bytes to the flow controller.
-                if (bytesToReturn > 0) {
-                    flowController.consumeBytes(ctx, stream, bytesToReturn);
-                }
+                flowController.consumeBytes(ctx, stream, bytesToReturn);
 
                 if (endOfStream) {
                     lifecycleManager.closeStreamRemote(stream, ctx.newSucceededFuture());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -253,14 +253,13 @@ public class DefaultHttp2ConnectionDecoderTest {
     public void emptyDataFrameShouldApplyFlowControl() throws Exception {
         final ByteBuf data = EMPTY_BUFFER;
         int padding = 0;
-        int processedBytes = data.readableBytes() + padding;
-        mockFlowControl(processedBytes);
+        mockFlowControl(0);
         try {
             decode().onDataRead(ctx, STREAM_ID, data, padding, true);
             verify(localFlow).receiveFlowControlledFrame(eq(ctx), eq(stream), eq(data), eq(padding), eq(true));
 
-            // No bytes were consumed, so there's no window update needed.
-            verify(localFlow, never()).consumeBytes(eq(ctx), eq(stream), eq(processedBytes));
+            // Now we ignore the empty bytes inside consumeBytes method, so it will be called once.
+            verify(localFlow).consumeBytes(eq(ctx), eq(stream), eq(0));
 
             // Verify that the empty data event was propagated to the observer.
             verify(listener).onDataRead(eq(ctx), eq(STREAM_ID), eq(data), eq(padding), eq(true));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -247,6 +247,16 @@ public class DefaultHttp2LocalFlowControllerTest {
         testRatio(ratio, DEFAULT_WINDOW_SIZE << 1, 3, true);
     }
 
+    @Test
+    public void consumeBytesForZeroNumBytesShouldIgnore() throws Http2Exception {
+        assertFalse(controller.consumeBytes(ctx, connection.stream(STREAM_ID), 0));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void consumeBytesForNegativeNumBytesShouldFail() throws Http2Exception {
+        assertFalse(controller.consumeBytes(ctx, connection.stream(STREAM_ID), -1));
+    }
+
     private void testRatio(float ratio, int newDefaultWindowSize, int newStreamId, boolean setStreamRatio)
             throws Http2Exception {
         int delta = newDefaultWindowSize - DEFAULT_WINDOW_SIZE;


### PR DESCRIPTION
…s when ignoring frame in FrameReadListener.onDataRead.

Motivation:

Sometimes people use a data frame with length 0 to end a stream(such as jetty http2-server). So it is possible that data.readableBytes and padding are all 0 for a data frame, and cause a IllegalArgumentException when calling flowController.consumeBytes.

Modifications:

Add a 'bytesToReturn > 0' check before calling flowController.consumeBytes.

Result:

Fix IllegalArgumentException.