### PR TITLE
Small perf improvements around read/write channel calls.

### DIFF
--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -40,6 +40,7 @@ public final class ResourceLeakDetector<T> {
     private static final String PROP_MAX_RECORDS = "io.netty.leakDetection.maxRecords";
     private static final int DEFAULT_MAX_RECORDS = 4;
     private static final int MAX_RECORDS;
+    public static final boolean ENABLED;
 
     /**
      * Represents the level of resource leak detection.
@@ -83,6 +84,7 @@ public final class ResourceLeakDetector<T> {
         }
 
         Level defaultLevel = disabled? Level.DISABLED : DEFAULT_LEVEL;
+        ENABLED = !disabled;
 
         // First read old property name
         String levelStr = SystemPropertyUtil.get(PROP_LEVEL_OLD, defaultLevel.name()).trim().toUpperCase();
@@ -119,7 +121,7 @@ public final class ResourceLeakDetector<T> {
      * Returns {@code true} if resource leak detection is enabled.
      */
     public static boolean isEnabled() {
-        return getLevel().ordinal() > Level.DISABLED.ordinal();
+        return ENABLED;
     }
 
     /**

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -40,7 +40,7 @@ public final class ResourceLeakDetector<T> {
     private static final String PROP_MAX_RECORDS = "io.netty.leakDetection.maxRecords";
     private static final int DEFAULT_MAX_RECORDS = 4;
     private static final int MAX_RECORDS;
-    public static final boolean ENABLED;
+    public static boolean ENABLED;
 
     /**
      * Represents the level of resource leak detection.
@@ -131,6 +131,8 @@ public final class ResourceLeakDetector<T> {
         if (level == null) {
             throw new NullPointerException("level");
         }
+        
+        ResourceLeakDetector.ENABLED = (level != Level.DISABLED);
         ResourceLeakDetector.level = level;
     }
 

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -16,10 +16,7 @@
 package io.netty.channel;
 
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.util.Attribute;
-import io.netty.util.AttributeKey;
-import io.netty.util.ReferenceCountUtil;
-import io.netty.util.ResourceLeakHint;
+import io.netty.util.*;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.internal.StringUtil;
 
@@ -153,7 +150,10 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     @Override
     public ChannelHandlerContext fireChannelRead(Object msg) {
         AbstractChannelHandlerContext next = findContextInbound();
-        ReferenceCountUtil.touch(msg, next);
+        if (ResourceLeakDetector.ENABLED) {
+            ReferenceCountUtil.touch(msg, next);
+        }
+
         next.invoker().invokeChannelRead(next, msg);
         return this;
     }
@@ -261,7 +261,10 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     @Override
     public ChannelFuture write(Object msg, ChannelPromise promise) {
         AbstractChannelHandlerContext next = findContextOutbound();
-        ReferenceCountUtil.touch(msg, next);
+        if (ResourceLeakDetector.ENABLED) {
+            ReferenceCountUtil.touch(msg, next);
+        }
+
         next.invoker().invokeWrite(next, msg, promise);
         return promise;
     }
@@ -276,7 +279,10 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     @Override
     public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
         AbstractChannelHandlerContext next = findContextOutbound();
-        ReferenceCountUtil.touch(msg, next);
+        if (ResourceLeakDetector.ENABLED) {
+            ReferenceCountUtil.touch(msg, next);
+        }
+
         ChannelHandlerInvoker invoker = next.invoker();
         invoker.invokeWrite(next, msg, promise);
         invoker.invokeFlush(next);


### PR DESCRIPTION
Motivation:

ReferenceCountUtil.touch is listed as hot spot when profiling, probably because of the "instanceof" call.

Modifications:

Use an inlined condition to check if leak detector is enabled before calling .touch

Result:

Small perf improvements around read/write channel calls, getting .touch out of the hot spots.