### PR TITLE
DefaultPropertyKey private member variable accessed outside scope

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -1153,7 +1153,7 @@ public class DefaultHttp2Connection implements Http2Connection {
      * Implementation of {@link PropertyKey} that specifies the index position of the property.
      */
     final class DefaultPropertyKey implements PropertyKey {
-        private final int index;
+        final int index;
 
         DefaultPropertyKey(int index) {
             this.index = index;


### PR DESCRIPTION
Motivation:
DefaultPropertyKey.index is currently private and accessed outside the class's scope.

Modifications:
- Change access level to package private

Result:
No chance of synthetic method generation for accessing this field