### PR TITLE
[#3987] Remove RC4 from default ciphers.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -107,15 +107,18 @@ public abstract class JdkSslContext extends SslContext {
                 "TLS_RSA_WITH_AES_128_CBC_SHA",
                 // AES256 requires JCE unlimited strength jurisdiction policy files.
                 "TLS_RSA_WITH_AES_256_CBC_SHA",
-                "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
-                "SSL_RSA_WITH_RC4_128_SHA");
+                "SSL_RSA_WITH_3DES_EDE_CBC_SHA");
 
-        if (!ciphers.isEmpty()) {
-            DEFAULT_CIPHERS = Collections.unmodifiableList(ciphers);
-        } else {
+        if (ciphers.isEmpty()) {
             // Use the default from JDK as fallback.
-            DEFAULT_CIPHERS = Collections.unmodifiableList(Arrays.asList(engine.getEnabledCipherSuites()));
+            for (String cipher : engine.getEnabledCipherSuites()) {
+                if (cipher.contains("_RC4_")) {
+                    continue;
+                }
+                ciphers.add(cipher);
+            }
         }
+        DEFAULT_CIPHERS = Collections.unmodifiableList(ciphers);
 
         if (logger.isDebugEnabled()) {
             logger.debug("Default protocols (JDK): {} ", Arrays.asList(PROTOCOLS));

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -107,8 +107,7 @@ public abstract class OpenSslContext extends SslContext {
                 "AES128-GCM-SHA256",
                 "AES128-SHA",
                 "AES256-SHA",
-                "DES-CBC3-SHA",
-                "RC4-SHA");
+                "DES-CBC3-SHA");
         DEFAULT_CIPHERS = Collections.unmodifiableList(ciphers);
 
         if (logger.isDebugEnabled()) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -152,7 +152,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                     if (rt == RenegotiationType.NONE) {
                         r = Renegotiation.NONE;
                     } else {
-                        r = new Renegotiation(rt, "SSL_RSA_WITH_RC4_128_SHA");
+                        r = new Renegotiation(rt, "SSL_RSA_WITH_3DES_EDE_CBC_SHA");
                     }
 
                     for (int i = 0; i < 32; i++) {


### PR DESCRIPTION
Motivation:

Remove RC4 from default ciphers as it is not known as secure anymore.

Modifications:

Remove RC4

Result:

Not use an insecure cipher as default.