### PR TITLE
Don't set HTTP/2 flow controller ctx to null

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -425,8 +425,6 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         // Call super class first, as this may result in decode being called.
         super.channelInactive(ctx);
         if (byteDecoder != null) {
-            encoder.flowController().channelHandlerContext(null);
-            decoder.flowController().channelHandlerContext(null);
             byteDecoder.channelInactive(ctx);
             byteDecoder = null;
         }


### PR DESCRIPTION
Motivation:

We currently set the flow controller ChannelHandlerContexts to null when the channel becomes inactive. This is bad :)

Modifications:

Just remove that code in Http2ConnectionHandler

Result:

Fixes #4240