### PR TITLE
Send full response for unsupported websocket versions

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
@@ -18,8 +18,9 @@ package io.netty.handler.codec.http.websocketx;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelPromise;
-import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderUtil;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -146,10 +147,11 @@ public class WebSocketServerHandshakerFactory {
      * Return that we need cannot not support the web socket version
      */
     public static ChannelFuture sendUnsupportedVersionResponse(Channel channel, ChannelPromise promise) {
-        HttpResponse res = new DefaultHttpResponse(
+        HttpResponse res = new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1,
                 HttpResponseStatus.UPGRADE_REQUIRED);
         res.headers().set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, WebSocketVersion.V13.toHttpHeaderValue());
-        return channel.write(res, promise);
+        HttpHeaderUtil.setContentLength(res, 0);
+        return channel.writeAndFlush(res, promise);
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactoryTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactoryTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.http.websocketx;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderUtil;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.ReferenceCountUtil;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class WebSocketServerHandshakerFactoryTest {
+
+    @Test
+    public void testUnsupportedVersion() throws Exception {
+        EmbeddedChannel ch = new EmbeddedChannel();
+        WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ch);
+        ch.runPendingTasks();
+        Object msg = ch.readOutbound();
+
+        if (!(msg instanceof FullHttpResponse)) {
+            fail("Got wrong response " + msg);
+        }
+        FullHttpResponse response = (FullHttpResponse) msg;
+
+        assertEquals(HttpResponseStatus.UPGRADE_REQUIRED, response.status());
+        assertEquals(WebSocketVersion.V13.toHttpHeaderValue(),
+                response.headers().get(HttpHeaderNames.SEC_WEBSOCKET_VERSION));
+        assertTrue(HttpHeaderUtil.isContentLengthSet(response));
+        assertEquals(0, HttpHeaderUtil.getContentLength(response));
+
+        ReferenceCountUtil.release(response);
+        assertFalse(ch.finish());
+    }
+}


### PR DESCRIPTION
When the WebSocketServerHandshakerFactory sent a response if the websocket verison was not expected, it had three problems, first it didn't send a LastHttpContent, leaving any upstream handlers that were tracking responses thinking the response wasn't finished, second it didn't flush, so the response was never actually sent, and third, if it did somehow manage to flush, it didn't send a content length, leaving the client waiting to receive a close delimited body.