### PR TITLE
Http2ConnectionHandler Builder instead of constructors

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2ConnectionDecoder.java
@@ -52,6 +52,11 @@ public class DecoratingHttp2ConnectionDecoder implements Http2ConnectionDecoder 
     }
 
     @Override
+    public Http2FrameListener frameListener() {
+        return delegate.frameListener();
+    }
+
+    @Override
     public void decodeFrame(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Http2Exception {
         delegate.decodeFrame(ctx, in, out);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -88,6 +88,11 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
     }
 
     @Override
+    public Http2FrameListener frameListener() {
+        return listener;
+    }
+
+    @Override
     public boolean prefaceReceived() {
         return FrameReadListener.class == internalFrameListener.getClass();
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionDecoder.java
@@ -51,6 +51,11 @@ public interface Http2ConnectionDecoder extends Closeable {
     void frameListener(Http2FrameListener listener);
 
     /**
+     * Get the {@link Http2FrameListener} which will be notified when frames are decoded.
+     */
+    Http2FrameListener frameListener();
+
+    /**
      * Called by the {@link Http2ConnectionHandler} to decode the next frame from the input buffer.
      */
     void decodeFrame(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Http2Exception;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
@@ -36,43 +36,20 @@ public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
     private final boolean validateHeaders;
     private int currentStreamId;
 
-    public HttpToHttp2ConnectionHandler(boolean server) {
-        this(server, true);
+    /**
+     * Builder which builds {@link HttpToHttp2ConnectionHandler} objects.
+     */
+    public static final class Builder extends BuilderBase<HttpToHttp2ConnectionHandler, Builder> {
+        @Override
+        public HttpToHttp2ConnectionHandler build0(Http2ConnectionDecoder decoder,
+                                                   Http2ConnectionEncoder encoder) {
+            return new HttpToHttp2ConnectionHandler(decoder, encoder, initialSettings(), isValidateHeaders());
+        }
     }
 
-    public HttpToHttp2ConnectionHandler(boolean server, boolean validateHeaders) {
-        super(server);
-        this.validateHeaders = validateHeaders;
-    }
-
-    public HttpToHttp2ConnectionHandler(Http2Connection connection) {
-        this(connection, true);
-    }
-
-    public HttpToHttp2ConnectionHandler(Http2Connection connection, boolean validateHeaders) {
-        super(connection);
-        this.validateHeaders = validateHeaders;
-    }
-
-    public HttpToHttp2ConnectionHandler(Http2Connection connection, Http2FrameReader frameReader,
-            Http2FrameWriter frameWriter) {
-        this(connection, frameReader, frameWriter, true);
-    }
-
-    public HttpToHttp2ConnectionHandler(Http2Connection connection, Http2FrameReader frameReader,
-            Http2FrameWriter frameWriter, boolean validateHeaders) {
-        super(connection, frameReader, frameWriter);
-        this.validateHeaders = validateHeaders;
-    }
-
-    public HttpToHttp2ConnectionHandler(Http2ConnectionDecoder decoder,
-                                        Http2ConnectionEncoder encoder) {
-        this(decoder, encoder, true);
-    }
-
-    public HttpToHttp2ConnectionHandler(Http2ConnectionDecoder decoder,
-            Http2ConnectionEncoder encoder, boolean validateHeaders) {
-        super(decoder, encoder);
+    protected HttpToHttp2ConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
+                                           Http2Settings initialSettings, boolean validateHeaders) {
+        super(decoder, encoder, initialSettings);
         this.validateHeaders = validateHeaders;
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -300,8 +300,9 @@ public class DataCompressionHttp2Test {
                         new DefaultHttp2ConnectionEncoder(serverConnection, new DefaultHttp2FrameWriter()));
                 Http2ConnectionDecoder decoder =
                         new DefaultHttp2ConnectionDecoder(serverConnection, encoder, new DefaultHttp2FrameReader());
-                decoder.frameListener(new DelegatingDecompressorFrameListener(serverConnection, serverListener));
-                Http2ConnectionHandler connectionHandler = new Http2ConnectionHandler(decoder, encoder);
+                Http2ConnectionHandler connectionHandler = new Http2ConnectionHandler.Builder()
+                        .frameListener(new DelegatingDecompressorFrameListener(serverConnection, serverListener))
+                        .build(decoder, encoder);
                 p.addLast(connectionHandler);
                 serverChannelLatch.countDown();
             }
@@ -318,11 +319,11 @@ public class DataCompressionHttp2Test {
                 Http2ConnectionDecoder decoder =
                         new DefaultHttp2ConnectionDecoder(clientConnection, clientEncoder,
                                 new DefaultHttp2FrameReader());
-                decoder.frameListener(new DelegatingDecompressorFrameListener(clientConnection, clientListener));
-                clientHandler = new Http2ConnectionHandler(decoder, clientEncoder);
-
-                // By default tests don't wait for server to gracefully shutdown streams
-                clientHandler.gracefulShutdownTimeoutMillis(0);
+                clientHandler = new Http2ConnectionHandler.Builder()
+                        .frameListener(new DelegatingDecompressorFrameListener(clientConnection, clientListener))
+                        // By default tests don't wait for server to gracefully shutdown streams
+                        .gracefulShutdownTimeoutMillis(0)
+                        .build(decoder, clientEncoder);
                 p.addLast(clientHandler);
             }
         });

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -180,7 +180,7 @@ public class Http2ConnectionHandlerTest {
     }
 
     private Http2ConnectionHandler newHandler() throws Exception {
-        Http2ConnectionHandler handler = new Http2ConnectionHandler(decoder, encoder);
+        Http2ConnectionHandler handler = new Http2ConnectionHandler.Builder().build(decoder, encoder);
         handler.handlerAdded(ctx);
         return handler;
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -482,9 +482,11 @@ public class Http2ConnectionRoundtripTest {
                 serverFrameCountDown =
                         new FrameCountDown(serverListener, serverSettingsAckLatch,
                                 requestLatch, dataLatch, trailersLatch, goAwayLatch);
-                Http2ConnectionHandler handler = new Http2ConnectionHandler(true, false);
-                handler.decoder().frameListener(serverFrameCountDown);
-                p.addLast(handler);
+                p.addLast(new Http2ConnectionHandler.Builder()
+                        .server(true)
+                        .frameListener(serverFrameCountDown)
+                        .validateHeaders(false)
+                        .build());
             }
         });
 
@@ -494,9 +496,11 @@ public class Http2ConnectionRoundtripTest {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 ChannelPipeline p = ch.pipeline();
-                Http2ConnectionHandler handler = new Http2ConnectionHandler(false, false);
-                handler.decoder().frameListener(clientListener);
-                p.addLast(handler);
+                p.addLast(new Http2ConnectionHandler.Builder()
+                        .server(false)
+                        .frameListener(clientListener)
+                        .validateHeaders(false)
+                        .build());
             }
         });
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -487,9 +487,10 @@ public class HttpToHttp2ConnectionHandlerTest {
                 ChannelPipeline p = ch.pipeline();
                 serverFrameCountDown =
                         new FrameCountDown(serverListener, serverSettingsAckLatch, requestLatch, null, trailersLatch);
-                HttpToHttp2ConnectionHandler handler = new HttpToHttp2ConnectionHandler(true);
-                handler.decoder().frameListener(serverFrameCountDown);
-                p.addLast(handler);
+                p.addLast(new HttpToHttp2ConnectionHandler.Builder()
+                           .server(true)
+                           .frameListener(serverFrameCountDown)
+                           .build());
             }
         });
 
