### PR TITLE
Http2RemoteFlowController stream writibility listener

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -14,21 +14,23 @@
  */
 package io.netty.handler.codec.http2;
 
-import static io.netty.handler.codec.http2.Http2CodecUtil.CONNECTION_STREAM_ID;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.StreamByteDistributor.Writer;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
 import static io.netty.handler.codec.http2.Http2Error.FLOW_CONTROL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.streamError;
+import static io.netty.handler.codec.http2.Http2Stream.State.HALF_CLOSED_LOCAL;
 import static io.netty.handler.codec.http2.Http2Stream.State.IDLE;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http2.Http2Stream.State;
-
-import java.util.ArrayDeque;
-import java.util.Deque;
 
 /**
  * Basic implementation of {@link Http2RemoteFlowController}.
@@ -37,38 +39,44 @@ import java.util.Deque;
  * Typically this thread is the event loop thread for the {@link ChannelHandlerContext} managed by this class.
  */
 public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowController {
+    private static final InternalLogger logger =
+            InternalLoggerFactory.getInstance(DefaultHttp2RemoteFlowController.class);
     private static final int MIN_WRITABLE_CHUNK = 32 * 1024;
-
-    private final StreamByteDistributor.Writer writer = new StreamByteDistributor.Writer() {
-        @Override
-        public void write(Http2Stream stream, int numBytes) {
-            int written = state(stream).writeAllocatedBytes(numBytes);
-            if (written != -1 && listener != null) {
-                listener.streamWritten(stream, written);
-            }
-        }
-    };
     private final Http2Connection connection;
     private final Http2Connection.PropertyKey stateKey;
     private final StreamByteDistributor streamByteDistributor;
     private final AbstractState connectionState;
     private int initialWindowSize = DEFAULT_WINDOW_SIZE;
+    private WritabilityMonitor monitor;
     private ChannelHandlerContext ctx;
-    private Listener listener;
 
     public DefaultHttp2RemoteFlowController(Http2Connection connection) {
-        this(connection, new PriorityStreamByteDistributor(connection));
+        this(connection, (Listener) null);
     }
 
     public DefaultHttp2RemoteFlowController(Http2Connection connection,
                                             StreamByteDistributor streamByteDistributor) {
+        this(connection, streamByteDistributor, null);
+    }
+
+    public DefaultHttp2RemoteFlowController(Http2Connection connection, final Listener listener) {
+        this(connection, new PriorityStreamByteDistributor(connection), listener);
+    }
+
+    public DefaultHttp2RemoteFlowController(Http2Connection connection,
+                                            StreamByteDistributor streamByteDistributor,
+                                            final Listener listener) {
         this.connection = checkNotNull(connection, "connection");
         this.streamByteDistributor = checkNotNull(streamByteDistributor, "streamWriteDistributor");
 
         // Add a flow state for the connection.
         stateKey = connection.newKey();
-        connectionState = new DefaultState(connection.connectionStream(), initialWindowSize);
+        connectionState = new DefaultState(connection.connectionStream(), initialWindowSize,
+                initialWindowSize > 0 && isChannelWritable());
         connection.connectionStream().setProperty(stateKey, connectionState);
+
+        // Monitor may depend upon connectionState, and so initialize after connectionState
+        listener(listener);
 
         // Register for notification of new streams.
         connection.addListener(new Http2ConnectionAdapter() {
@@ -78,7 +86,8 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
                 // only requires the ReducedFlowState. Otherwise the full amount of memory is required.
                 stream.setProperty(stateKey, stream.state() == IDLE ?
                         new ReducedState(stream) :
-                        new DefaultState(stream, 0));
+                        new DefaultState(stream, 0,
+                                isWritable(DefaultHttp2RemoteFlowController.this.connection.connectionStream())));
             }
 
             @Override
@@ -104,13 +113,16 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
                 // decrease the amount of memory required for this stream because no flow controlled frames can
                 // be exchanged on this stream
                 if (stream.prioritizableForTree() != 0) {
-                    stream.setProperty(stateKey, new ReducedState(state));
+                    state = new ReducedState(state);
+                    stream.setProperty(stateKey, state);
                 }
+                // Tell the monitor after cancel has been called and after the new state is used.
+                monitor.stateCancelled(state);
             }
 
             @Override
             public void onStreamHalfClosed(Http2Stream stream) {
-                if (State.HALF_CLOSED_LOCAL.equals(stream.state())) {
+                if (HALF_CLOSED_LOCAL.equals(stream.state())) {
                     /**
                      * When this method is called there should not be any
                      * pending frames left if the API is used correctly. However,
@@ -122,7 +134,9 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
                      *
                      * This is to cancel any such illegal writes.
                      */
-                    state(stream).cancel();
+                    AbstractState state = state(stream);
+                    state.cancel();
+                    monitor.stateCancelled(state);
                 }
             }
         });
