### PR TITLE
Fixed #3904

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -624,6 +624,12 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 if (result.bytesProduced() == 0) {
                     break;
                 }
+
+                // It should not consume empty buffers when it is not handshaking
+                // Fix for Android, where it was encrypting empty buffers even when not handshaking
+                if (result.bytesConsumed() == 0 && result.getHandshakeStatus() == HandshakeStatus.NOT_HANDSHAKING) {
+                    break;
+                }
             }
         } catch (SSLException e) {
             setHandshakeFailure(ctx, e);


### PR DESCRIPTION
Fixed issue of Infinite loop in SSLHandler in Android versions less than Lollipop. Before Android Lollipop, Apache harmony is used in Android for security provider which is different from SunJSSE. Engine directly goes to NOT_HANDSHAKING state instead of FINISHED. Even after that it continues to encrypt empty buffers, it should throw under flow exception but it does not. Thus causing an infinite loop in Android which takes too much memory.
This commit is based on the fact engine should not consume empty buffers when it is not handshaking.
It is based on fix in restlest framework[1]
Working fine on Android devices. Not tested with SunJSSE

[1] https://github.com/restlet/restlet-framework-java/issues/852
