### PR TITLE
[#4355] OpenSslServerContext reinitializes the provided TrustManagerF…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -367,16 +367,13 @@ public final class OpenSslServerContext extends OpenSslContext {
                     throw new SSLException("failed to set certificate: " + keyCertChainFile + " and " + keyFile, e);
                 }
                 try {
-                    if (trustManagerFactory == null) {
+                    if (trustCertChainFile != null) {
+                        trustManagerFactory = buildTrustManagerFactory(trustCertChainFile, trustManagerFactory);
+                    } else if (trustManagerFactory == null) {
                         // Mimic the way SSLContext.getInstance(KeyManager[], null, null) works
                         trustManagerFactory = TrustManagerFactory.getInstance(
                                 TrustManagerFactory.getDefaultAlgorithm());
-                    }
-                    if (trustCertChainFile != null) {
-                        trustManagerFactory = buildTrustManagerFactory(trustCertChainFile, trustManagerFactory);
-                    } else {
-                        KeyStore ks = buildKeyStore(keyCertChainFile, keyFile, keyPassword);
-                        trustManagerFactory.init(ks);
+                        trustManagerFactory.init((KeyStore) null);
                     }
 
                     final X509TrustManager manager = chooseTrustManager(trustManagerFactory.getTrustManagers());
@@ -484,16 +481,13 @@ public final class OpenSslServerContext extends OpenSslContext {
                     }
                 }
                 try {
-                    if (trustManagerFactory == null) {
+                    if (trustCertChain != null) {
+                        trustManagerFactory = buildTrustManagerFactory(trustCertChain, trustManagerFactory);
+                    } else if (trustManagerFactory == null) {
                         // Mimic the way SSLContext.getInstance(KeyManager[], null, null) works
                         trustManagerFactory = TrustManagerFactory.getInstance(
                                 TrustManagerFactory.getDefaultAlgorithm());
-                    }
-                    if (trustCertChain != null) {
-                        trustManagerFactory = buildTrustManagerFactory(trustCertChain, trustManagerFactory);
-                    } else {
-                        KeyStore ks = buildKeyStore(keyCertChain, key, keyPassword.toCharArray());
-                        trustManagerFactory.init(ks);
+                        trustManagerFactory.init((KeyStore) null);
                     }
 
                     final X509TrustManager manager = chooseTrustManager(trustManagerFactory.getTrustManagers());


### PR DESCRIPTION
…actory with the key cert chain.

Motivation:

OpenSslServerContext should not reinitialize the provided TrustManagerFactory with the key cert chain as the user should be able to pass a fully initialized TrustManagerFactory. This is also in line with how JdkSslServerContext works.

Modifications:

Not reinitialize the provided TrustManagerFactory with the key cert chain.

Result:

Correct and consistent behavior.