### PR TITLE
Build fails with java 1.8_u60

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,28 +180,31 @@
       See: http://www.eclipse.org/jetty/documentation/current/alpn-chapter.html#alpn-versions
     -->
     <profile>
-      <id>npn-alpn-7</id>
+      <id>alpn-7latest</id>
       <activation>
-        <property>
-          <name>java.version</name>
-          <value>1.7</value>
-        </property>
+        <jdk>[1.7,1.8)</jdk>
       </activation>
       <properties>
-        <jetty.npn.version>${jetty.npn.version.latest}</jetty.npn.version>
-        <jetty.alpn.version>${jetty.alpn.version.latest7}</jetty.alpn.version>
+        <jetty.alpn.version>7.1.3.v20150130</jetty.alpn.version>
       </properties>
     </profile>
     <profile>
-      <id>alpn-8</id>
+      <id>npn-latest</id>
       <activation>
-        <property>
-          <name>java.version</name>
-          <value>1.8</value>
-        </property>
+        <!--Even though npn is only supported on 1.7, allow it to still be included so dependencies can be resolved-->
+        <jdk>[1.7,)</jdk>
       </activation>
       <properties>
-        <jetty.alpn.version>${jetty.alpn.version.latest8}</jetty.alpn.version>
+        <jetty.npn.version>1.1.11.v20150415</jetty.npn.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>alpn-8latest</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <jetty.alpn.version>8.1.4.v20150727</jetty.alpn.version>
       </properties>
     </profile>
     <profile>
@@ -588,12 +591,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jboss.marshalling.version>1.3.18.GA</jboss.marshalling.version>
-    <jetty.npn.version.latest>1.1.11.v20150415</jetty.npn.version.latest>
-    <jetty.alpn.version.latest7>7.1.3.v20150130</jetty.alpn.version.latest7>
-    <jetty.alpn.version.latest8>8.1.4.v20150727</jetty.alpn.version.latest8>
-    <jetty.npn.version>${jetty.npn.version.latest}</jetty.npn.version>
     <jetty.npn.path>${settings.localRepository}/org/mortbay/jetty/npn/npn-boot/${jetty.npn.version}/npn-boot-${jetty.npn.version}.jar</jetty.npn.path>
-    <jetty.alpn.version>${jetty.alpn.version.latest7}</jetty.alpn.version>
     <jetty.alpn.path>${settings.localRepository}/org/mortbay/jetty/alpn/alpn-boot/${jetty.alpn.version}/alpn-boot-${jetty.alpn.version}.jar</jetty.alpn.path>
     <argLine.common>
       -server


### PR DESCRIPTION
Motivation:
The alpn / npn dependency versions are dependent on java version. If a java version 1.8+ is used that is not explicitly listed in the pom file then ALPN tests will fail because the java 1.7 version of alpn will be loaded by out pom file.

Modifications:
- Ensure there is a latest version to fall back up for npn 1.7+
- Ensure there is a latest version to fall back upon from alpn 1.8+

Result:
Build can complete despite having a newer jdk which is not listed in our pom file.