### PR TITLE
Correctly register for EPOLLRDHUP when construct EpollSocketChannel f…

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -92,6 +92,9 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel {
 
     protected AbstractEpollStreamChannel(FileDescriptor fd) {
         super(null, fd, Native.EPOLLIN, Native.getSoError(fd.intValue()) == 0);
+
+        // Add EPOLLRDHUP so we are notified once the remote peer close the connection.
+        flags |= Native.EPOLLRDHUP;
     }
 
     @Override


### PR DESCRIPTION
…rom FileDescriptor

Motivation:

We missed to register for EPOLLRDHUP events when construct the EpollSocketChannel from an existing FileDescriptor. This could cause to miss connection-resets.

Modifications:

Add Native.EPOLLRDHUP to the events we are interested in.

Result:

Connection-resets are detected correctly.