### PR TITLE
Added a Builder for ProxyHandler

### DIFF
--- a/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandlerBuilder.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandlerBuilder.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.proxy;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+import io.netty.util.internal.StringUtil;
+
+/**
+ * Creates a new {@link ProxyHandler} of desired type with requested proxy
+ * address and authentication. The builder gracefully accepts null or empty
+ * values for username and password, which allows callers to pass in values from
+ * configuration files without additional checking.
+ */
+public final class ProxyHandlerBuilder {
+
+    public static enum ProxyType {
+        HTTP, SOCKS4, SOCKS5
+    }
+
+    /**
+     * Obtains a ProxyHandlerBuilder for a given ProxyType.
+     */
+    public static ProxyHandlerBuilder forType(ProxyType proxyType) {
+        return new ProxyHandlerBuilder(proxyType);
+    }
+
+    /**
+     * Obtains a ProxyHandlerBuilder for a given proxy type String. It will
+     * lookup it case-insensitive from ProxyType and throw an exception if it
+     * cannot be found.
+     *
+     * @throws IllegalArgumentException
+     *             if the proxyType cannot be resolved to a ProxyType enum.
+     */
+    public static ProxyHandlerBuilder forType(String proxyType) {
+        for (ProxyType type : ProxyType.values()) {
+            if (type.name().equalsIgnoreCase(proxyType)) {
+                return new ProxyHandlerBuilder(type);
+            }
+        }
+        throw new IllegalArgumentException("Proxy type " + proxyType + " not supported.");
+    }
+
+    private final ProxyType type;
+    private SocketAddress proxyAddress;
+    private String username;
+    private String password;
+
+    private ProxyHandlerBuilder(ProxyType type) {
+        this.type = type;
+    }
+
+    /**
+     * Sets an existing SocketAddress as the remote address of the proxy.
+     */
+    public ProxyHandlerBuilder proxyAddress(SocketAddress proxyAddress) {
+        this.proxyAddress = checkNotNull(proxyAddress, "proxyAddress");
+        return this;
+    }
+
+    /**
+     * Sets an unresolved InetSocketAddress as the remote address of the proxy.
+     */
+    public ProxyHandlerBuilder proxyAddress(String host, int port) {
+        this.proxyAddress = InetSocketAddress.createUnresolved(checkNotNull(host, "proxyHost"), port);
+        return this;
+    }
+
+    /**
+     * Sets the username for proxy authentication. An HTTP proxy requires a
+     * non-null password if a non-null username is set
+     */
+    public ProxyHandlerBuilder username(String username) {
+        this.username = username;
+        return this;
+    }
+
+    /**
+     * Sets the password for proxy authentication. A SOCKS4 proxy will ignore
+     * this password however.
+     */
+    public ProxyHandlerBuilder password(String password) {
+        this.password = password;
+        return this;
+    }
+
+    /**
+     * Builds a ProxyHandler using the configured parameters.
+     *
+     * @return a ProxyHandler subclass for the specified ProxyType. Never null.
+     * @throws IllegalStateException
+     *             when proxyAddress was not set.
+     */
+    public ProxyHandler build() {
+        if (proxyAddress == null) {
+            throw new IllegalStateException("Cannot build a ProxyHandler without proxyAddress.");
+        }
+        switch (type) {
+        case HTTP:
+            if (StringUtil.isNullOrEmpty(username)) {
+                return new HttpProxyHandler(proxyAddress);
+            } else {
+                return new HttpProxyHandler(proxyAddress, username, password);
+            }
+        case SOCKS4:
+            if (StringUtil.isNullOrEmpty(username)) {
+                return new Socks4ProxyHandler(proxyAddress);
+            } else {
+                return new Socks4ProxyHandler(proxyAddress, username);
+            }
+        case SOCKS5:
+            if (StringUtil.isNullOrEmpty(username)) {
+                return new Socks5ProxyHandler(proxyAddress);
+            } else {
+                return new Socks5ProxyHandler(proxyAddress, username, password);
+            }
+        default:
+            throw new Error("Proxy type " + type + " not supported.");
+        }
+    }
+}

