### PR TITLE
Upgrade to netty-tcnative 1.1.33.Fork7

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <classifier>${os.detected.classifier}</classifier>
+      <classifier>${tcnative.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.npn</groupId>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <classifier>${os.detected.classifier}</classifier>
+      <classifier>${tcnative.classifier}</classifier>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -682,8 +682,8 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>1.1.33.Fork6</version>
-        <classifier>${os.detected.classifier}</classifier>
+        <version>1.1.33.Fork7</version>
+        <classifier>${tcnative.classifier}</classifier>
         <scope>compile</scope>
         <optional>true</optional>
       </dependency>
@@ -899,7 +899,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.2.3.Final</version>
+        <version>1.4.0.Final</version>
       </extension>
     </extensions>
 
@@ -1288,6 +1288,14 @@
                   <entry key="${project.artifactId}.longCommitHash" value="${longCommitHash}" />
                   <entry key="${project.artifactId}.repoStatus" value="${repoStatus}" />
                 </propertyfile>
+              </target>
+              <exportAntProperties>true</exportAntProperties>
+              <target>
+                <condition property="tcnative.classifier"
+                           value="${os.detected.classifier}-fedora"
+                           else="${os.detected.classifier}">
+                  <isset property="os.detected.release.fedora"/>
+                </condition>
               </target>
             </configuration>
           </execution>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <classifier>${os.detected.classifier}</classifier>
+      <classifier>${tcnative.classifier}</classifier>
       <optional>true</optional>
     </dependency>
 

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <classifier>${os.detected.classifier}</classifier>
+      <classifier>${tcnative.classifier}</classifier>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Motivation:

Upgrade to latest netty-tcnative release and use latest os-maven-plugin.

Modifications:

- Upgrade netty-tcnative
- Upgrade os-maven-plugin

Result:

Latest releases are used.