### PR TITLE
Proper shutdown of HTTP2 encoder when channelInactive

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -181,25 +181,21 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         public void channelActive(ChannelHandlerContext ctx) throws Exception { }
 
         public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-            try {
-                final Http2Connection connection = connection();
-                // Check if there are streams to avoid the overhead of creating the ChannelFuture.
-                if (connection.numActiveStreams() > 0) {
-                    final ChannelFuture future = ctx.newSucceededFuture();
-                    connection.forEachActiveStream(new Http2StreamVisitor() {
-                        @Override
-                        public boolean visit(Http2Stream stream) throws Http2Exception {
-                            closeStream(stream, future);
-                            return true;
-                        }
-                    });
-                }
-            } finally {
-                try {
-                    encoder().close();
-                } finally {
-                    decoder().close();
-                }
+            // Connection has terminated, close the encoder and decoder.
+            encoder().close();
+            decoder().close();
+
+            final Http2Connection connection = connection();
+            // Check if there are streams to avoid the overhead of creating the ChannelFuture.
+            if (connection.numActiveStreams() > 0) {
+                final ChannelFuture future = ctx.newSucceededFuture();
+                connection.forEachActiveStream(new Http2StreamVisitor() {
+                    @Override
+                    public boolean visit(Http2Stream stream) throws Http2Exception {
+                        closeStream(stream, future);
+                        return true;
+                    }
+                });
             }
         }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -41,8 +41,8 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
-import io.netty.handler.codec.http2.StreamBufferingEncoder.ChannelClosedException;
-import io.netty.handler.codec.http2.StreamBufferingEncoder.GoAwayException;
+import io.netty.handler.codec.http2.StreamBufferingEncoder.Http2ChannelClosedException;
+import io.netty.handler.codec.http2.StreamBufferingEncoder.Http2GoAwayException;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import org.junit.After;
@@ -233,7 +233,7 @@ public class StreamBufferingEncoderTest {
 
         assertEquals(1, connection.numActiveStreams());
         assertEquals(2, encoder.numBufferedStreams());
-        verify(promise, never()).setFailure(any(GoAwayException.class));
+        verify(promise, never()).setFailure(any(Http2GoAwayException.class));
     }
 
     @Test
@@ -420,7 +420,7 @@ public class StreamBufferingEncoderTest {
         encoderWriteHeaders(7, promise);
 
         encoder.close();
-        verify(promise, times(3)).setFailure(any(ChannelClosedException.class));
+        verify(promise, times(3)).setFailure(any(Http2ChannelClosedException.class));
     }
 
     @Test
@@ -429,7 +429,7 @@ public class StreamBufferingEncoderTest {
         encoder.close();
 
         encoderWriteHeaders(3, promise);
-        verify(promise).setFailure(any(ChannelClosedException.class));
+        verify(promise).setFailure(any(Http2ChannelClosedException.class));
     }
 
     private void setMaxConcurrentStreams(int newValue) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -41,9 +41,9 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
+import io.netty.handler.codec.http2.StreamBufferingEncoder.ChannelClosedException;
 import io.netty.handler.codec.http2.StreamBufferingEncoder.GoAwayException;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.ReferenceCounted;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import org.junit.After;
 import org.junit.Before;
@@ -208,7 +208,7 @@ public class StreamBufferingEncoderTest {
         }
         assertEquals(4, encoder.numBufferedStreams());
 
-        connection.goAwayReceived(11, 8, null);
+        connection.goAwayReceived(11, 8, EMPTY_BUFFER);
 
         assertEquals(5, connection.numActiveStreams());
         // The 4 buffered streams must have been failed.
@@ -408,6 +408,28 @@ public class StreamBufferingEncoderTest {
         verify(rstPromise).setSuccess();
         verify(promise, times(2)).setSuccess();
         verify(data).release();
+    }
+
+    @Test
+    public void closeShouldCancelAllBufferedStreams() {
+        encoder.writeSettingsAck(ctx, promise);
+        connection.local().maxActiveStreams(0);
+
+        encoderWriteHeaders(3, promise);
+        encoderWriteHeaders(5, promise);
+        encoderWriteHeaders(7, promise);
+
+        encoder.close();
+        verify(promise, times(3)).setFailure(any(ChannelClosedException.class));
+    }
+
+    @Test
+    public void headersAfterCloseShouldImmediatelyFail() {
+        encoder.writeSettingsAck(ctx, promise);
+        encoder.close();
+
+        encoderWriteHeaders(3, promise);
+        verify(promise).setFailure(any(ChannelClosedException.class));
     }
 
     private void setMaxConcurrentStreams(int newValue) {


### PR DESCRIPTION
Motivation:

The problem is described in https://github.com/grpc/grpc-java/issues/605. Basically, when using `StreamBufferingEncoder` there is a chance of creating zombie streams that never get closed.

Modifications:

Change `Http2ConnectionHandler`'s `channelInactive` handling logic to shutdown the encoder/decoder before shutting down the active streams.

Result:

Fixes https://github.com/grpc/grpc-java/issues/605