### PR TITLE
Lazy compute SSLSession creation time.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -212,7 +212,7 @@ public final class OpenSslEngine extends SSLEngine {
         this.apn = checkNotNull(apn, "apn");
         this.clientAuth = clientMode ? ClientAuth.NONE : checkNotNull(clientAuth, "clientAuth");
         ssl = SSL.newSSL(sslCtx, !clientMode);
-        session = new OpenSslSession(ssl, sessionContext);
+        session = new OpenSslSession(sessionContext);
         networkBIO = SSL.makeNetworkBIO(ssl);
         this.clientMode = clientMode;
         this.engineMap = engineMap;
@@ -1281,7 +1281,6 @@ public final class OpenSslEngine extends SSLEngine {
 
     private final class OpenSslSession implements SSLSession, ApplicationProtocolAccessor {
         private final OpenSslSessionContext sessionContext;
-        private final long creationTime;
 
         // These are guarded by synchronized(OpenSslEngine.this) as handshakeFinished() may be triggered by any
         // thread.
@@ -1291,12 +1290,12 @@ public final class OpenSslEngine extends SSLEngine {
         private Certificate[] peerCerts;
         private String cipher;
         private byte[] id;
+        private long creationTime;
 
         // lazy init for memory reasons
         private Map<String, Object> values;
 
-        OpenSslSession(long ssl, OpenSslSessionContext sessionContext) {
-            creationTime = SSL.getTime(ssl) * 1000L;
+        OpenSslSession(OpenSslSessionContext sessionContext) {
             this.sessionContext = sessionContext;
         }
 
@@ -1317,6 +1316,11 @@ public final class OpenSslEngine extends SSLEngine {
 
         @Override
         public long getCreationTime() {
+            synchronized (OpenSslEngine.this) {
+                if (creationTime == 0 && !isDestroyed()) {
+                    creationTime = SSL.getTime(ssl) * 1000L;
+                }
+            }
             return creationTime;
         }
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -43,6 +43,12 @@ public class OpenSslEngineTest extends SSLEngineTest {
     }
 
     @Override
+    public void testGetCreationTime() throws Exception {
+        assumeTrue(OpenSsl.isAvailable());
+        super.testGetCreationTime();
+    }
+
+    @Override
     protected SslProvider sslProvider() {
         return SslProvider.OPENSSL;
     }

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -19,6 +19,7 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerAdapter;
@@ -284,6 +285,13 @@ public abstract class SSLEngineTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testGetCreationTime() throws Exception {
+        SslContext context = SslContextBuilder.forClient().sslProvider(sslProvider()).build();
+        SSLEngine engine = context.newEngine(UnpooledByteBufAllocator.DEFAULT);
+        assertTrue(engine.getSession().getCreationTime() <= System.currentTimeMillis());
     }
 
     protected abstract SslProvider sslProvider();


### PR DESCRIPTION
Motivation:

As a SSL session may be created later at some time we should compute the creation time in a lazy fashion.

Modifications:

- Lazy compute creation time
- Add some unit test

Result:

More correct behavior