### PR TITLE
[#4347] Remove not needed write operation from example.

### DIFF
--- a/example/src/main/java/io/netty/example/proxy/HexDumpProxyBackendHandler.java
+++ b/example/src/main/java/io/netty/example/proxy/HexDumpProxyBackendHandler.java
@@ -15,7 +15,6 @@
  */
 package io.netty.example.proxy;
 
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -33,7 +32,6 @@ public class HexDumpProxyBackendHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void channelActive(ChannelHandlerContext ctx) {
         ctx.read();
-        ctx.write(Unpooled.EMPTY_BUFFER);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

The proxy example contains some code that is not needed. This can confuse the reader.

Modifications:

Remove the not needed ctx.write(...).

Result:

Less confusing code.