### PR TITLE
[#4010] Correctly handle whitespaces in HttpPostMultipartRequestDecoder

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpConstants.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpConstants.java
@@ -71,6 +71,11 @@ public final class HttpConstants {
      */
     public static final Charset DEFAULT_CHARSET = CharsetUtil.UTF_8;
 
+    /**
+     * Horizontal space
+     */
+    public static final char SP_CHAR = (char) SP;
+
     private HttpConstants() {
         // Unused
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -46,6 +46,7 @@ import static io.netty.buffer.Unpooled.*;
  *
  */
 public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequestDecoder {
+
     /**
      * Factory used to create InterfaceHttpData
      */
@@ -1705,15 +1706,15 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
         for (int i = 0; i < field.length(); i++) {
             char nextChar = field.charAt(i);
             if (nextChar == HttpConstants.COLON) {
-                sb.append(HttpConstants.SP);
+                sb.append(HttpConstants.SP_CHAR);
             } else if (nextChar == HttpConstants.COMMA) {
-                sb.append(HttpConstants.SP);
+                sb.append(HttpConstants.SP_CHAR);
             } else if (nextChar == HttpConstants.EQUALS) {
-                sb.append(HttpConstants.SP);
+                sb.append(HttpConstants.SP_CHAR);
             } else if (nextChar == HttpConstants.SEMICOLON) {
-                sb.append(HttpConstants.SP);
+                sb.append(HttpConstants.SP_CHAR);
             } else if (nextChar == HttpConstants.HT) {
-                sb.append(HttpConstants.SP);
+                sb.append(HttpConstants.SP_CHAR);
             } else if (nextChar == HttpConstants.DOUBLE_QUOTE) {
                 // nothing added, just removes it
             } else {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -347,4 +347,33 @@ public class HttpPostRequestDecoderTest {
         assertFalse(decoder.getBodyHttpDatas().isEmpty());
         decoder.destroy();
     }
+
+    @Test
+    public void testFilenameContainingSemicolon2() throws Exception {
+        final String boundary = "dLV9Wyq26L_-JQxk6ferf-RT153LhOO";
+        final DefaultFullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST,
+                                                                      "http://localhost");
+        req.headers().add(HttpHeaders.Names.CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
+        // Force to use memory-based data.
+        final DefaultHttpDataFactory inMemoryFactory = new DefaultHttpDataFactory(false);
+        final String data = "asdf";
+        final String filename = "tmp;0.txt";
+        final String body =
+                "--" + boundary + "\r\n" +
+                "Content-Disposition: form-data; name=\"file\"; filename=\"" + filename + "\"\r\n" +
+                "Content-Type: image/gif\r\n" +
+                "\r\n" +
+                data + "\r\n" +
+                "--" + boundary + "--\r\n";
+
+        req.content().writeBytes(body.getBytes(CharsetUtil.UTF_8.name()));
+        // Create decoder instance to test.
+        final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
+        assertFalse(decoder.getBodyHttpDatas().isEmpty());
+        InterfaceHttpData part1 = decoder.getBodyHttpDatas().get(0);
+        assertTrue(part1 instanceof FileUpload);
+        FileUpload fileUpload = (FileUpload) part1;
+        assertEquals("tmp 0.txt", fileUpload.getFilename());
+        decoder.destroy();
+    }
 }


### PR DESCRIPTION
Motivation:

Due not using a cast we insert 32 and not a whitespace into the String.

Modifications:

Correclty cast to char.

Result:

Correct handling of whitespaces.