### PR TITLE
EPOLL exception processing feedback loop

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
@@ -16,12 +16,27 @@
 package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class EpollSocketChannelTest {
 
@@ -97,5 +112,98 @@ public class EpollSocketChannelTest {
         Assert.assertTrue(info.rcvRtt() >= 0);
         Assert.assertTrue(info.rcvSpace() >= 0);
         Assert.assertTrue(info.totalRetrans() >= 0);
+    }
+
+    @Test
+    public void testExceptionHandlingDoesNotInfiniteLoop() throws InterruptedException {
+        EventLoopGroup group = new EpollEventLoopGroup();
+        try {
+            runExceptionHandleFeedbackLoop(group, EpollServerSocketChannel.class, EpollSocketChannel.class,
+                    new InetSocketAddress(0));
+            runExceptionHandleFeedbackLoop(group, EpollServerDomainSocketChannel.class, EpollDomainSocketChannel.class,
+                    EpollSocketTestPermutation.newSocketAddress());
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    private void runExceptionHandleFeedbackLoop(EventLoopGroup group, Class<? extends ServerChannel> serverChannelClass,
+            Class<? extends Channel> channelClass, SocketAddress bindAddr) throws InterruptedException {
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        try {
+            MyInitializer serverInitializer = new MyInitializer();
+            ServerBootstrap sb = new ServerBootstrap();
+            sb.option(ChannelOption.SO_BACKLOG, 1024);
+            sb.group(group)
+            .channel(serverChannelClass)
+            .childHandler(serverInitializer);
+
+            serverChannel = sb.bind(bindAddr).syncUninterruptibly().channel();
+
+            Bootstrap b = new Bootstrap();
+            b.group(group);
+            b.channel(channelClass);
+            b.option(ChannelOption.SO_KEEPALIVE, true);
+            b.remoteAddress(serverChannel.localAddress());
+            b.handler(new MyInitializer());
+            clientChannel = b.connect().syncUninterruptibly().channel();
+
+            clientChannel.writeAndFlush(Unpooled.wrappedBuffer(new byte[1024]));
+
+            // We expect to get 2 exceptions (1 from BuggyChannelHandler and 1 from ExceptionHandler).
+            assertTrue(serverInitializer.exceptionHandler.latch1.await(2, TimeUnit.SECONDS));
+
+            // After we get the first exception, we should get no more, this is expected to timeout.
+            assertFalse("Encountered " + serverInitializer.exceptionHandler.count.get() +
+                    " exceptions when 1 was expected",
+                    serverInitializer.exceptionHandler.latch2.await(2, TimeUnit.SECONDS));
+        } finally {
+            if (serverChannel != null) {
+                serverChannel.close().syncUninterruptibly();
+            }
+            if (clientChannel != null) {
+                clientChannel.close().syncUninterruptibly();
+            }
+        }
+    }
+
+    private static class MyInitializer extends ChannelInitializer<Channel> {
+        final ExceptionHandler exceptionHandler = new ExceptionHandler();
+        @Override
+        protected void initChannel(Channel ch) throws Exception {
+            ChannelPipeline pipeline = ch.pipeline();
+
+            pipeline.addLast(new BuggyChannelHandler());
+            pipeline.addLast(exceptionHandler);
+        }
+    }
+
+    private static class BuggyChannelHandler extends ChannelInboundHandlerAdapter {
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            throw new NullPointerException("I am a bug!");
+        }
+    }
+
+    private static class ExceptionHandler extends ChannelInboundHandlerAdapter {
+        final AtomicLong count = new AtomicLong();
+        /**
+         * We expect to get 2 calls to {@link #exceptionCaught(ChannelHandlerContext, Throwable)}.
+         * 1 call from BuggyChannelHandler and 1 from closing the channel in this class.
+         */
+        final CountDownLatch latch1 = new CountDownLatch(2);
+        final CountDownLatch latch2 = new CountDownLatch(1);
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            if (count.incrementAndGet() <= 2) {
+                latch1.countDown();
+            } else {
+                latch2.countDown();
+            }
+            // This is expected to throw an exception!
+            ctx.close();
+        }
     }
 }


### PR DESCRIPTION
Motivation:
Commit cf171ff52555b9e984a3b9103287f6b897dc8626 changed the way read operations were done. This change introduced a feedback loop between fireException and epollInReady.

Modifications:
- All EPOLL*Channel* classes should not call fireException and also continue to read. Instead a read operation should be executed on the eventloop (if the channel's input is not closed, and other conditions are satisfied)

Result:
Exception processing and channelRead will not be in a feedback loop.
Fixes https://github.com/netty/netty/issues/4091