### PR TITLE
Fixing NPE in StreamBufferingEncoderTest

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -204,7 +204,7 @@ public class StreamBufferingEncoderTest {
     public void bufferingNewStreamFailsAfterGoAwayReceived() {
         encoder.writeSettingsAck(ctx, promise);
         setMaxConcurrentStreams(0);
-        connection.goAwayReceived(1, 8, null);
+        connection.goAwayReceived(1, 8, EMPTY_BUFFER);
 
         promise = mock(ChannelPromise.class);
         encoderWriteHeaders(3, promise);


### PR DESCRIPTION
Motivation:

The bufferingNewStreamFailsAfterGoAwayReceived method currently causes an NPE.

Modifications:

Fixed the test so that a valid ByteBuf is passed in.

Result:

The test no longer throws an NPE.