### PR TITLE
SocketChannel write IllegalArgumentException

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -51,7 +51,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     private static final InternalLogger logger =
             InternalLoggerFactory.getInstance(AbstractNioChannel.class);
 
-    private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = new ClosedChannelException();
+    protected static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = new ClosedChannelException();
 
     static {
         CLOSED_CHANNEL_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);


### PR DESCRIPTION
Motiviation:
It has been observed that a SocketChannel.write operation can result in a IllegalArgumentException if the low level native code in the JDK fails.

Modifications:
- Translate this error to an IOException so Netty can properly clean up.

Result:
No more unexpected IllegalArgumentException exception.