### PR TITLE
Ensure OpenSslSession informations can be retrieved even after shutdown

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslJavaxX509Certificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslJavaxX509Certificate.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import javax.security.cert.CertificateException;
+import javax.security.cert.CertificateExpiredException;
+import javax.security.cert.CertificateNotYetValidException;
+import javax.security.cert.X509Certificate;
+import java.math.BigInteger;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.Principal;
+import java.security.PublicKey;
+import java.security.SignatureException;
+import java.util.Date;
+
+final class OpenSslJavaxX509Certificate extends X509Certificate {
+    private final byte[] bytes;
+    private X509Certificate wrapped;
+
+    public OpenSslJavaxX509Certificate(byte[] bytes) {
+        this.bytes = bytes;
+    }
+
+    @Override
+    public void checkValidity() throws CertificateExpiredException, CertificateNotYetValidException {
+        unwrap().checkValidity();
+    }
+
+    @Override
+    public void checkValidity(Date date) throws CertificateExpiredException, CertificateNotYetValidException {
+        unwrap().checkValidity(date);
+    }
+
+    @Override
+    public int getVersion() {
+        return unwrap().getVersion();
+    }
+
+    @Override
+    public BigInteger getSerialNumber() {
+        return unwrap().getSerialNumber();
+    }
+
+    @Override
+    public Principal getIssuerDN() {
+        return unwrap().getIssuerDN();
+    }
+
+    @Override
+    public Principal getSubjectDN() {
+        return unwrap().getSubjectDN();
+    }
+
+    @Override
+    public Date getNotBefore() {
+        return unwrap().getNotBefore();
+    }
+
+    @Override
+    public Date getNotAfter() {
+        return unwrap().getNotAfter();
+    }
+
+    @Override
+    public String getSigAlgName() {
+        return unwrap().getSigAlgName();
+    }
+
+    @Override
+    public String getSigAlgOID() {
+        return unwrap().getSigAlgOID();
+    }
+
+    @Override
+    public byte[] getSigAlgParams() {
+        return unwrap().getSigAlgParams();
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        return bytes.clone();
+    }
+
+    @Override
+    public void verify(PublicKey key)
+            throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException,
+                   SignatureException {
+        unwrap().verify(key);
+    }
+
+    @Override
+    public void verify(PublicKey key, String sigProvider)
+            throws CertificateException, NoSuchAlgorithmException, InvalidKeyException, NoSuchProviderException,
+                   SignatureException {
+        unwrap().verify(key, sigProvider);
+    }
+
+    @Override
+    public String toString() {
+        return unwrap().toString();
+    }
+
+    @Override
+    public PublicKey getPublicKey() {
+        return unwrap().getPublicKey();
+    }
+
+    private X509Certificate unwrap() {
+        X509Certificate wrapped = this.wrapped;
+        if (wrapped == null) {
+            try {
+                wrapped = this.wrapped = X509Certificate.getInstance(bytes);
+            } catch (CertificateException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        return wrapped;
+    }
+}


### PR DESCRIPTION
Motivation:

If a user tries to access various informations on the OpenSslSession after the SSLEngine was closed it will not work if these were not accessed before as we lazy init most of them.

Modifications:

Directly populate the whole OpenSslSession once the handshake is complete and before the user is notified about it.

Result:

OpenSslSession informations are avaible until it is GC'ed.