### PR TITLE
HttpObjectDecoder: Create methods for HttpContent and LastHttpContent

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -119,11 +119,11 @@ public class HttpObjectAggregator
 
         HttpHeaderUtil.setTransferEncodingChunked(start, false);
 
-        AggregatedFullHttpMessage ret;
+        AggregatedHttpMessage ret;
         if (start instanceof HttpRequest) {
-            ret = new AggregatedFullHttpRequest((HttpRequest) start, content, null);
+            ret = newAggregatedHttpRequest((HttpRequest) start, content, null);
         } else if (start instanceof HttpResponse) {
-            ret = new AggregatedFullHttpResponse((HttpResponse) start, content, null);
+            ret = newAggregatedHttpResponse((HttpResponse) start, content, null);
         } else {
             throw new Error();
         }
@@ -134,7 +134,7 @@ public class HttpObjectAggregator
     protected void aggregate(FullHttpMessage aggregated, HttpContent content) throws Exception {
         if (content instanceof LastHttpContent) {
             // Merge trailing headers into the message.
-            ((AggregatedFullHttpMessage) aggregated).setTrailingHeaders(((LastHttpContent) content).trailingHeaders());
+            ((AggregatedHttpMessage) aggregated).setTrailingHeaders(((LastHttpContent) content).trailingHeaders());
         }
     }
 
@@ -188,12 +188,32 @@ public class HttpObjectAggregator
         }
     }
 
-    private abstract static class AggregatedFullHttpMessage implements ByteBufHolder, FullHttpMessage {
+    protected AggregatedHttpRequest newAggregatedHttpRequest(HttpRequest request,
+                                                             ByteBuf content, HttpHeaders trailingHeaders) {
+        return new DefaultAggregatedHttpRequest(request, content, trailingHeaders);
+    }
+
+    protected AggregatedHttpResponse newAggregatedHttpResponse(HttpResponse response,
+                                                               ByteBuf content, HttpHeaders trailingHeaders) {
+        return new DefaultAggregatedHttpResponse(response, content, trailingHeaders);
+    }
+
+    public interface AggregatedHttpMessage extends FullHttpMessage {
+        void setTrailingHeaders(HttpHeaders trailingHeaders);
+    }
+
+    public interface AggregatedHttpRequest extends AggregatedHttpMessage, FullHttpRequest {
+    }
+
+    public interface AggregatedHttpResponse extends AggregatedHttpMessage, FullHttpResponse {
+    }
+
+    private abstract static class AbstractAggregatedHttpMessage implements ByteBufHolder, AggregatedHttpMessage {
         protected final HttpMessage message;
         private final ByteBuf content;
         private HttpHeaders trailingHeaders;
 
-        AggregatedFullHttpMessage(HttpMessage message, ByteBuf content, HttpHeaders trailingHeaders) {
+        AbstractAggregatedHttpMessage(HttpMessage message, ByteBuf content, HttpHeaders trailingHeaders) {
             this.message = message;
             this.content = content;
             this.trailingHeaders = trailingHeaders;
@@ -209,7 +229,8 @@ public class HttpObjectAggregator
             }
         }
 
-        void setTrailingHeaders(HttpHeaders trailingHeaders) {
+        @Override
+        public void setTrailingHeaders(HttpHeaders trailingHeaders) {
             this.trailingHeaders = trailingHeaders;
         }
 
@@ -300,9 +321,10 @@ public class HttpObjectAggregator
         public abstract FullHttpMessage duplicate();
     }
 
-    private static final class AggregatedFullHttpRequest extends AggregatedFullHttpMessage implements FullHttpRequest {
+    private static final class DefaultAggregatedHttpRequest extends AbstractAggregatedHttpMessage
+            implements AggregatedHttpRequest {
 
-        AggregatedFullHttpRequest(HttpRequest request, ByteBuf content, HttpHeaders trailingHeaders) {
+        DefaultAggregatedHttpRequest(HttpRequest request, ByteBuf content, HttpHeaders trailingHeaders) {
             super(request, content, trailingHeaders);
         }
 
@@ -418,10 +440,10 @@ public class HttpObjectAggregator
         }
     }
 
-    private static final class AggregatedFullHttpResponse extends AggregatedFullHttpMessage
-            implements FullHttpResponse {
+    private static final class DefaultAggregatedHttpResponse extends AbstractAggregatedHttpMessage
+            implements AggregatedHttpResponse {
 
-        AggregatedFullHttpResponse(HttpResponse message, ByteBuf content, HttpHeaders trailingHeaders) {
+        DefaultAggregatedHttpResponse(HttpResponse message, ByteBuf content, HttpHeaders trailingHeaders) {
             super(message, content, trailingHeaders);
         }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -229,7 +229,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 // fast-path
                 // No content is expected.
                 out.add(message);
-                out.add(LastHttpContent.EMPTY_LAST_CONTENT);
+                out.add(newEmptyLastHttpContent());
                 resetNow();
                 return;
             case READ_CHUNK_SIZE:
@@ -249,7 +249,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 long contentLength = contentLength();
                 if (contentLength == 0 || contentLength == -1 && isDecodingRequest()) {
                     out.add(message);
-                    out.add(LastHttpContent.EMPTY_LAST_CONTENT);
+                    out.add(newEmptyLastHttpContent());
                     resetNow();
                     return;
                 }
@@ -276,7 +276,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             int toRead = Math.min(buffer.readableBytes(), maxChunkSize);
             if (toRead > 0) {
                 ByteBuf content = buffer.readSlice(toRead).retain();
-                out.add(new DefaultHttpContent(content));
+                out.add(newHttpContent(content));
             }
             return;
         }
@@ -305,7 +305,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 out.add(new DefaultLastHttpContent(content, validateHeaders));
                 resetNow();
             } else {
-                out.add(new DefaultHttpContent(content));
+                out.add(newHttpContent(content));
             }
             return;
         }
@@ -337,7 +337,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             if (toRead == 0) {
                 return;
             }
-            HttpContent chunk = new DefaultHttpContent(buffer.readSlice(toRead).retain());
+            HttpContent chunk = newHttpContent(buffer.readSlice(toRead).retain());
             chunkSize -= toRead;
 
             out.add(chunk);
@@ -401,7 +401,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             boolean chunked = HttpHeaderUtil.isTransferEncodingChunked(message);
             if (currentState == State.READ_VARIABLE_LENGTH_CONTENT && !in.isReadable() && !chunked) {
                 // End of connection.
-                out.add(LastHttpContent.EMPTY_LAST_CONTENT);
+                out.add(newEmptyLastHttpContent());
                 reset();
                 return;
             }
@@ -419,7 +419,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             resetNow();
 
             if (!prematureClosure) {
-                out.add(LastHttpContent.EMPTY_LAST_CONTENT);
+                out.add(newEmptyLastHttpContent());
             }
         }
     }
@@ -512,7 +512,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         // when we produced an invalid message without consuming anything.
         in.skipBytes(in.readableBytes());
 
-        HttpContent chunk = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER);
+        HttpContent chunk = newLastHttpContent(Unpooled.EMPTY_BUFFER);
         chunk.setDecoderResult(DecoderResult.failure(cause));
         message = null;
         trailer = null;
