### PR TITLE
[#4265] Not allow to add/set DefaultHttpHeaders to itself.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -59,6 +59,9 @@ public class DefaultHttpHeaders extends HttpHeaders {
     @Override
     public HttpHeaders add(HttpHeaders headers) {
         if (headers instanceof DefaultHttpHeaders) {
+            if (headers == this) {
+                throw new IllegalArgumentException("can't add to itself.");
+            }
             DefaultHttpHeaders defaultHttpHeaders = (DefaultHttpHeaders) headers;
             HeaderEntry e = defaultHttpHeaders.head.after;
             while (e != defaultHttpHeaders.head) {
@@ -74,6 +77,9 @@ public class DefaultHttpHeaders extends HttpHeaders {
     @Override
     public HttpHeaders set(HttpHeaders headers) {
         if (headers instanceof DefaultHttpHeaders) {
+            if (headers == this) {
+                throw new IllegalArgumentException("can't add to itself.");
+            }
             clear();
             DefaultHttpHeaders defaultHttpHeaders = (DefaultHttpHeaders) headers;
             HeaderEntry e = defaultHttpHeaders.head.after;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
@@ -67,4 +67,16 @@ public class HttpHeadersTest {
         HttpHeaders headers = new DefaultHttpHeaders(false);
         headers.set("test", (CharSequence) null);
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddSelf() {
+        HttpHeaders headers = new DefaultHttpHeaders(false);
+        headers.add(headers);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetSelf() {
+        HttpHeaders headers = new DefaultHttpHeaders(false);
+        headers.set(headers);
+    }
 }


### PR DESCRIPTION
Motivation:

We should prevent to add/set DefaultHttpHeaders to itself to prevent unexpected side-effects.

Modifications:

Throw IllegalArgumentException if user tries to pass the same instance to set/add.

Result:

No surprising side-effects.