@@ -137,11 +151,15 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
     public void channelHandlerContext(ChannelHandlerContext ctx) throws Http2Exception {
         this.ctx = ctx;
 
+        // Writing the pending bytes will not check writability change and instead a writability change notification
+        // to be provided by an explicit call.
+        channelWritabilityChanged();
+
         // Don't worry about cleaning up queued frames here if ctx is null. It is expected that all streams will be
         // closed and the queue cleanup will occur when the stream state transitions occur.
 
         // If any frames have been queued up, we should send them now that we have a channel context.
-        if (ctx != null && ctx.channel().isWritable()) {
+        if (isChannelWritable()) {
             writePendingBytes();
         }
     }
@@ -154,25 +172,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
     @Override
     public void initialWindowSize(int newWindowSize) throws Http2Exception {
         assert ctx == null || ctx.executor().inEventLoop();
-        if (newWindowSize < 0) {
-            throw new IllegalArgumentException("Invalid initial window size: " + newWindowSize);
-        }
-
-        final int delta = newWindowSize - initialWindowSize;
-        initialWindowSize = newWindowSize;
-        connection.forEachActiveStream(new Http2StreamVisitor() {
-            @Override
-            public boolean visit(Http2Stream stream) throws Http2Exception {
-                // Verify that the maximum value is not exceeded by this change.
-                state(stream).incrementStreamWindow(delta);
-                return true;
-            }
-        });
-
-        if (delta > 0) {
-            // The window size increased, send any pending frames for all streams.
-            writePendingBytes();
-        }
+        monitor.initialWindowSize(newWindowSize);
     }
 
     @Override
@@ -186,6 +186,29 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
     }
 
     @Override
+    public boolean isWritable(Http2Stream stream) {
+        return monitor.isWritable(state(stream));
+    }
+
+    @Override
+    public void channelWritabilityChanged() throws Http2Exception {
+        monitor.channelWritabilityChange();
+    }
+
+    private boolean isChannelWritable() {
+        return ctx != null && isChannelWritable0();
+    }
+
+    private boolean isChannelWritable0() {
+        return ctx.channel().isWritable();
+    }
+
+    @Override
+    public void listener(Listener listener) {
+        monitor = listener == null ? new DefaultWritabilityMonitor() : new ListenerWritabilityMonitor(listener);
+    }
+
+    @Override
     public int initialWindowSize(Http2Stream stream) {
         return state(stream).initialWindowSize();
     }
@@ -193,24 +216,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
     @Override
     public void incrementWindowSize(Http2Stream stream, int delta) throws Http2Exception {
         assert ctx == null || ctx.executor().inEventLoop();
-        if (stream.id() == CONNECTION_STREAM_ID) {
-            // Update the connection window
-            connectionState.incrementStreamWindow(delta);
-        } else {
-            // Update the stream window
-            AbstractState state = state(stream);
-            state.incrementStreamWindow(delta);
-        }
-    }
-
-    @Override
-    public void listener(Listener listener) {
-        this.listener = listener;
-    }
-
-    @Override
-    public Listener listener() {
-        return this.listener;
+        monitor.incrementWindowSize(state(stream), delta);
     }
 
     @Override
