### PR TITLE
ce6931e0e51096c5b6f1fc23ac939fb95ee70bc1 buffer leak in EpollSocketCh…

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
@@ -26,6 +26,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
+import io.netty.util.ReferenceCountUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -182,6 +183,7 @@ public class EpollSocketChannelTest {
     private static class BuggyChannelHandler extends ChannelInboundHandlerAdapter {
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            ReferenceCountUtil.release(msg);
             throw new NullPointerException("I am a bug!");
         }
     }


### PR DESCRIPTION
…annelTest

Motivation:
ce6931e0e51096c5b6f1fc23ac939fb95ee70bc1 introduced a buffer leak in EpollSocketChannelTest.

Modifications:
- Fix buffer leak

Result:
No more buffer leak.