@@ -499,9 +500,11 @@ public class HttpToHttp2ConnectionHandlerTest {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 ChannelPipeline p = ch.pipeline();
-                HttpToHttp2ConnectionHandler handler = new HttpToHttp2ConnectionHandler(false);
-                handler.decoder().frameListener(clientListener);
-                handler.gracefulShutdownTimeoutMillis(0);
+                HttpToHttp2ConnectionHandler handler = new HttpToHttp2ConnectionHandler.Builder()
+                        .server(false)
+                        .frameListener(clientListener)
+                        .gracefulShutdownTimeoutMillis(0)
+                        .build();
                 p.addLast(handler);
             }
         });

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -111,9 +111,9 @@ public class StreamBufferingEncoderTest {
         encoder = new StreamBufferingEncoder(defaultEncoder);
         DefaultHttp2ConnectionDecoder decoder =
                 new DefaultHttp2ConnectionDecoder(connection, encoder, mock(Http2FrameReader.class));
-        decoder.frameListener(mock(Http2FrameListener.class));
+        Http2ConnectionHandler handler = new Http2ConnectionHandler.Builder()
+                .frameListener(mock(Http2FrameListener.class)).build(decoder, encoder);
 
-        Http2ConnectionHandler handler = new Http2ConnectionHandler(decoder, encoder);
         // Set LifeCycleManager on encoder and decoder
         when(ctx.channel()).thenReturn(channel);
         when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);

