### PR TITLE
Update twitter hpack version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -662,7 +662,7 @@
       <dependency>
         <groupId>com.twitter</groupId>
         <artifactId>hpack</artifactId>
-        <version>0.11.0</version>
+        <version>v1.0.1</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty.npn</groupId>


### PR DESCRIPTION
Motivation:
https://github.com/twitter/hpack released version v1.0.1.

Modifications:
- Update pom files to pull in new version

Results:
Depend on the most recent hpack library.