### PR TITLE
Faster and more memory efficient headers for HTTP, HTTP/2, STOMP and …

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -15,29 +15,29 @@
  */
 package io.netty.handler.codec.http;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.handler.codec.DefaultHeaders.NameConverter;
+import io.netty.handler.codec.DefaultHeaders;
 import io.netty.handler.codec.DefaultTextHeaders;
-import io.netty.handler.codec.DefaultTextHeaders.DefaultTextValueTypeConverter;
-import io.netty.handler.codec.Headers.EntryVisitor;
+import io.netty.handler.codec.DefaultTextHeaders.CharSequenceConverter;
 import io.netty.handler.codec.TextHeaders;
 import io.netty.util.AsciiString;
-import io.netty.util.ByteProcessor;
-import io.netty.util.internal.PlatformDependent;
 
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeMap;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * Default implementation of {@link HttpHeaders}.
  */
 public class DefaultHttpHeaders extends HttpHeaders {
-
     private static final int HIGHEST_INVALID_NAME_CHAR_MASK = ~63;
     private static final int HIGHEST_INVALID_VALUE_CHAR_MASK = ~15;
 
@@ -59,234 +59,27 @@ public class DefaultHttpHeaders extends HttpHeaders {
     }
 
     private final TextHeaders headers;
-    private static final class HttpHeadersValidationConverter extends DefaultTextValueTypeConverter {
-        private final boolean validate;
-
-        HttpHeadersValidationConverter(boolean validate) {
-            this.validate = validate;
-        }
-
-        @Override
-        public CharSequence convertObject(Object value) {
-            if (value == null) {
-                throw new NullPointerException("value");
-            }
-
-            CharSequence seq;
-            if (value instanceof CharSequence) {
-                seq = (CharSequence) value;
-            } else if (value instanceof Number) {
-                seq = value.toString();
-            } else if (value instanceof Date) {
-                seq = HttpHeaderDateFormat.get().format((Date) value);
-            } else if (value instanceof Calendar) {
-                seq = HttpHeaderDateFormat.get().format(((Calendar) value).getTime());
-            } else {
-                seq = value.toString();
-            }
-
-            if (validate) {
-                if (value instanceof AsciiString) {
-                    validateValue((AsciiString) seq);
-                } else {
-                    validateValue(seq);
-                }
-            }
-
-            return seq;
-        }
-
-        private static final class ValidateValueProcessor implements ByteProcessor {
-            private final CharSequence seq;
-            private int state;
-
-            public ValidateValueProcessor(CharSequence seq) {
-                this.seq = seq;
-            }
-
-            @Override
-            public boolean process(byte value) throws Exception {
-                state = validateValueChar(state, (char) value, seq);
-                return true;
-            }
-
-            public int state() {
-                return state;
-            }
-        }
-
-        private static void validateValue(AsciiString seq) {
-            ValidateValueProcessor processor = new ValidateValueProcessor(seq);
-            try {
-                seq.forEachByte(processor);
-            } catch (Throwable t) {
-                PlatformDependent.throwException(t);
-            }
-
-            if (processor.state() != 0) {
-                throw new IllegalArgumentException("a header value must not end with '\\r' or '\\n':" + seq);
-            }
-        }
-
-        private static void validateValue(CharSequence seq) {
-            int state = 0;
-            // Start looping through each of the character
-            for (int index = 0; index < seq.length(); index++) {
-                state = validateValueChar(state, seq.charAt(index), seq);
-            }
-
-            if (state != 0) {
-                throw new IllegalArgumentException("a header value must not end with '\\r' or '\\n':" + seq);
-            }
-        }
-
-        private static int validateValueChar(int state, char c, CharSequence seq) {
-            /*
-             * State:
-             * 0: Previous character was neither CR nor LF
-             * 1: The previous character was CR
-             * 2: The previous character was LF
-             */
-            if ((c & HIGHEST_INVALID_VALUE_CHAR_MASK) == 0) {
-                // Check the absolutely prohibited characters.
-                switch (c) {
-                case 0x0: // NULL
-                    throw new IllegalArgumentException("a header value contains a prohibited character '\0': " + seq);
-                case 0x0b: // Vertical tab
-                    throw new IllegalArgumentException("a header value contains a prohibited character '\\v': " + seq);
-                case '\f':
-                    throw new IllegalArgumentException("a header value contains a prohibited character '\\f': " + seq);
-                }
-            }
-
-            // Check the CRLF (HT | SP) pattern
-            switch (state) {
-            case 0:
-                switch (c) {
-                case '\r':
-                    state = 1;
-                    break;
-                case '\n':
-                    state = 2;
-                    break;
-                }
-                break;
-            case 1:
-                switch (c) {
-                case '\n':
-                    state = 2;
-                    break;
-                default:
-                    throw new IllegalArgumentException("only '\\n' is allowed after '\\r': " + seq);
-                }
-                break;
-            case 2:
-                switch (c) {
-                case '\t':
-                case ' ':
-                    state = 0;
-                    break;
-                default:
-                    throw new IllegalArgumentException("only ' ' and '\\t' are allowed after '\\n': " + seq);
-                }
-            }
-            return state;
-        }
-    }
-
-    static class HttpHeadersNameConverter implements NameConverter<CharSequence> {
-        protected final boolean validate;
-
-        private static final class ValidateNameProcessor implements ByteProcessor {
-            private final CharSequence seq;
-
-            public ValidateNameProcessor(CharSequence seq) {
-                this.seq = seq;
-            }
-
-            @Override
-            public boolean process(byte value) throws Exception {
-                // Check to see if the character is not an ASCII character.
-                if (value < 0) {
-                    throw new IllegalArgumentException("a header name cannot contain non-ASCII character: " + seq);
-                }
-                validateNameChar(value, seq);
-                return true;
-            }
-        }
-
-        HttpHeadersNameConverter(boolean validate) {
-            this.validate = validate;
-        }
-
-        @Override
-        public CharSequence convertName(CharSequence name) {
-            if (validate) {
-                if (name instanceof AsciiString) {
-                    validateName((AsciiString) name);
-                } else {
-                    validateName(name);
-                }
-            }
-
-            return name;
-        }
-
-        private static void validateName(AsciiString name) {
-            try {
-                name.forEachByte(new ValidateNameProcessor(name));
-            } catch (Throwable t) {
-                PlatformDependent.throwException(t);
-            }
-        }
-
-        private static void validateName(CharSequence name) {
-            // Go through each characters in the name.
-            for (int index = 0; index < name.length(); index++) {
-                char c = name.charAt(index);
-
-                // Check to see if the character is not an ASCII character.
-                if (c > 127) {
-                    throw new IllegalArgumentException("a header name cannot contain non-ASCII characters: " + name);
-                }
-
-                // Check for prohibited characters.
-                validateNameChar(c, name);
-            }
-        }
-
-        private static void validateNameChar(int character, CharSequence seq) {
-            if ((character & HIGHEST_INVALID_NAME_CHAR_MASK) == 0 && LOOKUP_TABLE[character] != 0) {
-                throw new IllegalArgumentException(
-                        "a header name cannot contain the following prohibited characters: =,;: \\t\\r\\n\\v\\f: " +
-                                seq);
-            }
-        }
-    }
-
-    private static final HttpHeadersValidationConverter
-        VALIDATE_OBJECT_CONVERTER = new HttpHeadersValidationConverter(true);
-    private static final HttpHeadersValidationConverter
-        NO_VALIDATE_OBJECT_CONVERTER = new HttpHeadersValidationConverter(false);
-    private static final HttpHeadersNameConverter VALIDATE_NAME_CONVERTER = new HttpHeadersNameConverter(true);
-    private static final HttpHeadersNameConverter NO_VALIDATE_NAME_CONVERTER = new HttpHeadersNameConverter(false);
 
     public DefaultHttpHeaders() {
         this(true);
     }
 
     public DefaultHttpHeaders(boolean validate) {
-        this(true, validate? VALIDATE_NAME_CONVERTER : NO_VALIDATE_NAME_CONVERTER, false);
+        this(validate, false);
     }
 
-    public DefaultHttpHeaders(boolean validate, boolean singleHeaderFields) {
-        this(true, validate? VALIDATE_NAME_CONVERTER : NO_VALIDATE_NAME_CONVERTER, singleHeaderFields);
+    protected DefaultHttpHeaders(boolean validate, boolean singleHeaderFields) {
+        this(true, validate ? HeaderNameValidator.INSTANCE : DefaultTextHeaders.NO_NAME_VALIDATOR, singleHeaderFields);
     }
 
-    protected DefaultHttpHeaders(boolean validate, NameConverter<CharSequence> nameConverter,
+    protected DefaultHttpHeaders(boolean validate,
+                                 DefaultHeaders.NameValidator<CharSequence> nameValidator,
                                  boolean singleHeaderFields) {
-        headers = new DefaultTextHeaders(true,
-                validate ? VALIDATE_OBJECT_CONVERTER : NO_VALIDATE_OBJECT_CONVERTER, nameConverter, singleHeaderFields);
+        headers = new DefaultTextHeaders(
+                    new TreeMap<CharSequence, Object>(AsciiString.CHARSEQUENCE_CASE_INSENSITIVE_ORDER),
+                    nameValidator,
+                    validate ? HeaderValueConverterAndValidator.INSTANCE : HeaderValueConverter.INSTANCE,
+                    singleHeaderFields);
     }
 
     @Override
@@ -426,7 +219,7 @@ public class DefaultHttpHeaders extends HttpHeaders {
 
     @Override
     public short getShort(CharSequence name, short defaultValue) {
-        return headers.getInt(name, defaultValue);
+        return headers.getShort(name, defaultValue);
     }
 
     @Override
@@ -450,13 +243,37 @@ public class DefaultHttpHeaders extends HttpHeaders {
     }
 
     @Override
-    public List<Map.Entry<String, String>> entries() {
-        return headers.entriesConverted();
+    public List<Entry<String, String>> entries() {
+        if (isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<Entry<String, String>> entriesConverted = new ArrayList<Entry<String, String>>(
+                headers.size());
+        for (Entry<String, String> entry : this) {
+            entriesConverted.add(entry);
+        }
+        return entriesConverted;
     }
 
+    /**
+     * @deprecated Use {@link #iteratorCharSequence()}.
+     */
     @Override
+    @Deprecated
     public Iterator<Map.Entry<String, String>> iterator() {
         return headers.iteratorConverted();
+    }
+
+    /**
+     * @deprecated Future major releases will have this be the default iterator.
+     * Get an iterator to traverse over the underlying name/value pairs.
+     * <p>
+     * This iterator should be preferred over {@link #iterator()} if {@link AsciiString} objects are used.
+     */
+    @Override
+    @Deprecated
+    public Iterator<Entry<CharSequence, CharSequence>> iteratorCharSequence() {
+        return headers.iterator();
     }
 
     @Override
@@ -475,6 +292,11 @@ public class DefaultHttpHeaders extends HttpHeaders {
     }
 
     @Override
+    public int size() {
+        return headers.size();
+    }
+
+    @Override
     public boolean contains(String name, String value, boolean ignoreCase) {
         return headers.contains(name, value, ignoreCase);
     }
@@ -485,32 +307,141 @@ public class DefaultHttpHeaders extends HttpHeaders {
     }
 
     @Override
-    public Entry<CharSequence, CharSequence> forEachEntry(EntryVisitor<CharSequence> visitor) throws Exception {
-        return headers.forEachEntry(visitor);
-    }
-
-    @Override
     public Set<String> names() {
         return headers.namesAndConvert(String.CASE_INSENSITIVE_ORDER);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof DefaultHttpHeaders)) {
-            return false;
-        }
-
-        DefaultHttpHeaders other = (DefaultHttpHeaders) o;
-
-        return headers.equals(other.headers);
+    public int hashCode() {
+        return headers.size();
     }
 
     @Override
-    public int hashCode() {
-        return headers.hashCode();
+    public boolean equals(Object other) {
+        if (!(other instanceof DefaultHttpHeaders)) {
+            return false;
+        }
+        DefaultHttpHeaders headers = (DefaultHttpHeaders) other;
+        return DefaultHeaders.comparatorEquals(this.headers, headers.headers,
+                AsciiString.CHARSEQUENCE_CASE_SENSITIVE_ORDER);
     }
 
-    void encode(ByteBuf buf) throws Exception {
-        headers.forEachEntry(new HttpHeadersEncoder(buf));
+    static final class HeaderNameValidator implements DefaultHeaders.NameValidator<CharSequence> {
+
+        public static final HeaderNameValidator INSTANCE = new HeaderNameValidator();
+
+        private HeaderNameValidator() {
+        }
+
+        @Override
+        public void validate(CharSequence name) {
+            // Go through each character in the name
+            for (int index = 0; index < name.length(); index++) {
+                char character = name.charAt(index);
+
+                // Check to see if the character is not an ASCII character
+                if (character > 127) {
+                    throw new IllegalArgumentException("a header name cannot contain non-ASCII characters: " + name);
+                }
+
+                // Check for prohibited characters.
+                if ((character & HIGHEST_INVALID_NAME_CHAR_MASK) == 0 && LOOKUP_TABLE[character] != 0) {
+                    throw new IllegalArgumentException(
+                            "a header name cannot contain the following prohibited characters: =,;: \\t\\r\\n\\v\\f: " +
+                            name);
+                }
+            }
+        }
+    }
+
+    private static class HeaderValueConverter extends CharSequenceConverter {
+
+        public static final HeaderValueConverter INSTANCE = new HeaderValueConverter();
+
+        @Override
+        public CharSequence convertObject(Object value) {
+            checkNotNull(value, "value");
+            CharSequence seq;
+            if (value instanceof CharSequence) {
+                seq = (CharSequence) value;
+            } else if (value instanceof Number) {
+                seq = value.toString();
+            } else if (value instanceof Date) {
+                seq = HttpHeaderDateFormat.get().format((Date) value);
+            } else if (value instanceof Calendar) {
+                seq = HttpHeaderDateFormat.get().format(((Calendar) value).getTime());
+            } else {
+                seq = value.toString();
+            }
+            return seq;
+        }
+    }
+
+    private static final class HeaderValueConverterAndValidator extends HeaderValueConverter {
+
+        public static final HeaderValueConverterAndValidator INSTANCE = new HeaderValueConverterAndValidator();
+
+        @Override
+        public CharSequence convertObject(Object value) {
+            CharSequence seq = super.convertObject(value);
+            int state = 0;
+            // Start looping through each of the character
+            for (int index = 0; index < seq.length(); index++) {
+                state = validateValueChar(seq, state, seq.charAt(index));
+            }
+
+            if (state != 0) {
+                throw new IllegalArgumentException("a header value must not end with '\\r' or '\\n':" + seq);
+            }
+            return seq;
+        }
+
+        private static int validateValueChar(CharSequence seq, int state, char character) {
+            /*
+             * State:
+             * 0: Previous character was neither CR nor LF
+             * 1: The previous character was CR
+             * 2: The previous character was LF
+             */
+            if ((character & HIGHEST_INVALID_VALUE_CHAR_MASK) == 0) {
+                // Check the absolutely prohibited characters.
+                switch (character) {
+                case 0x0: // NULL
+                    throw new IllegalArgumentException("a header value contains a prohibited character '\0': " + seq);
+                case 0x0b: // Vertical tab
+                    throw new IllegalArgumentException("a header value contains a prohibited character '\\v': " + seq);
+                case '\f':
+                    throw new IllegalArgumentException("a header value contains a prohibited character '\\f': " + seq);
+                }
+            }
+
+            // Check the CRLF (HT | SP) pattern
+            switch (state) {
+                case 0:
+                    switch (character) {
+                        case '\r':
+                            return 1;
+                        case '\n':
+                            return 2;
+                    }
+                    break;
+                case 1:
+                    switch (character) {
+                        case '\n':
+                            return 2;
+                        default:
+                            throw new IllegalArgumentException("only '\\n' is allowed after '\\r': " + seq);
+                    }
+                case 2:
+                    switch (character) {
+                        case '\t':
+                        case ' ':
+                            return 0;
+                        default:
+                            throw new IllegalArgumentException("only ' ' and '\\t' are allowed after '\\n': " + seq);
+                    }
+            }
+            return state;
+        }
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderUtil.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -230,11 +231,13 @@ public final class HttpHeaderUtil {
             m.headers().add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
             m.headers().remove(HttpHeaderNames.CONTENT_LENGTH);
         } else {
-            List<String> values = m.headers().getAll(HttpHeaderNames.TRANSFER_ENCODING);
-            if (values.isEmpty()) {
+            // Make a copy to be able to modify values while iterating
+            List<String> encodings = m.headers().getAll(HttpHeaderNames.TRANSFER_ENCODING);
+            if (encodings.isEmpty()) {
                 return;
             }
-            Iterator<String> valuesIt = values.iterator();
+            List<CharSequence> values = new ArrayList<CharSequence>(encodings);
+            Iterator<CharSequence> valuesIt = values.iterator();
             while (valuesIt.hasNext()) {
                 CharSequence value = valuesIt.next();
                 if (HttpHeaderValues.CHUNKED.equalsIgnoreCase(value)) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeadersEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeadersEncoder.java
@@ -18,24 +18,14 @@ package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
-import io.netty.handler.codec.TextHeaders.EntryVisitor;
 import io.netty.util.AsciiString;
 
-import java.util.Map.Entry;
+final class HttpHeadersEncoder {
 
-final class HttpHeadersEncoder implements EntryVisitor {
-
-    private final ByteBuf buf;
-
-    HttpHeadersEncoder(ByteBuf buf) {
-        this.buf = buf;
+    private HttpHeadersEncoder() {
     }
 
-    @Override
-    public boolean visit(Entry<CharSequence, CharSequence> entry) throws Exception {
-        final CharSequence name = entry.getKey();
-        final CharSequence value = entry.getValue();
-        final ByteBuf buf = this.buf;
+    public static void encoderHeader(CharSequence name, CharSequence value, ByteBuf buf) throws Exception {
         final int nameLen = name.length();
         final int valueLen = value.length();
         final int entryLen = nameLen + valueLen + 4;
@@ -50,7 +40,6 @@ final class HttpHeadersEncoder implements EntryVisitor {
         buf.setByte(offset ++, '\r');
         buf.setByte(offset ++, '\n');
         buf.writerIndex(offset);
-        return true;
     }
 
     private static void writeAscii(ByteBuf buf, int offset, CharSequence value, int valueLen) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
@@ -23,10 +23,15 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map.Entry;
 
-import static io.netty.buffer.Unpooled.*;
-import static io.netty.handler.codec.http.HttpConstants.*;
+import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
+import static io.netty.buffer.Unpooled.directBuffer;
+import static io.netty.buffer.Unpooled.unreleasableBuffer;
+import static io.netty.handler.codec.http.HttpConstants.CR;
+import static io.netty.handler.codec.http.HttpConstants.LF;
 
 /**
  * Encodes an {@link HttpMessage} or an {@link HttpContent} into
@@ -137,7 +142,11 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
      * Encode the {@link HttpHeaders} into a {@link ByteBuf}.
      */
     protected void encodeHeaders(HttpHeaders headers, ByteBuf buf) throws Exception {
-        HttpHeaders.encode(headers, buf);
+        Iterator<Entry<CharSequence, CharSequence>> iter = headers.iteratorCharSequence();
+        while (iter.hasNext()) {
+            Entry<CharSequence, CharSequence> header = iter.next();
+            HttpHeadersEncoder.encoderHeader(header.getKey(), header.getValue(), buf);
+        }
     }
 
     private void encodeChunkedContent(ChannelHandlerContext ctx, Object msg, long contentLength, List<Object> out) {

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyHeaders.java
@@ -16,44 +16,17 @@
 package io.netty.handler.codec.spdy;
 
 import io.netty.handler.codec.DefaultTextHeaders;
-import io.netty.handler.codec.Headers;
 import io.netty.handler.codec.TextHeaders;
-import io.netty.util.AsciiString;
 
-import java.util.Locale;
+import java.util.LinkedHashMap;
 
 public class DefaultSpdyHeaders extends DefaultTextHeaders implements SpdyHeaders {
-    private static final Headers.ValueConverter<CharSequence> SPDY_VALUE_CONVERTER =
-            new DefaultTextValueTypeConverter() {
-        @Override
-        public CharSequence convertObject(Object value) {
-            CharSequence seq;
-            if (value instanceof CharSequence) {
-                seq = (CharSequence) value;
-            } else {
-                seq = value.toString();
-            }
-
-            SpdyCodecUtil.validateHeaderValue(seq);
-            return seq;
-        }
-    };
-
-    private static final NameConverter<CharSequence> SPDY_NAME_CONVERTER = new NameConverter<CharSequence>() {
-        @Override
-        public CharSequence convertName(CharSequence name) {
-            if (name instanceof AsciiString) {
-                name = ((AsciiString) name).toLowerCase();
-            } else {
-                name = name.toString().toLowerCase(Locale.US);
-            }
-            SpdyCodecUtil.validateHeaderName(name);
-            return name;
-        }
-    };
 
     public DefaultSpdyHeaders() {
-        super(true, SPDY_VALUE_CONVERTER, SPDY_NAME_CONVERTER);
+        super(new LinkedHashMap<CharSequence, Object>(),
+              HeaderNameValidator.INSTANCE,
+              HeaderValueConverterAndValidator.INSTANCE,
+              false);
     }
 
     @Override
@@ -258,5 +231,33 @@ public class DefaultSpdyHeaders extends DefaultTextHeaders implements SpdyHeader
     public SpdyHeaders clear() {
         super.clear();
         return this;
+    }
+
+    private static class HeaderNameValidator implements NameValidator<CharSequence> {
+
+        public static final HeaderNameValidator INSTANCE = new HeaderNameValidator();
+
+        @Override
+        public void validate(CharSequence name) {
+            SpdyCodecUtil.validateHeaderName(name);
+        }
+    }
+
+    private static class HeaderValueConverterAndValidator extends CharSequenceConverter {
+
+        public static final HeaderValueConverterAndValidator INSTANCE = new HeaderValueConverterAndValidator();
+
+        @Override
+        public CharSequence convertObject(Object value) {
+            CharSequence seq;
+            if (value instanceof CharSequence) {
+                seq = (CharSequence) value;
+            } else {
+                seq = value.toString();
+            }
+
+            SpdyCodecUtil.validateHeaderValue(seq);
+            return seq;
+        }
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+public class DefaultHttpHeadersTest {
+
+    @Test
+    public void keysShouldBeCaseInsensitive() {
+        DefaultHttpHeaders headers = new DefaultHttpHeaders();
+        headers.add("Name", "value1");
+        headers.add("name", "value2");
+        headers.add("NAME", "value3");
+        assertEquals(3, headers.size());
+
+        List<String> values = asList("value1", "value2", "value3");
+
+        assertEquals(values, headers.getAll("NAME"));
+        assertEquals(values, headers.getAll("name"));
+        assertEquals(values, headers.getAll("Name"));
+        assertEquals(values, headers.getAll("nAmE"));
+    }
+
+    @Test
+    public void keysShouldBeCaseInsensitiveInHeadersEquals() {
+        DefaultHttpHeaders headers1 = new DefaultHttpHeaders();
+        headers1.add("name1", Arrays.asList("value1", "value2", "value3"));
+        headers1.add("nAmE2", "value4");
+
+        DefaultHttpHeaders headers2 = new DefaultHttpHeaders();
+        headers2.add("naMe1", Arrays.asList("value1", "value2", "value3"));
+        headers2.add("NAME2", "value4");
+
+        assertEquals(headers1, headers1);
+        assertEquals(headers2, headers2);
+        assertEquals(headers1, headers2);
+        assertEquals(headers2, headers1);
+        assertEquals(headers1.hashCode(), headers2.hashCode());
+    }
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdySessionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdySessionHandlerTest.java
@@ -22,6 +22,7 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -83,7 +84,7 @@ public class SpdySessionHandlerTest {
         assertEquals(last, spdyHeadersFrame.isLast());
         for (CharSequence name: headers.names()) {
             List<CharSequence> expectedValues = headers.getAll(name);
-            List<CharSequence> receivedValues = spdyHeadersFrame.headers().getAll(name);
+            List<CharSequence> receivedValues = new ArrayList<CharSequence>(spdyHeadersFrame.headers().getAll(name));
             assertTrue(receivedValues.containsAll(expectedValues));
             receivedValues.removeAll(expectedValues);
             assertTrue(receivedValues.isEmpty());
@@ -105,7 +106,7 @@ public class SpdySessionHandlerTest {
 
         SpdySynStreamFrame spdySynStreamFrame =
                 new DefaultSpdySynStreamFrame(localStreamId, 0, (byte) 0);
-        spdySynStreamFrame.headers().set("Compression", "test");
+        spdySynStreamFrame.headers().set("compression", "test");
 
         SpdyDataFrame spdyDataFrame = new DefaultSpdyDataFrame(localStreamId);
         spdyDataFrame.setLast(true);
@@ -138,8 +139,8 @@ public class SpdySessionHandlerTest {
         assertNull(sessionHandler.readOutbound());
         SpdyHeadersFrame spdyHeadersFrame = new DefaultSpdyHeadersFrame(localStreamId);
 
-        spdyHeadersFrame.headers().add("HEADER", "test1");
-        spdyHeadersFrame.headers().add("HEADER", "test2");
+        spdyHeadersFrame.headers().add("header", "test1");
+        spdyHeadersFrame.headers().add("header", "test2");
 
         sessionHandler.writeInbound(spdyHeadersFrame);
         assertHeaders(sessionHandler.readOutbound(), localStreamId, false, spdyHeadersFrame.headers());
@@ -245,7 +246,7 @@ public class SpdySessionHandlerTest {
 
         SpdySynStreamFrame spdySynStreamFrame =
                 new DefaultSpdySynStreamFrame(localStreamId, 0, (byte) 0);
-        spdySynStreamFrame.headers().set("Compression", "test");
+        spdySynStreamFrame.headers().set("compression", "test");
 
         SpdyDataFrame spdyDataFrame = new DefaultSpdyDataFrame(localStreamId);
         spdyDataFrame.setLast(true);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -14,86 +14,19 @@
  */
 package io.netty.handler.codec.http2;
 
-import static io.netty.util.internal.StringUtil.UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET;
 import io.netty.handler.codec.BinaryHeaders;
 import io.netty.handler.codec.DefaultBinaryHeaders;
-import io.netty.util.AsciiString;
-import io.netty.util.ByteProcessor;
+import io.netty.handler.codec.DefaultHeaders;
 import io.netty.util.ByteString;
-import io.netty.util.internal.PlatformDependent;
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.List;
+import java.util.TreeMap;
 
 public class DefaultHttp2Headers extends DefaultBinaryHeaders implements Http2Headers {
-    private static final ByteProcessor HTTP2_ASCII_UPPERCASE_PROCESSOR = new ByteProcessor() {
-        @Override
-        public boolean process(byte value) throws Exception {
-            return value < 'A' || value > 'Z';
-        }
-    };
 
-    private static final class Http2AsciiToLowerCaseConverter implements ByteProcessor {
-        private final byte[] result;
-        private int i;
-
-        public Http2AsciiToLowerCaseConverter(int length) {
-            result = new byte[length];
-        }
-
-        @Override
-        public boolean process(byte value) throws Exception {
-            result[i++] = (value >= 'A' && value <= 'Z')
-                    ? (byte) (value + UPPER_CASE_TO_LOWER_CASE_ASCII_OFFSET) : value;
-            return true;
-        }
-
-        public byte[] result() {
-            return result;
-        }
-    };
-
-    private static final NameConverter<ByteString> HTTP2_ASCII_TO_LOWER_CONVERTER = new NameConverter<ByteString>() {
-        @Override
-        public ByteString convertName(ByteString name) {
-            if (name instanceof AsciiString) {
-                return ((AsciiString) name).toLowerCase();
-            }
-
-            try {
-                if (name.forEachByte(HTTP2_ASCII_UPPERCASE_PROCESSOR) == -1) {
-                    return name;
-                }
-
-                Http2AsciiToLowerCaseConverter converter = new Http2AsciiToLowerCaseConverter(name.length());
-                name.forEachByte(converter);
-                return new ByteString(converter.result(), false);
-            } catch (Exception e) {
-                PlatformDependent.throwException(e);
-                return null;
-            }
-        }
-    };
-
-    /**
-     * Creates an instance that will convert all header names to lowercase.
-     */
     public DefaultHttp2Headers() {
-        this(true);
-    }
-
-    /**
-     * Creates an instance that can be configured to either do header field name conversion to
-     * lowercase, or not do any conversion at all.
-     * <p>
-     *
-     * <strong>Note</strong> that setting {@code forceKeyToLower} to {@code false} can violate the
-     * <a href="https://tools.ietf.org/html/draft-ietf-httpbis-http2-16#section-8.1.2">HTTP/2 specification</a>
-     * which specifies that a request or response containing an uppercase header field MUST be treated
-     * as malformed. Only set {@code forceKeyToLower} to {@code false} if you are explicitly using lowercase
-     * header field names and want to avoid the conversion to lowercase.
-     *
-     * @param forceKeyToLower if @{code false} no header name conversion will be performed
-     */
-    public DefaultHttp2Headers(boolean forceKeyToLower) {
-        super(forceKeyToLower ? HTTP2_ASCII_TO_LOWER_CONVERTER : IDENTITY_NAME_CONVERTER);
+        super(new TreeMap<ByteString, Object>(Http2HeaderNameComparator.INSTANCE));
     }
 
     @Override
@@ -353,5 +286,46 @@ public class DefaultHttp2Headers extends DefaultBinaryHeaders implements Http2He
     @Override
     public ByteString status() {
         return get(PseudoHeaderName.STATUS.value());
+    }
+
+    @Override
+    public int hashCode() {
+        return size();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof Http2Headers)) {
+            return false;
+        }
+        Http2Headers headers = (Http2Headers) other;
+        return DefaultHeaders.comparatorEquals(this, headers, ByteString.DEFAULT_COMPARATOR);
+    }
+
+    private static class Http2HeaderNameComparator implements Comparator<ByteString>, Serializable {
+
+        public static final Http2HeaderNameComparator INSTANCE = new Http2HeaderNameComparator();
+        private static final long serialVersionUID = 1109871697664666478L;
+
+        @Override
+        public int compare(ByteString one, ByteString two) {
+            // Reserved header names come first.
+            final boolean isPseudoHeader1 = !one.isEmpty() && one.byteAt(0) == ':';
+            final boolean isPseudoHeader2 = !two.isEmpty() && two.byteAt(0) == ':';
+            if (isPseudoHeader1 != isPseudoHeader2) {
+                return isPseudoHeader1 ? -1 : 1;
+            }
+            final int delta = one.hashCode() - two.hashCode();
+            if (delta == 0) {
+                // If the hash code matches it's very likely for the two strings to be equal
+                // and thus we optimistically compare them with the much faster equals method.
+                if (one.equals(two)) {
+                    return 0;
+                } else {
+                    return ByteString.DEFAULT_COMPARATOR.compare(one, two);
+                }
+            }
+            return delta;
+        }
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoder.java
@@ -23,7 +23,6 @@ import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
-import io.netty.handler.codec.BinaryHeaders.EntryVisitor;
 import io.netty.util.ByteString;
 
 import java.io.ByteArrayOutputStream;
@@ -65,26 +64,9 @@ public class DefaultHttp2HeadersEncoder implements Http2HeadersEncoder, Http2Hea
                 tableSizeChangeOutput.reset();
             }
 
-            // Write pseudo headers first as required by the HTTP/2 spec.
-            for (Http2Headers.PseudoHeaderName pseudoHeader : Http2Headers.PseudoHeaderName.values()) {
-                ByteString name = pseudoHeader.value();
-                ByteString value = headers.get(name);
-                if (value != null) {
-                    encodeHeader(name, value, stream);
-                }
+            for (Entry<ByteString, ByteString> header : headers) {
+                encodeHeader(header.getKey(), header.getValue(), stream);
             }
-
-            headers.forEachEntry(new EntryVisitor() {
-                @Override
-                public boolean visit(Entry<ByteString, ByteString> entry) throws Exception {
-                    final ByteString name = entry.getKey();
-                    final ByteString value = entry.getValue();
-                    if (!Http2Headers.PseudoHeaderName.isPseudoHeader(name)) {
-                        encodeHeader(name, value, stream);
-                    }
-                    return true;
-                }
-            });
         } catch (Http2Exception e) {
             throw e;
         } catch (Throwable t) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -20,6 +20,8 @@ import io.netty.util.ByteString;
 import io.netty.util.CharsetUtil;
 
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map.Entry;
 import java.util.Set;
 
 /**
@@ -182,6 +184,14 @@ public interface Http2Headers extends BinaryHeaders {
 
     @Override
     Http2Headers clear();
+
+    /**
+     * Returns an iterator over all HTTP/2 headers from this instance. The iteration order is as follows:
+     *   1. All non-pseudo headers (in no particular order).
+     *   2. Headers with multiple values will have their values appear in insertion order.
+     */
+    @Override
+    Iterator<Entry<ByteString, ByteString>> iterator();
 
     /**
      * Sets the {@link PseudoHeaderName#METHOD} header or {@code null} if there is no such header

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpPriorityAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpPriorityAdapter.java
@@ -17,10 +17,10 @@ package io.netty.handler.codec.http2;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 
+import java.util.Iterator;
 import java.util.Map.Entry;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.TextHeaders.EntryVisitor;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -137,13 +137,11 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
      */
     private static void addHttpHeadersToHttp2Headers(HttpHeaders httpHeaders, final Http2Headers http2Headers) {
         try {
-            httpHeaders.forEachEntry(new EntryVisitor() {
-                @Override
-                public boolean visit(Entry<CharSequence, CharSequence> entry) throws Exception {
-                    http2Headers.add(AsciiString.of(entry.getKey()), AsciiString.of(entry.getValue()));
-                    return true;
-                }
-            });
+            Iterator<Entry<CharSequence, CharSequence>> iter = httpHeaders.iteratorCharSequence();
+            while (iter.hasNext()) {
+                Entry<CharSequence, CharSequence> entry = iter.next();
+                http2Headers.add(AsciiString.of(entry.getKey()), AsciiString.of(entry.getValue()));
+            }
         } catch (Exception ex) {
             PlatformDependent.throwException(ex);
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -1,55 +1,57 @@
 /*
  * Copyright 2014 The Netty Project
  *
- * The Netty Project licenses this file to you under the Apache License, version
- * 2.0 (the "License"); you may not use this file except in compliance with the
- * License. You may obtain a copy of the License at:
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * License for the specific language governing permissions and limitations
+ * under the License.
  */
+
 package io.netty.handler.codec.http2;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import io.netty.util.AsciiString;
 import io.netty.util.ByteString;
 import io.netty.util.CharsetUtil;
-
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertTrue;
 
 public class DefaultHttp2HeadersTest {
 
-    private static final byte[] NAME_BYTES = { 'T', 'E', 's', 'T' };
-    private static final byte[] NAME_BYTES_LOWERCASE = { 't', 'e', 's', 't' };
-    private static final ByteString NAME_BYTESTRING = new ByteString(NAME_BYTES);
-    private static final AsciiString NAME_ASCIISTRING = new AsciiString("Test");
-    private static final ByteString VALUE = new ByteString("some value", CharsetUtil.UTF_8);
-
     @Test
-    public void defaultLowercase() {
-        Http2Headers headers = new DefaultHttp2Headers().set(NAME_BYTESTRING, VALUE);
-        assertArrayEquals(NAME_BYTES_LOWERCASE, first(headers).toByteArray());
+    public void pseudoHeadersMustComeFirstWhenIterating() {
+        DefaultHttp2Headers headers = new DefaultHttp2Headers();
+        headers.add(bs("name1"), bs("value1"), bs("value2"));
+        headers.method(bs("POST"));
+        headers.add(bs("2name"), bs("value3"));
+        headers.path(bs("/index.html"));
+        headers.status(bs("200"));
+        headers.authority(bs("netty.io"));
+        headers.add(bs("name3"), bs("value4"));
+        headers.scheme(bs("https"));
+
+        Iterator<Entry<ByteString, ByteString>> iter = headers.iterator();
+        List<ByteString> names = new ArrayList<ByteString>();
+        for (int i = 0; i < 5; i++) {
+            names.add(iter.next().getKey());
+        }
+        assertTrue(names.containsAll(asList(bs(":method"), bs(":status"), bs(":path"), bs(":scheme"),
+                                            bs(":authority"))));
     }
 
-    @Test
-    public void defaultLowercaseAsciiString() {
-        Http2Headers headers = new DefaultHttp2Headers().set(NAME_ASCIISTRING, VALUE);
-        assertEquals(NAME_ASCIISTRING.toLowerCase(), first(headers));
-    }
-
-    @Test
-    public void caseInsensitive() {
-        Http2Headers headers = new DefaultHttp2Headers(false).set(NAME_BYTESTRING, VALUE);
-        assertArrayEquals(NAME_BYTES, first(headers).toByteArray());
-    }
-
-    private static ByteString first(Http2Headers headers) {
-        return headers.names().iterator().next();
+    private static ByteString bs(String str) {
+        return new ByteString(str, CharsetUtil.US_ASCII);
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -60,9 +60,9 @@ final class Http2TestUtil {
     }
 
     /**
-     * Converts a byte array into an {@link AsciiString}.
+     * Converts a byte array into a {@link ByteString}.
      */
-    public static ByteString as(byte[] value) {
+    public static ByteString bs(byte[] value) {
         return new ByteString(value);
     }
 
@@ -86,7 +86,7 @@ final class Http2TestUtil {
      * Returns an {@link AsciiString} that wraps a randomly-filled byte array.
      */
     public static ByteString randomString() {
-        return as(randomBytes());
+        return bs(randomBytes());
     }
 
     private Http2TestUtil() {

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeaders.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeaders.java
@@ -19,7 +19,13 @@ package io.netty.handler.codec.stomp;
 import io.netty.handler.codec.DefaultTextHeaders;
 import io.netty.handler.codec.TextHeaders;
 
+import java.util.TreeMap;
+
 public class DefaultStompHeaders extends DefaultTextHeaders implements StompHeaders {
+
+    public DefaultStompHeaders() {
+        super(new TreeMap<CharSequence, Object>(), NO_NAME_VALIDATOR, CharSequenceConverter.INSTANCE, false);
+    }
 
     @Override
     public StompHeaders add(CharSequence name, CharSequence value) {

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeEncoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeEncoder.java
@@ -25,6 +25,7 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.internal.PlatformDependent;
 
 import java.util.List;
+import java.util.Map.Entry;
 
 /**
  * Encodes a {@link StompFrame} or a {@link StompSubframe} into a {@link ByteBuf}.
@@ -66,11 +67,9 @@ public class StompSubframeEncoder extends MessageToMessageEncoder<StompSubframe>
 
         buf.writeBytes(frame.command().toString().getBytes(CharsetUtil.US_ASCII));
         buf.writeByte(StompConstants.LF);
-        try {
-            frame.headers().forEachEntry(new AsciiHeadersEncoder(buf, SeparatorType.COLON, NewlineType.LF));
-        } catch (Exception ex) {
-            buf.release();
-            PlatformDependent.throwException(ex);
+        AsciiHeadersEncoder headersEncoder = new AsciiHeadersEncoder(buf, SeparatorType.COLON, NewlineType.LF);
+        for (Entry<CharSequence, CharSequence> entry : frame.headers()) {
+            headersEncoder.encode(entry);
         }
         buf.writeByte(StompConstants.LF);
         return buf;

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompTestConstants.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompTestConstants.java
@@ -18,8 +18,8 @@ package io.netty.handler.codec.stomp;
 public final class StompTestConstants {
     public static final String CONNECT_FRAME =
         "CONNECT\n" +
-            "host:stomp.github.org\n" +
             "accept-version:1.1,1.2\n" +
+            "host:stomp.github.org\n" +
             '\n' +
             '\0';
     public static final String CONNECTED_FRAME =

--- a/codec/src/main/java/io/netty/handler/codec/AsciiHeadersEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/AsciiHeadersEncoder.java
@@ -21,10 +21,9 @@ import java.util.Map.Entry;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
-import io.netty.handler.codec.TextHeaders.EntryVisitor;
 import io.netty.util.AsciiString;
 
-public final class AsciiHeadersEncoder implements EntryVisitor {
+public final class AsciiHeadersEncoder {
 
     /**
      * The separator characters to insert between a header name and a header value.
@@ -78,8 +77,7 @@ public final class AsciiHeadersEncoder implements EntryVisitor {
         this.newlineType = newlineType;
     }
 
-    @Override
-    public boolean visit(Entry<CharSequence, CharSequence> entry) throws Exception {
+    public void encode(Entry<CharSequence, CharSequence> entry) {
         final CharSequence name = entry.getKey();
         final CharSequence value = entry.getValue();
         final ByteBuf buf = this.buf;
@@ -119,7 +117,6 @@ public final class AsciiHeadersEncoder implements EntryVisitor {
         }
 
         buf.writerIndex(offset);
-        return true;
     }
 
     private static void writeAscii(ByteBuf buf, int offset, CharSequence value, int valueLen) {

--- a/codec/src/main/java/io/netty/handler/codec/BinaryHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/BinaryHeaders.java
@@ -24,17 +24,6 @@ import io.netty.util.ByteString;
  * some additional utility when handling text data.
  */
 public interface BinaryHeaders extends Headers<ByteString> {
-    /**
-     * Provides an abstraction to iterate over elements maintained in the {@link Headers} collection.
-     */
-    interface EntryVisitor extends Headers.EntryVisitor<ByteString> {
-    }
-
-    /**
-     * Provides an abstraction to iterate over elements maintained in the {@link Headers} collection.
-     */
-    interface NameVisitor extends Headers.NameVisitor<ByteString> {
-    }
 
     @Override
     BinaryHeaders add(ByteString name, ByteString value);

--- a/codec/src/main/java/io/netty/handler/codec/ConvertibleHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/ConvertibleHeaders.java
@@ -90,13 +90,6 @@ public interface ConvertibleHeaders<UnconvertedType, ConvertedType> extends Head
     List<ConvertedType> getAllAndRemoveAndConvert(UnconvertedType name);
 
     /**
-     * Invokes {@link Headers#entries()} and lazily does a conversion on the results as they are accessed
-     *
-     * @return The values corresponding to {@code name} and then lazily converted
-     */
-    List<Map.Entry<ConvertedType, ConvertedType>> entriesConverted();
-
-    /**
      * Invokes {@link Headers#iterator()} and lazily does a conversion on the results as they are accessed
      *
      * @return Iterator which will provide converted values corresponding to {@code name}

--- a/codec/src/main/java/io/netty/handler/codec/DefaultBinaryHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultBinaryHeaders.java
@@ -20,128 +20,24 @@ import io.netty.util.internal.PlatformDependent;
 
 import java.nio.charset.Charset;
 import java.text.ParseException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
 
 public class DefaultBinaryHeaders extends DefaultHeaders<ByteString> implements BinaryHeaders {
-    private static final ValueConverter<ByteString> OBJECT_TO_BYTE = new ValueConverter<ByteString>() {
-        private final Charset DEFAULT_CHARSET = CharsetUtil.UTF_8;
-        @Override
-        public ByteString convertObject(Object value) {
-            if (value instanceof ByteString) {
-                return (ByteString) value;
-            }
-            if (value instanceof CharSequence) {
-                return new ByteString((CharSequence) value, DEFAULT_CHARSET);
-            }
-            return new ByteString(value.toString(), DEFAULT_CHARSET);
-        }
 
-        @Override
-        public ByteString convertInt(int value) {
-            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
-        }
-
-        @Override
-        public ByteString convertLong(long value) {
-            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
-        }
-
-        @Override
-        public ByteString convertDouble(double value) {
-            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
-        }
-
-        @Override
-        public ByteString convertChar(char value) {
-            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
-        }
-
-        @Override
-        public ByteString convertBoolean(boolean value) {
-            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
-        }
-
-        @Override
-        public ByteString convertFloat(float value) {
-            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
-        }
-
-        @Override
-        public int convertToInt(ByteString value) {
-            return value.parseAsciiInt();
-        }
-
-        @Override
-        public long convertToLong(ByteString value) {
-            return value.parseAsciiLong();
-        }
-
-        @Override
-        public ByteString convertTimeMillis(long value) {
-            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
-        }
-
-        @Override
-        public long convertToTimeMillis(ByteString value) {
-            try {
-                return HeaderDateFormat.get().parse(value.toString());
-            } catch (ParseException e) {
-                PlatformDependent.throwException(e);
-            }
-            return 0;
-        }
-
-        @Override
-        public double convertToDouble(ByteString value) {
-            return value.parseAsciiDouble();
-        }
-
-        @Override
-        public char convertToChar(ByteString value) {
-            return value.parseChar();
-        }
-
-        @Override
-        public boolean convertToBoolean(ByteString value) {
-            return value.byteAt(0) != 0;
-        }
-
-        @Override
-        public float convertToFloat(ByteString value) {
-            return value.parseAsciiFloat();
-        }
-
-        @Override
-        public ByteString convertShort(short value) {
-            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
-        }
-
-        @Override
-        public short convertToShort(ByteString value) {
-            return value.parseAsciiShort();
-        }
-
-        @Override
-        public ByteString convertByte(byte value) {
-            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
-        }
-
-        @Override
-        public byte convertToByte(ByteString value) {
-            return value.byteAt(0);
-        }
-    };
-
-    private static final HashCodeGenerator<ByteString> JAVA_HASH_CODE_GENERATOR =
-            new JavaHashCodeGenerator<ByteString>();
-    protected static final NameConverter<ByteString> IDENTITY_NAME_CONVERTER = new IdentityNameConverter<ByteString>();
+    private static final NameValidator<ByteString> NO_NAME_VALIDATOR = DefaultHeaders.NoNameValidator.instance();
 
     public DefaultBinaryHeaders() {
-        this(IDENTITY_NAME_CONVERTER);
+        this(new TreeMap<ByteString, Object>(ByteString.DEFAULT_COMPARATOR));
     }
 
-    public DefaultBinaryHeaders(NameConverter<ByteString> nameConverter) {
-        super(ByteString.DEFAULT_COMPARATOR, ByteString.DEFAULT_COMPARATOR,
-                JAVA_HASH_CODE_GENERATOR, OBJECT_TO_BYTE, nameConverter);
+    public DefaultBinaryHeaders(Map<ByteString, Object> map) {
+        this(map, NO_NAME_VALIDATOR);
+    }
+
+    public DefaultBinaryHeaders(Map<ByteString, Object> map, NameValidator<ByteString> nameValidator) {
+        super(map, nameValidator, ByteStringConverter.INSTANCE);
     }
 
     @Override
@@ -346,5 +242,120 @@ public class DefaultBinaryHeaders extends DefaultHeaders<ByteString> implements 
     public BinaryHeaders clear() {
         super.clear();
         return this;
+    }
+
+    public static final class ByteStringConverter implements ValueConverter<ByteString> {
+
+        public static final ByteStringConverter INSTANCE = new ByteStringConverter();
+        private static final Charset DEFAULT_CHARSET = CharsetUtil.UTF_8;
+
+        private ByteStringConverter() {
+        }
+
+        @Override
+        public ByteString convertObject(Object value) {
+            if (value instanceof ByteString) {
+                return (ByteString) value;
+            }
+            if (value instanceof CharSequence) {
+                return new ByteString((CharSequence) value, DEFAULT_CHARSET);
+            }
+            return new ByteString(value.toString(), DEFAULT_CHARSET);
+        }
+
+        @Override
+        public ByteString convertInt(int value) {
+            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
+        }
+
+        @Override
+        public ByteString convertLong(long value) {
+            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
+        }
+
+        @Override
+        public ByteString convertDouble(double value) {
+            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
+        }
+
+        @Override
+        public ByteString convertChar(char value) {
+            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
+        }
+
+        @Override
+        public ByteString convertBoolean(boolean value) {
+            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
+        }
+
+        @Override
+        public ByteString convertFloat(float value) {
+            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
+        }
+
+        @Override
+        public int convertToInt(ByteString value) {
+            return value.parseAsciiInt();
+        }
+
+        @Override
+        public long convertToLong(ByteString value) {
+            return value.parseAsciiLong();
+        }
+
+        @Override
+        public ByteString convertTimeMillis(long value) {
+            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
+        }
+
+        @Override
+        public long convertToTimeMillis(ByteString value) {
+            try {
+                return HeaderDateFormat.get().parse(value.toString());
+            } catch (ParseException e) {
+                PlatformDependent.throwException(e);
+            }
+            return 0;
+        }
+
+        @Override
+        public double convertToDouble(ByteString value) {
+            return value.parseAsciiDouble();
+        }
+
+        @Override
+        public char convertToChar(ByteString value) {
+            return value.parseChar();
+        }
+
+        @Override
+        public boolean convertToBoolean(ByteString value) {
+            return value.byteAt(0) != 0;
+        }
+
+        @Override
+        public float convertToFloat(ByteString value) {
+            return value.parseAsciiFloat();
+        }
+
+        @Override
+        public ByteString convertShort(short value) {
+            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
+        }
+
+        @Override
+        public short convertToShort(ByteString value) {
+            return value.parseAsciiShort();
+        }
+
+        @Override
+        public ByteString convertByte(byte value) {
+            return new ByteString(String.valueOf(value), DEFAULT_CHARSET);
+        }
+
+        @Override
+        public byte convertToByte(ByteString value) {
+            return value.byteAt(0);
+        }
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/DefaultConvertibleHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultConvertibleHeaders.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
@@ -27,22 +28,11 @@ public class DefaultConvertibleHeaders<UnconvertedType, ConvertedType> extends D
 
     private final TypeConverter<UnconvertedType, ConvertedType> typeConverter;
 
-    public DefaultConvertibleHeaders(Comparator<? super UnconvertedType> keyComparator,
-            Comparator<? super UnconvertedType> valueComparator,
-            HashCodeGenerator<UnconvertedType> hashCodeGenerator,
-            ValueConverter<UnconvertedType> valueConverter,
-            TypeConverter<UnconvertedType, ConvertedType> typeConverter) {
-        super(keyComparator, valueComparator, hashCodeGenerator, valueConverter);
-        this.typeConverter = typeConverter;
-    }
-
-    public DefaultConvertibleHeaders(Comparator<? super UnconvertedType> keyComparator,
-            Comparator<? super UnconvertedType> valueComparator,
-            HashCodeGenerator<UnconvertedType> hashCodeGenerator,
-            ValueConverter<UnconvertedType> valueConverter,
-            TypeConverter<UnconvertedType, ConvertedType> typeConverter,
-            NameConverter<UnconvertedType> nameConverter) {
-        super(keyComparator, valueComparator, hashCodeGenerator, valueConverter, nameConverter);
+    public DefaultConvertibleHeaders(Map<UnconvertedType, Object> map,
+                                     NameValidator<UnconvertedType> nameValidator,
+                                     ValueConverter<UnconvertedType> valueConverter,
+                                     TypeConverter<UnconvertedType, ConvertedType> typeConverter) {
+        super(map, nameValidator, valueConverter);
         this.typeConverter = typeConverter;
     }
 
@@ -92,17 +82,6 @@ public class DefaultConvertibleHeaders<UnconvertedType, ConvertedType> extends D
             allConverted.add(typeConverter.toConvertedType(all.get(i)));
         }
         return allConverted;
-    }
-
-    @Override
-    public List<Entry<ConvertedType, ConvertedType>> entriesConverted() {
-        List<Entry<UnconvertedType, UnconvertedType>> entries = entries();
-        List<Entry<ConvertedType, ConvertedType>> entriesConverted = new ArrayList<Entry<ConvertedType, ConvertedType>>(
-                entries.size());
-        for (int i = 0; i < entries.size(); ++i) {
-            entriesConverted.add(new ConvertedEntry(entries.get(i)));
-        }
-        return entriesConverted;
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/DefaultTextHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultTextHeaders.java
@@ -24,147 +24,13 @@ import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 
 import java.text.ParseException;
-import java.util.Comparator;
 import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
 
 public class DefaultTextHeaders extends DefaultConvertibleHeaders<CharSequence, String> implements TextHeaders {
-    private static final HashCodeGenerator<CharSequence> CHARSEQUECE_CASE_INSENSITIVE_HASH_CODE_GENERATOR =
-            new HashCodeGenerator<CharSequence>() {
-        @Override
-        public int generateHashCode(CharSequence name) {
-            return AsciiString.caseInsensitiveHashCode(name);
-        }
-    };
 
-    private static final HashCodeGenerator<CharSequence> CHARSEQUECE_CASE_SENSITIVE_HASH_CODE_GENERATOR =
-            new JavaHashCodeGenerator<CharSequence>();
-
-    public static class DefaultTextValueTypeConverter implements ValueConverter<CharSequence> {
-        @Override
-        public CharSequence convertObject(Object value) {
-            if (value instanceof CharSequence) {
-                return (CharSequence) value;
-            }
-            return value.toString();
-        }
-
-        @Override
-        public CharSequence convertInt(int value) {
-            return String.valueOf(value);
-        }
-
-        @Override
-        public CharSequence convertLong(long value) {
-            return String.valueOf(value);
-        }
-
-        @Override
-        public CharSequence convertDouble(double value) {
-            return String.valueOf(value);
-        }
-
-        @Override
-        public CharSequence convertChar(char value) {
-            return String.valueOf(value);
-        }
-
-        @Override
-        public CharSequence convertBoolean(boolean value) {
-            return String.valueOf(value);
-        }
-
-        @Override
-        public CharSequence convertFloat(float value) {
-            return String.valueOf(value);
-        }
-
-        @Override
-        public boolean convertToBoolean(CharSequence value) {
-            return Boolean.parseBoolean(value.toString());
-        }
-
-        @Override
-        public CharSequence convertByte(byte value) {
-            return String.valueOf(value);
-        }
-
-        @Override
-        public byte convertToByte(CharSequence value) {
-            return Byte.valueOf(value.toString());
-        }
-
-        @Override
-        public char convertToChar(CharSequence value) {
-            return value.charAt(0);
-        }
-
-        @Override
-        public CharSequence convertShort(short value) {
-            return String.valueOf(value);
-        }
-
-        @Override
-        public short convertToShort(CharSequence value) {
-            return Short.valueOf(value.toString());
-        }
-
-        @Override
-        public int convertToInt(CharSequence value) {
-            return Integer.parseInt(value.toString());
-        }
-
-        @Override
-        public long convertToLong(CharSequence value) {
-            return Long.parseLong(value.toString());
-        }
-
-        @Override
-        public AsciiString convertTimeMillis(long value) {
-            return new AsciiString(String.valueOf(value));
-        }
-
-        @Override
-        public long convertToTimeMillis(CharSequence value) {
-            try {
-                return HeaderDateFormat.get().parse(value.toString());
-            } catch (ParseException e) {
-                PlatformDependent.throwException(e);
-            }
-            return 0;
-        }
-
-        @Override
-        public float convertToFloat(CharSequence value) {
-            return Float.valueOf(value.toString());
-        }
-
-        @Override
-        public double convertToDouble(CharSequence value) {
-            return Double.valueOf(value.toString());
-        }
-    }
-
-    private static final ValueConverter<CharSequence> CHARSEQUENCE_FROM_OBJECT_CONVERTER =
-            new DefaultTextValueTypeConverter();
-    private static final TypeConverter<CharSequence, String> CHARSEQUENCE_TO_STRING_CONVERTER =
-            new TypeConverter<CharSequence, String>() {
-        @Override
-        public String toConvertedType(CharSequence value) {
-            return value.toString();
-        }
-
-        @Override
-        public CharSequence toUnconvertedType(String value) {
-            return value;
-        }
-    };
-
-    private static final NameConverter<CharSequence> CHARSEQUENCE_IDENTITY_CONVERTER =
-            new IdentityNameConverter<CharSequence>();
-    /**
-     * An estimate of the size of a header value.
-     */
-    private static final int DEFAULT_VALUE_SIZE = 10;
+    public static final NameValidator<CharSequence> NO_NAME_VALIDATOR = NoNameValidator.instance();
 
     private final ValuesComposer valuesComposer;
 
@@ -172,36 +38,23 @@ public class DefaultTextHeaders extends DefaultConvertibleHeaders<CharSequence, 
         this(true);
     }
 
-    public DefaultTextHeaders(boolean ignoreCase) {
-        this(ignoreCase, CHARSEQUENCE_FROM_OBJECT_CONVERTER, CHARSEQUENCE_IDENTITY_CONVERTER);
+    public DefaultTextHeaders(boolean singleHeaderFields) {
+        this(new TreeMap<CharSequence, Object>(CHARSEQUENCE_CASE_INSENSITIVE_ORDER), NO_NAME_VALIDATOR,
+             CharSequenceConverter.INSTANCE, singleHeaderFields);
     }
 
-    public DefaultTextHeaders(boolean ignoreCase, boolean singleHeaderFields) {
-        this(ignoreCase, CHARSEQUENCE_FROM_OBJECT_CONVERTER, CHARSEQUENCE_IDENTITY_CONVERTER, singleHeaderFields);
-    }
-
-    public DefaultTextHeaders(boolean ignoreCase, ValueConverter<CharSequence> valueConverter,
-            NameConverter<CharSequence> nameConverter) {
-        this(ignoreCase, valueConverter, nameConverter, false);
-    }
-
-    public DefaultTextHeaders(boolean ignoreCase, ValueConverter<CharSequence> valueConverter,
-                              NameConverter<CharSequence> nameConverter, boolean singleHeaderFields) {
-        super(comparator(ignoreCase), comparator(ignoreCase),
-                ignoreCase ? CHARSEQUECE_CASE_INSENSITIVE_HASH_CODE_GENERATOR
-                        : CHARSEQUECE_CASE_SENSITIVE_HASH_CODE_GENERATOR, valueConverter,
-                CHARSEQUENCE_TO_STRING_CONVERTER, nameConverter);
+    public DefaultTextHeaders(Map<CharSequence, Object> map,
+                              NameValidator<CharSequence> nameValidator,
+                              ValueConverter<CharSequence> valueConverter,
+                              boolean singleHeaderFields) {
+        super(map, nameValidator, valueConverter, CharSequenceToStringConverter.INSTANCE);
         valuesComposer = singleHeaderFields ? new SingleHeaderValuesComposer() : new MultipleFieldsValueComposer();
     }
 
     @Override
     public boolean contains(CharSequence name, CharSequence value, boolean ignoreCase) {
-        return contains(name, value, comparator(ignoreCase));
-    }
-
-    @Override
-    public boolean containsObject(CharSequence name, Object value, boolean ignoreCase) {
-        return containsObject(name, value, comparator(ignoreCase));
+        return contains(name, value,
+                ignoreCase ? CHARSEQUENCE_CASE_INSENSITIVE_ORDER : CHARSEQUENCE_CASE_SENSITIVE_ORDER);
     }
 
     @Override
@@ -398,10 +251,6 @@ public class DefaultTextHeaders extends DefaultConvertibleHeaders<CharSequence, 
         return this;
     }
 
-    private static Comparator<CharSequence> comparator(boolean ignoreCase) {
-        return ignoreCase ? CHARSEQUENCE_CASE_INSENSITIVE_ORDER : CHARSEQUENCE_CASE_SENSITIVE_ORDER;
-    }
-
     /*
      * This interface enables different implementations for adding/setting header values.
      * Concrete implementations can control how values are added, for example to add all
@@ -413,6 +262,7 @@ public class DefaultTextHeaders extends DefaultConvertibleHeaders<CharSequence, 
         TextHeaders add(CharSequence name, CharSequence... values);
         TextHeaders add(CharSequence name, Iterable<? extends CharSequence> values);
 
+        TextHeaders addObject(CharSequence name, Object value);
         TextHeaders addObject(CharSequence name, Iterable<?> values);
         TextHeaders addObject(CharSequence name, Object... values);
 
@@ -443,6 +293,12 @@ public class DefaultTextHeaders extends DefaultConvertibleHeaders<CharSequence, 
         @Override
         public TextHeaders add(CharSequence name, Iterable<? extends CharSequence> values) {
             DefaultTextHeaders.super.add(name, values);
+            return DefaultTextHeaders.this;
+        }
+
+        @Override
+        public TextHeaders addObject(CharSequence name, Object value) {
+            DefaultTextHeaders.super.addObject(name, value);
             return DefaultTextHeaders.this;
         }
 
@@ -535,6 +391,11 @@ public class DefaultTextHeaders extends DefaultConvertibleHeaders<CharSequence, 
         }
 
         @Override
+        public TextHeaders addObject(CharSequence name, Object value) {
+            return addEscapedValue(name, objectEscaper().escape(value));
+        }
+
+        @Override
         public TextHeaders addObject(CharSequence name, Iterable<?> values) {
             return addEscapedValue(name, commaSeparate(objectEscaper(), values));
         }
@@ -579,7 +440,8 @@ public class DefaultTextHeaders extends DefaultConvertibleHeaders<CharSequence, 
         }
 
         private <T> CharSequence commaSeparate(CsvValueEscaper<T> escaper, T... values) {
-            StringBuilder sb = new StringBuilder(values.length * DEFAULT_VALUE_SIZE);
+            final int lengthEstimate = 10;
+            StringBuilder sb = new StringBuilder(values.length * lengthEstimate);
             if (values.length > 0) {
                 int end = values.length - 1;
                 for (int i = 0; i < end; i++) {
@@ -624,5 +486,131 @@ public class DefaultTextHeaders extends DefaultConvertibleHeaders<CharSequence, 
          * @param value the value to be appended, escaped if necessary
          */
         CharSequence escape(T value);
+    }
+
+    private static final class CharSequenceToStringConverter implements TypeConverter<CharSequence, String> {
+
+        private static final CharSequenceToStringConverter INSTANCE = new CharSequenceToStringConverter();
+
+        @Override
+        public String toConvertedType(CharSequence value) {
+            return value.toString();
+        }
+
+        @Override
+        public CharSequence toUnconvertedType(String value) {
+            return value;
+        }
+    }
+
+    public static class CharSequenceConverter implements ValueConverter<CharSequence> {
+
+        public static final CharSequenceConverter INSTANCE = new CharSequenceConverter();
+
+        @Override
+        public CharSequence convertObject(Object value) {
+            if (value instanceof CharSequence) {
+                return (CharSequence) value;
+            }
+            return value.toString();
+        }
+
+        @Override
+        public CharSequence convertInt(int value) {
+            return String.valueOf(value);
+        }
+
+        @Override
+        public CharSequence convertLong(long value) {
+            return String.valueOf(value);
+        }
+
+        @Override
+        public CharSequence convertDouble(double value) {
+            return String.valueOf(value);
+        }
+
+        @Override
+        public CharSequence convertChar(char value) {
+            return String.valueOf(value);
+        }
+
+        @Override
+        public CharSequence convertBoolean(boolean value) {
+            return String.valueOf(value);
+        }
+
+        @Override
+        public CharSequence convertFloat(float value) {
+            return String.valueOf(value);
+        }
+
+        @Override
+        public boolean convertToBoolean(CharSequence value) {
+            return Boolean.parseBoolean(value.toString());
+        }
+
+        @Override
+        public CharSequence convertByte(byte value) {
+            return String.valueOf(value);
+        }
+
+        @Override
+        public byte convertToByte(CharSequence value) {
+            return Byte.valueOf(value.toString());
+        }
+
+        @Override
+        public char convertToChar(CharSequence value) {
+            if (value.length() == 0) {
+                throw new IllegalArgumentException("'value' is empty.");
+            }
+            return value.charAt(0);
+        }
+
+        @Override
+        public CharSequence convertShort(short value) {
+            return String.valueOf(value);
+        }
+
+        @Override
+        public short convertToShort(CharSequence value) {
+            return Short.valueOf(value.toString());
+        }
+
+        @Override
+        public int convertToInt(CharSequence value) {
+            return Integer.parseInt(value.toString());
+        }
+
+        @Override
+        public long convertToLong(CharSequence value) {
+            return Long.parseLong(value.toString());
+        }
+
+        @Override
+        public CharSequence convertTimeMillis(long value) {
+            return String.valueOf(value);
+        }
+
+        @Override
+        public long convertToTimeMillis(CharSequence value) {
+            try {
+                return HeaderDateFormat.get().parse(value.toString());
+            } catch (ParseException e) {
+                PlatformDependent.throwException(e);
+            }
+            return 0;
+        }
+
+        @Override
+        public float convertToFloat(CharSequence value) {
+            return Float.valueOf(value.toString());
+        }
+
+        @Override
+        public double convertToDouble(CharSequence value) {
+            return Double.valueOf(value.toString());
+        }
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/EmptyConvertibleHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/EmptyConvertibleHeaders.java
@@ -55,13 +55,9 @@ public class EmptyConvertibleHeaders<UnconvertedType, ConvertedType> extends
     }
 
     @Override
-    public List<Entry<ConvertedType, ConvertedType>> entriesConverted() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public Iterator<Entry<ConvertedType, ConvertedType>> iteratorConverted() {
-        return entriesConverted().iterator();
+        List<Entry<ConvertedType, ConvertedType>> empty = Collections.emptyList();
+        return empty.iterator();
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/EmptyHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/EmptyHeaders.java
@@ -88,7 +88,7 @@ public class EmptyHeaders<T> implements Headers<T> {
     }
 
     @Override
-    public short getInt(T name, short defaultValue) {
+    public short getShort(T name, short defaultValue) {
         return defaultValue;
     }
 
@@ -233,11 +233,6 @@ public class EmptyHeaders<T> implements Headers<T> {
     }
 
     @Override
-    public List<Entry<T, T>> entries() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public boolean contains(T name) {
         return false;
     }
@@ -298,24 +293,7 @@ public class EmptyHeaders<T> implements Headers<T> {
     }
 
     @Override
-    public boolean contains(T name, T value, Comparator<? super T> comparator) {
-        return false;
-    }
-
-    @Override
-    public boolean contains(T name, T value,
-            Comparator<? super T> keyComparator, Comparator<? super T> valueComparator) {
-        return false;
-    }
-
-    @Override
-    public boolean containsObject(T name, Object value, Comparator<? super T> comparator) {
-        return false;
-    }
-
-    @Override
-    public boolean containsObject(T name, Object value, Comparator<? super T> keyComparator,
-            Comparator<? super T> valueComparator) {
+    public boolean contains(T name, T value, Comparator<? super T> valueComparator) {
         return false;
     }
 
@@ -332,11 +310,6 @@ public class EmptyHeaders<T> implements Headers<T> {
     @Override
     public Set<T> names() {
         return Collections.emptySet();
-    }
-
-    @Override
-    public List<T> namesList() {
-        return Collections.emptyList();
     }
 
     @Override
@@ -415,7 +388,7 @@ public class EmptyHeaders<T> implements Headers<T> {
     }
 
     @Override
-    public Headers<T> add(Headers<T> headers) {
+    public Headers<T> add(Headers<? extends T> headers) {
         throw new UnsupportedOperationException("read only");
     }
 
@@ -495,12 +468,12 @@ public class EmptyHeaders<T> implements Headers<T> {
     }
 
     @Override
-    public Headers<T> set(Headers<T> headers) {
+    public Headers<T> set(Headers<? extends T> headers) {
         throw new UnsupportedOperationException("read only");
     }
 
     @Override
-    public Headers<T> setAll(Headers<T> headers) {
+    public Headers<T> setAll(Headers<? extends T> headers) {
         throw new UnsupportedOperationException("read only");
     }
 
@@ -516,17 +489,8 @@ public class EmptyHeaders<T> implements Headers<T> {
 
     @Override
     public Iterator<Entry<T, T>> iterator() {
-        return entries().iterator();
-    }
-
-    @Override
-    public Entry<T, T> forEachEntry(Headers.EntryVisitor<T> visitor) throws Exception {
-        return null;
-    }
-
-    @Override
-    public T forEachName(Headers.NameVisitor<T> visitor) throws Exception {
-        return null;
+        List<Entry<T, T>> empty = Collections.emptyList();
+        return empty.iterator();
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/EmptyTextHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/EmptyTextHeaders.java
@@ -26,11 +26,6 @@ public class EmptyTextHeaders extends EmptyConvertibleHeaders<CharSequence, Stri
     }
 
     @Override
-    public boolean containsObject(CharSequence name, Object value, boolean ignoreCase) {
-        return false;
-    }
-
-    @Override
     public TextHeaders add(CharSequence name, CharSequence value) {
         super.add(name, value);
         return this;

--- a/codec/src/main/java/io/netty/handler/codec/Headers.java
+++ b/codec/src/main/java/io/netty/handler/codec/Headers.java
@@ -17,39 +17,13 @@ package io.netty.handler.codec;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-public interface Headers<T> extends Iterable<Map.Entry<T, T>> {
-    /**
-     * Provides an abstraction to iterate over elements maintained in the {@link Headers} collection.
-     */
-    interface EntryVisitor<T> {
-        /**
-         * @return <ul>
-         *         <li>{@code true} if the processor wants to continue the loop and handle the entry.</li>
-         *         <li>{@code false} if the processor wants to stop handling headers and abort the loop.</li>
-         *         </ul>
-         */
-        boolean visit(Map.Entry<T, T> entry) throws Exception;
-    }
+public interface Headers<T> extends Iterable<Entry<T, T>> {
 
     /**
-     * Provides an abstraction to iterate over elements maintained in the {@link Headers} collection.
-     */
-    interface NameVisitor<T> {
-        /**
-         * @return <ul>
-         *         <li>{@code true} if the processor wants to continue the loop and handle the entry.</li>
-         *         <li>{@code false} if the processor wants to stop handling headers and abort the loop.</li>
-         *         </ul>
-         */
-        boolean visit(T name) throws Exception;
-    }
-
-    /**
-     * Converts to/from a generic object to the type of the name for this map
+     * Converts to/from a generic object to the type of the headers.
      */
     interface ValueConverter<T> {
         T convertObject(Object value);
@@ -92,458 +66,469 @@ public interface Headers<T> extends Iterable<Map.Entry<T, T>> {
     }
 
     /**
-     * Returns the value of a header with the specified name. If there are more than one values for the specified name,
-     * the first value is returned.
+     * Returns the value of a header with the specified name. If there is more than one value for the specified name,
+     * the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
-     * @return the first header value if the header is found. {@code null} if there's no such header.
+     * @param name the name of the header to retrieve
+     * @return the first header value if the header is found. {@code null} if there's no such header
      */
     T get(T name);
 
     /**
-     * Returns the value of a header with the specified name. If there are more than one values for the specified name,
-     * the first value is returned.
+     * Returns the value of a header with the specified name. If there is more than one value for the specified name,
+     * the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
+     * @param name the name of the header to retrieve
      * @param defaultValue the default value
-     * @return the first header value if the header is found. {@code defaultValue} if there's no such header.
+     * @return the first header value or {@code defaultValue} if there is no such header
      */
     T get(T name, T defaultValue);
 
     /**
-     * Returns and removes the value of a header with the specified name. If there are more than one values for the
-     * specified name, the first value is returned.
+     * Returns the value of a header with the specified name and removes it from this object. If there is more than
+     * one value for the specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
+     * @param name the name of the header to retrieve
      * @return the first header value or {@code null} if there is no such header
      */
     T getAndRemove(T name);
 
     /**
-     * Returns and removes the value of a header with the specified name. If there are more than one values for the
-     * specified name, the first value is returned.
+     * Returns the value of a header with the specified name and removes it from this object. If there is more than
+     * one value for the specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
+     * @param name the name of the header to retrieve
      * @param defaultValue the default value
      * @return the first header value or {@code defaultValue} if there is no such header
      */
     T getAndRemove(T name, T defaultValue);
 
     /**
-     * Returns the values of headers with the specified name
+     * Returns all values for the header with the specified name. The returned {@link List} can't be modified.
      *
-     * @param name The name of the headers to search
-     * @return A {@link List} of header values which will be empty if no values are found
+     * @param name the name of the header to retrieve
+     * @return a {@link List} of header values or an empty {@link List} if no values are found.
      */
     List<T> getAll(T name);
 
     /**
-     * Returns and Removes the values of headers with the specified name
+     * Returns all values for the header with the specified name and removes them from this object.
+     * The returned {@link List} can't be modified.
      *
-     * @param name The name of the headers to search
-     * @return A {@link List} of header values which will be empty if no values are found
+     * @param name the name of the header to retrieve
+     * @return a {@link List} of header values or an empty {@link List} if no values are found.
      */
     List<T> getAllAndRemove(T name);
 
     /**
-     * Returns the boolean value of a header with the specified name. If there are more than one values for the
-     * specified name, the first value is returned.
+     * Returns the {@code boolean} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is a boolean. {@code null} if there's no such
-     *         header or its value is not a boolean.
+     * @param name the name of the header to retrieve
+     * @return the {@code boolean} value of the first value in insertion order or {@code null} if there is no such
+     *         value or it can't be converted to {@code boolean}.
      */
     Boolean getBoolean(T name);
 
     /**
-     * Returns the boolean value of a header with the specified name. If there are more than one values for the
-     * specified name, the first value is returned.
+     * Returns the {@code boolean} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
+     * @param name the name of the header to retrieve
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is a boolean. {@code defaultValue} if there's
-     *         no such header or its value is not a boolean.
+     * @return the {@code boolean} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code boolean}.
      */
     boolean getBoolean(T name, boolean defaultValue);
 
     /**
-     * Returns the byte value of a header with the specified name. If there are more than one values for the specified
-     * name, the first value is returned.
+     * Returns the {@code byte} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is a byte. {@code null} if there's no such
-     *         header or its value is not a byte.
+     * @param name the name of the header to retrieve
+     * @return the {@code byte} value of the first value in insertion order or {@code null} if there is no such
+     *         value or it can't be converted to {@code byte}.
      */
     Byte getByte(T name);
 
     /**
-     * Returns the byte value of a header with the specified name. If there are more than one values for the specified
-     * name, the first value is returned.
+     * Returns the {@code byte} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
+     * @param name the name of the header to retrieve
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is a byte. {@code defaultValue} if there's no
-     *         such header or its value is not a byte.
+     * @return the {@code byte} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code byte}.
      */
     byte getByte(T name, byte defaultValue);
 
     /**
-     * Returns the char value of a header with the specified name. If there are more than one values for the specified
-     * name, the first value is returned.
+     * Returns the {@code char} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is a char. {@code null} if there's no such
-     *         header or its value is not a char.
+     * @param name the name of the header to retrieve
+     * @return the {@code char} value of the first value in insertion order or {@code null} if there is no such
+     *         value or it can't be converted to {@code char}.
      */
     Character getChar(T name);
 
     /**
-     * Returns the char value of a header with the specified name. If there are more than one values for the specified
-     * name, the first value is returned.
+     * Returns the {@code char} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
+     * @param name the name of the header to retrieve
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is a char. {@code defaultValue} if there's no
-     *         such header or its value is not a char.
+     * @return the {@code char} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code char}.
      */
     char getChar(T name, char defaultValue);
 
     /**
-     * Returns the short value of a header with the specified name. If there are more than one values for the specified
-     * name, the first value is returned.
+     * Returns the {@code short} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is a short. {@code null} if there's no such
-     *         header or its value is not a short.
+     * @param name the name of the header to retrieve
+     * @return the {@code short} value of the first value in insertion order or {@code null} if there is no such
+     *         value or it can't be converted to {@code short}.
      */
     Short getShort(T name);
 
     /**
-     * Returns the short value of a header with the specified name. If there are more than one values for the specified
-     * name, the first value is returned.
+     * Returns the {@code short} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
+     * @param name the name of the header to retrieve
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is a short. {@code defaultValue} if there's
-     *         no such header or its value is not a short.
+     * @return the {@code short} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code short}.
      */
-    short getInt(T name, short defaultValue);
+    short getShort(T name, short defaultValue);
 
     /**
-     * Returns the integer value of a header with the specified name. If there are more than one values for the
-     * specified name, the first value is returned.
+     * Returns the {@code int} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is an integer. {@code null} if there's no
-     *         such header or its value is not an integer.
+     * @param name the name of the header to retrieve
+     * @return the {@code int} value of the first value in insertion order or {@code null} if there is no such
+     *         value or it can't be converted to {@code int}.
      */
     Integer getInt(T name);
 
     /**
-     * Returns the integer value of a header with the specified name. If there are more than one values for the
-     * specified name, the first value is returned.
+     * Returns the {@code int} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
+     * @param name the name of the header to retrieve
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is an integer. {@code defaultValue} if
-     *         there's no such header or its value is not an integer.
+     * @return the {@code int} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code int}.
      */
     int getInt(T name, int defaultValue);
 
     /**
-     * Returns the long value of a header with the specified name. If there are more than one values for the specified
-     * name, the first value is returned.
+     * Returns the {@code long} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is a long. {@code null} if there's no such
-     *         header or its value is not a long.
+     * @param name the name of the header to retrieve
+     * @return the {@code long} value of the first value in insertion order or {@code null} if there is no such
+     *         value or it can't be converted to {@code long}.
      */
     Long getLong(T name);
 
     /**
-     * Returns the long value of a header with the specified name. If there are more than one values for the specified
-     * name, the first value is returned.
+     * Returns the {@code long} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
+     * @param name the name of the header to retrieve
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is a long. {@code defaultValue} if there's no
-     *         such header or its value is not a long.
+     * @return the {@code long} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code long}.
      */
     long getLong(T name, long defaultValue);
 
     /**
-     * Returns the float value of a header with the specified name. If there are more than one values for the specified
-     * name, the first value is returned.
+     * Returns the {@code float} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is a float. {@code null} if there's no such
-     *         header or its value is not a float.
+     * @param name the name of the header to retrieve
+     * @return the {@code float} value of the first value in insertion order or {@code null} if there is no such
+     *         value or it can't be converted to {@code float}.
      */
     Float getFloat(T name);
 
     /**
-     * Returns the float value of a header with the specified name. If there are more than one values for the specified
-     * name, the first value is returned.
+     * Returns the {@code float} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
+     * @param name the name of the header to retrieve
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is a float. {@code defaultValue} if there's
-     *         no such header or its value is not a float.
+     * @return the {@code float} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code float}.
      */
     float getFloat(T name, float defaultValue);
 
     /**
-     * Returns the double value of a header with the specified name. If there are more than one values for the specified
-     * name, the first value is returned.
+     * Returns the {@code double} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is a double. {@code null} if there's no such
-     *         header or its value is not a double.
+     * @param name the name of the header to retrieve
+     * @return the {@code double} value of the first value in insertion order or {@code null} if there is no such
+     *         value or it can't be converted to {@code double}.
      */
     Double getDouble(T name);
 
     /**
-     * Returns the double value of a header with the specified name. If there are more than one values for the specified
-     * name, the first value is returned.
+     * Returns the {@code double} value of a header with the specified name. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name the name of the header to search
+     * @param name the name of the header to retrieve
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is a double. {@code defaultValue} if there's
-     *         no such header or its value is not a double.
+     * @return the {@code double} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code double}.
      */
     double getDouble(T name, double defaultValue);
 
     /**
-     * Returns the date value of a header with the specified name as milliseconds. If there are more than one values for
-     * the specified name, the first value is returned.
+     * Returns the value of a header with the specified name in milliseconds. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name The name of the header to search
-     * @return the first header value in milliseconds if the header is found and its value is a date. {@code null} if
-     *         there's no such header or its value is not a date.
+     * @param name the name of the header to retrieve
+     * @return the milliseconds value of the first value in insertion order or {@code null} if there is no such
+     *         value or it can't be converted to milliseconds.
      */
     Long getTimeMillis(T name);
 
     /**
-     * Returns the date value of a header with the specified name as milliseconds. If there are more than one values for
-     * the specified name, the first value is returned.
+     * Returns the value of a header with the specified name in milliseconds. If there is more than one value for the
+     * specified name, the first value in insertion order is returned.
      *
-     * @param name The name of the header to search
-     * @param defaultValue default value
-     * @return the first header value in milliseconds if the header is found and its value is a date.
-     *         {@code defaultValue} if there's no such header or its value is not a date.
+     * @param name the name of the header to retrieve
+     * @param defaultValue the default value
+     * @return the milliseconds value of the first value in insertion order or {@code defaultValue} if there is no such
+     *         value or it can't be converted to milliseconds.
      */
     long getTimeMillis(T name, long defaultValue);
 
     /**
-     * Returns and removes the boolean value of a header with the specified name. If there are more than one values for
-     * the specified name, the first value is returned.
+     * Returns the {@code boolean} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
-     * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is a boolean. {@code null} if there's no such
-     *         header or its value is not a boolean.
+     * @param name the name of the header to retrieve
+     * @return the {@code boolean} value of the first value in insertion order or {@code null} if there is no
+     *         such value or it can't be converted to {@code boolean}.
      */
     Boolean getBooleanAndRemove(T name);
 
     /**
-     * Returns and removes the boolean value of a header with the specified name. If there are more than one values for
-     * the specified name, the first value is returned.
+     * Returns the {@code boolean} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
      * @param name the name of the header to search
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is a boolean. {@code defaultValue} if there
-     *         is no such header or its value of header is not a boolean.
+     * @return the {@code boolean} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code boolean}.
      */
     boolean getBooleanAndRemove(T name, boolean defaultValue);
 
     /**
-     * Returns and removes the byte value of a header with the specified name. If there are more than one values for the
-     * specified name, the first value is returned.
+     * Returns the {@code byte} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
      * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is a byte. {@code null} if there's no such
-     *         header or its value is not a byte.
+     * @return the {@code byte} value of the first value in insertion order or {@code null} if there is no
+     *         such value or it can't be converted to {@code byte}.
      */
     Byte getByteAndRemove(T name);
 
     /**
-     * Returns and removes the byte value of a header with the specified name. If there are more than one values for the
-     * specified name, the first value is returned.
+     * Returns the {@code byte} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
      * @param name the name of the header to search
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is a byte. {@code defaultValue} if there is
-     *         no such header or its value of header is not a byte.
+     * @return the {@code byte} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code byte}.
      */
     byte getByteAndRemove(T name, byte defaultValue);
 
     /**
-     * Returns and removes the char value of a header with the specified name. If there are more than one values for the
-     * specified name, the first value is returned.
+     * Returns the {@code char} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
      * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is a char. {@code null} if there's no such
-     *         header or its value is not a char.
+     * @return the {@code char} value of the first value in insertion order or {@code null} if there is no
+     *         such value or it can't be converted to {@code char}.
      */
     Character getCharAndRemove(T name);
 
     /**
-     * Returns and removes the char value of a header with the specified name. If there are more than one values for the
-     * specified name, the first value is returned.
+     * Returns the {@code char} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
      * @param name the name of the header to search
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is a char. {@code defaultValue} if there is
-     *         no such header or its value of header is not a char.
+     * @return the {@code char} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code char}.
      */
     char getCharAndRemove(T name, char defaultValue);
 
     /**
-     * Returns and removes the short value of a header with the specified name. If there are more than one values for
-     * the specified name, the first value is returned.
+     * Returns the {@code short} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
      * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is a short. {@code null} if there's no such
-     *         header or its value is not a short.
+     * @return the {@code short} value of the first value in insertion order or {@code null} if there is no
+     *         such value or it can't be converted to {@code short}.
      */
     Short getShortAndRemove(T name);
 
     /**
-     * Returns and removes the short value of a header with the specified name. If there are more than one values for
-     * the specified name, the first value is returned.
+     * Returns the {@code short} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
      * @param name the name of the header to search
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is a short. {@code defaultValue} if there is
-     *         no such header or its value of header is not a short.
+     * @return the {@code short} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code short}.
      */
     short getShortAndRemove(T name, short defaultValue);
 
     /**
-     * Returns and removes the integer value of a header with the specified name. If there are more than one values for
-     * the specified name, the first value is returned.
+     * Returns the {@code int} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
      * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is an integer. {@code null} if there's no
-     *         such header or its value is not an integer.
+     * @return the {@code int} value of the first value in insertion order or {@code null} if there is no
+     *         such value or it can't be converted to {@code int}.
      */
     Integer getIntAndRemove(T name);
 
     /**
-     * Returns and removes the integer value of a header with the specified name. If there are more than one values for
-     * the specified name, the first value is returned.
+     * Returns the {@code int} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
      * @param name the name of the header to search
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is an integer. {@code defaultValue} if there
-     *         is no such header or its value of header is not an integer.
+     * @return the {@code int} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code int}.
      */
     int getIntAndRemove(T name, int defaultValue);
 
     /**
-     * Returns and removes the long value of a header with the specified name. If there are more than one values for the
-     * specified name, the first value is returned.
+     * Returns the {@code long} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
      * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is a long. {@code null} if there's no such
-     *         header or its value is not a long.
+     * @return the {@code long} value of the first value in insertion order or {@code null} if there is no
+     *         such value or it can't be converted to {@code long}.
      */
     Long getLongAndRemove(T name);
 
     /**
-     * Returns and removes the long value of a header with the specified name. If there are more than one values for the
-     * specified name, the first value is returned.
+     * Returns the {@code long} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
      * @param name the name of the header to search
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is a long. {@code defaultValue} if there's no
-     *         such header or its value is not a long.
+     * @return the {@code long} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code long}.
      */
     long getLongAndRemove(T name, long defaultValue);
 
     /**
-     * Returns and removes the float value of a header with the specified name. If there are more than one values for
-     * the specified name, the first value is returned.
+     * Returns the {@code float} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
      * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is a float. {@code null} if there's no such
-     *         header or its value is not a float.
+     * @return the {@code float} value of the first value in insertion order or {@code null} if there is no
+     *         such value or it can't be converted to {@code float}.
      */
     Float getFloatAndRemove(T name);
 
     /**
-     * Returns and removes the float value of a header with the specified name. If there are more than one values for
-     * the specified name, the first value is returned.
+     * Returns the {@code float} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
      * @param name the name of the header to search
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is a float. {@code defaultValue} if there's
-     *         no such header or its value is not a float.
+     * @return the {@code float} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code float}.
      */
     float getFloatAndRemove(T name, float defaultValue);
 
     /**
-     * Returns and removes the double value of a header with the specified name. If there are more than one values for
-     * the specified name, the first value is returned.
+     * Returns the {@code double} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
      * @param name the name of the header to search
-     * @return the first header value if the header is found and its value is a double. {@code null} if there's no such
-     *         header or its value is not a double.
+     * @return the {@code double} value of the first value in insertion order or {@code null} if there is no
+     *         such value or it can't be converted to {@code double}.
      */
     Double getDoubleAndRemove(T name);
 
     /**
-     * Returns and removes the double value of a header with the specified name. If there are more than one values for
-     * the specified name, the first value is returned.
+     * Returns the {@code double} value of a header with the specified {@code name} and removes the header from this
+     * object. If there is more than one value for the specified name, the first value in insertion order is returned.
+     * In any case all values for {@code name} are removed.
      *
      * @param name the name of the header to search
      * @param defaultValue the default value
-     * @return the first header value if the header is found and its value is a double. {@code defaultValue} if there's
-     *         no such header or its value is not a double.
+     * @return the {@code double} value of the first value in insertion order or {@code defaultValue} if there is no
+     *         such value or it can't be converted to {@code double}.
      */
     double getDoubleAndRemove(T name, double defaultValue);
 
     /**
-     * Returns and removes the date value of a header with the specified name as milliseconds. If there are more than
-     * one values for the specified name, the first value is returned.
+     * Returns the value of a header with the specified {@code name} in milliseconds and removes the header from this
+     * object. If there is more than one value for the specified {@code name}, the first value in insertion order is
+     * returned. In any case all values for {@code name} are removed.
      *
-     * @param name The name of the header to search
-     * @return the first header value in milliseconds if the header is found and its value is a date. {@code null} if
-     *         there's no such header or its value is not a date.
+     * @param name the name of the header to retrieve
+     * @return the milliseconds value of the first value in insertion order or {@code null} if there is no such
+     *         value or it can't be converted to milliseconds.
      */
     Long getTimeMillisAndRemove(T name);
 
     /**
-     * Returns and removes the date value of a header with the specified name as milliseconds. If there are more than
-     * one values for the specified name, the first value is returned.
+     * Returns the value of a header with the specified {@code name} in milliseconds and removes the header from this
+     * object. If there is more than one value for the specified {@code name}, the first value in insertion order is
+     * returned. In any case all values for {@code name} are removed.
      *
-     * @param name The name of the header to search
-     * @param defaultValue default value
-     * @return the first header value in milliseconds if the header is found and its value is a date.
-     *         {@code defaultValue} if there's no such header or its value is not a date.
+     * @param name the name of the header to retrieve
+     * @param defaultValue the default value
+     * @return the milliseconds value of the first value in insertion order or {@code defaultValue} if there is no such
+     *         value or it can't be converted to milliseconds.
      */
     long getTimeMillisAndRemove(T name, long defaultValue);
 
     /**
-     * Returns a new {@link List} that contains all headers in this object. Note that modifying the returned
-     * {@link List} will not affect the state of this object. If you intend to enumerate over the header entries only,
-     * use {@link #iterator()} instead, which has much less overhead.
-     */
-    List<Entry<T, T>> entries();
-
-    /**
-     * Returns {@code true} if and only if this collection contains the header with the specified name.
+     * Returns {@code true} if a header with the {@code name} exists, {@code false} otherwise.
      *
-     * @param name The name of the header to search for
-     * @return {@code true} if at least one header is found
+     * @param name the header name
      */
     boolean contains(T name);
 
     /**
-     * Returns {@code true} if a header with the name and value exists.
-     *
+     * Returns {@code true} if a header with the {@code name} and {@code value} exists, {@code false} otherwise.
+     * <p>
+     * The {@link Object#equals(Object)} method is used to test for equality of {@code value}.
+     * </p>
      * @param name the header name
-     * @param value the header value
-     * @return {@code true} if it contains it {@code false} otherwise
      */
     boolean contains(T name, T value);
 
@@ -638,353 +623,281 @@ public interface Headers<T> extends Iterable<Map.Entry<T, T>> {
     boolean containsTimeMillis(T name, long value);
 
     /**
-     * Returns {@code true} if a header with the name and value exists.
+     * Returns {@code true} if a header with the {@code name} and {@code value} exists.
      *
      * @param name the header name
      * @param value the header value
-     * @param comparator The comparator to use when comparing {@code name} and {@code value} to entries in this map
+     * @param valueComparator The comparator to use when comparing {@code value} to entries in this map
      * @return {@code true} if it contains it {@code false} otherwise
      */
-    boolean contains(T name, T value, Comparator<? super T> comparator);
+    boolean contains(T name, T value, Comparator<? super T> valueComparator);
 
     /**
-     * Returns {@code true} if a header with the name and value exists.
-     *
-     * @param name the header name
-     * @param value the header value
-     * @param keyComparator The comparator to use when comparing {@code name} to names in this map
-     * @param valueComparator The comparator to use when comparing {@code value} to values in this map
-     * @return {@code true} if it contains it {@code false} otherwise
-     */
-    boolean contains(T name, T value, Comparator<? super T> keyComparator, Comparator<? super T> valueComparator);
-
-    /**
-     * Returns {@code true} if a header with the name and value exists.
-     *
-     * @param name the header name
-     * @param value the header value
-     * @param comparator The comparator to use when comparing {@code name} and {@code value} to entries in this map
-     * @return {@code true} if it contains it {@code false} otherwise
-     */
-    boolean containsObject(T name, Object value, Comparator<? super T> comparator);
-
-    /**
-     * Returns {@code true} if a header with the name and value exists.
-     *
-     * @param name the header name
-     * @param value the header value
-     * @param keyComparator The comparator to use when comparing {@code name} to names in this map
-     * @param valueComparator The comparator to use when comparing {@code value} to values in this map
-     * @return {@code true} if it contains it {@code false} otherwise
-     */
-    boolean containsObject(T name, Object value, Comparator<? super T> keyComparator,
-            Comparator<? super T> valueComparator);
-
-    /**
-     * Returns the number of header entries in this collection.
+     * Returns the number of headers in this object.
      */
     int size();
 
     /**
-     * Returns {@code true} if and only if this collection contains no header entries.
+     * Returns {@code true} if {@link #size()} equals {@code 0}.
      */
     boolean isEmpty();
 
     /**
-     * Returns a new {@link Set} that contains the names of all headers in this object. Note that modifying the returned
-     * {@link Set} will not affect the state of this object. If you intend to enumerate over the header entries only,
-     * use {@link #iterator()} instead, which has much less overhead.
+     * Returns a {@link Set} of all header names in this object. The returned {@link Set} cannot be modified.
      */
     Set<T> names();
 
     /**
-     * Returns a new {@link List} that contains the names of all headers in this object. Note that modifying the
-     * returned {@link List} will not affect the state of this object. If you intend to enumerate over the header
-     * entries only, use {@link #iterator()} instead, which has much less overhead.
-     */
-    List<T> namesList();
-
-    /**
-     * Adds a new header with the specified name and value. If the specified value is not a {@link String}, it is
-     * converted into a {@link String} by {@link Object#toString()}, except in the cases of {@link java.util.Date} and
-     * {@link java.util.Calendar}, which are formatted to the date format defined in <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1">RFC2616</a>.
+     * Adds a new header with the specified {@code name} and {@code value}.
      *
-     * @param name the name of the header being added
-     * @param value the value of the header being added
+     * @param name the name of the header
+     * @param value the value of the header
      * @return {@code this}
      */
     Headers<T> add(T name, T value);
 
     /**
-     * Adds a new header with the specified name and values. This getMethod can be represented approximately as the
-     * following code:
+     * Adds new headers with the specified {@code name} and {@code values}. This method is semantically equivalent to
      *
      * <pre>
-     * for (Object v : values) {
-     *     if (v == null) {
-     *         break;
-     *     }
-     *     headers.add(name, v);
+     * for (T value : values) {
+     *     headers.add(name, value);
      * }
      * </pre>
      *
-     * @param name the name of the headepublic abstract rs being set
-     * @param values the values of the headers being set
+     * @param name the header name
+     * @param values the values of the header
      * @return {@code this}
      */
     Headers<T> add(T name, Iterable<? extends T> values);
 
     /**
-     * Adds a new header with the specified name and values. This getMethod can be represented approximately as the
-     * following code:
+     * Adds new headers with the specified {@code name} and {@code values}. This method is semantically equivalent to
      *
      * <pre>
-     * for (Object v : values) {
-     *     if (v == null) {
-     *         break;
-     *     }
-     *     headers.add(name, v);
+     * for (T value : values) {
+     *     headers.add(name, value);
      * }
      * </pre>
      *
-     * @param name the name of the headepublic abstract rs being set
-     * @param values the values of the headers being set
+     * @param name the header name
+     * @param values the values of the header
      * @return {@code this}
      */
     Headers<T> add(T name, T... values);
 
     /**
-     * Adds a new header with the specified name and value. If the specified value is not a {@link String}, it is
-     * converted into a {@link String} by {@link Object#toString()}, except in the cases of {@link java.util.Date} and
-     * {@link java.util.Calendar}, which are formatted to the date format defined in <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1">RFC2616</a>.
+     * Adds a new header. Before the {@code value} is add, it's converted to type {@code T} by a call to
+     * {@link ValueConverter#convertObject(java.lang.Object)}.
      *
-     * @param name the name of the header being added
-     * @param value the value of the header being added
+     * @param name the header name
+     * @param value the value of the header
      * @return {@code this}
      */
     Headers<T> addObject(T name, Object value);
 
     /**
-     * Adds a new header with the specified name and values. This getMethod can be represented approximately as the
-     * following code:
+     * Adds a new header with the specified name and values. This method is equivalent to
      *
      * <pre>
      * for (Object v : values) {
-     *     if (v == null) {
-     *         break;
-     *     }
-     *     headers.add(name, v);
+     *     headers.addObject(name, v);
      * }
      * </pre>
      *
-     * @param name the name of the headepublic abstract rs being set
-     * @param values the values of the headers being set
+     * @param name the header name
+     * @param values the value of the header
      * @return {@code this}
      */
     Headers<T> addObject(T name, Iterable<?> values);
 
     /**
-     * Adds a new header with the specified name and values. This getMethod can be represented approximately as the
-     * following code:
+     * Adds a new header with the specified name and values. This method is equivalent to
      *
      * <pre>
      * for (Object v : values) {
-     *     if (v == null) {
-     *         break;
-     *     }
-     *     headers.add(name, v);
+     *     headers.addObject(name, v);
      * }
      * </pre>
      *
-     * @param name the name of the headepublic abstract rs being set
-     * @param values the values of the headers being set
+     * @param name the header name
+     * @param values the value of the header
      * @return {@code this}
      */
     Headers<T> addObject(T name, Object... values);
 
     /**
-     * Add the {@code name} to {@code value}.
-     * @param name The name to modify
-     * @param value The value
+     * Adds a new header.
+     *
+     * @param name the header name
+     * @param value the value of the header
      * @return {@code this}
      */
     Headers<T> addBoolean(T name, boolean value);
 
     /**
-     * Add the {@code name} to {@code value}.
-     * @param name The name to modify
-     * @param value The value
+     * Adds a new header.
+     *
+     * @param name the header name
+     * @param value the value of the header
      * @return {@code this}
      */
     Headers<T> addByte(T name, byte value);
 
     /**
-     * Add the {@code name} to {@code value}.
-     * @param name The name to modify
-     * @param value The value
+     * Adds a new header.
+     *
+     * @param name the header name
+     * @param value the value of the header
      * @return {@code this}
      */
     Headers<T> addChar(T name, char value);
 
     /**
-     * Add the {@code name} to {@code value}.
-     * @param name The name to modify
-     * @param value The value
+     * Adds a new header.
+     *
+     * @param name the header name
+     * @param value the value of the header
      * @return {@code this}
      */
     Headers<T> addShort(T name, short value);
 
     /**
-     * Add the {@code name} to {@code value}.
-     * @param name The name to modify
-     * @param value The value
+     * Adds a new header.
+     *
+     * @param name the header name
+     * @param value the value of the header
      * @return {@code this}
      */
     Headers<T> addInt(T name, int value);
 
     /**
-     * Add the {@code name} to {@code value}.
-     * @param name The name to modify
-     * @param value The value
+     * Adds a new header.
+     *
+     * @param name the header name
+     * @param value the value of the header
      * @return {@code this}
      */
     Headers<T> addLong(T name, long value);
 
     /**
-     * Add the {@code name} to {@code value}.
-     * @param name The name to modify
-     * @param value The value
+     * Adds a new header.
+     *
+     * @param name the header name
+     * @param value the value of the header
      * @return {@code this}
      */
     Headers<T> addFloat(T name, float value);
 
     /**
-     * Add the {@code name} to {@code value}.
-     * @param name The name to modify
-     * @param value The value
+     * Adds a new header.
+     *
+     * @param name the header name
+     * @param value the value of the header
      * @return {@code this}
      */
     Headers<T> addDouble(T name, double value);
 
     /**
-     * Add the {@code name} to {@code value}.
-     * @param name The name to modify
-     * @param value The value
+     * Adds a new header.
+     *
+     * @param name the header name
+     * @param value the value of the header
      * @return {@code this}
      */
     Headers<T> addTimeMillis(T name, long value);
 
     /**
-     * Adds all header entries of the specified {@code headers}.
+     * Adds all header names and values of {@code headers} to this object.
      *
+     * @throws IllegalArgumentException if {@code headers == this}.
      * @return {@code this}
      */
-    Headers<T> add(Headers<T> headers);
+    Headers<T> add(Headers<? extends T> headers);
 
     /**
-     * Sets a header with the specified name and value. If there is an existing header with the same name, it is
-     * removed. If the specified value is not a {@link String}, it is converted into a {@link String} by
-     * {@link Object#toString()}, except for {@link java.util.Date} and {@link java.util.Calendar}, which are formatted
-     * to the date format defined in <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1">RFC2616</a>.
+     * Sets a header with the specified name and value. Any existing headers with the same name are overwritten.
      *
-     * @param name The name of the header being set
-     * @param value The value of the header being set
+     * @param name the header name
+     * @param value the value of the header
      * @return {@code this}
      */
     Headers<T> set(T name, T value);
 
     /**
-     * Sets a header with the specified name and values. If there is an existing header with the same name, it is
-     * removed. This getMethod can be represented approximately as the following code:
+     * Sets a new header with the specified name and values. This method is equivalent to
      *
      * <pre>
-     * headers.remove(name);
-     * for (Object v : values) {
-     *     if (v == null) {
-     *         break;
-     *     }
-     *     headers.add(name, v);
+     * for (T v : values) {
+     *     headers.addObject(name, v);
      * }
      * </pre>
      *
-     * @param name the name of the headers being set
-     * @param values the values of the headers being set
+     * @param name the header name
+     * @param values the value of the header
      * @return {@code this}
      */
     Headers<T> set(T name, Iterable<? extends T> values);
 
     /**
-     * Sets a header with the specified name and values. If there is an existing header with the same name, it is
-     * removed. This getMethod can be represented approximately as the following code:
+     * Sets a header with the specified name and values. Any existing headers with this name are removed. This method
+     * is equivalent to:
      *
      * <pre>
      * headers.remove(name);
-     * for (Object v : values) {
-     *     if (v == null) {
-     *         break;
-     *     }
+     * for (T v : values) {
      *     headers.add(name, v);
      * }
      * </pre>
      *
-     * @param name the name of the headers being set
-     * @param values the values of the headers being set
+     * @param name the header name
+     * @param values the value of the header
      * @return {@code this}
      */
     Headers<T> set(T name, T... values);
 
     /**
-     * Sets a header with the specified name and value. If there is an existing header with the same name, it is
-     * removed. If the specified value is not a {@link String}, it is converted into a {@link String} by
-     * {@link Object#toString()}, except for {@link java.util.Date} and {@link java.util.Calendar}, which are formatted
-     * to the date format defined in <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1">RFC2616</a>.
+     * Sets a new header. Any existing headers with this name are removed. Before the {@code value} is add, it's
+     * converted to type {@code T} by a call to {@link ValueConverter#convertObject(java.lang.Object)}.
      *
-     * @param name The name of the header being set
-     * @param value The value of the header being set
+     * @param name the header name
+     * @param value the value of the header
+     * @throws NullPointerException if either {@code name} or {@code value} before or after its conversion is
+     *                              {@code null}.
      * @return {@code this}
      */
     Headers<T> setObject(T name, Object value);
 
     /**
-     * Sets a header with the specified name and values. If there is an existing header with the same name, it is
-     * removed. This getMethod can be represented approximately as the following code:
+     * Sets a header with the specified name and values. Any existing headers with this name are removed. This method
+     * is equivalent to:
      *
      * <pre>
      * headers.remove(name);
      * for (Object v : values) {
-     *     if (v == null) {
-     *         break;
-     *     }
-     *     headers.add(name, v);
+     *     headers.addObject(name, v);
      * }
      * </pre>
      *
-     * @param name the name of the headers being set
-     * @param values the values of the headers being set
+     * @param name the header name
+     * @param values the values of the header
      * @return {@code this}
      */
     Headers<T> setObject(T name, Iterable<?> values);
 
     /**
-     * Sets a header with the specified name and values. If there is an existing header with the same name, it is
-     * removed. This getMethod can be represented approximately as the following code:
+     * Sets a header with the specified name and values. Any existing headers with this name are removed. This method
+     * is equivalent to:
      *
      * <pre>
      * headers.remove(name);
      * for (Object v : values) {
-     *     if (v == null) {
-     *         break;
-     *     }
-     *     headers.add(name, v);
+     *     headers.addObject(name, v);
      * }
      * </pre>
      *
-     * @param name the name of the headers being set
-     * @param values the values of the headers being set
+     * @param name the header name
+     * @param values the values of the header
      * @return {@code this}
      */
     Headers<T> setObject(T name, Object... values);
@@ -1062,30 +975,30 @@ public interface Headers<T> extends Iterable<Map.Entry<T, T>> {
     Headers<T> setTimeMillis(T name, long value);
 
     /**
-     * Cleans the current header entries and copies all header entries of the specified {@code headers}.
+     * Clears the current header entries and copies all header entries of the specified {@code headers}.
      *
      * @return {@code this}
      */
-    Headers<T> set(Headers<T> headers);
+    Headers<T> set(Headers<? extends T> headers);
 
     /**
-     * Retains all current headers but calls {@link #set(Object, Object)} for each entry in {@code headers}
+     * Retains all current headers but calls {@link #set(T, T)} for each entry in {@code headers}.
      *
-     * @param headers The headers used to {@link #set(Object, Object)} values in this instance
+     * @param headers The headers used to {@link #set(T, T)} values in this instance
      * @return {@code this}
      */
-    Headers<T> setAll(Headers<T> headers);
+    Headers<T> setAll(Headers<? extends T> headers);
 
     /**
-     * Removes the header with the specified name.
+     * Removes all headers with the specified {@code name}.
      *
-     * @param name The name of the header to remove
-     * @return {@code true} if and only if at least one entry has been removed
+     * @param name the header name
+     * @return {@code true} if at least one entry has been removed.
      */
     boolean remove(T name);
 
     /**
-     * Removes all headers.
+     * Removes all headers. After a call to this method {@link #size()} equals {@code 0}.
      *
      * @return {@code this}
      */
@@ -1093,18 +1006,4 @@ public interface Headers<T> extends Iterable<Map.Entry<T, T>> {
 
     @Override
     Iterator<Entry<T, T>> iterator();
-
-    /**
-     * Provides an abstraction to iterate over elements maintained in the {@link Headers} collection.
-     * @param visitor The visitor which will visit each element in this map
-     * @return The last entry before iteration stopped or {@code null} if iteration went past the end
-     */
-    Map.Entry<T, T> forEachEntry(EntryVisitor<T> visitor) throws Exception;
-
-    /**
-     * Provides an abstraction to iterate over elements maintained in the {@link Headers} collection.
-     * @param visitor The visitor which will visit each element in this map
-     * @return The last key before iteration stopped or {@code null} if iteration went past the end
-     */
-    T forEachName(NameVisitor<T> visitor) throws Exception;
 }

--- a/codec/src/main/java/io/netty/handler/codec/TextHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/TextHeaders.java
@@ -25,17 +25,6 @@ package io.netty.handler.codec;
  * .
  */
 public interface TextHeaders extends ConvertibleHeaders<CharSequence, String> {
-    /**
-     * A visitor that helps reduce GC pressure while iterating over a collection of {@link Headers}.
-     */
-    interface EntryVisitor extends Headers.EntryVisitor<CharSequence> {
-    }
-
-    /**
-     * A visitor that helps reduce GC pressure while iterating over a collection of {@link Headers}.
-     */
-    interface NameVisitor extends Headers.NameVisitor<CharSequence> {
-    }
 
     /**
      * Returns {@code true} if a header with the name and value exists.
@@ -44,14 +33,6 @@ public interface TextHeaders extends ConvertibleHeaders<CharSequence, String> {
      * @return {@code true} if it contains it {@code false} otherwise
      */
     boolean contains(CharSequence name, CharSequence value, boolean ignoreCase);
-
-    /**
-     * Returns {@code true} if a header with the name and value exists.
-     * @param name the header name
-     * @param value the header value
-     * @return {@code true} if it contains it {@code false} otherwise
-     */
-    boolean containsObject(CharSequence name, Object value, boolean ignoreCase);
 
     @Override
     TextHeaders add(CharSequence name, CharSequence value);

--- a/codec/src/test/java/io/netty/handler/codec/DefaultTextHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DefaultTextHeadersTest.java
@@ -243,11 +243,11 @@ public class DefaultTextHeadersTest {
     }
 
     private static TextHeaders newDefaultTextHeaders() {
-        return new DefaultTextHeaders();
+        return new DefaultTextHeaders(false);
     }
 
     private static TextHeaders newCsvTextHeaders() {
-        return new DefaultTextHeaders(true, true);
+        return new DefaultTextHeaders(true);
     }
 
     private static void addValues(final TextHeaders headers, HeaderValue... headerValues) {

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -54,64 +54,53 @@ public final class AsciiString extends ByteString implements CharSequence, Compa
     };
 
     public static final Comparator<CharSequence> CHARSEQUENCE_CASE_INSENSITIVE_ORDER = new Comparator<CharSequence>() {
+
         @Override
         public int compare(CharSequence o1, CharSequence o2) {
-            if (o1 == o2) {
-                return 0;
+            int len1 = o1.length();
+            int delta = len1 - o2.length();
+            if (delta != 0) {
+                return delta;
             }
-
-            AsciiString a1 = o1 instanceof AsciiString ? (AsciiString) o1 : null;
-            AsciiString a2 = o2 instanceof AsciiString ? (AsciiString) o2 : null;
-
-            int result;
-            int length1 = o1.length();
-            int length2 = o2.length();
-            int minLength = Math.min(length1, length2);
-            if (a1 != null && a2 != null) {
-                final int a1Len = minLength + a1.arrayOffset();
+            if (o1.getClass().equals(AsciiString.class) && o2.getClass().equals(AsciiString.class)) {
+                AsciiString a1 = (AsciiString) o1;
+                AsciiString a2 = (AsciiString) o2;
+                final int a1Len = a1.length() + a1.arrayOffset();
                 for (int i = a1.arrayOffset(), j = a2.arrayOffset(); i < a1Len; i++, j++) {
-                    byte v1 = a1.value[i];
-                    byte v2 = a2.value[j];
-                    if (v1 == v2) {
-                        continue;
-                    }
-                    int c1 = toLowerCase(v1);
-                    int c2 = toLowerCase(v2);
-                    result = c1 - c2;
-                    if (result != 0) {
-                        return result;
-                    }
-                }
-            } else if (a1 != null) {
-                for (int i = a1.arrayOffset(), j = 0; j < minLength; i++, j++) {
-                    int c1 = toLowerCase(a1.value[i]);
-                    int c2 = toLowerCase(o2.charAt(j));
-                    result = c1 - c2;
-                    if (result != 0) {
-                        return result;
-                    }
-                }
-            } else if (a2 != null) {
-                for (int i = 0, j = a2.arrayOffset(); i < minLength; i++, j++) {
-                    int c1 = toLowerCase(o1.charAt(i));
-                    int c2 = toLowerCase(a2.value[j]);
-                    result = c1 - c2;
-                    if (result != 0) {
-                        return result;
+                    byte c1 = a1.value[i];
+                    byte c2 = a2.value[j];
+                    if (c1 != c2) {
+                        if (c1 >= 'A' && c1 <= 'Z') {
+                            c1 += 32;
+                        }
+                        if (c2 >= 'A' && c2 <= 'Z') {
+                            c2 += 32;
+                        }
+                        delta = c1 - c2;
+                        if (delta != 0) {
+                            return delta;
+                        }
                     }
                 }
             } else {
-                for (int i = 0; i < minLength; i++) {
-                    int c1 = toLowerCase(o1.charAt(i));
-                    int c2 = toLowerCase(o2.charAt(i));
-                    result = c1 - c2;
-                    if (result != 0) {
-                        return result;
+                for (int i = len1 - 1; i >= 0; i --) {
+                    char c1 = o1.charAt(i);
+                    char c2 = o2.charAt(i);
+                    if (c1 != c2) {
+                        if (c1 >= 'A' && c1 <= 'Z') {
+                            c1 += 32;
+                        }
+                        if (c2 >= 'A' && c2 <= 'Z') {
+                            c2 += 32;
+                        }
+                        delta = c1 - c2;
+                        if (delta != 0) {
+                            return delta;
+                        }
                     }
                 }
             }
-
-            return length1 - length2;
+            return 0;
         }
     };
 

--- a/example/src/main/java/io/netty/example/http/upload/HttpUploadClient.java
+++ b/example/src/main/java/io/netty/example/http/upload/HttpUploadClient.java
@@ -187,13 +187,13 @@ public final class HttpUploadClient {
         );
 
         // send request
-        List<Entry<String, String>> entries = headers.entries();
         channel.writeAndFlush(request);
 
         // Wait for the server to close the connection.
         channel.closeFuture().sync();
 
-        return entries;
+        // convert headers to list
+        return headers.entries();
     }
 
     /**

--- a/microbench/src/main/java/io/netty/microbench/headers/ExampleHeaders.java
+++ b/microbench/src/main/java/io/netty/microbench/headers/ExampleHeaders.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.headers;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class ExampleHeaders {
+
+    public enum HeaderExample {
+        THREE,
+        FIVE,
+        SIX,
+        EIGHT,
+        ELEVEN,
+        TWENTYTWO,
+        THIRTY
+    }
+
+    public static final Map<HeaderExample, Map<String, String>> EXAMPLES =
+            new EnumMap<HeaderExample, Map<String, String>>(HeaderExample.class);
+
+    static {
+        Map<String, String> header = new HashMap<String, String>();
+        header.put(":method", "GET");
+        header.put(":scheme", "https");
+        header.put(":path", "/index.html");
+        EXAMPLES.put(HeaderExample.THREE, header);
+
+        // Headers used by Norman's HTTP benchmarks with wrk
+        header = new HashMap<String, String>();
+        header.put("Method", "GET");
+        header.put("Path", "/plaintext");
+        header.put("Host", "localhost");
+        header.put("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+        header.put("Connection", "keep-alive");
+        EXAMPLES.put(HeaderExample.FIVE, header);
+
+        header = new HashMap<String, String>();
+        header.put(":authority", "127.0.0.1:33333");
+        header.put(":method", "POST");
+        header.put(":path", "/grpc.testing.TestService/UnaryCall");
+        header.put(":scheme", "http");
+        header.put("content-type", "application/grpc");
+        header.put("te", "trailers");
+        EXAMPLES.put(HeaderExample.SIX, header);
+
+        header = new HashMap<String, String>();
+        header.put(":method", "POST");
+        header.put(":scheme", "http");
+        header.put(":path", "/google.pubsub.v2.PublisherService/CreateTopic");
+        header.put(":authority", "pubsub.googleapis.com");
+        header.put("grpc-timeout", "1S");
+        header.put("content-type", "application/grpc+proto");
+        header.put("grpc-encoding", "gzip");
+        header.put("authorization", "Bearer y235.wef315yfh138vh31hv93hv8h3v");
+        EXAMPLES.put(HeaderExample.EIGHT, header);
+
+        header = new HashMap<String, String>();
+        header.put(":host", "twitter.com");
+        header.put(":method", "GET");
+        header.put(":path", "/");
+        header.put(":scheme", "https");
+        header.put(":version", "HTTP/1.1");
+        header.put("accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
+        header.put("accept-encoding", "gzip, deflate, sdch");
+        header.put("accept-language", "en-US,en;q=0.8");
+        header.put("cache-control", "max-age=0");
+        header.put("cookie:", "noneofyourbusiness");
+        header.put("user-agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)");
+        EXAMPLES.put(HeaderExample.ELEVEN, header);
+
+        header = new HashMap<String, String>();
+        header.put("cache-control", "no-cache, no-store, must-revalidate, pre-check=0, post-check=0");
+        header.put("content-encoding", "gzip");
+        header.put("content-security-policy", "default-src https:; connect-src https:;");
+        header.put("content-type", "text/html;charset=utf-8");
+        header.put("date", "Wed, 22 Apr 2015 00:40:28 GMT");
+        header.put("expires", "Tue, 31 Mar 1981 05:00:00 GMT");
+        header.put("last-modified", "Wed, 22 Apr 2015 00:40:28 GMT");
+        header.put("ms", "ms");
+        header.put("pragma", "no-cache");
+        header.put("server", "tsa_b");
+        header.put("set-cookie", "noneofyourbusiness");
+        header.put("status", "200 OK");
+        header.put("strict-transport-security", "max-age=631138519");
+        header.put("version", "HTTP/1.1");
+        header.put("x-connection-hash", "e176fe40accc1e2c613a34bc1941aa98");
+        header.put("x-content-type-options", "nosniff");
+        header.put("x-frame-options", "SAMEORIGIN");
+        header.put("x-response-time", "22");
+        header.put("x-transaction", "a54142ede693444d9");
+        header.put("x-twitter-response-tags", "BouncerCompliant");
+        header.put("x-ua-compatible", "IE=edge,chrome=1");
+        header.put("x-xss-protection", "1; mode=block");
+        EXAMPLES.put(HeaderExample.TWENTYTWO, header);
+
+        header = new HashMap<String, String>();
+        header.put("Cache-Control", "no-cache");
+        header.put("Content-Encoding", "gzip");
+        header.put("Content-Security-Policy", "default-src *; script-src assets-cdn.github.com ...");
+        header.put("Content-Type", "text/html; charset=utf-8");
+        header.put("Date", "Fri, 10 Apr 2015 02:15:38 GMT");
+        header.put("Server", "GitHub.com");
+        header.put("Set-Cookie", "_gh_sess=eyJzZXNza...; path=/; secure; HttpOnly");
+        header.put("Status", "200 OK");
+        header.put("Strict-Transport-Security", "max-age=31536000; includeSubdomains; preload");
+        header.put("Transfer-Encoding", "chunked");
+        header.put("Vary", "X-PJAX");
+        header.put("X-Content-Type-Options", "nosniff");
+        header.put("X-Frame-Options", "deny");
+        header.put("X-GitHub-Request-Id", "1");
+        header.put("X-GitHub-Session-Id", "1");
+        header.put("X-GitHub-User", "buchgr");
+        header.put("X-Request-Id", "28f245e02fc872dcf7f31149e52931dd");
+        header.put("X-Runtime", "0.082529");
+        header.put("X-Served-By", "b9c2a233f7f3119b174dbd8be2");
+        header.put("X-UA-Compatible", "IE=Edge,chrome=1");
+        header.put("X-XSS-Protection", "1; mode=block");
+        header.put("Via", "http/1.1 ir50.fp.bf1.yahoo.com (ApacheTrafficServer)");
+        header.put("Content-Language", "en");
+        header.put("Connection", "keep-alive");
+        header.put("Pragma", "no-cache");
+        header.put("Expires", "Sat, 01 Jan 2000 00:00:00 GMT");
+        header.put("X-Moose", "majestic");
+        header.put("x-ua-compatible", "IE=edge");
+        header.put("CF-Cache-Status", "HIT");
+        header.put("CF-RAY", "6a47f4f911e3-");
+        EXAMPLES.put(HeaderExample.THIRTY, header);
+    }
+
+    private ExampleHeaders() {
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/headers/HeadersBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/headers/HeadersBenchmark.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.headers;
+
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http2.DefaultHttp2Headers;
+import io.netty.handler.codec.http2.Http2Headers;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.AsciiString;
+import io.netty.util.ByteString;
+import io.netty.util.CharsetUtil;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+
+@Threads(1)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class HeadersBenchmark extends AbstractMicrobenchmark {
+
+    @Param
+    ExampleHeaders.HeaderExample exampleHeader;
+
+    AsciiString[] httpNames;
+    AsciiString[] httpValues;
+
+    ByteString[] http2Names;
+    ByteString[] http2Values;
+
+    DefaultHttpHeaders httpHeaders;
+    DefaultHttp2Headers http2Headers;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        Map<String, String> headers = ExampleHeaders.EXAMPLES.get(exampleHeader);
+        httpNames = new AsciiString[headers.size()];
+        httpValues = new AsciiString[headers.size()];
+        http2Names = new ByteString[headers.size()];
+        http2Values = new ByteString[headers.size()];
+        httpHeaders = new DefaultHttpHeaders(false);
+        http2Headers = new DefaultHttp2Headers();
+        int idx = 0;
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            String name = header.getKey();
+            String value = header.getValue();
+            httpNames[idx] = new AsciiString(name);
+            httpValues[idx] = new AsciiString(value);
+            http2Names[idx] = new ByteString(name, CharsetUtil.US_ASCII);
+            http2Values[idx] = new ByteString(value, CharsetUtil.US_ASCII);
+            idx++;
+            httpHeaders.add(new AsciiString(name), new AsciiString(value));
+            http2Headers.add(new ByteString(name, CharsetUtil.US_ASCII), new ByteString(value, CharsetUtil.US_ASCII));
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public void httpGet(Blackhole bh) {
+        for (AsciiString name : httpNames) {
+            bh.consume(httpHeaders.get(name));
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public DefaultHttpHeaders httpPut() {
+        DefaultHttpHeaders headers = new DefaultHttpHeaders(false);
+        for (int i = 0; i < httpNames.length; i++) {
+            headers.add(httpNames[i], httpValues[i]);
+        }
+        return headers;
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public void httpIterate(Blackhole bh) {
+        Iterator<Entry<CharSequence, CharSequence>> itr = httpHeaders.iteratorCharSequence();
+        while (itr.hasNext()) {
+            bh.consume(itr.next());
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public void http2Get(Blackhole bh) {
+        for (ByteString name : http2Names) {
+            bh.consume(http2Headers.get(name));
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public DefaultHttp2Headers http2Put() {
+        DefaultHttp2Headers headers = new DefaultHttp2Headers();
+        for (int i = 0; i < httpNames.length; i++) {
+            headers.add(httpNames[i], httpValues[i]);
+        }
+        return headers;
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public void http2IterateNew(Blackhole bh) {
+        for (Entry<ByteString, ByteString> entry : http2Headers) {
+            bh.consume(entry);
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public void http2IterateOld(Blackhole bh) {
+        // This is how we had to iterate in the Http2HeadersEncoder when writing the frames on the wire
+        // in order to ensure that reserved headers come first.
+        for (Http2Headers.PseudoHeaderName pseudoHeader : Http2Headers.PseudoHeaderName.values()) {
+            ByteString name = pseudoHeader.value();
+            ByteString value = http2Headers.get(name);
+            if (value != null) {
+                bh.consume(value);
+            }
+        }
+        for (Entry<ByteString, ByteString> entry : http2Headers) {
+            final ByteString name = entry.getKey();
+            final ByteString value = entry.getValue();
+            if (!Http2Headers.PseudoHeaderName.isPseudoHeader(name)) {
+                bh.consume(value);
+            }
+        }
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/headers/package-info.java
+++ b/microbench/src/main/java/io/netty/microbench/headers/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Benchmarks for HTTP and HTTP/2 Headers.
+ */
+package io.netty.microbench.headers;


### PR DESCRIPTION
…SPYD. Fixes #3600

Motivation:

We noticed that the headers implementation in Netty for HTTP/2 uses quite a lot of memory
and that also at least the performance of randomly accessing a header is quite poor. The main
concern however was memory usage, as profiling has shown that a DefaultHttp2Headers
not only use a lot of memory it also wastes a lot due to the underlying hashmaps having
to be resized potentially several times as new headers are being inserted.

This is tracked as issue #3600.

Modifications:
We redesigned the DefaultHeaders to simply take a Map object in its constructor and
reimplemented the class using only the Map primitives. That way the implementation
is very concise and hopefully easy to understand and it allows each concrete headers
implementation to provide its own map or to even use a different headers implementation
for processing requests and writing responses i.e. incoming headers need to provide
fast random access while outgoing headers need fast insertion and fast iteration. The
new implementation can support this with hardly any code changes. It also comes
with the advantage that if the Netty project decides to add a third party collections library
as a dependency, one can simply plug in one of those very fast and memory efficient map
implementations and get faster and smaller headers for free.

For now, we are using the JDK's TreeMap for HTTP and HTTP/2 default headers.

Result:

- Significantly fewer lines of code in the implementation. While the total commit is still
  roughly 400 lines less, the actual implementation is a lot less. I just added some more
  tests and microbenchmarks.

- Overall performance is up. The current implementation should be significantly faster
  for insertion and retrieval. However, it is slower when it comes to iteration. There is simply
  no way a TreeMap can have the same iteration performance as a linked list (as used in the
  current headers implementation). That's totally fine though, because when looking at the
  benchmark results @ejona86 pointed out that the performance of the headers is completely
  dominated by insertion, that is insertion is so significantly faster in the new implementation
  that it does make up for several times the iteration speed. You can't iterate what you haven't
  inserted. I am demonstrating that in this spreadsheet [1]. (Actually, iteration performance is
  only down for HTTP, it's significantly improved for HTTP/2).

- Memory is down. The implementation with TreeMap uses on avg ~30% less memory. It also does not
  produce any garbage while being resized. In load tests for GRPC we have seen a memory reduction
  of up to 1.2KB per RPC. I summarized the memory improvements in this spreadsheet [1]. The data
  was generated by [2] using JOL.

- While it was my original intend to only improve the memory usage for HTTP/2, it should be similarly
  improved for HTTP, SPDY and STOMP as they all share a common implementation.

[1] https://docs.google.com/spreadsheets/d/1ck3RQklyzEcCLlyJoqDXPCWRGVUuS-ArZf0etSXLVDQ/edit#gid=0
[2] https://gist.github.com/buchgr/4458a8bdb51dd58c82b4