### PR TITLE
HttpObjectDecoder half close behavior

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.TooLongFrameException;
@@ -239,6 +240,12 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 out.add(message);
                 return;
             default:
+                /**
+                 * <a href="https://tools.ietf.org/html/rfc7230#section-3.3.3">RFC 7230, 3.3.3</a> states that if a
+                 * request does not have either a transfer-encoding or a content-length header then the message body
+                 * length is 0. However for a response the body length is the number of octets received prior to the
+                 * server closing the connection. So we treat this as variable length chunked encoding.
+                 */
                 long contentLength = contentLength();
                 if (contentLength == 0 || contentLength == -1 && isDecodingRequest()) {
                     out.add(message);
@@ -415,6 +422,17 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 out.add(LastHttpContent.EMPTY_LAST_CONTENT);
             }
         }
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt instanceof ChannelInputShutdownEvent) {
+            // The decodeLast method is invoked when a channelInactive event is encountered.
+            // This method is responsible for ending requests in some situations and must be called
+            // when the input has been shutdown.
+            super.channelInactive(ctx);
+        }
+        super.userEventTriggered(ctx, evt);
     }
 
     protected boolean isContentAlwaysEmpty(HttpMessage msg) {


### PR DESCRIPTION
Motivation:
In the event an HTTP message does not include either a content-length or a transfer-encoding header [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.3.3) states the behavior must be treated differently for requests and responses. If the channel is half closed then the HttpObjectDecoder is not invoking decodeLast and thus not checking if messages should be sent up the pipeline.

Modifications:
- Add comments to clarify regular decode default case.
- Handle the ChannelInputShutdownEvent in the HttpObjectDecoder and evaluate if messages need to be generated.

Result:
Messages are generated on half closed, and comments clarify existing logic.