### PR TITLE
HTTP/2 Listener Exceptions Close Connection

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -41,7 +41,6 @@ import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.REFUSED_STREAM;
 import static io.netty.handler.codec.http2.Http2Exception.closedStreamError;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
-import static io.netty.handler.codec.http2.Http2Exception.isStreamError;
 import static io.netty.handler.codec.http2.Http2Exception.streamError;
 import static io.netty.handler.codec.http2.Http2Stream.State.CLOSED;
 import static io.netty.handler.codec.http2.Http2Stream.State.HALF_CLOSED_LOCAL;
@@ -156,10 +155,8 @@ public class DefaultHttp2Connection implements Http2Connection {
             for (int i = 0; i < listeners.size(); ++i) {
                 listeners.get(i).onGoAwayReceived(lastKnownStream, errorCode, debugData);
             }
-        } catch (Http2Exception e) {
-            throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
         } catch (Throwable cause) {
-            throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
+            throw connectionError(INTERNAL_ERROR, cause, "unexpected error from onGoAwayReceived");
         }
 
         forEachActiveStream(new Http2StreamVisitor() {
@@ -185,10 +182,8 @@ public class DefaultHttp2Connection implements Http2Connection {
             for (int i = 0; i < listeners.size(); ++i) {
                 listeners.get(i).onGoAwaySent(lastKnownStream, errorCode, debugData);
             }
-        } catch (Http2Exception e) {
-            throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
         } catch (Throwable cause) {
-            throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
+            throw connectionError(INTERNAL_ERROR, cause, "unexpected error from onGoAwaySent");
         }
 
         forEachActiveStream(new Http2StreamVisitor() {
@@ -222,10 +217,8 @@ public class DefaultHttp2Connection implements Http2Connection {
                 for (int i = 0; i < listeners.size(); i++) {
                     listeners.get(i).onStreamRemoved(stream);
                 }
-            } catch (Http2Exception e) {
-                throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
             } catch (Throwable cause) {
-                throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
+                throw connectionError(INTERNAL_ERROR, cause, "unexpected error from onStreamRemoved");
             }
         }
     }
@@ -250,10 +243,8 @@ public class DefaultHttp2Connection implements Http2Connection {
             for (int i = 0; i < listeners.size(); i++) {
                 listeners.get(i).onStreamHalfClosed(stream);
             }
-        } catch (Http2Exception e) {
-            throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
         } catch (Throwable cause) {
-            throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
+            throw connectionError(INTERNAL_ERROR, cause, "unexpected error from onStreamHalfClosed");
         }
     }
 
@@ -262,10 +253,8 @@ public class DefaultHttp2Connection implements Http2Connection {
             for (int i = 0; i < listeners.size(); i++) {
                 listeners.get(i).onStreamClosed(stream);
             }
-        } catch (Http2Exception e) {
-            throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
         } catch (Throwable cause) {
-            throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
+            throw connectionError(INTERNAL_ERROR, cause, "unexpected error from onStreamClosed");
         }
     }
 
@@ -580,10 +569,8 @@ public class DefaultHttp2Connection implements Http2Connection {
                     for (int i = 0; i < listeners.size(); i++) {
                         listeners.get(i).onWeightChanged(this, oldWeight);
                     }
-                } catch (Http2Exception e) {
-                    throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
                 } catch (Throwable cause) {
-                    throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
+                    throw connectionError(INTERNAL_ERROR, cause, "unexpected error from onWeightChanged");
                 }
             }
         }
@@ -759,10 +746,8 @@ public class DefaultHttp2Connection implements Http2Connection {
         public void notifyListener(Listener l) throws Http2Exception {
             try {
                 l.onPriorityTreeParentChanged(stream, oldParent);
-            } catch (Http2Exception e) {
-                throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
             } catch (Throwable cause) {
-                throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
+                throw connectionError(INTERNAL_ERROR, cause, "unexpected error from onPriorityTreeParentChanged");
             }
         }
     }
@@ -786,10 +771,8 @@ public class DefaultHttp2Connection implements Http2Connection {
             for (int i = 0; i < listeners.size(); i++) {
                 listeners.get(i).onPriorityTreeParentChanging(stream, newParent);
             }
-        } catch (Http2Exception e) {
-            throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
         } catch (Throwable cause) {
-            throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
+            throw connectionError(INTERNAL_ERROR, cause, "unexpected error from onPriorityTreeParentChanging");
         }
     }
 
@@ -955,10 +938,8 @@ public class DefaultHttp2Connection implements Http2Connection {
                 for (int i = 0; i < listeners.size(); i++) {
                     listeners.get(i).onStreamAdded(stream);
                 }
-            } catch (Http2Exception e) {
-                throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
             } catch (Throwable cause) {
-                throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
+                throw connectionError(INTERNAL_ERROR, cause, "unexpected error from onStreamAdded");
             }
 
             notifyParentChanged(events);
@@ -1138,10 +1119,8 @@ public class DefaultHttp2Connection implements Http2Connection {
                     for (int i = 0; i < listeners.size(); i++) {
                         listeners.get(i).onStreamActive(stream);
                     }
-                } catch (Http2Exception e) {
-                    throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
                 } catch (Throwable cause) {
-                    throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
+                    throw connectionError(INTERNAL_ERROR, cause, "unexpected error from onStreamActive");
                 }
             }
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -15,33 +15,13 @@
 
 package io.netty.handler.codec.http2;
 
-import static io.netty.handler.codec.http2.Http2CodecUtil.CONNECTION_STREAM_ID;
-import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
-import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_WEIGHT;
-import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_WEIGHT;
-import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
-import static io.netty.handler.codec.http2.Http2Error.REFUSED_STREAM;
-import static io.netty.handler.codec.http2.Http2Exception.closedStreamError;
-import static io.netty.handler.codec.http2.Http2Exception.connectionError;
-import static io.netty.handler.codec.http2.Http2Exception.streamError;
-import static io.netty.handler.codec.http2.Http2Stream.State.CLOSED;
-import static io.netty.handler.codec.http2.Http2Stream.State.HALF_CLOSED_LOCAL;
-import static io.netty.handler.codec.http2.Http2Stream.State.HALF_CLOSED_REMOTE;
-import static io.netty.handler.codec.http2.Http2Stream.State.IDLE;
-import static io.netty.handler.codec.http2.Http2Stream.State.OPEN;
-import static io.netty.handler.codec.http2.Http2Stream.State.RESERVED_LOCAL;
-import static io.netty.handler.codec.http2.Http2Stream.State.RESERVED_REMOTE;
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http2.Http2Stream.State;
 import io.netty.util.collection.IntCollections;
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
 import io.netty.util.internal.EmptyArrays;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -52,11 +32,30 @@ import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 
+import static io.netty.handler.codec.http2.Http2CodecUtil.CONNECTION_STREAM_ID;
+import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_WEIGHT;
+import static io.netty.handler.codec.http2.Http2CodecUtil.MIN_WEIGHT;
+import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
+import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
+import static io.netty.handler.codec.http2.Http2Error.REFUSED_STREAM;
+import static io.netty.handler.codec.http2.Http2Exception.closedStreamError;
+import static io.netty.handler.codec.http2.Http2Exception.connectionError;
+import static io.netty.handler.codec.http2.Http2Exception.isStreamError;
+import static io.netty.handler.codec.http2.Http2Exception.streamError;
+import static io.netty.handler.codec.http2.Http2Stream.State.CLOSED;
+import static io.netty.handler.codec.http2.Http2Stream.State.HALF_CLOSED_LOCAL;
+import static io.netty.handler.codec.http2.Http2Stream.State.HALF_CLOSED_REMOTE;
+import static io.netty.handler.codec.http2.Http2Stream.State.IDLE;
+import static io.netty.handler.codec.http2.Http2Stream.State.OPEN;
+import static io.netty.handler.codec.http2.Http2Stream.State.RESERVED_LOCAL;
+import static io.netty.handler.codec.http2.Http2Stream.State.RESERVED_REMOTE;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
 /**
  * Simple implementation of {@link Http2Connection}.
  */
 public class DefaultHttp2Connection implements Http2Connection {
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultHttp2Connection.class);
     // Fields accessed by inner classes
     final IntObjectMap<Http2Stream> streamMap = new IntObjectHashMap<Http2Stream>();
     final PropertyKeyRegistry propertyKeyRegistry = new PropertyKeyRegistry();
@@ -151,29 +150,27 @@ public class DefaultHttp2Connection implements Http2Connection {
     }
 
     @Override
