### PR TITLE
Replace infinite Iterable/Iterator with dedicated types

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddresses.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddresses.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.resolver.dns;
+
+import java.net.InetSocketAddress;
+
+abstract class DefaultDnsServerAddresses extends DnsServerAddresses {
+
+    protected final InetSocketAddress[] addresses;
+    private final String strVal;
+
+    DefaultDnsServerAddresses(String type, InetSocketAddress[] addresses) {
+        this.addresses = addresses;
+
+        final StringBuilder buf = new StringBuilder(type.length() + 2 + addresses.length * 16);
+        buf.append(type).append('(');
+
+        for (InetSocketAddress a: addresses) {
+            buf.append(a).append(", ");
+        }
+
+        buf.setLength(buf.length() - 2);
+        buf.append(')');
+
+        strVal = buf.toString();
+    }
+
+    @Override
+    public String toString() {
+        return strVal;
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -67,7 +67,7 @@ abstract class DnsNameResolverContext<T> {
             };
 
     private final DnsNameResolver parent;
-    private final Iterator<InetSocketAddress> nameServerAddrs;
+    private final DnsServerAddressStream nameServerAddrs;
     private final Promise<T> promise;
     private final String hostname;
     private final boolean traceEnabled;
@@ -88,7 +88,7 @@ abstract class DnsNameResolverContext<T> {
         this.promise = promise;
         this.hostname = hostname;
 
-        nameServerAddrs = parent.nameServerAddresses.iterator();
+        nameServerAddrs = parent.nameServerAddresses.stream();
         maxAllowedQueries = parent.maxQueriesPerResolve();
         resolveAddressTypes = parent.resolveAddressTypesUnsafe();
         traceEnabled = parent.isTraceEnabled();

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverGroup.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverGroup.java
@@ -36,53 +36,27 @@ public final class DnsNameResolverGroup extends NameResolverGroup<InetSocketAddr
 
     private final ChannelFactory<? extends DatagramChannel> channelFactory;
     private final InetSocketAddress localAddress;
-    private final Iterable<InetSocketAddress> nameServerAddresses;
+    private final DnsServerAddresses nameServerAddresses;
 
     public DnsNameResolverGroup(
-            Class<? extends DatagramChannel> channelType,
-            InetSocketAddress nameServerAddress) {
-        this(channelType, ANY_LOCAL_ADDR, nameServerAddress);
-    }
-
-    public DnsNameResolverGroup(
-            Class<? extends DatagramChannel> channelType,
-            InetSocketAddress localAddress, InetSocketAddress nameServerAddress) {
-        this(new ReflectiveChannelFactory<DatagramChannel>(channelType), localAddress, nameServerAddress);
-    }
-
-    public DnsNameResolverGroup(
-            ChannelFactory<? extends DatagramChannel> channelFactory,
-            InetSocketAddress nameServerAddress) {
-        this(channelFactory, ANY_LOCAL_ADDR, nameServerAddress);
-    }
-
-    public DnsNameResolverGroup(
-            ChannelFactory<? extends DatagramChannel> channelFactory,
-            InetSocketAddress localAddress, InetSocketAddress nameServerAddress) {
-        this(channelFactory, localAddress, DnsServerAddresses.singleton(nameServerAddress));
-    }
-
-    public DnsNameResolverGroup(
-            Class<? extends DatagramChannel> channelType,
-            Iterable<InetSocketAddress> nameServerAddresses) {
+            Class<? extends DatagramChannel> channelType, DnsServerAddresses nameServerAddresses) {
         this(channelType, ANY_LOCAL_ADDR, nameServerAddresses);
     }
 
     public DnsNameResolverGroup(
             Class<? extends DatagramChannel> channelType,
-            InetSocketAddress localAddress, Iterable<InetSocketAddress> nameServerAddresses) {
+            InetSocketAddress localAddress, DnsServerAddresses nameServerAddresses) {
         this(new ReflectiveChannelFactory<DatagramChannel>(channelType), localAddress, nameServerAddresses);
     }
 
     public DnsNameResolverGroup(
-            ChannelFactory<? extends DatagramChannel> channelFactory,
-            Iterable<InetSocketAddress> nameServerAddresses) {
+            ChannelFactory<? extends DatagramChannel> channelFactory, DnsServerAddresses nameServerAddresses) {
         this(channelFactory, ANY_LOCAL_ADDR, nameServerAddresses);
     }
 
     public DnsNameResolverGroup(
             ChannelFactory<? extends DatagramChannel> channelFactory,
-            InetSocketAddress localAddress, Iterable<InetSocketAddress> nameServerAddresses) {
+            InetSocketAddress localAddress, DnsServerAddresses nameServerAddresses) {
         this.channelFactory = channelFactory;
         this.localAddress = localAddress;
         this.nameServerAddresses = nameServerAddresses;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStream.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.resolver.dns;
+
+import java.net.InetSocketAddress;
+
+/**
+ * An infinite stream of DNS server addresses.
+ */
+public interface DnsServerAddressStream {
+    /**
+     * Retrieves the next DNS server address from the stream.
+     */
+    InetSocketAddress next();
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/RotationalDnsServerAddresses.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/RotationalDnsServerAddresses.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.resolver.dns;
+
+import io.netty.util.internal.PlatformDependent;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+final class RotationalDnsServerAddresses extends DefaultDnsServerAddresses {
+
+    private static final AtomicIntegerFieldUpdater<RotationalDnsServerAddresses> startIdxUpdater;
+
+    static {
+        AtomicIntegerFieldUpdater<RotationalDnsServerAddresses> updater =
+                PlatformDependent.newAtomicIntegerFieldUpdater(RotationalDnsServerAddresses.class, "startIdx");
+
+        if (updater == null) {
+            updater = AtomicIntegerFieldUpdater.newUpdater(RotationalDnsServerAddresses.class, "startIdx");
+        }
+
+        startIdxUpdater = updater;
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    private volatile int startIdx;
+
+    RotationalDnsServerAddresses(InetSocketAddress[] addresses) {
+        super("rotational", addresses);
+    }
+
+    @Override
+    public DnsServerAddressStream stream() {
+        for (;;) {
+            int curStartIdx = startIdx;
+            int nextStartIdx = curStartIdx + 1;
+            if (nextStartIdx >= addresses.length) {
+                nextStartIdx = 0;
+            }
+            if (startIdxUpdater.compareAndSet(this, curStartIdx, nextStartIdx)) {
+                return new SequentialDnsServerAddressStream(addresses, curStartIdx);
+            }
+        }
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/SequentialDnsServerAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/SequentialDnsServerAddressStream.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.resolver.dns;
+
+import java.net.InetSocketAddress;
+
+final class SequentialDnsServerAddressStream implements DnsServerAddressStream {
+
+    private final InetSocketAddress[] addresses;
+    private int i;
+
+    SequentialDnsServerAddressStream(InetSocketAddress[] addresses, int startIdx) {
+        this.addresses = addresses;
+        i = startIdx;
+    }
+
+    @Override
+    public InetSocketAddress next() {
+        int i = this.i;
+        InetSocketAddress next = addresses[i];
+        if (++ i < addresses.length) {
+            this.i = i;
+        } else {
+            this.i = 0;
+        }
+        return next;
+    }
+
+    @Override
+    public String toString() {
+        return toString("sequential", i, addresses);
+    }
+
+    static String toString(String type, int index, InetSocketAddress[] addresses) {
+        final StringBuilder buf = new StringBuilder(type.length() + 2 + addresses.length * 16);
+        buf.append(type).append("(index: ").append(index);
+        buf.append(", addrs: (");
+        for (InetSocketAddress a: addresses) {
+            buf.append(a).append(", ");
+        }
+
+        buf.setLength(buf.length() - 2);
+        buf.append("))");
+
+        return buf.toString();
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/ShuffledDnsServerAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/ShuffledDnsServerAddressStream.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.resolver.dns;
+
+import io.netty.util.internal.ThreadLocalRandom;
+
+import java.net.InetSocketAddress;
+import java.util.Random;
+
+final class ShuffledDnsServerAddressStream implements DnsServerAddressStream {
+
+    private final InetSocketAddress[] addresses;
+    private int i;
+
+    ShuffledDnsServerAddressStream(InetSocketAddress[] addresses) {
+        this.addresses = addresses.clone();
+
+        shuffle();
+    }
+
+    private void shuffle() {
+        final InetSocketAddress[] addresses = this.addresses;
+        final Random r = ThreadLocalRandom.current();
+
+        for (int i = addresses.length - 1; i >= 0; i --) {
+            InetSocketAddress tmp = addresses[i];
+            int j = r.nextInt(i + 1);
+            addresses[i] = addresses[j];
+            addresses[j] = tmp;
+        }
+    }
+
+    @Override
+    public InetSocketAddress next() {
+        int i = this.i;
+        InetSocketAddress next = addresses[i];
+        if (++ i < addresses.length) {
+            this.i = i;
+        } else {
+            this.i = 0;
+            shuffle();
+        }
+        return next;
+    }
+
+    @Override
+    public String toString() {
+        return SequentialDnsServerAddressStream.toString("shuffled", i, addresses);
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/SingletonDnsServerAddresses.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/SingletonDnsServerAddresses.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.resolver.dns;
+
+import java.net.InetSocketAddress;
+
+final class SingletonDnsServerAddresses extends DnsServerAddresses {
+
+    private final InetSocketAddress address;
+    private final String strVal;
+
+    private final DnsServerAddressStream stream = new DnsServerAddressStream() {
+        @Override
+        public InetSocketAddress next() {
+            return address;
+        }
+
+        @Override
+        public String toString() {
+            return SingletonDnsServerAddresses.this.toString();
+        }
+    };
+
+    SingletonDnsServerAddresses(InetSocketAddress address) {
+        this.address = address;
+        strVal = new StringBuilder(32).append("singleton(").append(address).append(')').toString();
+    }
+
+    @Override
+    public DnsServerAddressStream stream() {
+        return stream;
+    }
+
+    @Override
+    public String toString() {
+        return strVal;
+    }
+}

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsServerAddressesTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsServerAddressesTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.IdentityHashMap;
-import java.util.Iterator;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.*;
@@ -36,16 +35,16 @@ public class DnsServerAddressesTest {
 
     @Test
     public void testDefaultAddresses() {
-        assertThat(DnsServerAddresses.defaultAddresses().size(), is(greaterThan(0)));
+        assertThat(DnsServerAddresses.defaultAddressList().size(), is(greaterThan(0)));
     }
 
     @Test
     public void testSequential() {
-        Iterable<InetSocketAddress> seq = DnsServerAddresses.sequential(ADDR1, ADDR2, ADDR3);
-        assertThat(seq.iterator(), is(not(sameInstance(seq.iterator()))));
+        DnsServerAddresses seq = DnsServerAddresses.sequential(ADDR1, ADDR2, ADDR3);
+        assertThat(seq.stream(), is(not(sameInstance(seq.stream()))));
 
         for (int j = 0; j < 2; j ++) {
-            Iterator<InetSocketAddress> i = seq.iterator();
+            DnsServerAddressStream i = seq.stream();
             assertNext(i, ADDR1);
             assertNext(i, ADDR2);
             assertNext(i, ADDR3);
@@ -57,9 +56,9 @@ public class DnsServerAddressesTest {
 
     @Test
     public void testRotational() {
-        Iterable<InetSocketAddress> seq = DnsServerAddresses.rotational(ADDR1, ADDR2, ADDR3);
+        DnsServerAddresses seq = DnsServerAddresses.rotational(ADDR1, ADDR2, ADDR3);
 
-        Iterator<InetSocketAddress> i = seq.iterator();
+        DnsServerAddressStream i = seq.stream();
         assertNext(i, ADDR1);
         assertNext(i, ADDR2);
         assertNext(i, ADDR3);
@@ -67,7 +66,7 @@ public class DnsServerAddressesTest {
         assertNext(i, ADDR2);
         assertNext(i, ADDR3);
 
-        i = seq.iterator();
+        i = seq.stream();
         assertNext(i, ADDR2);
         assertNext(i, ADDR3);
         assertNext(i, ADDR1);
@@ -75,7 +74,7 @@ public class DnsServerAddressesTest {
         assertNext(i, ADDR3);
         assertNext(i, ADDR1);
 
-        i = seq.iterator();
+        i = seq.stream();
         assertNext(i, ADDR3);
         assertNext(i, ADDR1);
         assertNext(i, ADDR2);
@@ -83,7 +82,7 @@ public class DnsServerAddressesTest {
         assertNext(i, ADDR1);
         assertNext(i, ADDR2);
 
-        i = seq.iterator();
+        i = seq.stream();
         assertNext(i, ADDR1);
         assertNext(i, ADDR2);
         assertNext(i, ADDR3);
@@ -94,36 +93,34 @@ public class DnsServerAddressesTest {
 
     @Test
     public void testShuffled() {
-        Iterable<InetSocketAddress> seq = DnsServerAddresses.shuffled(ADDR1, ADDR2, ADDR3);
+        DnsServerAddresses seq = DnsServerAddresses.shuffled(ADDR1, ADDR2, ADDR3);
 
         // Ensure that all three addresses are returned by the iterator.
         // In theory, this test can fail at extremely low chance, but we don't really care.
         Set<InetSocketAddress> set = Collections.newSetFromMap(new IdentityHashMap<InetSocketAddress, Boolean>());
-        Iterator<InetSocketAddress> i = seq.iterator();
+        DnsServerAddressStream i = seq.stream();
         for (int j = 0; j < 1048576; j ++) {
-            assertThat(i.hasNext(), is(true));
             set.add(i.next());
         }
 
         assertThat(set.size(), is(3));
-        assertThat(seq.iterator(), is(not(sameInstance(seq.iterator()))));
+        assertThat(seq.stream(), is(not(sameInstance(seq.stream()))));
     }
 
     @Test
     public void testSingleton() {
-        Iterable<InetSocketAddress> seq = DnsServerAddresses.singleton(ADDR1);
+        DnsServerAddresses seq = DnsServerAddresses.singleton(ADDR1);
 
         // Should return the same iterator instance for least possible footprint.
-        assertThat(seq.iterator(), is(sameInstance(seq.iterator())));
+        assertThat(seq.stream(), is(sameInstance(seq.stream())));
 
-        Iterator<InetSocketAddress> i = seq.iterator();
+        DnsServerAddressStream i = seq.stream();
         assertNext(i, ADDR1);
         assertNext(i, ADDR1);
         assertNext(i, ADDR1);
     }
 
-    private static void assertNext(Iterator<InetSocketAddress> i, InetSocketAddress addr) {
-        assertThat(i.hasNext(), is(true));
+    private static void assertNext(DnsServerAddressStream i, InetSocketAddress addr) {
         assertThat(i.next(), is(sameInstance(addr)));
     }
 }


### PR DESCRIPTION
Related: #4065 

Motivation:

DnsNameResolver was using a special Iterable/Iterator implementation that yields an infinite stream of DNS server addresses. However, this seems to cause confusion.

Modifications:

- Make DnsServerAddresses an abstract class with an abstract stream() method that returns DnsServerAddressStream
- Add DnsServerAddressStream that yields DNS server address infinitely
- Remove DnsServerResolver(Group) constructors that accepts only a single server address, which wasn't very useful in practice
- Extract the DnsServerAddresses implementations to top level
- DnsServerAddresses.defaultAddresses() now returns DnsServerAddresses.
  - Add DnsServerAddresses.defaultAddressList() instead

Result:

Less confusion and more explicitness