### PR TITLE
Adding client auth to SslContextBuilder

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ClientAuth.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ClientAuth.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.ssl;
+
+/**
+ * Indicates the state of the {@link javax.net.ssl.SSLEngine} with respect to client authentication.
+ * This configuration item really only applies when building the server-side {@link SslContext}.
+ */
+public enum ClientAuth {
+    /**
+     * Indicates that the {@link javax.net.ssl.SSLEngine} will not request client authentication.
+     */
+    NONE,
+
+    /**
+     * Indicates that the {@link javax.net.ssl.SSLEngine} will request client authentication.
+     */
+    OPTIONAL,
+
+    /**
+     * Indicates that the {@link javax.net.ssl.SSLEngine} will *require* client authentication.
+     */
+    REQUIRE
+}

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslClientContext.java
@@ -243,7 +243,7 @@ public final class JdkSslClientContext extends JdkSslContext {
             File keyCertChainFile, File keyFile, String keyPassword, KeyManagerFactory keyManagerFactory,
             Iterable<String> ciphers, CipherSuiteFilter cipherFilter, JdkApplicationProtocolNegotiator apn,
             long sessionCacheSize, long sessionTimeout) throws SSLException {
-        super(ciphers, cipherFilter, apn);
+        super(ciphers, cipherFilter, apn, ClientAuth.NONE);
         try {
             ctx = newSSLContext(toX509Certificates(trustCertChainFile), trustManagerFactory,
                                 toX509Certificates(keyCertChainFile), toPrivateKey(keyFile, keyPassword),
@@ -260,7 +260,7 @@ public final class JdkSslClientContext extends JdkSslContext {
                         X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
                         KeyManagerFactory keyManagerFactory, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
                         ApplicationProtocolConfig apn, long sessionCacheSize, long sessionTimeout) throws SSLException {
-        super(ciphers, cipherFilter, toNegotiator(apn, false));
+        super(ciphers, cipherFilter, toNegotiator(apn, false), ClientAuth.NONE);
         ctx = newSSLContext(trustCertChain, trustManagerFactory, keyCertChain, key, keyPassword,
                             keyManagerFactory, sessionCacheSize, sessionTimeout);
     }

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslServerContext.java
@@ -208,7 +208,7 @@ public final class JdkSslServerContext extends JdkSslContext {
             File keyCertChainFile, File keyFile, String keyPassword, KeyManagerFactory keyManagerFactory,
             Iterable<String> ciphers, CipherSuiteFilter cipherFilter, JdkApplicationProtocolNegotiator apn,
             long sessionCacheSize, long sessionTimeout) throws SSLException {
-        super(ciphers, cipherFilter, apn);
+        super(ciphers, cipherFilter, apn, ClientAuth.NONE);
         try {
             ctx = newSSLContext(toX509Certificates(trustCertChainFile), trustManagerFactory,
                                 toX509Certificates(keyCertChainFile), toPrivateKey(keyFile, keyPassword),
@@ -224,8 +224,9 @@ public final class JdkSslServerContext extends JdkSslContext {
     JdkSslServerContext(X509Certificate[] trustCertChain, TrustManagerFactory trustManagerFactory,
                         X509Certificate[] keyCertChain, PrivateKey key, String keyPassword,
                         KeyManagerFactory keyManagerFactory, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
-                        ApplicationProtocolConfig apn, long sessionCacheSize, long sessionTimeout) throws SSLException {
-        super(ciphers, cipherFilter, toNegotiator(apn, true));
+                        ApplicationProtocolConfig apn, long sessionCacheSize, long sessionTimeout,
+                        ClientAuth clientAuth) throws SSLException {
+        super(ciphers, cipherFilter, toNegotiator(apn, true), clientAuth);
         ctx = newSSLContext(trustCertChain, trustManagerFactory, keyCertChain, key,
                             keyPassword, keyManagerFactory, sessionCacheSize, sessionTimeout);
     }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
@@ -171,7 +171,8 @@ public final class OpenSslClientContext extends OpenSslContext {
                                 CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
                                 long sessionCacheSize, long sessionTimeout)
             throws SSLException {
-        super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_CLIENT, null);
+        super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_CLIENT, null,
+                ClientAuth.NONE);
         boolean success = false;
         try {
             if (trustCertChainFile != null && !trustCertChainFile.isFile()) {
@@ -271,7 +272,8 @@ public final class OpenSslClientContext extends OpenSslContext {
                                 CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
                                 long sessionCacheSize, long sessionTimeout)
             throws SSLException {
-        super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_CLIENT, keyCertChain);
+        super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_CLIENT, keyCertChain,
+                ClientAuth.NONE);
         boolean success = false;
         try {
             if (key == null && keyCertChain != null || key != null && keyCertChain == null) {

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -317,7 +317,8 @@ public final class OpenSslServerContext extends OpenSslContext {
             File keyCertChainFile, File keyFile, String keyPassword, KeyManagerFactory keyManagerFactory,
             Iterable<String> ciphers, CipherSuiteFilter cipherFilter, OpenSslApplicationProtocolNegotiator apn,
             long sessionCacheSize, long sessionTimeout) throws SSLException {
-        super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_SERVER, null);
+        super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_SERVER, null,
+                ClientAuth.NONE);
         OpenSsl.ensureAvailability();
 
         checkNotNull(keyCertChainFile, "keyCertChainFile");
@@ -417,8 +418,9 @@ public final class OpenSslServerContext extends OpenSslContext {
             X509Certificate[] trustCertChain, TrustManagerFactory trustManagerFactory,
             X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
             Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
-            long sessionCacheSize, long sessionTimeout) throws SSLException {
-        super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_SERVER, keyCertChain);
+            long sessionCacheSize, long sessionTimeout, ClientAuth clientAuth) throws SSLException {
+        super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_SERVER, keyCertChain,
+                clientAuth);
         OpenSsl.ensureAvailability();
 
         checkNotNull(keyCertChain, "keyCertChainFile");

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -377,7 +377,7 @@ public abstract class SslContext {
                                             toX509Certificates(keyCertChainFile),
                                             toPrivateKey(keyFile, keyPassword),
                                             keyPassword, keyManagerFactory, ciphers, cipherFilter, apn,
-                                            sessionCacheSize, sessionTimeout);
+                                            sessionCacheSize, sessionTimeout, ClientAuth.NONE);
         } catch (Exception e) {
             if (e instanceof SSLException) {
                 throw (SSLException) e;
@@ -391,7 +391,8 @@ public abstract class SslContext {
             X509Certificate[] trustCertChain, TrustManagerFactory trustManagerFactory,
             X509Certificate[] keyCertChain, PrivateKey key, String keyPassword, KeyManagerFactory keyManagerFactory,
             Iterable<String> ciphers, CipherSuiteFilter cipherFilter, ApplicationProtocolConfig apn,
-            long sessionCacheSize, long sessionTimeout) throws SSLException {
+            long sessionCacheSize, long sessionTimeout,
+            ClientAuth clientAuth) throws SSLException {
 
         if (provider == null) {
             provider = defaultServerProvider();
@@ -401,11 +402,13 @@ public abstract class SslContext {
         case JDK:
             return new JdkSslServerContext(
                     trustCertChain, trustManagerFactory, keyCertChain, key, keyPassword,
-                    keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
+                    keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
+                    clientAuth);
         case OPENSSL:
             return new OpenSslServerContext(
                     trustCertChain, trustManagerFactory, keyCertChain, key, keyPassword,
-                    keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
+                    keyManagerFactory, ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout,
+                    clientAuth);
         default:
             throw new Error(provider.toString());
         }

--- a/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContextBuilder.java
@@ -110,6 +110,7 @@ public final class SslContextBuilder {
     private ApplicationProtocolConfig apn;
     private long sessionCacheSize;
     private long sessionTimeout;
+    private ClientAuth clientAuth = ClientAuth.NONE;
 
     private SslContextBuilder(boolean forServer) {
         this.forServer = forServer;
@@ -299,13 +300,21 @@ public final class SslContextBuilder {
     }
 
     /**
+     * Sets the client authentication mode.
+     */
+    public SslContextBuilder clientAuth(ClientAuth clientAuth) {
+        this.clientAuth = checkNotNull(clientAuth, "clientAuth");
+        return this;
+    }
+
+    /**
      * Create new {@code SslContext} instance with configured settings.
      */
     public SslContext build() throws SSLException {
         if (forServer) {
             return SslContext.newServerContextInternal(provider, trustCertChain,
                 trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,
-                ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout);
+                ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, clientAuth);
         } else {
             return SslContext.newClientContextInternal(provider, trustCertChain,
                 trustManagerFactory, keyCertChain, key, keyPassword, keyManagerFactory,

--- a/handler/src/test/java/io/netty/handler/ssl/SslContextBuilderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslContextBuilderTest.java
@@ -15,6 +15,9 @@
  */
 package io.netty.handler.ssl;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import org.junit.Assume;
@@ -70,20 +73,31 @@ public class SslContextBuilderTest {
 
     private static void testClientContextFromFile(SslProvider provider) throws Exception {
         SelfSignedCertificate cert = new SelfSignedCertificate();
-        SslContextBuilder builder = SslContextBuilder.forClient().sslProvider(provider).keyManager(
-                cert.certificate(), cert.privateKey()).trustManager(cert.certificate());
+        SslContextBuilder builder = SslContextBuilder.forClient()
+                                                     .sslProvider(provider)
+                                                     .keyManager(cert.certificate(),
+                                                             cert.privateKey())
+                                                     .trustManager(cert.certificate())
+                                                     .clientAuth(ClientAuth.OPTIONAL);
         SslContext context = builder.build();
         SSLEngine engine = context.newEngine(UnpooledByteBufAllocator.DEFAULT);
+        assertFalse(engine.getWantClientAuth());
+        assertFalse(engine.getNeedClientAuth());
         engine.closeInbound();
         engine.closeOutbound();
     }
 
     private static void testClientContext(SslProvider provider) throws Exception {
         SelfSignedCertificate cert = new SelfSignedCertificate();
-        SslContextBuilder builder = SslContextBuilder.forClient().sslProvider(provider).keyManager(
-                cert.key(), cert.cert()).trustManager(cert.cert());
+        SslContextBuilder builder = SslContextBuilder.forClient()
+                                                     .sslProvider(provider)
+                                                     .keyManager(cert.key(), cert.cert())
+                                                     .trustManager(cert.cert())
+                                                     .clientAuth(ClientAuth.OPTIONAL);
         SslContext context = builder.build();
         SSLEngine engine = context.newEngine(UnpooledByteBufAllocator.DEFAULT);
+        assertFalse(engine.getWantClientAuth());
+        assertFalse(engine.getNeedClientAuth());
         engine.closeInbound();
         engine.closeOutbound();
     }
@@ -91,9 +105,13 @@ public class SslContextBuilderTest {
     private static void testServerContextFromFile(SslProvider provider) throws Exception {
         SelfSignedCertificate cert = new SelfSignedCertificate();
         SslContextBuilder builder = SslContextBuilder.forServer(cert.certificate(), cert.privateKey())
-                                                     .sslProvider(provider).trustManager(cert.certificate());
+                                                     .sslProvider(provider)
+                                                     .trustManager(cert.certificate())
+                                                     .clientAuth(ClientAuth.OPTIONAL);
         SslContext context = builder.build();
         SSLEngine engine = context.newEngine(UnpooledByteBufAllocator.DEFAULT);
+        assertTrue(engine.getWantClientAuth());
+        assertFalse(engine.getNeedClientAuth());
         engine.closeInbound();
         engine.closeOutbound();
     }
@@ -101,9 +119,13 @@ public class SslContextBuilderTest {
     private static void testServerContext(SslProvider provider) throws Exception {
         SelfSignedCertificate cert = new SelfSignedCertificate();
         SslContextBuilder builder = SslContextBuilder.forServer(cert.key(), cert.cert())
-                                                     .sslProvider(provider).trustManager(cert.cert());
+                                                     .sslProvider(provider)
+                                                     .trustManager(cert.cert())
+                                                     .clientAuth(ClientAuth.REQUIRE);
         SslContext context = builder.build();
         SSLEngine engine = context.newEngine(UnpooledByteBufAllocator.DEFAULT);
+        assertFalse(engine.getWantClientAuth());
+        assertTrue(engine.getNeedClientAuth());
         engine.closeInbound();
         engine.closeOutbound();
     }


### PR DESCRIPTION
Motivation:

To simplify the use of client auth, we need to add it to the SslContextBuilder.

Modifications:

Added a ClientAuth enum and plumbed it through the builder, down into the contexts/engines.

Result:

Client auth can be configured when building an SslContext.