### PR TITLE
STOMP Headers Name Comparator

### DIFF
--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeaders.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeaders.java
@@ -30,7 +30,7 @@ import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
 
 public class DefaultStompHeaders extends DefaultHeaders<CharSequence> implements StompHeaders {
     public DefaultStompHeaders() {
-        super(CharSequenceValueConverter.INSTANCE);
+        super(CASE_SENSITIVE_HASHER, CharSequenceValueConverter.INSTANCE);
     }
 
     @Override

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompHeadersTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompHeadersTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.stomp;
+
+import io.netty.util.AsciiString;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class StompHeadersTest {
+    @Test
+    public void testHeadersCaseSensative() {
+        DefaultStompHeaders headers = new DefaultStompHeaders();
+        AsciiString foo = new AsciiString("foo");
+        AsciiString value = new AsciiString("value");
+        headers.add(foo, value);
+        assertNull(headers.get("Foo"));
+        assertEquals(value, headers.get(foo));
+        assertEquals(value, headers.get(foo.toString()));
+    }
+}

--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -85,12 +85,17 @@ public class DefaultHeaders<T> implements Headers<T> {
 
     @SuppressWarnings("unchecked")
     public DefaultHeaders(ValueConverter<T> valueConverter) {
-        this(valueConverter, NameValidator.NOT_NULL);
+        this(JAVA_HASHER, valueConverter);
     }
 
     @SuppressWarnings("unchecked")
     public DefaultHeaders(ValueConverter<T> valueConverter, NameValidator<T> nameValidator) {
         this(JAVA_HASHER, valueConverter, nameValidator);
+    }
+
+    @SuppressWarnings("unchecked")
+    public DefaultHeaders(HashingStrategy<T> nameHashingStrategy, ValueConverter<T> valueConverter) {
+        this(nameHashingStrategy, valueConverter, NameValidator.NOT_NULL);
     }
 
     public DefaultHeaders(HashingStrategy<T> nameHashingStrategy,


### PR DESCRIPTION
Motivation:
The HashingStrategy for DefaultStompHeaders was using the java .equals() method which would fail to compare String, AsciiString, and other CharSequence objects as equal.

Modifications:
- Use AsciiString.CASE_SENSITIVE_HASHER for DefaultStompHeaders

Result:
DefaultStompHeaders work with all CharSequence objects.
Fixes netty#4247