### PR TITLE
HTTP/2 Thread Context Interface Clarifications

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowControllerTest.java
@@ -31,8 +31,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-
+import io.netty.util.concurrent.EventExecutor;
 import junit.framework.AssertionFailedError;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -56,6 +57,9 @@ public class DefaultHttp2LocalFlowControllerTest {
     private ChannelHandlerContext ctx;
 
     @Mock
+    private EventExecutor executor;
+
+    @Mock
     private ChannelPromise promise;
 
     private DefaultHttp2Connection connection;
@@ -75,6 +79,8 @@ public class DefaultHttp2LocalFlowControllerTest {
 
         connection.local().createStream(STREAM_ID, false);
         controller.channelHandlerContext(ctx);
+        when(ctx.executor()).thenReturn(executor);
+        when(executor.inEventLoop()).thenReturn(true);
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -43,6 +43,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.Http2FrameWriter.Configuration;
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
+import io.netty.util.concurrent.EventExecutor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -89,6 +90,9 @@ public class DefaultHttp2RemoteFlowControllerTest {
     private ChannelConfig config;
 
     @Mock
+    private EventExecutor executor;
+
+    @Mock
     private ChannelPromise promise;
 
     @Mock
@@ -104,6 +108,7 @@ public class DefaultHttp2RemoteFlowControllerTest {
         when(ctx.flush()).thenThrow(new AssertionFailedError("forbidden"));
         setChannelWritability(true);
         when(channel.config()).thenReturn(config);
+        when(executor.inEventLoop()).thenReturn(true);
 
         initConnectionAndController();
 
@@ -1444,6 +1449,7 @@ public class DefaultHttp2RemoteFlowControllerTest {
     private void resetCtx() {
         reset(ctx);
         when(ctx.channel()).thenReturn(channel);
+        when(ctx.executor()).thenReturn(executor);
     }
 
     private void setChannelWritability(boolean isWritable) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -44,6 +44,7 @@ import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.codec.http2.StreamBufferingEncoder.Http2ChannelClosedException;
 import io.netty.handler.codec.http2.StreamBufferingEncoder.Http2GoAwayException;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 
 import org.junit.After;
@@ -76,6 +77,9 @@ public class StreamBufferingEncoderTest {
 
     @Mock
     private ChannelConfig config;
+
+    @Mock
+    private EventExecutor executor;
 
     @Mock
     private ChannelPromise promise;
@@ -114,7 +118,9 @@ public class StreamBufferingEncoderTest {
         when(ctx.channel()).thenReturn(channel);
         when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
         when(channel.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
+        when(executor.inEventLoop()).thenReturn(true);
         when(ctx.newPromise()).thenReturn(promise);
+        when(ctx.executor()).thenReturn(executor);
         when(promise.channel()).thenReturn(channel);
         when(channel.isActive()).thenReturn(false);
         when(channel.config()).thenReturn(config);


### PR DESCRIPTION
Motivation:
It is currently assumed that all usages of the HTTP/2 codec will be from the same event loop context. If the methods are used outside of the assumed thread context then unexpected behavior is observed. This assumption should be more clearly communicated and enforced in key areas.

Modifications:
- The flow controller interfaces have assert statements and updated javadocs indicating the assumptions.

Result:
Interfaces more clearly indicate thread context limitations.