### PR TITLE
StringUtil not closing Formatter

### DIFF
--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -51,11 +51,14 @@ public final class StringUtil {
         // Determine the newline character of the current platform.
         String newLine;
 
+        Formatter formatter = new Formatter();
         try {
-            newLine = new Formatter().format("%n").toString();
+            newLine = formatter.format("%n").toString();
         } catch (Exception e) {
             // Should not reach here, but just in case.
             newLine = "\n";
+        } finally {
+            formatter.close();
         }
 
         NEWLINE = newLine;
@@ -372,6 +375,20 @@ public final class StringUtil {
         }
         return escapedDoubleQuote || foundSpecialCharacter && !quoted ?
                 escaped.append(DOUBLE_QUOTE) : value;
+    }
+
+    /**
+     * Get the length of a string, {@code null} input is considered {@code 0} length.
+     */
+    public static int length(String s) {
+        return s == null ? 0 : s.length();
+    }
+
+    /**
+     * Determine if a string is {@code null} or {@link String#isEmpty()} returns {@code true}.
+     */
+    public static boolean isNullOrEmpty(String s) {
+        return s == null || s.isEmpty();
     }
 
     private static boolean isDoubleQuote(char c) {


### PR DESCRIPTION
Motivation:
The StringUtil class creates a Formatter object, but does not close it. There are also a 2 utility methods which would be generally useful.

Modifications:
- Close the Formatter
- Add length and isNullOrEmpty

Result:
No more resource leaks. Additional utility methods.