### PR TITLE
[#4244] Convert urlencoded uri to http2 path correctly

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -353,18 +353,18 @@ public final class HttpConversionUtil {
      * <a href="https://tools.ietf.org/html/rfc7230#section-5.3">rfc7230, 5.3</a>.
      */
     private static AsciiString toHttp2Path(URI uri) {
-        StringBuilder pathBuilder = new StringBuilder(length(uri.getPath()) +
-                length(uri.getQuery()) + length(uri.getFragment()) + 2);
-        if (!isNullOrEmpty(uri.getPath())) {
-            pathBuilder.append(uri.getPath());
+        StringBuilder pathBuilder = new StringBuilder(length(uri.getRawPath()) +
+                length(uri.getRawQuery()) + length(uri.getRawFragment()) + 2);
+        if (!isNullOrEmpty(uri.getRawPath())) {
+            pathBuilder.append(uri.getRawPath());
         }
-        if (!isNullOrEmpty(uri.getQuery())) {
+        if (!isNullOrEmpty(uri.getRawQuery())) {
             pathBuilder.append('?');
-            pathBuilder.append(uri.getQuery());
+            pathBuilder.append(uri.getRawQuery());
         }
-        if (!isNullOrEmpty(uri.getFragment())) {
+        if (!isNullOrEmpty(uri.getRawFragment())) {
             pathBuilder.append('#');
-            pathBuilder.append(uri.getFragment());
+            pathBuilder.append(uri.getRawFragment());
         }
         String path = pathBuilder.toString();
         return path.isEmpty() ? EMPTY_REQUEST_PATH : new AsciiString(path);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -158,6 +158,23 @@ public class HttpToHttp2ConnectionHandlerTest {
     }
 
     @Test
+    public void testOriginFormRequestTargetHandledFromUrlencodedUri() throws Exception {
+        bootstrapEnv(2, 1, 0);
+        final FullHttpRequest request = new DefaultFullHttpRequest(
+                HTTP_1_1, GET, "/where%2B0?q=now%2B0&f=then%2B0#section1%2B0");
+        final HttpHeaders httpHeaders = request.headers();
+        httpHeaders.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 5);
+        httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http");
+        final Http2Headers http2Headers =
+                new DefaultHttp2Headers().method(new AsciiString("GET"))
+                                         .path(new AsciiString("/where%2B0?q=now%2B0&f=then%2B0#section1%2B0"))
+                                         .scheme(new AsciiString("http"));
+
+        ChannelPromise writePromise = newPromise();
+        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+    }
+
+    @Test
     public void testAbsoluteFormRequestTargetHandledFromHeaders() throws Exception {
         bootstrapEnv(2, 1, 0);
         final FullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, "/pub/WWW/TheProject.html");


### PR DESCRIPTION
Motivation:

HttpConversionUtil.toHttp2Headers does not convert urlencoded uri to http2 path properly.

Modifications:

Use getRawPath(), getRawQuery(), getRawFragment() in java.net.URI when converts to http2 path

Result:

HttpConversionUtil.toHttp2Headers does not urldecode uri unproperly.