### PR TITLE
Http2ConnectionHandler not flushing on writabilityChange

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -167,7 +167,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     @Override
     public void flush(ChannelHandlerContext ctx) throws Http2Exception {
         // Trigger pending writes in the remote flow controller.
-        connection().remote().flowController().writePendingBytes();
+        encoder.flowController().writePendingBytes();
         try {
             super.flush(ctx);
         } catch (Throwable t) {
@@ -396,10 +396,13 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
         // Writability is expected to change while we are writing. We cannot allow this event to trigger reentering
         // the allocation and write loop. Reentering the event loop will lead to over or illegal allocation.
-        if (ctx.channel().isWritable()) {
-            encoder.flowController().writePendingBytes();
+        try {
+            if (ctx.channel().isWritable()) {
+                flush(ctx);
+            }
+        } finally {
+            super.channelWritabilityChanged(ctx);
         }
-        super.channelWritabilityChanged(ctx);
     }
 
     @Override


### PR DESCRIPTION
Motivation:
The Http2ConnectionHandler was writing pending bytes, but was not flushing. This may result in deadlock.

Modifications:
- Http2ConnectionHandler must writePendingBytes and also flush.

Result:
Data is now flushed after writabilityChange writes more data to underlying layers.