### PR TITLE
HTTP/2 limit header accumulated size

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersDecoder.java
@@ -29,6 +29,11 @@ public interface Http2HeadersDecoder {
          * Access the Http2HeaderTable for this {@link Http2HeadersDecoder}
          */
         Http2HeaderTable headerTable();
+
+        /**
+         * Get the maximum number of bytes that is allowed before truncation occurs.
+         */
+        int maxHeaderSize();
     }
 
     /**

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
@@ -15,11 +15,13 @@
 
 package io.netty.handler.codec.http2;
 
+import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_MAX_HEADER_SIZE;
 import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_HEADER_TABLE_SIZE;
 import static io.netty.handler.codec.http2.Http2TestUtil.as;
 import static io.netty.handler.codec.http2.Http2TestUtil.randomBytes;
 import static io.netty.util.CharsetUtil.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
@@ -50,6 +52,17 @@ public class DefaultHttp2HeadersDecoderTest {
             assertEquals(3, headers.size());
             assertEquals("GET", headers.method().toString());
             assertEquals("avalue", headers.get(as("akey")).toString());
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test(expected = Http2Exception.class)
+    public void testExceedHeaderSize() throws Exception {
+        ByteBuf buf = encode(randomBytes(DEFAULT_MAX_HEADER_SIZE), randomBytes(1));
+        try {
+            decoder.decodeHeaders(buf);
+            fail();
         } finally {
             buf.release();
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -1057,6 +1057,7 @@ public class DefaultHttp2RemoteFlowControllerTest {
         final Http2RemoteFlowController.FlowControlled flowControlled = mockedFlowControlledThatThrowsOnWrite();
         final Http2Stream stream = stream(STREAM_A);
         doAnswer(new Answer<Void>() {
+            @Override
             public Void answer(InvocationOnMock invocationOnMock) {
                 stream.closeLocalSide();
                 return null;
@@ -1079,6 +1080,7 @@ public class DefaultHttp2RemoteFlowControllerTest {
         final Http2RemoteFlowController.FlowControlled flowControlled = mockedFlowControlledThatThrowsOnWrite();
         final Http2Stream stream = stream(STREAM_A);
         doAnswer(new Answer<Void>() {
+            @Override
             public Void answer(InvocationOnMock invocationOnMock) {
                 throw new RuntimeException("error failed");
             }
@@ -1123,6 +1125,7 @@ public class DefaultHttp2RemoteFlowControllerTest {
 
         final Http2Stream stream = stream(STREAM_A);
         doAnswer(new Answer<Void>() {
+            @Override
             public Void answer(InvocationOnMock invocationOnMock) {
                 throw new RuntimeException("writeComplete failed");
             }
@@ -1151,6 +1154,7 @@ public class DefaultHttp2RemoteFlowControllerTest {
         when(flowControlled.size()).thenReturn(100);
         doThrow(new RuntimeException("write failed")).when(flowControlled).write(anyInt());
         doAnswer(new Answer<Void>() {
+            @Override
             public Void answer(InvocationOnMock invocationOnMock) {
                 stream.close();
                 return null;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -70,7 +70,14 @@ final class Http2TestUtil {
      * Returns a byte array filled with random data.
      */
     public static byte[] randomBytes() {
-        byte[] data = new byte[100];
+        return randomBytes(100);
+    }
+
+    /**
+     * Returns a byte array filled with random data.
+     */
+    public static byte[] randomBytes(int size) {
+        byte[] data = new byte[size];
         new Random().nextBytes(data);
         return data;
     }


### PR DESCRIPTION
Motivation:
The Http2FrameListener requires that the Http2FrameReader accumulate ByteBuf objects. There is currently no way to limit the amount of bytes that is accumulated.

Modifications:
- DefaultHttp2FrameReader supports maxHeaderSize which will fail fast as soon as the maximum size is exceeded.
- DefaultHttp2HeadersDecoder will respect the return value of endHeaderBlock() and fail if the max size is exceeded.

Result:
Frames which carry header data now respect a maximum number of bytes that can be accumulated.