### PR TITLE
[#3899] Fix javadoc to use netty 4 API.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -87,7 +87,7 @@ import java.nio.charset.UnsupportedCharsetException;
  * <pre>
  * // Iterates the readable bytes of a buffer.
  * {@link ByteBuf} buffer = ...;
- * while (buffer.readable()) {
+ * while (buffer.isReadable()) {
  *     System.out.println(buffer.readByte());
  * }
  * </pre>


### PR DESCRIPTION
Motivation:

The javadoc of ByteBuf contained some out-dated code.

Modifications:

Update code example in javadoc to use netty 4+ API

Result:

Correct javadocs