### PR TITLE
Minimize object allocation when calling AbstractByteBuf.toString(...,…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -950,20 +950,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public String toString(int index, int length, Charset charset) {
-        if (length == 0) {
-            return "";
-        }
-
-        ByteBuffer nioBuffer;
-        if (nioBufferCount() == 1) {
-            nioBuffer = nioBuffer(index, length);
-        } else {
-            nioBuffer = ByteBuffer.allocate(length);
-            getBytes(index, nioBuffer);
-            nioBuffer.flip();
-        }
-
-        return ByteBufUtil.decodeString(nioBuffer, charset);
+        return ByteBufUtil.decodeString(this, index, length, charset);
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -20,6 +20,8 @@ import io.netty.util.ReferenceCountUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.charset.Charset;
+
 public class ByteBufUtilTest {
 
     @Test
@@ -42,5 +44,21 @@ public class ByteBufUtilTest {
         ByteBufUtil.writeUtf8(buf2, usAscii);
 
         Assert.assertEquals(buf, buf2);
+    }
+
+    @Test
+    public void testDecodeUsAscii() {
+        testDecodeString("This is a test", CharsetUtil.US_ASCII);
+    }
+
+    @Test
+    public void testDecodeUtf8() {
+        testDecodeString("Some UTF-8 like äÄ∏ŒŒ", CharsetUtil.UTF_8);
+    }
+
+    private static void testDecodeString(String text, Charset charset) {
+        ByteBuf buffer = Unpooled.copiedBuffer(text, charset);
+        Assert.assertEquals(text, ByteBufUtil.decodeString(buffer, 0, buffer.readableBytes(), charset));
+        buffer.release();
     }
 }

--- a/microbench/src/test/java/io/netty/microbench/buffer/ByteBufUtilBenchmark.java
+++ b/microbench/src/test/java/io/netty/microbench/buffer/ByteBufUtilBenchmark.java
@@ -30,12 +30,14 @@ import org.openjdk.jmh.annotations.Warmup;
 
 
 @State(Scope.Benchmark)
-@Warmup(iterations = 10)
-@Measurement(iterations = 25)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
 public class
     ByteBufUtilBenchmark extends AbstractMicrobenchmark {
     private ByteBuf buffer;
     private ByteBuf wrapped;
+    private ByteBuf asciiBuffer;
+    private ByteBuf utf8Buffer;
 
     private StringBuilder asciiSequence;
     private String ascii;
@@ -62,12 +64,17 @@ public class
         }
         utf8 = utf8Sequence.toString();
         asciiSequence = utf8Sequence;
+
+        asciiBuffer = Unpooled.copiedBuffer(ascii, CharsetUtil.US_ASCII);
+        utf8Buffer = Unpooled.copiedBuffer(utf8, CharsetUtil.UTF_8);
     }
 
     @TearDown
     public void tearDown() {
         buffer.release();
         wrapped.release();
+        asciiBuffer.release();
+        utf8Buffer.release();
     }
 
     @Benchmark
@@ -164,5 +171,15 @@ public class
     public void writeUtf8Wrapped() {
         wrapped.resetWriterIndex();
         ByteBufUtil.writeUtf8(wrapped, utf8Sequence);
+    }
+
+    @Benchmark
+    public String decodeStringAscii() {
+        return asciiBuffer.toString(CharsetUtil.US_ASCII);
+    }
+
+    @Benchmark
+    public String decodeStringUtf8() {
+        return utf8Buffer.toString(CharsetUtil.UTF_8);
     }
 }


### PR DESCRIPTION
… Charset)

Motivation:

Calling AbstractByteBuf.toString(..., Charset) is used quite frequently by users but produce a lot of GC.

Modification:

- Use a FastThreadLocal to store the CharBuffer that are needed for decoding.
- Use internalNioBuffer(...) when possible

Result:

Less object creation / Less GC