### PR TITLE
[#4185] SpdyHttpEncoder fails to convert HttpResponse to SpdyFrame

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpEncoder.java
@@ -27,6 +27,7 @@ import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.LastHttpContent;
+import io.netty.util.AsciiString;
 
 import java.util.List;
 import java.util.Map;
@@ -172,7 +173,7 @@ public class SpdyHttpEncoder extends MessageToMessageEncoder<HttpObject> {
                     SpdyHeadersFrame spdyHeadersFrame = new DefaultSpdyHeadersFrame(currentStreamId);
                     spdyHeadersFrame.setLast(true);
                     for (Map.Entry<CharSequence, CharSequence> entry: trailers) {
-                        spdyHeadersFrame.headers().add(entry.getKey(), entry.getValue());
+                        spdyHeadersFrame.headers().add(AsciiString.of(entry.getKey()).toLowerCase(), entry.getValue());
                     }
 
                     // Write DATA frame and append HEADERS frame
@@ -233,7 +234,7 @@ public class SpdyHttpEncoder extends MessageToMessageEncoder<HttpObject> {
 
         // Transfer the remaining HTTP headers
         for (Map.Entry<CharSequence, CharSequence> entry: httpHeaders) {
-            frameHeaders.add(entry.getKey(), entry.getValue());
+            frameHeaders.add(AsciiString.of(entry.getKey()).toLowerCase(), entry.getValue());
         }
         currentStreamId = spdySynStreamFrame.streamId();
         if (associatedToStreamId == 0) {
@@ -272,7 +273,7 @@ public class SpdyHttpEncoder extends MessageToMessageEncoder<HttpObject> {
 
         // Transfer the remaining HTTP headers
         for (Map.Entry<CharSequence, CharSequence> entry: httpHeaders) {
-            spdyHeadersFrame.headers().add(entry.getKey(), entry.getValue());
+            spdyHeadersFrame.headers().add(AsciiString.of(entry.getKey()).toLowerCase(), entry.getValue());
         }
 
         currentStreamId = streamId;


### PR DESCRIPTION
Motivation:

When ```SpdyHttpEncoder``` attempts to create an ```SpdyHeadersFrame``` from a ```HttpResponse``` an ```IllegalArgumentException``` is thrown if the original ```HttpResponse``` contains a header that includes uppercase characters. The ```IllegalArgumentException``` is thrown due to the additional validation check introduced by #4047.

Previous versions of the SPDY codec would handle this by converting the HTTP header name to lowercase before adding the header to the ```SpdyHeadersFrame```.

Modifications:

Convert the header name to lowercase before adding it to ```SpdyHeaders```

Result:

```SpdyHttpEncoder``` can now convert a valid ```HttpResponse``` into a valid ```SpdyFrame```