### PR TITLE
Accept over 2^31-1 MAX_HEADER_LIST_SIZE

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeaderTableListSize.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeaderTableListSize.java
@@ -25,9 +25,11 @@ class DefaultHttp2HeaderTableListSize {
 
     public void maxHeaderListSize(int max) throws Http2Exception {
         if (max < 0) {
-            throw connectionError(PROTOCOL_ERROR, "Header List Size must be non-negative but was %d", max);
+            // Over 2^31 - 1 (minus in integer) size is set to the maximun value
+            maxHeaderListSize = Integer.MAX_VALUE;
+        } else {
+            maxHeaderListSize = max;
         }
-        maxHeaderListSize = max;
     }
 
     public int maxHeaderListSize() {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Settings.java
@@ -162,7 +162,14 @@ public final class Http2Settings extends CharObjectHashMap<Long> {
      * Gets the {@code SETTINGS_MAX_HEADER_LIST_SIZE} value. If unavailable, returns {@code null}.
      */
     public Integer maxHeaderListSize() {
-        return getIntValue(SETTINGS_MAX_HEADER_LIST_SIZE);
+        Integer value = getIntValue(SETTINGS_MAX_HEADER_LIST_SIZE);
+
+        // Over 2^31 - 1 (minus in integer) size is set to the maximun value
+        if (value != null && value < 0) {
+            value = Integer.MAX_VALUE;
+        }
+
+        return value;
     }
 
     /**
@@ -171,6 +178,11 @@ public final class Http2Settings extends CharObjectHashMap<Long> {
      * @throws IllegalArgumentException if verification of the setting fails.
      */
     public Http2Settings maxHeaderListSize(int value) {
+        // Over 2^31 - 1 (minus in integer) size is set to the maximun value
+        if (value < 0) {
+            value = Integer.MAX_VALUE;
+        }
+
         put(SETTINGS_MAX_HEADER_LIST_SIZE, (long) value);
         return this;
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeaderTableListSizeTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeaderTableListSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Netty Project
+ * Copyright 2015 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
  * "License"); you may not use this file except in compliance with the License. You may obtain a
@@ -39,30 +39,18 @@ public class DefaultHttp2HeaderTableListSizeTest {
     }
 
     @Test
-    public void standardMaxHeaderListSizeShouldSucceed() {
-        try {
-            headerTable.maxHeaderListSize(123);
-            assertEquals(123L, (long) headerTable.maxHeaderListSize());
-        } catch (Http2Exception e) {
-            fail();
-        }
+    public void standardMaxHeaderListSizeShouldSucceed() throws Http2Exception {
+        headerTable.maxHeaderListSize(123);
+        assertEquals(123L, (long) headerTable.maxHeaderListSize());
     }
 
     @Test
-    public void boundaryMaxHeaderListSizeShouldSucceed() {
-        try {
-            headerTable.maxHeaderListSize(Integer.MAX_VALUE);
-            assertEquals(Integer.MAX_VALUE, (long) headerTable.maxHeaderListSize());
-        } catch (Http2Exception e) {
-            fail();
-        }
+    public void boundaryMaxHeaderListSizeShouldSucceed() throws Http2Exception {
+        headerTable.maxHeaderListSize(Integer.MAX_VALUE);
+        assertEquals(Integer.MAX_VALUE, (long) headerTable.maxHeaderListSize());
 
-        try {
-            final long settingsValueUpperBound = (1L << 32) - 1L;
-            headerTable.maxHeaderListSize((int) settingsValueUpperBound);
-            assertEquals(Integer.MAX_VALUE, (long) headerTable.maxHeaderListSize());
-        } catch (Http2Exception e) {
-            fail();
-        }
+        final long settingsValueUpperBound = (1L << 32) - 1L;
+        headerTable.maxHeaderListSize((int) settingsValueUpperBound);
+        assertEquals(Integer.MAX_VALUE, (long) headerTable.maxHeaderListSize());
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeaderTableListSizeTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeaderTableListSizeTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.netty.handler.codec.http2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link DefaultHttp2HeaderTableListSize}.
+ */
+public class DefaultHttp2HeaderTableListSizeTest {
+
+    private DefaultHttp2HeaderTableListSize headerTable;
+
+    @Before
+    public void setup() {
+        headerTable = new DefaultHttp2HeaderTableListSize();
+    }
+
+    @Test
+    public void defaultMaxHeaderListSizeShouldSucceed() {
+        assertEquals(Integer.MAX_VALUE, (long) headerTable.maxHeaderListSize());
+    }
+
+    @Test
+    public void standardMaxHeaderListSizeShouldSucceed() {
+        try {
+            headerTable.maxHeaderListSize(123);
+            assertEquals(123L, (long) headerTable.maxHeaderListSize());
+        } catch (Http2Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void boundaryMaxHeaderListSizeShouldSucceed() {
+        try {
+            headerTable.maxHeaderListSize(Integer.MAX_VALUE);
+            assertEquals(Integer.MAX_VALUE, (long) headerTable.maxHeaderListSize());
+        } catch (Http2Exception e) {
+            fail();
+        }
+
+        try {
+            final long settingsValueUpperBound = (1L << 32) - 1L;
+            headerTable.maxHeaderListSize((int) settingsValueUpperBound);
+            assertEquals(Integer.MAX_VALUE, (long) headerTable.maxHeaderListSize());
+        } catch (Http2Exception e) {
+            fail();
+        }
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SettingsTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SettingsTest.java
@@ -75,4 +75,14 @@ public class Http2SettingsTest {
         settings.put(key, 123L);
         assertEquals(123L, (long) settings.get(key));
     }
+
+    @Test
+    public void boundarySettingsShouldBeSet() {
+        settings.maxHeaderListSize(Integer.MAX_VALUE + 1);
+        assertEquals(Integer.MAX_VALUE, (long) settings.maxHeaderListSize());
+
+        final long settingsValueUpperBound = (1L << 32) - 1L;
+        settings.maxHeaderListSize((int) settingsValueUpperBound);
+        assertEquals(Integer.MAX_VALUE, (long) settings.maxHeaderListSize());
+    }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SettingsTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2SettingsTest.java
@@ -78,7 +78,8 @@ public class Http2SettingsTest {
 
     @Test
     public void boundarySettingsShouldBeSet() {
-        settings.maxHeaderListSize(Integer.MAX_VALUE + 1);
+        final long overIntegerMaxValue = 1L << 31;
+        settings.maxHeaderListSize((int) overIntegerMaxValue);
         assertEquals(Integer.MAX_VALUE, (long) settings.maxHeaderListSize());
 
         final long settingsValueUpperBound = (1L << 32) - 1L;


### PR DESCRIPTION
Motivation:

The MAX_HEADER_LIST_SIZE of SETTINGS is represented by
unsigned 32-bit value and this value isn't limited in RFC7540.
But in current implementation, its stored to int variable so
over 2^31-1 value is recognized as minus and handled as
PROTOCOL_ERROR.

Modifications:

If a value of MAX_HEADER_LIST_SIZE is larger than 2^31-1, its
handled as 2^31-1

Result:

Over 2^31-1 MAX_HEADER_LIST_SIZE is became acceptable

I've agreed with the ICLA.