@@ -218,10 +224,8 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
         // The context can be null assuming the frame will be queued and send later when the context is set.
         assert ctx == null || ctx.executor().inEventLoop();
         checkNotNull(frame, "frame");
-        final AbstractState state;
         try {
-            state = state(stream);
-            state.enqueueFrame(frame);
+            monitor.enqueueFrame(state(stream), frame);
         } catch (Throwable t) {
             frame.error(ctx, t);
         }
@@ -245,16 +249,12 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
         // an "adequate" amount of connection window before allocation is attempted. This is not foolproof as if the
         // number of streams is >= this minimal number then we may still have the issue, but the idea is to narrow the
         // circumstances in which this can happen without rewriting the allocation algorithm.
-        return Math.max(ctx.channel().config().getWriteBufferLowWaterMark(), MIN_WRITABLE_CHUNK);
+        return max(ctx.channel().config().getWriteBufferLowWaterMark(), MIN_WRITABLE_CHUNK);
     }
 
     private int maxUsableChannelBytes() {
-        if (ctx == null) {
-            return 0;
-        }
-
         // If the channel isWritable, allow at least minUseableChannelBytes.
-        int channelWritableBytes = (int) Math.min(Integer.MAX_VALUE, ctx.channel().bytesBeforeUnwritable());
+        int channelWritableBytes = (int) min(Integer.MAX_VALUE, ctx.channel().bytesBeforeUnwritable());
         int useableBytes = channelWritableBytes > 0 ? max(channelWritableBytes, minUsableChannelBytes()) : 0;
 
         // Clip the usable bytes by the connection window.
@@ -262,29 +262,16 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
     }
 
     /**
-     * Package private for testing purposes only!
-     *
-     * @return The amount of bytes that can be supported by underlying {@link
-     * io.netty.channel.Channel} without queuing "too-much".
+     * The amount of bytes that can be supported by underlying {@link io.netty.channel.Channel} without
+     * queuing "too-much".
      */
     private int writableBytes() {
-        return Math.min(connectionWindowSize(), maxUsableChannelBytes());
+        return min(connectionWindowSize(), maxUsableChannelBytes());
     }
 
-    /**
-     * Writes as many pending bytes as possible, according to stream priority.
-     */
     @Override
     public void writePendingBytes() throws Http2Exception {
-        int bytesToWrite = writableBytes();
-        boolean haveUnwrittenBytes;
-
-        // Using a do-while loop so that we always write at least once, regardless if we have
-        // bytesToWrite or not. This ensures that zero-length frames will always be written.
-        do {
-            // Distribute the connection window across the streams and write the data.
-            haveUnwrittenBytes = streamByteDistributor.distribute(bytesToWrite, writer);
-        } while (haveUnwrittenBytes && (bytesToWrite = writableBytes()) > 0 && ctx.channel().isWritable());
+        monitor.writePendingBytes();
     }
 
     /**
@@ -299,8 +286,8 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
         // Set to true if cancel() was called.
         private boolean cancelled;
 
-        DefaultState(Http2Stream stream, int initialWindowSize) {
-            super(stream);
+        DefaultState(Http2Stream stream, int initialWindowSize, boolean markedWritable) {
+            super(stream, markedWritable);
             window(initialWindowSize);
             pendingWriteQueue = new ArrayDeque<FlowControlled>(2);
         }
@@ -348,13 +335,21 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
             return window;
         }
 
-        int writableWindow() {
+        @Override
+        public int streamableBytes() {
+            return max(0, min(pendingBytes, window));
+        }
+
+        /**
+         * Returns the maximum writable window (minimum of the stream and connection windows).
+         */
+        private int writableWindow() {
             return min(window, connectionWindowSize());
         }
 
         @Override
-        public int streamableBytes() {
-            return max(0, min(pendingBytes, window));
+        int pendingBytes() {
+            return pendingBytes;
         }
 
         @Override
@@ -401,6 +396,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
                 writeError(frame, streamError(stream.id(), INTERNAL_ERROR, cause,
                                               "Stream closed before write could take place"));
             }
