### PR TITLE
[#4198] Fix race-condition when allocate from multiple-thread.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -183,8 +183,8 @@ abstract class PoolArena<T> implements PoolArenaMetric {
             final PoolSubpage<T> head = table[tableIdx];
 
             /**
-             * Synchronize on the head. This is needed as {@link PoolSubpage#allocate()} and
-             * {@link PoolSubpage#free(int)} may modify the doubly linked list as well.
+             * Synchronize on the head. This is needed as {@link PoolChunk#allocateSubpage(int)} and
+             * {@link PoolChunk#free(long)} may modify the doubly linked list as well.
              */
             synchronized (head) {
                 final PoolSubpage<T> s = head.next;

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer;
+
+import io.netty.util.internal.SystemPropertyUtil;
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class PooledByteBufAllocatorTest {
+
+    private static final int[] ALLOCATION_SIZES = new int[16 * 1024];
+    static {
+        for (int i = 0; i < ALLOCATION_SIZES.length; i++) {
+            ALLOCATION_SIZES[i] = i;
+        }
+    }
+
+    @Test
+    public void testConcurrentUsage() throws Throwable {
+        long runningTime = TimeUnit.MILLISECONDS.toNanos(SystemPropertyUtil.getLong(
+                "io.netty.buffer.PooledByteBufAllocatorTest.testConcurrentUsageTime", 15000));
+
+        // We use no caches and only one arena to maximize the chance of hitting the race-condition we
+        // had before.
+        ByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 1, 8192, 11, 0, 0, 0);
+        List<AllocationThread> threads = new ArrayList<AllocationThread>();
+        try {
+            for (int i = 0; i < 512; i++) {
+                AllocationThread thread = new AllocationThread(allocator);
+                thread.start();
+                threads.add(thread);
+            }
+
+            long start = System.nanoTime();
+            while (!isExpired(start, runningTime)) {
+                checkForErrors(threads);
+                Thread.sleep(100);
+            }
+        } finally {
+            for (AllocationThread t : threads) {
+                t.finish();
+            }
+        }
+    }
+
+    private static boolean isExpired(long start, long expireTime) {
+        return System.nanoTime() - start > expireTime;
+    }
+
+    private static void checkForErrors(List<AllocationThread> threads) throws Throwable {
+        for (AllocationThread t : threads) {
+            if (t.isFinished()) {
+                t.checkForError();
+            }
+        }
+    }
+
+    private static final class AllocationThread extends Thread {
+        private final CountDownLatch latch = new CountDownLatch(1);
+        private final Queue<ByteBuf> buffers = new ArrayDeque<ByteBuf>(10);
+        private final ByteBufAllocator allocator;
+        private volatile boolean finished;
+        private volatile Throwable error;
+
+        public AllocationThread(ByteBufAllocator allocator) {
+            this.allocator = allocator;
+        }
+
+        @Override
+        public void run() {
+            try {
+                int idx = 0;
+                while (!finished) {
+                    for (int i = 0; i < 10; i++) {
+                        buffers.add(allocator.directBuffer(
+                                ALLOCATION_SIZES[Math.abs(idx++ % ALLOCATION_SIZES.length)],
+                                Integer.MAX_VALUE));
+                    }
+                    releaseBuffers();
+                }
+            } catch (Throwable cause) {
+                error = cause;
+                finished = true;
+            } finally {
+                releaseBuffers();
+            }
+            latch.countDown();
+        }
+
+        private void releaseBuffers() {
+            for (;;) {
+                ByteBuf buf = buffers.poll();
+                if (buf == null) {
+                    break;
+                }
+                buf.release();
+            }
+        }
+
+        public boolean isFinished() {
+            return finished;
+        }
+
+        public void finish() throws Throwable {
+            try {
+                finished = true;
+                latch.await();
+                checkForError();
+            } finally {
+                releaseBuffers();
+            }
+        }
+
+        public void checkForError() throws Throwable {
+            if (error != null) {
+                throw error;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

Fix a race condition that was introduced by f18990a8a507d52fc40416d169db340105b10ec0 that could lead to a NPE when allocate from the PooledByteBufAllocator concurrently by many threads.

Modifications:

Correctly synchronize on the PoolSubPage head.

Result:

No more race.