@@ -605,7 +605,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         if (line.length() > 0) {
             LastHttpContent trailer = this.trailer;
             if (trailer == null) {
-                trailer = this.trailer = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER, validateHeaders);
+                trailer = this.trailer = newLastHttpContent(Unpooled.EMPTY_BUFFER);
             }
             do {
                 char firstChar = line.charAt(0);
@@ -646,12 +646,24 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             return trailer;
         }
 
-        return LastHttpContent.EMPTY_LAST_CONTENT;
+        return newEmptyLastHttpContent();
     }
 
     protected abstract boolean isDecodingRequest();
     protected abstract HttpMessage createMessage(String[] initialLine) throws Exception;
     protected abstract HttpMessage createInvalidMessage();
+
+    protected HttpContent newHttpContent(ByteBuf content) {
+        return new DefaultHttpContent(content);
+    }
+
+    protected LastHttpContent newLastHttpContent(ByteBuf content) {
+        return new DefaultLastHttpContent(content, validateHeaders);
+    }
+
+    protected LastHttpContent newEmptyLastHttpContent() {
+        return LastHttpContent.EMPTY_LAST_CONTENT;
+    }
 
     private static int getChunkSize(String hex) {
         hex = hex.trim();


### PR DESCRIPTION
See https://github.com/netty/netty/issues/4060

```
Adding create() methods for HttpContent and LastHttpContent objects in the
HttpObjectDecoder and create() methods in the HttpObjectAggregator.

https://github.com/netty/netty/issues/4060

Motivation:

This change allows us to implement higher level HTTP features such as "request scopes" 
or "session scopes" by being able to customize the HttpMessage and share state that 
spans HttpMessage over HttpContent to LastHttpContent.

Modifications:

The HttpObjectDecoder was changed to use explcit create() methods for HttpContent 
and LastHttpContent objects. The HttpObjectAggregator was changed to expose its 
internal "aggregated" message types and two create() methods were added.

Result:

It's now possible to customize the message types that HttpObjectDecoder return and 
possibly share state that spans from HttpMessage, over HttpContent to LastHttpContent 
and effectivly implement higher level HTTP abstractions such as "request scopes" or 
"session scopes".
```