### PR TITLE
Update Netty to latest netty-tcnative

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -94,7 +94,7 @@
           <groupId>${project.groupId}</groupId>
           <artifactId>netty-transport-native-epoll</artifactId>
           <version>${project.version}</version>
-          <classifier>${os.detected.classifier}</classifier>
+          <classifier>${epoll.classifier}</classifier>
           <scope>compile</scope>
           <optional>true</optional>
         </dependency>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-tcnative</artifactId>
-        <classifier>${os.detected.classifier}</classifier>
+        <classifier>${tcnative.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.npn</groupId>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <classifier>${os.detected.classifier}</classifier>
+      <classifier>${tcnative.classifier}</classifier>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -68,7 +68,7 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
       <version>${project.version}</version>
-      <classifier>linux-${epoll.arch}</classifier>
+      <classifier>${epoll.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
                         Release process must be performed on linux-x86_64.
                       </regexMessage>
                       <property>os.detected.classifier</property>
-                      <regex>^linux-x86_64$</regex>
+                      <regex>^linux-x86_64(\\-fedora)?$</regex>
                     </requireProperty>
                     <requireFilesContent>
                       <message>
@@ -607,6 +607,11 @@
     <argLine.bootcp>-Xbootclasspath/p:${jetty.alpn.path}</argLine.bootcp>
     <argLine.leak>-D_</argLine.leak> <!-- Overridden when 'leak' profile is active -->
     <argLine.coverage>-D_</argLine.coverage> <!-- Overridden when 'coverage' profile is active -->
+    <!-- Configure the os-maven-plugin extension to expand the classifier on                  -->
+    <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
+    <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
+    <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
+    <epoll.classifier>${os.detected.name}-${os.detected.arch}</epoll.classifier>
   </properties>
 
   <modules>
@@ -696,8 +701,8 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>1.1.33.Fork6</version>
-        <classifier>${os.detected.classifier}</classifier>
+        <version>1.1.33.Fork7</version>
+        <classifier>${tcnative.classifier}</classifier>
         <scope>compile</scope>
         <optional>true</optional>
       </dependency>
@@ -942,7 +947,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.2.3.Final</version>
+        <version>1.4.0.Final</version>
       </extension>
     </extensions>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <classifier>${os.detected.classifier}</classifier>
+      <classifier>${tcnative.classifier}</classifier>
       <optional>true</optional>
     </dependency>
 

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <classifier>${os.detected.classifier}</classifier>
+      <classifier>${tcnative.classifier}</classifier>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -105,7 +105,7 @@
               <goal>jar</goal>
             </goals>
             <configuration>
-              <classifier>${os.detected.classifier}</classifier>
+              <classifier>${epoll.classifier}</classifier>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Motivation:

The latest netty-tcnative fixes a bug in determining the version of the runtime openssl lib.  It also publishes an artificact with the classifier linux-<arch>-fedora for fedora-based systems.

Modifications:

Modified the build files to use the "-fedora" classifier when appropriate for tcnative. Care is taken, however, to not change the classifier for the native epoll transport.

Result:

Netty is updated the the new shiny netty-tcnative.