### PR TITLE
[#4284] Improve buffer rotation by a more often call to channelRead(.…

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -324,6 +324,8 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                     // Something was read, call fireChannelReadComplete()
                     ctx.fireChannelReadComplete();
                 }
+
+                ctx.fireChannelInactive();
             }
         }
     }

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -21,6 +21,7 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.RecyclableArrayList;
 import io.netty.util.internal.StringUtil;
 
@@ -135,20 +136,9 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
     private boolean singleDecode;
     private boolean decodeWasNull;
     private boolean first;
-    private int fireAfterReads = 16;
 
     protected ByteToMessageDecoder() {
         CodecUtil.ensureNotSharable(this);
-    }
-
-    /**
-     * Sets the number of reads after which the messages will be passed to the next handler(before the full decoding is over), allowing quicker re-use of pooled objects like ByteBufs.
-     */
-    public void setFireAfterReads(int fireAfterReads) {
-        if (fireAfterReads <= 0) {
-            throw new IllegalArgumentException("fireAfterReads must be > 0");
-        }
-        this.fireAfterReads = fireAfterReads;
     }
 
     /**
@@ -229,6 +219,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (msg instanceof ByteBuf) {
+            boolean somethingRead = false;
             RecyclableArrayList out = RecyclableArrayList.newInstance();
             try {
                 ByteBuf data = (ByteBuf) msg;
@@ -238,7 +229,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                 } else {
                     cumulation = cumulator.cumulate(ctx.alloc(), cumulation, data);
                 }
-                callDecode(ctx, cumulation, out);
+                somethingRead = callDecode(ctx, cumulation, out);
             } catch (DecoderException e) {
                 throw e;
             } catch (Throwable t) {
@@ -248,12 +239,16 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                     cumulation.release();
                     cumulation = null;
                 }
-                int size = out.size();
-                decodeWasNull = size == 0;
 
-                for (int i = 0; i < size; i ++) {
-                    ctx.fireChannelRead(out.get(i));
+                int size = out.size();
+
+                // this should trigger only when an exception was thrown by decoder
+                for (int i = 0; i < size; i++) {
+                    // release without firing to avoid firing the same message TWICE if an exception happened
+                    ReferenceCountUtil.safeRelease(out.get(i));
                 }
+
+                decodeWasNull = !somethingRead;
                 out.recycle();
             }
         } else {
@@ -289,9 +284,11 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         RecyclableArrayList out = RecyclableArrayList.newInstance();
+        boolean somethingRead = false;
+
         try {
             if (cumulation != null) {
-                callDecode(ctx, cumulation, out);
+                somethingRead = callDecode(ctx, cumulation, out);
                 decodeLast(ctx, cumulation, out);
             } else {
                 decodeLast(ctx, Unpooled.EMPTY_BUFFER, out);
@@ -301,22 +298,27 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
         } catch (Exception e) {
             throw new DecoderException(e);
         } finally {
+            int size = out.size();
             try {
                 if (cumulation != null) {
                     cumulation.release();
                     cumulation = null;
                 }
-                int size = out.size();
+
+                // this will fire if decodeLast(...) was in use
                 for (int i = 0; i < size; i++) {
                     ctx.fireChannelRead(out.get(i));
                 }
-                if (size > 0) {
+                if (size > 0 || somethingRead) {
                     // Something was read, call fireChannelReadComplete()
                     ctx.fireChannelReadComplete();
                 }
                 ctx.fireChannelInactive();
             } finally {
                 // recycle in all cases
+                for (int i = 0; i < out.size(); i++) {
+                    ReferenceCountUtil.safeRelease(out.get(i));
+                }
                 out.recycle();
             }
         }
@@ -330,56 +332,56 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
      * @param in            the {@link ByteBuf} from which to read data
      * @param out           the {@link List} to which decoded messages should be added
      */
