### PR TITLE
Added debug logging with effective value for io.netty.leakDetection.acquireAndReleaseOnly property

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
@@ -18,6 +18,8 @@ package io.netty.buffer;
 
 import io.netty.util.ResourceLeak;
 import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,8 +35,14 @@ final class AdvancedLeakAwareByteBuf extends WrappedByteBuf {
     private static final String PROP_ACQUIRE_AND_RELEASE_ONLY = "io.netty.leakDetection.acquireAndReleaseOnly";
     private static final boolean ACQUIRE_AND_RELEASE_ONLY;
 
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(AdvancedLeakAwareByteBuf.class);
+
     static {
         ACQUIRE_AND_RELEASE_ONLY = SystemPropertyUtil.getBoolean(PROP_ACQUIRE_AND_RELEASE_ONLY, false);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("-D{}: {}", PROP_ACQUIRE_AND_RELEASE_ONLY, ACQUIRE_AND_RELEASE_ONLY);
+        }
     }
 
     private final ResourceLeak leak;


### PR DESCRIPTION
Motivation:
The configurable property value recently added was not logged like others properties.

Modifications:
Added debug log with effective value applied.

Result:
Consistent with other properties