### PR TITLE
Fix wrong class mentioned in setter,Update ChannelConfig.java

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/ChannelConfig.java
@@ -245,7 +245,7 @@ public interface ChannelConfig {
     MessageSizeEstimator getMessageSizeEstimator();
 
     /**
-     * Set the {@link ByteBufAllocator} which is used for the channel
+     * Set the {@link MessageSizeEstimator} which is used for the channel
      * to detect the size of a message.
      */
     ChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator);


### PR DESCRIPTION
Documentation: wrong class mentioned in setter
{@link ByteBufAllocator} -> {@link MessageSizeEstimator} on
https://github.com/netty/netty/blob/4.0/transport/src/main/java/io/netty/channel/ChannelConfig.java#L248