### PR TITLE
Share code between Heap ByteBuf implementations

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/HeapByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/HeapByteBufUtil.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+/**
+ * Utility class for heap buffers.
+ */
+final class HeapByteBufUtil {
+
+    static byte getByte(byte[] memory, int index) {
+        return memory[index];
+    }
+
+    static short getShort(byte[] memory, int index) {
+        return (short) (memory[index] << 8 | memory[index + 1] & 0xFF);
+    }
+
+    static int getUnsignedMedium(byte[] memory, int index) {
+        return  (memory[index]     & 0xff) << 16 |
+                (memory[index + 1] & 0xff) <<  8 |
+                memory[index + 2] & 0xff;
+    }
+
+    static int getInt(byte[] memory, int index) {
+        return  (memory[index]     & 0xff) << 24 |
+                (memory[index + 1] & 0xff) << 16 |
+                (memory[index + 2] & 0xff) <<  8 |
+                memory[index + 3] & 0xff;
+    }
+
+    static long getLong(byte[] memory, int index) {
+        return  ((long) memory[index]     & 0xff) << 56 |
+                ((long) memory[index + 1] & 0xff) << 48 |
+                ((long) memory[index + 2] & 0xff) << 40 |
+                ((long) memory[index + 3] & 0xff) << 32 |
+                ((long) memory[index + 4] & 0xff) << 24 |
+                ((long) memory[index + 5] & 0xff) << 16 |
+                ((long) memory[index + 6] & 0xff) <<  8 |
+                (long) memory[index + 7] & 0xff;
+    }
+
+    static void setByte(byte[] memory, int index, int value) {
+        memory[index] = (byte) value;
+    }
+
+    static void setShort(byte[] memory, int index, int value) {
+        memory[index]     = (byte) (value >>> 8);
+        memory[index + 1] = (byte) value;
+    }
+
+    static void setMedium(byte[] memory, int index, int value) {
+        memory[index]     = (byte) (value >>> 16);
+        memory[index + 1] = (byte) (value >>> 8);
+        memory[index + 2] = (byte) value;
+    }
+
+    static void setInt(byte[] memory, int index, int value) {
+        memory[index]     = (byte) (value >>> 24);
+        memory[index + 1] = (byte) (value >>> 16);
+        memory[index + 2] = (byte) (value >>> 8);
+        memory[index + 3] = (byte) value;
+    }
+
+    static void setLong(byte[] memory, int index, long value) {
+        memory[index]     = (byte) (value >>> 56);
+        memory[index + 1] = (byte) (value >>> 48);
+        memory[index + 2] = (byte) (value >>> 40);
+        memory[index + 3] = (byte) (value >>> 32);
+        memory[index + 4] = (byte) (value >>> 24);
+        memory[index + 5] = (byte) (value >>> 16);
+        memory[index + 6] = (byte) (value >>> 8);
+        memory[index + 7] = (byte) value;
+    }
+
+    private HeapByteBufUtil() { }
+}

--- a/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
@@ -51,43 +51,27 @@ class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
 
     @Override
     protected byte _getByte(int index) {
-        return memory[idx(index)];
+        return HeapByteBufUtil.getByte(memory, idx(index));
     }
 
     @Override
     protected short _getShort(int index) {
-        index = idx(index);
-        return (short) (memory[index] << 8 | memory[index + 1] & 0xFF);
+        return HeapByteBufUtil.getShort(memory, idx(index));
     }
 
     @Override
     protected int _getUnsignedMedium(int index) {
-        index = idx(index);
-        return (memory[index]     & 0xff) << 16 |
-               (memory[index + 1] & 0xff) <<  8 |
-                memory[index + 2] & 0xff;
+        return HeapByteBufUtil.getUnsignedMedium(memory, idx(index));
     }
 
     @Override
     protected int _getInt(int index) {
-        index = idx(index);
-        return (memory[index]     & 0xff) << 24 |
-               (memory[index + 1] & 0xff) << 16 |
-               (memory[index + 2] & 0xff) <<  8 |
-                memory[index + 3] & 0xff;
+        return HeapByteBufUtil.getInt(memory, idx(index));
     }
 
     @Override
     protected long _getLong(int index) {
-        index = idx(index);
-        return ((long) memory[index]     & 0xff) << 56 |
-               ((long) memory[index + 1] & 0xff) << 48 |
-               ((long) memory[index + 2] & 0xff) << 40 |
-               ((long) memory[index + 3] & 0xff) << 32 |
-               ((long) memory[index + 4] & 0xff) << 24 |
-               ((long) memory[index + 5] & 0xff) << 16 |
-               ((long) memory[index + 6] & 0xff) <<  8 |
-                (long) memory[index + 7] & 0xff;
+        return HeapByteBufUtil.getLong(memory, idx(index));
     }
 
     @Override
