### PR TITLE
Eclipse SPDY docs moved

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkNpnApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkNpnApplicationProtocolNegotiator.java
@@ -25,7 +25,7 @@ public final class JdkNpnApplicationProtocolNegotiator extends JdkBaseApplicatio
         {
             if (!JdkNpnSslEngine.isAvailable()) {
                 throw new RuntimeException("NPN unsupported. Is your classpatch configured correctly?"
-                        + " See http://www.eclipse.org/jetty/documentation/current/npn-chapter.html#npn-starting");
+                        + " See https://wiki.eclipse.org/Jetty/Feature/NPN");
             }
         }
 


### PR DESCRIPTION
Motivation:
We provide a hyperlink to the docs for SPDY if the runtime is not setup correctly to help users. These docs have moved.

Modifications:
- Update the hyperlink to point to the new doc location.

Result:
Users are able to find docs more easily.