### PR TITLE
Fail build on warnings in the native transport

### DIFF
--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -186,7 +186,7 @@
               <value>${linux.sendmmsg.support}${glibc.sendmmsg.support}</value>
               <!-- If glibc and linux kernel are both not sufficient...then define the CFLAGS -->
               <regex>.*IO_NETTY_SENDMSSG_NOT_FOUND.*</regex>
-              <replacement>CFLAGS=-O3 -DIO_NETTY_SENDMMSG_NOT_FOUND</replacement>
+              <replacement>CFLAGS=-O3 -DIO_NETTY_SENDMMSG_NOT_FOUND -Werror</replacement>
               <failIfNoMatch>false</failIfNoMatch>
             </configuration>
           </execution>
@@ -202,7 +202,7 @@
               <value>${jni.compiler.args}</value>
               <!-- If glibc and linux kernel are both not sufficient...then define the CFLAGS -->
               <regex>^((?!CFLAGS=).)*$</regex>
-              <replacement>CFLAGS=-O3</replacement>
+              <replacement>CFLAGS=-O3 -Werror</replacement>
               <failIfNoMatch>false</failIfNoMatch>
             </configuration>
           </execution>

--- a/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.h
+++ b/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.h
@@ -130,7 +130,7 @@ jint Java_io_netty_channel_epoll_Native_sizeofEpollEvent(JNIEnv* env, jclass cla
 jint Java_io_netty_channel_epoll_Native_offsetofEpollData(JNIEnv* env, jclass clazz);
 
 jlong Java_io_netty_channel_epoll_Native_pipe0(JNIEnv* env, jclass clazz);
-jint Java_io_netty_channel_epoll_Native_splice0(JNIEnv* env, jclass clazz, jint fd, jint offIn, jint fdOut, jint offOut, jint len);
+jint Java_io_netty_channel_epoll_Native_splice0(JNIEnv* env, jclass clazz, jint fd, jlong offIn, jint fdOut, jlong offOut, jlong len);
 
 jint Java_io_netty_channel_epoll_Native_tcpMd5SigMaxKeyLen(JNIEnv* env, jclass clazz);
 void Java_io_netty_channel_epoll_Native_setTcpMd5Sig0(JNIEnv* env, jclass clazz, jint fd, jbyteArray address, jint scopeId, jbyteArray key);

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -205,7 +205,7 @@ public final class Native {
 
     private static native int close0(int fd);
 
-    public static int splice(int fd, int offIn, int fdOut, int offOut, int len) throws IOException {
+    public static int splice(int fd, long offIn, int fdOut, long offOut, long len) throws IOException {
         int res = splice0(fd, offIn, fdOut, offOut, len);
         if (res >= 0) {
             return res;
@@ -213,7 +213,7 @@ public final class Native {
         return ioResult("splice", res, CONNECTION_RESET_EXCEPTION_SPLICE);
     }
 
-    private static native int splice0(int fd, int offIn, int fdOut, int offOut, int len);
+    private static native int splice0(int fd, long offIn, int fdOut, long offOut, long len);
 
     public static long pipe() throws IOException {
         long res = pipe0();


### PR DESCRIPTION
Motivation:

We should fail the build on warnings in the JNI/c code.

Modifications:

- Add GCC flag to fail build on warnings.
- Fix warnings (which also fixed a bug when using splice with offsets).

Result:

Better code quality.