--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyBuilderTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyBuilderTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.proxy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetSocketAddress;
+
+import org.junit.Test;
+
+import io.netty.handler.proxy.ProxyHandlerBuilder.ProxyType;
+
+public class ProxyBuilderTest {
+
+    @Test
+    public void instanceHttp() {
+        ProxyHandler proxyHandler = ProxyHandlerBuilder.forType(ProxyType.HTTP).proxyAddress("localhost", 8080).build();
+        assertTrue(proxyHandler instanceof HttpProxyHandler);
+        assertEquals("none", proxyHandler.authScheme());
+        InetSocketAddress proxyAddress = proxyHandler.proxyAddress();
+        assertEquals("localhost", proxyAddress.getHostName());
+        assertEquals(8080, proxyAddress.getPort());
+    }
+
+    @Test
+    public void instanceSocks4() {
+        ProxyHandler proxyHandler = ProxyHandlerBuilder.forType(ProxyType.SOCKS4).proxyAddress("localhost", 8080)
+                .build();
+        assertTrue(proxyHandler instanceof Socks4ProxyHandler);
+        assertEquals("none", proxyHandler.authScheme());
+        InetSocketAddress proxyAddress = proxyHandler.proxyAddress();
+        assertEquals("localhost", proxyAddress.getHostName());
+        assertEquals(8080, proxyAddress.getPort());
+    }
+
+    @Test
+    public void instanceSocks5() {
+        ProxyHandler proxyHandler = ProxyHandlerBuilder.forType(ProxyType.SOCKS5).proxyAddress("localhost", 8080)
+                .build();
+        assertTrue(proxyHandler instanceof Socks5ProxyHandler);
+        assertEquals("none", proxyHandler.authScheme());
+        InetSocketAddress proxyAddress = proxyHandler.proxyAddress();
+        assertEquals("localhost", proxyAddress.getHostName());
+        assertEquals(8080, proxyAddress.getPort());
+    }
+
+    @Test
+    public void instanceSocks5StringType() {
+        ProxyHandler proxyHandler = ProxyHandlerBuilder.forType("socks5").proxyAddress("localhost", 8080).build();
+        assertTrue(proxyHandler instanceof Socks5ProxyHandler);
+    }
+
+    @Test
+    public void proxyAuthHttp() {
+        ProxyHandler proxyHandler = ProxyHandlerBuilder.forType(ProxyType.HTTP).proxyAddress("localhost", 8080)
+                .username("foo").password("bar").build();
+        assertEquals("basic", proxyHandler.authScheme());
+        HttpProxyHandler httpProxyhandler = (HttpProxyHandler) proxyHandler;
+        assertEquals("foo", httpProxyhandler.username());
+        assertEquals("bar", httpProxyhandler.password());
+    }
+
+    @Test
+    public void proxyAuthSocks4() {
+        ProxyHandler proxyHandler = ProxyHandlerBuilder.forType(ProxyType.SOCKS4).proxyAddress("localhost", 8080)
+                .username("foo").build();
+        assertEquals("username", proxyHandler.authScheme());
+        Socks4ProxyHandler socksProxyhandler = (Socks4ProxyHandler) proxyHandler;
+        assertEquals("foo", socksProxyhandler.username());
+    }
+
+    @Test
+    public void proxyAuthSocks5() {
+        ProxyHandler proxyHandler = ProxyHandlerBuilder.forType(ProxyType.SOCKS5).proxyAddress("localhost", 8080)
+                .username("foo").password("bar").build();
+        assertEquals("password", proxyHandler.authScheme());
+        Socks5ProxyHandler socksProxyhandler = (Socks5ProxyHandler) proxyHandler;
+        assertEquals("foo", socksProxyhandler.username());
+        assertEquals("bar", socksProxyhandler.password());
+    }
+
+    @Test
+    public void proxyAddress() {
+        ProxyHandler proxyHandler = ProxyHandlerBuilder.forType(ProxyType.HTTP).proxyAddress("localhost", 8080).build();
+        InetSocketAddress proxyAddress = proxyHandler.proxyAddress();
+        assertEquals("localhost", proxyAddress.getHostName());
+        assertEquals(8080, proxyAddress.getPort());
+
+        InetSocketAddress testProxyAddress = InetSocketAddress.createUnresolved("127.0.0.1", 8888);
+        proxyHandler = ProxyHandlerBuilder.forType(ProxyType.HTTP).proxyAddress(testProxyAddress).build();
+        // a Socket address is used as is without conversion
+        assertTrue(testProxyAddress == proxyHandler.proxyAddress());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void exceptionWithoutProxyAddress() {
+        ProxyHandlerBuilder.forType(ProxyType.HTTP).build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void exceptionForUnsupportedTypeString() {
+        ProxyHandlerBuilder.forType("foo").build();
+    }
+}


### PR DESCRIPTION
Because @trustin and @normanmaurer agreed in #4125 that having a Factory for proxy handler is nice to have, here my first stab at it.

I marked this as WIP, because I want to have feedback on the following first, before I complete it with doc, test and commit message.
* I chose a builder over a factory, however it gracefully accepts empty values for username and password. The rationale is that this Builder is supposed to free users from checking all parameters and decide which class to construct, so validating them would turn this builder useless
* I used InetSocketAddress.createUnresolved - I assume that is common pattern in Netty, because resolving the address happens on usage not on construction, right?
* I am throwing RuntimeExceptions on unsupported proxy types. I checked a couple of other places, and this pattern seems ok, can you suggest a different exception?
* I am using an enum, which allows preventing getting an exception for type. I have not found other places in netty with a similar pattern. is that ok? Note that I have a lenient parser to also accept the string "socks5". Should the enum be a top level type?

Sorry for that many questions, but I want my contribution to fit netty style :)
