### PR TITLE
HTTP/2 defines using String instead of CharSequence

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
@@ -75,13 +75,13 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator implements Ch
         /**
          * Returns the name of the protocol supported by this codec, as indicated by the {@code 'UPGRADE'} header.
          */
-        String protocol();
+        CharSequence protocol();
 
         /**
          * Sets any protocol-specific headers required to the upgrade request. Returns the names of
          * all headers that were added. These headers will be used to populate the CONNECTION header.
          */
-        Collection<String> setUpgradeHeaders(ChannelHandlerContext ctx, HttpRequest upgradeRequest);
+        Collection<CharSequence> setUpgradeHeaders(ChannelHandlerContext ctx, HttpRequest upgradeRequest);
 
         /**
          * Performs an HTTP protocol upgrade from the source codec. This method is responsible for
@@ -257,12 +257,12 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator implements Ch
         request.headers().set(HttpHeaderNames.UPGRADE, upgradeCodec.protocol());
 
         // Add all protocol-specific headers to the request.
-        Set<String> connectionParts = new LinkedHashSet<String>(2);
+        Set<CharSequence> connectionParts = new LinkedHashSet<CharSequence>(2);
         connectionParts.addAll(upgradeCodec.setUpgradeHeaders(ctx, request));
 
         // Set the CONNECTION header from the set of all protocol-specific headers that were added.
         StringBuilder builder = new StringBuilder();
-        for (String part : connectionParts) {
+        for (CharSequence part : connectionParts) {
             builder.append(part);
             builder.append(',');
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
@@ -157,6 +157,10 @@ public final class HttpHeaderValues {
      */
     public static final AsciiString NONE = new AsciiString("none");
     /**
+     * {@code "0"}
+     */
+    public static final AsciiString ZERO = new AsciiString("0");
+    /**
      * {@code "only-if-cached"}
      */
     public static final AsciiString ONLY_IF_CACHED = new AsciiString("only-if-cached");

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodec.java
@@ -41,7 +41,7 @@ import java.util.List;
  */
 public class Http2ClientUpgradeCodec implements HttpClientUpgradeHandler.UpgradeCodec {
 
-    private static final List<String> UPGRADE_HEADERS = Collections.singletonList(HTTP_UPGRADE_SETTINGS_HEADER);
+    private static final List<CharSequence> UPGRADE_HEADERS = Collections.singletonList(HTTP_UPGRADE_SETTINGS_HEADER);
 
     private final String handlerName;
     private final Http2ConnectionHandler connectionHandler;
@@ -69,14 +69,14 @@ public class Http2ClientUpgradeCodec implements HttpClientUpgradeHandler.Upgrade
     }
 
     @Override
