### PR TITLE
CorsHandler should not attempt to set response headers if request is null

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
@@ -89,27 +89,29 @@ public class CorsHandler extends ChannelHandlerAdapter {
     }
 
     private boolean setOrigin(final HttpResponse response) {
-        final CharSequence origin = request.headers().get(HttpHeaderNames.ORIGIN);
-        if (origin != null) {
-            if ("null".equals(origin) && config.isNullOriginAllowed()) {
-                setAnyOrigin(response);
-                return true;
-            }
-            if (config.isAnyOriginSupported()) {
-                if (config.isCredentialsAllowed()) {
-                    echoRequestOrigin(response);
-                    setVaryHeader(response);
-                } else {
+        if (request != null) {
+            final CharSequence origin = request.headers().get(HttpHeaderNames.ORIGIN);
+            if (origin != null) {
+                if ("null".equals(origin) && config.isNullOriginAllowed()) {
                     setAnyOrigin(response);
+                    return true;
                 }
-                return true;
+                if (config.isAnyOriginSupported()) {
+                    if (config.isCredentialsAllowed()) {
+                        echoRequestOrigin(response);
+                        setVaryHeader(response);
+                    } else {
+                        setAnyOrigin(response);
+                    }
+                    return true;
+                }
+                if (config.origins().contains(origin)) {
+                    setOrigin(response, origin);
+                    setVaryHeader(response);
+                    return true;
+                }
+                logger.debug("Request origin [" + origin + "] was not among the configured origins " + config.origins());
             }
-            if (config.origins().contains(origin)) {
-                setOrigin(response, origin);
-                setVaryHeader(response);
-                return true;
-            }
-            logger.debug("Request origin [" + origin + "] was not among the configured origins " + config.origins());
         }
         return false;
     }


### PR DESCRIPTION
Motivation:

If no HttpRequest is received by the CorsHandler, it will throw a NullPointerException when
trying to access the headers on the request when writing a response.

Modification:

- Check request is not null before trying to check Origin header in CorsHandler#setOrigin.

Result:

Fixes NullPointerException and message being written to client writes successfully.