### PR TITLE
Cleanup buffer tests.

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -60,7 +60,6 @@ public abstract class AbstractByteBufTest {
     private ByteBuf buffer;
 
     protected abstract ByteBuf newBuffer(int capacity);
-    protected abstract ByteBuf[] components();
 
     protected boolean discardReadBytesDoesNotMoveWritableBytes() {
         return true;

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -46,12 +46,9 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         this.order = order;
     }
 
-    private List<ByteBuf> buffers;
-    private ByteBuf buffer;
-
     @Override
     protected ByteBuf newBuffer(int length) {
-        buffers = new ArrayList<ByteBuf>();
+        List<ByteBuf> buffers = new ArrayList<ByteBuf>();
         for (int i = 0; i < length + 45; i += 45) {
             buffers.add(EMPTY_BUFFER);
             buffers.add(wrappedBuffer(new byte[1]));
@@ -74,7 +71,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
             buffers.add(EMPTY_BUFFER);
         }
 
-        buffer = wrappedBuffer(Integer.MAX_VALUE, buffers.toArray(new ByteBuf[buffers.size()])).order(order);
+        ByteBuf buffer = wrappedBuffer(Integer.MAX_VALUE, buffers.toArray(new ByteBuf[buffers.size()])).order(order);
 
         // Truncate to the requested capacity.
         buffer.capacity(length);
@@ -84,11 +81,6 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         assertFalse(buffer.isWritable());
         buffer.writerIndex(0);
         return buffer;
-    }
-
-    @Override
-    protected ByteBuf[] components() {
-        return buffers.toArray(new ByteBuf[buffers.size()]);
     }
 
     // Composite buffer does not waste bandwidth on discardReadBytes, but

--- a/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
@@ -21,21 +21,14 @@ import static org.junit.Assert.*;
 
 public abstract class AbstractPooledByteBufTest extends AbstractByteBufTest {
 
-    private ByteBuf buffer;
-
     protected abstract ByteBuf alloc(int length);
 
     @Override
     protected ByteBuf newBuffer(int length) {
-        buffer = alloc(length);
+        ByteBuf buffer = alloc(length);
         assertEquals(0, buffer.writerIndex());
         assertEquals(0, buffer.readerIndex());
         return buffer;
-    }
-
-    @Override
-    protected ByteBuf[] components() {
-        return new ByteBuf[] { buffer };
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/BigEndianDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianDirectByteBufTest.java
@@ -24,19 +24,12 @@ import java.nio.ByteOrder;
  */
 public class BigEndianDirectByteBufTest extends AbstractByteBufTest {
 
-    private ByteBuf buffer;
-
     @Override
     protected ByteBuf newBuffer(int length) {
-        buffer = newDirectBuffer(length);
+        ByteBuf buffer = newDirectBuffer(length);
         assertSame(ByteOrder.BIG_ENDIAN, buffer.order());
         assertEquals(0, buffer.writerIndex());
         return buffer;
-    }
-
-    @Override
-    protected ByteBuf[] components() {
-        return new ByteBuf[] { buffer };
     }
 
     protected ByteBuf newDirectBuffer(int length) {

--- a/buffer/src/test/java/io/netty/buffer/BigEndianHeapByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianHeapByteBufTest.java
@@ -24,18 +24,11 @@ import static org.junit.Assert.*;
  */
 public class BigEndianHeapByteBufTest extends AbstractByteBufTest {
 
-    private ByteBuf buffer;
-
     @Override
     protected ByteBuf newBuffer(int length) {
-        buffer = Unpooled.buffer(length);
+        ByteBuf buffer = Unpooled.buffer(length);
         assertEquals(0, buffer.writerIndex());
         return buffer;
-    }
-
-    @Override
-    protected ByteBuf[] components() {
-        return new ByteBuf[] { buffer };
     }
 
     @Test(expected = NullPointerException.class)

--- a/buffer/src/test/java/io/netty/buffer/DuplicateByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/DuplicateByteBufTest.java
@@ -24,20 +24,13 @@ import static org.junit.Assert.assertEquals;
  */
 public class DuplicateByteBufTest extends AbstractByteBufTest {
 
-    private ByteBuf buffer;
-
     @Override
     protected ByteBuf newBuffer(int length) {
         ByteBuf wrapped = Unpooled.buffer(length);
-        buffer = new DuplicatedByteBuf(wrapped);
+        ByteBuf buffer = new DuplicatedByteBuf(wrapped);
         assertEquals(wrapped.writerIndex(), buffer.writerIndex());
         assertEquals(wrapped.readerIndex(), buffer.readerIndex());
         return buffer;
-    }
-
-    @Override
-    protected ByteBuf[] components() {
-        return new ByteBuf[] { buffer };
     }
 
     @Test(expected = NullPointerException.class)
@@ -48,6 +41,7 @@ public class DuplicateByteBufTest extends AbstractByteBufTest {
     // See https://github.com/netty/netty/issues/1800
     @Test
     public void testIncreaseCapacityWrapped() {
+        ByteBuf buffer = newBuffer(8);
         ByteBuf wrapped = buffer.unwrap();
         wrapped.writeByte(0);
         wrapped.readerIndex(wrapped.readerIndex() + 1);

--- a/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
@@ -14,7 +14,6 @@
  * under the License.
  */package io.netty.buffer;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.*;
@@ -25,15 +24,15 @@ public class EmptyByteBufTest {
     @Test
     public void testIsWritable() {
         EmptyByteBuf empty = new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT);
-        Assert.assertFalse(empty.isWritable());
-        Assert.assertFalse(empty.isWritable(1));
+        assertFalse(empty.isWritable());
+        assertFalse(empty.isWritable(1));
     }
 
     @Test
     public void testIsReadable() {
         EmptyByteBuf empty = new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT);
-        Assert.assertFalse(empty.isReadable());
-        Assert.assertFalse(empty.isReadable(1));
+        assertFalse(empty.isReadable());
+        assertFalse(empty.isReadable(1));
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/FixedCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/FixedCompositeByteBufTest.java
@@ -58,7 +58,7 @@ public class FixedCompositeByteBufTest {
         }
     }
 
-    private ByteBuf newBuffer(ByteBuf... buffers) {
+    private static ByteBuf newBuffer(ByteBuf... buffers) {
         return new FixedCompositeByteBuf(UnpooledByteBufAllocator.DEFAULT, buffers);
     }
 
@@ -97,17 +97,17 @@ public class FixedCompositeByteBufTest {
         ByteBuf buf = newBuffer(Unpooled.wrappedBuffer(new byte[8]));
         buf.setBytes(0, new ScatteringByteChannel() {
             @Override
-            public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
+            public long read(ByteBuffer[] dsts, int offset, int length) {
                 return 0;
             }
 
             @Override
-            public long read(ByteBuffer[] dsts) throws IOException {
+            public long read(ByteBuffer[] dsts) {
                 return 0;
             }
 
             @Override
-            public int read(ByteBuffer dst) throws IOException {
+            public int read(ByteBuffer dst) {
                 return 0;
             }
 
@@ -117,7 +117,7 @@ public class FixedCompositeByteBufTest {
             }
 
             @Override
-            public void close() throws IOException {
+            public void close() {
             }
         }, 4);
     }
@@ -240,7 +240,7 @@ public class FixedCompositeByteBufTest {
                 PooledByteBufAllocator.DEFAULT.directBuffer());
     }
 
-    private void testGatheringWritesPartial(ByteBuf buf1, ByteBuf buf2) throws Exception {
+    private static void testGatheringWritesPartial(ByteBuf buf1, ByteBuf buf2) throws Exception {
         buf1.writeBytes(new byte[]{1, 2, 3, 4});
         buf2.writeBytes(new byte[]{1, 2, 3, 4});
         ByteBuf buf = newBuffer(buf1, buf2);
@@ -266,7 +266,7 @@ public class FixedCompositeByteBufTest {
         testGatheringWritesSingleBuf(directBuffer());
     }
 
-    private void testGatheringWritesSingleBuf(ByteBuf buf1) throws Exception {
+    private static void testGatheringWritesSingleBuf(ByteBuf buf1) throws Exception {
         ByteBuf buf = newBuffer(buf1.writeBytes(new byte[]{1, 2, 3, 4}));
         buf.readerIndex(1);
 

--- a/buffer/src/test/java/io/netty/buffer/LittleEndianDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LittleEndianDirectByteBufTest.java
@@ -24,19 +24,12 @@ import java.nio.ByteOrder;
  */
 public class LittleEndianDirectByteBufTest extends AbstractByteBufTest {
 
-    private ByteBuf buffer;
-
     @Override
     protected ByteBuf newBuffer(int length) {
-        buffer = newDirectBuffer(length).order(ByteOrder.LITTLE_ENDIAN);
+        ByteBuf buffer = newDirectBuffer(length).order(ByteOrder.LITTLE_ENDIAN);
         assertSame(ByteOrder.LITTLE_ENDIAN, buffer.order());
         assertEquals(0, buffer.writerIndex());
         return buffer;
-    }
-
-    @Override
-    protected ByteBuf[] components() {
-        return new ByteBuf[] { buffer };
     }
 
     protected ByteBuf newDirectBuffer(int length) {

--- a/buffer/src/test/java/io/netty/buffer/LittleEndianHeapByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LittleEndianHeapByteBufTest.java
@@ -24,17 +24,10 @@ import java.nio.ByteOrder;
  */
 public class LittleEndianHeapByteBufTest extends AbstractByteBufTest {
 
-    private ByteBuf buffer;
-
     @Override
     protected ByteBuf newBuffer(int length) {
-        buffer = Unpooled.buffer(length).order(ByteOrder.LITTLE_ENDIAN);
+        ByteBuf buffer = Unpooled.buffer(length).order(ByteOrder.LITTLE_ENDIAN);
         assertEquals(0, buffer.writerIndex());
         return buffer;
-    }
-
-    @Override
-    protected ByteBuf[] components() {
-        return new ByteBuf[] { buffer };
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -15,7 +15,6 @@
  */
 package io.netty.buffer;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -23,12 +22,11 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
-import java.util.ArrayDeque;
-import java.util.Queue;
+
+import static io.netty.util.ReferenceCountUtil.releaseLater;
 
 public class ReadOnlyDirectByteBufferBufTest {
 
-    private final Queue<ByteBuf> buffers = new ArrayDeque<ByteBuf>();
     protected ByteBuf buffer(ByteBuffer buffer) {
         return new ReadOnlyByteBufferBuf(UnpooledByteBufAllocator.DEFAULT, buffer);
     }
@@ -37,84 +35,64 @@ public class ReadOnlyDirectByteBufferBufTest {
         return ByteBuffer.allocateDirect(size);
     }
 
-    @After
-    public void dispose() {
-       for (;;) {
-           ByteBuf buf = buffers.poll();
-           if (buf == null) {
-               break;
-           }
-           buf.release();
-       }
-    }
-
     @Test(expected = IllegalArgumentException.class)
     public void testConstructWithWritable() {
-        buffers.add(buffer(allocate(1)));
+        releaseLater(buffer(allocate(1)));
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetByte() {
-        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
-        buffers.add(buf);
+        ByteBuf buf = releaseLater(buffer(allocate(8).asReadOnlyBuffer()));
         buf.setByte(0, 1);
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetInt() {
-        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
-        buffers.add(buf);
-
+        ByteBuf buf = releaseLater(buffer(allocate(8).asReadOnlyBuffer()));
         buf.setInt(0, 1);
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetShort() {
-        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
-        buffers.add(buf);
+        ByteBuf buf = releaseLater(buffer(allocate(8).asReadOnlyBuffer()));
         buf.setShort(0, 1);
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetMedium() {
-        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
-        buffers.add(buf);
+        ByteBuf buf = releaseLater(buffer(allocate(8).asReadOnlyBuffer()));
         buf.setMedium(0, 1);
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetLong() {
-        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
-        buffers.add(buf);
+        ByteBuf buf = releaseLater(buffer(allocate(8).asReadOnlyBuffer()));
         buf.setLong(0, 1);
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetBytesViaArray() {
-        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
-        buffers.add(buf);
+        ByteBuf buf = releaseLater(buffer(allocate(8).asReadOnlyBuffer()));
         buf.setBytes(0, "test".getBytes());
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetBytesViaBuffer() {
-        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
-        buffers.add(buf);
+        ByteBuf buf = releaseLater(buffer(allocate(8).asReadOnlyBuffer()));
         buf.setBytes(0, Unpooled.copyInt(1));
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetBytesViaStream() throws IOException {
-        ByteBuf buf = buffer(ByteBuffer.allocateDirect(8).asReadOnlyBuffer());
-        buffers.add(buf);
+        ByteBuf buf = releaseLater(buffer(ByteBuffer.allocateDirect(8).asReadOnlyBuffer()));
         buf.setBytes(0, new ByteArrayInputStream("test".getBytes()), 2);
         buf.release();
     }
 
     @Test
     public void testGetReadByte() {
-        ByteBuf buf = buffer(((ByteBuffer) allocate(2).put(new byte[]{(byte) 1, (byte) 2}).flip()).asReadOnlyBuffer());
-        buffers.add(buf);
+        ByteBuf buf = releaseLater(buffer(
+                ((ByteBuffer) allocate(2).put(new byte[] { (byte) 1, (byte) 2 }).flip()).asReadOnlyBuffer()));
 
         Assert.assertEquals(1, buf.getByte(0));
         Assert.assertEquals(2, buf.getByte(1));
@@ -126,8 +104,7 @@ public class ReadOnlyDirectByteBufferBufTest {
 
     @Test
     public void testGetReadInt() {
-        ByteBuf buf = buffer(((ByteBuffer) allocate(8).putInt(1).putInt(2).flip()).asReadOnlyBuffer());
-        buffers.add(buf);
+        ByteBuf buf = releaseLater(buffer(((ByteBuffer) allocate(8).putInt(1).putInt(2).flip()).asReadOnlyBuffer()));
 
         Assert.assertEquals(1, buf.getInt(0));
         Assert.assertEquals(2, buf.getInt(4));
@@ -139,9 +116,8 @@ public class ReadOnlyDirectByteBufferBufTest {
 
     @Test
     public void testGetReadShort() {
-        ByteBuf buf = buffer(((ByteBuffer) allocate(8).putShort((short) 1)
-                .putShort((short) 2).flip()).asReadOnlyBuffer());
-        buffers.add(buf);
+        ByteBuf buf = releaseLater(buffer(((ByteBuffer) allocate(8)
+                .putShort((short) 1).putShort((short) 2).flip()).asReadOnlyBuffer()));
 
         Assert.assertEquals(1, buf.getShort(0));
         Assert.assertEquals(2, buf.getShort(2));
@@ -153,8 +129,8 @@ public class ReadOnlyDirectByteBufferBufTest {
 
     @Test
     public void testGetReadLong() {
-        ByteBuf buf = buffer(((ByteBuffer) allocate(16).putLong(1).putLong(2).flip()).asReadOnlyBuffer());
-        buffers.add(buf);
+        ByteBuf buf = releaseLater(buffer(((ByteBuffer) allocate(16)
+                .putLong(1).putLong(2).flip()).asReadOnlyBuffer()));
 
         Assert.assertEquals(1, buf.getLong(0));
         Assert.assertEquals(2, buf.getLong(8));
@@ -166,21 +142,16 @@ public class ReadOnlyDirectByteBufferBufTest {
 
     @Test
     public void testCopy() {
-        ByteBuf buf = buffer(((ByteBuffer) allocate(16).putLong(1).putLong(2).flip()).asReadOnlyBuffer());
-        buffers.add(buf);
-        ByteBuf copy = buf.copy();
-        buffers.add(copy);
+        ByteBuf buf = releaseLater(buffer(((ByteBuffer) allocate(16).putLong(1).putLong(2).flip()).asReadOnlyBuffer()));
+        ByteBuf copy = releaseLater(buf.copy());
 
         Assert.assertEquals(buf, copy);
     }
 
     @Test
     public void testCopyWithOffset() {
-        ByteBuf buf = buffer(((ByteBuffer) allocate(16).putLong(1).putLong(2).flip()).asReadOnlyBuffer());
-        buffers.add(buf);
-
-        ByteBuf copy = buf.copy(1, 9);
-        buffers.add(copy);
+        ByteBuf buf = releaseLater(buffer(((ByteBuffer) allocate(16).putLong(1).putLong(2).flip()).asReadOnlyBuffer()));
+        ByteBuf copy = releaseLater(buf.copy(1, 9));
 
         Assert.assertEquals(buf.slice(1, 9), copy);
     }
@@ -188,8 +159,8 @@ public class ReadOnlyDirectByteBufferBufTest {
     // Test for https://github.com/netty/netty/issues/1708
     @Test
     public void testWrapBufferWithNonZeroPosition() {
-        ByteBuf buf = buffer(((ByteBuffer) allocate(16).putLong(1).flip().position(1)).asReadOnlyBuffer());
-        buffers.add(buf);
+        ByteBuf buf = releaseLater(buffer(((ByteBuffer) allocate(16)
+                .putLong(1).flip().position(1)).asReadOnlyBuffer()));
 
         ByteBuf slice = buf.slice();
         Assert.assertEquals(buf, slice);
@@ -197,8 +168,7 @@ public class ReadOnlyDirectByteBufferBufTest {
 
     @Test
     public void testWrapBufferRoundTrip() {
-        ByteBuf buf = buffer(((ByteBuffer) allocate(16).putInt(1).putInt(2).flip()).asReadOnlyBuffer());
-        buffers.add(buf);
+        ByteBuf buf = releaseLater(buffer(((ByteBuffer) allocate(16).putInt(1).putInt(2).flip()).asReadOnlyBuffer()));
 
         Assert.assertEquals(1, buf.readInt());
 

--- a/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
@@ -28,19 +28,13 @@ import static org.junit.Assert.assertEquals;
 public class SlicedByteBufTest extends AbstractByteBufTest {
 
     private final Random random = new Random();
-    private ByteBuf buffer;
 
     @Override
     protected ByteBuf newBuffer(int length) {
-        buffer = Unpooled.wrappedBuffer(
+        ByteBuf buffer = Unpooled.wrappedBuffer(
                 new byte[length * 2], random.nextInt(length - 1) + 1, length);
         assertEquals(length, buffer.writerIndex());
         return buffer;
-    }
-
-    @Override
-    protected ByteBuf[] components() {
-        return new ByteBuf[] { buffer };
     }
 
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
Motivation:

Some of the tests in the buffer module contained unused code. Some of the tests also used unnecessary inheritance which could be avoided to simplify code.

Modifications:

Cleanup the test cases.

Result:

Cleaner code, less cruft.