### PR TITLE
[#4110] Correct javadocs of MpscLinkedQueue

### DIFF
--- a/common/src/main/java/io/netty/util/internal/MpscLinkedQueue.java
+++ b/common/src/main/java/io/netty/util/internal/MpscLinkedQueue.java
@@ -32,22 +32,19 @@ import java.util.Queue;
  * A lock-free concurrent single-consumer multi-producer {@link Queue}.
  * It allows multiple producer threads to perform the following operations simultaneously:
  * <ul>
- * <li>{@link #offer(Object)}, {@link #add(Object)}, and {@link #addAll(Collection)}</li>
- * <li>All other read-only operations:
- *     <ul>
- *     <li>{@link #contains(Object)} and {@link #containsAll(Collection)}</li>
- *     <li>{@link #element()}, {@link #peek()}</li>
- *     <li>{@link #size()} and {@link #isEmpty()}</li>
- *     <li>{@link #iterator()} (except {@link Iterator#remove()}</li>
- *     <li>{@link #toArray()} and {@link #toArray(Object[])}</li>
- *     </ul>
- * </li>
+ *     <li>{@link #offer(Object)}, {@link #add(Object)}, {@link #addAll(Collection)}</li>
+ *     <li>{@link #isEmpty()}</li>
  * </ul>
  * .. while only one consumer thread is allowed to perform the following operations exclusively:
  * <ul>
- * <li>{@link #poll()} and {@link #remove()}</li>
- * <li>{@link #remove(Object)}, {@link #removeAll(Collection)}, and {@link #retainAll(Collection)}</li>
- * <li>{@link #clear()}</li> {@link #}
+ *     <li>{@link #poll()} and {@link #remove()}</li>
+ *     <li>{@link #element()}, {@link #peek()}</li>
+ *     <li>{@link #remove(Object)}, {@link #removeAll(Collection)}, and {@link #retainAll(Collection)}</li>
+ *     <li>{@link #clear()}</li> {@link #}
+ *     <li>{@link #iterator()}</li>
+ *     <li>{@link #toArray()} and {@link #toArray(Object[])}</li>
+ *     <li>{@link #contains(Object)} and {@link #containsAll(Collection)}</li>
+ *     <li>{@link #size()}</li>
  * </ul>
  *
  * <strong>The behavior of this implementation is undefined if you perform the operations for a consumer thread only
@@ -184,7 +181,7 @@ final class MpscLinkedQueue<E> extends MpscLinkedQueueTailRef<E> implements Queu
 
     @Override
     public boolean isEmpty() {
-        return peekNode() == null;
+        return headRef() == tailRef();
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/internal/MpscLinkedQueueHeadRef.java
+++ b/common/src/main/java/io/netty/util/internal/MpscLinkedQueueHeadRef.java
@@ -38,7 +38,7 @@ abstract class MpscLinkedQueueHeadRef<E> extends MpscLinkedQueuePad0<E> implemen
         UPDATER = updater;
     }
 
-    private transient  volatile MpscLinkedQueueNode<E> headRef;
+    private transient volatile MpscLinkedQueueNode<E> headRef;
 
     protected final MpscLinkedQueueNode<E> headRef() {
         return headRef;


### PR DESCRIPTION
Motivation:

The javadocs are incorrect and so give false impressions of use-pattern.

Modifications:

- Fix javadocs of which operations are allowed from multiple threads concurrently.
- Let isEmpty() work concurrently.

Result:

Correctly document usage-patterns.