### PR TITLE
[#4316] Ensure pending tasks are run when EmbeddedChannel.close(...) …

### DIFF
--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -243,14 +243,42 @@ public class EmbeddedChannel extends AbstractChannel {
      */
     public boolean finish() {
         close();
-        runPendingTasks();
+        checkException();
+        return isNotEmpty(inboundMessages) || isNotEmpty(outboundMessages);
+    }
 
+    private void finishPendingTasks() {
+        runPendingTasks();
         // Cancel all scheduled tasks that are left.
         loop.cancelScheduledTasks();
+    }
 
-        checkException();
+    @Override
+    public final ChannelFuture close() {
+        ChannelFuture future = super.close();
+        finishPendingTasks();
+        return future;
+    }
 
-        return isNotEmpty(inboundMessages) || isNotEmpty(outboundMessages);
+    @Override
+    public final ChannelFuture disconnect() {
+        ChannelFuture future = super.disconnect();
+        finishPendingTasks();
+        return future;
+    }
+
+    @Override
+    public final ChannelFuture close(ChannelPromise promise) {
+        ChannelFuture future = super.close(promise);
+        finishPendingTasks();
+        return future;
+    }
+
+    @Override
+    public final ChannelFuture disconnect(ChannelPromise promise) {
+        ChannelFuture future = super.disconnect(promise);
+        finishPendingTasks();
+        return future;
     }
 
     private static boolean isNotEmpty(Queue<Object> queue) {

--- a/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
@@ -248,9 +248,10 @@ public class PendingWriteQueueTest {
     @Test
     public void testCloseChannelOnCreation() {
         EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter());
+        ChannelHandlerContext context = channel.pipeline().firstContext();
         channel.close().syncUninterruptibly();
 
-        final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
+        final PendingWriteQueue queue = new PendingWriteQueue(context);
 
         IllegalStateException ex = new IllegalStateException();
         ChannelPromise promise = channel.newPromise();


### PR DESCRIPTION
…or disconnect(...) is called.

Motivation:

We missed to run all pending tasks when EmbeddedChannel.close(...) or disconnect(...) was called. Because of this channelInactive(...) / channelUnregistered(...) of the handlers were never called.

Modifications:

Correctly run all pending tasks and cancel all not ready scheduled tasks when close or disconnect was called.

Result:

Correctly run tasks on close / disconnect and have channelInactive(...) / channelUnregistered(...) called.