### PR TITLE
Use NetUtil.LOCALHOST4 instead of InetAddress.getLocalHost()

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
@@ -25,13 +25,14 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 
+import io.netty.util.NetUtil;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class EpollSocketTcpMd5Test  {
+public class EpollSocketTcpMd5Test {
     private static final byte[] SERVER_KEY = "abc".getBytes(CharsetUtil.US_ASCII);
     private static final byte[] BAD_KEY = "def".getBytes(CharsetUtil.US_ASCII);
     private static EventLoopGroup GROUP;
@@ -63,8 +64,8 @@ public class EpollSocketTcpMd5Test  {
 
     @Test
     public void testServerSocketChannelOption() throws Exception {
-        server.config().setOption(EpollChannelOption.TCP_MD5SIG, Collections.singletonMap(InetAddress.getLocalHost(),
-            SERVER_KEY));
+        server.config().setOption(EpollChannelOption.TCP_MD5SIG,
+                Collections.<InetAddress, byte[]>singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
         server.config().setOption(EpollChannelOption.TCP_MD5SIG, Collections.<InetAddress, byte[]>emptyMap());
     }
 
@@ -76,8 +77,8 @@ public class EpollSocketTcpMd5Test  {
                 .handler(new ChannelInboundHandlerAdapter())
                 .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
 
-        ch.config().setOption(EpollChannelOption.TCP_MD5SIG, Collections.singletonMap(InetAddress.getLocalHost(),
-            SERVER_KEY));
+        ch.config().setOption(EpollChannelOption.TCP_MD5SIG,
+                Collections.<InetAddress, byte[]>singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
         ch.config().setOption(EpollChannelOption.TCP_MD5SIG, Collections.<InetAddress, byte[]>emptyMap());
 
         ch.close().syncUninterruptibly();
@@ -85,28 +86,28 @@ public class EpollSocketTcpMd5Test  {
 
     @Test(expected = ConnectTimeoutException.class)
     public void testKeyMismatch() throws Exception {
-        server.config().setOption(EpollChannelOption.TCP_MD5SIG, Collections.singletonMap(InetAddress.getLocalHost(),
-            SERVER_KEY));
+        server.config().setOption(EpollChannelOption.TCP_MD5SIG,
+                Collections.<InetAddress, byte[]>singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
 
         EpollSocketChannel client = (EpollSocketChannel) new Bootstrap().group(GROUP)
                 .channel(EpollSocketChannel.class)
                 .handler(new ChannelInboundHandlerAdapter())
                 .option(EpollChannelOption.TCP_MD5SIG,
-                    Collections.singletonMap(InetAddress.getLocalHost(), BAD_KEY))
+                        Collections.<InetAddress, byte[]>singletonMap(NetUtil.LOCALHOST4, BAD_KEY))
                 .connect(server.localAddress()).syncUninterruptibly().channel();
         client.close().syncUninterruptibly();
     }
 
     @Test
     public void testKeyMatch() throws Exception {
-        server.config().setOption(EpollChannelOption.TCP_MD5SIG, Collections.singletonMap(InetAddress.getLocalHost(),
-            SERVER_KEY));
+        server.config().setOption(EpollChannelOption.TCP_MD5SIG,
+                Collections.<InetAddress, byte[]>singletonMap(NetUtil.LOCALHOST4, SERVER_KEY));
 
         EpollSocketChannel client = (EpollSocketChannel) new Bootstrap().group(GROUP)
                 .channel(EpollSocketChannel.class)
                 .handler(new ChannelInboundHandlerAdapter())
                 .option(EpollChannelOption.TCP_MD5SIG,
-                    Collections.singletonMap(InetAddress.getLocalHost(), SERVER_KEY))
+                        Collections.<InetAddress, byte[]>singletonMap(NetUtil.LOCALHOST4, SERVER_KEY))
                 .connect(server.localAddress()).syncUninterruptibly().channel();
         client.close().syncUninterruptibly();
     }


### PR DESCRIPTION
Motivation:

On ubuntu, InetAddress.getLocalHost() will return 127.0.1.1 this causes EpollSocketTcpMd5Test to fail.
NetUtil.LOCALHOST4 is more portable.

Modifications:

Made changes in EpollSocketTcpMd5Test to make test passing on ubuntu.

Result:

EpollSocketTcpMd5Test now also passes on ubuntu.