### PR TITLE
Correctly update internal handshake state on beginHandshake()

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -1043,8 +1043,8 @@ public final class OpenSslEngine extends SSLEngine {
     public synchronized void beginHandshake() throws SSLException {
         switch (handshakeState) {
             case NOT_STARTED:
-                handshake();
                 handshakeState = HandshakeState.STARTED_EXPLICITLY;
+                handshake();
                 break;
             case STARTED_IMPLICITLY:
                 checkEngineClosed();
@@ -1058,6 +1058,7 @@ public final class OpenSslEngine extends SSLEngine {
                 handshakeState = HandshakeState.STARTED_EXPLICITLY; // Next time this method is invoked by the user,
                                                           // we should raise an exception.
                 break;
+            case FINISHED:
             case STARTED_EXPLICITLY:
                 throw RENEGOTIATION_UNSUPPORTED;
             default:


### PR DESCRIPTION
Motivation:

We missed to correctly update the internal handshake state on beginHandshake() if we was able to finish the handshake directly. Also we not handled the case correctly when beginHandshake() was called after the first handshake was finished, which incorrectly throw an Error.

Modifications:

- Correctly set internal handshake state in all cases
- Correctly handle beginHandshake() once first handshake was finished.

Result:

Correctly handle OpenSslEngine.beginHandshake()