### PR TITLE
Fix read timeouts in transport-epoll, an issue relating to apps using…

### DIFF
--- a/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.c
+++ b/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.c
@@ -1217,10 +1217,6 @@ JNIEXPORT void JNICALL Java_io_netty_channel_epoll_Native_setTcpNotSentLowAt(JNI
 }
 
 JNIEXPORT void JNICALL Java_io_netty_channel_epoll_Native_setSoLinger(JNIEnv* env, jclass clazz, jint fd, jint optval) {
-    setOption(env, fd, IPPROTO_IP, IP_TOS, &optval, sizeof(optval));
-}
-
-JNIEXPORT void JNICALL Java_io_netty_channel_epoll_Native_setTrafficClass(JNIEnv* env, jclass clazz, jint fd, jint optval) {
     struct linger solinger;
     if (optval < 0) {
         solinger.l_onoff = 0;
@@ -1230,6 +1226,10 @@ JNIEXPORT void JNICALL Java_io_netty_channel_epoll_Native_setTrafficClass(JNIEnv
         solinger.l_linger = optval;
     }
     setOption(env, fd, SOL_SOCKET, SO_LINGER, &solinger, sizeof(solinger));
+}
+
+JNIEXPORT void JNICALL Java_io_netty_channel_epoll_Native_setTrafficClass(JNIEnv* env, jclass clazz, jint fd, jint optval) {
+    setOption(env, fd, IPPROTO_IP, IP_TOS, &optval, sizeof(optval));
 }
 
 JNIEXPORT void JNICALL Java_io_netty_channel_epoll_Native_setBroadcast(JNIEnv* env, jclass clazz, jint fd, jint optval) {


### PR DESCRIPTION
… IP_TOS.

This commit fixes the problem of epoll timeouts by changing the behaviour to match the NIO.
Without this patch apps that switched from NIO to epoll suffered from a regression that caused closed connections to stay in place and/or cause read timeouts.

The bug was caused by two native functions being swapped (setTrafficClass and setSoLinger).

#4127