### PR TITLE
StreamBufferingEncoderTest leak

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -96,11 +96,11 @@ public class StreamBufferingEncoderTest {
         when(writer.configuration()).thenReturn(configuration);
         when(configuration.frameSizePolicy()).thenReturn(frameSizePolicy);
         when(frameSizePolicy.maxFrameSize()).thenReturn(DEFAULT_MAX_FRAME_SIZE);
-        when(writer.writeData(eq(ctx), anyInt(), any(ByteBuf.class), anyInt(), anyBoolean(),
-                eq(promise))).thenAnswer(successAnswer());
+        when(writer.writeData(any(ChannelHandlerContext.class), anyInt(), any(ByteBuf.class), anyInt(), anyBoolean(),
+                any(ChannelPromise.class))).thenAnswer(successAnswer());
         when(writer.writeRstStream(eq(ctx), anyInt(), anyLong(), eq(promise))).thenAnswer(
                 successAnswer());
-        when(writer.writeGoAway(eq(ctx), anyInt(), anyLong(), any(ByteBuf.class),
+        when(writer.writeGoAway(any(ChannelHandlerContext.class), anyInt(), anyLong(), any(ByteBuf.class),
                 any(ChannelPromise.class)))
                 .thenAnswer(successAnswer());
 
@@ -141,7 +141,9 @@ public class StreamBufferingEncoderTest {
         encoder.writeSettingsAck(ctx, promise);
         encoderWriteHeaders(3, promise);
         assertEquals(0, encoder.numBufferedStreams());
-        encoder.writeData(ctx, 3, data(), 0, false, promise);
+        ByteBuf data = data();
+        final int expectedBytes = data.readableBytes() * 3;
+        encoder.writeData(ctx, 3, data, 0, false, promise);
         encoder.writeData(ctx, 3, data(), 0, false, promise);
         encoder.writeData(ctx, 3, data(), 0, false, promise);
         encoderWriteHeaders(3, promise);
@@ -151,7 +153,7 @@ public class StreamBufferingEncoderTest {
         ArgumentCaptor<ByteBuf> bufCaptor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(writer, times(1))
                 .writeData(eq(ctx), eq(3), bufCaptor.capture(), eq(0), eq(false), eq(promise));
-        assertEquals(data().readableBytes() * 3, bufCaptor.getValue().readableBytes());
+        assertEquals(expectedBytes, bufCaptor.getValue().readableBytes());
     }
 
     @Test


### PR DESCRIPTION
Motivation:
Buffer leak in StreamBufferingEncoderTest

Modifications:
- Make sure buffers are released in StreamBufferingEncoderTest

Result:
Fixes https://github.com/netty/netty/issues/4230