-    public void goAwayReceived(final int lastKnownStream, long errorCode, ByteBuf debugData) {
+    public void goAwayReceived(final int lastKnownStream, long errorCode, ByteBuf debugData) throws Http2Exception {
         localEndpoint.lastStreamKnownByPeer(lastKnownStream);
-        for (int i = 0; i < listeners.size(); ++i) {
-            try {
+        try {
+            for (int i = 0; i < listeners.size(); ++i) {
                 listeners.get(i).onGoAwayReceived(lastKnownStream, errorCode, debugData);
-            } catch (RuntimeException e) {
-                logger.error("Caught RuntimeException from listener onGoAwayReceived.", e);
             }
+        } catch (Http2Exception e) {
+            throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
+        } catch (Throwable cause) {
+            throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
         }
 
-        try {
-            forEachActiveStream(new Http2StreamVisitor() {
-                @Override
-                public boolean visit(Http2Stream stream) {
-                    if (stream.id() > lastKnownStream && localEndpoint.isValidStreamId(stream.id())) {
-                        stream.close();
-                    }
-                    return true;
+        forEachActiveStream(new Http2StreamVisitor() {
+            @Override
+            public boolean visit(Http2Stream stream) throws Http2Exception {
+                if (stream.id() > lastKnownStream && localEndpoint.isValidStreamId(stream.id())) {
+                    stream.close();
                 }
-            });
-        } catch (Http2Exception e) {
-            PlatformDependent.throwException(e);
-        }
+                return true;
+            }
+        });
     }
 
     @Override
@@ -182,29 +179,27 @@ public class DefaultHttp2Connection implements Http2Connection {
     }
 
     @Override
-    public void goAwaySent(final int lastKnownStream, long errorCode, ByteBuf debugData) {
+    public void goAwaySent(final int lastKnownStream, long errorCode, ByteBuf debugData) throws Http2Exception {
         remoteEndpoint.lastStreamKnownByPeer(lastKnownStream);
-        for (int i = 0; i < listeners.size(); ++i) {
-            try {
+        try {
+            for (int i = 0; i < listeners.size(); ++i) {
                 listeners.get(i).onGoAwaySent(lastKnownStream, errorCode, debugData);
-            } catch (RuntimeException e) {
-                logger.error("Caught RuntimeException from listener onGoAwaySent.", e);
             }
+        } catch (Http2Exception e) {
+            throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
+        } catch (Throwable cause) {
+            throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
         }
 
-        try {
-            forEachActiveStream(new Http2StreamVisitor() {
-                @Override
-                public boolean visit(Http2Stream stream) {
-                    if (stream.id() > lastKnownStream && remoteEndpoint.isValidStreamId(stream.id())) {
-                        stream.close();
-                    }
-                    return true;
+        forEachActiveStream(new Http2StreamVisitor() {
+            @Override
+            public boolean visit(Http2Stream stream) throws Http2Exception {
+                if (stream.id() > lastKnownStream && remoteEndpoint.isValidStreamId(stream.id())) {
+                    stream.close();
                 }
-            });
-        } catch (Http2Exception e) {
-            PlatformDependent.throwException(e);
-        }
+                return true;
+            }
+        });
     }
 
     /**
@@ -215,19 +210,22 @@ public class DefaultHttp2Connection implements Http2Connection {
      * When a priority tree edge changes we also have to re-evaluate viable nodes
      * (see [3] {@link DefaultStream#takeChild(DefaultStream, boolean, List)}).
      * @param stream The stream to remove.
+     * @throws Http2Exception If an error occurs from {@link Http2Connection.Listener#onStreamRemoved(Http2Stream)}.
      */
-    void removeStream(DefaultStream stream) {
+    final void removeStream(DefaultStream stream) throws Http2Exception {
         // [1] Check if this stream can be removed because it has no prioritizable descendants.
         if (stream.parent().removeChild(stream)) {
             // Remove it from the map and priority tree.
             streamMap.remove(stream.id());
 
-            for (int i = 0; i < listeners.size(); i++) {
-                try {
+            try {
+                for (int i = 0; i < listeners.size(); i++) {
                     listeners.get(i).onStreamRemoved(stream);
-                } catch (RuntimeException e) {
-                    logger.error("Caught RuntimeException from listener onStreamRemoved.", e);
                 }
+            } catch (Http2Exception e) {
+                throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
+            } catch (Throwable cause) {
+                throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
             }
         }
     }
@@ -247,23 +245,27 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
     }
 
-    void notifyHalfClosed(Http2Stream stream) {
-        for (int i = 0; i < listeners.size(); i++) {
-            try {
+    final void notifyHalfClosed(Http2Stream stream) throws Http2Exception {
+        try {
+            for (int i = 0; i < listeners.size(); i++) {
                 listeners.get(i).onStreamHalfClosed(stream);
-            } catch (RuntimeException e) {
-                logger.error("Caught RuntimeException from listener onStreamHalfClosed.", e);
             }
+        } catch (Http2Exception e) {
+            throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
+        } catch (Throwable cause) {
+            throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
         }
     }
 
-    void notifyClosed(Http2Stream stream) {
-        for (int i = 0; i < listeners.size(); i++) {
-            try {
+    final void notifyClosed(Http2Stream stream) throws Http2Exception {
+        try {
+            for (int i = 0; i < listeners.size(); i++) {
                 listeners.get(i).onStreamClosed(stream);
-            } catch (RuntimeException e) {
-                logger.error("Caught RuntimeException from listener onStreamClosed.", e);
             }
+        } catch (Http2Exception e) {
+            throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
+        } catch (Throwable cause) {
+            throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
         }
     }
 
@@ -436,12 +438,12 @@ public class DefaultHttp2Connection implements Http2Connection {
             return this;
         }
 
-        void activate() {
+        final void activate() throws Http2Exception {
             activeStreams.activate(this);
         }
 
         @Override
-        public Http2Stream close() {
+        public Http2Stream close() throws Http2Exception {
             if (state == CLOSED) {
                 return this;
             }
@@ -454,7 +456,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         @Override
-        public Http2Stream closeLocalSide() {
+        public Http2Stream closeLocalSide() throws Http2Exception {
             switch (state) {
             case OPEN:
                 state = HALF_CLOSED_LOCAL;
@@ -470,7 +472,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
 
         @Override
-        public Http2Stream closeRemoteSide() {
+        public Http2Stream closeRemoteSide() throws Http2Exception {
             switch (state) {
             case OPEN:
                 state = HALF_CLOSED_REMOTE;
@@ -566,7 +568,7 @@ public class DefaultHttp2Connection implements Http2Connection {
             return localEndpoint.isValidStreamId(id);
         }
 
-        final void weight(short weight) {
+        final void weight(short weight) throws Http2Exception {
             if (weight != this.weight) {
                 if (parent != null) {
                     int delta = weight - this.weight;
@@ -574,12 +576,14 @@ public class DefaultHttp2Connection implements Http2Connection {
                 }
                 final short oldWeight = this.weight;
                 this.weight = weight;
-                for (int i = 0; i < listeners.size(); i++) {
-                    try {
+                try {
+                    for (int i = 0; i < listeners.size(); i++) {
                         listeners.get(i).onWeightChanged(this, oldWeight);
-                    } catch (RuntimeException e) {
-                        logger.error("Caught RuntimeException from listener onWeightChanged.", e);
                     }
+                } catch (Http2Exception e) {
+                    throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
+                } catch (Throwable cause) {
+                    throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
                 }
             }
         }
@@ -610,8 +614,10 @@ public class DefaultHttp2Connection implements Http2Connection {
         /**
          * Adds a child to this priority. If exclusive is set, any children of this node are moved to being dependent on
          * the child.
+         * @throws Http2Exception If an error is caught from a {@link Listener} method.
          */
-        final void takeChild(DefaultStream child, boolean exclusive, List<ParentChangedEvent> events) {
+        final void takeChild(DefaultStream child, boolean exclusive, List<ParentChangedEvent> events)
+                throws Http2Exception {
             DefaultStream oldParent = child.parent();
 
             if (oldParent != this) {
@@ -657,8 +663,9 @@ public class DefaultHttp2Connection implements Http2Connection {
 
         /**
          * Removes the child priority and moves any of its dependencies to being direct dependencies on this node.
+         * @throws Http2Exception If an error is caught from a {@link Listener} method.
          */
-        final boolean removeChild(DefaultStream child) {
+        final boolean removeChild(DefaultStream child) throws Http2Exception {
             if (child.prioritizableForTree() == 0 && children.remove(child.id()) != null) {
                 List<ParentChangedEvent> events = new ArrayList<ParentChangedEvent>(1 + child.numChildren());
                 events.add(new ParentChangedEvent(child, child.parent()));
@@ -746,12 +753,16 @@ public class DefaultHttp2Connection implements Http2Connection {
         /**
          * Notify all listeners of the tree change event
          * @param l The listener to notify
+         * @throws Http2Exception If an error from a
+         * {@link Listener#onPriorityTreeParentChanged(Http2Stream, Http2Stream)} occurs.
          */
-        public void notifyListener(Listener l) {
+        public void notifyListener(Listener l) throws Http2Exception {
             try {
                 l.onPriorityTreeParentChanged(stream, oldParent);
-            } catch (RuntimeException e) {
-                logger.error("Caught RuntimeException from listener onPriorityTreeParentChanged.", e);
+            } catch (Http2Exception e) {
+                throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
+            } catch (Throwable cause) {
+                throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
             }
         }
     }
@@ -759,8 +770,9 @@ public class DefaultHttp2Connection implements Http2Connection {
     /**
      * Notify all listeners of the priority tree change events (in ascending order)
      * @param events The events (top down order) which have changed
+     * @throws Http2Exception If an error from a {@link Listener} is caught.
      */
-    private void notifyParentChanged(List<ParentChangedEvent> events) {
+    private void notifyParentChanged(List<ParentChangedEvent> events) throws Http2Exception {
         for (int i = 0; i < events.size(); ++i) {
             ParentChangedEvent event = events.get(i);
             for (int j = 0; j < listeners.size(); j++) {
@@ -769,13 +781,15 @@ public class DefaultHttp2Connection implements Http2Connection {
         }
     }
 
-    private void notifyParentChanging(Http2Stream stream, Http2Stream newParent) {
-        for (int i = 0; i < listeners.size(); i++) {
-            try {
+    private void notifyParentChanging(Http2Stream stream, Http2Stream newParent) throws Http2Exception {
+        try {
+            for (int i = 0; i < listeners.size(); i++) {
                 listeners.get(i).onPriorityTreeParentChanging(stream, newParent);
-            } catch (RuntimeException e) {
-                logger.error("Caught RuntimeException from listener onPriorityTreeParentChanging.", e);
             }
+        } catch (Http2Exception e) {
+            throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
+        } catch (Throwable cause) {
+            throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
         }
     }
 
@@ -929,20 +943,22 @@ public class DefaultHttp2Connection implements Http2Connection {
             return stream;
         }
 
-        private void addStream(DefaultStream stream) {
+        private void addStream(DefaultStream stream) throws Http2Exception {
             // Add the stream to the map and priority tree.
             streamMap.put(stream.id(), stream);
 
             List<ParentChangedEvent> events = new ArrayList<ParentChangedEvent>(1);
             connectionStream.takeChild(stream, false, events);
 
-            // Notify the listeners of the event.
-            for (int i = 0; i < listeners.size(); i++) {
-                try {
+            try {
+                // Notify the listeners of the event.
+                for (int i = 0; i < listeners.size(); i++) {
                     listeners.get(i).onStreamAdded(stream);
-                } catch (RuntimeException e) {
-                    logger.error("Caught RuntimeException from listener onStreamAdded.", e);
                 }
+            } catch (Http2Exception e) {
+                throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
+            } catch (Throwable cause) {
+                throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
             }
 
             notifyParentChanged(events);
@@ -1035,17 +1051,14 @@ public class DefaultHttp2Connection implements Http2Connection {
     }
 
     /**
-     * Allows events which would modify the collection of active streams to be queued while iterating via {@link
-     * #forEachActiveStream(Http2StreamVisitor)}.
+     * Allows events which would modify the collection of active streams to be queued while iterating via
+     * {@link #forEachActiveStream(Http2StreamVisitor)}.
      */
     interface Event {
         /**
          * Trigger the original intention of this event. Expect to modify the active streams list.
-         * <p/>
-         * If a {@link RuntimeException} object is thrown it will be logged and <strong>not propagated</strong>.
-         * Throwing from this method is not supported and is considered a programming error.
          */
-        void process();
+        void process() throws Http2Exception;
     }
 
     /**
@@ -1067,26 +1080,26 @@ public class DefaultHttp2Connection implements Http2Connection {
             return streams.size();
         }
 
-        public void activate(final DefaultStream stream) {
+        public void activate(final DefaultStream stream) throws Http2Exception {
             if (allowModifications()) {
                 addToActiveStreams(stream);
             } else {
                 pendingEvents.add(new Event() {
                     @Override
-                    public void process() {
+                    public void process() throws Http2Exception {
                         addToActiveStreams(stream);
                     }
                 });
             }
         }
 
-        public void deactivate(final DefaultStream stream) {
+        public void deactivate(final DefaultStream stream) throws Http2Exception {
             if (allowModifications()) {
                 removeFromActiveStreams(stream);
             } else {
                 pendingEvents.add(new Event() {
                     @Override
-                    public void process() {
+                    public void process() throws Http2Exception {
                         removeFromActiveStreams(stream);
                     }
                 });
@@ -1110,32 +1123,30 @@ public class DefaultHttp2Connection implements Http2Connection {
                         if (event == null) {
                             break;
                         }
-                        try {
-                            event.process();
-                        } catch (RuntimeException e) {
-                            logger.error("Caught RuntimeException while processing pending ActiveStreams$Event.", e);
-                        }
+                        event.process();
                     }
                 }
             }
         }
 
-        void addToActiveStreams(DefaultStream stream) {
+        void addToActiveStreams(DefaultStream stream) throws Http2Exception {
             if (streams.add(stream)) {
                 // Update the number of active streams initiated by the endpoint.
                 stream.createdBy().numActiveStreams++;
 
-                for (int i = 0; i < listeners.size(); i++) {
-                    try {
+                try {
+                    for (int i = 0; i < listeners.size(); i++) {
                         listeners.get(i).onStreamActive(stream);
-                    } catch (RuntimeException e) {
-                        logger.error("Caught RuntimeException from listener onStreamActive.", e);
                     }
+                } catch (Http2Exception e) {
+                    throw isStreamError(e) ? connectionError(INTERNAL_ERROR, e, "unexpected stream error") : e;
+                } catch (Throwable cause) {
+                    throw connectionError(INTERNAL_ERROR, cause, "unexpected error");
                 }
             }
         }
 
-        void removeFromActiveStreams(DefaultStream stream) {
+        void removeFromActiveStreams(DefaultStream stream) throws Http2Exception {
             if (streams.remove(stream)) {
                 // Update the number of active streams initiated by the endpoint.
                 stream.createdBy().numActiveStreams--;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -252,7 +252,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                 flowController.consumeBytes(stream, bytesToReturn);
 
                 if (endOfStream) {
-                    lifecycleManager.closeStreamRemote(stream, ctx.newSucceededFuture());
+                    lifecycleManager.closeStreamRemote(ctx, stream, ctx.newSucceededFuture());
                 }
             }
         }
@@ -315,7 +315,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
 
             // If the headers completes this stream, close it.
             if (endOfStream) {
-                lifecycleManager.closeStreamRemote(stream, ctx.newSucceededFuture());
+                lifecycleManager.closeStreamRemote(ctx, stream, ctx.newSucceededFuture());
             }
         }
 
@@ -369,7 +369,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
 
             listener.onRstStreamRead(ctx, streamId, errorCode);
 
-            lifecycleManager.closeStream(stream, ctx.newSucceededFuture());
+            lifecycleManager.closeStream(ctx, stream, ctx.newSucceededFuture());
         }
 
         @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -444,14 +444,14 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
         }
 
         @Override
-        public void writeComplete() {
+        public final void writeComplete(ChannelHandlerContext ctx) {
             if (endOfStream) {
-                lifecycleManager.closeStreamLocal(stream, promise);
+                lifecycleManager.closeStreamLocal(ctx, stream, promise);
             }
         }
 
         @Override
-        public void operationComplete(ChannelFuture future) throws Exception {
+        public final void operationComplete(ChannelFuture future) throws Exception {
             if (!future.isSuccess()) {
                 error(flowController().channelHandlerContext(), future.cause());
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeaderTableListSize.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeaderTableListSize.java
@@ -14,9 +14,6 @@
  */
 package io.netty.handler.codec.http2;
 
-import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
-import static io.netty.handler.codec.http2.Http2Exception.connectionError;
-
 /**
  * Provides common functionality for {@link Http2HeaderTable}
  */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -28,95 +28,92 @@ public interface Http2Connection {
         /**
          * Notifies the listener that the given stream was added to the connection. This stream may
          * not yet be active (i.e. {@code OPEN} or {@code HALF CLOSED}).
-         * <p>
-         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
-         * Throwing from this method is not supported and is considered a programming error.
+         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
+         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
+         * and then the connection will be shutdown.
          */
-        void onStreamAdded(Http2Stream stream);
+        void onStreamAdded(Http2Stream stream) throws Http2Exception;
 
         /**
          * Notifies the listener that the given stream was made active (i.e. {@code OPEN} or {@code HALF CLOSED}).
-         * <p>
-         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
-         * Throwing from this method is not supported and is considered a programming error.
+         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
+         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
+         * and then the connection will be shutdown.
          */
-        void onStreamActive(Http2Stream stream);
+        void onStreamActive(Http2Stream stream) throws Http2Exception;
 
         /**
          * Notifies the listener that the given stream has transitioned from {@code OPEN} to {@code HALF CLOSED}.
          * This method will <strong>not</strong> be called until a state transition occurs from when
          * {@link #onStreamActive(Http2Stream)} was called.
          * The stream can be inspected to determine which side is {@code HALF CLOSED}.
-         * <p>
-         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
-         * Throwing from this method is not supported and is considered a programming error.
+         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
+         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
+         * and then the connection will be shutdown.
          */
-        void onStreamHalfClosed(Http2Stream stream);
+        void onStreamHalfClosed(Http2Stream stream) throws Http2Exception;
 
         /**
          * Notifies the listener that the given stream is now {@code CLOSED} in both directions and will no longer
          * be accessible via {@link #forEachActiveStream(Http2StreamVisitor)}.
-         * <p>
-         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
-         * Throwing from this method is not supported and is considered a programming error.
          */
-        void onStreamClosed(Http2Stream stream);
+        void onStreamClosed(Http2Stream stream) throws Http2Exception;
 
         /**
          * Notifies the listener that the given stream has now been removed from the connection and
          * will no longer be returned via {@link Http2Connection#stream(int)}. The connection may
          * maintain inactive streams for some time before removing them.
-         * <p>
-         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
-         * Throwing from this method is not supported and is considered a programming error.
+         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
+         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
+         * and then the connection will be shutdown.
          */
-        void onStreamRemoved(Http2Stream stream);
+        void onStreamRemoved(Http2Stream stream) throws Http2Exception;
 
         /**
          * Notifies the listener that a priority tree parent change has occurred. This method will be invoked
          * in a top down order relative to the priority tree. This method will also be invoked after all tree
          * structure changes have been made and the tree is in steady state relative to the priority change
          * which caused the tree structure to change.
-         * <p>
-         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
-         * Throwing from this method is not supported and is considered a programming error.
          * @param stream The stream which had a parent change (new parent and children will be steady state)
          * @param oldParent The old parent which {@code stream} used to be a child of (may be {@code null})
+         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
+         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
+         * and then the connection will be shutdown.
          */
-        void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent);
+        void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) throws Http2Exception;
 
         /**
          * Notifies the listener that a parent dependency is about to change
          * This is called while the tree is being restructured and so the tree
          * structure is not necessarily steady state.
-         * <p>
-         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
-         * Throwing from this method is not supported and is considered a programming error.
          * @param stream The stream which the parent is about to change to {@code newParent}
          * @param newParent The stream which will be the parent of {@code stream}
+         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
+         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
+         * and then the connection will be shutdown.
          */
-        void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent);
+        void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) throws Http2Exception;
 
         /**
          * Notifies the listener that the weight has changed for {@code stream}.
-         * <p>
-         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
-         * Throwing from this method is not supported and is considered a programming error.
          * @param stream The stream which the weight has changed
          * @param oldWeight The old weight for {@code stream}
+         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
+         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
+         * and then the connection will be shutdown.
          */
-        void onWeightChanged(Http2Stream stream, short oldWeight);
+        void onWeightChanged(Http2Stream stream, short oldWeight) throws Http2Exception;
 
         /**
          * Called when a {@code GOAWAY} frame was sent for the connection.
-         * <p>
-         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
-         * Throwing from this method is not supported and is considered a programming error.
          * @param lastStreamId the last known stream of the remote endpoint.
          * @param errorCode    the error code, if abnormal closure.
          * @param debugData    application-defined debug data.
+         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
+         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
+         * and then the connection will be shutdown.
          */
-        void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData);
+        void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) throws Http2Exception;
 
         /**
          * Called when a {@code GOAWAY} was received from the remote endpoint. This event handler duplicates {@link
@@ -124,14 +121,14 @@ public interface Http2Connection {
          * but is added here in order to simplify application logic for handling {@code GOAWAY} in a uniform way. An
          * application should generally not handle both events, but if it does this method is called second, after
          * notifying the {@link Http2FrameListener}.
-         * <p>
-         * If a {@link RuntimeException} is thrown it will be logged and <strong>not propagated</strong>.
-         * Throwing from this method is not supported and is considered a programming error.
          * @param lastStreamId the last known stream of the remote endpoint.
          * @param errorCode    the error code, if abnormal closure.
          * @param debugData    application-defined debug data.
+         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
+         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
+         * and then the connection will be shutdown.
          */
-        void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData);
+        void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) throws Http2Exception;
     }
 
     /**
@@ -354,8 +351,9 @@ public interface Http2Connection {
 
     /**
      * Indicates that a {@code GOAWAY} was received from the remote endpoint and sets the last known stream.
+     * @throws Http2Exception If an error from {@link Listener} is caught.
      */
-    void goAwayReceived(int lastKnownStream, long errorCode, ByteBuf message);
+    void goAwayReceived(int lastKnownStream, long errorCode, ByteBuf message) throws Http2Exception;
 
     /**
      * Indicates whether or not a {@code GOAWAY} was sent to the remote endpoint.
@@ -364,6 +362,7 @@ public interface Http2Connection {
 
     /**
      * Indicates that a {@code GOAWAY} was sent to the remote endpoint and sets the last known stream.
+     * @throws Http2Exception If an error from {@link Listener} is caught.
      */
-    void goAwaySent(int lastKnownStream, long errorCode, ByteBuf message);
+    void goAwaySent(int lastKnownStream, long errorCode, ByteBuf message) throws Http2Exception;
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -28,46 +28,49 @@ public interface Http2Connection {
         /**
          * Notifies the listener that the given stream was added to the connection. This stream may
          * not yet be active (i.e. {@code OPEN} or {@code HALF CLOSED}).
-         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
-         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
-         * and then the connection will be shutdown.
+         * <p>
+         * Any exception thrown from this method will be translated into a fatal connection error, cause a
+         * {@code GO_AWAY} frame to be sent with a fatal error code, and then the connection will be shutdown.
          */
-        void onStreamAdded(Http2Stream stream) throws Http2Exception;
+        void onStreamAdded(Http2Stream stream);
 
         /**
          * Notifies the listener that the given stream was made active (i.e. {@code OPEN} or {@code HALF CLOSED}).
-         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
-         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
-         * and then the connection will be shutdown.
+         * <p>
+         * Any exception thrown from this method will be translated into a fatal connection error, cause a
+         * {@code GO_AWAY} frame to be sent with a fatal error code, and then the connection will be shutdown.
          */
-        void onStreamActive(Http2Stream stream) throws Http2Exception;
+        void onStreamActive(Http2Stream stream);
 
         /**
          * Notifies the listener that the given stream has transitioned from {@code OPEN} to {@code HALF CLOSED}.
          * This method will <strong>not</strong> be called until a state transition occurs from when
          * {@link #onStreamActive(Http2Stream)} was called.
          * The stream can be inspected to determine which side is {@code HALF CLOSED}.
-         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
-         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
-         * and then the connection will be shutdown.
+         * <p>
+         * Any exception thrown from this method will be translated into a fatal connection error, cause a
+         * {@code GO_AWAY} frame to be sent with a fatal error code, and then the connection will be shutdown.
          */
-        void onStreamHalfClosed(Http2Stream stream) throws Http2Exception;
+        void onStreamHalfClosed(Http2Stream stream);
 
         /**
          * Notifies the listener that the given stream is now {@code CLOSED} in both directions and will no longer
          * be accessible via {@link #forEachActiveStream(Http2StreamVisitor)}.
+         * <p>
+         * Any exception thrown from this method will be translated into a fatal connection error, cause a
+         * {@code GO_AWAY} frame to be sent with a fatal error code, and then the connection will be shutdown.
          */
-        void onStreamClosed(Http2Stream stream) throws Http2Exception;
+        void onStreamClosed(Http2Stream stream);
 
         /**
          * Notifies the listener that the given stream has now been removed from the connection and
          * will no longer be returned via {@link Http2Connection#stream(int)}. The connection may
          * maintain inactive streams for some time before removing them.
-         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
-         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
-         * and then the connection will be shutdown.
+         * <p>
+         * Any exception thrown from this method will be translated into a fatal connection error, cause a
+         * {@code GO_AWAY} frame to be sent with a fatal error code, and then the connection will be shutdown.
          */
-        void onStreamRemoved(Http2Stream stream) throws Http2Exception;
+        void onStreamRemoved(Http2Stream stream);
 
         /**
          * Notifies the listener that a priority tree parent change has occurred. This method will be invoked
@@ -76,11 +79,11 @@ public interface Http2Connection {
          * which caused the tree structure to change.
          * @param stream The stream which had a parent change (new parent and children will be steady state)
          * @param oldParent The old parent which {@code stream} used to be a child of (may be {@code null})
-         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
-         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
-         * and then the connection will be shutdown.
+         * <p>
+         * Any exception thrown from this method will be translated into a fatal connection error, cause a
+         * {@code GO_AWAY} frame to be sent with a fatal error code, and then the connection will be shutdown.
          */
-        void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) throws Http2Exception;
+        void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent);
 
         /**
          * Notifies the listener that a parent dependency is about to change
@@ -88,32 +91,32 @@ public interface Http2Connection {
          * structure is not necessarily steady state.
          * @param stream The stream which the parent is about to change to {@code newParent}
          * @param newParent The stream which will be the parent of {@code stream}
-         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
-         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
-         * and then the connection will be shutdown.
+         * <p>
+         * Any exception thrown from this method will be translated into a fatal connection error, cause a
+         * {@code GO_AWAY} frame to be sent with a fatal error code, and then the connection will be shutdown.
          */
-        void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) throws Http2Exception;
+        void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent);
 
         /**
          * Notifies the listener that the weight has changed for {@code stream}.
          * @param stream The stream which the weight has changed
          * @param oldWeight The old weight for {@code stream}
-         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
-         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
-         * and then the connection will be shutdown.
+         * <p>
+         * Any exception thrown from this method will be translated into a fatal connection error, cause a
+         * {@code GO_AWAY} frame to be sent with a fatal error code, and then the connection will be shutdown.
          */
-        void onWeightChanged(Http2Stream stream, short oldWeight) throws Http2Exception;
+        void onWeightChanged(Http2Stream stream, short oldWeight);
 
         /**
          * Called when a {@code GOAWAY} frame was sent for the connection.
          * @param lastStreamId the last known stream of the remote endpoint.
          * @param errorCode    the error code, if abnormal closure.
          * @param debugData    application-defined debug data.
-         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
-         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
-         * and then the connection will be shutdown.
+         * <p>
+         * Any exception thrown from this method will be translated into a fatal connection error, cause a
+         * {@code GO_AWAY} frame to be sent with a fatal error code, and then the connection will be shutdown.
          */
-        void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) throws Http2Exception;
+        void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData);
 
         /**
          * Called when a {@code GOAWAY} was received from the remote endpoint. This event handler duplicates {@link
@@ -124,11 +127,11 @@ public interface Http2Connection {
          * @param lastStreamId the last known stream of the remote endpoint.
          * @param errorCode    the error code, if abnormal closure.
          * @param debugData    application-defined debug data.
-         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
-         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
-         * and then the connection will be shutdown.
+         * <p>
+         * Any exception thrown from this method will be translated into a fatal connection error, cause a
+         * {@code GO_AWAY} frame to be sent with a fatal error code, and then the connection will be shutdown.
          */
-        void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) throws Http2Exception;
+        void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData);
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionAdapter.java
@@ -22,42 +22,42 @@ import io.netty.buffer.ByteBuf;
 public class Http2ConnectionAdapter implements Http2Connection.Listener {
 
     @Override
-    public void onStreamAdded(Http2Stream stream) throws Http2Exception {
+    public void onStreamAdded(Http2Stream stream) {
     }
 
     @Override
-    public void onStreamActive(Http2Stream stream) throws Http2Exception {
+    public void onStreamActive(Http2Stream stream) {
     }
 
     @Override
-    public void onStreamHalfClosed(Http2Stream stream) throws Http2Exception {
+    public void onStreamHalfClosed(Http2Stream stream) {
     }
 
     @Override
-    public void onStreamClosed(Http2Stream stream) throws Http2Exception {
+    public void onStreamClosed(Http2Stream stream) {
     }
 
     @Override
-    public void onStreamRemoved(Http2Stream stream) throws Http2Exception {
+    public void onStreamRemoved(Http2Stream stream) {
     }
 
     @Override
-    public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) throws Http2Exception {
+    public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) {
     }
 
     @Override
-    public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) throws Http2Exception {
+    public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
     }
 
     @Override
-    public void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) throws Http2Exception {
+    public void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) {
     }
 
     @Override
-    public void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) throws Http2Exception {
+    public void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) {
     }
 
     @Override
-    public void onWeightChanged(Http2Stream stream, short oldWeight) throws Http2Exception {
+    public void onWeightChanged(Http2Stream stream, short oldWeight) {
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionAdapter.java
@@ -22,42 +22,42 @@ import io.netty.buffer.ByteBuf;
 public class Http2ConnectionAdapter implements Http2Connection.Listener {
 
     @Override
-    public void onStreamAdded(Http2Stream stream) {
+    public void onStreamAdded(Http2Stream stream) throws Http2Exception {
     }
 
     @Override
-    public void onStreamActive(Http2Stream stream) {
+    public void onStreamActive(Http2Stream stream) throws Http2Exception {
     }
 
     @Override
-    public void onStreamHalfClosed(Http2Stream stream) {
+    public void onStreamHalfClosed(Http2Stream stream) throws Http2Exception {
     }
 
     @Override
-    public void onStreamClosed(Http2Stream stream) {
+    public void onStreamClosed(Http2Stream stream) throws Http2Exception {
     }
 
     @Override
-    public void onStreamRemoved(Http2Stream stream) {
+    public void onStreamRemoved(Http2Stream stream) throws Http2Exception {
     }
 
     @Override
-    public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) {
+    public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) throws Http2Exception {
     }
 
     @Override
-    public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
+    public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) throws Http2Exception {
     }
 
     @Override
-    public void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) {
+    public void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) throws Http2Exception {
     }
 
     @Override
-    public void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) {
+    public void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) throws Http2Exception {
     }
 
     @Override
-    public void onWeightChanged(Http2Stream stream, short oldWeight) {
+    public void onWeightChanged(Http2Stream stream, short oldWeight) throws Http2Exception {
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -70,6 +70,14 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     private ChannelFutureListener closeListener;
     private BaseDecoder byteDecoder;
     private long gracefulShutdownTimeoutMillis = DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_MILLIS;
+    /**
+     * It is possible that a users's Listener object will generate an unexpected exception, which we will translate
+     * into a connection error. However while processing that connection error it is possible a Listener will throw
+     * another unexpected error which will also be translated into a connection error. To be sure we don't fall into
+     * an infinite recursive cycle we only allow 1 fatal connection error to be processed at a time. The assumption
+     * is a fatal connection error is a terminal state and will close the connection.
+     */
+    private boolean inFatalConnectionError;
 
     public Http2ConnectionHandler(boolean server, Http2FrameListener listener) {
         this(server, listener, true);
@@ -222,7 +230,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         public void handlerRemoved(ChannelHandlerContext ctx) throws Exception { }
         public void channelActive(ChannelHandlerContext ctx) throws Exception { }
 
-        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        public void channelInactive(final ChannelHandlerContext ctx) throws Exception {
             // Connection has terminated, close the encoder and decoder.
             encoder().close();
             decoder().close();
@@ -234,7 +242,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
                 connection.forEachActiveStream(new Http2StreamVisitor() {
                     @Override
                     public boolean visit(Http2Stream stream) throws Http2Exception {
-                        closeStream(stream, future);
+                        closeStream(ctx, stream, future);
                         return true;
                     }
                 });
@@ -531,49 +539,47 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         }
     }
 
-    /**
-     * Closes the local side of the given stream. If this causes the stream to be closed, adds a
-     * hook to close the channel after the given future completes.
-     *
-     * @param stream the stream to be half closed.
-     * @param future If closing, the future after which to close the channel.
-     */
     @Override
-    public void closeStreamLocal(Http2Stream stream, ChannelFuture future) {
+    public void closeStreamLocal(ChannelHandlerContext ctx, Http2Stream stream, ChannelFuture future) {
         switch (stream.state()) {
             case HALF_CLOSED_LOCAL:
             case OPEN:
-                stream.closeLocalSide();
+                try {
+                    stream.closeLocalSide();
+                } catch (Throwable cause) {
+                    onError(ctx, cause);
+                }
                 break;
             default:
-                closeStream(stream, future);
+                closeStream(ctx, stream, future);
                 break;
         }
     }
 
-    /**
-     * Closes the remote side of the given stream. If this causes the stream to be closed, adds a
-     * hook to close the channel after the given future completes.
-     *
-     * @param stream the stream to be half closed.
-     * @param future If closing, the future after which to close the channel.
-     */
     @Override
-    public void closeStreamRemote(Http2Stream stream, ChannelFuture future) {
+    public void closeStreamRemote(ChannelHandlerContext ctx, Http2Stream stream, ChannelFuture future) {
         switch (stream.state()) {
             case HALF_CLOSED_REMOTE:
             case OPEN:
-                stream.closeRemoteSide();
+                try {
+                    stream.closeRemoteSide();
+                } catch (Throwable cause) {
+                    onError(ctx, cause);
+                }
                 break;
             default:
-                closeStream(stream, future);
+                closeStream(ctx, stream, future);
                 break;
         }
     }
 
     @Override
-    public void closeStream(final Http2Stream stream, ChannelFuture future) {
-        stream.close();
+    public void closeStream(ChannelHandlerContext ctx, final Http2Stream stream, ChannelFuture future) {
+        try {
+            stream.close();
+        } catch (Throwable cause) {
+            onError(ctx, cause);
+        }
 
         if (future.isDone()) {
             checkCloseConnection(future);
@@ -629,15 +635,28 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             http2Ex = new Http2Exception(INTERNAL_ERROR, cause.getMessage(), cause);
         }
 
-        ChannelPromise promise = ctx.newPromise();
-        ChannelFuture future = goAway(ctx, http2Ex);
-        switch (http2Ex.shutdownHint()) {
-        case GRACEFUL_SHUTDOWN:
-            doGracefulShutdown(ctx, future, promise);
-            break;
-        default:
-            future.addListener(new ClosingChannelFutureListener(ctx, promise));
-            break;
+        boolean isFatal = http2Ex.error() != Http2Error.NO_ERROR;
+        if (isFatal && inFatalConnectionError) {
+            logger.error("Reentrant call to onConnectionError while processing a fatal connection error.", cause);
+            return;
+        }
+
+        inFatalConnectionError = isFatal;
+        try {
+            ChannelPromise promise = ctx.newPromise();
+            ChannelFuture future = goAway(ctx, http2Ex);
+            switch (http2Ex.shutdownHint()) {
+            case GRACEFUL_SHUTDOWN:
+                doGracefulShutdown(ctx, future, promise);
+                break;
+            default:
+                future.addListener(new ClosingChannelFutureListener(ctx, promise));
+                break;
+            }
+        } finally {
+            if (isFatal) {
+                inFatalConnectionError = false;
+            }
         }
     }
 
@@ -676,7 +695,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             @Override
             public void operationComplete(ChannelFuture future) throws Exception {
                 if (future.isSuccess()) {
-                    closeStream(stream, promise);
+                    closeStream(ctx, stream, promise);
                 } else {
                     // The connection will be closed and so no need to change the resetSent flag to false.
                     onConnectionError(ctx, future.cause(), null);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
@@ -84,42 +84,42 @@ public class Http2EventAdapter implements Http2Connection.Listener, Http2FrameLi
     }
 
     @Override
-    public void onStreamAdded(Http2Stream stream) throws Http2Exception {
+    public void onStreamAdded(Http2Stream stream) {
     }
 
     @Override
-    public void onStreamActive(Http2Stream stream) throws Http2Exception {
+    public void onStreamActive(Http2Stream stream) {
     }
 
     @Override
-    public void onStreamHalfClosed(Http2Stream stream) throws Http2Exception {
+    public void onStreamHalfClosed(Http2Stream stream) {
     }
 
     @Override
-    public void onStreamClosed(Http2Stream stream) throws Http2Exception {
+    public void onStreamClosed(Http2Stream stream) {
     }
 
     @Override
-    public void onStreamRemoved(Http2Stream stream) throws Http2Exception {
+    public void onStreamRemoved(Http2Stream stream) {
     }
 
     @Override
-    public void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) throws Http2Exception {
+    public void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) {
     }
 
     @Override
-    public void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) throws Http2Exception {
+    public void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) {
     }
 
     @Override
-    public void onWeightChanged(Http2Stream stream, short oldWeight) throws Http2Exception {
+    public void onWeightChanged(Http2Stream stream, short oldWeight) {
     }
 
     @Override
-    public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) throws Http2Exception {
+    public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) {
     }
 
     @Override
-    public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) throws Http2Exception {
+    public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2EventAdapter.java
@@ -84,42 +84,42 @@ public class Http2EventAdapter implements Http2Connection.Listener, Http2FrameLi
     }
 
     @Override
-    public void onStreamAdded(Http2Stream stream) {
+    public void onStreamAdded(Http2Stream stream) throws Http2Exception {
     }
 
     @Override
-    public void onStreamActive(Http2Stream stream) {
+    public void onStreamActive(Http2Stream stream) throws Http2Exception {
     }
 
     @Override
-    public void onStreamHalfClosed(Http2Stream stream) {
+    public void onStreamHalfClosed(Http2Stream stream) throws Http2Exception {
     }
 
     @Override
-    public void onStreamClosed(Http2Stream stream) {
+    public void onStreamClosed(Http2Stream stream) throws Http2Exception {
     }
 
     @Override
-    public void onStreamRemoved(Http2Stream stream) {
+    public void onStreamRemoved(Http2Stream stream) throws Http2Exception {
     }
 
     @Override
-    public void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) {
+    public void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) throws Http2Exception {
     }
 
     @Override
-    public void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) {
+    public void onPriorityTreeParentChanging(Http2Stream stream, Http2Stream newParent) throws Http2Exception {
     }
 
     @Override
-    public void onWeightChanged(Http2Stream stream, short oldWeight) {
+    public void onWeightChanged(Http2Stream stream, short oldWeight) throws Http2Exception {
     }
 
     @Override
-    public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) {
+    public void onGoAwaySent(int lastStreamId, long errorCode, ByteBuf debugData) throws Http2Exception {
     }
 
     @Override
-    public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) {
+    public void onGoAwayReceived(int lastStreamId, long errorCode, ByteBuf debugData) throws Http2Exception {
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LifecycleManager.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LifecycleManager.java
@@ -28,27 +28,30 @@ public interface Http2LifecycleManager {
     /**
      * Closes the local side of the {@code stream}. Depending on the {@code stream} state this may result in
      * {@code stream} being closed. See {@link closeStream(Http2Stream, ChannelFuture)}.
+     * @param ctx Context used to propagate a connection error if necessary.
      * @param stream the stream to be half closed.
      * @param future See {@link closeStream(Http2Stream, ChannelFuture)}.
      */
-    void closeStreamLocal(Http2Stream stream, ChannelFuture future);
+    void closeStreamLocal(ChannelHandlerContext ctx, Http2Stream stream, ChannelFuture future);
 
     /**
      * Closes the remote side of the {@code stream}. Depending on the {@code stream} state this may result in
      * {@code stream} being closed. See {@link closeStream(Http2Stream, ChannelFuture)}.
+     * @param ctx Context used to propagate a connection error if necessary.
      * @param stream the stream to be half closed.
      * @param future See {@link closeStream(Http2Stream, ChannelFuture)}.
      */
-    void closeStreamRemote(Http2Stream stream, ChannelFuture future);
+    void closeStreamRemote(ChannelHandlerContext ctx, Http2Stream stream, ChannelFuture future);
 
     /**
      * Closes and deactivates the given {@code stream}. A listener is also attached to {@code future} and upon
      * completion the underlying channel will be closed if {@link Http2Connection#numActiveStreams()} is 0.
+     * @param ctx Context used to propagate a connection error if necessary.
      * @param stream the stream to be closed and deactivated.
      * @param future when completed if {@link Http2Connection#numActiveStreams()} is 0 then the underlying channel
      * will be closed.
      */
-    void closeStream(Http2Stream stream, ChannelFuture future);
+    void closeStream(ChannelHandlerContext ctx, Http2Stream stream, ChannelFuture future);
 
     /**
      * Ensure the stream identified by {@code streamId} is reset. If our local state does not indicate the stream has

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
@@ -106,8 +106,9 @@ public interface Http2RemoteFlowController extends Http2FlowController {
          * The {@link Http2RemoteFlowController} will make exactly one call to either {@link #error(Throwable)} or
          * {@link #writeComplete()}.
          * </p>
+         * @param ctx Used to send a connection error if necessary.
          */
-        void writeComplete();
+        void writeComplete(ChannelHandlerContext ctx);
 
         /**
          * Writes up to {@code allowedBytes} of the encapsulated payload to the stream. Note that
@@ -147,15 +148,21 @@ public interface Http2RemoteFlowController extends Http2FlowController {
          * @param stream that had bytes written.
          * @param writtenBytes the number of bytes written for a stream, can be 0 in the case of an
          *                     empty DATA frame.
+         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
+         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
+         * and then the connection will be shutdown.
          */
-        void streamWritten(Http2Stream stream, int writtenBytes);
+        void streamWritten(Http2Stream stream, int writtenBytes) throws Http2Exception;
 
         /**
          * Notification that {@link Http2RemoteFlowController#isWritable(Http2Stream)} has changed for {@code stream}.
          * <p>
          * This method should not throw. Any thrown exceptions are considered a programming error and are ignored.
          * @param stream The stream which writability has changed for.
+         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
+         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
+         * and then the connection will be shutdown.
          */
-        void writabilityChanged(Http2Stream stream);
+        void writabilityChanged(Http2Stream stream) throws Http2Exception;
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
@@ -144,25 +144,21 @@ public interface Http2RemoteFlowController extends Http2FlowController {
          * Report the number of {@code writtenBytes} for a {@code stream}. Called after the
          * flow-controller has flushed bytes for the given stream.
          * <p>
-         * This method should not throw. Any thrown exceptions are considered a programming error and are ignored.
+         * Any exception thrown from this method will be translated into a fatal connection error, cause a
+         * {@code GO_AWAY} frame to be sent with a fatal error code, and then the connection will be shutdown.
          * @param stream that had bytes written.
          * @param writtenBytes the number of bytes written for a stream, can be 0 in the case of an
          *                     empty DATA frame.
-         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
-         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
-         * and then the connection will be shutdown.
          */
-        void streamWritten(Http2Stream stream, int writtenBytes) throws Http2Exception;
+        void streamWritten(Http2Stream stream, int writtenBytes);
 
         /**
          * Notification that {@link Http2RemoteFlowController#isWritable(Http2Stream)} has changed for {@code stream}.
          * <p>
-         * This method should not throw. Any thrown exceptions are considered a programming error and are ignored.
+         * Any exception thrown from this method will be translated into a fatal connection error, cause a
+         * {@code GO_AWAY} frame to be sent with a fatal error code, and then the connection will be shutdown.
          * @param stream The stream which writability has changed for.
-         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
-         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
-         * and then the connection will be shutdown.
          */
-        void writabilityChanged(Http2Stream stream) throws Http2Exception;
+        void writabilityChanged(Http2Stream stream);
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -60,20 +60,23 @@ public interface Http2Stream {
 
     /**
      * Closes the stream.
+     * @throws Http2Exception If an error from {@link Http2Connection.Listener} is caught.
      */
-    Http2Stream close();
+    Http2Stream close() throws Http2Exception;
 
     /**
      * Closes the local side of this stream. If this makes the stream closed, the child is closed as
      * well.
+     * @throws Http2Exception If an error from {@link Http2Connection.Listener} is caught.
      */
-    Http2Stream closeLocalSide();
+    Http2Stream closeLocalSide() throws Http2Exception;
 
     /**
      * Closes the remote side of this stream. If this makes the stream closed, the child is closed
      * as well.
+     * @throws Http2Exception If an error from {@link Http2Connection.Listener} is caught.
      */
-    Http2Stream closeRemoteSide();
+    Http2Stream closeRemoteSide() throws Http2Exception;
 
     /**
      * Indicates whether a {@code RST_STREAM} frame has been sent from the local endpoint for this stream.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamByteDistributor.java
@@ -52,14 +52,14 @@ public interface StreamByteDistributor {
     interface Writer {
         /**
          * Writes the allocated bytes for this stream.
+         * <p>
+         * Any exception thrown from this method will be translated into a fatal connection error, cause a
+         * {@code GO_AWAY} frame to be sent with a fatal error code, and then the connection will be shutdown.
          * @param stream the stream for which to perform the write.
          * @param numBytes the number of bytes to write.
          * @throws Http2Exception If a connection error occurs.
-         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
-         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
-         * and then the connection will be shutdown.
          */
-        void write(Http2Stream stream, int numBytes) throws Http2Exception;
+        void write(Http2Stream stream, int numBytes);
     }
 
     /**
@@ -74,15 +74,16 @@ public interface StreamByteDistributor {
      * iterates across those streams to write the appropriate bytes. Criteria for
      * traversing streams is undefined and it is up to the implementation to determine when to stop
      * at a given stream.
-     *
-     * <p>The streamable bytes are not automatically updated by calling this method. It is up to the
+     * <p>
+     * The streamable bytes are not automatically updated by calling this method. It is up to the
      * caller to indicate the number of bytes streamable after the write by calling
      * {@link #updateStreamableBytes(StreamState)}.
-     *
+     * <p>
+     * Any exception thrown from this method will be translated into a fatal connection error, cause a
+     * {@code GO_AWAY} frame to be sent with a fatal error code, and then the connection will be shutdown.
      * @param maxBytes the maximum number of bytes to write.
      * @return {@code true} if there are still streamable bytes that have not yet been written,
      * otherwise {@code false}.
-     * @throws Http2Exception if an exception is thrown {@link Writer#write(Http2Stream, int)}.
      */
-    boolean distribute(int maxBytes, Writer writer) throws Http2Exception;
+    boolean distribute(int maxBytes, Writer writer);
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamByteDistributor.java
@@ -54,8 +54,12 @@ public interface StreamByteDistributor {
          * Writes the allocated bytes for this stream.
          * @param stream the stream for which to perform the write.
          * @param numBytes the number of bytes to write.
+         * @throws Http2Exception If a connection error occurs.
+         * @throws Http2Exception  Any exception thrown from this method (even of type {@link RutimeException}) will be
+         * translated into a fatal connection error, cause a {@code GO_AWAY} frame to be sent with a fatal error code,
+         * and then the connection will be shutdown.
          */
-        void write(Http2Stream stream, int numBytes);
+        void write(Http2Stream stream, int numBytes) throws Http2Exception;
     }
 
     /**
@@ -78,6 +82,7 @@ public interface StreamByteDistributor {
      * @param maxBytes the maximum number of bytes to write.
      * @return {@code true} if there are still streamable bytes that have not yet been written,
      * otherwise {@code false}.
+     * @throws Http2Exception if an exception is thrown {@link Writer#write(Http2Stream, int)}.
      */
-    boolean distribute(int maxBytes, Writer writer);
+    boolean distribute(int maxBytes, Writer writer) throws Http2Exception;
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -315,7 +315,7 @@ public class DefaultHttp2ConnectionDecoderTest {
         try {
             decode().onDataRead(ctx, STREAM_ID, data, 10, true);
             verify(localFlow).receiveFlowControlledFrame(eq(stream), eq(data), eq(10), eq(true));
-            verify(lifecycleManager).closeStreamRemote(eq(stream), eq(future));
+            verify(lifecycleManager).closeStreamRemote(any(ChannelHandlerContext.class), eq(stream), eq(future));
             verify(listener).onDataRead(eq(ctx), eq(STREAM_ID), eq(data), eq(10), eq(true));
         } finally {
             data.release();
@@ -358,7 +358,7 @@ public class DefaultHttp2ConnectionDecoderTest {
         } catch (RuntimeException cause) {
             verify(localFlow)
                     .receiveFlowControlledFrame(eq(stream), eq(data), eq(padding), eq(true));
-            verify(lifecycleManager).closeStreamRemote(eq(stream), eq(future));
+            verify(lifecycleManager).closeStreamRemote(any(ChannelHandlerContext.class), eq(stream), eq(future));
             verify(listener).onDataRead(eq(ctx), eq(STREAM_ID), eq(data), eq(padding), eq(true));
             assertEquals(0, localFlow.unconsumedBytes(stream));
         } finally {
@@ -426,7 +426,7 @@ public class DefaultHttp2ConnectionDecoderTest {
         when(stream.state()).thenReturn(RESERVED_REMOTE);
         decode().onHeadersRead(ctx, STREAM_ID, EmptyHttp2Headers.INSTANCE, 0, true);
         verify(stream).open(true);
-        verify(lifecycleManager).closeStreamRemote(eq(stream), eq(future));
+        verify(lifecycleManager).closeStreamRemote(any(ChannelHandlerContext.class), eq(stream), eq(future));
         verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(EmptyHttp2Headers.INSTANCE), eq(0),
                 eq(DEFAULT_PRIORITY_WEIGHT), eq(false), eq(0), eq(true));
     }
@@ -439,7 +439,8 @@ public class DefaultHttp2ConnectionDecoderTest {
         verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(EmptyHttp2Headers.INSTANCE), eq(STREAM_DEPENDENCY_ID),
                 eq(weight), eq(true), eq(0), eq(true));
         verify(stream).setPriority(eq(STREAM_DEPENDENCY_ID), eq(weight), eq(true));
-        verify(lifecycleManager).closeStreamRemote(eq(stream), any(ChannelFuture.class));
+        verify(lifecycleManager).closeStreamRemote(any(ChannelHandlerContext.class),
+                eq(stream), any(ChannelFuture.class));
     }
 
     @Test
@@ -456,7 +457,8 @@ public class DefaultHttp2ConnectionDecoderTest {
         verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(EmptyHttp2Headers.INSTANCE), eq(STREAM_DEPENDENCY_ID),
                 eq(weight), eq(true), eq(0), eq(true));
         verify(stream).setPriority(eq(STREAM_DEPENDENCY_ID), eq(weight), eq(true));
-        verify(lifecycleManager).closeStreamRemote(eq(stream), any(ChannelFuture.class));
+        verify(lifecycleManager).closeStreamRemote(any(ChannelHandlerContext.class),
+                eq(stream), any(ChannelFuture.class));
     }
 
     @Test(expected = RuntimeException.class)
@@ -473,7 +475,8 @@ public class DefaultHttp2ConnectionDecoderTest {
         verify(listener, never()).onHeadersRead(any(ChannelHandlerContext.class), anyInt(), any(Http2Headers.class),
                 anyInt(), anyShort(), anyBoolean(), anyInt(), anyBoolean());
         verify(stream).setPriority(eq(STREAM_DEPENDENCY_ID), eq(weight), eq(true));
-        verify(lifecycleManager, never()).closeStreamRemote(eq(stream), any(ChannelFuture.class));
+        verify(lifecycleManager, never()).closeStreamRemote(any(ChannelHandlerContext.class),
+                eq(stream), any(ChannelFuture.class));
     }
 
     @Test
@@ -596,7 +599,7 @@ public class DefaultHttp2ConnectionDecoderTest {
     public void rstStreamReadAfterGoAwayShouldSucceed() throws Exception {
         when(connection.goAwaySent()).thenReturn(true);
         decode().onRstStreamRead(ctx, STREAM_ID, PROTOCOL_ERROR.code());
-        verify(lifecycleManager).closeStream(eq(stream), eq(future));
+        verify(lifecycleManager).closeStream(any(ChannelHandlerContext.class), eq(stream), eq(future));
         verify(listener).onRstStreamRead(eq(ctx), anyInt(), anyLong());
     }
 
@@ -611,14 +614,14 @@ public class DefaultHttp2ConnectionDecoderTest {
     public void rstStreamReadForUnknownStreamShouldBeIgnored() throws Exception {
         when(connection.stream(STREAM_ID)).thenReturn(null);
         decode().onRstStreamRead(ctx, STREAM_ID, PROTOCOL_ERROR.code());
-        verify(lifecycleManager, never()).closeStream(eq(stream), eq(future));
+        verify(lifecycleManager, never()).closeStream(any(ChannelHandlerContext.class), eq(stream), eq(future));
         verify(listener, never()).onRstStreamRead(eq(ctx), anyInt(), anyLong());
     }
 
     @Test
     public void rstStreamReadShouldCloseStream() throws Exception {
         decode().onRstStreamRead(ctx, STREAM_ID, PROTOCOL_ERROR.code());
-        verify(lifecycleManager).closeStream(eq(stream), eq(future));
+        verify(lifecycleManager).closeStream(any(ChannelHandlerContext.class), eq(stream), eq(future));
         verify(listener).onRstStreamRead(eq(ctx), eq(STREAM_ID), eq(PROTOCOL_ERROR.code()));
     }
 
@@ -626,7 +629,7 @@ public class DefaultHttp2ConnectionDecoderTest {
     public void rstStreamOnIdleStreamShouldThrow() throws Exception {
         when(stream.state()).thenReturn(IDLE);
         decode().onRstStreamRead(ctx, STREAM_ID, PROTOCOL_ERROR.code());
-        verify(lifecycleManager).closeStream(eq(stream), eq(future));
+        verify(lifecycleManager).closeStream(any(ChannelHandlerContext.class), eq(stream), eq(future));
         verify(listener, never()).onRstStreamRead(any(ChannelHandlerContext.class), anyInt(), anyLong());
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -504,7 +504,7 @@ public class DefaultHttp2ConnectionEncoderTest {
         ByteBuf data = dummyData();
         encoder.writeData(ctx, STREAM_ID, data.retain(), 0, true, promise);
         verify(remoteFlow).addFlowControlled(eq(stream), any(FlowControlled.class));
-        verify(lifecycleManager).closeStreamLocal(stream, promise);
+        verify(lifecycleManager).closeStreamLocal(any(ChannelHandlerContext.class), eq(stream), eq(promise));
         assertEquals(data.toString(UTF_8), writtenData.get(0));
         data.release();
     }
@@ -526,7 +526,7 @@ public class DefaultHttp2ConnectionEncoderTest {
         assertNotNull(payloadCaptor.getValue());
         payloadCaptor.getValue().write(ctx, 0);
         promise.trySuccess();
-        verify(lifecycleManager).closeStreamLocal(eq(stream), eq(promise));
+        verify(lifecycleManager).closeStreamLocal(any(ChannelHandlerContext.class), eq(stream), eq(promise));
     }
 
     @Test
@@ -541,7 +541,7 @@ public class DefaultHttp2ConnectionEncoderTest {
         verify(stream).open(true);
 
         promise.trySuccess();
-        verify(lifecycleManager).closeStreamLocal(eq(stream), eq(promise));
+        verify(lifecycleManager).closeStreamLocal(any(ChannelHandlerContext.class), eq(stream), eq(promise));
     }
 
     @Test
@@ -614,7 +614,7 @@ public class DefaultHttp2ConnectionEncoderTest {
             public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
                 FlowControlled flowControlled = (FlowControlled) invocationOnMock.getArguments()[1];
                 flowControlled.write(ctx, Integer.MAX_VALUE);
-                flowControlled.writeComplete();
+                flowControlled.writeComplete(ctx);
                 return null;
             }
         }).when(remoteFlow).addFlowControlled(eq(stream), payloadCaptor.capture());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -351,9 +351,9 @@ public class Http2ConnectionHandlerTest {
         if (future.isDone()) {
             when(connection.numActiveStreams()).thenReturn(0);
         }
-        handler.closeStream(stream, future);
+        handler.closeStream(ctx, stream, future);
         // Simulate another stream close call being made after the context should already be closed.
-        handler.closeStream(stream, future);
+        handler.closeStream(ctx, stream, future);
         verify(ctx, times(1)).close(any(ChannelPromise.class));
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -124,11 +124,11 @@ final class Http2TestUtil {
             return null;
         }
 
-        private void closeStream(Http2Stream stream) {
+        private void closeStream(Http2Stream stream) throws Http2Exception {
             closeStream(stream, false);
         }
 
-        protected void closeStream(Http2Stream stream, boolean dataRead) {
+        protected void closeStream(Http2Stream stream, boolean dataRead) throws Http2Exception {
             if (stream != null) {
                 stream.close();
             }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -805,7 +805,7 @@ public class InboundHttp2ToHttpAdapterTest {
         }
 
         @Override
-        protected void closeStream(Http2Stream stream, boolean dataRead) {
+        protected void closeStream(Http2Stream stream, boolean dataRead) throws Http2Exception {
             if (!dataRead) { // NOTE: Do not close the stream to allow the out of order messages to be processed
                 super.closeStream(stream, dataRead);
             }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/PriorityStreamByteDistributorTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/PriorityStreamByteDistributorTest.java
@@ -124,9 +124,8 @@ public class PriorityStreamByteDistributorTest {
         try {
             write(10);
             fail("Expected an exception");
-        } catch (Http2Exception e) {
-            assertFalse(isStreamError(e));
-            assertSame(fakeException, e.getCause());
+        } catch (RuntimeException e) {
+            assertSame(fakeException, e);
         }
 
         verifyWrite(atMost(1), STREAM_A, 1);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -157,7 +157,7 @@ public class StreamBufferingEncoderTest {
     }
 
     @Test
-    public void ensureCanCreateNextStreamWhenStreamCloses() {
+    public void ensureCanCreateNextStreamWhenStreamCloses() throws Http2Exception {
         encoder.writeSettingsAck(ctx, promise);
         setMaxConcurrentStreams(1);
 
@@ -203,7 +203,7 @@ public class StreamBufferingEncoderTest {
     }
 
     @Test
-    public void bufferingNewStreamFailsAfterGoAwayReceived() {
+    public void bufferingNewStreamFailsAfterGoAwayReceived() throws Http2Exception {
         encoder.writeSettingsAck(ctx, promise);
         setMaxConcurrentStreams(0);
         connection.goAwayReceived(1, 8, EMPTY_BUFFER);
@@ -215,7 +215,7 @@ public class StreamBufferingEncoderTest {
     }
 
     @Test
-    public void receivingGoAwayFailsBufferedStreams() {
+    public void receivingGoAwayFailsBufferedStreams() throws Http2Exception {
         encoder.writeSettingsAck(ctx, promise);
         setMaxConcurrentStreams(5);
 


### PR DESCRIPTION
Motivation:
There are a few Listener interfaces, or generally interfaces that call out to user code while the codec detects events of interest. These interfaces roughly share the same constraint that exceptions are not supported, but do not handle them consistently. Some log the exception as an error and continue, others attempt to propagate the exception as is after state is assumed to be consistent. The former approach can make debugging difficult, and the latter makes assumptions about state being consistent and the user is responsible for catching these RuntimeExceptions somewhere. An improvement over this situation in terms of ease of debugging and visibility is to change these Listener interfaces to explicitly throw Http2Exceptions and ensure the connection is closed as a result (with a GO_AWAY). The exception will thus be visible through normal means of HTTP/2 frames and tools.
    
Modifications:
- Change all Listener type interfaces (as described above) to throw Http2Exception
- The interface is defined as any exception thrown from these interfaces will result in a GO_AWAY and the connection being closed
    
Result:
Exceptions are more explicit, handled consistently, and more visible for debugging.