### PR TITLE
Unhealthy channel is not offered back to the pool.

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -121,7 +121,34 @@ public final class FixedChannelPool extends SimpleChannelPool {
                             ChannelHealthChecker healthCheck, AcquireTimeoutAction action,
                             final long acquireTimeoutMillis,
                             int maxConnections, int maxPendingAcquires) {
-        super(bootstrap, handler, healthCheck);
+        this(bootstrap, handler, healthCheck, action, acquireTimeoutMillis, maxConnections, maxPendingAcquires, true);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param bootstrap             the {@link Bootstrap} that is used for connections
+     * @param handler               the {@link ChannelPoolHandler} that will be notified for the different pool actions
+     * @param healthCheck           the {@link ChannelHealthChecker} that will be used to check if a {@link Channel} is
+     *                              still healty when obtain from the {@link ChannelPool}
+     * @param action                the {@link AcquireTimeoutAction} to use or {@code null} if non should be used.
+     *                              In this case {@param acquireTimeoutMillis} must be {@code -1}.
+     * @param acquireTimeoutMillis  the time (in milliseconds) after which an pending acquire must complete or
+     *                              the {@link AcquireTimeoutAction} takes place.
+     * @param maxConnections        the numnber of maximal active connections, once this is reached new tries to
+     *                              acquire a {@link Channel} will be delayed until a connection is returned to the
+     *                              pool again.
+     * @param maxPendingAcquires    the maximum number of pending acquires. Once this is exceed acquire tries will
+     *                              be failed.
+     * @param releaseHealthCheck    will check channel health before offering back if this parameter set to
+     *                              {@code true}.
+     */
+    public FixedChannelPool(Bootstrap bootstrap,
+                            ChannelPoolHandler handler,
+                            ChannelHealthChecker healthCheck, AcquireTimeoutAction action,
+                            final long acquireTimeoutMillis,
+                            int maxConnections, int maxPendingAcquires, final boolean releaseHealthCheck) {
+        super(bootstrap, handler, healthCheck, releaseHealthCheck);
         if (maxConnections < 1) {
             throw new IllegalArgumentException("maxConnections: " + maxConnections + " (expected: >= 1)");
         }

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -43,13 +43,17 @@ import static io.netty.util.internal.ObjectUtil.*;
 public class SimpleChannelPool implements ChannelPool {
     private static final AttributeKey<SimpleChannelPool> POOL_KEY = AttributeKey.newInstance("channelPool");
     private static final IllegalStateException FULL_EXCEPTION = new IllegalStateException("ChannelPool full");
+    private static final IllegalStateException UNHEALTHY_NON_OFFERED_TO_POOL =
+            new IllegalStateException("Channel is unhealthy not offering it back to pool");
     static {
         FULL_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
+        UNHEALTHY_NON_OFFERED_TO_POOL.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
     }
     private final Deque<Channel> deque = PlatformDependent.newConcurrentDeque();
     private final ChannelPoolHandler handler;
     private final ChannelHealthChecker healthCheck;
     private final Bootstrap bootstrap;
+    private final boolean releaseHealthCheck;
 
     /**
      * Creates a new instance using the {@link ChannelHealthChecker#ACTIVE}.
@@ -67,11 +71,27 @@ public class SimpleChannelPool implements ChannelPool {
      * @param bootstrap         the {@link Bootstrap} that is used for connections
      * @param handler           the {@link ChannelPoolHandler} that will be notified for the different pool actions
      * @param healthCheck       the {@link ChannelHealthChecker} that will be used to check if a {@link Channel} is
-     *                          still healty when obtain from the {@link ChannelPool}
+     *                          still healthy when obtain from the {@link ChannelPool}
      */
     public SimpleChannelPool(Bootstrap bootstrap, final ChannelPoolHandler handler, ChannelHealthChecker healthCheck) {
+        this(bootstrap, handler, healthCheck, true);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param bootstrap          the {@link Bootstrap} that is used for connections
+     * @param handler            the {@link ChannelPoolHandler} that will be notified for the different pool actions
+     * @param healthCheck        the {@link ChannelHealthChecker} that will be used to check if a {@link Channel} is
+     *                           still healthy when obtain from the {@link ChannelPool}
+     * @param releaseHealthCheck will offercheck channel health before offering back if this parameter set to
+     *                           {@code true}.
+     */
+    public SimpleChannelPool(Bootstrap bootstrap, final ChannelPoolHandler handler, ChannelHealthChecker healthCheck,
+                             boolean releaseHealthCheck) {
         this.handler = checkNotNull(handler, "handler");
         this.healthCheck = checkNotNull(healthCheck, "healthCheck");
+        this.releaseHealthCheck = releaseHealthCheck;
         // Clone the original Bootstrap as we want to set our own handler
         this.bootstrap = checkNotNull(bootstrap, "bootstrap").clone();
         this.bootstrap.handler(new ChannelInitializer<Channel>() {
@@ -183,9 +203,9 @@ public class SimpleChannelPool implements ChannelPool {
     }
 
     /**
-     * Bootstrap a new {@link Channel}. The default implementation uses {@link Bootstrap#connect()},
-     * sub-classes may override this.
-     *
+     * Bootstrap a new {@link Channel}. The default implementation uses {@link Bootstrap#connect()}, sub-classes may
+     * override this.
+     * <p>
      * The {@link Bootstrap} that is passed in here is cloned via {@link Bootstrap#clone()}, so it is safe to modify.
      */
     protected ChannelFuture connectChannel(Bootstrap bs) {
@@ -230,15 +250,54 @@ public class SimpleChannelPool implements ChannelPool {
                          promise);
         } else {
             try {
-                if (offerChannel(channel)) {
-                    handler.channelReleased(channel);
-                    promise.setSuccess(null);
+                if (releaseHealthCheck) {
+                    doHealthCheckOnRelease(channel, promise);
                 } else {
-                    closeAndFail(channel, FULL_EXCEPTION, promise);
+                    releaseAndOffer(channel, promise);
                 }
             } catch (Throwable cause) {
                 closeAndFail(channel, cause, promise);
             }
+        }
+    }
+
+    private void doHealthCheckOnRelease(final Channel channel, final Promise<Void> promise) throws Exception {
+        final Future<Boolean> f = healthCheck.isHealthy(channel);
+        if (f.isDone()) {
+            releaseAndOfferIfHealthy(channel, promise, f);
+        } else {
+            f.addListener(new FutureListener<Boolean>() {
+                @Override
+                public void operationComplete(Future<Boolean> future) throws Exception {
+                    releaseAndOfferIfHealthy(channel, promise, f);
+                }
+            });
+        }
+    }
+
+    /**
+     * Adds the channel back to the pool only if the channel is healty.
+     * @param channel the channel to put back to the pool
+     * @param promise offer operation promise.
+     * @param future the future that contains information fif channel is healthy or not.
+     * @throws Exception in case when failed to notify handler about release operation.
+     */
+    private void releaseAndOfferIfHealthy(Channel channel, Promise<Void> promise, Future<Boolean> future)
+            throws Exception {
+        if (future.getNow()) { //channel turns out to be healthy, offering and releasing it.
+            releaseAndOffer(channel, promise);
+        } else { //channel ont healthy, just releasing it.
+            handler.channelReleased(channel);
+            closeAndFail(channel, UNHEALTHY_NON_OFFERED_TO_POOL, promise);
+        }
+    }
+
+    private void releaseAndOffer(Channel channel, Promise<Void> promise) throws Exception {
+        if (offerChannel(channel)) {
+            handler.channelReleased(channel);
+            promise.setSuccess(null);
+        } else {
+            closeAndFail(channel, FULL_EXCEPTION, promise);
         }
     }
 


### PR DESCRIPTION
Motivation:
When releasing unhealthy channel back to a pool we don't have to offer it since on acquire it will be discarded anyways.
 Also checking healthiness at release is a good idea so we don't end up having tons of unhealthy channels in the pool(unless they became unhealthy after being offered)

Modifications:
private SimpleChannelPool.offerIfHealthy() method added that is called from SimpleChannelPool.doReleaseChannel(). SimpleChannelPool.offerIfHealthy() offers channel back to pool only if channel is healthy.
Otherwise it throws setFailure exception to the promise.

 Result:
The pool is now much cleaner and not spammed with unhealthy channels.

See https://github.com/netty/netty/issues/4077 for more details.