### PR TITLE
[#4053] Add unit tests for HTTP and SPDY headers

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
@@ -25,10 +25,7 @@ import java.util.List;
 import static io.netty.util.AsciiString.contentEquals;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class DefaultHttpHeadersTest {
     private static final String HEADER_NAME = "testHeader";
@@ -67,6 +64,42 @@ public class DefaultHttpHeadersTest {
     }
 
     @Test
+    public void testStringKeyRetrievedAsAsciiString() {
+        final HttpHeaders headers = new DefaultHttpHeaders(false);
+
+        // Test adding String key and retrieving it using a AsciiString key
+        final String connection = "keep-alive";
+        headers.add("Connection", connection);
+
+        // Passes
+        final String value = headers.getAsString(HttpHeaderNames.CONNECTION.toString());
+        assertNotNull(value);
+        assertEquals(connection, value);
+
+        // Passes
+        final String value2 = headers.getAsString(HttpHeaderNames.CONNECTION);
+        assertNotNull(value2);
+        assertEquals(connection, value2);
+    }
+
+    @Test
+    public void testAsciiStringKeyRetrievedAsString() {
+        final HttpHeaders headers = new DefaultHttpHeaders(false);
+
+        // Test adding AsciiString key and retrieving it using a String key
+        final String cacheControl = "no-cache";
+        headers.add(HttpHeaderNames.CACHE_CONTROL, cacheControl);
+
+        final String value = headers.getAsString(HttpHeaderNames.CACHE_CONTROL);
+        assertNotNull(value);
+        assertEquals(cacheControl, value);
+
+        final String value2 = headers.getAsString(HttpHeaderNames.CACHE_CONTROL.toString());
+        assertNotNull(value2);
+        assertEquals(cacheControl, value2);
+    }
+
+    @Test
     public void testRemoveTransferEncodingIgnoreCase() {
         HttpMessage message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
         message.headers().set(HttpHeaderNames.TRANSFER_ENCODING, "Chunked");
@@ -91,7 +124,7 @@ public class DefaultHttpHeadersTest {
     }
 
     @Test
-    public void testEquansIgnoreCase() {
+    public void testEqualsIgnoreCase() {
         assertThat(AsciiString.contentEqualsIgnoreCase(null, null), is(true));
         assertThat(AsciiString.contentEqualsIgnoreCase(null, "foo"), is(false));
         assertThat(AsciiString.contentEqualsIgnoreCase("bar", null), is(false));

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/DefaultSpdyHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/DefaultSpdyHeadersTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.spdy;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class DefaultSpdyHeadersTest {
+
+    @Test
+    public void testStringKeyRetrievedAsAsciiString() {
+        final SpdyHeaders headers = new DefaultSpdyHeaders();
+
+        // Test adding String key and retrieving it using a AsciiString key
+        final String method = "GET";
+        headers.add(":method", method);
+
+        final String value = headers.getAsString(SpdyHeaders.HttpNames.METHOD.toString());
+        assertNotNull(value);
+        assertEquals(method, value);
+
+        final String value2 = headers.getAsString(SpdyHeaders.HttpNames.METHOD);
+        assertNotNull(value2);
+        assertEquals(method, value2);
+    }
+
+    @Test
+    public void testAsciiStringKeyRetrievedAsString() {
+        final SpdyHeaders headers = new DefaultSpdyHeaders();
+
+        // Test adding AsciiString key and retrieving it using a String key
+        final String path = "/";
+        headers.add(SpdyHeaders.HttpNames.PATH, path);
+
+        final String value = headers.getAsString(SpdyHeaders.HttpNames.PATH);
+        assertNotNull(value);
+        assertEquals(path, value);
+
+        final String value2 = headers.getAsString(SpdyHeaders.HttpNames.PATH.toString());
+        assertNotNull(value2);
+        assertEquals(path, value2);
+    }
+}


### PR DESCRIPTION
Motivation:

When attempting to retrieve a SPDY header using an ```AsciiString``` key, if the header was inserted using a ```String``` based key, the lookup would fail. Similarly, the lookup would fail if the header was inserted with an ```AsciiString``` key, and retrieved using a ```String``` key. This has been fixed with the header simplification commit (1a43923aa89769ae3711e0d9451abfdee4a4327c).

Extra unit tests have been added to protect against this issue occurring in the future.  The tests check that a header added using ```String``` or ```AsciiString``` can be retrieved using ```AsciiString``` or ```String``` respectively.

Modifications:

Added more unit tests

Result:

Protect against issue #4053 happening again.