### PR TITLE
[#4313] ByteBufUtil.writeUtf8 should use fast-path for WrappedByteBuf

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -27,6 +27,13 @@ import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 import java.nio.charset.Charset;
 
+/**
+ * Wraps another {@link ByteBuf}.
+ *
+ * It's important that the {@link #readerIndex()} and {@link #writerIndex()} will not do any adjustments on the
+ * indices on the fly because of internal optimizations made by {@link ByteBufUtil#writeAscii(ByteBuf, CharSequence)}
+ * and {@link ByteBufUtil#writeUtf8(ByteBuf, CharSequence)}.
+ */
 class WrappedByteBuf extends ByteBuf {
 
     protected final ByteBuf buf;
@@ -39,17 +46,17 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
-    public boolean hasMemoryAddress() {
+    public final boolean hasMemoryAddress() {
         return buf.hasMemoryAddress();
     }
 
     @Override
-    public long memoryAddress() {
+    public final long memoryAddress() {
         return buf.memoryAddress();
     }
 
     @Override
-    public int capacity() {
+    public final int capacity() {
         return buf.capacity();
     }
 
@@ -60,17 +67,17 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
-    public int maxCapacity() {
+    public final int maxCapacity() {
         return buf.maxCapacity();
     }
 
     @Override
-    public ByteBufAllocator alloc() {
+    public final ByteBufAllocator alloc() {
         return buf.alloc();
     }
 
     @Override
-    public ByteOrder order() {
+    public final ByteOrder order() {
         return buf.order();
     }
 
@@ -80,33 +87,33 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
-    public ByteBuf unwrap() {
+    public final ByteBuf unwrap() {
         return buf;
     }
 
     @Override
-    public boolean isDirect() {
+    public final boolean isDirect() {
         return buf.isDirect();
     }
 
     @Override
-    public int readerIndex() {
+    public final int readerIndex() {
         return buf.readerIndex();
     }
 
     @Override
-    public ByteBuf readerIndex(int readerIndex) {
+    public final ByteBuf readerIndex(int readerIndex) {
         buf.readerIndex(readerIndex);
         return this;
     }
 
     @Override
-    public int writerIndex() {
+    public final int writerIndex() {
         return buf.writerIndex();
     }
 
     @Override
-    public ByteBuf writerIndex(int writerIndex) {
+    public final ByteBuf writerIndex(int writerIndex) {
         buf.writerIndex(writerIndex);
         return this;
     }
@@ -118,56 +125,56 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
-    public int readableBytes() {
+    public final int readableBytes() {
         return buf.readableBytes();
     }
 
     @Override
-    public int writableBytes() {
+    public final int writableBytes() {
         return buf.writableBytes();
     }
 
     @Override
-    public int maxWritableBytes() {
+    public final int maxWritableBytes() {
         return buf.maxWritableBytes();
     }
 
     @Override
-    public boolean isReadable() {
+    public final boolean isReadable() {
         return buf.isReadable();
     }
 
     @Override
-    public boolean isWritable() {
+    public final boolean isWritable() {
         return buf.isWritable();
     }
 
     @Override
-    public ByteBuf clear() {
+    public final ByteBuf clear() {
         buf.clear();
         return this;
     }
 
     @Override
-    public ByteBuf markReaderIndex() {
+    public final ByteBuf markReaderIndex() {
         buf.markReaderIndex();
         return this;
     }
 
     @Override
-    public ByteBuf resetReaderIndex() {
+    public final ByteBuf resetReaderIndex() {
         buf.resetReaderIndex();
         return this;
     }
 
     @Override
-    public ByteBuf markWriterIndex() {
+    public final ByteBuf markWriterIndex() {
         buf.markWriterIndex();
         return this;
     }
 
     @Override
-    public ByteBuf resetWriterIndex() {
+    public final ByteBuf resetWriterIndex() {
         buf.resetWriterIndex();
         return this;
     }
@@ -801,17 +808,17 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
-    public boolean isReadable(int size) {
+    public final boolean isReadable(int size) {
         return buf.isReadable(size);
     }
 
     @Override
-    public boolean isWritable(int size) {
+    public final boolean isWritable(int size) {
         return buf.isWritable(size);
     }
 
     @Override
-    public int refCnt() {
+    public final int refCnt() {
         return buf.refCnt();
     }
 

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -34,6 +34,19 @@ public class ByteBufUtilTest {
     }
 
     @Test
+    public void testWriteUsAsciiWrapped() {
+        String usAscii = "NettyRocks";
+        ByteBuf buf = Unpooled.unreleasableBuffer(ReferenceCountUtil.releaseLater(Unpooled.buffer(16)));
+        assertWrapped(buf);
+        buf.writeBytes(usAscii.getBytes(CharsetUtil.US_ASCII));
+        ByteBuf buf2 = Unpooled.unreleasableBuffer(ReferenceCountUtil.releaseLater(Unpooled.buffer(16)));
+        assertWrapped(buf2);
+        ByteBufUtil.writeAscii(buf2, usAscii);
+
+        Assert.assertEquals(buf, buf2);
+    }
+
+    @Test
     public void testWriteUtf8() {
         String usAscii = "Some UTF-8 like äÄ∏ŒŒ";
         ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(16));
@@ -42,5 +55,22 @@ public class ByteBufUtilTest {
         ByteBufUtil.writeUtf8(buf2, usAscii);
 
         Assert.assertEquals(buf, buf2);
+    }
+
+    @Test
+    public void testWriteUtf8Wrapped() {
+        String usAscii = "Some UTF-8 like äÄ∏ŒŒ";
+        ByteBuf buf = Unpooled.unreleasableBuffer(ReferenceCountUtil.releaseLater(Unpooled.buffer(16)));
+        assertWrapped(buf);
+        buf.writeBytes(usAscii.getBytes(CharsetUtil.UTF_8));
+        ByteBuf buf2 = Unpooled.unreleasableBuffer(ReferenceCountUtil.releaseLater(Unpooled.buffer(16)));
+        assertWrapped(buf2);
+        ByteBufUtil.writeUtf8(buf2, usAscii);
+
+        Assert.assertEquals(buf, buf2);
+    }
+
+    private static void assertWrapped(ByteBuf buf) {
+        Assert.assertTrue(buf instanceof WrappedByteBuf);
     }
 }


### PR DESCRIPTION
Motivation:

ByteBufUtil.writeUtf8(...) / writeUsAscii(...) can use a fast-path when writing into AbstractByteBuf. We should try to unwrap WrappedByteBuf implementations so
we are able to do the same on wrapped AbstractByteBuf instances.

Modifications:

- Try to unwrap WrappedByteBuf to use the fast-path

Result:

Faster writing of utf8 and usascii for WrappedByteBuf instances.