### PR TITLE
Correctly handle bitshifting if system does not support unaligned a…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
@@ -19,15 +19,12 @@ package io.netty.buffer;
 import io.netty.util.internal.PlatformDependent;
 
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-
 
 
 /**
  * Read-only ByteBuf which wraps a read-only direct ByteBuffer and use unsafe for best performance.
  */
 final class ReadOnlyUnsafeDirectByteBuf extends ReadOnlyByteBufferBuf {
-    private static final boolean NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
     private final long memoryAddress;
 
     ReadOnlyUnsafeDirectByteBuf(ByteBufAllocator allocator, ByteBuffer buffer) {
@@ -37,33 +34,27 @@ final class ReadOnlyUnsafeDirectByteBuf extends ReadOnlyByteBufferBuf {
 
     @Override
     protected byte _getByte(int index) {
-        return PlatformDependent.getByte(addr(index));
+        return UnsafeByteBufUtil.getByte(addr(index));
     }
 
     @Override
     protected short _getShort(int index) {
-        short v = PlatformDependent.getShort(addr(index));
-        return NATIVE_ORDER? v : Short.reverseBytes(v);
+        return UnsafeByteBufUtil.getShort(addr(index));
     }
 
     @Override
     protected int _getUnsignedMedium(int index) {
-        long addr = addr(index);
-        return (PlatformDependent.getByte(addr) & 0xff) << 16 |
-                (PlatformDependent.getByte(addr + 1) & 0xff) << 8 |
-                PlatformDependent.getByte(addr + 2) & 0xff;
+        return UnsafeByteBufUtil.getUnsignedMedium(addr(index));
     }
 
     @Override
     protected int _getInt(int index) {
-        int v = PlatformDependent.getInt(addr(index));
-        return NATIVE_ORDER? v : Integer.reverseBytes(v);
+        return UnsafeByteBufUtil.getInt(addr(index));
     }
 
     @Override
     protected long _getLong(int index) {
-        long v = PlatformDependent.getLong(addr(index));
-        return NATIVE_ORDER? v : Long.reverseBytes(v);
+        return UnsafeByteBufUtil.getLong(addr(index));
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.internal.PlatformDependent;
+
+import java.nio.ByteOrder;
+
+/**
+ * All operations get and set as {@link ByteOrder#BIG_ENDIAN}.
+ */
+final class UnsafeByteBufUtil {
+
+    private static final boolean NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
+    private static final boolean UNALIGNED = PlatformDependent.isUnaligned();
+
+    static byte getByte(long address) {
+        return PlatformDependent.getByte(address);
+    }
+
+    static short getShort(long address) {
+        if (UNALIGNED) {
+            short v = PlatformDependent.getShort(address);
+            return NATIVE_ORDER ? v : Short.reverseBytes(v);
+        }
+        return (short) (PlatformDependent.getByte(address) << 8 | PlatformDependent.getByte(address + 1) & 0xff);
+    }
+
+    static int getUnsignedMedium(long address) {
+        if (UNALIGNED) {
+            if (NATIVE_ORDER) {
+                return (PlatformDependent.getByte(address) & 0xff) |
+                        (PlatformDependent.getShort(address + 1) & 0xffff) << 8;
+            }
+            return (Short.reverseBytes(PlatformDependent.getShort(address)) & 0xffff) << 8 |
+                    PlatformDependent.getByte(address + 2) & 0xff;
+        }
+        return (PlatformDependent.getByte(address) & 0xff) << 16 |
+               (PlatformDependent.getByte(address + 1) & 0xff) << 8 |
+               PlatformDependent.getByte(address + 2) & 0xff;
+    }
+
+    static int getInt(long address) {
+        if (UNALIGNED) {
+            int v = PlatformDependent.getInt(address);
+            return NATIVE_ORDER ? v : Integer.reverseBytes(v);
+        }
+        return PlatformDependent.getByte(address) << 24 |
+               (PlatformDependent.getByte(address + 1) & 0xff) << 16 |
+               (PlatformDependent.getByte(address + 2) & 0xff) <<  8 |
+               PlatformDependent.getByte(address + 3) & 0xff;
+    }
+
+    static long getLong(long address) {
+        if (UNALIGNED) {
+            long v = PlatformDependent.getLong(address);
+            return NATIVE_ORDER ? v : Long.reverseBytes(v);
+        }
+        return (long) PlatformDependent.getByte(address) << 56 |
+               ((long) PlatformDependent.getByte(address + 1) & 0xff) << 48 |
+               ((long) PlatformDependent.getByte(address + 2) & 0xff) << 40 |
+               ((long) PlatformDependent.getByte(address + 3) & 0xff) << 32 |
+               ((long) PlatformDependent.getByte(address + 4) & 0xff) << 24 |
+               ((long) PlatformDependent.getByte(address + 5) & 0xff) << 16 |
+               ((long) PlatformDependent.getByte(address + 6) & 0xff) <<  8 |
+               (long) PlatformDependent.getByte(address + 7) & 0xff;
+    }
+
+    static void setByte(long address, int value) {
+        PlatformDependent.putByte(address, (byte) value);
+    }
+
+    static void setShort(long address, int value) {
+        if (UNALIGNED) {
+            PlatformDependent.putShort(address, NATIVE_ORDER ? (short) value : Short.reverseBytes((short) value));
+        } else {
+            PlatformDependent.putByte(address, (byte) (value >>> 8));
+            PlatformDependent.putByte(address + 1, (byte) value);
+        }
+    }
+
+    static void setMedium(long address, int value) {
+        if (UNALIGNED) {
+            if (NATIVE_ORDER) {
+                PlatformDependent.putByte(address, (byte) value);
+                PlatformDependent.putShort(address + 1, (short) (value >>> 8));
+            } else {
+                PlatformDependent.putShort(address, Short.reverseBytes((short) (value >>> 8)));
+                PlatformDependent.putByte(address + 2, (byte) value);
+            }
+        } else {
+            PlatformDependent.putByte(address, (byte) (value >>> 16));
+            PlatformDependent.putByte(address + 1, (byte) (value >>> 8));
+            PlatformDependent.putByte(address + 2, (byte) value);
+        }
+    }
+
+    static void setInt(long address, int value) {
+        if (UNALIGNED) {
+            PlatformDependent.putInt(address, NATIVE_ORDER ? value : Integer.reverseBytes(value));
+        } else {
+            PlatformDependent.putByte(address, (byte) (value >>> 24));
+            PlatformDependent.putByte(address + 1, (byte) (value >>> 16));
+            PlatformDependent.putByte(address + 2, (byte) (value >>> 8));
+            PlatformDependent.putByte(address + 3, (byte) value);
+        }
+    }
+
+    static void setLong(long address, long value) {
+        if (UNALIGNED) {
+            PlatformDependent.putLong(address, NATIVE_ORDER ? value : Long.reverseBytes(value));
+        } else {
+            PlatformDependent.putByte(address, (byte) (value >>> 56));
+            PlatformDependent.putByte(address + 1, (byte) (value >>> 48));
+            PlatformDependent.putByte(address + 2, (byte) (value >>> 40));
+            PlatformDependent.putByte(address + 3, (byte) (value >>> 32));
+            PlatformDependent.putByte(address + 4, (byte) (value >>> 24));
+            PlatformDependent.putByte(address + 5, (byte) (value >>> 16));
+            PlatformDependent.putByte(address + 6, (byte) (value >>> 8));
+            PlatformDependent.putByte(address + 7, (byte) value);
+        }
+    }
+
+    private UnsafeByteBufUtil() { }
+}

--- a/buffer/src/main/java/io/netty/buffer/UnsafeDirectSwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeDirectSwappedByteBuf.java
@@ -30,6 +30,7 @@ final class UnsafeDirectSwappedByteBuf extends SwappedByteBuf {
 
     UnsafeDirectSwappedByteBuf(AbstractByteBuf buf) {
         super(buf);
+        assert PlatformDependent.isUnaligned();
         wrapped = buf;
         nativeByteOrder = NATIVE_ORDER == (order() == ByteOrder.BIG_ENDIAN);
     }

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -153,6 +153,15 @@ public final class PlatformDependent {
     }
 
     /**
+     * {@code true} if and only if the platform supports unaligned access.
+     *
+     * @see <a href="http://en.wikipedia.org/wiki/Segmentation_fault#Bus_error">Wikipedia on segfault</a>
+     */
+    public static boolean isUnaligned() {
+        return PlatformDependent0.isUnaligned();
+    }
+
+    /**
      * Returns {@code true} if the platform has reliable low-level direct buffer access API and a user has not specified
      * {@code -Dio.netty.noPreferDirect} option.
      */


### PR DESCRIPTION

    Motivation:

    We had a bug in our implemention which double "reversed" bytes on systems which not support unaligned access.

    Modifications:

    - Correctly only reverse bytes if needed.
    - Share code between unsafe implementations.

    Result:

    No more data-corruption on sytems without unaligned access.