### PR TITLE
Upgrade jzlib version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -704,7 +704,7 @@
       <dependency>
         <groupId>com.jcraft</groupId>
         <artifactId>jzlib</artifactId>
-        <version>1.1.2</version>
+        <version>1.1.3</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Motivation:

A new version of jzlib was released some time ago.

Modifications:

Upgrade to the newest jzlib version.

Result:

Using latest release.