### PR TITLE
Update LineBasedFrameDecoder.java

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/LineBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LineBasedFrameDecoder.java
@@ -110,7 +110,7 @@ public class LineBasedFrameDecoder extends ByteToMessageDecoder {
             } else {
                 final int length = buffer.readableBytes();
                 if (length > maxLength) {
-                    discardedBytes = length;
+                    discardedBytes += length;
                     buffer.readerIndex(buffer.writerIndex());
                     discarding = true;
                     if (failFast) {


### PR DESCRIPTION
Wrong count of discardedByes, because already discarded count is overwritten.