### PR TITLE
[#4289] Use a mock DNS Server for dns tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -893,6 +893,14 @@
         <artifactId>xz</artifactId>
         <version>1.5</version>
       </dependency>
+
+      <!-- Test dependency for resolver-dns -->
+      <dependency>
+        <groupId>org.apache.directory.server</groupId>
+        <artifactId>apacheds-protocol-dns</artifactId>
+        <version>1.5.7</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -44,6 +44,11 @@
       <artifactId>netty-transport</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.directory.server</groupId>
+      <artifactId>apacheds-protocol-dns</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -129,6 +129,7 @@ public class DnsNameResolver extends SimpleNameResolver<InetSocketAddress> {
     private volatile boolean recursionDesired = true;
 
     private volatile int maxPayloadSize;
+    private volatile boolean optResourceEnabled = true;
 
     /**
      * Creates a new DNS-based name resolver that communicates with the specified list of DNS servers.
@@ -518,6 +519,24 @@ public class DnsNameResolver extends SimpleNameResolver<InetSocketAddress> {
         ch.config().setRecvByteBufAllocator(new FixedRecvByteBufAllocator(maxPayloadSize));
 
         return this;
+    }
+
+    /**
+     * Enable the automatic inclusion of a optional records that tries to give the remote DNS server a hint about how
+     * much data the resolver can read per response. Some DNSServer may not support this and so fail to answer
+     * queries. If you find problems you may want to disable this.
+     */
+    public DnsNameResolver setOptResourceEnabled(boolean optResourceEnabled) {
+        this.optResourceEnabled = optResourceEnabled;
+        return this;
+    }
+
+    /**
+     * Returns the automatic inclusion of a optional records that tries to give the remote DNS server a hint about how
+     * much data the resolver can read per response is enabled.
+     */
+    public boolean isOptResourceEnabled() {
+        return optResourceEnabled;
     }
 
     /**

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -63,8 +63,12 @@ final class DnsQueryContext {
 
         id = allocateId();
         recursionDesired = parent.isRecursionDesired();
-        optResource = new DefaultDnsRawRecord(
-                StringUtil.EMPTY_STRING, DnsRecordType.OPT, parent.maxPayloadSize(), 0, Unpooled.EMPTY_BUFFER);
+        if (parent.isOptResourceEnabled()) {
+            optResource = new DefaultDnsRawRecord(
+                    StringUtil.EMPTY_STRING, DnsRecordType.OPT, parent.maxPayloadSize(), 0, Unpooled.EMPTY_BUFFER);
+        } else {
+            optResource = null;
+        }
     }
 
     private int allocateId() {
@@ -89,7 +93,9 @@ final class DnsQueryContext {
         final DatagramDnsQuery query = new DatagramDnsQuery(null, nameServerAddr, id);
         query.setRecursionDesired(recursionDesired);
         query.setRecord(DnsSection.QUESTION, question);
-        query.setRecord(DnsSection.ADDITIONAL, optResource);
+        if (optResource != null) {
+            query.setRecord(DnsSection.ADDITIONAL, optResource);
+        }
 
         if (logger.isDebugEnabled()) {
             logger.debug("{} WRITE: [{}: {}], {}", parent.ch, id, nameServerAddr, question);

--- a/resolver-dns/src/test/resources/logback-test.xml
+++ b/resolver-dns/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  // Disable logging for apacheds to reduce noise.
+  <logger name="org.apache.directory" level="off"/>
+</configuration>


### PR DESCRIPTION
Motivation:

As relaying on external DNS Server can result to test-failures we should better use a mock DNS Server for the dns tests.

Modifications:

- Refactor the DnsNameResolverTest to use a mock DNS Server which is using apacheds.
- Allow to disable adding an opt resources as some servers not support it.

Result:

More stable testsuite.