### PR TITLE
Allow to create SslContext from existing PrivateKey / X509Certificate

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -15,7 +15,6 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.util.internal.EmptyArrays;
 import org.apache.tomcat.jni.SSL;
 import org.apache.tomcat.jni.SSLContext;
 
@@ -28,6 +27,7 @@ import javax.net.ssl.X509ExtendedTrustManager;
 import javax.net.ssl.X509TrustManager;
 import java.io.File;
 import java.security.KeyStore;
+import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 
 import static io.netty.util.internal.ObjectUtil.*;
@@ -43,7 +43,9 @@ public final class OpenSslServerContext extends OpenSslContext {
      *
      * @param certChainFile an X.509 certificate chain file in PEM format
      * @param keyFile a PKCS#8 private key file in PEM format
+     * @deprecated use {@link SslContextBuilder}
      */
+    @Deprecated
     public OpenSslServerContext(File certChainFile, File keyFile) throws SSLException {
         this(certChainFile, keyFile, null);
     }
@@ -55,16 +57,15 @@ public final class OpenSslServerContext extends OpenSslContext {
      * @param keyFile a PKCS#8 private key file in PEM format
      * @param keyPassword the password of the {@code keyFile}.
      *                    {@code null} if it's not password-protected.
+     * @deprecated use {@link SslContextBuilder}
      */
+    @Deprecated
     public OpenSslServerContext(File certChainFile, File keyFile, String keyPassword) throws SSLException {
         this(certChainFile, keyFile, keyPassword, null, IdentityCipherSuiteFilter.INSTANCE,
              ApplicationProtocolConfig.DISABLED, 0, 0);
     }
 
     /**
-     * @deprecated use {@link #OpenSslServerContext(
-     *             File, File, String, Iterable, CipherSuiteFilter, ApplicationProtocolConfig, long, long)}
-     *
      * Creates a new instance.
      *
      * @param certChainFile an X.509 certificate chain file in PEM format
@@ -78,6 +79,7 @@ public final class OpenSslServerContext extends OpenSslContext {
      *                         {@code 0} to use the default value.
      * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
      *                       {@code 0} to use the default value.
+     * @deprecated use {@link SslContextBuilder}
      */
     @Deprecated
     public OpenSslServerContext(
@@ -89,9 +91,6 @@ public final class OpenSslServerContext extends OpenSslContext {
     }
 
     /**
-     * @deprecated Use the constructors that accepts {@link ApplicationProtocolConfig} or
-     *             {@link ApplicationProtocolNegotiator} instead.
-     *
      * Creates a new instance.
      *
      * @param certChainFile an X.509 certificate chain file in PEM format
@@ -106,6 +105,7 @@ public final class OpenSslServerContext extends OpenSslContext {
      *                         {@code 0} to use the default value.
      * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
      *                       {@code 0} to use the default value.
+     * @deprecated use {@link SslContextBuilder}
      */
     @Deprecated
     public OpenSslServerContext(
@@ -130,8 +130,7 @@ public final class OpenSslServerContext extends OpenSslContext {
      *                         {@code 0} to use the default value.
      * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
      *                       {@code 0} to use the default value.
-     * @deprecated use {@link #OpenSslServerContext(File, TrustManagerFactory, File, File, String, KeyManagerFactory,
-     * Iterable, CipherSuiteFilter, ApplicationProtocolConfig, long, long)}
+     * @deprecated use {@link SslContextBuilder}
      */
     @Deprecated
     public OpenSslServerContext(
@@ -156,8 +155,7 @@ public final class OpenSslServerContext extends OpenSslContext {
      *                         {@code 0} to use the default value.
      * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
      *                       {@code 0} to use the default value.
-     * @deprecated use {@link #OpenSslServerContext(File, TrustManagerFactory, File, File, String, KeyManagerFactory,
-     * Iterable, CipherSuiteFilter, ApplicationProtocolConfig, long, long)}
+     * @deprecated use {@link SslContextBuilder}
      */
     @Deprecated
     public OpenSslServerContext(
@@ -183,7 +181,9 @@ public final class OpenSslServerContext extends OpenSslContext {
      *                         {@code 0} to use the default value.
      * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
      *                       {@code 0} to use the default value.
+     * @deprecated use {@link SslContextBuilder}
      */
+    @Deprecated
     public OpenSslServerContext(
             File certChainFile, File keyFile, String keyPassword,
             Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
@@ -218,7 +218,9 @@ public final class OpenSslServerContext extends OpenSslContext {
      *                         {@code 0} to use the default value.
      * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
      *                       {@code 0} to use the default value.
+     * @deprecated use {@link SslContextBuilder}
      */
+    @Deprecated
     public OpenSslServerContext(
             File trustCertChainFile, TrustManagerFactory trustManagerFactory,
             File keyCertChainFile, File keyFile, String keyPassword, KeyManagerFactory keyManagerFactory,
@@ -243,6 +245,7 @@ public final class OpenSslServerContext extends OpenSslContext {
      *                         {@code 0} to use the default value.
      * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
      *                       {@code 0} to use the default value.
+     * @deprecated use {@link SslContextBuilder}
      */
     @Deprecated
     public OpenSslServerContext(File certChainFile, File keyFile, String keyPassword,
@@ -268,8 +271,7 @@ public final class OpenSslServerContext extends OpenSslContext {
      *                         {@code 0} to use the default value.
      * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
      *                       {@code 0} to use the default value.
-     * @deprecated use {@link #OpenSslServerContext(File, TrustManagerFactory, File, File, String, KeyManagerFactory,
-     * Iterable, CipherSuiteFilter, OpenSslApplicationProtocolNegotiator, long, long)}
+     * @deprecated use {@link SslContextBuilder}}
      */
     @Deprecated
     public OpenSslServerContext(
@@ -307,7 +309,9 @@ public final class OpenSslServerContext extends OpenSslContext {
      *                         {@code 0} to use the default value.
      * @param sessionTimeout the timeout for the cached SSL session objects, in seconds.
      *                       {@code 0} to use the default value.
+     * @deprecated use {@link SslContextBuilder}
      */
+    @Deprecated
     public OpenSslServerContext(
             File trustCertChainFile, TrustManagerFactory trustManagerFactory,
             File keyCertChainFile, File keyFile, String keyPassword, KeyManagerFactory keyManagerFactory,
@@ -370,10 +374,123 @@ public final class OpenSslServerContext extends OpenSslContext {
                     if (trustCertChainFile != null) {
                         trustManagerFactory = buildTrustManagerFactory(trustCertChainFile, trustManagerFactory);
                     } else {
-                        char[] keyPasswordChars =
-                                keyPassword == null ? EmptyArrays.EMPTY_CHARS : keyPassword.toCharArray();
+                        KeyStore ks = buildKeyStore(keyCertChainFile, keyFile, keyPassword);
+                        trustManagerFactory.init(ks);
+                    }
 
-                        KeyStore ks = buildKeyStore(keyCertChainFile, keyFile, keyPasswordChars);
+                    final X509TrustManager manager = chooseTrustManager(trustManagerFactory.getTrustManagers());
+
+                    // Use this to prevent an error when running on java < 7
+                    if (useExtendedTrustManager(manager)) {
+                        final X509ExtendedTrustManager extendedManager = (X509ExtendedTrustManager) manager;
+                        SSLContext.setCertVerifyCallback(ctx, new AbstractCertificateVerifier() {
+                            @Override
+                            void verify(OpenSslEngine engine, X509Certificate[] peerCerts, String auth)
+                                    throws Exception {
+                                extendedManager.checkClientTrusted(peerCerts, auth, engine);
+                            }
+                        });
+                    } else {
+                        SSLContext.setCertVerifyCallback(ctx, new AbstractCertificateVerifier() {
+                            @Override
+                            void verify(OpenSslEngine engine, X509Certificate[] peerCerts, String auth)
+                                    throws Exception {
+                                manager.checkClientTrusted(peerCerts, auth);
+                            }
+                        });
+                    }
+                } catch (Exception e) {
+                    throw new SSLException("unable to setup trustmanager", e);
+                }
+            }
+            sessionContext = new OpenSslServerSessionContext(ctx);
+            success = true;
+        } finally {
+            if (!success) {
+                destroy();
+            }
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    OpenSslServerContext(
+            X509Certificate[] trustCertChain, TrustManagerFactory trustManagerFactory,
+            X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
+            Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
+            long sessionCacheSize, long sessionTimeout) throws SSLException {
+        super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_SERVER);
+        OpenSsl.ensureAvailability();
+
+        checkNotNull(keyCertChain, "keyCertChainFile");
+        checkNotNull(key, "keyFile");
+
+        if (keyPassword == null) {
+            keyPassword = "";
+        }
+
+        // Create a new SSL_CTX and configure it.
+        boolean success = false;
+        try {
+            synchronized (OpenSslContext.class) {
+                /* Set certificate verification policy. */
+                SSLContext.setVerify(ctx, SSL.SSL_CVERIFY_NONE, VERIFY_DEPTH);
+                long keyCertChainBio = 0;
+                try {
+                    keyCertChainBio = toBIO(keyCertChain);
+                    /* Load the certificate chain. We must skip the first cert when server mode */
+                    if (!SSLContext.setCertificateChainBio(ctx, keyCertChainBio, true)) {
+                        long error = SSL.getLastErrorNumber();
+                        if (OpenSsl.isError(error)) {
+                            String err = SSL.getErrorString(error);
+                            throw new SSLException(
+                                    "failed to set certificate chain: " + err);
+                        }
+                    }
+                } catch (Exception e) {
+                    throw new SSLException(
+                            "failed to set certificate chain", e);
+                } finally {
+                    if (keyCertChainBio != 0) {
+                        SSL.freeBIO(keyCertChainBio);
+                    }
+                }
+
+                /* Load the certificate file and private key. */
+                long keyBio = 0;
+                keyCertChainBio = 0;
+                try {
+                    keyBio = toBIO(key);
+                    keyCertChainBio = toBIO(keyCertChain);
+                    if (!SSLContext.setCertificateBio(
+                            ctx, keyCertChainBio, keyBio, keyPassword, SSL.SSL_AIDX_RSA)) {
+                        long error = SSL.getLastErrorNumber();
+                        if (OpenSsl.isError(error)) {
+                            String err = SSL.getErrorString(error);
+                            throw new SSLException("failed to set certificate and key: " + err);
+                        }
+                    }
+                } catch (SSLException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new SSLException("failed to set certificate and key", e);
+                } finally {
+                    if (keyBio != 0) {
+                        SSL.freeBIO(keyBio);
+                    }
+                    if (keyCertChainBio != 0) {
+                        SSL.freeBIO(keyCertChainBio);
+                    }
+                }
+                try {
+                    if (trustManagerFactory == null) {
+                        // Mimic the way SSLContext.getInstance(KeyManager[], null, null) works
+                        trustManagerFactory = TrustManagerFactory.getInstance(
+                                TrustManagerFactory.getDefaultAlgorithm());
+                    }
+                    if (trustCertChain != null) {
+                        trustManagerFactory = buildTrustManagerFactory(trustCertChain, trustManagerFactory);
+                    } else {
+                        KeyStore ks = buildKeyStore(keyCertChain, key, keyPassword.toCharArray());
                         trustManagerFactory.init(ks);
                     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -22,11 +22,14 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.File;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
 
 /**
  * Builder for configuring a new SslContext for creation.
  */
 public final class SslContextBuilder {
+
     /**
      * Creates a builder for new client-side {@link SslContext}.
      */
@@ -48,6 +51,17 @@ public final class SslContextBuilder {
     /**
      * Creates a builder for new server-side {@link SslContext}.
      *
+     * @param key a PKCS#8 private key
+     * @param keyCertChain the X.509 certificate chain
+     * @see #keyManager(PrivateKey, X509Certificate[])
+     */
+    public static SslContextBuilder forServer(PrivateKey key, X509Certificate... keyCertChain) {
+        return new SslContextBuilder(true).keyManager(key, keyCertChain);
+    }
+
+    /**
+     * Creates a builder for new server-side {@link SslContext}.
+     *
      * @param keyCertChainFile an X.509 certificate chain file in PEM format
      * @param keyFile a PKCS#8 private key file in PEM format
      * @param keyPassword the password of the {@code keyFile}, or {@code null} if it's not
@@ -62,6 +76,20 @@ public final class SslContextBuilder {
     /**
      * Creates a builder for new server-side {@link SslContext}.
      *
+     * @param key a PKCS#8 private key
+     * @param keyCertChain the X.509 certificate chain
+     * @param keyPassword the password of the {@code keyFile}, or {@code null} if it's not
+     *     password-protected
+     * @see #keyManager(File, File, String)
+     */
+    public static SslContextBuilder forServer(
+            PrivateKey key, String keyPassword, X509Certificate... keyCertChain) {
+        return new SslContextBuilder(true).keyManager(key, keyPassword, keyCertChain);
+    }
+
+    /**
+     * Creates a builder for new server-side {@link SslContext}.
+     *
      * @param keyManagerFactory non-{@code null} factory for server's private key
      * @see #keyManager(KeyManagerFactory)
      */
@@ -71,10 +99,10 @@ public final class SslContextBuilder {
 
     private final boolean forServer;
     private SslProvider provider;
-    private File trustCertChainFile;
+    private X509Certificate[] trustCertChain;
     private TrustManagerFactory trustManagerFactory;
-    private File keyCertChainFile;
-    private File keyFile;
+    private X509Certificate[] keyCertChain;
+    private PrivateKey key;
     private String keyPassword;
     private KeyManagerFactory keyManagerFactory;
     private Iterable<String> ciphers;
@@ -100,8 +128,19 @@ public final class SslContextBuilder {
      * contain an X.509 certificate chain in PEM format. {@code null} uses the system default.
      */
     public SslContextBuilder trustManager(File trustCertChainFile) {
-        this.trustCertChainFile = trustCertChainFile;
-        this.trustManagerFactory = null;
+        try {
+            return trustManager(SslContext.toX509Certificates(trustCertChainFile));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("File does not contain valid certificates: " + trustCertChainFile, e);
+        }
+    }
+
+    /**
+     * Trusted certificates for verifying the remote endpoint's certificate, {@code null} uses the system default.
+     */
+    public SslContextBuilder trustManager(X509Certificate... trustCertChain) {
+        this.trustCertChain = trustCertChain != null ? trustCertChain.clone() : null;
+        trustManagerFactory = null;
         return this;
     }
 
@@ -111,7 +150,7 @@ public final class SslContextBuilder {
      * you must use {@link #trustManager(File)}. {@code null} uses the system default.
      */
     public SslContextBuilder trustManager(TrustManagerFactory trustManagerFactory) {
-        this.trustCertChainFile = null;
+        trustCertChain = null;
         this.trustManagerFactory = trustManagerFactory;
         return this;
     }
@@ -128,6 +167,17 @@ public final class SslContextBuilder {
     }
 
     /**
+     * Identifying certificate for this host. {@code keyCertChain} and {@code key} may
+     * be {@code null} for client contexts, which disables mutual authentication.
+     *
+     * @param key a PKCS#8 private key
+     * @param keyCertChain an X.509 certificate chain
+     */
+    public SslContextBuilder keyManager(PrivateKey key, X509Certificate... keyCertChain) {
+        return keyManager(key, null, keyCertChain);
+    }
+
+    /**
      * Identifying certificate for this host. {@code keyCertChainFile} and {@code keyFile} may
      * be {@code null} for client contexts, which disables mutual authentication.
      *
@@ -137,14 +187,51 @@ public final class SslContextBuilder {
      *     password-protected
      */
     public SslContextBuilder keyManager(File keyCertChainFile, File keyFile, String keyPassword) {
-        if (forServer) {
-            checkNotNull(keyCertChainFile, "keyCertChainFile required for servers");
-            checkNotNull(keyFile, "keyFile required for servers");
+        X509Certificate[] keyCertChain;
+        PrivateKey key;
+        try {
+            keyCertChain = SslContext.toX509Certificates(keyCertChainFile);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("File does not contain valid certificates: " + keyCertChainFile, e);
         }
-        this.keyCertChainFile = keyCertChainFile;
-        this.keyFile = keyFile;
+        try {
+            key = SslContext.toPrivateKey(keyFile, keyPassword);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("File does not contain valid private key: " + keyFile, e);
+        }
+        return keyManager(key, keyPassword, keyCertChain);
+    }
+
+    /**
+     * Identifying certificate for this host. {@code keyCertChain} and {@code key} may
+     * be {@code null} for client contexts, which disables mutual authentication.
+     *
+     * @param key a PKCS#8 private key file
+     * @param keyPassword the password of the {@code key}, or {@code null} if it's not
+     *     password-protected
+     * @param keyCertChain an X.509 certificate chain
+     */
+    public SslContextBuilder keyManager(PrivateKey key, String keyPassword, X509Certificate... keyCertChain) {
+        if (forServer) {
+            checkNotNull(keyCertChain, "keyCertChain required for servers");
+            if (keyCertChain.length == 0) {
+                throw new IllegalArgumentException("keyCertChain must be non-empty");
+            }
+            checkNotNull(key, "key required for servers");
+        }
+        if (keyCertChain == null || keyCertChain.length == 0) {
+            this.keyCertChain = null;
+        } else {
+            for (X509Certificate cert: keyCertChain) {
+                if (cert == null) {
+                    throw new IllegalArgumentException("keyCertChain contains null entry");
+                }
+            }
+            this.keyCertChain = keyCertChain.clone();
+        }
+        this.key = key;
         this.keyPassword = keyPassword;
-        this.keyManagerFactory = null;
+        keyManagerFactory = null;
         return this;
     }
 
@@ -158,9 +245,9 @@ public final class SslContextBuilder {
         if (forServer) {
             checkNotNull(keyManagerFactory, "keyManagerFactory required for servers");
         }
-        this.keyCertChainFile = null;
-        this.keyFile = null;
-        this.keyPassword = null;
+        keyCertChain = null;
+        key = null;
+        keyPassword = null;
         this.keyManagerFactory = keyManagerFactory;
         return this;
     }
@@ -216,12 +303,12 @@ public final class SslContextBuilder {
      */
     public SslContext build() throws SSLException {
         if (forServer) {
-            return SslContext.newServerContextInternal(provider, trustCertChainFile,
-                trustManagerFactory, keyCertChainFile, keyFile, keyPassword, keyManagerFactory,
+            return SslContext.newServerContextInternal(provider, trustCertChain,
+                trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
                 ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
         } else {
-            return SslContext.newClientContextInternal(provider, trustCertChainFile,
-                trustManagerFactory, keyCertChainFile, keyFile, keyPassword, keyManagerFactory,
+            return SslContext.newClientContextInternal(provider, trustCertChain,
+                trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
                 ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
         }
     }

--- a/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
@@ -23,6 +23,7 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -33,6 +34,7 @@ import java.security.PrivateKey;
 import java.security.SecureRandom;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 
@@ -63,6 +65,8 @@ public final class SelfSignedCertificate {
 
     private final File certificate;
     private final File privateKey;
+    private final X509Certificate cert;
+    private final PrivateKey key;
 
     /**
      * Creates a new instance.
@@ -120,6 +124,13 @@ public final class SelfSignedCertificate {
 
         certificate = new File(paths[0]);
         privateKey = new File(paths[1]);
+        key = keypair.getPrivate();
+        try {
+            cert = (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(
+                    new FileInputStream(certificate));
+        } catch (Exception e) {
+            throw new CertificateEncodingException(e);
+        }
     }
 
     /**
@@ -134,6 +145,20 @@ public final class SelfSignedCertificate {
      */
     public File privateKey() {
         return privateKey;
+    }
+
+    /**
+     *  Returns the generated X.509 certificate.
+     */
+    public X509Certificate cert() {
+        return cert;
+    }
+
+    /**
+     * Returns the generated RSA private key.
+     */
+    public PrivateKey key() {
+        return key;
     }
 
     /**

--- a/handler/src/test/java/io/netty/handler/ssl/SslContextBuilderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslContextBuilderTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import org.junit.Assume;
+import org.junit.Test;
+
+import javax.net.ssl.SSLEngine;
+
+public class SslContextBuilderTest {
+
+    @Test
+    public void testClientContextFromFileJdk() throws Exception {
+        testClientContextFromFile(SslProvider.JDK);
+    }
+
+    @Test
+    public void testClientContextFromFileOpenssl() throws Exception {
+        Assume.assumeTrue(OpenSsl.isAvailable());
+        testClientContextFromFile(SslProvider.OPENSSL);
+    }
+
+    @Test
+    public void testClientContextJdk() throws Exception {
+        testClientContext(SslProvider.JDK);
+    }
+
+    @Test
+    public void testClientContextOpenssl() throws Exception {
+        Assume.assumeTrue(OpenSsl.isAvailable());
+        testClientContext(SslProvider.OPENSSL);
+    }
+
+    @Test
+    public void testServerContextFromFileJdk() throws Exception {
+        testServerContextFromFile(SslProvider.JDK);
+    }
+
+    @Test
+    public void testServerContextFromFileOpenssl() throws Exception {
+        Assume.assumeTrue(OpenSsl.isAvailable());
+        testServerContextFromFile(SslProvider.OPENSSL);
+    }
+
+    @Test
+    public void testServerContextJdk() throws Exception {
+        testServerContext(SslProvider.JDK);
+    }
+
+    @Test
+    public void testServerContextOpenssl() throws Exception {
+        Assume.assumeTrue(OpenSsl.isAvailable());
+        testServerContext(SslProvider.OPENSSL);
+    }
+
+    private static void testClientContextFromFile(SslProvider provider) throws Exception {
+        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SslContextBuilder builder = SslContextBuilder.forClient().sslProvider(provider).keyManager(
+                cert.certificate(), cert.privateKey()).trustManager(cert.certificate());
+        SslContext context = builder.build();
+        SSLEngine engine = context.newEngine(UnpooledByteBufAllocator.DEFAULT);
+        engine.closeInbound();
+        engine.closeOutbound();
+    }
+
+    private static void testClientContext(SslProvider provider) throws Exception {
+        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SslContextBuilder builder = SslContextBuilder.forClient().sslProvider(provider).keyManager(
+                cert.key(), cert.cert()).trustManager(cert.cert());
+        SslContext context = builder.build();
+        SSLEngine engine = context.newEngine(UnpooledByteBufAllocator.DEFAULT);
+        engine.closeInbound();
+        engine.closeOutbound();
+    }
+
+    private static void testServerContextFromFile(SslProvider provider) throws Exception {
+        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SslContextBuilder builder = SslContextBuilder.forServer(cert.certificate(), cert.privateKey())
+                                                     .sslProvider(provider).trustManager(cert.certificate());
+        SslContext context = builder.build();
+        SSLEngine engine = context.newEngine(UnpooledByteBufAllocator.DEFAULT);
+        engine.closeInbound();
+        engine.closeOutbound();
+    }
+
+    private static void testServerContext(SslProvider provider) throws Exception {
+        SelfSignedCertificate cert = new SelfSignedCertificate();
+        SslContextBuilder builder = SslContextBuilder.forServer(cert.key(), cert.cert())
+                                                     .sslProvider(provider).trustManager(cert.cert());
+        SslContext context = builder.build();
+        SSLEngine engine = context.newEngine(UnpooledByteBufAllocator.DEFAULT);
+        engine.closeInbound();
+        engine.closeOutbound();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -672,7 +672,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>1.1.33.Fork4</version>
+        <version>1.1.33.Fork5</version>
         <classifier>${os.detected.classifier}</classifier>
         <scope>compile</scope>
         <optional>true</optional>

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -26,15 +26,13 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.handler.ssl.JdkSslClientContext;
-import io.netty.handler.ssl.JdkSslServerContext;
 import io.netty.handler.ssl.OpenSsl;
-import io.netty.handler.ssl.OpenSslClientContext;
 import io.netty.handler.ssl.OpenSslContext;
-import io.netty.handler.ssl.OpenSslServerContext;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.handler.stream.ChunkedWriteHandler;
 import io.netty.testsuite.util.TestUtils;
@@ -125,15 +123,17 @@ public class SocketSslEchoTest extends AbstractSocketTest {
             "autoRead = {5}, useChunkedWriteHandler = {6}, useCompositeByteBuf = {7}")
     public static Collection<Object[]> data() throws Exception {
         List<SslContext> serverContexts = new ArrayList<SslContext>();
-        serverContexts.add(new JdkSslServerContext(CERT_FILE, KEY_FILE));
+        serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE).sslProvider(SslProvider.JDK).build());
 
         List<SslContext> clientContexts = new ArrayList<SslContext>();
-        clientContexts.add(new JdkSslClientContext(CERT_FILE));
+        clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.JDK).trustManager(CERT_FILE).build());
 
         boolean hasOpenSsl = OpenSsl.isAvailable();
         if (hasOpenSsl) {
-            serverContexts.add(new OpenSslServerContext(CERT_FILE, KEY_FILE));
-            clientContexts.add(new OpenSslClientContext(CERT_FILE));
+            serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
+                                                .sslProvider(SslProvider.OPENSSL).build());
+            clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.OPENSSL)
+                                                .trustManager(CERT_FILE).build());
         } else {
             logger.warn("OpenSSL is unavailable and thus will not be tested.", OpenSsl.unavailabilityCause());
         }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -26,12 +26,10 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
-import io.netty.handler.ssl.JdkSslClientContext;
-import io.netty.handler.ssl.JdkSslServerContext;
 import io.netty.handler.ssl.OpenSsl;
-import io.netty.handler.ssl.OpenSslClientContext;
-import io.netty.handler.ssl.OpenSslServerContext;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -76,15 +74,17 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
     @Parameters(name = "{index}: serverEngine = {0}, clientEngine = {1}")
     public static Collection<Object[]> data() throws Exception {
         List<SslContext> serverContexts = new ArrayList<SslContext>();
-        serverContexts.add(new JdkSslServerContext(CERT_FILE, KEY_FILE));
+        serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE).sslProvider(SslProvider.JDK).build());
 
         List<SslContext> clientContexts = new ArrayList<SslContext>();
-        clientContexts.add(new JdkSslClientContext(CERT_FILE));
+        clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.JDK).trustManager(CERT_FILE).build());
 
         boolean hasOpenSsl = OpenSsl.isAvailable();
         if (hasOpenSsl) {
-            serverContexts.add(new OpenSslServerContext(CERT_FILE, KEY_FILE));
-            clientContexts.add(new OpenSslClientContext(CERT_FILE));
+            serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
+                                                .sslProvider(SslProvider.OPENSSL).build());
+            clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.OPENSSL)
+                                                .trustManager(CERT_FILE).build());
         } else {
             logger.warn("OpenSSL is unavailable and thus will not be tested.", OpenSsl.unavailabilityCause());
         }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStartTlsTest.java
@@ -29,13 +29,11 @@ import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.codec.string.StringEncoder;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
-import io.netty.handler.ssl.JdkSslClientContext;
-import io.netty.handler.ssl.JdkSslServerContext;
 import io.netty.handler.ssl.OpenSsl;
-import io.netty.handler.ssl.OpenSslClientContext;
-import io.netty.handler.ssl.OpenSslServerContext;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.EventExecutorGroup;
@@ -84,15 +82,17 @@ public class SocketStartTlsTest extends AbstractSocketTest {
     @Parameters(name = "{index}: serverEngine = {0}, clientEngine = {1}")
     public static Collection<Object[]> data() throws Exception {
         List<SslContext> serverContexts = new ArrayList<SslContext>();
-        serverContexts.add(new JdkSslServerContext(CERT_FILE, KEY_FILE));
+        serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE).sslProvider(SslProvider.JDK).build());
 
         List<SslContext> clientContexts = new ArrayList<SslContext>();
-        clientContexts.add(new JdkSslClientContext(CERT_FILE));
+        clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.JDK).trustManager(CERT_FILE).build());
 
         boolean hasOpenSsl = OpenSsl.isAvailable();
         if (hasOpenSsl) {
-            serverContexts.add(new OpenSslServerContext(CERT_FILE, KEY_FILE));
-            clientContexts.add(new OpenSslClientContext(CERT_FILE));
+            serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE)
+                                                .sslProvider(SslProvider.OPENSSL).build());
+            clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.OPENSSL)
+                                                .trustManager(CERT_FILE).build());
         } else {
             logger.warn("OpenSSL is unavailable and thus will not be tested.", OpenSsl.unavailabilityCause());
         }


### PR DESCRIPTION
Motivation:

Sometimes the user already has a PrivateKey / X509Certificate which should be used to create a new SslContext. At the moment we only allow to construct it via Files.

Modifications:

- Add new methods to the SslContextBuilder to allow creating a SslContext from PrivateKey / X509Certificate
- Mark all public constructors of *SslContext as @Deprecated, the user should use SslContextBuilder
- Update tests to us SslContextBuilder.

Result:

Creating of SslContext is possible with PrivateKay/X509Certificate