### PR TITLE
Always return a real slice even when the length is 0

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
@@ -153,9 +153,6 @@ public class SlicedByteBuf extends AbstractDerivedByteBuf {
     @Override
     public ByteBuf slice(int index, int length) {
         checkIndex(index, length);
-        if (length == 0) {
-            return Unpooled.EMPTY_BUFFER;
-        }
         return buffer.slice(idx(index), length);
     }
 

--- a/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 /**
  * Tests sliced channel buffers
@@ -136,5 +136,28 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
         } finally {
             wrapped.release();
         }
+    }
+
+    @Test
+    public void sliceEmptyNotLeak() {
+        ByteBuf buffer = Unpooled.buffer(8).retain();
+        assertEquals(2, buffer.refCnt());
+
+        ByteBuf slice1 = buffer.slice();
+        assertEquals(2, slice1.refCnt());
+
+        ByteBuf slice2 = slice1.slice();
+        assertEquals(2, slice2.refCnt());
+
+        assertFalse(slice2.release());
+        assertEquals(1, buffer.refCnt());
+        assertEquals(1, slice1.refCnt());
+        assertEquals(1, slice2.refCnt());
+
+        assertTrue(slice2.release());
+
+        assertEquals(0, buffer.refCnt());
+        assertEquals(0, slice1.refCnt());
+        assertEquals(0, slice2.refCnt());
     }
 }


### PR DESCRIPTION
Motivation:

We need to always return a real slice even when the requested length is 0. This is needed as otherwise we not correctly share the reference count and so may leak a buffer if the user call release() on the returned slice and expect it to decrement the reference count of the "parent" buffer.

Modifications:

- Always return a real slice
- Add unit test for the bug.

Result:

No more leak possible when a user requests a slice of length 0 of a SlicedByteBuf.