### PR TITLE
[#4327] Ensure toString() will not throw IllegalReferenceCountException

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/DefaultByteBufHolder.java
+++ b/buffer/src/main/java/io/netty/buffer/DefaultByteBufHolder.java
@@ -90,8 +90,16 @@ public class DefaultByteBufHolder implements ByteBufHolder {
         return data.release(decrement);
     }
 
+    /**
+     * Return {@link ByteBuf#toString()} without checking the reference count first. This is useful to implemement
+     * {@link #toString()}.
+     */
+    protected final String contentToString() {
+        return data.toString();
+    }
+
     @Override
     public String toString() {
-        return StringUtil.simpleClassName(this) + '(' + content().toString() + ')';
+        return StringUtil.simpleClassName(this) + '(' + contentToString() + ')';
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/DefaultByteBufHolderTest.java
+++ b/buffer/src/test/java/io/netty/buffer/DefaultByteBufHolderTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DefaultByteBufHolderTest {
+
+    @Test
+    public void testToString() {
+        ByteBufHolder holder = new DefaultByteBufHolder(Unpooled.buffer());
+        assertEquals(1, holder.refCnt());
+        assertNotNull(holder.toString());
+        assertTrue(holder.release());
+        assertNotNull(holder.toString());
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrame.java
@@ -68,7 +68,7 @@ public abstract class WebSocketFrame extends DefaultByteBufHolder {
 
     @Override
     public String toString() {
-        return StringUtil.simpleClassName(this) + "(data: " + content() + ')';
+        return StringUtil.simpleClassName(this) + "(data: " + contentToString() + ')';
     }
 
     @Override

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
@@ -17,7 +17,6 @@ package io.netty.channel.sctp;
 
 import com.sun.nio.sctp.MessageInfo;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.DefaultByteBufHolder;
 
 /**
@@ -191,15 +190,9 @@ public final class SctpMessage extends DefaultByteBufHolder {
 
     @Override
     public String toString() {
-        if (refCnt() == 0) {
-            return "SctpFrame{" +
-                    "streamIdentifier=" + streamIdentifier + ", protocolIdentifier=" + protocolIdentifier +
-                    ", unordered=" + unordered +
-                    ", data=(FREED)}";
-        }
         return "SctpFrame{" +
-                "streamIdentifier=" + streamIdentifier + ", protocolIdentifier=" + protocolIdentifier +
-                ", unordered=" + unordered +
-                ", data=" + ByteBufUtil.hexDump(content()) + '}';
+               "streamIdentifier=" + streamIdentifier + ", protocolIdentifier=" + protocolIdentifier +
+               ", unordered=" + unordered +
+               ", data=" + contentToString() + '}';
     }
 }


### PR DESCRIPTION
Motivation:

As toString() is often used while logging we need to ensure this produces no exception.

Modifications:

Ensure we never throw an IllegalReferenceCountException.

Result:

Be able to log without produce exceptions.