### PR TITLE
Allow servers to specify ENABLE_PUSH to 0 explicitly

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -77,8 +77,9 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
         Http2HeaderTable outboundHeaderTable = config.headerTable();
         Http2FrameSizePolicy outboundFrameSizePolicy = config.frameSizePolicy();
         if (pushEnabled != null) {
-            if (!connection.isServer()) {
-                throw connectionError(PROTOCOL_ERROR, "Client received SETTINGS frame with ENABLE_PUSH specified");
+            if (!connection.isServer() && pushEnabled) {
+                throw connectionError(PROTOCOL_ERROR,
+                    "Client received a value of ENABLE_PUSH specified to other than 0");
             }
             connection.remote().allowPushTo(pushEnabled);
         }


### PR DESCRIPTION
Motivation:

If server sends SETTINGS with ENABLE_PUSH, its handled as
PROTOCOL_ERROR in spite of the value. But the value specified to
0 may be allowed in RFC7540.

Modifications:

Check whether ENABLE_PUSH sent from a server is 0 or not.

Result:

When server specifies ENABLE_PUSH to 0 explicitly, client doesn't
handle it as PROTOCOL_ERROR.