### PR TITLE
[#3946] Support conversion of HttpMessage and HttpContent to HTTP/2 Frames

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
@@ -15,11 +15,16 @@
 
 package io.netty.handler.codec.http2;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.FullHttpMessage;
+import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http2.Http2CodecUtil.SimpleChannelPromiseAggregator;
+import io.netty.util.ReferenceCountUtil;
 
 /**
  * Translates HTTP/1.x object writes into HTTP/2 frames.
@@ -27,6 +32,9 @@ import io.netty.handler.codec.http2.Http2CodecUtil.SimpleChannelPromiseAggregato
  * See {@link InboundHttp2ToHttpAdapter} to get translation from HTTP/2 frames to HTTP/1.x objects.
  */
 public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
+
+    private int currentStreamId;
+
     public HttpToHttp2ConnectionHandler(boolean server, Http2FrameListener listener) {
         super(server, listener);
     }
@@ -57,45 +65,64 @@ public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
     }
 
     /**
-     * Handles conversion of a {@link FullHttpMessage} to HTTP/2 frames.
+     * Handles conversion of {@link HttpMessage} and {@link HttpContent} to HTTP/2 frames.
      */
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-        if (msg instanceof FullHttpMessage) {
-            FullHttpMessage httpMsg = (FullHttpMessage) msg;
-            boolean hasData = httpMsg.content().isReadable();
-            boolean httpMsgNeedRelease = true;
-            SimpleChannelPromiseAggregator promiseAggregator = null;
-            try {
+
+        if (!(msg instanceof HttpMessage || msg instanceof HttpContent)) {
+            ctx.write(msg, promise);
+            return;
+        }
+
+        boolean release = true;
+        SimpleChannelPromiseAggregator promiseAggregator =
+                new SimpleChannelPromiseAggregator(promise, ctx.channel(), ctx.executor());
+        try {
+            Http2ConnectionEncoder encoder = encoder();
+            boolean endStream = false;
+            if (msg instanceof HttpMessage) {
+                final HttpMessage httpMsg = (HttpMessage) msg;
+
                 // Provide the user the opportunity to specify the streamId
-                int streamId = getStreamId(httpMsg.headers());
+                currentStreamId = getStreamId(httpMsg.headers());
 
                 // Convert and write the headers.
                 Http2Headers http2Headers = HttpUtil.toHttp2Headers(httpMsg);
-                Http2ConnectionEncoder encoder = encoder();
+                endStream = msg instanceof FullHttpMessage && !((FullHttpMessage) msg).content().isReadable();
+                encoder.writeHeaders(ctx, currentStreamId, http2Headers, 0, endStream, promiseAggregator.newPromise());
+            }
 
-                if (hasData) {
-                    promiseAggregator = new SimpleChannelPromiseAggregator(promise, ctx.channel(), ctx.executor());
-                    encoder.writeHeaders(ctx, streamId, http2Headers, 0, false, promiseAggregator.newPromise());
-                    httpMsgNeedRelease = false;
-                    encoder.writeData(ctx, streamId, httpMsg.content(), 0, true, promiseAggregator.newPromise());
-                    promiseAggregator.doneAllocatingPromises();
-                } else {
-                    encoder.writeHeaders(ctx, streamId, http2Headers, 0, true, promise);
+            if (!endStream && msg instanceof HttpContent) {
+                boolean isLastContent = false;
+                Http2Headers trailers = EmptyHttp2Headers.INSTANCE;
+                if (msg instanceof LastHttpContent) {
+                    isLastContent = true;
+
+                    // Convert any trailing headers.
+                    final LastHttpContent lastContent = (LastHttpContent) msg;
+                    trailers = HttpUtil.toHttp2Headers(lastContent.trailingHeaders());
                 }
-            } catch (Throwable t) {
-                if (promiseAggregator == null) {
-                    promise.tryFailure(t);
-                } else {
-                    promiseAggregator.setFailure(t);
-                }
-            } finally {
-                if (httpMsgNeedRelease) {
-                    httpMsg.release();
+
+                // Write the data
+                final ByteBuf content = ((HttpContent) msg).content();
+                endStream = isLastContent && trailers.isEmpty();
+                release = false;
+                encoder.writeData(ctx, currentStreamId, content, 0, endStream, promiseAggregator.newPromise());
+
+                if (!trailers.isEmpty()) {
+                    // Write trailing headers.
+                    encoder.writeHeaders(ctx, currentStreamId, trailers, 0, true, promiseAggregator.newPromise());
                 }
             }
-        } else {
-            ctx.write(msg, promise);
+
+            promiseAggregator.doneAllocatingPromises();
+        } catch (Throwable t) {
+            promiseAggregator.setFailure(t);
+        } finally {
+            if (release) {
+                ReferenceCountUtil.release(msg);
+            }
         }
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpUtil.java
@@ -29,6 +29,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderUtil;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
@@ -265,7 +266,7 @@ public final class HttpUtil {
     /**
      * Converts the given HTTP/1.x headers into HTTP/2 headers.
      */
-    public static Http2Headers toHttp2Headers(FullHttpMessage in) throws Exception {
+    public static Http2Headers toHttp2Headers(HttpMessage in) throws Exception {
         final Http2Headers out = new DefaultHttp2Headers();
         HttpHeaders inHeaders = in.headers();
         if (in instanceof HttpRequest) {
@@ -304,6 +305,16 @@ public final class HttpUtil {
         }
 
         // Add the HTTP headers which have not been consumed above
+        return out.add(toHttp2Headers(inHeaders));
+    }
+
+    public static Http2Headers toHttp2Headers(HttpHeaders inHeaders) throws Exception {
+        if (inHeaders.isEmpty()) {
+            return EmptyHttp2Headers.INSTANCE;
+        }
+
+        final Http2Headers out = new DefaultHttp2Headers();
+
         inHeaders.forEachEntry(new EntryVisitor() {
             @Override
             public boolean visit(Entry<CharSequence, CharSequence> entry) throws Exception {


### PR DESCRIPTION
Motivation:

```HttpToHttp2ConnectionHandler``` only converts ```FullHttpMessage``` to HTTP/2 Frames. This does not support other use cases such as adding a ```HttpContentCompressor``` to the pipeline, which writes ```HttpMessage``` and ```HttpContent```.

Additionally ```HttpToHttp2ConnectionHandler``` ignores converting and sending HTTP trailing headers, which is a bug as the HTTP/2 spec states that they should be sent.

Modifications:

Update ```HttpToHttp2ConnectionHandler``` to support converting ```HttpMessage``` and ```HttpContent``` to HTTP/2 Frames.
Additionally, include an extra call to ```writeHeaders``` if the message includes trailing headers.

Result:

One can now write ```HttpMessage``` and ```HttpContent``` (http chunking) down the pipeline and they will be converted to HTTP/2 Frames.  If any trailing headers exist, they will be converted and sent as well.