### PR TITLE
EPOLL Shutdown Input Half Closed

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -377,8 +377,14 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                 inputShutdown = true;
                 if (isOpen()) {
                     if (Boolean.TRUE.equals(config().getOption(ChannelOption.ALLOW_HALF_CLOSURE))) {
-                        clearEpollIn0();
-                        pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
+                        try {
+                            Native.shutdown(fd().intValue(), true, false);
+                            clearEpollIn0();
+                            pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
+                        } catch (IOException e) {
+                            pipeline().fireExceptionCaught(e);
+                            close(voidPromise());
+                        }
                     } else {
                         close(voidPromise());
                     }


### PR DESCRIPTION
Motivation:
EPOLL attempts to support half closed socket, but fails to call shutdown to close the read portion of the file descriptor.

Motivation:
- If half closed is supported shutting down the input should call underlying Native.shutdown(...) to make sure the peer is notified of the half closed state.

Result:
EPOLL half closed is more correct.