### PR TITLE
Optimize ByteBufUtil.writeUsAscii(...) when AsciiString is used.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -17,6 +17,7 @@ package io.netty.buffer;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
+import io.netty.util.AsciiString;
 import io.netty.util.ByteProcessor;
 import io.netty.util.ByteString;
 import io.netty.util.CharsetUtil;
@@ -498,7 +499,10 @@ public final class ByteBufUtil {
         // ASCII uses 1 byte per char
         final int len = seq.length();
         buf.ensureWritable(len);
-        if (buf instanceof AbstractByteBuf) {
+        if (seq instanceof AsciiString) {
+            AsciiString asciiString = (AsciiString) seq;
+            buf.writeBytes(asciiString.array(), asciiString.arrayOffset(), asciiString.length());
+        } else if (buf instanceof AbstractByteBuf) {
             // Fast-Path
             AbstractByteBuf buffer = (AbstractByteBuf) buf;
             int writerIndex = buffer.writerIndex;

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -17,6 +17,8 @@ package io.netty.buffer;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
 
@@ -102,6 +104,17 @@ public class ByteBufUtilTest {
         buf.writeBytes(usAscii.getBytes(CharsetUtil.UTF_8));
         ByteBuf buf2 = ReferenceCountUtil.releaseLater(Unpooled.buffer(16));
         ByteBufUtil.writeUtf8(buf2, usAscii);
+
+        Assert.assertEquals(buf, buf2);
+    }
+
+    @Test
+    public void testWriteUsAsciiString() {
+        AsciiString usAscii = new AsciiString("NettyRocks");
+        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(16));
+        buf.writeBytes(usAscii.toString().getBytes(CharsetUtil.US_ASCII));
+        ByteBuf buf2 = ReferenceCountUtil.releaseLater(Unpooled.buffer(16));
+        ByteBufUtil.writeAscii(buf2, usAscii);
 
         Assert.assertEquals(buf, buf2);
     }


### PR DESCRIPTION
Motivation:

When AsciiString is used we can optimize the write operation done by ByteBufUtil.writeUsAscii(...)

Modifications:

Sepcial handle AsciiString.

Result:

Faster writing of AsciiString.