### PR TITLE
[#4357] Fix possible assert error in GlobalEventExecutor

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/GlobalEventExecutor.java
@@ -218,8 +218,11 @@ public final class GlobalEventExecutor extends AbstractScheduledEventExecutor {
     private void startThread() {
         if (started.compareAndSet(false, true)) {
             Thread t = threadFactory.newThread(taskRunner);
-            t.start();
+            // Set the thread before starting it as otherwise inEventLoop() may return false and so produce
+            // an assert error.
+            // See https://github.com/netty/netty/issues/4357
             thread = t;
+            t.start();
         }
     }
 


### PR DESCRIPTION
Motivation:

We started the thread before store it in a field which could lead to an assert error when the thread is executed before we actually store it.

Modifications:

Store thread before start it.

Result:

No more assert error possible.