### PR TITLE
RecvByteBufAllocator.DelegatingHandle accessor

### DIFF
--- a/transport/src/main/java/io/netty/channel/RecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/RecvByteBufAllocator.java
@@ -113,6 +113,14 @@ public interface RecvByteBufAllocator {
             this.delegate = checkNotNull(delegate, "delegate");
         }
 
+        /**
+         * Get the {@link Handle} which all methods will be delegated to.
+         * @return the {@link Handle} which all methods will be delegated to.
+         */
+        protected final Handle delegate() {
+            return delegate;
+        }
+
         @Override
         public ByteBuf allocate(ByteBufAllocator alloc) {
             return delegate.allocate(alloc);


### PR DESCRIPTION
Motivation:
RecvByteBufAllocator.DelegatingHandle does not provide an accessor to get the delegate handle. This may be useful for classes that extend DelegatingHandle.

Modifications:
- add delegate() method to DelegatingHandle

Result:
Classes which inherit from DelegatingHandle can now access the delegate Handle.