### PR TITLE
Allow to disable reference count checks on every access of the ByteBuf

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -19,6 +19,9 @@ import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,6 +37,16 @@ import java.nio.charset.Charset;
  * A skeletal implementation of a buffer.
  */
 public abstract class AbstractByteBuf extends ByteBuf {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractByteBuf.class);
+    private static final String PROP_MODE = "io.netty.buffer.bytebuf.checkAccessible";
+    private static final boolean checkAccessible;
+
+    static {
+        checkAccessible = SystemPropertyUtil.getBoolean(PROP_MODE, true);
+        if (logger.isDebugEnabled()) {
+            logger.debug("-D{}: {}", PROP_MODE, checkAccessible);
+        }
+    }
 
     static final ResourceLeakDetector<ByteBuf> leakDetector = new ResourceLeakDetector<ByteBuf>(ByteBuf.class);
 
@@ -1173,7 +1186,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
      * if the buffer was released before.
      */
     protected final void ensureAccessible() {
-        if (refCnt() == 0) {
+        if (checkAccessible && refCnt() == 0) {
             throw new IllegalReferenceCountException(0);
         }
     }

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -47,12 +47,12 @@
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
-      <version>0.9</version>
+      <version>1.11.1</version>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
-      <version>0.9</version>
+      <version>1.11.1</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/microbench/src/test/java/io/netty/microbench/buffer/ByteBufBenchmark.java
+++ b/microbench/src/test/java/io/netty/microbench/buffer/ByteBufBenchmark.java
@@ -1,0 +1,80 @@
+/*
+* Copyright 2015 The Netty Project
+*
+* The Netty Project licenses this file to you under the Apache License,
+* version 2.0 (the "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at:
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+package io.netty.microbench.buffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.nio.ByteBuffer;
+
+public class ByteBufBenchmark extends AbstractMicrobenchmark {
+    static {
+        System.setProperty("io.netty.buffer.bytebuf.checkAccessible", "false");
+    }
+    private static final byte BYTE = '0';
+
+    private ByteBuffer byteBuffer;
+    private ByteBuffer directByteBuffer;
+    private ByteBuf buffer;
+    private ByteBuf directBuffer;
+    private ByteBuf directBufferPooled;
+
+    @Setup
+    public void setup() {
+        byteBuffer = ByteBuffer.allocate(8);
+        directByteBuffer = ByteBuffer.allocateDirect(8);
+        buffer = Unpooled.buffer(8);
+        directBuffer = Unpooled.directBuffer(8);
+        directBufferPooled = PooledByteBufAllocator.DEFAULT.directBuffer(8);
+    }
+
+    @TearDown
+    public void tearDown() {
+        buffer.release();
+        directBuffer.release();
+        directBufferPooled.release();
+    }
+
+    @Benchmark
+    public void setByteBufferHeap() {
+        byteBuffer.put(0, BYTE);
+    }
+
+    @Benchmark
+    public void setByteBufferDirect() {
+        directByteBuffer.put(0, BYTE);
+    }
+
+    @Benchmark
+    public void setByteBufHeap() {
+        buffer.setByte(0, BYTE);
+    }
+
+    @Benchmark
+    public void setByteBufDirect() {
+        directBuffer.setByte(0, BYTE);
+    }
+
+    @Benchmark
+    public void setByteBufDirectPooled() {
+        directBufferPooled.setByte(0, BYTE);
+    }
+}


### PR DESCRIPTION
Motiviation:

Checking reference count on every access on a ByteBuf can have some big performance overhead depending on how the access pattern is. If the user is sure that there are no reference count errors on his side it should be possible to disable the check and so gain the max performance.

Modification:

- Add io.netty.buffer.bytebuf.checkAccessible system property which allows to disable the checks. Enabled by default.
- Add microbenchmark

Result:

Increased performance for operations on the ByteBuf.