### PR TITLE
SpdyHttpHeaders are not lowercase

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyHeaders.java
@@ -39,6 +39,7 @@ public class DefaultSpdyHeaders extends DefaultHeaders<CharSequence> implements 
         this(true);
     }
 
+    @SuppressWarnings("unchecked")
     public DefaultSpdyHeaders(boolean validate) {
         super(CASE_INSENSITIVE_HASHER,
                 validate ? HeaderValueConverterAndValidator.INSTANCE : HeaderValueConverter.INSTANCE,

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpHeaders.java
@@ -28,21 +28,21 @@ public final class SpdyHttpHeaders {
      */
     public static final class Names {
         /**
-         * {@code "X-SPDY-Stream-ID"}
+         * {@code "x-spdy-stream-id"}
          */
-        public static final AsciiString STREAM_ID = new AsciiString("X-SPDY-Stream-ID");
+        public static final AsciiString STREAM_ID = new AsciiString("x-spdy-stream-id");
         /**
-         * {@code "X-SPDY-Associated-To-Stream-ID"}
+         * {@code "x-spdy-associated-to-stream-id"}
          */
-        public static final AsciiString ASSOCIATED_TO_STREAM_ID = new AsciiString("X-SPDY-Associated-To-Stream-ID");
+        public static final AsciiString ASSOCIATED_TO_STREAM_ID = new AsciiString("x-spdy-associated-to-stream-id");
         /**
-         * {@code "X-SPDY-Priority"}
+         * {@code "x-spdy-priority"}
          */
-        public static final AsciiString PRIORITY = new AsciiString("X-SPDY-Priority");
+        public static final AsciiString PRIORITY = new AsciiString("x-spdy-priority");
         /**
-         * {@code "X-SPDY-Scheme"}
+         * {@code "x-spdy-scheme"}
          */
-        public static final AsciiString SCHEME = new AsciiString("X-SPDY-Scheme");
+        public static final AsciiString SCHEME = new AsciiString("x-spdy-scheme");
 
         private Names() { }
     }


### PR DESCRIPTION
Motivation:
According to the SPDY spec https://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3-1#TOC-3.2.1-Request header names must be lowercase. Our predefined SPDY extension headers are not lowercase.

Modifications
- SpdyHttpHeaders should define header names in lower case

Result:
Compliant with SPDY spec, and header validation code does not detect errors for our own header names.