### PR TITLE
UNSAFE.throwException null arg crashes JVM

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -30,6 +30,8 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
 /**
  * The {@link PlatformDependent} operations which requires access to {@code sun.misc.*}.
  */
@@ -137,8 +139,9 @@ final class PlatformDependent0 {
         return UNSAFE != null;
     }
 
-    static void throwException(Throwable t) {
-        UNSAFE.throwException(t);
+    static void throwException(Throwable cause) {
+        // JVM has been observed to crash when passing a null argument. See https://github.com/netty/netty/issues/4131.
+        UNSAFE.throwException(checkNotNull(cause, "cause"));
     }
 
     static void freeDirectBuffer(ByteBuffer buffer) {


### PR DESCRIPTION
Motivation:
It has been observed that passing a null argument to Unsafe.throwException can crash the JVM.

Modifications:
- PlatformUnsafe0.throwException should honor http://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.18 and throw a NPE

Result:
No risk of JVM crashing for null argument.
Fixes https://github.com/netty/netty/issues/4131