-    public String protocol() {
+    public CharSequence protocol() {
         return HTTP_UPGRADE_PROTOCOL_NAME;
     }
 
     @Override
-    public Collection<String> setUpgradeHeaders(ChannelHandlerContext ctx,
+    public Collection<CharSequence> setUpgradeHeaders(ChannelHandlerContext ctx,
             HttpRequest upgradeRequest) {
-        String settingsValue = getSettingsHeaderValue(ctx);
+        CharSequence settingsValue = getSettingsHeaderValue(ctx);
         upgradeRequest.headers().set(HTTP_UPGRADE_SETTINGS_HEADER, settingsValue);
         return UPGRADE_HEADERS;
     }
@@ -95,7 +95,7 @@ public class Http2ClientUpgradeCodec implements HttpClientUpgradeHandler.Upgrade
      * Converts the current settings for the handler to the Base64-encoded representation used in
      * the HTTP2-Settings upgrade header.
      */
-    private String getSettingsHeaderValue(ChannelHandlerContext ctx) {
+    private CharSequence getSettingsHeaderValue(ChannelHandlerContext ctx) {
         ByteBuf buf = null;
         ByteBuf encodedBuf = null;
         try {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.util.AsciiString;
 import io.netty.util.concurrent.EventExecutor;
 
 import static io.netty.buffer.Unpooled.directBuffer;
@@ -36,9 +37,9 @@ import static io.netty.util.CharsetUtil.UTF_8;
 public final class Http2CodecUtil {
     public static final int CONNECTION_STREAM_ID = 0;
     public static final int HTTP_UPGRADE_STREAM_ID = 1;
-    public static final String HTTP_UPGRADE_SETTINGS_HEADER = "HTTP2-Settings";
-    public static final String HTTP_UPGRADE_PROTOCOL_NAME = "h2c";
-    public static final String TLS_UPGRADE_PROTOCOL_NAME = ApplicationProtocolNames.HTTP_2;
+    public static final CharSequence HTTP_UPGRADE_SETTINGS_HEADER = new AsciiString("HTTP2-Settings");
+    public static final CharSequence HTTP_UPGRADE_PROTOCOL_NAME = "h2c";
+    public static final CharSequence TLS_UPGRADE_PROTOCOL_NAME = ApplicationProtocolNames.HTTP_2;
 
     public static final int PING_FRAME_PAYLOAD_LENGTH = 8;
     public static final short MAX_UNSIGNED_BYTE = 0xFF;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
@@ -41,7 +41,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  */
 public class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.UpgradeCodec {
 
-    private static final List<String> REQUIRED_UPGRADE_HEADERS =
+    private static final List<CharSequence> REQUIRED_UPGRADE_HEADERS =
             Collections.singletonList(HTTP_UPGRADE_SETTINGS_HEADER);
 
     private final String handlerName;
@@ -72,7 +72,7 @@ public class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.Upgrade
     }
 
     @Override
-    public Collection<String> requiredUpgradeHeaders() {
+    public Collection<CharSequence> requiredUpgradeHeaders() {
         return REQUIRED_UPGRADE_HEADERS;
     }
 

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -22,6 +22,7 @@ import io.netty.util.internal.PlatformDependent;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -881,6 +882,42 @@ public final class AsciiString extends ByteString implements CharSequence, Compa
             char c1 = a.charAt(i);
             char c2 = b.charAt(j);
             if (c1 != c2 && toLowerCase(c1) != toLowerCase(c2)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Determine if {@code collection} contains {@code value} and using
+     * {@link #contentEqualsIgnoreCase(CharSequence, CharSequence)} to compare values.
+     * @param collection The collection to look for and equivalent element as {@code value}.
+     * @param value The value to look for in {@code collection}.
+     * @return {@code true} if {@code collection} contains {@code value} according to
+     * {@link #contentEqualsIgnoreCase(CharSequence, CharSequence)}. {@code false} otherwise.
+     * @see #contentEqualsIgnoreCase(CharSequence, CharSequence)
+     */
+    public static boolean containsContentEqualsIgnoreCase(Collection<CharSequence> collection, CharSequence value) {
+        for (CharSequence v : collection) {
+            if (contentEqualsIgnoreCase(value, v)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Determine if {@code a} contains all of the values in {@code b} using
+     * {@link #contentEqualsIgnoreCase(CharSequence, CharSequence)} to compare values.
+     * @param a The collection under test.
+     * @param b The values to test for.
+     * @return {@code true} if {@code a} contains all of the values in {@code b} using
+     * {@link #contentEqualsIgnoreCase(CharSequence, CharSequence)} to compare values. {@code false} otherwise.
+     * @see #contentEqualsIgnoreCase(CharSequence, CharSequence)
+     */
+    public static boolean containsAllContentEqualsIgnoreCase(Collection<CharSequence> a, Collection<CharSequence> b) {
+        for (CharSequence v : b) {
+            if (!containsContentEqualsIgnoreCase(a, v)) {
                 return false;
             }
         }

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/Http2ServerInitializer.java
@@ -31,6 +31,7 @@ import io.netty.handler.codec.http.HttpServerUpgradeHandler.UpgradeCodecFactory;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
 import io.netty.handler.ssl.SslContext;
+import io.netty.util.AsciiString;
 
 /**
  * Sets up the Netty pipeline for the example server. Depending on the endpoint config, sets up the
@@ -40,8 +41,8 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
 
     private static final UpgradeCodecFactory upgradeCodecFactory = new UpgradeCodecFactory() {
         @Override
-        public UpgradeCodec newUpgradeCodec(String protocol) {
-            if (Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME.equals(protocol)) {
+        public UpgradeCodec newUpgradeCodec(CharSequence protocol) {
+            if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
                 return new Http2ServerUpgradeCodec(new HelloWorldHttp2Handler());
             } else {
                 return null;


### PR DESCRIPTION
Motivation:
Http2CodecUtils has some static variables which are defined as Strings instead of CharSequence. One of these defines is used as a header name and should be AsciiString.

Modifications:
- Change the String defines in Http2CodecUtils to CharSequence

Result:
Types are more consistently using CharSequence and adding the upgrade header will require less work.