### PR TITLE
HTTP/2 to HTTP/1.x headers conversion more accessible

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -95,10 +95,33 @@ public final class HttpUtil {
      *     <li>remove otherwise.</li>
      *     </ul></li>
      * </ul>
+     * @see #setKeepAlive(HttpHeaders, HttpVersion, boolean)
      */
     public static void setKeepAlive(HttpMessage message, boolean keepAlive) {
-        HttpHeaders h = message.headers();
-        if (message.protocolVersion().isKeepAliveDefault()) {
+        setKeepAlive(message.headers(), message.protocolVersion(), keepAlive);
+    }
+
+    /**
+     * Sets the value of the {@code "Connection"} header depending on the
+     * protocol version of the specified message. This getMethod sets or removes
+     * the {@code "Connection"} header depending on what the default keep alive
+     * mode of the message's protocol version is, as specified by
+     * {@link HttpVersion#isKeepAliveDefault()}.
+     * <ul>
+     * <li>If the connection is kept alive by default:
+     *     <ul>
+     *     <li>set to {@code "close"} if {@code keepAlive} is {@code false}.</li>
+     *     <li>remove otherwise.</li>
+     *     </ul></li>
+     * <li>If the connection is closed by default:
+     *     <ul>
+     *     <li>set to {@code "keep-alive"} if {@code keepAlive} is {@code true}.</li>
+     *     <li>remove otherwise.</li>
+     *     </ul></li>
+     * </ul>
+     */
+    public static void setKeepAlive(HttpHeaders h, HttpVersion httpVersion, boolean keepAlive) {
+        if (httpVersion.isKeepAliveDefault()) {
             if (keepAlive) {
                 h.remove(HttpHeaderNames.CONNECTION);
             } else {


### PR DESCRIPTION
Motivation:
Currently there is a HttpConversionUtil.addHttp2ToHttpHeaders which requires a FullHttpMessage, but this may not always be available. There is no interface that can be used with just Http2Headers and HttpHeaders.

Modifications:
- add an overload for HttpConversionUtil.addHttp2ToHttpHeaders which does not take FullHttpMessage

Result:
An overload for HttpConversionUtil.addHttp2ToHttpHeaders exists which does not require FullHttpMessage.