### PR TITLE
[#3945] Http2ConnectionHandler breaks channelReadComplete pipeline no…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -455,7 +455,11 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
         // Trigger flush after read on the assumption that flush is cheap if there is nothing to write and that
         // for flow-control the read may release window that causes data to be written that can now be flushed.
-        flush(ctx);
+        try {
+            flush(ctx);
+        } finally {
+            super.channelReadComplete(ctx);
+        }
     }
 
     /**


### PR DESCRIPTION
…tification

Motivation:

Http2ConnectionHandler missed to forward channelReadComplete(...) events.

Modifications:

Ensure we notify the next handler in the pipeline via ctx.fireChannelReadComplete().

Result:

Correctly forwarding of event.