-    protected void callDecode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
-        try {
-            while (in.isReadable()) {
-                int outSize = out.size();
-                int oldInputLength = in.readableBytes();
+    protected boolean callDecode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
+        boolean somethingRead = false;
+
+        while (in.isReadable()) {
+            int outSize = out.size();
+            int oldInputLength = in.readableBytes();
+
+            try {
                 decode(ctx, in, out);
+            } catch (DecoderException e) {
+                throw e;
+            } catch (Throwable cause) {
+                throw new DecoderException(cause);
+            }
 
-                // Check if this handler was removed before continuing the loop.
-                // If it was removed, it is not safe to continue to operate on the buffer.
-                //
-                // See https://github.com/netty/netty/issues/1664
-                if (ctx.isRemoved()) {
-                    break;
-                }
-                if (outSize == out.size()) {
-                    if (oldInputLength == in.readableBytes()) {
-                        break;
-                    } else {
-                        continue;
-                    }
-                }
+            // Check if this handler was removed before continuing the loop.
+            // If it was removed, it is not safe to continue to operate on the buffer.
+            //
+            // See https://github.com/netty/netty/issues/1664
+            if (ctx.isRemoved()) {
+                break;
+            }
 
+            if (outSize == out.size()) {
                 if (oldInputLength == in.readableBytes()) {
-                    throw new DecoderException(
-                            StringUtil.simpleClassName(getClass()) +
-                            ".decode() did not read anything but decoded a message.");
-                }
-
-                if (isSingleDecode()) {
                     break;
-                }
-
-                if (out.size() < fireAfterReads) {
+                } else {
                     continue;
-                }
-
-                if (out.size() == 1) {
-                    ctx.fireChannelRead(out.remove(0));
-                    continue;
-                }
-
-                for (int i = 0; i < out.size(); i++) {
-                    ctx.fireChannelRead(out.remove(0));
                 }
             }
-        } catch (DecoderException e) {
-            throw e;
-        } catch (Throwable cause) {
-            throw new DecoderException(cause);
+
+            if (oldInputLength == in.readableBytes()) {
+                throw new DecoderException(
+                        StringUtil.simpleClassName(getClass()) +
+                        ".decode() did not read anything but decoded a message.");
+            }
+
+            for (int i = 0; i < out.size(); i++) {
+                ctx.fireChannelRead(out.get(i));
+            }
+
+            somethingRead = somethingRead || out.size() > 0;
+            out.clear();
+
+            if (isSingleDecode()) {
+                break;
+            }
         }
+
+        return somethingRead;
     }
 
     /**

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -243,9 +243,11 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                 int size = out.size();
 
                 // this should trigger only when an exception was thrown by decoder
-                for (int i = 0; i < size; i++) {
-                    // release without firing to avoid firing the same message TWICE if an exception happened
-                    ReferenceCountUtil.safeRelease(out.get(i));
+                if (size != 0) {
+                    for (int i = 0; i < size; i++) {
+                        // release without firing to avoid firing the same message TWICE if an exception happened
+                        ReferenceCountUtil.safeRelease(out.get(i));
+                    }
                 }
 
                 decodeWasNull = !somethingRead;
@@ -316,8 +318,10 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                 ctx.fireChannelInactive();
             } finally {
                 // recycle in all cases
-                for (int i = 0; i < out.size(); i++) {
-                    ReferenceCountUtil.safeRelease(out.get(i));
+                if (!out.isEmpty()) {
+                    for (int i = 0; i < out.size(); i++) {
+                        ReferenceCountUtil.safeRelease(out.get(i));
+                    }
                 }
                 out.recycle();
             }

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -311,11 +311,6 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                 for (int i = 0; i < size; i++) {
                     ctx.fireChannelRead(out.get(i));
                 }
-                if (size > 0 || somethingRead) {
-                    // Something was read, call fireChannelReadComplete()
-                    ctx.fireChannelReadComplete();
-                }
-                ctx.fireChannelInactive();
             } finally {
                 // recycle in all cases
                 if (!out.isEmpty()) {
@@ -324,6 +319,11 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                     }
                 }
                 out.recycle();
+
+                if (size > 0 || somethingRead) {
+                    // Something was read, call fireChannelReadComplete()
+                    ctx.fireChannelReadComplete();
+                }
             }
         }
     }

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
@@ -372,6 +372,7 @@ public abstract class ReplayingDecoder<S> extends ByteToMessageDecoder {
                     decode(ctx, replayable, out);
                     somethingRead = somethingRead || out.size() > 0;
 
+
                     // Check if this handler was removed before continuing the loop.
                     // If it was removed, it is not safe to continue to operate on the buffer.
                     //
@@ -427,6 +428,12 @@ public abstract class ReplayingDecoder<S> extends ByteToMessageDecoder {
         } catch (Throwable cause) {
             throw new DecoderException(cause);
         }
+
+        for (int i = 0; i < out.size(); i++) {
+            ctx.fireChannelRead(out.get(0));
+        }
+
+        out.clear();
 
         return somethingRead;
     }

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
@@ -429,7 +429,7 @@ public abstract class ReplayingDecoder<S> extends ByteToMessageDecoder {
         }
 
         for (int i = 0; i < out.size(); i++) {
-            ctx.fireChannelRead(out.get(0));
+            ctx.fireChannelRead(out.get(i));
         }
 
         out.clear();

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
@@ -372,7 +372,6 @@ public abstract class ReplayingDecoder<S> extends ByteToMessageDecoder {
                     decode(ctx, replayable, out);
                     somethingRead = somethingRead || out.size() > 0;
 
-
                     // Check if this handler was removed before continuing the loop.
                     // If it was removed, it is not safe to continue to operate on the buffer.
                     //


### PR DESCRIPTION
…..) at ByteToMessageDecoder

Motivation:

A long fight against spam of ChannelOutboundBuffer.Entry instances has revealed a need
to pass decoded messages earlier in the decoding process so they could be released and instantly reused (ByteBufs).

Modifications:

ByteToMessageDecoder has been modified to fire channelRead(...) every 16 decoded messages with an option to override that number.

Results:

The buffers are more quickly reused and the number of recycled entries has been reduced.

Related issue: #4285 (and #4284 from the title)