### PR TITLE
Possibility of firing user event in outbound direction.

### DIFF
--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelWriteReleaseHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelWriteReleaseHandlerContext.java
@@ -155,9 +155,9 @@ public abstract class EmbeddedChannelWriteReleaseHandlerContext implements Chann
     }
 
     @Override
-    public ChannelHandlerContext fireUserEventTriggeredOutbound(Object event) {
+    public ChannelHandlerContext fireUserEventTriggeredBackward(Object event) {
         try {
-            handler().userEventTriggeredOutbound(this, event);
+            handler().userEventTriggeredBackward(this, event);
         } catch (Exception e) {
             handleException(e);
         }

--- a/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelWriteReleaseHandlerContext.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/EmbeddedChannelWriteReleaseHandlerContext.java
@@ -155,6 +155,16 @@ public abstract class EmbeddedChannelWriteReleaseHandlerContext implements Chann
     }
 
     @Override
+    public ChannelHandlerContext fireUserEventTriggeredOutbound(Object event) {
+        try {
+            handler().userEventTriggeredOutbound(this, event);
+        } catch (Exception e) {
+            handleException(e);
+        }
+        return this;
+    }
+
+    @Override
     public ChannelHandlerContext fireChannelRead(Object msg) {
         try {
             handler().channelRead(this, msg);

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -353,6 +353,13 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     }
 
     @Override
+    public ChannelHandlerContext fireUserEventTriggeredOutbound(Object event) {
+        AbstractChannelHandlerContext prev = findContextOutbound();
+        prev.invoker().invokeUserEventTriggered(prev, event);
+        return this;
+    }
+
+    @Override
     public ChannelHandlerContext fireChannelRead(Object msg) {
         AbstractChannelHandlerContext next = findContextInbound();
         ReferenceCountUtil.touch(msg, next);

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -353,9 +353,9 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     }
 
     @Override
-    public ChannelHandlerContext fireUserEventTriggeredOutbound(Object event) {
+    public ChannelHandlerContext fireUserEventTriggeredBackward(Object event) {
         AbstractChannelHandlerContext prev = findContextOutbound();
-        prev.invoker().invokeUserEventTriggered(prev, event);
+        prev.invoker().invokeUserEventTriggeredBackward(prev, event);
         return this;
     }
 

--- a/transport/src/main/java/io/netty/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandler.java
@@ -231,6 +231,11 @@ public interface ChannelHandler {
     void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception;
 
     /**
+     * Gets called if an user event was triggered.
+     */
+    void userEventTriggeredOutbound(ChannelHandlerContext ctx, Object evt) throws Exception;
+
+    /**
      * Gets called once the writable state of a {@link Channel} changed. You can check the state with
      * {@link Channel#isWritable()}.
      */

--- a/transport/src/main/java/io/netty/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandler.java
@@ -233,7 +233,7 @@ public interface ChannelHandler {
     /**
      * Gets called if an user event was triggered.
      */
-    void userEventTriggeredOutbound(ChannelHandlerContext ctx, Object evt) throws Exception;
+    void userEventTriggeredBackward(ChannelHandlerContext ctx, Object evt) throws Exception;
 
     /**
      * Gets called once the writable state of a {@link Channel} changed. You can check the state with

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerAdapter.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerAdapter.java
@@ -174,8 +174,8 @@ public class ChannelHandlerAdapter implements ChannelHandler {
      */
     @Skip
     @Override
-    public void userEventTriggeredOutbound(ChannelHandlerContext ctx, Object evt) throws Exception {
-        ctx.fireUserEventTriggeredOutbound(evt);
+    public void userEventTriggeredBackward(ChannelHandlerContext ctx, Object evt) throws Exception {
+        ctx.fireUserEventTriggeredBackward(evt);
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerAdapter.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerAdapter.java
@@ -167,6 +167,18 @@ public class ChannelHandlerAdapter implements ChannelHandler {
     }
 
     /**
+     * Calls {@link ChannelHandlerContext#fireUserEventTriggered(Object)} to forward
+     * to the next {@link ChannelHandler} in the {@link ChannelPipeline}.
+     *
+     * Sub-classes may override this method to change behavior.
+     */
+    @Skip
+    @Override
+    public void userEventTriggeredOutbound(ChannelHandlerContext ctx, Object evt) throws Exception {
+        ctx.fireUserEventTriggeredOutbound(evt);
+    }
+
+    /**
      * Calls {@link ChannelHandlerContext#fireChannelWritabilityChanged()} to forward
      * to the next {@link ChannelHandler} in the {@link ChannelPipeline}.
      *

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
@@ -220,7 +220,7 @@ public interface ChannelHandlerContext extends AttributeMap {
      */
     ChannelHandlerContext fireUserEventTriggered(Object event);
 
-    ChannelHandlerContext fireUserEventTriggeredOutbound(Object event);
+    ChannelHandlerContext fireUserEventTriggeredBackward(Object event);
 
     /**
      * A {@link Channel} received a message.

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
@@ -220,6 +220,8 @@ public interface ChannelHandlerContext extends AttributeMap {
      */
     ChannelHandlerContext fireUserEventTriggered(Object event);
 
+    ChannelHandlerContext fireUserEventTriggeredOutbound(Object event);
+
     /**
      * A {@link Channel} received a message.
      *

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerInvoker.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerInvoker.java
@@ -75,6 +75,13 @@ public interface ChannelHandlerInvoker {
     void invokeUserEventTriggered(ChannelHandlerContext ctx, Object event);
 
     /**
+     * Invokes {@link ChannelHandler#userEventTriggeredBackward(ChannelHandlerContext, Object)}. This method is not for
+     * a user but for the internal {@link ChannelHandlerContext} implementation. To trigger an event, use the methods in
+     * {@link ChannelHandlerContext} instead.
+     */
+    void invokeUserEventTriggeredBackward(ChannelHandlerContext ctx, Object event);
+
+    /**
      * Invokes {@link ChannelHandler#channelRead(ChannelHandlerContext, Object)}. This method is not for a user
      * but for the internal {@link ChannelHandlerContext} implementation. To trigger an event, use the methods in
      * {@link ChannelHandlerContext} instead.

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerInvokerUtil.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerInvokerUtil.java
@@ -78,6 +78,14 @@ public final class ChannelHandlerInvokerUtil {
         }
     }
 
+    public static void invokeUserEventTriggeredBackwardNow(final ChannelHandlerContext ctx, final Object event) {
+        try {
+            ctx.handler().userEventTriggeredBackward(ctx, event);
+        } catch (Throwable t) {
+            notifyHandlerException(ctx, t);
+        }
+    }
+
     public static void invokeChannelReadNow(final ChannelHandlerContext ctx, final Object msg) {
         try {
             ctx.handler().channelRead(ctx, msg);

--- a/transport/src/main/java/io/netty/channel/DefaultChannelHandlerInvoker.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelHandlerInvoker.java
@@ -144,6 +144,24 @@ public class DefaultChannelHandlerInvoker implements ChannelHandlerInvoker {
     }
 
     @Override
+    public void invokeUserEventTriggeredBackward(final ChannelHandlerContext ctx, final Object event) {
+        if (event == null) {
+            throw new NullPointerException("event");
+        }
+
+        if (executor.inEventLoop()) {
+            invokeUserEventTriggeredBackwardNow(ctx, event);
+        } else {
+            safeExecuteInbound(new OneTimeTask() {
+                @Override
+                public void run() {
+                    invokeUserEventTriggeredBackwardNow(ctx, event);
+                }
+            }, event);
+        }
+    }
+
+    @Override
     public void invokeChannelRead(final ChannelHandlerContext ctx, final Object msg) {
         if (msg == null) {
             throw new NullPointerException("msg");

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -1138,6 +1138,11 @@ final class DefaultChannelPipeline implements ChannelPipeline {
         }
 
         @Override
+        public void userEventTriggeredOutbound(ChannelHandlerContext ctx, Object evt) throws Exception {
+            ctx.fireUserEventTriggeredOutbound(evt);
+        }
+
+        @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
             try {
                 logger.warn(
@@ -1345,6 +1350,12 @@ final class DefaultChannelPipeline implements ChannelPipeline {
         @Override
         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
             ctx.fireUserEventTriggered(evt);
+        }
+
+        @Skip
+        @Override
+        public void userEventTriggeredOutbound(ChannelHandlerContext ctx, Object evt) throws Exception {
+            ctx.fireUserEventTriggeredOutbound(evt);
         }
 
         @Skip

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -1138,8 +1138,8 @@ final class DefaultChannelPipeline implements ChannelPipeline {
         }
 
         @Override
-        public void userEventTriggeredOutbound(ChannelHandlerContext ctx, Object evt) throws Exception {
-            ctx.fireUserEventTriggeredOutbound(evt);
+        public void userEventTriggeredBackward(ChannelHandlerContext ctx, Object evt) throws Exception {
+            ctx.fireUserEventTriggeredBackward(evt);
         }
 
         @Override
@@ -1354,8 +1354,8 @@ final class DefaultChannelPipeline implements ChannelPipeline {
 
         @Skip
         @Override
-        public void userEventTriggeredOutbound(ChannelHandlerContext ctx, Object evt) throws Exception {
-            ctx.fireUserEventTriggeredOutbound(evt);
+        public void userEventTriggeredBackward(ChannelHandlerContext ctx, Object evt) throws Exception {
+            ctx.fireUserEventTriggeredBackward(evt);
         }
 
         @Skip

--- a/transport/src/main/java/io/netty/channel/PausableChannelEventExecutor.java
+++ b/transport/src/main/java/io/netty/channel/PausableChannelEventExecutor.java
@@ -82,6 +82,11 @@ abstract class PausableChannelEventExecutor implements PausableEventExecutor, Ch
     }
 
     @Override
+    public void invokeUserEventTriggeredBackward(ChannelHandlerContext ctx, Object event) {
+        unwrapInvoker().invokeUserEventTriggeredBackward(ctx, event);
+    }
+
+    @Override
     public void invokeChannelRead(ChannelHandlerContext ctx, Object msg) {
         unwrapInvoker().invokeChannelRead(ctx, msg);
     }

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
@@ -191,6 +191,11 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
     }
 
     @Override
+    public void invokeUserEventTriggeredBackward(ChannelHandlerContext ctx, Object event) {
+        invokeUserEventTriggeredBackwardNow(ctx, event);
+    }
+
+    @Override
     public void invokeChannelRead(ChannelHandlerContext ctx, Object msg) {
         invokeChannelReadNow(ctx, msg);
     }

--- a/transport/src/test/java/io/netty/channel/LoggingHandler.java
+++ b/transport/src/test/java/io/netty/channel/LoggingHandler.java
@@ -23,7 +23,7 @@ final class LoggingHandler implements ChannelHandler {
 
     enum Event {
         WRITE, FLUSH, BIND, CONNECT, DISCONNECT, CLOSE, DEREGISTER, READ, WRITABILITY, HANDLER_ADDED,
-        HANDLER_REMOVED, EXCEPTION, READ_COMPLETE, REGISTERED, UNREGISTERED, ACTIVE, INACTIVE, USER, USER_OUTBOUND
+        HANDLER_REMOVED, EXCEPTION, READ_COMPLETE, REGISTERED, UNREGISTERED, ACTIVE, INACTIVE, USER, USER_BACKWARD
     }
 
     private StringBuilder log = new StringBuilder();
@@ -144,9 +144,9 @@ final class LoggingHandler implements ChannelHandler {
     }
 
     @Override
-    public void userEventTriggeredOutbound(ChannelHandlerContext ctx, Object evt) throws Exception {
-        log(Event.USER_OUTBOUND, evt.toString());
-        ctx.fireUserEventTriggeredOutbound(evt);
+    public void userEventTriggeredBackward(ChannelHandlerContext ctx, Object evt) throws Exception {
+        log(Event.USER_BACKWARD, evt.toString());
+        ctx.fireUserEventTriggeredBackward(evt);
     }
 
     String getLog() {

--- a/transport/src/test/java/io/netty/channel/LoggingHandler.java
+++ b/transport/src/test/java/io/netty/channel/LoggingHandler.java
@@ -23,7 +23,7 @@ final class LoggingHandler implements ChannelHandler {
 
     enum Event {
         WRITE, FLUSH, BIND, CONNECT, DISCONNECT, CLOSE, DEREGISTER, READ, WRITABILITY, HANDLER_ADDED,
-        HANDLER_REMOVED, EXCEPTION, READ_COMPLETE, REGISTERED, UNREGISTERED, ACTIVE, INACTIVE, USER
+        HANDLER_REMOVED, EXCEPTION, READ_COMPLETE, REGISTERED, UNREGISTERED, ACTIVE, INACTIVE, USER, USER_OUTBOUND
     }
 
     private StringBuilder log = new StringBuilder();
@@ -141,6 +141,12 @@ final class LoggingHandler implements ChannelHandler {
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         log(Event.USER, evt.toString());
         ctx.fireUserEventTriggered(evt);
+    }
+
+    @Override
+    public void userEventTriggeredOutbound(ChannelHandlerContext ctx, Object evt) throws Exception {
+        log(Event.USER_OUTBOUND, evt.toString());
+        ctx.fireUserEventTriggeredOutbound(evt);
     }
 
     String getLog() {


### PR DESCRIPTION
Currently my test fail half-way through, but I don't think it's the issue with the changes. it says:

```
[ERROR] Failed to execute goal ....:autobahntestsuite-maven-plugin:0.1.3:fuzzingclient (default) on project netty-testsuite: Execution default of goal .....fuzzingclient failed: unable to find a free port
```

Motivation:

In a proxy application it is desirable to propagate a user event
backward, from proxy destination end-point to client end-point.
Currently the only way is to set a List<ChannelHandler> attribute on
channel context and pass event object to them however benefits of
Netty's event firing (easy access to proper context, exception
handling, ...) is lost.

Modifications:

Very similar to fireUserEventTriggered() and userEventTriggered(), two
method fireUserEventTriggeredOutbound() and userEventTriggeredOutbound()
were added. in the channel handler context implementation instead of
next handler, previous handler is found and called.

Result:

It's possible to send a user event from end of pipeline to the beginning
of it. However the changes are backward-incompatible and direct implementations
 of ChannelHandler and ChannelHandlerContext need to implement the
methods.