### PR TITLE
FixedChannelPool acquired connection counter bug fixed

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -360,9 +360,7 @@ public final class FixedChannelPool extends SimpleChannelPool {
             if (future.isSuccess()) {
                 originalPromise.setSuccess(future.getNow());
             } else {
-                if (acquired) {
-                    decrementAndRunTaskQueue();
-                } else {
+                if (!acquired) {
                     runTaskQueue();
                 }
 

--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -245,6 +245,15 @@ public final class FixedChannelPool extends SimpleChannelPool {
         return p;
     }
 
+    /**
+     * Called after channel failed to be acquired so we know to decrease the {@link #acquiredChannelCount}
+     * and pull the next pending task from {@link #pendingAcquireQueue}.
+     */
+    @Override
+    protected void channelClosedCauseUnhealthy() {
+        decrementAndRunTaskQueue();
+    }
+
     private void decrementAndRunTaskQueue() {
         --acquiredChannelCount;
 

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -24,6 +24,7 @@ import io.netty.channel.EventLoop;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.OneTimeTask;
@@ -50,6 +51,13 @@ public class SimpleChannelPool implements ChannelPool {
     private final ChannelPoolHandler handler;
     private final ChannelHealthChecker healthCheck;
     private final Bootstrap bootstrap;
+    private GenericFutureListener<Future<? super Void>> channelWasNotAcuired =
+            new GenericFutureListener<Future<? super Void>>() {
+                @Override
+                public void operationComplete(Future<? super Void> future) throws Exception {
+                    channelClosedCauseUnhealthy();
+                }
+            };
 
     /**
      * Creates a new instance using the {@link ChannelHealthChecker#ACTIVE}.
@@ -161,16 +169,29 @@ public class SimpleChannelPool implements ChannelPool {
                     handler.channelAcquired(ch);
                     promise.setSuccess(ch);
                 } catch (Throwable cause) {
-                    closeAndFail(ch, cause, promise);
+                    Promise<Void> channelClosePromise = ch.eventLoop().newPromise();
+                    channelClosePromise.addListener(channelWasNotAcuired);
+                    closeAndFail(ch, cause, promise, channelClosePromise);
                 }
             } else {
-                closeChannel(ch);
+                Promise<Void> channelClosePromise = ch.eventLoop().newPromise();
+                channelClosePromise.addListener(channelWasNotAcuired);
+                closeChannel(ch, channelClosePromise);
                 acquire(promise);
             }
         } else {
-            closeChannel(ch);
+            Promise<Void> channelClosePromise = ch.eventLoop().newPromise();
+            channelClosePromise.addListener(channelWasNotAcuired);
+            closeChannel(ch, channelClosePromise);
             acquire(promise);
         }
+    }
+
+    /**
+     * Called once channel failed to be acquired.
+     * This is useful for the cases when we need to perform cleanup operations after channel failed to be acquired.
+     */
+    protected void channelClosedCauseUnhealthy() {
     }
 
     /**
@@ -205,7 +226,7 @@ public class SimpleChannelPool implements ChannelPool {
                 });
             }
         } catch (Throwable cause) {
-            closeAndFail(channel, cause, promise);
+            closeAndFail(channel, cause, promise, null);
         }
         return promise;
     }
@@ -218,28 +239,39 @@ public class SimpleChannelPool implements ChannelPool {
                          // Better include a stracktrace here as this is an user error.
                          new IllegalArgumentException(
                                  "Channel " + channel + " was not acquired from this ChannelPool"),
-                         promise);
+                         promise, null);
         } else {
             try {
                 if (offerChannel(channel)) {
                     handler.channelReleased(channel);
                     promise.setSuccess(null);
                 } else {
-                    closeAndFail(channel, FULL_EXCEPTION, promise);
+                    closeAndFail(channel, FULL_EXCEPTION, promise, null);
                 }
             } catch (Throwable cause) {
-                closeAndFail(channel, cause, promise);
+                closeAndFail(channel, cause, promise, null);
             }
         }
     }
 
-    private static void closeChannel(Channel channel) {
+    private static void closeChannel(final Channel channel, final Promise channelClosePromise) {
         channel.attr(POOL_KEY).getAndSet(null);
-        channel.close();
+        ChannelFuture future = channel.close();
+        if (channelClosePromise != null) {
+            future.addListener(new GenericFutureListener<Future<? super Void>>() {
+                @Override
+                public void operationComplete(Future<? super Void> future) throws Exception {
+                    if (future.isSuccess()) {
+                        channelClosePromise.setSuccess(true);
+                    }
+                }
+            });
+        }
     }
 
-    private static void closeAndFail(Channel channel, Throwable cause, Promise<?> promise) {
-        closeChannel(channel);
+    private static void closeAndFail(Channel channel, Throwable cause, Promise<?> promise,
+                                     Promise<Void> channelClosePromise) {
+        closeChannel(channel, channelClosePromise);
         promise.setFailure(cause);
     }
 


### PR DESCRIPTION
Motivation:
The FixedChannelPool once requested for a channel from the pool that is unhealthy will:
a) close this channel
b) will try to acquire new channel if acquiredChannelCount < maxConnections.
c) If acquiredChannelCount >= maxConnections it will add task for the queue.
Now for the case with maxConnections==1 this will cause infinite grow of pendingAcquireQueue in FixedChannelPool because acquire is not decremented after step a) when SimpleChannelPool realised that channel is unhealthy.
For mode details see: #4023

Modifications:
Added promises to notifyHealthCheck function so that when unhealthy channel closing routine is done it will call unAcquireChannel function that is overridden in FixedChannelPool and inside thins function it will call decrementAndRunTaskQueue(). This way we will make sure that when unhealthy channel pulled from queue after it closed we decrement the acquiredChannelCount as well as we force to check if there any tasks in queue that may be executed.

Result:
The bug where acquiredChannelsCount calculated incorrectly had been fixed. Now when pulled channel from queue turned out to be unhealthy the acquired channels count is decremented.

P.S. this is copy of https://github.com/netty/netty/pull/4027. Sorry for the confusion. I thought I was suppose to squash all my commits, but that seemed to just close my original pull request.