### PR TITLE
[#3967] Guard against NPE in PendingWriteQueue

### DIFF
--- a/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
+++ b/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
@@ -87,7 +87,12 @@ public final class PendingWriteQueue {
             tail = write;
         }
         size ++;
-        buffer.incrementPendingOutboundBytes(write.size);
+        // We need to guard against null as channel.unsafe().outboundBuffer() may returned null
+        // if the channel was already closed when constructing the PendingWriteQueue.
+        // See https://github.com/netty/netty/issues/3967
+        if (buffer != null) {
+            buffer.incrementPendingOutboundBytes(write.size);
+        }
     }
 
     /**
@@ -245,7 +250,12 @@ public final class PendingWriteQueue {
         }
 
         write.recycle();
-        buffer.decrementPendingOutboundBytes(writeSize);
+        // We need to guard against null as channel.unsafe().outboundBuffer() may returned null
+        // if the channel was already closed when constructing the PendingWriteQueue.
+        // See https://github.com/netty/netty/issues/3967
+        if (buffer != null) {
+            buffer.decrementPendingOutboundBytes(writeSize);
+        }
     }
 
     private static void safeFail(ChannelPromise promise, Throwable cause) {

--- a/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
@@ -244,6 +244,21 @@ public class PendingWriteQueueTest {
         assertNull(channel.readInbound());
     }
 
+    // See https://github.com/netty/netty/issues/3967
+    @Test
+    public void testCloseChannelOnCreation() {
+        EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter());
+        channel.close().syncUninterruptibly();
+
+        final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
+
+        IllegalStateException ex = new IllegalStateException();
+        ChannelPromise promise = channel.newPromise();
+        queue.add(1L, promise);
+        queue.removeAndFailAll(ex);
+        assertSame(ex, promise.cause());
+    }
+
     private static class TestHandler extends ChannelDuplexHandler {
         protected PendingWriteQueue queue;
         private int expectedSize;


### PR DESCRIPTION
Motivation:

If the Channel is already closed when the PendingWriteQueue is created it will generate a NPE when add or remove is called later.

Modifications:

Add null checks to guard against NPE.

Result:

No more NPE possible.