### PR TITLE
HTTP/2 SimpleChannelPromiseAggregator failure condition

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -261,7 +261,7 @@ public final class Http2CodecUtil {
          */
         @Override
         public ChannelPromise setFailure(Throwable cause) {
-            if (awaitingPromises()) {
+            if (awaitingPromises() || expectedCount == 0) {
                 ++failureCount;
                 if (failureCount == 1) {
                     promise.setFailure(cause);


### PR DESCRIPTION
Motivation:
If a SimpleChannelPromiseAggregator is failed before any new promises are generated, the failure is not propegated through to the aggregated promise.

Modifications:
- Failures should be allowed to occur even if no new promises have been generated

Result:
Failures are always allowed.