### PR TITLE
Not use RC4 for renegation as it is not supported in more recent java…

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -158,7 +158,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
         Future<Channel> clientHandshakeFuture = clientSslHandler.handshakeFuture();
         clientHandshakeFuture.sync();
 
-        String renegotiation = "SSL_RSA_WITH_RC4_128_SHA";
+        String renegotiation = "SSL_RSA_WITH_3DES_EDE_CBC_SHA";
         clientSslHandler.engine().setEnabledCipherSuites(new String[] { renegotiation });
         clientSslHandler.renegotiate().await();
         serverChannel.close().awaitUninterruptibly();


### PR DESCRIPTION
… versions.

Motivation:

RC4 is not supported by default in more recent java versions as RC4 is considered insecure. We should not use it in tests as these test will fail on more recent java version.

Modifications:

Use SSL_RSA_WITH_3DES_EDE_CBC_SHA for test.

Result:

Non failing test on more recent java versions.