### PR TITLE
HTTP/2 SimplePromiseAggregator tryFailure not consistent with setFailure

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -240,7 +240,7 @@ public final class Http2CodecUtil {
 
         @Override
         public boolean tryFailure(Throwable cause) {
-            if (awaitingPromises()) {
+            if (allowFailure()) {
                 ++failureCount;
                 if (failureCount == 1) {
                     promise.tryFailure(cause);
@@ -261,7 +261,7 @@ public final class Http2CodecUtil {
          */
         @Override
         public ChannelPromise setFailure(Throwable cause) {
-            if (awaitingPromises() || expectedCount == 0) {
+            if (allowFailure()) {
                 ++failureCount;
                 if (failureCount == 1) {
                     promise.setFailure(cause);
@@ -269,6 +269,10 @@ public final class Http2CodecUtil {
                 }
             }
             return this;
+        }
+
+        private boolean allowFailure() {
+            return awaitingPromises() || expectedCount == 0;
         }
 
         private boolean awaitingPromises() {


### PR DESCRIPTION
Motivation:
The SimplePromiseAggregator.setFailure allows a failure to occur before newPromise is called, but tryFailure doesn't. These methods should be consistent.

Modifications:
- tryFailure should use the same logic as setFailure

Result:
Consistent failure routines.