### PR TITLE
EPOLL Shutdown and Half Closed

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -112,6 +112,9 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
         @Override
         void epollInReady() {
             assert eventLoop().inEventLoop();
+            if (fd().isInputShutdown()) {
+                return;
+            }
             boolean edgeTriggered = isFlagSet(Native.EPOLLET);
 
             final ChannelConfig config = config();

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -71,8 +71,6 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel {
     private SocketAddress requestedRemoteAddress;
     private final Queue<SpliceInTask> spliceQueue = PlatformDependent.newMpscQueue();
 
-    private volatile boolean outputShutdown;
-
     // Lazy init these if we need to splice(...)
     private FileDescriptor pipeIn;
     private FileDescriptor pipeOut;
@@ -528,14 +526,9 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel {
                 "unsupported message type: " + StringUtil.simpleClassName(msg) + EXPECTED_TYPES);
     }
 
-    protected boolean isOutputShutdown0() {
-        return outputShutdown || !isActive();
-    }
-
     protected void shutdownOutput0(final ChannelPromise promise) {
         try {
             fd().shutdown(false, true);
-            outputShutdown = true;
             promise.setSuccess();
         } catch (Throwable cause) {
             promise.setFailure(cause);
@@ -774,6 +767,9 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel {
 
         @Override
         void epollInReady() {
+            if (fd().isInputShutdown()) {
+                return;
+            }
             final ChannelConfig config = config();
             boolean edgeTriggered = isFlagSet(Native.EPOLLET);
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -526,6 +526,9 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         @Override
         void epollInReady() {
             assert eventLoop().inEventLoop();
+            if (fd().isInputShutdown()) {
+                return;
+            }
             DatagramChannelConfig config = config();
             boolean edgeTriggered = isFlagSet(Native.EPOLLET);
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
@@ -148,6 +148,9 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
         }
 
         private void epollInReadFd() {
+            if (fd().isInputShutdown()) {
+                return;
+            }
             boolean edgeTriggered = isFlagSet(Native.EPOLLET);
             final ChannelConfig config = config();
             if (!readPending && !edgeTriggered && !config.isAutoRead()) {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -323,7 +323,7 @@ final class EpollEventLoop extends SingleThreadEventLoop {
                     // In either case epollOutReady() will do the correct thing (finish connecting, or fail
                     // the connection).
                     // See https://github.com/netty/netty/issues/3848
-                    if ((ev & (Native.EPOLLERR | Native.EPOLLOUT)) != 0 && ch.isOpen()) {
+                    if ((ev & (Native.EPOLLERR | Native.EPOLLOUT)) != 0) {
                         // Force flush of data as the epoll is writable again
                         unsafe.epollOutReady();
                     }
@@ -333,7 +333,7 @@ final class EpollEventLoop extends SingleThreadEventLoop {
                     //
                     // If EPOLLIN or EPOLLERR was received and the channel is still open call epollInReady(). This will
                     // try to read from the underlying file descriptor and so notify the user about the error.
-                    if ((ev & (Native.EPOLLERR | Native.EPOLLIN)) != 0 && ch.isOpen()) {
+                    if ((ev & (Native.EPOLLERR | Native.EPOLLIN)) != 0) {
                         // The Channel is still open and there is something to read. Do it now.
                         unsafe.epollInReady();
                     }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -149,12 +149,12 @@ public final class EpollSocketChannel extends AbstractEpollStreamChannel impleme
 
     @Override
     public boolean isInputShutdown() {
-        return isInputShutdown0();
+        return fd().isInputShutdown();
     }
 
     @Override
     public boolean isOutputShutdown() {
-        return isOutputShutdown0();
+        return fd().isOutputShutdown();
     }
 
     @Override

--- a/transport-native-epoll/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/unix/Socket.java
@@ -58,6 +58,10 @@ public final class Socket extends FileDescriptor {
         }
     }
 
+    public void shutdown() throws IOException {
+        shutdown(true, true);
+    }
+
     public boolean isShutdown() {
         return isInputShutdown() && isOutputShutdown();
     }


### PR DESCRIPTION
Motivation:
The EPOLL module was not completly respecting the half closed state. It may have missed events, or procssed events when it should not have due to checking isOpen instead of the appropriate shutdown state.

Modifications:
- use FileDescriptor's isShutdown* methods instead of isOpen to check for processing events.

Result:
Half closed code in EPOLL module is more correct.