### PR TITLE
Implement SSLSession.invalidate() and isValid() for OpenSSLEngine.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -1411,11 +1411,20 @@ public final class OpenSslEngine extends SSLEngine {
 
         @Override
         public void invalidate() {
-            // NOOP
+            synchronized (OpenSslEngine.this) {
+                if (!isDestroyed()) {
+                    SSL.setTimeout(ssl, 0);
+                }
+            }
         }
 
         @Override
         public boolean isValid() {
+            synchronized (OpenSslEngine.this) {
+                if (!isDestroyed()) {
+                    return System.currentTimeMillis() - (SSL.getTimeout(ssl) * 1000L) < (SSL.getTime(ssl) * 1000L);
+                }
+            }
             return false;
         }
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -49,6 +49,12 @@ public class OpenSslEngineTest extends SSLEngineTest {
     }
 
     @Override
+    public void testSessionInvalidate() throws Exception {
+        assumeTrue(OpenSsl.isAvailable());
+        super.testSessionInvalidate();
+    }
+
+    @Override
     protected SslProvider sslProvider() {
         return SslProvider.OPENSSL;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -687,7 +687,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>1.1.33.Fork9</version>
+        <version>1.1.33.Fork10</version>
         <classifier>${tcnative.classifier}</classifier>
         <scope>compile</scope>
         <optional>true</optional>


### PR DESCRIPTION
Motivation:

The SSLSession allows to invalidate a SSLSession and so disallow resume of a session. We should support this for OpenSSLEngine as well.

Modifications:

- Correctly implement SSLSession.isValid() and invalidate() in OpenSSLEngine
- Add unit test.

Result:

Invalidate of SSL sessions is supported when using OpenSSL now.