### PR TITLE
[#4170] Shutdown socket before close fd when using epoll transport

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -101,15 +101,27 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
 
     @Override
     protected void doClose() throws Exception {
-        active = false;
+        boolean active = this.active;
+        this.active = false;
+        FileDescriptor fd = fileDescriptor;
         try {
-            // deregister from epoll now
+            // deregister from epoll now and shutdown the socket.
             doDeregister();
+            if (active) {
+                shutdown(fd.intValue());
+            }
         } finally {
             // Ensure the file descriptor is closed in all cases.
-            FileDescriptor fd = fileDescriptor;
             fd.close();
         }
+    }
+
+    /**
+     * Called on {@link #doClose()} before the actual {@link FileDescriptor} is closed.
+     * This implementation does nothing.
+     */
+    protected void shutdown(int fd) throws IOException {
+        // NOOP
     }
 
     @Override

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -95,6 +95,11 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel {
     }
 
     @Override
+    protected void shutdown(int fd) throws IOException {
+        Native.shutdown(fd, true, true);
+    }
+
+    @Override
     protected AbstractEpollUnsafe newUnsafe() {
         return new EpollStreamUnsafe();
     }


### PR DESCRIPTION
Motivation:

We should call shutdown(...) on the socket before closing the filedescriptor to ensure it is closed gracefully.

Modifications:

Call shutdown(...) before close.

Result:

Sockets are gracefully shutdown when using native transport.