### PR TITLE
Use standard syntax for logging HTTP/2 stream ID.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
@@ -68,7 +68,7 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
     public void logHeaders(Direction direction, int streamId, Http2Headers headers, int padding,
             boolean endStream) {
         if (enabled()) {
-            log(direction, "HEADERS: streamId:%d, headers=%s, padding=%d, endStream=%b",
+            log(direction, "HEADERS: streamId=%d, headers=%s, padding=%d, endStream=%b",
                     streamId, headers, padding, endStream);
         }
     }
@@ -77,7 +77,7 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
             int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) {
         if (enabled()) {
             log(direction,
-                    "HEADERS: streamId:%d, headers=%s, streamDependency=%d, weight=%d, exclusive=%b, "
+                    "HEADERS: streamId=%d, headers=%s, streamDependency=%d, weight=%d, exclusive=%b, "
                             + "padding=%d, endStream=%b", streamId, headers,
                     streamDependency, weight, exclusive, padding, endStream);
         }


### PR DESCRIPTION
Motivation:

When looking through the logs for entries pertaining to a specific stream, it's difficult because header entries use the syntax "streamId:<id>" but all other entries use "streamId=<id>". We should make all of the entries consistent.

Modifications:

Changed header entries to use "streamId=<id>" to match the other entries.

Result:

Easier HTTP/2 log navigation.