### PR TITLE
Use ChannelException when ChannelConfig operation fails in epoll.

### DIFF
--- a/transport-native-epoll/src/main/c/exception_helper.h
+++ b/transport-native-epoll/src/main/c/exception_helper.h
@@ -16,6 +16,7 @@
 
 void throwRuntimeException(JNIEnv* env, char* message);
 void throwRuntimeExceptionErrorNo(JNIEnv* env, char* message, int errorNumber);
+void throwChannelExceptionErrorNo(JNIEnv* env, char* message, int errorNumber);
 void throwIOException(JNIEnv* env, char* message);
 void throwIOExceptionErrorNo(JNIEnv* env, char* message, int errorNumber);
 void throwClosedChannelException(JNIEnv* env);

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollChannelConfigTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.channel.ChannelException;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class EpollChannelConfigTest {
+
+    @Test
+    public void testOptionGetThrowsChannelException() throws Exception {
+        Epoll.ensureAvailability();
+        EpollSocketChannel channel = new EpollSocketChannel();
+        channel.config().getSoLinger();
+        channel.fd().close();
+        try {
+            channel.config().getSoLinger();
+            fail();
+        } catch (ChannelException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testOptionSetThrowsChannelException() throws Exception {
+        Epoll.ensureAvailability();
+        EpollSocketChannel channel = new EpollSocketChannel();
+        channel.config().setKeepAlive(true);
+        channel.fd().close();
+        try {
+            channel.config().setKeepAlive(true);
+            fail();
+        } catch (ChannelException e) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

In NIO and OIO we throw a ChannelException if a ChannelConfig operation fails. We should do the same with epoll to be consistent.

Modifications:

Use ChannelException

Result:

Consistent behaviour across different transport implementations.