### PR TITLE
[#3687] Correctly store WebSocketServerHandshaker in Channel attributes

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -102,7 +103,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     @Override
     protected void decode(ChannelHandlerContext ctx, WebSocketFrame frame, List<Object> out) throws Exception {
         if (frame instanceof CloseWebSocketFrame) {
-            WebSocketServerHandshaker handshaker = getHandshaker(ctx);
+            WebSocketServerHandshaker handshaker = getHandshaker(ctx.channel());
             if (handshaker != null) {
                 frame.retain();
                 handshaker.close(ctx.channel(), (CloseWebSocketFrame) frame);
@@ -125,12 +126,12 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
         }
     }
 
-    static WebSocketServerHandshaker getHandshaker(ChannelHandlerContext ctx) {
-        return ctx.attr(HANDSHAKER_ATTR_KEY).get();
+    static WebSocketServerHandshaker getHandshaker(Channel channel) {
+        return channel.attr(HANDSHAKER_ATTR_KEY).get();
     }
 
-    static void setHandshaker(ChannelHandlerContext ctx, WebSocketServerHandshaker handshaker) {
-        ctx.attr(HANDSHAKER_ATTR_KEY).set(handshaker);
+    static void setHandshaker(Channel channel, WebSocketServerHandshaker handshaker) {
+        channel.attr(HANDSHAKER_ATTR_KEY).set(handshaker);
     }
 
     static ChannelHandler forbiddenHttpRequestResponder() {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -78,7 +78,7 @@ class WebSocketServerProtocolHandshakeHandler
                         }
                     }
                 });
-                WebSocketServerProtocolHandler.setHandshaker(ctx, handshaker);
+                WebSocketServerProtocolHandler.setHandshaker(ctx.channel(), handshaker);
                 ctx.pipeline().replace(this, "WS403Responder",
                         WebSocketServerProtocolHandler.forbiddenHttpRequestResponder());
             }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
@@ -55,7 +55,7 @@ public class WebSocketServerProtocolHandlerTest {
         ChannelHandlerContext handshakerCtx = ch.pipeline().context(WebSocketServerProtocolHandshakeHandler.class);
         writeUpgradeRequest(ch);
         assertEquals(SWITCHING_PROTOCOLS, ReferenceCountUtil.releaseLater(responses.remove()).getStatus());
-        assertNotNull(WebSocketServerProtocolHandler.getHandshaker(handshakerCtx));
+        assertNotNull(WebSocketServerProtocolHandler.getHandshaker(handshakerCtx.channel()));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

As we stored the WebSocketServerHandshaker in the ChannelHandlerContext it was always null and so no close frame was send if WebSocketServerProtocolHandler was used.

Modifications:

Store WebSocketServerHAndshaker in the Channel attributes and so make it visibile between different handlers.

Result:

Correctly send close frame.