### PR TITLE
Add GCC optimization flag when compile native transport

### DIFF
--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -186,7 +186,7 @@
               <value>${linux.sendmmsg.support}${glibc.sendmmsg.support}</value>
               <!-- If glibc and linux kernel are both not sufficient...then define the CFLAGS -->
               <regex>.*IO_NETTY_SENDMSSG_NOT_FOUND.*</regex>
-              <replacement>CFLAGS="-DIO_NETTY_SENDMMSG_NOT_FOUND"</replacement>
+              <replacement>CFLAGS=-O3 -DIO_NETTY_SENDMMSG_NOT_FOUND</replacement>
               <failIfNoMatch>false</failIfNoMatch>
             </configuration>
           </execution>
@@ -202,7 +202,7 @@
               <value>${jni.compiler.args}</value>
               <!-- If glibc and linux kernel are both not sufficient...then define the CFLAGS -->
               <regex>^((?!CFLAGS=).)*$</regex>
-              <replacement>CFLAGS=""</replacement>
+              <replacement>CFLAGS=-O3</replacement>
               <failIfNoMatch>false</failIfNoMatch>
             </configuration>
           </execution>


### PR DESCRIPTION
Motivation:

We not set any optimization flag when compile native transport

Modification:

Add -O3 to CFLAGS to have GCC do optimizations

Result:

Ship optimized native code