### PR TITLE
DnsResolver.resolve(...) fails when ipaddress is used.

### DIFF
--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -418,6 +418,16 @@ public class DnsNameResolverTest {
         }
     }
 
+    @Test
+    public void testResolveIp() {
+        InetSocketAddress unresolved =
+                InetSocketAddress.createUnresolved("10.0.0.1", ThreadLocalRandom.current().nextInt(65536));
+
+        InetSocketAddress address = resolver.resolve(unresolved).syncUninterruptibly().getNow();
+
+        assertEquals("10.0.0.1", address.getHostName());
+    }
+
     private static void resolve(
             Map<InetSocketAddress, Future<InetSocketAddress>> futures, String hostname) {
         InetSocketAddress unresolved =


### PR DESCRIPTION
Motivation:

DnsResolver.resolve(...) fails when an InetSocketAddress is used that was constructed of an ipaddress string.

Modifications:

Don't try to lookup when the InetSocketAddress was constructed via an ipaddress.

Result:

DnsResolver.resolve(...) works in all cases.