### PR TITLE
Deprecation cleanup for HTTP headers

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/Cookie.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/Cookie.java
@@ -89,6 +89,7 @@ public interface Cookie extends io.netty.handler.codec.http.cookie.Cookie {
      * @deprecated Not part of RFC6265
      */
     @Deprecated
+    @Override
     long maxAge();
 
     /**
@@ -103,6 +104,7 @@ public interface Cookie extends io.netty.handler.codec.http.cookie.Cookie {
      * @deprecated Not part of RFC6265
      */
     @Deprecated
+    @Override
     void setMaxAge(long maxAge);
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -114,7 +114,6 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return this;
     }
 
-    @Deprecated
     @Override
     public HttpHeaders add(CharSequence name, Object value) {
         headers.addObject(name, value);
@@ -128,7 +127,6 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return this;
     }
 
-    @Deprecated
     @Override
     public HttpHeaders add(CharSequence name, Iterable<?> values) {
         headers.addObject(name, values);
@@ -154,7 +152,6 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return this;
     }
 
-    @Deprecated
     @Override
     public HttpHeaders remove(CharSequence name) {
         headers.remove(name);
@@ -168,7 +165,6 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return this;
     }
 
-    @Deprecated
     @Override
     public HttpHeaders set(CharSequence name, Object value) {
         headers.setObject(name, value);
@@ -182,7 +178,6 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return this;
     }
 
-    @Deprecated
     @Override
     public HttpHeaders set(CharSequence name, Iterable<?> values) {
         headers.setObject(name, values);
@@ -207,13 +202,11 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return this;
     }
 
-    @Deprecated
     @Override
     public String get(String name) {
         return get((CharSequence) name);
     }
 
-    @Deprecated
     @Override
     public String get(CharSequence name) {
         return HeadersUtils.getAsString(headers, name);
@@ -255,7 +248,6 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return getAll((CharSequence) name);
     }
 
-    @Deprecated
     @Override
     public List<String> getAll(CharSequence name) {
         return HeadersUtils.getAllAsString(headers, name);
@@ -281,13 +273,11 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return HeadersUtils.iteratorAsString(headers);
     }
 
-    @Deprecated
     @Override
     public Iterator<Entry<CharSequence, CharSequence>> iteratorCharSequence() {
         return headers.iterator();
     }
 
-    @Deprecated
     @Override
     public boolean contains(String name) {
         return contains((CharSequence) name);
@@ -318,7 +308,6 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return headers.contains(name, value, ignoreCase ? CASE_INSENSITIVE_HASHER : CASE_SENSITIVE_HASHER);
     }
 