+
             streamByteDistributor.updateStreamableBytes(this);
         }
 
@@ -412,7 +408,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
             FlowControlled frame = peek();
             int maxBytes = min(bytes, writableWindow());
             if (maxBytes <= 0 && frame.size() != 0) {
-                // The frame had data and all of it was written.
+                // The frame still has data, but the amount of allocated bytes has been exhausted.
                 return -1;
             }
             int originalBytes = bytes;
@@ -423,7 +419,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
                 frame = peek();
                 maxBytes = min(bytes, writableWindow());
                 if (maxBytes <= 0 && frame.size() != 0) {
-                    // The frame had data and all of it was written.
+                    // The frame still has data, but the amount of allocated bytes has been exhausted.
                     break;
                 }
                 bytes -= write(frame, maxBytes);
@@ -477,7 +473,9 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
          */
         private void incrementPendingBytes(int numBytes) {
             pendingBytes += numBytes;
+
             streamByteDistributor.updateStreamableBytes(this);
+            monitor.incrementPendingBytes(numBytes);
         }
 
         /**
@@ -518,7 +516,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
      */
     private final class ReducedState extends AbstractState {
         ReducedState(Http2Stream stream) {
-            super(stream);
+            super(stream, false);
         }
 
         ReducedState(AbstractState existingState) {
@@ -537,6 +535,11 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
 
         @Override
         public int streamableBytes() {
+            return 0;
+        }
+
+        @Override
+        int pendingBytes() {
             return 0;
         }
 
@@ -577,13 +580,16 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
      */
     private abstract class AbstractState implements StreamByteDistributor.StreamState {
         protected final Http2Stream stream;
+        private boolean markedWritable;
 
-        AbstractState(Http2Stream stream) {
+        AbstractState(Http2Stream stream, boolean markedWritable) {
             this.stream = stream;
+            this.markedWritable = markedWritable;
         }
 
         AbstractState(AbstractState existingState) {
-            this.stream = existingState.stream();
+            stream = existingState.stream();
+            markedWritable = existingState.markWritability();
         }
 
         /**
@@ -592,6 +598,20 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
         @Override
         public final Http2Stream stream() {
             return stream;
+        }
+
+        /**
+         * Returns the parameter from the last call to {@link #markWritability(boolean)}.
+         */
+        final boolean markWritability() {
+            return markedWritable;
+        }
+
+        /**
+         * Save the state of writability.
+         */
+        final void markWritability(boolean isWritable) {
+            this.markedWritable = isWritable;
         }
 
         abstract int windowSize();
@@ -604,6 +624,11 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
          * @return the number of bytes written for a stream or {@code -1} if no write occurred.
          */
         abstract int writeAllocatedBytes(int allocated);
+
+        /**
+         * Get the number of bytes pending to be written.
+         */
+        abstract int pendingBytes();
 
         /**
          * Any operations that may be pending are cleared and the status of these operations is failed.
@@ -624,5 +649,266 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
          * Adds the {@code frame} to the pending queue and increments the pending byte count.
          */
         abstract void enqueueFrame(FlowControlled frame);
+    }
+
+    /**
+     * Abstract class which provides common functionality for {@link WritabilityMonitorfoo} implementations.
+     */
+    private abstract class WritabilityMonitor {
+        private long totalPendingBytes;
+
+        /**
+         * Increment all windows by {@code newWindowSize} amount, and write data if streams change from not writable
+         * to writable.
+         * @param newWindowSize The new window size.
+         * @throws Http2Exception If an overflow occurs or an exception on write occurs.
+         */
+        public abstract void initialWindowSize(int newWindowSize) throws Http2Exception;
+
+        /**
+         * Attempt to allocate bytes to streams which have frames queued.
+         * @throws Http2Exception If a write occurs and an exception happens in the write operation.
+         */
+        public abstract void writePendingBytes() throws Http2Exception;
+
+        /**
+         * Called when the writability of the underlying channel changes.
+         * @throws Http2Exception If a write occurs and an exception happens in the write operation.
+         */
+        public void channelWritabilityChange() throws Http2Exception { }
+
+        /**
+         * Called when the state is cancelled outside of a write operation.
+         * @param state the state that was cancelled.
+         */
+        public void stateCancelled(AbstractState state) { }
+
+        /**
+         * Increment the window size for a particular stream.
+         * @param state the state associated with the stream whose window is being incremented.
+         * @param delta The amount to increment by.
+         * @throws Http2Exception If this operation overflows the window for {@code state}.
+         */
+        public void incrementWindowSize(AbstractState state, int delta) throws Http2Exception {
+            state.incrementStreamWindow(delta);
+        }
+
+        /**
+         * Add a frame to be sent via flow control.
+         * @param state The state associated with the stream which the {@code frame} is associated with.
+         * @param frame the frame to enqueue.
+         * @throws Http2Exception If a writability error occurs.
+         */
+        public void enqueueFrame(AbstractState state, FlowControlled frame) throws Http2Exception {
+            state.enqueueFrame(frame);
+        }
+
+        /**
+         * Increment the total amount of pending bytes for all streams. When any stream's pending bytes changes
+         * method should be called.
+         * @param delta The amount to increment by.
+         */
+        public final void incrementPendingBytes(int delta) {
+            totalPendingBytes += delta;
+
+            // Notification of writibilty change should be delayed until the end of the top level event.
+            // This is to ensure the flow controller is more consistent state before calling external listener methods.
+        }
+
+        /**
+         * Determine if the stream associated with {@code state} is writable.
+         * @param state The state which is associated with the stream to test writability for.
+         * @return {@code true} if {@link AbstractState#stream()} is writable. {@code false} otherwise.
+         */
+        public final boolean isWritable(AbstractState state) {
+            return isWritableConnection() && state.windowSize() - state.pendingBytes() > 0;
+        }
+
+        protected final void writePendingBytes(Writer writer) throws Http2Exception {
+            int bytesToWrite = writableBytes();
+
+            // Make sure we always write at least once, regardless if we have bytesToWrite or not.
+            // This ensures that zero-length frames will always be written.
+            for (;;) {
+                if (!streamByteDistributor.distribute(bytesToWrite, writer) ||
+                    (bytesToWrite = writableBytes()) <= 0 ||
+                    !isChannelWritable0()) {
+                    break;
+                }
+            }
+        }
+
+        protected final boolean initialWindowSize(int newWindowSize, Writer writer)
+                throws Http2Exception {
+            if (newWindowSize < 0) {
+                throw new IllegalArgumentException("Invalid initial window size: " + newWindowSize);
+            }
+
+            final int delta = newWindowSize - initialWindowSize;
+            initialWindowSize = newWindowSize;
+            connection.forEachActiveStream(new Http2StreamVisitor() {
+                @Override
+                public boolean visit(Http2Stream stream) throws Http2Exception {
+                    state(stream).incrementStreamWindow(delta);
+                    return true;
+                }
+            });
+
+            if (delta > 0) {
+                // The window size increased, send any pending frames for all streams.
+                writePendingBytes(writer);
+                return false;
+            }
+            return true;
+        }
+
+        protected final boolean isWritableConnection() {
+            return connectionState.windowSize() - totalPendingBytes > 0 && isChannelWritable();
+        }
+    }
+
+    /**
+     * Provides no notification or tracking of writablity changes.
+     */
+    private final class DefaultWritabilityMonitor extends WritabilityMonitor {
+        private final Writer writer = new StreamByteDistributor.Writer() {
+            @Override
+            public void write(Http2Stream stream, int numBytes) {
+                state(stream).writeAllocatedBytes(numBytes);
+            }
+        };
+
+        @Override
+        public void writePendingBytes() throws Http2Exception {
+            writePendingBytes(writer);
+        }
+
+        @Override
+        public void initialWindowSize(int newWindowSize) throws Http2Exception {
+            initialWindowSize(newWindowSize, writer);
+        }
+    }
+
+    /**
+     * Writability of a {@code stream} is calculated using the following:
+     * <pre>
+     * Connection Window - Total Queued Bytes > 0 &&
+     * Stream Window - Bytes Queued for Stream > 0 &&
+     * isChannelWritable()
+     * </pre>
+     */
+    private final class ListenerWritabilityMonitor extends WritabilityMonitor {
+        private final Listener listener;
+        private final Http2StreamVisitor checkStreamWritabilityVisitor = new Http2StreamVisitor() {
+            @Override
+            public boolean visit(Http2Stream stream) throws Http2Exception {
+                AbstractState state = state(stream);
+                if (isWritable(state) != state.markWritability()) {
+                    notifyWritabilityChanged(state);
+                }
+                return true;
+            }
+        };
+        private final Writer initialWindowSizeWriter = new StreamByteDistributor.Writer() {
+            @Override
+            public void write(Http2Stream stream, int numBytes) {
+                AbstractState state = state(stream);
+                writeAllocatedBytes(state, numBytes);
+                if (isWritable(state) != state.markWritability()) {
+                    notifyWritabilityChanged(state);
+                }
+            }
+        };
+        private final Writer writeAllocatedBytesWriter = new StreamByteDistributor.Writer() {
+            @Override
+            public void write(Http2Stream stream, int numBytes) {
+                writeAllocatedBytes(state(stream), numBytes);
+            }
+        };
+
+        ListenerWritabilityMonitor(Listener listener) {
+            this.listener = listener;
+        }
+
+        @Override
+        public void writePendingBytes() throws Http2Exception {
+            writePendingBytes(writeAllocatedBytesWriter);
+        }
+
+        @Override
+        public void incrementWindowSize(AbstractState state, int delta) throws Http2Exception {
+            super.incrementWindowSize(state, delta);
+            if (isWritable(state) != state.markWritability()) {
+                if (state == connectionState) {
+                    checkAllWritabilityChanged();
+                } else {
+                    notifyWritabilityChanged(state);
+                }
+            }
+        }
+
+        @Override
+        public void initialWindowSize(int newWindowSize) throws Http2Exception {
+            if (initialWindowSize(newWindowSize, initialWindowSizeWriter)) {
+                if (isWritableConnection()) {
+                    // If the write operation does not occur we still need to check all streams because they
+                    // may have transitioned from writable to not writable.
+                    checkAllWritabilityChanged();
+                }
+            }
+        }
+
+        @Override
+        public void enqueueFrame(AbstractState state, FlowControlled frame) throws Http2Exception {
+            super.enqueueFrame(state, frame);
+            checkConnectionThenStreamWritabilityChanged(state);
+        }
+
+        @Override
+        public void stateCancelled(AbstractState state) {
+            try {
+                checkConnectionThenStreamWritabilityChanged(state);
+            } catch (Http2Exception e) {
+                logger.error("Caught unexpected exception from checkAllWritabilityChanged", e);
+            }
+        }
+
+        @Override
+        public void channelWritabilityChange() throws Http2Exception {
+            if (connectionState.markWritability() != isChannelWritable()) {
+                checkAllWritabilityChanged();
+            }
+        }
+
+        private void notifyWritabilityChanged(AbstractState state) {
+            state.markWritability(!state.markWritability());
+            try {
+                listener.writabilityChanged(state.stream);
+            } catch (RuntimeException e) {
+                logger.error("Caught unexpected exception from listener.writabilityChanged", e);
+            }
+        }
+
+        private void checkConnectionThenStreamWritabilityChanged(AbstractState state) throws Http2Exception {
+            // It is possible that the connection window and/or the individual stream writability could change.
+            if (isWritableConnection() != connectionState.markWritability()) {
+                checkAllWritabilityChanged();
+            } else if (isWritable(state) != state.markWritability()) {
+                notifyWritabilityChanged(state);
+            }
+        }
+
+        private void checkAllWritabilityChanged() throws Http2Exception {
+            // Make sure we mark that we have notified as a result of this change.
+            connectionState.markWritability(isWritableConnection());
+            connection.forEachActiveStream(checkStreamWritabilityVisitor);
+        }
+
+        private void writeAllocatedBytes(AbstractState state, int numBytes) {
+            int written = state.writeAllocatedBytes(numBytes);
+            if (written != -1) {
+                listener.streamWritten(state.stream(), written);
+            }
+        }
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -441,6 +441,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             if (ctx.channel().isWritable()) {
                 flush(ctx);
             }
+            encoder.flowController().channelWritabilityChanged();
         } finally {
             super.channelWritabilityChanged(ctx);
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
@@ -56,11 +56,21 @@ public interface Http2RemoteFlowController extends Http2FlowController {
     void listener(Listener listener);
 
     /**
-     * Get the current listener to flow-control events.
-     *
-     * @return the current listener or {@code null} if one is not set.
+     * Determine if the {@code stream} has bytes remaining for use in the flow control window.
+     * <p>
+     * Note that this only takes into account HTTP/2 flow control. It does <strong>not</strong> take into account
+     * the underlying {@link io.netty.channel.Channel#isWritable()}.
+     * @param stream The stream to test.
+     * @return {@code true} if if the {@code stream} has bytes remaining for use in the flow control window.
+     * {@code false} otherwise.
      */
-    Listener listener();
+    boolean isWritable(Http2Stream stream);
+
+    /**
+     * Notification that the writability of {@link #channelHandlerContext()} has changed.
+     * @throws Http2Exception If any writes occur as a result of this call and encounter errors.
+     */
+    void channelWritabilityChanged() throws Http2Exception;
 
     /**
      * Implementations of this interface are used to progressively write chunks of the underlying
@@ -132,11 +142,20 @@ public interface Http2RemoteFlowController extends Http2FlowController {
         /**
          * Report the number of {@code writtenBytes} for a {@code stream}. Called after the
          * flow-controller has flushed bytes for the given stream.
-         *
+         * <p>
+         * This method should not throw. Any thrown exceptions are considered a programming error and are ignored.
          * @param stream that had bytes written.
          * @param writtenBytes the number of bytes written for a stream, can be 0 in the case of an
          *                     empty DATA frame.
          */
         void streamWritten(Http2Stream stream, int writtenBytes);
+
+        /**
+         * Notification that {@link Http2RemoteFlowController#isWritable(Http2Stream)} has changed for {@code stream}.
+         * <p>
+         * This method should not throw. Any thrown exceptions are considered a programming error and are ignored.
+         * @param stream The stream which writability has changed for.
+         */
+        void writabilityChanged(Http2Stream stream);
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/PriorityStreamByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/PriorityStreamByteDistributor.java
@@ -54,7 +54,7 @@ public final class PriorityStreamByteDistributor implements StreamByteDistributo
             public void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) {
                 Http2Stream parent = stream.parent();
                 if (parent != null) {
-                    int delta = state(stream).unallocatedStreamableBytesForTree();
+                    long delta = state(stream).unallocatedStreamableBytesForTree();
                     if (delta != 0) {
                         state(parent).unallocatedStreamableBytesForTreeChanged(delta);
                     }
@@ -65,7 +65,7 @@ public final class PriorityStreamByteDistributor implements StreamByteDistributo
             public void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) {
                 Http2Stream parent = stream.parent();
                 if (parent != null) {
-                    int delta = state(stream).unallocatedStreamableBytesForTree();
+                    long delta = state(stream).unallocatedStreamableBytesForTree();
                     if (delta != 0) {
                         state(parent).unallocatedStreamableBytesForTreeChanged(-delta);
                     }
@@ -103,7 +103,7 @@ public final class PriorityStreamByteDistributor implements StreamByteDistributo
     /**
      * For testing only.
      */
-    int unallocatedStreamableBytesForTree(Http2Stream stream) {
+    long unallocatedStreamableBytesForTree(Http2Stream stream) {
         return state(stream).unallocatedStreamableBytesForTree();
     }
 
@@ -307,7 +307,7 @@ public final class PriorityStreamByteDistributor implements StreamByteDistributo
         boolean hasFrame;
         int streamableBytes;
         int allocated;
-        int unallocatedStreamableBytesForTree;
+        long unallocatedStreamableBytesForTree;
 
         PriorityState(Http2Stream stream) {
             this.stream = stream;
@@ -317,7 +317,7 @@ public final class PriorityStreamByteDistributor implements StreamByteDistributo
          * Recursively increments the {@link #unallocatedStreamableBytesForTree()} for this branch in
          * the priority tree starting at the current node.
          */
-        void unallocatedStreamableBytesForTreeChanged(int delta) {
+        void unallocatedStreamableBytesForTreeChanged(long delta) {
             unallocatedStreamableBytesForTree += delta;
             if (!stream.isRoot()) {
                 state(stream.parent()).unallocatedStreamableBytesForTreeChanged(delta);
@@ -371,7 +371,7 @@ public final class PriorityStreamByteDistributor implements StreamByteDistributo
             return streamableBytes - allocated;
         }
 
-        int unallocatedStreamableBytesForTree() {
+        long unallocatedStreamableBytesForTree() {
             return unallocatedStreamableBytesForTree;
         }
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/PriorityStreamByteDistributorTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/PriorityStreamByteDistributorTest.java
@@ -15,6 +15,21 @@
 
 package io.netty.handler.codec.http2;
 
+import io.netty.util.collection.IntObjectHashMap;
+import io.netty.util.collection.IntObjectMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.AdditionalMatchers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.mockito.verification.VerificationMode;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -31,21 +46,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
-import io.netty.util.collection.IntObjectHashMap;
-import io.netty.util.collection.IntObjectMap;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.AdditionalMatchers;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-import org.mockito.verification.VerificationMode;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Tests for {@link PriorityStreamByteDistributor}.
@@ -661,7 +661,7 @@ public class PriorityStreamByteDistributorTest {
         stream(streamId).setPriority(parent, (short) weight, exclusive);
     }
 
-    private int streamableBytesForTree(Http2Stream stream) {
+    private long streamableBytesForTree(Http2Stream stream) {
         return distributor.unallocatedStreamableBytesForTree(stream);
     }
 
@@ -681,8 +681,8 @@ public class PriorityStreamByteDistributorTest {
         verify(writer).write(same(stream(streamId)), (int) AdditionalMatchers.eq(numBytes, delta));
     }
 
-    private static int calculateStreamSizeSum(IntObjectMap<Integer> streamSizes, List<Integer> streamIds) {
-        int sum = 0;
+    private static long calculateStreamSizeSum(IntObjectMap<Integer> streamSizes, List<Integer> streamIds) {
+        long sum = 0;
         for (Integer streamId : streamIds) {
             Integer streamSize = streamSizes.get(streamId);
             if (streamSize != null) {

--- a/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
@@ -42,6 +42,11 @@ public final class NoopHttp2RemoteFlowController implements Http2RemoteFlowContr
     }
 
     @Override
+    public boolean isWritable(Http2Stream stream) {
+        return true;
+    }
+
+    @Override
     public int initialWindowSize(Http2Stream stream) {
         return MAX_INITIAL_WINDOW_SIZE;
     }
@@ -56,11 +61,6 @@ public final class NoopHttp2RemoteFlowController implements Http2RemoteFlowContr
 
     @Override
     public void listener(Listener listener) {
-    }
-
-    @Override
-    public Listener listener() {
-        return null;
     }
 
     @Override
@@ -79,5 +79,9 @@ public final class NoopHttp2RemoteFlowController implements Http2RemoteFlowContr
     @Override
     public ChannelHandlerContext channelHandlerContext() {
         return ctx;
+    }
+
+    @Override
+    public void channelWritabilityChanged() throws Http2Exception {
     }
 }


### PR DESCRIPTION
Motivation:
For implementations that want to manage flow control down to the stream level it is useful to be notified when stream writability changes.

Modifications:
- Add writabilityChanged to Http2RemoteFlowController.Listener
- Add isWritable to Http2RemoteFlowController

Result:
The Http2RemoteFlowController provides notification when writability of a stream changes.