### PR TITLE
Only try to obtain SO_LINGER on close if fd is still open.

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -197,7 +197,9 @@ public final class EpollSocketChannel extends AbstractEpollStreamChannel impleme
     private final class EpollSocketChannelUnsafe extends EpollStreamUnsafe {
         @Override
         protected Executor closeExecutor() {
-            if (config().getSoLinger() > 0) {
+            // Check isOpen() first as otherwise it will throw a RuntimeException
+            // when call getSoLinger() as the fd is not valid anymore.
+            if (isOpen() && config().getSoLinger() > 0) {
                 return GlobalEventExecutor.INSTANCE;
             }
             return null;


### PR DESCRIPTION
Motivation:

When try to get SO_LINGER from a fd that is closed an Exception is thrown. We should only try to get SO_LINGER if the fd is still open otherwise an Exception is thrown that can be ignored anyway.

Modifications:

First check if the fd is still open before try to obtain SO_LINGER setting when get the closeExecutor. This is also the same that we do in the NIO transport.

Result:

No more exception when calling unsafe.close() on a channel that has a closed file descriptor.