### PR TITLE
HTTP/2 CompressorHttp2ConnectionEncoder bug

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -114,7 +114,7 @@ final class Http2TestUtil {
             this.latch = latch;
         }
 
-        public Http2Stream getOrCreateStream(int streamId, boolean halfClosed) throws Http2Exception {
+        private Http2Stream getOrCreateStream(int streamId, boolean halfClosed) throws Http2Exception {
             return getOrCreateStream(connection, streamId, halfClosed);
         }
 


### PR DESCRIPTION
Motivation:
The CompressorHttp2ConnectionEncoder is attempting to attach a property to streams before the exist.

Modifications:
- Allow the super class to create the streams before attempting to attach a property to the stream.

Result:
CompressorHttp2ConnectionEncoder is able to set the property and access the compressor.