### PR TITLE
[#3705] Correct usage and compare of System.nanoTime()

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -31,8 +31,12 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
 
     Queue<ScheduledFutureTask<?>> scheduledTaskQueue;
 
+    /**
+     * @deprecated use {@link System#nanoTime()}.
+     */
+    @Deprecated
     protected static long nanoTime() {
-        return ScheduledFutureTask.nanoTime();
+        return System.nanoTime();
     }
 
     Queue<ScheduledFutureTask<?>> scheduledTaskQueue() {
@@ -72,12 +76,12 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
      * @see {@link #pollScheduledTask(long)}
      */
     protected final Runnable pollScheduledTask() {
-        return pollScheduledTask(nanoTime());
+        return pollScheduledTask(System.nanoTime());
     }
 
     /**
      * Return the {@link Runnable} which is ready to be executed with the given {@code nanoTime}.
-     * You should use {@link #nanoTime()} to retrieve the the correct {@code nanoTime}.
+     * You should use {@link System#nanoTime()} to retrieve the the correct {@code nanoTime}.
      */
     protected final Runnable pollScheduledTask(long nanoTime) {
         assert inEventLoop();
@@ -88,7 +92,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
             return null;
         }
 
-        if (scheduledTask.deadlineNanos() <= nanoTime) {
+        if (scheduledTask.deadlineNanos() - nanoTime <= 0) {
             scheduledTaskQueue.remove();
             return scheduledTask;
         }
@@ -104,7 +108,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         if (scheduledTask == null) {
             return -1;
         }
-        return Math.max(0, scheduledTask.deadlineNanos() - nanoTime());
+        return Math.max(0, scheduledTask.deadlineNanos() - System.nanoTime());
     }
 
     final ScheduledFutureTask<?> peekScheduledTask() {
@@ -121,7 +125,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
     protected final boolean hasScheduledTasks() {
         Queue<ScheduledFutureTask<?>> scheduledTaskQueue = this.scheduledTaskQueue;
         ScheduledFutureTask<?> scheduledTask = scheduledTaskQueue == null ? null : scheduledTaskQueue.peek();
-        return scheduledTask != null && scheduledTask.deadlineNanos() <= nanoTime();
+        return scheduledTask != null && scheduledTask.deadlineNanos() - System.nanoTime() <= 0;
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -109,7 +109,7 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor {
 
     private void fetchFromScheduledTaskQueue() {
         if (hasScheduledTasks()) {
-            long nanoTime = AbstractScheduledEventExecutor.nanoTime();
+            long nanoTime = System.nanoTime();
             for (;;) {
                 Runnable scheduledTask = pollScheduledTask(nanoTime);
                 if (scheduledTask == null) {

--- a/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
+++ b/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
@@ -25,14 +25,9 @@ import java.util.concurrent.atomic.AtomicLong;
 @SuppressWarnings("ComparableImplementedButEqualsNotOverridden")
 final class ScheduledFutureTask<V> extends PromiseTask<V> implements ScheduledFuture<V> {
     private static final AtomicLong nextTaskId = new AtomicLong();
-    private static final long START_TIME = System.nanoTime();
-
-    static long nanoTime() {
-        return System.nanoTime() - START_TIME;
-    }
 
     static long deadlineNanos(long delay) {
-        return nanoTime() + delay;
+        return System.nanoTime() + delay;
     }
 
     private final long id = nextTaskId.getAndIncrement();
@@ -78,11 +73,11 @@ final class ScheduledFutureTask<V> extends PromiseTask<V> implements ScheduledFu
     }
 
     public long delayNanos() {
-        return Math.max(0, deadlineNanos() - nanoTime());
+        return Math.max(0, deadlineNanos() - System.nanoTime());
     }
 
     public long delayNanos(long currentTimeNanos) {
-        return Math.max(0, deadlineNanos() - (currentTimeNanos - START_TIME));
+        return Math.max(0, deadlineNanos() - currentTimeNanos);
     }
 
     @Override
@@ -129,7 +124,7 @@ final class ScheduledFutureTask<V> extends PromiseTask<V> implements ScheduledFu
                         if (p > 0) {
                             deadlineNanos += p;
                         } else {
-                            deadlineNanos = nanoTime() - p;
+                            deadlineNanos = System.nanoTime() - p;
                         }
                         if (!isCancelled()) {
                             // scheduledTaskQueue can never be null as we lazy init it before submit the task!

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
@@ -52,7 +52,7 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
     }
 
     long runScheduledTasks() {
-        long time = AbstractScheduledEventExecutor.nanoTime();
+        long time = System.nanoTime();
         for (;;) {
             Runnable task = pollScheduledTask(time);
             if (task == null) {


### PR DESCRIPTION
Motivation:

We should use the recommended way of compare two instances of nanoTime().

Modifications:

Change usage to recommended way.

Result:

Recommend way of compared two System.nanoTimes() calls.