@@ -151,44 +135,27 @@ class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
 
     @Override
     protected void _setByte(int index, int value) {
-        memory[idx(index)] = (byte) value;
+        HeapByteBufUtil.setByte(memory, idx(index), value);
     }
 
     @Override
     protected void _setShort(int index, int value) {
-        index = idx(index);
-        memory[index]     = (byte) (value >>> 8);
-        memory[index + 1] = (byte) value;
+        HeapByteBufUtil.setShort(memory, idx(index), value);
     }
 
     @Override
     protected void _setMedium(int index, int   value) {
-        index = idx(index);
-        memory[index]     = (byte) (value >>> 16);
-        memory[index + 1] = (byte) (value >>> 8);
-        memory[index + 2] = (byte) value;
+        HeapByteBufUtil.setMedium(memory, idx(index), value);
     }
 
     @Override
     protected void _setInt(int index, int   value) {
-        index = idx(index);
-        memory[index]     = (byte) (value >>> 24);
-        memory[index + 1] = (byte) (value >>> 16);
-        memory[index + 2] = (byte) (value >>> 8);
-        memory[index + 3] = (byte) value;
+        HeapByteBufUtil.setInt(memory, idx(index), value);
     }
 
     @Override
     protected void _setLong(int index, long  value) {
-        index = idx(index);
-        memory[index]     = (byte) (value >>> 56);
-        memory[index + 1] = (byte) (value >>> 48);
-        memory[index + 2] = (byte) (value >>> 40);
-        memory[index + 3] = (byte) (value >>> 32);
-        memory[index + 4] = (byte) (value >>> 24);
-        memory[index + 5] = (byte) (value >>> 16);
-        memory[index + 6] = (byte) (value >>> 8);
-        memory[index + 7] = (byte) value;
+        HeapByteBufUtil.setLong(memory, idx(index), value);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -289,7 +289,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected byte _getByte(int index) {
-        return array[index];
+        return HeapByteBufUtil.getByte(array, index);
     }
 
     @Override
@@ -300,7 +300,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected short _getShort(int index) {
-        return (short) (array[index] << 8 | array[index + 1] & 0xFF);
+        return HeapByteBufUtil.getShort(array, index);
     }
 
     @Override
@@ -311,9 +311,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected int _getUnsignedMedium(int index) {
-        return  (array[index]     & 0xff) << 16 |
-                (array[index + 1] & 0xff) <<  8 |
-                 array[index + 2] & 0xff;
+        return HeapByteBufUtil.getUnsignedMedium(array, index);
     }
 
     @Override
@@ -324,10 +322,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected int _getInt(int index) {
-        return  (array[index]     & 0xff) << 24 |
-                (array[index + 1] & 0xff) << 16 |
-                (array[index + 2] & 0xff) <<  8 |
-                 array[index + 3] & 0xff;
+        return HeapByteBufUtil.getInt(array, index);
     }
 
     @Override
@@ -338,14 +333,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected long _getLong(int index) {
-        return  ((long) array[index]     & 0xff) << 56 |
-                ((long) array[index + 1] & 0xff) << 48 |
-                ((long) array[index + 2] & 0xff) << 40 |
-                ((long) array[index + 3] & 0xff) << 32 |
-                ((long) array[index + 4] & 0xff) << 24 |
-                ((long) array[index + 5] & 0xff) << 16 |
-                ((long) array[index + 6] & 0xff) <<  8 |
-                 (long) array[index + 7] & 0xff;
+        return HeapByteBufUtil.getLong(array, index);
     }
 
     @Override
@@ -357,7 +345,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected void _setByte(int index, int value) {
-        array[index] = (byte) value;
+        HeapByteBufUtil.setByte(array, index, value);
     }
 
     @Override
@@ -369,8 +357,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected void _setShort(int index, int value) {
-        array[index]     = (byte) (value >>> 8);
-        array[index + 1] = (byte) value;
+        HeapByteBufUtil.setShort(array, index, value);
     }
 
     @Override
@@ -382,9 +369,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected void _setMedium(int index, int value) {
-        array[index]     = (byte) (value >>> 16);
-        array[index + 1] = (byte) (value >>> 8);
-        array[index + 2] = (byte) value;
+        HeapByteBufUtil.setMedium(array, index, value);
     }
 
     @Override
@@ -396,10 +381,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected void _setInt(int index, int value) {
-        array[index]     = (byte) (value >>> 24);
-        array[index + 1] = (byte) (value >>> 16);
-        array[index + 2] = (byte) (value >>> 8);
-        array[index + 3] = (byte) value;
+        HeapByteBufUtil.setInt(array, index, value);
     }
 
     @Override
@@ -411,14 +393,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected void _setLong(int index, long value) {
-        array[index]     = (byte) (value >>> 56);
-        array[index + 1] = (byte) (value >>> 48);
-        array[index + 2] = (byte) (value >>> 40);
-        array[index + 3] = (byte) (value >>> 32);
-        array[index + 4] = (byte) (value >>> 24);
-        array[index + 5] = (byte) (value >>> 16);
-        array[index + 6] = (byte) (value >>> 8);
-        array[index + 7] = (byte) value;
+        HeapByteBufUtil.setLong(array, index, value);
     }
 
     @Override


### PR DESCRIPTION
Motiviation:

We have a lot of duplicated code which makes it hard to maintain.

Modification:

Move shared code to HeapByteBufUtil and use it in the implementations.

Result:

Less duplicated code and so easier to maintain.