### PR TITLE
Added DuplicatedAbstractByteBuf that can provide fast-path for _get* …

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -446,7 +446,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf setBoolean(int index, boolean value) {
-        setByte(index, value ? 1 : 0);
+        setByte(index, value? 1 : 0);
         return this;
     }
 
@@ -920,7 +920,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf duplicate() {
-        return new DuplicatedByteBuf(this);
+        return new DuplicatedAbstractByteBuf(this);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/DuplicatedAbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DuplicatedAbstractByteBuf.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+/**
+ * {@link DuplicatedByteBuf} implementation that can do optimizations because it knows the duplicated buffer
+ * is of type {@link AbstractByteBuf}.
+ */
+final class DuplicatedAbstractByteBuf extends DuplicatedByteBuf {
+    public DuplicatedAbstractByteBuf(AbstractByteBuf buffer) {
+        super(buffer);
+    }
+
+    @Override
+    protected byte _getByte(int index) {
+        return unwrap0()._getByte(index);
+    }
+
+    @Override
+    protected short _getShort(int index) {
+        return unwrap0()._getShort(index);
+    }
+
+    @Override
+    protected int _getUnsignedMedium(int index) {
+        return unwrap0()._getUnsignedMedium(index);
+    }
+
+    @Override
+    protected int _getInt(int index) {
+        return unwrap0()._getInt(index);
+    }
+
+    @Override
+    protected long _getLong(int index) {
+        return unwrap0()._getLong(index);
+    }
+
+    @Override
+    protected void _setByte(int index, int value) {
+        unwrap0()._setByte(index, value);
+    }
+
+    @Override
+    protected void _setShort(int index, int value) {
+        unwrap0()._setShort(index, value);
+    }
+
+    @Override
+    protected void _setMedium(int index, int value) {
+        unwrap0()._setMedium(index, value);
+    }
+
+    @Override
+    protected void _setInt(int index, int value) {
+        unwrap0()._setInt(index, value);
+    }
+
+    @Override
+    protected void _setLong(int index, long value) {
+        unwrap0()._setLong(index, value);
+    }
+
+    private AbstractByteBuf unwrap0() {
+        return (AbstractByteBuf) unwrap();
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/DuplicatedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DuplicatedByteBuf.java
@@ -105,7 +105,7 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public byte getByte(int index) {
-        return _getByte(index);
+        return buffer.getByte(index);
     }
 
     @Override
@@ -115,7 +115,7 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public short getShort(int index) {
-        return _getShort(index);
+        return buffer.getShort(index);
     }
 
     @Override
@@ -125,7 +125,7 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public int getUnsignedMedium(int index) {
-        return _getUnsignedMedium(index);
+        return buffer.getUnsignedMedium(index);
     }
 
     @Override
@@ -135,7 +135,7 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public int getInt(int index) {
-        return _getInt(index);
+        return buffer.getInt(index);
     }
 
     @Override
@@ -145,7 +145,7 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public long getLong(int index) {
-        return _getLong(index);
+        return buffer.getLong(index);
     }
 
     @Override
@@ -183,7 +183,7 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public ByteBuf setByte(int index, int value) {
-        _setByte(index, value);
+        buffer.setByte(index, value);
         return this;
     }
 
@@ -194,7 +194,7 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public ByteBuf setShort(int index, int value) {
-        _setShort(index, value);
+        buffer.setShort(index, value);
         return this;
     }
 
@@ -205,7 +205,7 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public ByteBuf setMedium(int index, int value) {
-        _setMedium(index, value);
+        buffer.setMedium(index, value);
         return this;
     }
 
@@ -216,7 +216,7 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public ByteBuf setInt(int index, int value) {
-        _setInt(index, value);
+        buffer.setInt(index, value);
         return this;
     }
 
@@ -227,7 +227,7 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public ByteBuf setLong(int index, long value) {
-        _setLong(index, value);
+        buffer.setLong(index, value);
         return this;
     }
 


### PR DESCRIPTION
…and _set* methods

Motivation:

DuplicatedByteBuf can be used for any ByteBuf implementations and so can not do any optimizations that could be done
when AbstractByteBuf is duplicated.

Modifications:

- Add DuplicatedAbstractByteBuf that can eliminate range and reference count checks for _get* and _set* methods.

Result:

Faster DuplicatedByteBuf implementations for AbstractByteBuf sub-classes.