--- a/example/src/main/java/io/netty/example/http2/helloworld/client/Http2ClientInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/client/Http2ClientInitializer.java
@@ -25,16 +25,10 @@ import io.netty.handler.codec.http.HttpClientUpgradeHandler;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http2.DefaultHttp2Connection;
-import io.netty.handler.codec.http2.DefaultHttp2FrameReader;
-import io.netty.handler.codec.http2.DefaultHttp2FrameWriter;
 import io.netty.handler.codec.http2.DelegatingDecompressorFrameListener;
 import io.netty.handler.codec.http2.Http2ClientUpgradeCodec;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2FrameLogger;
-import io.netty.handler.codec.http2.Http2FrameReader;
-import io.netty.handler.codec.http2.Http2FrameWriter;
-import io.netty.handler.codec.http2.Http2InboundFrameLogger;
-import io.netty.handler.codec.http2.Http2OutboundFrameLogger;
 import io.netty.handler.codec.http2.HttpToHttp2ConnectionHandler;
 import io.netty.handler.codec.http2.InboundHttp2ToHttpAdapter;
 import io.netty.handler.ssl.SslContext;
@@ -61,13 +55,14 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
     @Override
     public void initChannel(SocketChannel ch) throws Exception {
         final Http2Connection connection = new DefaultHttp2Connection(false);
-        final Http2FrameWriter frameWriter = frameWriter();
-        connectionHandler = new HttpToHttp2ConnectionHandler(connection, frameReader(), frameWriter);
-        connectionHandler.decoder().frameListener(new DelegatingDecompressorFrameListener(connection,
+        connectionHandler = new HttpToHttp2ConnectionHandler.Builder()
+                .frameListener(new DelegatingDecompressorFrameListener(connection,
                         new InboundHttp2ToHttpAdapter.Builder(connection)
-                                .maxContentLength(maxContentLength)
-                                .propagateSettings(true)
-                                .build()));
+                            .maxContentLength(maxContentLength)
+                            .propagateSettings(true)
+                            .build()))
+                .frameLogger(logger)
+                .build(connection);
         responseHandler = new HttpResponseHandler();
         settingsHandler = new Http2SettingsHandler(ch.newPromise());
         if (sslCtx != null) {
@@ -141,13 +136,5 @@ public class Http2ClientInitializer extends ChannelInitializer<SocketChannel> {
             System.out.println("User Event Triggered: " + evt);
             ctx.fireUserEventTriggered(evt);
         }
-    }
-
-    private static Http2FrameReader frameReader() {
-        return new Http2InboundFrameLogger(new DefaultHttp2FrameReader(), logger);
-    }
-
-    private static Http2FrameWriter frameWriter() {
-        return new Http2OutboundFrameLogger(new DefaultHttp2FrameWriter(), logger);
     }
 }

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/Http2OrHttpHandler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/Http2OrHttpHandler.java
@@ -35,7 +35,7 @@ public class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {
     @Override
     protected void configurePipeline(ChannelHandlerContext ctx, String protocol) throws Exception {
         if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
-            ctx.pipeline().addLast(new HelloWorldHttp2Handler());
+            ctx.pipeline().addLast(new HelloWorldHttp2Handler.Builder().build());
             return;
         }
 

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/Http2ServerInitializer.java
@@ -43,7 +43,7 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
         @Override
         public UpgradeCodec newUpgradeCodec(CharSequence protocol) {
             if (AsciiString.contentEquals(Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME, protocol)) {
-                return new Http2ServerUpgradeCodec(new HelloWorldHttp2Handler());
+                return new Http2ServerUpgradeCodec(new HelloWorldHttp2Handler.Builder().build());
             } else {
                 return null;
             }

--- a/example/src/main/java/io/netty/example/http2/tiles/Http2OrHttpHandler.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/Http2OrHttpHandler.java
@@ -56,19 +56,13 @@ public class Http2OrHttpHandler extends ApplicationProtocolNegotiationHandler {
 
     private static void configureHttp2(ChannelHandlerContext ctx) {
         DefaultHttp2Connection connection = new DefaultHttp2Connection(true);
-        DefaultHttp2FrameWriter writer = new DefaultHttp2FrameWriter();
-        DefaultHttp2FrameReader reader = new DefaultHttp2FrameReader();
         InboundHttp2ToHttpAdapter listener = new InboundHttp2ToHttpAdapter.Builder(connection)
                 .propagateSettings(true).validateHttpHeaders(false).maxContentLength(MAX_CONTENT_LENGTH).build();
 
-        HttpToHttp2ConnectionHandler handler = new HttpToHttp2ConnectionHandler(
-                connection,
-                // Loggers can be activated for debugging purposes
-                // new Http2InboundFrameLogger(reader, TilesHttp2ToHttpHandler.logger),
-                // new Http2OutboundFrameLogger(writer, TilesHttp2ToHttpHandler.logger)
-                reader, writer);
-        handler.decoder().frameListener(listener);
-        ctx.pipeline().addLast(handler);
+        ctx.pipeline().addLast(new HttpToHttp2ConnectionHandler.Builder()
+                .frameListener(listener)
+                // .frameLogger(TilesHttp2ToHttpHandler.logger)
+                .build(connection));
         ctx.pipeline().addLast(new Http2RequestHandler());
     }
 

--- a/microbench/src/main/java/io/netty/microbench/http2/Http2FrameWriterBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/Http2FrameWriterBenchmark.java
@@ -263,8 +263,9 @@ public class Http2FrameWriterBenchmark extends AbstractSharedExecutorMicrobenchm
                 Http2ConnectionEncoder encoder = new DefaultHttp2ConnectionEncoder(connection, environment.writer());
                 Http2ConnectionDecoder decoder =
                         new DefaultHttp2ConnectionDecoder(connection, encoder, new DefaultHttp2FrameReader());
-                decoder.frameListener(new Http2FrameAdapter());
-                Http2ConnectionHandler connectionHandler = new Http2ConnectionHandler(decoder, encoder);
+                Http2ConnectionHandler connectionHandler = new Http2ConnectionHandler.Builder()
+                            .encoderEnforceMaxConcurrentStreams(false)
+                            .frameListener(new Http2FrameAdapter()).build(decoder, encoder);
                 p.addLast(connectionHandler);
                 environment.context(p.lastContext());
                 // Must wait for context to be set.
@@ -292,8 +293,9 @@ public class Http2FrameWriterBenchmark extends AbstractSharedExecutorMicrobenchm
         Http2ConnectionEncoder encoder = new DefaultHttp2ConnectionEncoder(connection, env.writer());
         Http2ConnectionDecoder decoder =
                 new DefaultHttp2ConnectionDecoder(connection, encoder, new DefaultHttp2FrameReader());
-        decoder.frameListener(new Http2FrameAdapter());
-        Http2ConnectionHandler connectionHandler = new Http2ConnectionHandler(decoder, encoder);
+        Http2ConnectionHandler connectionHandler = new Http2ConnectionHandler.Builder()
+                    .encoderEnforceMaxConcurrentStreams(false)
+                    .frameListener(new Http2FrameAdapter()).build(decoder, encoder);
         env.context(new EmbeddedChannelWriteReleaseHandlerContext(alloc, connectionHandler) {
             @Override
             protected void handleException(Throwable t) {


### PR DESCRIPTION
Motivation:
Using the builder pattern for Http2ConnectionHandler (and subclasses) would be advantageous for the following reasons:
1. Provides the consistent construction afforded by the builder pattern for 'optional' arguments. Users can specify these options 1 time in the builder and then re-use the builder after this.
2. Enforces that the Http2ConnectionHandler's internals (decoder Http2FrameListener) are initialized after construction.
    
Modifications:
- Add an extensible builder which can be used to build Http2ConnectionHandler objects
- Update classes which inherit from Http2ConnectionHandler
    
Result:
It is easier to specify options and construct Http2ConnectionHandler objects.