### PR TITLE
Stop calling BIO_write once internal buffer is full.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -664,6 +664,11 @@ public final class OpenSslEngine extends SSLEngine {
 
                     if (written == remaining) {
                         srcsOffset ++;
+                    } else {
+                        // We was not able to write everything into the BIO so break the write loop as otherwise
+                        // we will produce an error on the next write attempt, which will trigger a SSL.clearError()
+                        // later.
+                        break;
                     }
                 } else {
                     // BIO_write returned a negative or zero number, this means we could not complete the write


### PR DESCRIPTION
Motivation:

Previous we called BIO_write until either everything was written into it or it returned an error, which meant that the buffer is full. This then needed a ERR_clear_error() call which is expensive.

Modifications:

Break out of writing loop once we detect that not everything was written and so the buffer is full.

Result:

Less overhead when writing more data then the internal buffer can take.