### PR TITLE
Fix DatagramChannel javadoc

### DIFF
--- a/transport/src/main/java/io/netty/channel/socket/DatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/DatagramChannel.java
@@ -24,7 +24,7 @@ import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 
 /**
- * A UDP/IP {@link Channel}}.
+ * A UDP/IP {@link Channel}.
  */
 public interface DatagramChannel extends Channel {
     @Override


### PR DESCRIPTION
There seems to be an incorrectly placed curly bracket when trying to link "Channel."