### PR TITLE
(POC) New Readable interface for ByteBuf and FileRegion

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/Readable.java
+++ b/buffer/src/main/java/io/netty/buffer/Readable.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer;
+
+import io.netty.util.ReferenceCounted;
+
+/**
+ * An object that contains a readable region. For simplicity, extends {@link ReferenceCounted}.
+ */
+public interface Readable extends ReferenceCounted {
+    /**
+     * Returns current read position in the object.
+     */
+    long readerPosition();
+
+    /**
+     * Returns {@code true} if and only if {@link #readableBytes()} > {@code 0}.
+     */
+    boolean isReadable();
+
+    /**
+     * Returns the number of readable bytes in this object.
+     */
+    long readableBytes();
+
+    /**
+     * Increases the current {@code readerPosition} by the specified
+     * {@code length} in this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code length} is greater than {@link #readableBytes()}
+     */
+    Readable skipBytes(long length);
+
+    /**
+     * Returns a slice of this object's readable region. This method is
+     * identical to {@code r.slice(r.readerPosition(), r.readableBytes())}.
+     * This method does not modify {@code readerPosition}.
+     * <p>
+     * Also be aware that this method will NOT call {@link #retain()} and so the
+     * reference count will NOT be increased.
+     */
+    Readable slice();
+
+    /**
+     * Returns a slice of this object's sub-region. This method does not modify
+     * {@code readerPosition}.
+     * <p>
+     * Also be aware that this method will NOT call {@link #retain()} and so the
+     * reference count will NOT be increased.
+     *
+     * @param position the starting position for the slice.
+     *
+     * @param length the size of the new slice relative to {@code position}.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if any part of the requested region falls outside of the currently readable region.
+     */
+    Readable slice(long position, long length);
+
+    /**
+     * Returns a new slice of this object's sub-region starting at the current
+     * {@link #readerPosition()} and increases the {@code readerPosition} by the size
+     * of the new slice (= {@code length}).
+     * <p>
+     * Also be aware that this method will NOT call {@link #retain()} and so the
+     * reference count will NOT be increased.
+     *
+     * @param length the size of the new slice
+     *
+     * @return the newly created slice
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code length} is greater than {@link #readableBytes()}
+     */
+    Readable readSlice(long length);
+}

--- a/buffer/src/main/java/io/netty/buffer/Readable.java
+++ b/buffer/src/main/java/io/netty/buffer/Readable.java
@@ -122,4 +122,16 @@ public interface Readable extends ReferenceCounted {
      *         if the specified channel threw an exception during I/O
      */
     long readTo(GatheringByteChannel channel, long length) throws IOException;
+
+    @Override
+    Readable retain();
+
+    @Override
+    Readable retain(int increment);
+
+    @Override
+    Readable touch(Object hint);
+
+    @Override
+    Readable touch();
 }

--- a/buffer/src/main/java/io/netty/buffer/Readable.java
+++ b/buffer/src/main/java/io/netty/buffer/Readable.java
@@ -18,6 +18,10 @@ package io.netty.buffer;
 
 import io.netty.util.ReferenceCounted;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.channels.GatheringByteChannel;
+
 /**
  * An object that contains a readable region. For simplicity, extends {@link ReferenceCounted}.
  */
