### PR TITLE
Skip empty buffers and not pass these to BIO_write

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -652,6 +652,12 @@ public final class OpenSslEngine extends SSLEngine {
             do {
                 ByteBuffer src = srcs[srcsOffset];
                 int remaining = src.remaining();
+                if (remaining == 0) {
+                    // We must skip empty buffers as BIO_write will return 0 if asked to write something
+                    // with length 0.
+                    srcsOffset ++;
+                    continue;
+                }
                 int written = writeEncryptedData(src);
                 if (written > 0) {
                     bytesConsumed += written;


### PR DESCRIPTION
Motivation:

When BIO_write is called with an empty buffer it will return 0 for which we call ERR_clear_error(). This is not neccessary as we should just skip these buffers. This eliminates a lot of overhead.

Modifications:

Skip empty src buffers when call unwrap(...).

Result:

Less overhead for unwrap(...) when called with empty buffers.