### PR TITLE
Allow to construct EmbeddedChannel without a ChannelHandler

### DIFF
--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -70,14 +70,6 @@ public class EmbeddedChannel extends AbstractChannel {
             throw new NullPointerException("handlers");
         }
 
-        int nHandlers = 0;
-        for (ChannelHandler h: handlers) {
-            if (h == null) {
-                break;
-            }
-            nHandlers ++;
-        }
-
         ChannelPipeline p = pipeline();
         p.addLast(new ChannelInitializer<Channel>() {
             @Override
@@ -91,10 +83,6 @@ public class EmbeddedChannel extends AbstractChannel {
                 }
             }
         });
-
-        if (nHandlers == 0) {
-            throw new IllegalArgumentException("handlers is empty.");
-        }
 
         ChannelFuture future = loop.register(this);
         assert future.isDone();

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -122,4 +122,16 @@ public class EmbeddedChannelTest {
             throw cause;
         }
     }
+
+    @Test
+    public void testConstructWithOutHandler() {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        Assert.assertTrue(channel.writeInbound(1));
+        Assert.assertTrue(channel.writeOutbound(2));
+        Assert.assertTrue(channel.finish());
+        Assert.assertSame(1, channel.readInbound());
+        Assert.assertNull(channel.readInbound());
+        Assert.assertSame(2, channel.readOutbound());
+        Assert.assertNull(channel.readOutbound());
+    }
 }


### PR DESCRIPTION
Motivation:

In 4.1 and master branch we allow to construct an EmbeddedChannel without ChannelHandlers, we should do the same in 4.0.

Modifications:

Backport behavoir.

Result:

It's now possible to construct an EmbeddedChannel without any ChannelHandler