### PR TITLE
Add validateHeaders and headersToLowerCase options for SPDY

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyHeaders.java
@@ -36,7 +36,13 @@ public class DefaultSpdyHeaders extends DefaultHeaders<CharSequence> implements 
     };
 
     public DefaultSpdyHeaders() {
-        super(CASE_INSENSITIVE_HASHER, HeaderValueConverterAndValidator.INSTANCE, SpydNameValidator);
+        this(true);
+    }
+
+    public DefaultSpdyHeaders(boolean validate) {
+        super(CASE_INSENSITIVE_HASHER,
+                validate ? HeaderValueConverterAndValidator.INSTANCE : HeaderValueConverter.INSTANCE,
+                validate ? SpydNameValidator : NameValidator.NOT_NULL);
     }
 
     @Override
@@ -269,8 +275,8 @@ public class DefaultSpdyHeaders extends DefaultHeaders<CharSequence> implements 
                 ignoreCase ? CASE_INSENSITIVE_HASHER : CASE_SENSITIVE_HASHER);
     }
 
-    private static final class HeaderValueConverterAndValidator extends CharSequenceValueConverter {
-        public static final HeaderValueConverterAndValidator INSTANCE = new HeaderValueConverterAndValidator();
+    private static class HeaderValueConverter extends CharSequenceValueConverter {
+        public static final HeaderValueConverter INSTANCE = new HeaderValueConverter();
 
         @Override
         public CharSequence convertObject(Object value) {
@@ -281,6 +287,16 @@ public class DefaultSpdyHeaders extends DefaultHeaders<CharSequence> implements 
                 seq = value.toString();
             }
 
+            return seq;
+        }
+    }
+
+    private static final class HeaderValueConverterAndValidator extends HeaderValueConverter {
+        public static final HeaderValueConverterAndValidator INSTANCE = new HeaderValueConverterAndValidator();
+
+        @Override
+        public CharSequence convertObject(Object value) {
+            final CharSequence seq = super.convertObject(value);
             SpdyCodecUtil.validateHeaderValue(seq);
             return seq;
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyHeadersFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyHeadersFrame.java
@@ -27,7 +27,7 @@ public class DefaultSpdyHeadersFrame extends DefaultSpdyStreamFrame
 
     private boolean invalid;
     private boolean truncated;
-    private final SpdyHeaders headers = new DefaultSpdyHeaders();
+    private final SpdyHeaders headers;
 
     /**
      * Creates a new instance.
@@ -35,7 +35,18 @@ public class DefaultSpdyHeadersFrame extends DefaultSpdyStreamFrame
      * @param streamId the Stream-ID of this frame
      */
     public DefaultSpdyHeadersFrame(int streamId) {
+        this(streamId, true);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param streamId the Stream-ID of this frame
+     * @param validate validate the header names and values when adding them to the {@link SpdyHeaders}
+     */
+    public DefaultSpdyHeadersFrame(int streamId, boolean validate) {
         super(streamId);
+        headers = new DefaultSpdyHeaders(validate);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdySynReplyFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdySynReplyFrame.java
@@ -32,6 +32,16 @@ public class DefaultSpdySynReplyFrame extends DefaultSpdyHeadersFrame
         super(streamId);
     }
 
+    /**
+     * Creates a new instance.
+     *
+     * @param streamId        the Stream-ID of this frame
+     * @param validateHeaders validate the header names and values when adding them to the {@link SpdyHeaders}
+     */
+    public DefaultSpdySynReplyFrame(int streamId, boolean validateHeaders) {
+        super(streamId, validateHeaders);
+    }
+
     @Override
     public SpdySynReplyFrame setStreamId(int streamId) {
         super.setStreamId(streamId);

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdySynStreamFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdySynStreamFrame.java
@@ -35,7 +35,19 @@ public class DefaultSpdySynStreamFrame extends DefaultSpdyHeadersFrame
      * @param priority           the priority of the stream
      */
     public DefaultSpdySynStreamFrame(int streamId, int associatedStreamId, byte priority) {
-        super(streamId);
+        this(streamId, associatedStreamId, priority, true);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param streamId           the Stream-ID of this frame
+     * @param associatedStreamId the Associated-To-Stream-ID of this frame
+     * @param priority           the priority of the stream
+     * @param validateHeaders    validate the header names and values when adding them to the {@link SpdyHeaders}
+     */
+    public DefaultSpdySynStreamFrame(int streamId, int associatedStreamId, byte priority, boolean validateHeaders) {
+        super(streamId, validateHeaders);
         setAssociatedStreamId(associatedStreamId);
         setPriority(priority);
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
@@ -44,35 +44,62 @@ public class SpdyFrameCodec extends ByteToMessageDecoder implements SpdyFrameDec
 
     private ChannelHandlerContext ctx;
     private boolean read;
+    private final boolean validateHeaders;
 
     /**
-     * Creates a new instance with the specified {@code version} and
+     * Creates a new instance with the specified {@code version},
+     * {@code validateHeaders (true)}, and
      * the default decoder and encoder options
      * ({@code maxChunkSize (8192)}, {@code maxHeaderSize (16384)},
      * {@code compressionLevel (6)}, {@code windowBits (15)},
      * and {@code memLevel (8)}).
      */
     public SpdyFrameCodec(SpdyVersion version) {
-        this(version, 8192, 16384, 6, 15, 8);
+        this(version, true);
     }
 
     /**
-     * Creates a new instance with the specified decoder and encoder options.
+     * Creates a new instance with the specified {@code version},
+     * {@code validateHeaders}, and
+     * the default decoder and encoder options
+     * ({@code maxChunkSize (8192)}, {@code maxHeaderSize (16384)},
+     * {@code compressionLevel (6)}, {@code windowBits (15)},
+     * and {@code memLevel (8)}).
+     */
+    public SpdyFrameCodec(SpdyVersion version, boolean validateHeaders) {
+        this(version, 8192, 16384, 6, 15, 8, validateHeaders);
+    }
+
+    /**
+     * Creates a new instance with the specified {@code version}, {@code validateHeaders (true)},
+     * decoder and encoder options.
      */
     public SpdyFrameCodec(
             SpdyVersion version, int maxChunkSize, int maxHeaderSize,
             int compressionLevel, int windowBits, int memLevel) {
+        this(version, maxChunkSize, maxHeaderSize, compressionLevel, windowBits, memLevel, true);
+    }
+
+    /**
+     * Creates a new instance with the specified {@code version}, {@code validateHeaders},
+     * decoder and encoder options.
+     */
+    public SpdyFrameCodec(
+            SpdyVersion version, int maxChunkSize, int maxHeaderSize,
+            int compressionLevel, int windowBits, int memLevel, boolean validateHeaders) {
         this(version, maxChunkSize,
                 SpdyHeaderBlockDecoder.newInstance(version, maxHeaderSize),
-                SpdyHeaderBlockEncoder.newInstance(version, compressionLevel, windowBits, memLevel));
+                SpdyHeaderBlockEncoder.newInstance(version, compressionLevel, windowBits, memLevel), validateHeaders);
     }
 
     protected SpdyFrameCodec(SpdyVersion version, int maxChunkSize,
-            SpdyHeaderBlockDecoder spdyHeaderBlockDecoder, SpdyHeaderBlockEncoder spdyHeaderBlockEncoder) {
+            SpdyHeaderBlockDecoder spdyHeaderBlockDecoder, SpdyHeaderBlockEncoder spdyHeaderBlockEncoder,
+            boolean validateHeaders) {
         spdyFrameDecoder = new SpdyFrameDecoder(version, this, maxChunkSize);
         spdyFrameEncoder = new SpdyFrameEncoder(version);
         this.spdyHeaderBlockDecoder = spdyHeaderBlockDecoder;
         this.spdyHeaderBlockEncoder = spdyHeaderBlockEncoder;
+        this.validateHeaders = validateHeaders;
     }
 
     @Override
@@ -235,7 +262,8 @@ public class SpdyFrameCodec extends ByteToMessageDecoder implements SpdyFrameDec
     @Override
     public void readSynStreamFrame(
             int streamId, int associatedToStreamId, byte priority, boolean last, boolean unidirectional) {
-        SpdySynStreamFrame spdySynStreamFrame = new DefaultSpdySynStreamFrame(streamId, associatedToStreamId, priority);
+        SpdySynStreamFrame spdySynStreamFrame =
+                new DefaultSpdySynStreamFrame(streamId, associatedToStreamId, priority, validateHeaders);
         spdySynStreamFrame.setLast(last);
         spdySynStreamFrame.setUnidirectional(unidirectional);
         spdyHeadersFrame = spdySynStreamFrame;
@@ -243,7 +271,7 @@ public class SpdyFrameCodec extends ByteToMessageDecoder implements SpdyFrameDec
 
     @Override
     public void readSynReplyFrame(int streamId, boolean last) {
-        SpdySynReplyFrame spdySynReplyFrame = new DefaultSpdySynReplyFrame(streamId);
+        SpdySynReplyFrame spdySynReplyFrame = new DefaultSpdySynReplyFrame(streamId, validateHeaders);
         spdySynReplyFrame.setLast(last);
         spdyHeadersFrame = spdySynReplyFrame;
     }
@@ -296,7 +324,7 @@ public class SpdyFrameCodec extends ByteToMessageDecoder implements SpdyFrameDec
 
     @Override
     public void readHeadersFrame(int streamId, boolean last) {
-        spdyHeadersFrame = new DefaultSpdyHeadersFrame(streamId);
+        spdyHeadersFrame = new DefaultSpdyHeadersFrame(streamId, validateHeaders);
         spdyHeadersFrame.setLast(last);
     }
 


### PR DESCRIPTION
Motivation:

Related to issue #4185.

HTTP has the option to disable header validation for optimisation purposes.  Introduce the same option for ```SpdyHeaders```.
Also, optimise ```SpdyHttpEncoder``` by allowing the user to specify whether or not the encoder needs to convert header names to lowercase.

Modifications:

Added flags for validation and conversion.

Result:

```SpdyHeader``` validation and conversion can be disabled.