### PR TITLE
Http2LifecycleManager.onException rename

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -171,7 +171,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
                             endOfStream, promise));
             return promise;
         } catch (Http2NoMoreStreamIdsException e) {
-            lifecycleManager.onException(ctx, e);
+            lifecycleManager.onError(ctx, e);
             return promise.setFailure(e);
         } catch (Throwable e) {
             return promise.setFailure(e);
@@ -332,7 +332,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
         @Override
         public void error(ChannelHandlerContext ctx, Throwable cause) {
             queue.releaseAndFailAll(cause);
-            lifecycleManager.onException(ctx, cause);
+            lifecycleManager.onError(ctx, cause);
             promise.tryFailure(cause);
         }
 
@@ -400,7 +400,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
         @Override
         public void error(ChannelHandlerContext ctx, Throwable cause) {
             if (ctx != null) {
-                lifecycleManager.onException(ctx, cause);
+                lifecycleManager.onError(ctx, cause);
             }
             promise.tryFailure(cause);
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -274,7 +274,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
                     byteDecoder.decode(ctx, in, out);
                 }
             } catch (Throwable e) {
-                onException(ctx, e);
+                onError(ctx, e);
             }
         }
 
@@ -391,7 +391,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             try {
                 decoder.decodeFrame(ctx, in, out);
             } catch (Throwable e) {
-                onException(ctx, e);
+                onError(ctx, e);
             }
         }
     }
@@ -526,7 +526,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         if (getEmbeddedHttp2Exception(cause) != null) {
             // Some exception in the causality chain is an Http2Exception - handle it.
-            onException(ctx, cause);
+            onError(ctx, cause);
         } else {
             super.exceptionCaught(ctx, cause);
         }
@@ -592,7 +592,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
      * Central handler for all exceptions caught during HTTP/2 processing.
      */
     @Override
-    public void onException(ChannelHandlerContext ctx, Throwable cause) {
+    public void onError(ChannelHandlerContext ctx, Throwable cause) {
         Http2Exception embedded = getEmbeddedHttp2Exception(cause);
         if (isStreamError(embedded)) {
             onStreamError(ctx, cause, (StreamException) embedded);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LifecycleManager.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LifecycleManager.java
@@ -85,7 +85,7 @@ public interface Http2LifecycleManager {
             ByteBuf debugData, ChannelPromise promise);
 
     /**
-     * Processes the given exception.
+     * Processes the given error.
      */
-    void onException(ChannelHandlerContext ctx, Throwable cause);
+    void onError(ChannelHandlerContext ctx, Throwable cause);
 }


### PR DESCRIPTION
Motivation:
Http2LifecycleManager.onException takes a Throwable as a paramter and not an Exception. There are also onConnectionError and onStreamError methods in the codec. We should rename this method to onError for consistency and clarity.

Modifications:
- Rename Http2LifecycleManager.onException to Http2LifecycleManager.onError

Result:
More consistent and clarified interface.