### PR TITLE
Fix read timeouts in transport-epoll, an issue relating to apps using…

### DIFF
--- a/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.c
+++ b/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.c
@@ -1227,7 +1227,7 @@ JNIEXPORT void JNICALL Java_io_netty_channel_epoll_Native_setTrafficClass(JNIEnv
         solinger.l_linger = 0;
     } else {
         solinger.l_onoff = 1;
-        solinger.l_linger = optval;
+        solinger.l_linger = 0;
     }
     setOption(env, fd, SOL_SOCKET, SO_LINGER, &solinger, sizeof(solinger));
 }


### PR DESCRIPTION
… IP_TOS.

This commit fixes the problem of epoll timeouts by changing the behaviour to match the NIO.
Without this patch apps that switched from NIO to epoll suffered from a regression that caused closed connections to stay in place and/or cause read timeouts.

Fixes #4127 