### PR TITLE
HTTP Headers Over Deprecation

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -107,7 +107,6 @@ public class DefaultHttpHeaders extends HttpHeaders {
         }
     }
 
-    @Deprecated
     @Override
     public HttpHeaders add(String name, Object value) {
         headers.addObject(name, value);
@@ -120,7 +119,6 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return this;
     }
 
-    @Deprecated
     @Override
     public HttpHeaders add(String name, Iterable<?> values) {
         headers.addObject(name, values);
@@ -145,7 +143,6 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return this;
     }
 
-    @Deprecated
     @Override
     public HttpHeaders remove(String name) {
         headers.remove(name);
@@ -158,7 +155,6 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return this;
     }
 
-    @Deprecated
     @Override
     public HttpHeaders set(String name, Object value) {
         headers.setObject(name, value);
@@ -171,7 +167,6 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return this;
     }
 
-    @Deprecated
     @Override
     public HttpHeaders set(String name, Iterable<?> values) {
         headers.setObject(name, values);
@@ -242,7 +237,6 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return headers.getTimeMillis(name, defaultValue);
     }
 
-    @Deprecated
     @Override
     public List<String> getAll(String name) {
         return getAll((CharSequence) name);
@@ -253,7 +247,6 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return HeadersUtils.getAllAsString(headers, name);
     }
 
-    @Deprecated
     @Override
     public List<Entry<String, String>> entries() {
         if (isEmpty()) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -532,8 +532,6 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
 
     /**
      * @deprecated Use {@link #get(CharSequence)} instead.
-     *
-     * @see {@link #getHeader(HttpMessage, CharSequence)}
      */
     @Deprecated
     public static String getHeader(HttpMessage message, String name) {
@@ -1174,10 +1172,8 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     protected HttpHeaders() { }
 
     /**
-     * @deprecated Use {@link #get(CharSequence)}
      * @see #get(CharSequence)
      */
-    @Deprecated
     public abstract String get(String name);
 
     /**
@@ -1271,9 +1267,8 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     public abstract long getTimeMillis(CharSequence name, long defaultValue);
 
     /**
-     * @deprecated Use {@link #getAll(CharSequence)}
+     * @see #getAll(CharSequence)
      */
-    @Deprecated
     public abstract List<String> getAll(String name);
 
     /**
@@ -1289,21 +1284,16 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     }
 
     /**
-     * @deprecated Use {@link #iteratorCharSequence()}
-     * <p>
      * Returns a new {@link List} that contains all headers in this object.  Note that modifying the
      * returned {@link List} will not affect the state of this object.  If you intend to enumerate over the header
      * entries only, use {@link #iterator()} instead, which has much less overhead.
+     * @see #iteratorCharSequence()
      */
-    @Deprecated
     public abstract List<Map.Entry<String, String>> entries();
 
     /**
-     * @deprecated Use {@link #contains(CharSequence)}
-     * <p>
      * @see {@link #contains(CharSequence)}
      */
-    @Deprecated
     public abstract boolean contains(String name);
 
     /**
@@ -1347,9 +1337,8 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     public abstract Set<String> names();
 
     /**
-     * @deprecated Use {@link #add(CharSequence, Object)}
+     * @see #add(CharSequence, Object)
      */
-    @Deprecated
     public abstract HttpHeaders add(String name, Object value);
 
     /**
@@ -1370,9 +1359,8 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     }
 
     /**
-     * @deprecated Use {@link #add(CharSequence, Iterable)}
+     * @see #add(CharSequence, Iterable)
      */
-    @Deprecated
     public abstract HttpHeaders add(String name, Iterable<?> values);
 
     /**
@@ -1428,9 +1416,8 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     public abstract HttpHeaders addShort(CharSequence name, short value);
 
     /**
-     * @deprecated Use {@link #set(CharSequence, Object)}
+     * @see #set(CharSequence, Object)
      */
-    @Deprecated
     public abstract HttpHeaders set(String name, Object value);
 
     /**
@@ -1451,9 +1438,8 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     }
 
     /**
-     * @deprecated {@link #set(CharSequence, Iterable)}
+     * @see #set(CharSequence, Iterable)
      */
-    @Deprecated
     public abstract HttpHeaders set(String name, Iterable<?> values);
 
     /**
@@ -1535,9 +1521,8 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     public abstract HttpHeaders setShort(CharSequence name, short value);
 
     /**
-     * @deprecated {@link #remove(CharSequence)}
+     * @see #remove(CharSequence)
      */
-    @Deprecated
     public abstract HttpHeaders remove(String name);
 
     /**
@@ -1558,9 +1543,8 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     public abstract HttpHeaders clear();
 
     /**
-     * @deprecated Use {@link #contains(CharSequence, CharSequence, boolean)}
+     * @see #contains(CharSequence, CharSequence, boolean)
      */
-    @Deprecated
     public boolean contains(String name, String value, boolean ignoreCase) {
         List<String> values = getAll(name);
         if (values.isEmpty()) {


### PR DESCRIPTION
Motivation:
As part of recent efforts to rectify performance and make 4.1 headers more similar to 5.0 some methods were deprecated. Some of these methods were deprecated because they used String instead of CharSequence in the signature, which may require casting at the user level. Some of the deprecated methods have no direct alternatives and were done to inform a user the method will go away in future releases.

Modifications:
- Remove the deprecated qualifier from methods where no direct replacement exists

Result:
Less warnings in user code.