### PR TITLE
Native getSoError bug

### DIFF
--- a/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.c
+++ b/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.c
@@ -1385,11 +1385,11 @@ JNIEXPORT jint JNICALL Java_io_netty_channel_epoll_Native_getSoLinger(JNIEnv* en
 }
 
 JNIEXPORT jint JNICALL Java_io_netty_channel_epoll_Native_getSoError(JNIEnv* env, jclass clazz, jint fd) {
-    int optval = 0;
+    int optval;
     if (getOption(env, fd, SOL_SOCKET, SO_ERROR, &optval, sizeof(optval)) == -1) {
-        return optval;
+        return -1;
     }
-    return 0;
+    return optval;
 }
 
 JNIEXPORT jint JNICALL Java_io_netty_channel_epoll_Native_getTrafficClass(JNIEnv* env, jclass clazz, jint fd) {


### PR DESCRIPTION
Motivation:
Java_io_netty_channel_epoll_Native_getSoError incorrectly returns the value from the get socket option function.

Modifications:
- return the value from the result of the get socket option call

Result:
Java_io_netty_channel_epoll_Native_getSoError returns the correct value.