### PR TITLE
HttpResponseStatus reasonPhrase equals usage

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
@@ -455,7 +455,7 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
                 int code = Integer.parseInt(status.substring(0, space));
                 String reasonPhrase = status.substring(space + 1);
                 HttpResponseStatus responseStatus = valueOf(code);
-                if (responseStatus.reasonPhrase().toString().equals(reasonPhrase)) {
+                if (responseStatus.reasonPhrase().contentEquals(reasonPhrase)) {
                     return responseStatus;
                 } else {
                     return new HttpResponseStatus(code, reasonPhrase);
@@ -507,7 +507,7 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
             status = valueOf(code);
             if (codeEnd < string.length()) {
                 String actualReason = string.toString(codeEnd + 1, string.length());
-                if (!status.reasonPhrase().equals(actualReason)) {
+                if (!status.reasonPhrase().contentEquals(actualReason)) {
                     status = new HttpResponseStatus(code, actualReason);
                 }
             }


### PR DESCRIPTION
Motivation:
HttpResponseStatus.reasonPhrase returns an AsciiString, but was compared using equals to a String. Other usages of the reasonPhrase also use the toString() method when not necessary.

Modifications:
- Use the contentEquals method

Result:
Correct comparison, and no toString() when not needed.