### PR TITLE
Http2ConnectionHandler channelInactive sequencing

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -417,11 +417,12 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        // Call super class first, as this may result in decode being called.
+        super.channelInactive(ctx);
         if (byteDecoder != null) {
             encoder.flowController().channelHandlerContext(null);
             decoder.flowController().channelHandlerContext(null);
             byteDecoder.channelInactive(ctx);
-            super.channelInactive(ctx);
             byteDecoder = null;
         }
     }


### PR DESCRIPTION
Motivation:
ByteToMessageDecoder may call decode after channelInactive is called. This will lead to a NPE.

Modifications:
- Call super.channelInactive() before we process the event in Http2ConnectionHandler

Result:
No more NPE in decode.