### PR TITLE
Expose new way of setting session keys

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
@@ -16,6 +16,7 @@
 package io.netty.handler.ssl;
 
 import org.apache.tomcat.jni.SSLContext;
+import org.apache.tomcat.jni.SessionTicketKey;
 
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionContext;
@@ -51,12 +52,28 @@ public abstract class OpenSslSessionContext implements SSLSessionContext {
 
     /**
      * Sets the SSL session ticket keys of this context.
+     * @deprecated use {@link #setTicketKeys(OpenSslSessionTicketKey...)}.
      */
+    @Deprecated
     public void setTicketKeys(byte[] keys) {
         if (keys == null) {
             throw new NullPointerException("keys");
         }
         SSLContext.setSessionTicketKeys(context, keys);
+    }
+
+    /**
+     * Sets the SSL session ticket keys of this context.
+     */
+    public void setTicketKeys(OpenSslSessionTicketKey... keys) {
+        if (keys == null) {
+            throw new NullPointerException("keys");
+        }
+        SessionTicketKey[] ticketKeys = new SessionTicketKey[keys.length];
+        for (int i = 0; i < ticketKeys.length; i++) {
+            ticketKeys[i] = keys[i].key;
+        }
+        SSLContext.setSessionTicketKeys(context, ticketKeys);
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionTicketKey.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionTicketKey.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import org.apache.tomcat.jni.SessionTicketKey;
+
+/**
+ * Session Ticket Key
+ */
+public final class OpenSslSessionTicketKey {
+
+    /**
+     * Size of session ticket key name
+     */
+    public static final int NAME_SIZE = SessionTicketKey.NAME_SIZE;
+    /**
+     * Size of session ticket key HMAC key
+     */
+    public static final int HMAC_KEY_SIZE = SessionTicketKey.HMAC_KEY_SIZE;
+    /**
+     * Size of session ticket key AES key
+     */
+    public static final int AES_KEY_SIZE = SessionTicketKey.AES_KEY_SIZE;
+    /**
+     * Size of session ticker key
+     */
+    public static final int TICKET_KEY_SIZE = SessionTicketKey.TICKET_KEY_SIZE;
+
+    final SessionTicketKey key;
+
+    /**
+     * Construct a OpenSslSessionTicketKey.
+     *
+     * @param name the name of the session ticket key
+     * @param hmacKey the HMAC key of the session ticket key
+     * @param aesKey the AES key of the session ticket key
+     */
+    public OpenSslSessionTicketKey(byte[] name, byte[] hmacKey, byte[] aesKey) {
+        key = new SessionTicketKey(name.clone(), hmacKey.clone(), aesKey.clone());
+    }
+
+    /**
+     * Get name.
+     * @return the name of the session ticket key
+     */
+    public byte[] name() {
+        return key.getName().clone();
+    }
+
+    /**
+     * Get HMAC key.
+     * @return the HMAC key of the session ticket key
+     */
+    public byte[] hmacKey() {
+        return key.getHmacKey().clone();
+    }
+
+    /**
+     * Get AES Key.
+     * @return the AES key of the session ticket key
+     */
+    public byte[] aesKey() {
+        return key.getAesKey().clone();
+    }
+}


### PR DESCRIPTION
Motivation:

We should provide a better way to set session keys that not use the deprecated method of netty-tcnative.

Modifications:

- Add OpenSslSessionTicketKey
- Expose new method on OpenSslServerContext and deprecate the old method.

Result:

Easier to use and can remove the deprecated method later on.