@@ -88,4 +92,34 @@ public interface Readable extends ReferenceCounted {
      *         if {@code length} is greater than {@link #readableBytes()}
      */
     Readable readSlice(long length);
+
+    /**
+     * Transfers this object's data to the specified stream starting at the
+     * current {@code readerPosition} and increases the {@code readerPosition} by
+     * the {@code length}.
+     *
+     * @param length the number of bytes to transfer
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code length} is greater than {@link #readableBytes()}
+     * @throws IOException
+     *         if the specified stream threw an exception during I/O
+     */
+    Readable readTo(OutputStream out, long length) throws IOException;
+
+    /**
+     * Transfers this object's data to the specified stream starting at the
+     * current {@code readerPosition} and increases the {@code readerPosition} by
+     * the number of bytes written.
+     *
+     * @param length the maximum number of bytes to transfer
+     *
+     * @return the actual number of bytes written out to the specified channel
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code length} is greater than {@code this.readableBytes}
+     * @throws IOException
+     *         if the specified channel threw an exception during I/O
+     */
+    long readTo(GatheringByteChannel channel, long length) throws IOException;
 }

--- a/buffer/src/main/java/io/netty/buffer/ReadableObject.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadableObject.java
@@ -93,6 +93,14 @@ public interface ReadableObject<T extends ReadableObject> extends ReferenceCount
     T readSlice(long length);
 
     /**
+     * Return the underlying {@link ReadableObject} instance if this is a wrapper around another
+     * object (e.g. a slice of another object)
+     *
+     * @return {@code null} if this is not a wrapper
+     */
+    T unwrap();
+
+    /**
      * Transfers this object's data to the specified stream starting at the
      * current {@code readPosition} and increases the {@code readPosition} by
      * the number of bytes written.

--- a/buffer/src/main/java/io/netty/buffer/ReadableObject.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadableObject.java
@@ -25,11 +25,11 @@ import java.nio.channels.GatheringByteChannel;
 /**
  * An object that contains a readable region. For simplicity, extends {@link ReferenceCounted}.
  */
-public interface Readable extends ReferenceCounted {
+public interface ReadableObject<T extends ReadableObject> extends ReferenceCounted {
     /**
      * Returns current read position in the object.
      */
-    long readerPosition();
+    long readPosition();
 
     /**
      * Returns {@code true} if and only if {@link #readableBytes()} > {@code 0}.
@@ -42,27 +42,27 @@ public interface Readable extends ReferenceCounted {
     long readableBytes();
 
     /**
-     * Increases the current {@code readerPosition} by the specified
+     * Increases the current {@code readPosition} by the specified
      * {@code length} in this buffer.
      *
      * @throws IndexOutOfBoundsException
      *         if {@code length} is greater than {@link #readableBytes()}
      */
-    Readable skipBytes(long length);
+    T skipBytes(long length);
 
     /**
      * Returns a slice of this object's readable region. This method is
-     * identical to {@code r.slice(r.readerPosition(), r.readableBytes())}.
-     * This method does not modify {@code readerPosition}.
+     * identical to {@code r.slice(r.readPosition(), r.readableBytes())}.
+     * This method does not modify {@code readPosition}.
      * <p>
      * Also be aware that this method will NOT call {@link #retain()} and so the
      * reference count will NOT be increased.
      */
-    Readable slice();
+    T slice();
 
     /**
      * Returns a slice of this object's sub-region. This method does not modify
-     * {@code readerPosition}.
+     * {@code readPosition}.
      * <p>
      * Also be aware that this method will NOT call {@link #retain()} and so the
      * reference count will NOT be increased.
@@ -74,11 +74,11 @@ public interface Readable extends ReferenceCounted {
      * @throws IndexOutOfBoundsException
      *         if any part of the requested region falls outside of the currently readable region.
      */
-    Readable slice(long position, long length);
+    T slice(long position, long length);
 
     /**
      * Returns a new slice of this object's sub-region starting at the current
-     * {@link #readerPosition()} and increases the {@code readerPosition} by the size
+     * {@link #readPosition()} and increases the {@code readPosition} by the size
      * of the new slice (= {@code length}).
      * <p>
      * Also be aware that this method will NOT call {@link #retain()} and so the
@@ -91,25 +91,27 @@ public interface Readable extends ReferenceCounted {
      * @throws IndexOutOfBoundsException
      *         if {@code length} is greater than {@link #readableBytes()}
      */
-    Readable readSlice(long length);
+    T readSlice(long length);
 
     /**
      * Transfers this object's data to the specified stream starting at the
-     * current {@code readerPosition} and increases the {@code readerPosition} by
-     * the {@code length}.
+     * current {@code readPosition} and increases the {@code readPosition} by
+     * the bytes written.
      *
      * @param length the number of bytes to transfer
+     *
+     * @return the actual number of bytes written out to the specified stream
      *
      * @throws IndexOutOfBoundsException
      *         if {@code length} is greater than {@link #readableBytes()}
      * @throws IOException
      *         if the specified stream threw an exception during I/O
      */
-    Readable readTo(OutputStream out, long length) throws IOException;
+    long readTo(OutputStream out, long length) throws IOException;
 
     /**
      * Transfers this object's data to the specified stream starting at the
-     * current {@code readerPosition} and increases the {@code readerPosition} by
+     * current {@code readPosition} and increases the {@code readPosition} by
      * the number of bytes written.
      *
      * @param length the maximum number of bytes to transfer
@@ -124,14 +126,14 @@ public interface Readable extends ReferenceCounted {
     long readTo(GatheringByteChannel channel, long length) throws IOException;
 
     @Override
-    Readable retain();
+    T retain();
 
     @Override
-    Readable retain(int increment);
+    T retain(int increment);
 
     @Override
-    Readable touch(Object hint);
+    T touch(Object hint);
 
     @Override
-    Readable touch();
+    T touch();
 }

--- a/buffer/src/main/java/io/netty/buffer/ReadableObject.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadableObject.java
@@ -19,8 +19,7 @@ package io.netty.buffer;
 import io.netty.util.ReferenceCounted;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.WritableByteChannel;
 
 /**
  * An object that contains a readable region. For simplicity, extends {@link ReferenceCounted}.
@@ -96,22 +95,6 @@ public interface ReadableObject<T extends ReadableObject> extends ReferenceCount
     /**
      * Transfers this object's data to the specified stream starting at the
      * current {@code readPosition} and increases the {@code readPosition} by
-     * the bytes written.
-     *
-     * @param length the number of bytes to transfer
-     *
-     * @return the actual number of bytes written out to the specified stream
-     *
-     * @throws IndexOutOfBoundsException
-     *         if {@code length} is greater than {@link #readableBytes()}
-     * @throws IOException
-     *         if the specified stream threw an exception during I/O
-     */
-    long readTo(OutputStream out, long length) throws IOException;
-
-    /**
-     * Transfers this object's data to the specified stream starting at the
-     * current {@code readPosition} and increases the {@code readPosition} by
      * the number of bytes written.
      *
      * @param length the maximum number of bytes to transfer
@@ -123,7 +106,7 @@ public interface ReadableObject<T extends ReadableObject> extends ReferenceCount
      * @throws IOException
      *         if the specified channel threw an exception during I/O
      */
-    long readTo(GatheringByteChannel channel, long length) throws IOException;
+    long readTo(WritableByteChannel channel, long length) throws IOException;
 
     @Override
     T retain();


### PR DESCRIPTION
Motivation:

There seems to be a general need within Netty to cleanly handle multiple bytes of readable data (i.e. ByteBuf, ByteBufHolder, CompositeByteBuf, FileRegion). Having a unified readable interface for these structures will help simplify code handling readable data, allowing us to write generic, less error-prone code.

Modifications:

Created a new `Readable` interface.

Result:

Introduces a new interface.