### PR TITLE
http2.HttpConversionUtil :authority conversion error

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -69,7 +69,6 @@ public final class HttpConversionUtil {
             add(HttpHeaderNames.HOST);
             add(HttpHeaderNames.UPGRADE);
             add(ExtensionHeaderNames.STREAM_ID.text());
-            add(ExtensionHeaderNames.AUTHORITY.text());
             add(ExtensionHeaderNames.SCHEME.text());
             add(ExtensionHeaderNames.PATH.text());
         }
@@ -113,14 +112,6 @@ public final class HttpConversionUtil {
          * {@code "x-http2-stream-id"}
          */
         STREAM_ID("x-http2-stream-id"),
-
-        /**
-         * HTTP extension header which will identify the authority pseudo header from the HTTP/2 event(s) responsible
-         * for generating a {@code HttpObject}
-         * <p>
-         * {@code "x-http2-authority"}
-         */
-        AUTHORITY("x-http2-authority"),
         /**
          * HTTP extension header which will identify the scheme pseudo header from the HTTP/2 event(s) responsible for
          * generating a {@code HttpObject}
@@ -312,11 +303,8 @@ public final class HttpConversionUtil {
             if (!isOriginForm(requestTargetUri) && !isAsteriskForm(requestTargetUri)) {
                 // Attempt to take from HOST header before taking from the request-line
                 String host = inHeaders.getAsString(HttpHeaderNames.HOST);
-                if (host == null || host.isEmpty()) {
-                    setHttp2Authority(inHeaders, requestTargetUri.getAuthority(), out);
-                } else {
-                    setHttp2Authority(inHeaders, host, out);
-                }
+                setHttp2Authority(inHeaders,
+                        (host == null || host.isEmpty()) ? requestTargetUri.getAuthority() : host, out);
             }
         } else if (in instanceof HttpResponse) {
             HttpResponse response = (HttpResponse) in;
@@ -384,13 +372,6 @@ public final class HttpConversionUtil {
             } else {
                 throw new IllegalArgumentException("autority: " + autority);
             }
-        } else {
-            // Consume the Authority extension header if present
-            CharSequence cValue = in.get(ExtensionHeaderNames.AUTHORITY.text());
-            if (cValue != null) {
-                // Assume this is sanitized of all "userinfo"
-                out.authority(AsciiString.of(cValue));
-            }
         }
     }
 
@@ -431,7 +412,7 @@ public final class HttpConversionUtil {
             RESPONSE_HEADER_TRANSLATIONS = new HashMap<ByteString, ByteString>();
         static {
             RESPONSE_HEADER_TRANSLATIONS.put(Http2Headers.PseudoHeaderName.AUTHORITY.value(),
-                            ExtensionHeaderNames.AUTHORITY.text());
+                            HttpHeaderNames.HOST);
             RESPONSE_HEADER_TRANSLATIONS.put(Http2Headers.PseudoHeaderName.SCHEME.value(),
                             ExtensionHeaderNames.SCHEME.text());
             REQUEST_HEADER_TRANSLATIONS.putAll(RESPONSE_HEADER_TRANSLATIONS);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -126,7 +126,6 @@ public class HttpToHttp2ConnectionHandlerTest {
         final HttpHeaders httpHeaders = request.headers();
         httpHeaders.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 5);
         httpHeaders.set(HttpHeaderNames.HOST, "my-user_name@www.example.org:5555");
-        httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.AUTHORITY.text(), "www.example.org:5555");
         httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http");
         httpHeaders.add(of("foo"), of("goo"));
         httpHeaders.add(of("foo"), of("goo2"));
@@ -183,25 +182,6 @@ public class HttpToHttp2ConnectionHandlerTest {
         httpHeaders.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 5);
         httpHeaders.set(HttpHeaderNames.HOST, "foouser@www.example.org:5555");
         httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.PATH.text(), "ignored_path");
-        httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.AUTHORITY.text(), "ignored_authority");
-        httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "https");
-        final Http2Headers http2Headers =
-                new DefaultHttp2Headers().method(new AsciiString("GET"))
-                .path(new AsciiString("/pub/WWW/TheProject.html"))
-                .authority(new AsciiString("www.example.org:5555")).scheme(new AsciiString("https"));
-
-        ChannelPromise writePromise = newPromise();
-        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
-    }
-
-    @Test
-    public void testAbsoluteFormRequestTargetHandledFromHeadersNoHost() throws Exception {
-        bootstrapEnv(2, 1, 0);
-        final FullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, "/pub/WWW/TheProject.html");
-        final HttpHeaders httpHeaders = request.headers();
-        httpHeaders.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 5);
-        httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.PATH.text(), "ignored_path");
-        httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.AUTHORITY.text(), "www.example.org:5555");
         httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "https");
         final Http2Headers http2Headers =
                 new DefaultHttp2Headers().method(new AsciiString("GET"))

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -135,7 +135,7 @@ public class InboundHttp2ToHttpAdapterTest {
         try {
             HttpHeaders httpHeaders = request.headers();
             httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "https");
-            httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.AUTHORITY.text(), "example.org");
+            httpHeaders.set(HttpHeaderNames.HOST, "example.org");
             httpHeaders.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 3);
             httpHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
             final Http2Headers http2Headers = new DefaultHttp2Headers().method(new AsciiString("GET")).
@@ -481,7 +481,7 @@ public class InboundHttp2ToHttpAdapterTest {
             httpHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, text.length());
             HttpHeaders httpHeaders2 = response2.headers();
             httpHeaders2.set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "https");
-            httpHeaders2.set(HttpConversionUtil.ExtensionHeaderNames.AUTHORITY.text(), "example.org");
+            httpHeaders2.set(HttpHeaderNames.HOST, "example.org");
             httpHeaders2.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 5);
             httpHeaders2.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_PROMISE_ID.text(), 3);
             httpHeaders2.setInt(HttpHeaderNames.CONTENT_LENGTH, text2.length());


### PR DESCRIPTION
Motiviation:
The http2 spec https://tools.ietf.org/html/rfc7540#section-8.1.2.3 states that the :authority header should be copied into the HOST header when converting from HTTP/2 to HTTP/1.x. We currently have an extension header to preserve the authority.

Modifications:
- Remove AUTHORITY extension header
- HTTP/2 :authority should map to HOST header when converting to HTTP/1.x.

Result:
More spec compliant.