### PR TITLE
Fix for RTSP protocol encoding and ecoding

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspDecoder.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.rtsp;
+
+import java.util.regex.Pattern;
+
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.HttpObjectDecoder;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Decodes {@link ByteBuf}s into RTSP messages represented in
+ * {@link HttpMessage}s.
+ * <p>
+ * <h3>Parameters that prevents excessive memory consumption</h3>
+ * <table border="1">
+ * <tr>
+ * <th>Name</th><th>Meaning</th>
+ * </tr>
+ * <tr>
+ * <td>{@code maxInitialLineLength}</td>
+ * <td>The maximum length of the initial line
+ *     (e.g. {@code "SETUP / RTSP/1.0"} or {@code "RTSP/1.0 200 OK"})
+ *     If the length of the initial line exceeds this value, a
+ *     {@link TooLongFrameException} will be raised.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code maxHeaderSize}</td>
+ * <td>The maximum length of all headers. If the sum of the length of each
+ *     header exceeds this value, a {@link TooLongFrameException} will be
+ *     raised.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code maxContentLength}</td>
+ * <td>The maximum length of the content.  If the content length exceeds this
+ *     value, a {@link TooLongFrameException} will be raised.</td>
+ * </tr>
+ * </table>
+ */
+public class RtspDecoder extends HttpObjectDecoder {
+    /**
+     * Status code for unknown responses.
+     */
+    private static final HttpResponseStatus UNKNOWN_STATUS =
+            new HttpResponseStatus(999, "Unknown");
+    /**
+     * True if the message to decode is a request.
+     * False if the message to decode is a response.
+     */
+    private boolean isDecodingRequest;
+
+    /**
+     * Regex used on first line in message to detect if it is a response.
+     */
+    private static final Pattern versionPattern = Pattern.compile("RTSP/\\d\\.\\d");
+
+    /**
+     * Constant for default max initial line length.
+     */
+    public static final int DEFAULT_MAX_INITIAL_LINE_LENGTH = 4096;
+
+    /**
+     * Constant for default max header size.
+     */
+    public static final int DEFAULT_MAX_HEADER_SIZE = 8192;
+
+    /**
+     * Constant for default max content length.
+     */
+    public static final int DEFAULT_MAX_CONTENT_LENGTH = 8192;
+
+    /**
+     * Creates a new instance with the default
+     * {@code maxInitialLineLength (4096)}, {@code maxHeaderSize (8192)}, and
+     * {@code maxContentLength (8192)}.
+     */
+    public RtspDecoder() {
+        this(DEFAULT_MAX_INITIAL_LINE_LENGTH,
+             DEFAULT_MAX_HEADER_SIZE,
+             DEFAULT_MAX_CONTENT_LENGTH);
+    }
+
+    /**
+     * Creates a new instance with the specified parameters.
+     * @param maxInitialLineLength The max allowed length of initial line
+     * @param maxHeaderSize The max allowed size of header
+     * @param maxContentLength The max allowed content length
+     */
+    public RtspDecoder(final int maxInitialLineLength,
+                       final int maxHeaderSize,
+                       final int maxContentLength) {
+        super(maxInitialLineLength, maxHeaderSize, maxContentLength * 2, false);
+    }
+
+    /**
+     * Creates a new instance with the specified parameters.
+     * @param maxInitialLineLength The max allowed length of initial line
+     * @param maxHeaderSize The max allowed size of header
+     * @param maxContentLength The max allowed content length
+     * @param validateHeaders Set to true if headers should be validated
+     */
+    public RtspDecoder(final int maxInitialLineLength,
+                       final int maxHeaderSize,
+                       final int maxContentLength,
+                       final boolean validateHeaders) {
+        super(maxInitialLineLength,
+              maxHeaderSize,
+              maxContentLength * 2,
+              false,
+              validateHeaders);
+    }
+
+    @Override
+    protected HttpMessage createMessage(final String[] initialLine)
+            throws Exception {
+        // If the first element of the initial line is a version string then
+        // this is a response
+        if (versionPattern.matcher(initialLine[0]).matches()) {
+            isDecodingRequest = false;
+            return new DefaultHttpResponse(RtspVersions.valueOf(initialLine[0]),
+                new HttpResponseStatus(Integer.parseInt(initialLine[1]),
+                                       initialLine[2]),
+                validateHeaders);
+        } else {
+            isDecodingRequest = true;
+            return new DefaultHttpRequest(RtspVersions.valueOf(initialLine[2]),
+                    RtspMethods.valueOf(initialLine[0]),
+                    initialLine[1],
+                    validateHeaders);
+        }
+    }
+
+    @Override
+    protected boolean isContentAlwaysEmpty(final HttpMessage msg) {
+        // Unlike HTTP, RTSP always assumes zero-length body if Content-Length
+        // header is absent.
+        return super.isContentAlwaysEmpty(msg) || !msg.headers().contains(RtspHeaderNames.CONTENT_LENGTH);
+    }
+
+    @Override
+    protected HttpMessage createInvalidMessage() {
+        if (isDecodingRequest) {
+            return new DefaultFullHttpRequest(RtspVersions.RTSP_1_0,
+                       RtspMethods.OPTIONS, "/bad-request", validateHeaders);
+        } else {
+            return new DefaultFullHttpResponse(RtspVersions.RTSP_1_0,
+                                               UNKNOWN_STATUS,
+                                               validateHeaders);
+        }
+    }
+
+    @Override
+    protected boolean isDecodingRequest() {
+        return isDecodingRequest;
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspEncoder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.rtsp;
+
+import static io.netty.handler.codec.http.HttpConstants.CR;
+import static io.netty.handler.codec.http.HttpConstants.LF;
+import static io.netty.handler.codec.http.HttpConstants.SP;
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.UnsupportedMessageTypeException;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpMessage;
+import io.netty.handler.codec.http.HttpObjectEncoder;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.util.CharsetUtil;
+import io.netty.util.internal.StringUtil;
+
+/**
+ * Encodes an RTSP message represented in {@link HttpMessage} or an {@link HttpContent} into
+ * a {@link ByteBuf}.
+ */
+public class RtspEncoder extends HttpObjectEncoder<HttpMessage> {
+    /**
+     * Constant for CRLF.
+     */
+    private static final byte[] CRLF = {CR, LF};
+
+    @Override
+    public boolean acceptOutboundMessage(final Object msg)
+           throws Exception {
+        return super.acceptOutboundMessage(msg) && ((msg instanceof HttpRequest) || (msg instanceof HttpResponse));
+    }
+
+    @Override
+    protected void encodeInitialLine(final ByteBuf buf, final HttpMessage message)
+           throws Exception {
+        if (message instanceof HttpRequest) {
+            HttpRequest request = (HttpRequest) message;
+            HttpHeaders.encodeAscii(request.method().toString(), buf);
+            buf.writeByte(SP);
+            buf.writeBytes(request.uri().getBytes(CharsetUtil.UTF_8));
+            buf.writeByte(SP);
+            HttpHeaders.encodeAscii(request.protocolVersion().toString(), buf);
+            buf.writeBytes(CRLF);
+        } else if (message instanceof HttpResponse) {
+            HttpResponse response = (HttpResponse) message;
+            HttpHeaders.encodeAscii(response.protocolVersion().toString(),
+                                    buf);
+            buf.writeByte(SP);
+            buf.writeBytes(String.valueOf(response.status().code())
+                                 .getBytes(CharsetUtil.US_ASCII));
+            buf.writeByte(SP);
+            HttpHeaders.encodeAscii(String.valueOf(response.status().reasonPhrase()),
+                                    buf);
+            buf.writeBytes(CRLF);
+        } else {
+            throw new UnsupportedMessageTypeException("Unsupported type "
+                                + StringUtil.simpleClassName(message));
+        }
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspHeaders.java
@@ -24,6 +24,7 @@ import io.netty.handler.codec.http.HttpHeaders;
  * Standard RTSP header names and values.
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public final class RtspHeaders {
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspObjectDecoder.java
@@ -47,7 +47,10 @@ import io.netty.handler.codec.http.HttpObjectDecoder;
  *     value, a {@link TooLongFrameException} will be raised.</td>
  * </tr>
  * </table>
+ *
+ * @deprecated Use {@link RtspDecoder} instead.
  */
+@Deprecated
 public abstract class RtspObjectDecoder extends HttpObjectDecoder {
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspObjectEncoder.java
@@ -24,8 +24,11 @@ import io.netty.handler.codec.http.HttpObjectEncoder;
 /**
  * Encodes an RTSP message represented in {@link FullHttpMessage} into
  * a {@link ByteBuf}.
+ *
+ * @deprecated Use {@link RtspEncoder} instead.
  */
 @Sharable
+@Deprecated
 public abstract class RtspObjectEncoder<H extends HttpMessage> extends HttpObjectEncoder<H> {
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspRequestDecoder.java
@@ -15,75 +15,9 @@
  */
 package io.netty.handler.codec.rtsp;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.handler.codec.TooLongFrameException;
-import io.netty.handler.codec.http.DefaultFullHttpRequest;
-import io.netty.handler.codec.http.DefaultHttpRequest;
-import io.netty.handler.codec.http.HttpMessage;
-import io.netty.handler.codec.http.HttpRequest;
-
 /**
- * Decodes {@link ByteBuf}s into RTSP requests represented in
- * {@link HttpRequest}s.
- * <p>
- * <h3>Parameters that prevents excessive memory consumption</h3>
- * <table border="1">
- * <tr>
- * <th>Name</th><th>Meaning</th>
- * </tr>
- * <tr>
- * <td>{@code maxInitialLineLength}</td>
- * <td>The maximum length of the initial line (e.g. {@code "SETUP / RTSP/1.0"})
- *     If the length of the initial line exceeds this value, a
- *     {@link TooLongFrameException} will be raised.</td>
- * </tr>
- * <tr>
- * <td>{@code maxHeaderSize}</td>
- * <td>The maximum length of all headers.  If the sum of the length of each
- *     header exceeds this value, a {@link TooLongFrameException} will be raised.</td>
- * </tr>
- * <tr>
- * <td>{@code maxContentLength}</td>
- * <td>The maximum length of the content.  If the content length exceeds this
- *     value, a {@link TooLongFrameException} will be raised.</td>
- * </tr>
- * </table>
+ * @deprecated Use {@link RtspDecoder} directly instead
  */
-public class RtspRequestDecoder extends RtspObjectDecoder {
-
-    /**
-     * Creates a new instance with the default
-     * {@code maxInitialLineLength (4096}}, {@code maxHeaderSize (8192)}, and
-     * {@code maxContentLength (8192)}.
-     */
-    public RtspRequestDecoder() {
-    }
-
-    /**
-     * Creates a new instance with the specified parameters.
-     */
-    public RtspRequestDecoder(int maxInitialLineLength, int maxHeaderSize, int maxContentLength) {
-        super(maxInitialLineLength, maxHeaderSize, maxContentLength);
-    }
-
-    public RtspRequestDecoder(
-            int maxInitialLineLength, int maxHeaderSize, int maxContentLength, boolean validateHeaders) {
-        super(maxInitialLineLength, maxHeaderSize, maxContentLength, validateHeaders);
-    }
-
-    @Override
-    protected HttpMessage createMessage(String[] initialLine) throws Exception {
-        return new DefaultHttpRequest(RtspVersions.valueOf(initialLine[2]),
-                RtspMethods.valueOf(initialLine[0]), initialLine[1], validateHeaders);
-    }
-
-    @Override
-    protected HttpMessage createInvalidMessage() {
-        return new DefaultFullHttpRequest(RtspVersions.RTSP_1_0, RtspMethods.OPTIONS, "/bad-request", validateHeaders);
-    }
-
-    @Override
-    protected boolean isDecodingRequest() {
-        return true;
-    }
+@Deprecated
+public class RtspRequestDecoder extends RtspDecoder {
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspRequestEncoder.java
@@ -15,35 +15,9 @@
  */
 package io.netty.handler.codec.rtsp;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.HttpHeaders;
-import io.netty.handler.codec.http.HttpRequest;
-import io.netty.util.CharsetUtil;
-
-import static io.netty.handler.codec.http.HttpConstants.*;
-
 /**
- * Encodes an RTSP request represented in {@link FullHttpRequest} into
- * a {@link ByteBuf}.
-
+ * @deprecated Use {@link RtspEncoder} directly instead
  */
-public class RtspRequestEncoder extends RtspObjectEncoder<HttpRequest> {
-    private static final byte[] CRLF = { CR, LF };
-
-    @Override
-    public boolean acceptOutboundMessage(Object msg) throws Exception {
-        return msg instanceof FullHttpRequest;
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    protected void encodeInitialLine(ByteBuf buf, HttpRequest request) throws Exception {
-        HttpHeaders.encodeAscii(request.method().toString(), buf);
-        buf.writeByte(SP);
-        buf.writeBytes(request.uri().getBytes(CharsetUtil.UTF_8));
-        buf.writeByte(SP);
-        HttpHeaders.encodeAscii(request.protocolVersion().toString(), buf);
-        buf.writeBytes(CRLF);
-    }
+@Deprecated
+public class RtspRequestEncoder extends RtspEncoder {
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspResponseDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspResponseDecoder.java
@@ -15,80 +15,9 @@
  */
 package io.netty.handler.codec.rtsp;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.handler.codec.TooLongFrameException;
-import io.netty.handler.codec.http.DefaultFullHttpResponse;
-import io.netty.handler.codec.http.DefaultHttpResponse;
-import io.netty.handler.codec.http.HttpMessage;
-import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.HttpResponseStatus;
-
 /**
- * Decodes {@link ByteBuf}s into RTSP responses represented in
- * {@link HttpResponse}s.
- * <p>
- * <h3>Parameters that prevents excessive memory consumption</h3>
- * <table border="1">
- * <tr>
- * <th>Name</th><th>Meaning</th>
- * </tr>
- * <tr>
- * <td>{@code maxInitialLineLength}</td>
- * <td>The maximum length of the initial line (e.g. {@code "RTSP/1.0 200 OK"})
- *     If the length of the initial line exceeds this value, a
- *     {@link TooLongFrameException} will be raised.</td>
- * </tr>
- * <tr>
- * <td>{@code maxHeaderSize}</td>
- * <td>The maximum length of all headers.  If the sum of the length of each
- *     header exceeds this value, a {@link TooLongFrameException} will be raised.</td>
- * </tr>
- * <tr>
- * <td>{@code maxContentLength}</td>
- * <td>The maximum length of the content.  If the content length exceeds this
- *     value, a {@link TooLongFrameException} will be raised.</td>
- * </tr>
- * </table>
+ * @deprecated Use {@link RtspDecoder} directly instead
  */
-public class RtspResponseDecoder extends RtspObjectDecoder {
-
-    private static final HttpResponseStatus UNKNOWN_STATUS = new HttpResponseStatus(999, "Unknown");
-
-    /**
-     * Creates a new instance with the default
-     * {@code maxInitialLineLength (4096}}, {@code maxHeaderSize (8192)}, and
-     * {@code maxContentLength (8192)}.
-     */
-    public RtspResponseDecoder() {
-    }
-
-    /**
-     * Creates a new instance with the specified parameters.
-     */
-    public RtspResponseDecoder(int maxInitialLineLength, int maxHeaderSize,
-            int maxContentLength) {
-        super(maxInitialLineLength, maxHeaderSize, maxContentLength);
-    }
-
-    public RtspResponseDecoder(int maxInitialLineLength, int maxHeaderSize,
-                               int maxContentLength, boolean validateHeaders) {
-        super(maxInitialLineLength, maxHeaderSize, maxContentLength, validateHeaders);
-    }
-
-    @Override
-    protected HttpMessage createMessage(String[] initialLine) throws Exception {
-        return new DefaultHttpResponse(
-                RtspVersions.valueOf(initialLine[0]),
-                new HttpResponseStatus(Integer.parseInt(initialLine[1]), initialLine[2]), validateHeaders);
-    }
-
-    @Override
-    protected HttpMessage createInvalidMessage() {
-        return new DefaultFullHttpResponse(RtspVersions.RTSP_1_0, UNKNOWN_STATUS, validateHeaders);
-    }
-
-    @Override
-    protected boolean isDecodingRequest() {
-        return false;
-    }
+@Deprecated
+public class RtspResponseDecoder extends RtspDecoder {
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspResponseEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspResponseEncoder.java
@@ -15,34 +15,9 @@
  */
 package io.netty.handler.codec.rtsp;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.handler.codec.http.FullHttpResponse;
-import io.netty.handler.codec.http.HttpHeaders;
-import io.netty.handler.codec.http.HttpResponse;
-import io.netty.util.CharsetUtil;
-
-import static io.netty.handler.codec.http.HttpConstants.*;
-
 /**
- * Encodes an RTSP response represented in {@link FullHttpResponse} into
- * a {@link ByteBuf}.
+ * @deprecated Use {@link RtspEncoder} directly instead
  */
-public class RtspResponseEncoder extends RtspObjectEncoder<HttpResponse> {
-    private static final byte[] CRLF = { CR, LF };
-
-    @Override
-    public boolean acceptOutboundMessage(Object msg) throws Exception {
-        return msg instanceof FullHttpResponse;
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    protected void encodeInitialLine(ByteBuf buf, HttpResponse response) throws Exception {
-        HttpHeaders.encodeAscii(response.protocolVersion().toString(), buf);
-        buf.writeByte(SP);
-        buf.writeBytes(String.valueOf(response.status().code()).getBytes(CharsetUtil.US_ASCII));
-        buf.writeByte(SP);
-        HttpHeaders.encodeAscii(String.valueOf(response.status().reasonPhrase()), buf);
-        buf.writeBytes(CRLF);
-    }
+@Deprecated
+public class RtspResponseEncoder extends RtspEncoder {
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspDecoderTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.rtsp;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+
+import org.junit.Test;
+
+/**
+ * Test cases for RTSP decoder.
+ */
+public class RtspDecoderTest {
+
+    /**
+     * There was a problem when an ANNOUNCE request was issued by the server,
+     * i.e. entered through the response decoder. First the decoder failed to
+     * parse the ANNOUNCE request, then it stopped receiving any more
+     * responses. This test verifies that the issue is solved.
+     */
+    @Test
+    public void testReceiveAnnounce() {
+        byte[] data1 = ("ANNOUNCE rtsp://172.20.184.218:554/d3abaaa7-65f2-"
+                      + "42b4-8d6b-379f492fcf0f RTSP/1.0\r\n"
+                      + "CSeq: 2\r\n"
+                      + "Session: 2777476816092819869\r\n"
+                      + "x-notice: 5402 \"Session Terminated by Server\" "
+                      + "event-date=20150514T075303Z\r\n"
+                      + "Range: npt=0\r\n\r\n").getBytes();
+
+        byte[] data2 = ("RTSP/1.0 200 OK\r\n" +
+                        "Server: Orbit2x\r\n" +
+                        "CSeq: 172\r\n" +
+                        "Session: 2547019973447939919\r\n" +
+                        "\r\n").getBytes();
+
+        EmbeddedChannel ch = new EmbeddedChannel(new RtspDecoder(),
+                                            new HttpObjectAggregator(1048576));
+        ch.writeInbound(Unpooled.wrappedBuffer(data1),
+                        Unpooled.wrappedBuffer(data2));
+
+        HttpObject res1 = ch.readInbound();
+        System.out.println(res1);
+        assertNotNull(res1);
+        assertTrue(res1 instanceof FullHttpRequest);
+        ((FullHttpRequest) res1).release();
+
+        HttpObject res2 = ch.readInbound();
+        System.out.println(res2);
+        assertNotNull(res2);
+        assertTrue(res2 instanceof FullHttpResponse);
+        ((FullHttpResponse) res2).release();
+    }
+}

--- a/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/rtsp/RtspEncoderTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.rtsp;
+
+import static org.junit.Assert.assertEquals;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.util.CharsetUtil;
+
+import org.junit.Test;
+
+/**
+ * Test cases for RTSP encoder.
+ */
+public class RtspEncoderTest {
+
+    /**
+     * Test of a SETUP request, with no body.
+     */
+    @Test
+    public void testSendSetupRequest() {
+        String expected = "SETUP rtsp://172.10.20.30:554/d3abaaa7-65f2-42b4-"
+                        + "8d6b-379f492fcf0f RTSP/1.0\r\n"
+                        + "transport: MP2T/DVBC/UDP;unicast;client=01234567;"
+                        + "source=172.10.20.30;"
+                        + "destination=1.1.1.1;client_port=6922\r\n"
+                        + "cseq: 1\r\n"
+                        + "\r\n";
+
+        HttpRequest request = new DefaultHttpRequest(RtspVersions.RTSP_1_0,
+               RtspMethods.SETUP,
+               "rtsp://172.10.20.30:554/d3abaaa7-65f2-42b4-8d6b-379f492fcf0f");
+        request.headers().add(RtspHeaderNames.TRANSPORT,
+               "MP2T/DVBC/UDP;unicast;client=01234567;source=172.10.20.30;" +
+               "destination=1.1.1.1;client_port=6922");
+        request.headers().add(RtspHeaderNames.CSEQ, "1");
+
+        EmbeddedChannel ch = new EmbeddedChannel(new RtspEncoder());
+        ch.writeOutbound(request);
+
+        ByteBuf buf = ch.readOutbound();
+        String actual = buf.toString(CharsetUtil.UTF_8);
+        buf.release();
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Test of a GET_PARAMETER request, with body.
+     */
+    @Test
+    public void testSendGetParameterRequest() {
+        String expected = "GET_PARAMETER rtsp://172.10.20.30:554 RTSP/1.0\r\n"
+                        + "session: 2547019973447939919\r\n"
+                        + "cseq: 3\r\n"
+                        + "content-length: 31\r\n"
+                        + "content-type: text/parameters\r\n"
+                        + "\r\n"
+                        + "stream_state\r\n"
+                        + "position\r\n"
+                        + "scale\r\n";
+
+        byte[] content = ("stream_state\r\n"
+                        + "position\r\n"
+                        + "scale\r\n").getBytes(CharsetUtil.UTF_8);
+
+        FullHttpRequest request = new DefaultFullHttpRequest(
+                RtspVersions.RTSP_1_0,
+                RtspMethods.GET_PARAMETER,
+                "rtsp://172.10.20.30:554");
+        request.headers().add(RtspHeaderNames.SESSION, "2547019973447939919");
+        request.headers().add(RtspHeaderNames.CSEQ, "3");
+        request.headers().add(RtspHeaderNames.CONTENT_LENGTH,
+                "" + content.length);
+        request.headers().add(RtspHeaderNames.CONTENT_TYPE, "text/parameters");
+        request.content().writeBytes(content);
+
+        EmbeddedChannel ch = new EmbeddedChannel(new RtspEncoder());
+        ch.writeOutbound(request);
+
+        ByteBuf buf = ch.readOutbound();
+        String actual = buf.toString(CharsetUtil.UTF_8);
+        buf.release();
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Test of a 200 OK response, without body.
+     */
+    @Test
+    public void testSend200OkResponseWithoutBody() {
+        String expected = "RTSP/1.0 200 OK\r\n"
+                        + "server: Testserver\r\n"
+                        + "cseq: 1\r\n"
+                        + "session: 2547019973447939919\r\n"
+                        + "\r\n";
+
+        HttpResponse response = new DefaultHttpResponse(RtspVersions.RTSP_1_0,
+                RtspResponseStatuses.OK);
+        response.headers().add(RtspHeaderNames.SERVER, "Testserver");
+        response.headers().add(RtspHeaderNames.CSEQ, "1");
+        response.headers().add(RtspHeaderNames.SESSION, "2547019973447939919");
+
+        EmbeddedChannel ch = new EmbeddedChannel(new RtspEncoder());
+        ch.writeOutbound(response);
+
+        ByteBuf buf = ch.readOutbound();
+        String actual = buf.toString(CharsetUtil.UTF_8);
+        buf.release();
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Test of a 200 OK response, with body.
+     */
+    @Test
+    public void testSend200OkResponseWithBody() {
+        String expected = "RTSP/1.0 200 OK\r\n"
+                        + "server: Testserver\r\n"
+                        + "session: 2547019973447939919\r\n"
+                        + "content-type: text/parameters\r\n"
+                        + "content-length: 50\r\n"
+                        + "cseq: 3\r\n"
+                        + "\r\n"
+                        + "position: 24\r\n"
+                        + "stream_state: playing\r\n"
+                        + "scale: 1.00\r\n";
+
+        byte[] content = ("position: 24\r\n"
+                        + "stream_state: playing\r\n"
+                        + "scale: 1.00\r\n").getBytes(CharsetUtil.UTF_8);
+
+        FullHttpResponse response =
+                new DefaultFullHttpResponse(RtspVersions.RTSP_1_0,
+                                            RtspResponseStatuses.OK);
+        response.headers().add(RtspHeaderNames.SERVER, "Testserver");
+        response.headers().add(RtspHeaderNames.SESSION, "2547019973447939919");
+        response.headers().add(RtspHeaderNames.CONTENT_TYPE,
+                "text/parameters");
+        response.headers().add(RtspHeaderNames.CONTENT_LENGTH,
+                "" + content.length);
+        response.headers().add(RtspHeaderNames.CSEQ, "3");
+        response.content().writeBytes(content);
+
+        EmbeddedChannel ch = new EmbeddedChannel(new RtspEncoder());
+        ch.writeOutbound(response);
+
+        ByteBuf buf = ch.readOutbound();
+        String actual = buf.toString(CharsetUtil.UTF_8);
+        buf.release();
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
The RTSP protocol isn't strict that only client issues requests and server gives responses, like http protocol. Specifically the server side of a connection may isssue an ANNOUNCE request to the client, which cased the RTSP decoder to go out of sync and fail to decode any more request/responses from the other side.

To solve that issue I've made RtspEncoder and RtspDecoder generic so that they can handle both requests and responses. For compatibility the previous classes RtspRequestEncoder and RtspResponseEncoder now just extends RtspEncoder but are deprecated, likewise for RtspRequestDecoder and RtspResponseDecoder which now extends RtspDecoder.

In RtspDecoderTest there is that specific use case which previously were failing where first an ANNOUNCE request was received and then any other response which made the decoder go out of sync but is now working fine. 