### PR TITLE
change type definition of pipeline from DefaultChannelPipeline to Cha…

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -54,7 +54,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     private final Channel parent;
     private final ChannelId id;
     private final Unsafe unsafe;
-    private final DefaultChannelPipeline pipeline;
+    private final ChannelPipeline pipeline;
     private final ChannelFuture succeededFuture = new SucceededChannelFuture(this, null);
     private final VoidChannelPromise voidPromise = new VoidChannelPromise(this, true);
     private final VoidChannelPromise unsafeVoidPromise = new VoidChannelPromise(this, false);


### PR DESCRIPTION
Netty version: 5.0.0.Alpha3-SNAPSHOT

Context:
I found that in class AbstractChannel, the type definition of pipeline is "DefaultChannelPipeline". I think we would better to use the interface ChannelPipeline, not a detail implementation DefaultChannelPipeline. In fact, in the code we don't use any DefaultChannelPipeline specified code but just use it as ChannelPipeline. 

```java
private final DefaultChannelPipeline pipeline;
```