### PR TITLE
Ensure cancelled scheduled tasks can be GC'ed ASAP

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -36,14 +36,18 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(GlobalEventExecutor.class);
 
-    private static final long SCHEDULE_PURGE_INTERVAL = TimeUnit.SECONDS.toNanos(1);
+    private static final long SCHEDULE_QUIET_PERIOD_INTERVAL = TimeUnit.SECONDS.toNanos(1);
 
     public static final GlobalEventExecutor INSTANCE = new GlobalEventExecutor();
 
     final BlockingQueue<Runnable> taskQueue = new LinkedBlockingQueue<Runnable>();
-    final ScheduledFutureTask<Void> purgeTask = new ScheduledFutureTask<Void>(
-            this, Executors.<Void>callable(new PurgeTask(), null),
-            ScheduledFutureTask.deadlineNanos(SCHEDULE_PURGE_INTERVAL), -SCHEDULE_PURGE_INTERVAL);
+    final ScheduledFutureTask<Void> QUIET_PERIOD_TASK = new ScheduledFutureTask<Void>(
+            this, Executors.<Void>callable(new Runnable() {
+        @Override
+        public void run() {
+            // NOOP
+        }
+    }, null), ScheduledFutureTask.deadlineNanos(SCHEDULE_QUIET_PERIOD_INTERVAL), -SCHEDULE_QUIET_PERIOD_INTERVAL);
 
     private final ThreadFactory threadFactory = new DefaultThreadFactory(getClass());
     private final TaskRunner taskRunner = new TaskRunner();
@@ -53,7 +57,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor {
     private final Future<?> terminationFuture = new FailedFuture<Object>(this, new UnsupportedOperationException());
 
     private GlobalEventExecutor() {
-        scheduledTaskQueue().add(purgeTask);
+        scheduledTaskQueue().add(QUIET_PERIOD_TASK);
     }
 
     @Override
@@ -231,13 +235,13 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor {
                         logger.warn("Unexpected exception from the global event executor: ", t);
                     }
 
-                    if (task != purgeTask) {
+                    if (task != QUIET_PERIOD_TASK) {
                         continue;
                     }
                 }
 
                 Queue<ScheduledFutureTask<?>> scheduledTaskQueue = GlobalEventExecutor.this.scheduledTaskQueue;
-                // Terminate if there is no task in the queue (except the purge task).
+                // Terminate if there is no task in the queue (except the noop task).
                 if (taskQueue.isEmpty() && (scheduledTaskQueue == null || scheduledTaskQueue.size() == 1)) {
                     // Mark the current thread as stopped.
                     // The following CAS must always success and must be uncontended,
@@ -266,13 +270,6 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor {
                     // -> keep this thread alive to handle the newly added entries.
                 }
             }
-        }
-    }
-
-    private final class PurgeTask implements Runnable {
-        @Override
-        public void run() {
-            purgeCancelledScheduledTasks();
         }
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
+++ b/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
@@ -147,6 +147,19 @@ final class ScheduledFutureTask<V> extends PromiseTask<V> implements ScheduledFu
     }
 
     @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        boolean canceled = super.cancel(mayInterruptIfRunning);
+        if (canceled) {
+            ((AbstractScheduledEventExecutor) executor()).removeScheduled(this);
+        }
+        return canceled;
+    }
+
+    boolean cancelWithoutRemove(boolean mayInterruptIfRunning) {
+        return super.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
     protected StringBuilder toStringBuilder() {
         StringBuilder buf = super.toStringBuilder();
         buf.setCharAt(buf.length() - 1, ',');

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.Semaphore;
@@ -714,18 +713,8 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     private void startThread() {
         if (STATE_UPDATER.get(this) == ST_NOT_STARTED) {
             if (STATE_UPDATER.compareAndSet(this, ST_NOT_STARTED, ST_STARTED)) {
-                schedule(new ScheduledFutureTask<Void>(
-                        this, Executors.<Void>callable(new PurgeTask(), null),
-                        ScheduledFutureTask.deadlineNanos(SCHEDULE_PURGE_INTERVAL), -SCHEDULE_PURGE_INTERVAL));
                 thread.start();
             }
-        }
-    }
-
-    private final class PurgeTask implements Runnable {
-        @Override
-        public void run() {
-            purgeCancelledScheduledTasks();
         }
     }
 }


### PR DESCRIPTION
Motivation:

Prior we used a purge task that would remove previous canceled scheduled tasks from the internal queue. This could introduce some delay and so use a lot of memory even if the task itself is already canceled.

Modifications:

Use a DelayedQueue to store the ScheduledFutureTasks and remove the tasks directly once it was canceled sucessfully.

Result:

Faster possibility to GC a canceled ScheduledFutureTask.