-    @Deprecated
     @Override
     public Set<String> names() {
         return HeadersUtils.namesAsString(headers);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/EmptyHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/EmptyHttpHeaders.java
@@ -26,7 +26,19 @@ public class EmptyHttpHeaders extends HttpHeaders {
     static final Iterator<Entry<CharSequence, CharSequence>> EMPTY_CHARS_ITERATOR =
             Collections.<Entry<CharSequence, CharSequence>>emptyList().iterator();
 
-    public static final EmptyHttpHeaders INSTANCE = new EmptyHttpHeaders();
+    public static final EmptyHttpHeaders INSTANCE = instance();
+
+    /**
+     * @deprecated Use {@link EmptyHttpHeaders#INSTANCE}
+     * <p>
+     * This is needed to break a cyclic static initialization loop between {@link HttpHeaders} and
+     * {@link EmptyHttpHeaders}.
+     * @see HttpUtil#EMPTY_HEADERS
+     */
+    @Deprecated
+    static EmptyHttpHeaders instance() {
+        return HttpUtil.EMPTY_HEADERS;
+    }
 
     protected EmptyHttpHeaders() {
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
@@ -98,7 +98,7 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
                 assert encoder == null;
 
                 final HttpResponse res = (HttpResponse) msg;
-                final int code = res.getStatus().code();
+                final int code = res.status().code();
                 if (code == CONTINUE_CODE) {
                     // We need to not poll the encoding when response with CONTINUE as another response will follow
                     // for the issued request. See https://github.com/netty/netty/issues/4079

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -38,9 +38,13 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>> {
     /**
      * @deprecated Use {@link EmptyHttpHeaders#INSTANCE}.
+     * <p>
+     * The instance is instantiated here to break the cyclic static initialization between {@link EmptyHttpHeaders} and
+     * {@link HttpHeaders}. The issue is that if someone accesses {@link EmptyHttpHeaders#INSTANCE} before
+     * {@link HttpHeaders#EMPTY_HEADERS} then {@link HttpHeaders#EMPTY_HEADERS} will be {@code null}.
      */
     @Deprecated
-    public static final HttpHeaders EMPTY_HEADERS = EmptyHttpHeaders.INSTANCE;
+    public static final HttpHeaders EMPTY_HEADERS = EmptyHttpHeaders.instance();
 
     /**
      * @deprecated Use {@link HttpHeaderNames} instead.
@@ -1148,7 +1152,6 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
         }
     }
 
-    @Deprecated
     public static void encodeAscii(CharSequence seq, ByteBuf buf) {
         if (seq instanceof AsciiString) {
             ByteBufUtil.copy((AsciiString) seq, 0, buf, seq.length());
@@ -1159,15 +1162,12 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
 
     /**
      * @deprecated Use {@link AsciiString} instead.
-     *
+     * <p>
      * Create a new {@link CharSequence} which is optimized for reuse as {@link HttpHeaders} name or value.
      * So if you have a Header name or value that you want to reuse you should make use of this.
      */
     @Deprecated
     public static CharSequence newEntity(String name) {
-        if (name == null) {
-            throw new NullPointerException("name");
-        }
         return new AsciiString(name);
     }
 
@@ -1175,35 +1175,30 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
 
     /**
      * @deprecated Use {@link #get(CharSequence)}
-     * @see {@link #get(CharSequence)}
+     * @see #get(CharSequence)
      */
     @Deprecated
     public abstract String get(String name);
 
     /**
-     * @deprecated Use {@link #getAsString(CharSequence)}
-     * <p>
      * Returns the value of a header with the specified name.  If there are
      * more than one values for the specified name, the first value is returned.
      *
      * @param name The name of the header to search
      * @return The first header value or {@code null} if there is no such header
+     * @see #getAsString(CharSequence)
      */
-    @Deprecated
     public String get(CharSequence name) {
         return get(name.toString());
     }
 
     /**
-     * @deprecated Future releases will use {@link CharSequence} instead of {@link String}.
-     * <p>
      * Returns the value of a header with the specified name.  If there are
      * more than one values for the specified name, the first value is returned.
      *
      * @param name The name of the header to search
      * @return The first header value or {@code defaultValue} if there is no such header
      */
-    @Deprecated
     public String get(CharSequence name, String defaultValue) {
         String value = get(name);
         if (value == null) {
@@ -1276,21 +1271,19 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     public abstract long getTimeMillis(CharSequence name, long defaultValue);
 
     /**
-     * @see {@link #getAll(CharSequence)}
+     * @deprecated Use {@link #getAll(CharSequence)}
      */
     @Deprecated
     public abstract List<String> getAll(String name);
 
     /**
-     * @deprecated Use {@link #getAllAsString(CharSequence)}
-     * <p>
      * Returns the values of headers with the specified name
      *
      * @param name The name of the headers to search
      * @return A {@link List} of header values which will be empty if no values
      *         are found
+     * @see #getAllAsString(CharSequence)
      */
-    @Deprecated
     public List<String> getAll(CharSequence name) {
         return getAll(name.toString());
     }
@@ -1316,18 +1309,14 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     /**
      * @deprecated It is preferred to use {@link #iteratorCharSequence()} unless you need {@link String}.
      * If {@link String} is required then use {@link #iteratorAsString()}.
-     * <p>
-     * {@inheritDoc}
      */
-    @Override
     @Deprecated
+    @Override
     public abstract Iterator<Entry<String, String>> iterator();
 
     /**
-     * @deprecated In future releases this method will be renamed to {@code iterator()}.
      * @return Iterator over the name/value header pairs.
      */
-    @Deprecated
     public abstract Iterator<Entry<CharSequence, CharSequence>> iteratorCharSequence();
 
     /**
@@ -1351,13 +1340,10 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     public abstract int size();
 
     /**
-     * @deprecated Future releases will return a {@link Set} of type {@link CharSequence}.
-     * <p>
      * Returns a new {@link Set} that contains the names of all headers in this object.  Note that modifying the
      * returned {@link Set} will not affect the state of this object.  If you intend to enumerate over the header
      * entries only, use {@link #iterator()} instead, which has much less overhead.
      */
-    @Deprecated
     public abstract Set<String> names();
 
     /**
@@ -1367,8 +1353,6 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     public abstract HttpHeaders add(String name, Object value);
 
     /**
-     * @deprecated Future releases will have a {@code addObject} method.
-     * <p>
      * Adds a new header with the specified name and value.
      *
      * If the specified value is not a {@link String}, it is converted
@@ -1381,7 +1365,6 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
      *
      * @return {@code this}
      */
-    @Deprecated
     public HttpHeaders add(CharSequence name, Object value) {
         return add(name.toString(), value);
     }
@@ -1393,8 +1376,6 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     public abstract HttpHeaders add(String name, Iterable<?> values);
 
     /**
-     * @deprecated Future release will have an {@code addObject(...)}.
-     * <p>
      * Adds a new header with the specified name and values.
      *
      * This getMethod can be represented approximately as the following code:
@@ -1411,7 +1392,6 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
      * @param values The values of the headers being set
      * @return {@code this}
      */
-    @Deprecated
     public HttpHeaders add(CharSequence name, Iterable<?> values) {
         return add(name.toString(), values);
     }
@@ -1454,8 +1434,6 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     public abstract HttpHeaders set(String name, Object value);
 
     /**
-     * @deprecated Future release will have a {@code setObject(...)}.
-     * <p>
      * Sets a header with the specified name and value.
      *
      * If there is an existing header with the same name, it is removed.
@@ -1468,7 +1446,6 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
      * @param value The value of the header being set
      * @return {@code this}
      */
-    @Deprecated
     public HttpHeaders set(CharSequence name, Object value) {
         return set(name.toString(), value);
     }
@@ -1480,8 +1457,6 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     public abstract HttpHeaders set(String name, Iterable<?> values);
 
     /**
-     * @deprecated Future release will have a {@code setObject(...)}.
-     * <p>
      * Sets a header with the specified name and values.
      *
      * If there is an existing header with the same name, it is removed.
@@ -1500,7 +1475,6 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
      * @param values The values of the headers being set
      * @return {@code this}
      */
-    @Deprecated
     public HttpHeaders set(CharSequence name, Iterable<?> values) {
         return set(name.toString(), values);
     }
@@ -1567,14 +1541,11 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     public abstract HttpHeaders remove(String name);
 
     /**
-     * @deprecated Future releases the signature will change.
-     * <p>
      * Removes the header with the specified name.
      *
      * @param name The name of the header to remove
      * @return {@code this}
      */
-    @Deprecated
     public HttpHeaders remove(CharSequence name) {
         return remove(name.toString());
     }
@@ -1587,8 +1558,9 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     public abstract HttpHeaders clear();
 
     /**
-     * @see {@link #contains(CharSequence, CharSequence, boolean)}
+     * @deprecated Use {@link #contains(CharSequence, CharSequence, boolean)}
      */
+    @Deprecated
     public boolean contains(String name, String value, boolean ignoreCase) {
         List<String> values = getAll(name);
         if (values.isEmpty()) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -232,7 +232,7 @@ public class HttpObjectAggregator
         public HttpHeaders trailingHeaders() {
             HttpHeaders trailingHeaders = this.trailingHeaders;
             if (trailingHeaders == null) {
-                return HttpHeaders.EMPTY_HEADERS;
+                return EmptyHttpHeaders.INSTANCE;
             } else {
                 return trailingHeaders;
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
@@ -295,7 +295,7 @@ public class HttpServerUpgradeHandler extends HttpObjectAggregator {
         }
 
         // Ensure that all required protocol-specific headers are found in the request.
-        for (String requiredHeader : requiredHeaders) {
+        for (CharSequence requiredHeader : requiredHeaders) {
             if (!request.headers().contains(requiredHeader)) {
                 return false;
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -26,6 +26,16 @@ import java.util.List;
  * Utility methods useful in the HTTP context.
  */
 public final class HttpUtil {
+    /**
+     * @deprecated Use {@link EmptyHttpHeaders#INSTANCE}
+     * <p>
+     * The instance is instantiated here to break the cyclic static initialization between {@link EmptyHttpHeaders} and
+     * {@link HttpHeaders}. The issue is that if someone accesses {@link EmptyHttpHeaders#INSTANCE} before
+     * {@link HttpHeaders#EMPTY_HEADERS} then {@link HttpHeaders#EMPTY_HEADERS} will be {@code null}.
+     */
+    @Deprecated
+    static final EmptyHttpHeaders EMPTY_HEADERS = new EmptyHttpHeaders();
+
     private HttpUtil() { }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/LastHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/LastHttpContent.java
@@ -46,7 +46,7 @@ public interface LastHttpContent extends HttpContent {
 
         @Override
         public HttpHeaders trailingHeaders() {
-            return HttpHeaders.EMPTY_HEADERS;
+            return EmptyHttpHeaders.INSTANCE;
         }
 
         @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsConfig.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsConfig.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http.cors;
 
 import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
@@ -202,7 +203,7 @@ public final class CorsConfig {
      */
     public HttpHeaders preflightResponseHeaders() {
         if (preflightHeaders.isEmpty()) {
-            return HttpHeaders.EMPTY_HEADERS;
+            return EmptyHttpHeaders.INSTANCE;
         }
         final HttpHeaders preflightHeaders = new DefaultHttpHeaders();
         for (Entry<CharSequence, Callable<?>> entry : this.preflightHeaders.entrySet()) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpContent;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpConstants;
 import io.netty.handler.codec.http.HttpContent;
@@ -1309,7 +1310,7 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
             if (content instanceof LastHttpContent) {
                 return ((LastHttpContent) content).trailingHeaders();
             } else {
-                return HttpHeaders.EMPTY_HEADERS;
+                return EmptyHttpHeaders.INSTANCE;
             }
         }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/CombinedHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/CombinedHttpHeadersTest.java
@@ -24,7 +24,7 @@ import static io.netty.util.AsciiString.contentEquals;
 import static org.junit.Assert.assertTrue;
 
 public class CombinedHttpHeadersTest {
-    private static final String HEADER_NAME = "testHeader";
+    private static final CharSequence HEADER_NAME = "testHeader";
 
     @Test
     public void addCharSequencesCsv() {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
@@ -23,39 +23,44 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
 import static io.netty.util.AsciiString.contentEquals;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class DefaultHttpHeadersTest {
-    private static final String HEADER_NAME = "testHeader";
+    private static final CharSequence HEADER_NAME = "testHeader";
 
     @Test
     public void keysShouldBeCaseInsensitive() {
         DefaultHttpHeaders headers = new DefaultHttpHeaders();
-        headers.add("Name", "value1");
-        headers.add("name", "value2");
-        headers.add("NAME", "value3");
+        headers.add(of("Name"), of("value1"));
+        headers.add(of("name"), of("value2"));
+        headers.add(of("NAME"), of("value3"));
         assertEquals(3, headers.size());
 
         List<String> values = asList("value1", "value2", "value3");
 
-        assertEquals(values, headers.getAll("NAME"));
-        assertEquals(values, headers.getAll("name"));
-        assertEquals(values, headers.getAll("Name"));
-        assertEquals(values, headers.getAll("nAmE"));
+        assertEquals(values, headers.getAll(of("NAME")));
+        assertEquals(values, headers.getAll(of("name")));
+        assertEquals(values, headers.getAll(of("Name")));
+        assertEquals(values, headers.getAll(of("nAmE")));
     }
 
     @Test
     public void keysShouldBeCaseInsensitiveInHeadersEquals() {
         DefaultHttpHeaders headers1 = new DefaultHttpHeaders();
-        headers1.add("name1", Arrays.asList("value1", "value2", "value3"));
-        headers1.add("nAmE2", "value4");
+        headers1.add(of("name1"), Arrays.asList("value1", "value2", "value3"));
+        headers1.add(of("nAmE2"), of("value4"));
 
         DefaultHttpHeaders headers2 = new DefaultHttpHeaders();
-        headers2.add("naMe1", Arrays.asList("value1", "value2", "value3"));
-        headers2.add("NAME2", "value4");
+        headers2.add(of("naMe1"), Arrays.asList("value1", "value2", "value3"));
+        headers2.add(of("NAME2"), of("value4"));
 
         assertEquals(headers1, headers1);
         assertEquals(headers2, headers2);
@@ -70,7 +75,7 @@ public class DefaultHttpHeadersTest {
 
         // Test adding String key and retrieving it using a AsciiString key
         final String connection = "keep-alive";
-        headers.add("Connection", connection);
+        headers.add(of("Connection"), connection);
 
         // Passes
         final String value = headers.getAsString(HttpHeaderNames.CONNECTION.toString());
@@ -113,12 +118,12 @@ public class DefaultHttpHeadersTest {
     @Test
     public void testGetOperations() {
         HttpHeaders headers = new DefaultHttpHeaders();
-        headers.add("Foo", "1");
-        headers.add("Foo", "2");
+        headers.add(of("Foo"), of("1"));
+        headers.add(of("Foo"), of("2"));
 
-        assertEquals("1", headers.get("Foo"));
+        assertEquals("1", headers.get(of("Foo")));
 
-        List<String> values = headers.getAll("Foo");
+        List<String> values = headers.getAll(of("Foo"));
         assertEquals(2, values.size());
         assertEquals("1", values.get(0));
         assertEquals("2", values.get(1));
@@ -135,13 +140,13 @@ public class DefaultHttpHeadersTest {
     @Test(expected = NullPointerException.class)
     public void testSetNullHeaderValueValidate() {
         HttpHeaders headers = new DefaultHttpHeaders(true);
-        headers.set("test", (CharSequence) null);
+        headers.set(of("test"), (CharSequence) null);
     }
 
     @Test(expected = NullPointerException.class)
     public void testSetNullHeaderValueNotValidate() {
         HttpHeaders headers = new DefaultHttpHeaders(false);
-        headers.set("test", (CharSequence) null);
+        headers.set(of("test"), (CharSequence) null);
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpRequestTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpRequestTest.java
@@ -15,9 +15,12 @@
  */
 package io.netty.handler.codec.http;
 
+import io.netty.util.AsciiString;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class DefaultHttpRequestTest {
 
@@ -28,17 +31,17 @@ public class DefaultHttpRequestTest {
 
         // Insert sample keys.
         for (int i = 0; i < 1000; i ++) {
-            h.set(String.valueOf(i), "");
+            h.set(of(String.valueOf(i)), AsciiString.EMPTY_STRING);
         }
 
         // Remove in reversed order.
         for (int i = 999; i >= 0; i --) {
-            h.remove(String.valueOf(i));
+            h.remove(of(String.valueOf(i)));
         }
 
         // Check if random access returns nothing.
         for (int i = 0; i < 1000; i ++) {
-            assertNull(h.get(String.valueOf(i)));
+            assertNull(h.get(of(String.valueOf(i))));
         }
 
         // Check if sequential access returns nothing.

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
@@ -24,8 +24,16 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class HttpContentCompressorTest {
 
@@ -159,7 +167,7 @@ public class HttpContentCompressorTest {
         ch.writeOutbound(new DefaultHttpContent(Unpooled.copiedBuffer("Hell", CharsetUtil.US_ASCII)));
         ch.writeOutbound(new DefaultHttpContent(Unpooled.copiedBuffer("o, w", CharsetUtil.US_ASCII)));
         LastHttpContent content = new DefaultLastHttpContent(Unpooled.copiedBuffer("orld", CharsetUtil.US_ASCII));
-        content.trailingHeaders().set("X-Test", "Netty");
+        content.trailingHeaders().set(of("X-Test"), of("Netty"));
         ch.writeOutbound(content);
 
         HttpContent chunk;
@@ -183,7 +191,7 @@ public class HttpContentCompressorTest {
         chunk = ch.readOutbound();
         assertThat(chunk.content().isReadable(), is(false));
         assertThat(chunk, is(instanceOf(LastHttpContent.class)));
-        assertEquals("Netty", ((LastHttpContent) chunk).trailingHeaders().get("X-Test"));
+        assertEquals("Netty", ((LastHttpContent) chunk).trailingHeaders().get(of("X-Test")));
         chunk.release();
 
         assertThat(ch.readOutbound(), is(nullValue()));
@@ -276,7 +284,7 @@ public class HttpContentCompressorTest {
 
         FullHttpResponse res = new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.EMPTY_BUFFER);
-        res.trailingHeaders().set("X-Test", "Netty");
+        res.trailingHeaders().set(of("X-Test"), of("Netty"));
         ch.writeOutbound(res);
 
         Object o = ch.readOutbound();
@@ -289,14 +297,14 @@ public class HttpContentCompressorTest {
         assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is(nullValue()));
         assertThat(res.content().readableBytes(), is(0));
         assertThat(res.content().toString(CharsetUtil.US_ASCII), is(""));
-        assertEquals("Netty", res.trailingHeaders().get("X-Test"));
+        assertEquals("Netty", res.trailingHeaders().get(of("X-Test")));
         assertThat(ch.readOutbound(), is(nullValue()));
     }
 
     @Test
     public void test100Continue() throws Exception {
         FullHttpRequest request = newRequest();
-        HttpHeaders.set100ContinueExpected(request);
+        HttpUtil.set100ContinueExpected(request, true);
 
         EmbeddedChannel ch = new EmbeddedChannel(new HttpContentCompressor());
         ch.writeInbound(request);
@@ -308,7 +316,7 @@ public class HttpContentCompressorTest {
 
         FullHttpResponse res = new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.EMPTY_BUFFER);
-        res.trailingHeaders().set("X-Test", "Netty");
+        res.trailingHeaders().set(of("X-Test"), of("Netty"));
         ch.writeOutbound(res);
 
         Object o = ch.readOutbound();
@@ -328,7 +336,7 @@ public class HttpContentCompressorTest {
         assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is(nullValue()));
         assertThat(res.content().readableBytes(), is(0));
         assertThat(res.content().toString(CharsetUtil.US_ASCII), is(""));
-        assertEquals("Netty", res.trailingHeaders().get("X-Test"));
+        assertEquals("Netty", res.trailingHeaders().get(of("X-Test")));
         assertThat(ch.readOutbound(), is(nullValue()));
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentEncoderTest.java
@@ -24,8 +24,13 @@ import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.util.CharsetUtil;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class HttpContentEncoderTest {
 
@@ -126,7 +131,7 @@ public class HttpContentEncoderTest {
         ch.writeOutbound(new DefaultHttpContent(Unpooled.wrappedBuffer(new byte[3])));
         ch.writeOutbound(new DefaultHttpContent(Unpooled.wrappedBuffer(new byte[2])));
         LastHttpContent content = new DefaultLastHttpContent(Unpooled.wrappedBuffer(new byte[1]));
-        content.trailingHeaders().set("X-Test", "Netty");
+        content.trailingHeaders().set(of("X-Test"), of("Netty"));
         ch.writeOutbound(content);
 
         HttpContent chunk;
@@ -146,7 +151,7 @@ public class HttpContentEncoderTest {
         chunk = ch.readOutbound();
         assertThat(chunk.content().isReadable(), is(false));
         assertThat(chunk, is(instanceOf(LastHttpContent.class)));
-        assertEquals("Netty", ((LastHttpContent) chunk).trailingHeaders().get("X-Test"));
+        assertEquals("Netty", ((LastHttpContent) chunk).trailingHeaders().get(of("X-Test")));
         chunk.release();
 
         assertThat(ch.readOutbound(), is(nullValue()));
@@ -235,7 +240,7 @@ public class HttpContentEncoderTest {
 
         FullHttpResponse res = new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1, HttpResponseStatus.OK, Unpooled.EMPTY_BUFFER);
-        res.trailingHeaders().set("X-Test", "Netty");
+        res.trailingHeaders().set(of("X-Test"), of("Netty"));
         ch.writeOutbound(res);
 
         Object o = ch.readOutbound();
@@ -248,7 +253,7 @@ public class HttpContentEncoderTest {
         assertThat(res.headers().get(HttpHeaderNames.CONTENT_ENCODING), is(nullValue()));
         assertThat(res.content().readableBytes(), is(0));
         assertThat(res.content().toString(CharsetUtil.US_ASCII), is(""));
-        assertEquals("Netty", res.trailingHeaders().get("X-Test"));
+        assertEquals("Netty", res.trailingHeaders().get(of("X-Test")));
         assertThat(ch.readOutbound(), is(nullValue()));
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
@@ -16,13 +16,16 @@
 package io.netty.handler.codec.http;
 
 import io.netty.util.AsciiString;
-
 import org.junit.Test;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class HttpHeadersTest {
 
@@ -39,12 +42,12 @@ public class HttpHeadersTest {
     @Test
     public void testGetOperations() {
         HttpHeaders headers = new DefaultHttpHeaders();
-        headers.add("Foo", "1");
-        headers.add("Foo", "2");
+        headers.add(of("Foo"), of("1"));
+        headers.add(of("Foo"), of("2"));
 
-        assertEquals("1", headers.get("Foo"));
+        assertEquals("1", headers.get(of("Foo")));
 
-        List<String> values = headers.getAll("Foo");
+        List<String> values = headers.getAll(of("Foo"));
         assertEquals(2, values.size());
         assertEquals("1", values.get(0));
         assertEquals("2", values.get(1));
@@ -61,12 +64,12 @@ public class HttpHeadersTest {
     @Test(expected = NullPointerException.class)
     public void testSetNullHeaderValueValidate() {
         HttpHeaders headers = new DefaultHttpHeaders(true);
-        headers.set("test", (CharSequence) null);
+        headers.set(of("test"), (CharSequence) null);
     }
 
     @Test(expected = NullPointerException.class)
     public void testSetNullHeaderValueNotValidate() {
         HttpHeaders headers = new DefaultHttpHeaders(false);
-        headers.set("test", (CharSequence) null);
+        headers.set(of("test"), (CharSequence) null);
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTestUtils.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTestUtils.java
@@ -23,8 +23,11 @@ import java.util.Map;
 import static io.netty.util.internal.StringUtil.COMMA;
 import static io.netty.util.internal.StringUtil.DOUBLE_QUOTE;
 
-class HttpHeadersTestUtils {
-    public enum HeaderValue {
+/**
+ * Utility methods for {@link HttpHeaders} related unit tests.
+ */
+public final class HttpHeadersTestUtils {
+    enum HeaderValue {
         UNKNOWN("Unknown", 0),
         ONE("One", 1),
         TWO("Two", 2),
@@ -127,4 +130,10 @@ class HttpHeadersTestUtils {
             return v == null ? UNKNOWN : v;
         }
     }
+
+    public static CharSequence of(String s) {
+        return s;
+    }
+
+    private HttpHeadersTestUtils() { }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpInvalidMessageTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpInvalidMessageTest.java
@@ -24,7 +24,11 @@ import org.junit.Test;
 
 import java.util.Random;
 
-import static org.junit.Assert.*;
+import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class HttpInvalidMessageTest {
 
@@ -52,7 +56,7 @@ public class HttpInvalidMessageTest {
         DecoderResult dr = req.decoderResult();
         assertFalse(dr.isSuccess());
         assertTrue(dr.isFailure());
-        assertEquals("Good Value", req.headers().get("Good_Name"));
+        assertEquals("Good Value", req.headers().get(of("Good_Name")));
         assertEquals("/maybe-something", req.uri());
         ensureInboundTrafficDiscarded(ch);
     }
@@ -80,7 +84,7 @@ public class HttpInvalidMessageTest {
         assertFalse(dr.isSuccess());
         assertTrue(dr.isFailure());
         assertEquals("Maybe OK", res.status().reasonPhrase());
-        assertEquals("Good Value", res.headers().get("Good_Name"));
+        assertEquals("Good Value", res.headers().get(of("Good_Name")));
         ensureInboundTrafficDiscarded(ch);
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import java.nio.channels.ClosedChannelException;
 import java.util.List;
 
+import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
 import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -48,7 +49,7 @@ public class HttpObjectAggregatorTest {
         EmbeddedChannel embedder = new EmbeddedChannel(aggr);
 
         HttpRequest message = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "http://localhost");
-        message.headers().set("X-Test", true);
+        message.headers().set(of("X-Test"), true);
         HttpContent chunk1 = new DefaultHttpContent(Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII));
         HttpContent chunk2 = new DefaultHttpContent(Unpooled.copiedBuffer("test2", CharsetUtil.US_ASCII));
         HttpContent chunk3 = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER);
@@ -64,7 +65,7 @@ public class HttpObjectAggregatorTest {
 
         assertEquals(chunk1.content().readableBytes() + chunk2.content().readableBytes(),
                 HttpUtil.getContentLength(aggratedMessage));
-        assertEquals(aggratedMessage.headers().get("X-Test"), Boolean.TRUE.toString());
+        assertEquals(aggratedMessage.headers().get(of("X-Test")), Boolean.TRUE.toString());
         checkContentBuffer(aggratedMessage);
         assertNull(embedder.readInbound());
     }
@@ -86,12 +87,12 @@ public class HttpObjectAggregatorTest {
         HttpObjectAggregator aggr = new HttpObjectAggregator(1024 * 1024);
         EmbeddedChannel embedder = new EmbeddedChannel(aggr);
         HttpRequest message = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "http://localhost");
-        message.headers().set("X-Test", true);
+        message.headers().set(of("X-Test"), true);
         HttpUtil.setTransferEncodingChunked(message, true);
         HttpContent chunk1 = new DefaultHttpContent(Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII));
         HttpContent chunk2 = new DefaultHttpContent(Unpooled.copiedBuffer("test2", CharsetUtil.US_ASCII));
         LastHttpContent trailer = new DefaultLastHttpContent();
-        trailer.trailingHeaders().set("X-Trailer", true);
+        trailer.trailingHeaders().set(of("X-Trailer"), true);
 
         assertFalse(embedder.writeInbound(message));
         assertFalse(embedder.writeInbound(chunk1));
@@ -105,8 +106,8 @@ public class HttpObjectAggregatorTest {
 
         assertEquals(chunk1.content().readableBytes() + chunk2.content().readableBytes(),
                 HttpUtil.getContentLength(aggratedMessage));
-        assertEquals(aggratedMessage.headers().get("X-Test"), Boolean.TRUE.toString());
-        assertEquals(aggratedMessage.trailingHeaders().get("X-Trailer"), Boolean.TRUE.toString());
+        assertEquals(aggratedMessage.headers().get(of("X-Test")), Boolean.TRUE.toString());
+        assertEquals(aggratedMessage.trailingHeaders().get(of("X-Trailer")), Boolean.TRUE.toString());
         checkContentBuffer(aggratedMessage);
         assertNull(embedder.readInbound());
     }
@@ -228,8 +229,8 @@ public class HttpObjectAggregatorTest {
         EmbeddedChannel embedder = new EmbeddedChannel(aggr);
 
         HttpRequest message = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.PUT, "http://localhost");
-        message.headers().set("X-Test", true);
-        message.headers().set("Transfer-Encoding", "Chunked");
+        message.headers().set(of("X-Test"), true);
+        message.headers().set(of("Transfer-Encoding"), of("Chunked"));
         HttpContent chunk1 = new DefaultHttpContent(Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII));
         HttpContent chunk2 = new DefaultHttpContent(Unpooled.copiedBuffer("test2", CharsetUtil.US_ASCII));
         HttpContent chunk3 = LastHttpContent.EMPTY_LAST_CONTENT;
@@ -245,7 +246,7 @@ public class HttpObjectAggregatorTest {
 
         assertEquals(chunk1.content().readableBytes() + chunk2.content().readableBytes(),
                 HttpUtil.getContentLength(aggratedMessage));
-        assertEquals(aggratedMessage.headers().get("X-Test"), Boolean.TRUE.toString());
+        assertEquals(aggratedMessage.headers().get(of("X-Test")), Boolean.TRUE.toString());
         checkContentBuffer(aggratedMessage);
         assertNull(embedder.readInbound());
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestDecoderTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty.handler.codec.http;
 
-
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
@@ -23,8 +22,16 @@ import org.junit.Test;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class HttpRequestDecoderTest {
     private static final byte[] CONTENT_CRLF_DELIMITERS = createContent("\r\n");
@@ -98,7 +105,7 @@ public class HttpRequestDecoderTest {
     }
 
     private static void checkHeader(HttpHeaders headers, String name, String value) {
-        List<String> header1 = headers.getAll(name);
+        List<String> header1 = headers.getAll(of(name));
         assertEquals(1, header1.size());
         assertEquals(value, header1.get(0));
     }
@@ -174,7 +181,7 @@ public class HttpRequestDecoderTest {
                 "EmptyHeader:" + crlf + crlf;
         channel.writeInbound(Unpooled.wrappedBuffer(request.getBytes(CharsetUtil.US_ASCII)));
         HttpRequest req = channel.readInbound();
-        assertEquals("", req.headers().get("EmptyHeader"));
+        assertEquals("", req.headers().get(of("EmptyHeader")));
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -24,8 +24,18 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class HttpResponseDecoderTest {
 
@@ -339,7 +349,7 @@ public class HttpResponseDecoderTest {
         HttpResponse res = ch.readInbound();
         assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
         assertThat(res.status(), is(HttpResponseStatus.OK));
-        assertThat(res.headers().get("X-Header"), is("h2=h2v2; Expires=Wed, 09-Jun-2021 10:18:14 GMT"));
+        assertThat(res.headers().get(of("X-Header")), is("h2=h2v2; Expires=Wed, 09-Jun-2021 10:18:14 GMT"));
         assertThat(ch.readInbound(), is(nullValue()));
 
         ch.writeInbound(Unpooled.wrappedBuffer(new byte[1024]));
@@ -377,7 +387,7 @@ public class HttpResponseDecoderTest {
         assertThat(lastContent.content().isReadable(), is(false));
         HttpHeaders headers = lastContent.trailingHeaders();
         assertEquals(1, headers.names().size());
-        List<String> values = headers.getAll("Set-Cookie");
+        List<String> values = headers.getAll(of("Set-Cookie"));
         assertEquals(2, values.size());
         assertTrue(values.contains("t1=t1v1"));
         assertTrue(values.contains("t2=t2v2; Expires=Wed, 09-Jun-2021 10:18:14 GMT"));
@@ -427,7 +437,7 @@ public class HttpResponseDecoderTest {
         assertThat(lastContent.content().isReadable(), is(false));
         HttpHeaders headers = lastContent.trailingHeaders();
         assertEquals(1, headers.names().size());
-        List<String> values = headers.getAll("Set-Cookie");
+        List<String> values = headers.getAll(of("Set-Cookie"));
         assertEquals(2, values.size());
         assertTrue(values.contains("t1=t1v1"));
         assertTrue(values.contains("t2=t2v2; Expires=Wed, 09-Jun-2021 10:18:14 GMT"));

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -16,13 +16,16 @@
 package io.netty.handler.codec.http;
 
 import io.netty.util.AsciiString;
-
 import org.junit.Test;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class HttpUtilTest {
 
@@ -39,12 +42,12 @@ public class HttpUtilTest {
     @Test
     public void testGetOperations() {
         HttpHeaders headers = new DefaultHttpHeaders();
-        headers.add("Foo", "1");
-        headers.add("Foo", "2");
+        headers.add(of("Foo"), of("1"));
+        headers.add(of("Foo"), of("2"));
 
-        assertEquals("1", headers.get("Foo"));
+        assertEquals("1", headers.get(of("Foo")));
 
-        List<String> values = headers.getAll("Foo");
+        List<String> values = headers.getAll(of("Foo"));
         assertEquals(2, values.size());
         assertEquals("1", values.get(0));
         assertEquals("2", values.get(1));

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsConfigTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsConfigTest.java
@@ -15,14 +15,21 @@
  */
 package io.netty.handler.codec.http.cors;
 
+import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import org.junit.Test;
 
-import static io.netty.handler.codec.http.cors.CorsConfig.*;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
+import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
+import static io.netty.handler.codec.http.cors.CorsConfig.withAnyOrigin;
+import static io.netty.handler.codec.http.cors.CorsConfig.withOrigin;
+import static io.netty.handler.codec.http.cors.CorsConfig.withOrigins;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CorsConfigTest {
 
@@ -96,13 +103,13 @@ public class CorsConfigTest {
     @Test
     public void preflightResponseHeadersSingleValue() {
         final CorsConfig cors = withAnyOrigin().preflightResponseHeader("SingleValue", "value").build();
-        assertThat(cors.preflightResponseHeaders().get("SingleValue"), equalTo("value"));
+        assertThat(cors.preflightResponseHeaders().get(of("SingleValue")), equalTo("value"));
     }
 
     @Test
     public void preflightResponseHeadersMultipleValues() {
         final CorsConfig cors = withAnyOrigin().preflightResponseHeader("MultipleValues", "value1", "value2").build();
-        assertThat(cors.preflightResponseHeaders().getAll("MultipleValues"), hasItems("value1", "value2"));
+        assertThat(cors.preflightResponseHeaders().getAll(of("MultipleValues")), hasItems("value1", "value2"));
     }
 
     @Test
@@ -115,7 +122,7 @@ public class CorsConfigTest {
     @Test
     public void emptyPreflightResponseHeaders() {
         final CorsConfig cors = withAnyOrigin().noPreflightResponseHeaders().build();
-        assertThat(cors.preflightResponseHeaders(), equalTo(HttpHeaders.EMPTY_HEADERS));
+        assertThat(cors.preflightResponseHeaders(), equalTo((HttpHeaders) EmptyHttpHeaders.INSTANCE));
     }
 
     @Test (expected = IllegalArgumentException.class)

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
@@ -28,12 +28,30 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 
-import static io.netty.handler.codec.http.HttpHeaderNames.*;
-import static io.netty.handler.codec.http.HttpMethod.*;
-import static io.netty.handler.codec.http.HttpResponseStatus.*;
-import static io.netty.handler.codec.http.HttpVersion.*;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS;
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS;
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS;
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN;
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCESS_CONTROL_EXPOSE_HEADERS;
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCESS_CONTROL_REQUEST_HEADERS;
+import static io.netty.handler.codec.http.HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.DATE;
+import static io.netty.handler.codec.http.HttpHeaderNames.ORIGIN;
+import static io.netty.handler.codec.http.HttpHeaderNames.VARY;
+import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
+import static io.netty.handler.codec.http.HttpMethod.DELETE;
+import static io.netty.handler.codec.http.HttpMethod.GET;
+import static io.netty.handler.codec.http.HttpMethod.OPTIONS;
+import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CorsHandlerTest {
 
@@ -116,7 +134,7 @@ public class CorsHandlerTest {
                 .preflightResponseHeader("CustomHeader", "somevalue")
                 .build();
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "content-type, xheader1");
-        assertThat(response.headers().get("CustomHeader"), equalTo("somevalue"));
+        assertThat(response.headers().get(of("CustomHeader")), equalTo("somevalue"));
         assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
     }
 
@@ -156,7 +174,7 @@ public class CorsHandlerTest {
                     }
                 }).build();
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "content-type, xheader1");
-        assertThat(response.headers().get("GenHeader"), equalTo("generatedValue"));
+        assertThat(response.headers().get(of("GenHeader")), equalTo("generatedValue"));
         assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
     }
 
@@ -326,7 +344,7 @@ public class CorsHandlerTest {
     }
 
     private static void assertValues(final HttpResponse response, final String headerName, final String... values) {
-        final String header = response.headers().get(headerName);
+        final String header = response.headers().get(of(headerName));
         for (String value : values) {
             assertThat(header, containsString(value));
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -26,7 +26,6 @@ import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
@@ -35,8 +34,11 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-import static io.netty.util.ReferenceCountUtil.*;
-import static org.junit.Assert.*;
+import static io.netty.util.ReferenceCountUtil.releaseLater;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /** {@link HttpPostRequestDecoder} test case. */
 public class HttpPostRequestDecoderTest {

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdySessionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdySessionHandlerTest.java
@@ -22,7 +22,6 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -75,6 +75,10 @@ final class Http2TestUtil {
         return new ByteString(randomBytes());
     }
 
+    public static CharSequence of(String s) {
+        return s;
+    }
+
     private Http2TestUtil() {
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -54,10 +54,11 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import static io.netty.handler.codec.http.HttpMethod.CONNECT;
-import static io.netty.handler.codec.http.HttpMethod.OPTIONS;
 import static io.netty.handler.codec.http.HttpMethod.GET;
+import static io.netty.handler.codec.http.HttpMethod.OPTIONS;
 import static io.netty.handler.codec.http.HttpMethod.POST;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static io.netty.handler.codec.http2.Http2TestUtil.of;
 import static io.netty.util.CharsetUtil.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -127,9 +128,9 @@ public class HttpToHttp2ConnectionHandlerTest {
         httpHeaders.set(HttpHeaderNames.HOST, "my-user_name@www.example.org:5555");
         httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.AUTHORITY.text(), "www.example.org:5555");
         httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http");
-        httpHeaders.add("foo", "goo");
-        httpHeaders.add("foo", "goo2");
-        httpHeaders.add("foo2", "goo2");
+        httpHeaders.add(of("foo"), of("goo"));
+        httpHeaders.add(of("foo"), of("goo2"));
+        httpHeaders.add(of("foo2"), of("goo2"));
         final Http2Headers http2Headers =
                 new DefaultHttp2Headers().method(new AsciiString("GET")).path(new AsciiString("/example"))
                 .authority(new AsciiString("www.example.org:5555")).scheme(new AsciiString("http"))
@@ -325,9 +326,9 @@ public class HttpToHttp2ConnectionHandlerTest {
                 Unpooled.copiedBuffer(text, UTF_8));
         final HttpHeaders httpHeaders = request.headers();
         httpHeaders.set(HttpHeaderNames.HOST, "www.example-origin.org:5555");
-        httpHeaders.add("foo", "goo");
-        httpHeaders.add("foo", "goo2");
-        httpHeaders.add("foo2", "goo2");
+        httpHeaders.add(of("foo"), of("goo"));
+        httpHeaders.add(of("foo"), of("goo2"));
+        httpHeaders.add(of("foo2"), of("goo2"));
         final Http2Headers http2Headers =
                 new DefaultHttp2Headers().method(new AsciiString("POST")).path(new AsciiString("/example"))
                 .authority(new AsciiString("www.example-origin.org:5555")).scheme(new AsciiString("http"))
@@ -368,9 +369,9 @@ public class HttpToHttp2ConnectionHandlerTest {
                 Unpooled.copiedBuffer(text, UTF_8));
         final HttpHeaders httpHeaders = request.headers();
         httpHeaders.set(HttpHeaderNames.HOST, "www.example.org:5555");
-        httpHeaders.add("foo", "goo");
-        httpHeaders.add("foo", "goo2");
-        httpHeaders.add("foo2", "goo2");
+        httpHeaders.add(of("foo"), of("goo"));
+        httpHeaders.add(of("foo"), of("goo2"));
+        httpHeaders.add(of("foo2"), of("goo2"));
         final Http2Headers http2Headers =
                 new DefaultHttp2Headers().method(new AsciiString("POST")).path(new AsciiString("/example"))
                         .authority(new AsciiString("www.example.org:5555")).scheme(new AsciiString("http"))
@@ -378,7 +379,7 @@ public class HttpToHttp2ConnectionHandlerTest {
                         .add(new AsciiString("foo"), new AsciiString("goo2"))
                         .add(new AsciiString("foo2"), new AsciiString("goo2"));
 
-        request.trailingHeaders().add("trailing", "bar");
+        request.trailingHeaders().add(of("trailing"), of("bar"));
 
         final Http2Headers http2TrailingHeaders = new DefaultHttp2Headers()
                 .add(new AsciiString("trailing"), new AsciiString("bar"));
@@ -420,9 +421,9 @@ public class HttpToHttp2ConnectionHandlerTest {
         final HttpHeaders httpHeaders = request.headers();
         httpHeaders.set(HttpHeaderNames.HOST, "www.example.org:5555");
         httpHeaders.add(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
-        httpHeaders.add("foo", "goo");
-        httpHeaders.add("foo", "goo2");
-        httpHeaders.add("foo2", "goo2");
+        httpHeaders.add(of("foo"), of("goo"));
+        httpHeaders.add(of("foo"), of("goo2"));
+        httpHeaders.add(of("foo2"), of("goo2"));
         final Http2Headers http2Headers =
                 new DefaultHttp2Headers().method(new AsciiString("POST")).path(new AsciiString("/example"))
                         .authority(new AsciiString("www.example.org:5555")).scheme(new AsciiString("http"))
@@ -433,7 +434,7 @@ public class HttpToHttp2ConnectionHandlerTest {
         final DefaultHttpContent httpContent = new DefaultHttpContent(Unpooled.copiedBuffer(text, UTF_8));
         final LastHttpContent lastHttpContent = new DefaultLastHttpContent(Unpooled.copiedBuffer(text2, UTF_8));
 
-        lastHttpContent.trailingHeaders().add("trailing", "bar");
+        lastHttpContent.trailingHeaders().add(of("trailing"), of("bar"));
 
         final Http2Headers http2TrailingHeaders = new DefaultHttp2Headers()
                 .add(new AsciiString("trailing"), new AsciiString("bar"));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -58,6 +58,7 @@ import java.util.concurrent.CountDownLatch;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.getEmbeddedHttp2Exception;
 import static io.netty.handler.codec.http2.Http2Exception.isStreamError;
+import static io.netty.handler.codec.http2.Http2TestUtil.of;
 import static io.netty.handler.codec.http2.Http2TestUtil.runInChannel;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -291,9 +292,9 @@ public class InboundHttp2ToHttpAdapterTest {
             httpHeaders.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 3);
             httpHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, text.length());
             HttpHeaders trailingHeaders = request.trailingHeaders();
-            trailingHeaders.set("FoO", "goo");
-            trailingHeaders.set("foO2", "goo2");
-            trailingHeaders.add("fOo2", "goo3");
+            trailingHeaders.set(of("FoO"), of("goo"));
+            trailingHeaders.set(of("foO2"), of("goo2"));
+            trailingHeaders.add(of("fOo2"), of("goo3"));
             final Http2Headers http2Headers = new DefaultHttp2Headers().method(new AsciiString("GET")).path(
                     new AsciiString("/some/path/resource2"));
             final Http2Headers http2Headers2 = new DefaultHttp2Headers()
@@ -331,9 +332,9 @@ public class InboundHttp2ToHttpAdapterTest {
             httpHeaders.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 3);
             httpHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, text.length());
             HttpHeaders trailingHeaders = request.trailingHeaders();
-            trailingHeaders.set("Foo", "goo");
-            trailingHeaders.set("fOo2", "goo2");
-            trailingHeaders.add("foO2", "goo3");
+            trailingHeaders.set(of("Foo"), of("goo"));
+            trailingHeaders.set(of("fOo2"), of("goo2"));
+            trailingHeaders.add(of("foO2"), of("goo3"));
             final Http2Headers http2Headers = new DefaultHttp2Headers().method(new AsciiString("GET")).path(
                     new AsciiString("/some/path/resource2"));
             final Http2Headers http2Headers2 = new DefaultHttp2Headers()


### PR DESCRIPTION
Motivaion:
The HttpHeaders and DefaultHttpHeaders have methods deprecated due to being removed in future releases, but no replacement method to use in the current release. The deprecation policy should not be so aggressive as to not provide any non-deprecated method to use.

Modifications:
- Remove deprecated annotations and javadocs from methods which are the best we can do in terms of matching the master's api for 4.1

Result:
There should be non-deprecated methods available for HttpHeaders in 4.1.