### PR TITLE
Upgrade to new os-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -904,7 +904,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.4.0.Final</version>
+        <version>1.4.1.Final</version>
       </extension>
     </extensions>
 


### PR DESCRIPTION
Motivation:

The last os-maven-plugin had a bug that sometimes missed to correctly detect fedora based linux.

Modifications:

Upgrade to 1.4.1

Result:

Correctly detect on all fedora based linux.