### PR TITLE
[#3780] Handle ChannelInitializer exception in exceptionCaught()

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelInitializer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelInitializer.java
@@ -56,29 +56,33 @@ public abstract class ChannelInitializer<C extends Channel> extends ChannelInbou
      * will be removed from the {@link ChannelPipeline} of the {@link Channel}.
      *
      * @param ch            the {@link Channel} which was registered.
-     * @throws Exception    is thrown if an error occurs. In that case the {@link Channel} will be closed.
+     * @throws Exception    is thrown if an error occurs. In that case it will be handled by
+     *                      {@link #exceptionCaught(ChannelHandlerContext, Throwable)} which will by default close
+     *                      the {@link Channel}.
      */
     protected abstract void initChannel(C ch) throws Exception;
 
     @Override
     @SuppressWarnings("unchecked")
     public final void channelRegistered(ChannelHandlerContext ctx) throws Exception {
-        ChannelPipeline pipeline = ctx.pipeline();
-        boolean success = false;
+        initChannel((C) ctx.channel());
+        ctx.pipeline().remove(this);
+        ctx.fireChannelRegistered();
+    }
+
+    /**
+     * Handle the {@link Throwable} by logging and closing the {@link Channel}. Sub-classes may override this.
+     */
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        logger.warn("Failed to initialize a channel. Closing: " + ctx.channel(), cause);
         try {
-            initChannel((C) ctx.channel());
-            pipeline.remove(this);
-            ctx.fireChannelRegistered();
-            success = true;
-        } catch (Throwable t) {
-            logger.warn("Failed to initialize a channel. Closing: " + ctx.channel(), t);
-        } finally {
+            ChannelPipeline pipeline = ctx.pipeline();
             if (pipeline.context(this) != null) {
                 pipeline.remove(this);
             }
-            if (!success) {
-                ctx.close();
-            }
+        } finally {
+            ctx.close();
         }
     }
 }

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -21,6 +21,7 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalEventLoopGroup;
@@ -533,6 +534,29 @@ public class DefaultChannelPipelineTest {
     public void testLastHandlerEmptyPipeline() throws Exception {
         ChannelPipeline pipeline = new LocalChannel().pipeline();
         assertNull(pipeline.last());
+    }
+
+    @Test(timeout = 5000)
+    public void testChannelInitializerException() throws Exception {
+        final IllegalStateException exception = new IllegalStateException();
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        EmbeddedChannel channel = new EmbeddedChannel(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                throw exception;
+            }
+
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                super.exceptionCaught(ctx, cause);
+                error.set(cause);
+                latch.countDown();
+            }
+        });
+        latch.await();
+        assertFalse(channel.isActive());
+        assertSame(exception, error.get());
     }
 
     private static int next(AbstractChannelHandlerContext ctx) {


### PR DESCRIPTION
Motivation:

At the moment we directly closed the Channel when an exception accoured durring initChannel(...) without giving the user any way to do extra or special handling.

Modifications:

Handle the exception in exceptionCaught(...) of the ChannelInitializer which will by default log and close the Channel. This way the user can override this.

Result:

More felixible handling of exceptions.