### PR TITLE
Consistent naming style for enum

### DIFF
--- a/handler/src/main/java/io/netty/handler/ipfilter/IpFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpFilterRule.java
@@ -27,10 +27,10 @@ public interface IpFilterRule {
     boolean matches(InetSocketAddress remoteAddress);
 
     /**
-     * @return This method should return {@link IpFilterRuleType#ACCEPT} if all
+     * @return This method should return {@link IpFilterRuleType#Accept} if all
      * {@link IpFilterRule#matches(InetSocketAddress)} for which {@link #matches(InetSocketAddress)}
      * returns true should the accepted. If you want to exclude all of those IP addresses then
-     * {@link IpFilterRuleType#REJECT} should be returned.
+     * {@link IpFilterRuleType#Reject} should be returned.
      */
     IpFilterRuleType ruleType();
 }

--- a/handler/src/main/java/io/netty/handler/ipfilter/IpFilterRuleType.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpFilterRuleType.java
@@ -19,6 +19,6 @@ package io.netty.handler.ipfilter;
  * Used in {@link IpFilterRule} to decide if a matching IP Address should be allowed or denied to connect.
  */
 public enum IpFilterRuleType {
-    ACCEPT,
-    REJECT
+    Accept,
+    Reject
 }

--- a/handler/src/main/java/io/netty/handler/ipfilter/RuleBasedIpFilter.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/RuleBasedIpFilter.java
@@ -51,7 +51,7 @@ public class RuleBasedIpFilter extends AbstractRemoteAddressFilter<InetSocketAdd
             }
 
             if (rule.matches(remoteAddress)) {
-                return rule.ruleType() == IpFilterRuleType.ACCEPT;
+                return rule.ruleType() == IpFilterRuleType.Accept;
             }
         }
 

--- a/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
@@ -31,7 +31,7 @@ public class IpSubnetFilterTest {
 
     @Test
     public void testIpv4DefaultRoute() {
-        IpSubnetFilterRule rule = new IpSubnetFilterRule("0.0.0.0", 0, IpFilterRuleType.ACCEPT);
+        IpSubnetFilterRule rule = new IpSubnetFilterRule("0.0.0.0", 0, IpFilterRuleType.Accept);
         Assert.assertTrue(rule.matches(newSockAddress("91.114.240.43")));
         Assert.assertTrue(rule.matches(newSockAddress("10.0.0.3")));
         Assert.assertTrue(rule.matches(newSockAddress("192.168.93.2")));
@@ -39,13 +39,13 @@ public class IpSubnetFilterTest {
 
     @Test
     public void testIp4SubnetFilterRule() throws Exception {
-        IpSubnetFilterRule rule = new IpSubnetFilterRule("192.168.56.1", 24, IpFilterRuleType.ACCEPT);
+        IpSubnetFilterRule rule = new IpSubnetFilterRule("192.168.56.1", 24, IpFilterRuleType.Accept);
         for (int i = 0; i <= 255; i++) {
             Assert.assertTrue(rule.matches(newSockAddress(String.format("192.168.56.%d", i))));
         }
         Assert.assertFalse(rule.matches(newSockAddress("192.168.57.1")));
 
-        rule = new IpSubnetFilterRule("91.114.240.1", 23, IpFilterRuleType.ACCEPT);
+        rule = new IpSubnetFilterRule("91.114.240.1", 23, IpFilterRuleType.Accept);
         Assert.assertTrue(rule.matches(newSockAddress("91.114.240.43")));
         Assert.assertTrue(rule.matches(newSockAddress("91.114.240.255")));
         Assert.assertTrue(rule.matches(newSockAddress("91.114.241.193")));
@@ -57,7 +57,7 @@ public class IpSubnetFilterTest {
     public void testIp6SubnetFilterRule() {
         IpSubnetFilterRule rule;
 
-        rule = new IpSubnetFilterRule("2001:db8:abcd:0000::", 52, IpFilterRuleType.ACCEPT);
+        rule = new IpSubnetFilterRule("2001:db8:abcd:0000::", 52, IpFilterRuleType.Accept);
         Assert.assertTrue(rule.matches(newSockAddress("2001:db8:abcd:0000::1")));
         Assert.assertTrue(rule.matches(newSockAddress("2001:db8:abcd:0fff:ffff:ffff:ffff:ffff")));
         Assert.assertFalse(rule.matches(newSockAddress("2001:db8:abcd:1000::")));
@@ -73,7 +73,7 @@ public class IpSubnetFilterTest {
 
             @Override
             public IpFilterRuleType ruleType() {
-                return IpFilterRuleType.REJECT;
+                return IpFilterRuleType.Reject;
             }
         };
 


### PR DESCRIPTION
Motivation:

We should use camel-case for Enums.

Modifications:

Rename enums to use camel-case.

Result:

Consistent naming