### PR TITLE
Fixed a typo [testEquansIgnoreCase() --> testEqualsIgnoreCase()]

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
@@ -51,7 +51,7 @@ public class HttpHeadersTest {
     }
 
     @Test
-    public void testEquansIgnoreCase() {
+    public void testEqualsIgnoreCase() {
         assertThat(AsciiString.contentEqualsIgnoreCase(null, null), is(true));
         assertThat(AsciiString.contentEqualsIgnoreCase(null, "foo"), is(false));
         assertThat(AsciiString.contentEqualsIgnoreCase("bar", null), is(false));


### PR DESCRIPTION
Fixed a typo in the test name.