### PR TITLE
SPDY codec must check headers are lower case

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyCodecUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyCodecUtil.java
@@ -306,6 +306,9 @@ final class SpdyCodecUtil {
                 throw new IllegalArgumentException(
                         "name contains null character: " + name);
             }
+            if (c >= 'A' && c <= 'Z') {
+                throw new IllegalArgumentException("name must be all lower case.");
+            }
             if (c > 127) {
                 throw new IllegalArgumentException(
                         "name contains non-ascii character: " + name);


### PR DESCRIPTION
Motivation:
The SPDY spec requires that all header names be lowercase (see https://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3-1#TOC-3.2-HTTP-Request-Response). The SPDY codec header name validator does not enforce this requirement.

Modifications:
- SpdyCodecUtil.validateHeaderName should check for upper case characters and throw an error if any are found.

Result:
SPDY codec header validation enforces specification requirement.