### PR TITLE
[#4333]  Re-add PooledSlicedByteBuf and DuplicatedByteBuf

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractDerivedByteBuf.java
@@ -47,12 +47,20 @@ public abstract class AbstractDerivedByteBuf extends AbstractByteBuf {
 
     @Override
     public final boolean release() {
-        return unwrap().release();
+        if (unwrap().release()) {
+            deallocate();
+            return true;
+        }
+        return false;
     }
 
     @Override
     public final boolean release(int decrement) {
-        return unwrap().release(decrement);
+        if (unwrap().release(decrement)) {
+            deallocate();
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -64,4 +72,6 @@ public abstract class AbstractDerivedByteBuf extends AbstractByteBuf {
     public ByteBuffer nioBuffer(int index, int length) {
         return unwrap().nioBuffer(index, length);
     }
+
+    protected void deallocate() { }
 }

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -1207,6 +1207,18 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract ByteBuf readSlice(int length);
 
     /**
+     * Returns a new slice of this buffer's sub-region starting at the current
+     * {@code readerIndex} and increases the {@code readerIndex} by the size
+     * of the new slice (= {@code length}).
+     * <p>
+     * If {@code retain} is {@code true} this implementation will call {@link #retain()} and so the
+     * reference count will be increased.
+     */
+    public ByteBuf readSlice(int length, boolean retain) {
+        return retain ? readSlice(length).retain() : readSlice(length);
+    }
+
+    /**
      * Transfers this buffer's data to the specified destination starting at
      * the current {@code readerIndex} until the destination becomes
      * non-writable, and increases the {@code readerIndex} by the number of the
@@ -1673,6 +1685,21 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract ByteBuf slice();
 
     /**
+     * Returns a slice of this buffer's readable bytes. Modifying the content
+     * of the returned buffer or this buffer affects each other's content
+     * while they maintain separate indexes and marks.  This method is
+     * identical to {@code buf.slice(buf.readerIndex(), buf.readableBytes())}.
+     * This method does not modify {@code readerIndex} or {@code writerIndex} of
+     * this buffer.
+     * <p>
+     * If {@code retain} is {@code true} this implementation will call {@link #retain()} and so the
+     * reference count will be increased.
+     */
+    public ByteBuf slice(boolean retain) {
+        return retain ? slice().retain() : slice();
+    }
+
+    /**
      * Returns a slice of this buffer's sub-region. Modifying the content of
      * the returned buffer or this buffer affects each other's content while
      * they maintain separate indexes and marks.
@@ -1683,6 +1710,20 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * reference count will NOT be increased.
      */
     public abstract ByteBuf slice(int index, int length);
+
+    /**
+     * Returns a slice of this buffer's sub-region. Modifying the content of
+     * the returned buffer or this buffer affects each other's content while
+     * they maintain separate indexes and marks.
+     * This method does not modify {@code readerIndex} or {@code writerIndex} of
+     * this buffer.
+     * <p>
+     * If {@code retain} is {@code true} this implementation will call {@link #retain()} and so the
+     * reference count will be increased.
+     */
+    public ByteBuf slice(int index, int length, boolean retain) {
+        return retain ? slice(index, length).retain() : slice(index, length);
+    }
 
     /**
      * Returns a buffer which shares the whole region of this buffer.
@@ -1696,6 +1737,21 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * NOT call {@link #retain()} and so the reference count will NOT be increased.
      */
     public abstract ByteBuf duplicate();
+
+    /**
+     * Returns a buffer which shares the whole region of this buffer.
+     * Modifying the content of the returned buffer or this buffer affects
+     * each other's content while they maintain separate indexes and marks.
+     * This method is identical to {@code buf.slice(0, buf.capacity())}.
+     * This method does not modify {@code readerIndex} or {@code writerIndex} of
+     * this buffer.
+     * <p>
+     * If {@code retain} is {@code true} this implementation will call {@link #retain()} and so the
+     * reference count will be increased.
+     */
+    public ByteBuf duplicate(boolean retain) {
+        return retain ? duplicate().retain() : duplicate();
+    }
 
     /**
      * Returns the maximum number of NIO {@link ByteBuffer}s that consist this buffer.  Note that {@link #nioBuffers()}

--- a/buffer/src/main/java/io/netty/buffer/DuplicatedAbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DuplicatedAbstractByteBuf.java
@@ -19,10 +19,12 @@ package io.netty.buffer;
  * {@link DuplicatedByteBuf} implementation that can do optimizations because it knows the duplicated buffer
  * is of type {@link AbstractByteBuf}.
  */
-final class DuplicatedAbstractByteBuf extends DuplicatedByteBuf {
+class DuplicatedAbstractByteBuf extends DuplicatedByteBuf {
     public DuplicatedAbstractByteBuf(AbstractByteBuf buffer) {
         super(buffer);
     }
+
+    DuplicatedAbstractByteBuf() { }
 
     @Override
     protected byte _getByte(int index) {

--- a/buffer/src/main/java/io/netty/buffer/DuplicatedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DuplicatedByteBuf.java
@@ -31,10 +31,23 @@ import java.nio.channels.ScatteringByteChannel;
  */
 public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
 
-    private final ByteBuf buffer;
+    private ByteBuf buffer;
 
     public DuplicatedByteBuf(ByteBuf buffer) {
         super(buffer.maxCapacity());
+        init(buffer);
+    }
+
+    /**
+     * Special constructor for sub-classes. Be aware that {@link #init(ByteBuf)} needs to be called after
+     * construction.
+     */
+    DuplicatedByteBuf() {
+        super(Integer.MAX_VALUE);
+    }
+
+    final void init(ByteBuf buffer) {
+        maxCapacity(buffer.maxCapacity());
 
         if (buffer instanceof DuplicatedByteBuf) {
             this.buffer = ((DuplicatedByteBuf) buffer).buffer;
@@ -42,7 +55,7 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
             this.buffer = buffer;
         }
 
-        setIndex(buffer.readerIndex(), buffer.writerIndex());
+        setIndex0(buffer.readerIndex(), buffer.writerIndex());
         markReaderIndex();
         markWriterIndex();
     }

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -134,6 +134,28 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
         return null;
     }
 
+    @Override
+    public final ByteBuf duplicate(boolean retain) {
+        return retain ? PooledDuplicatedByteBuf.newInstance(this) : duplicate();
+    }
+
+    @Override
+    public final ByteBuf slice(int index, int length, boolean retain) {
+        return retain ? PooledSlicedByteBuf.newInstance(this, index, length) : slice(index, length);
+    }
+
+    @Override
+    public final ByteBuf slice(boolean retain) {
+        return slice(readerIndex(), readableBytes(), retain);
+    }
+
+    @Override
+    public final ByteBuf readSlice(int length, boolean retain) {
+        ByteBuf slice = slice(readerIndex(), length, retain);
+        readerIndex += length;
+        return slice;
+    }
+
     protected final ByteBuffer internalNioBuffer() {
         ByteBuffer tmpNioBuf = this.tmpNioBuf;
         if (tmpNioBuf == null) {

--- a/buffer/src/main/java/io/netty/buffer/PooledDuplicatedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDuplicatedByteBuf.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.Recycler;
+
+final class PooledDuplicatedByteBuf extends DuplicatedAbstractByteBuf {
+
+    private final Recycler.Handle recyclerHandle;
+
+    private static final Recycler<PooledDuplicatedByteBuf> RECYCLER = new Recycler<PooledDuplicatedByteBuf>() {
+        @Override
+        protected PooledDuplicatedByteBuf newObject(Handle handle) {
+            return new PooledDuplicatedByteBuf(handle);
+        }
+    };
+
+    static PooledDuplicatedByteBuf newInstance(ByteBuf buffer) {
+        PooledDuplicatedByteBuf buf = RECYCLER.get();
+        buf.init(buffer);
+        buffer.retain();
+        return buf;
+    }
+
+    private PooledDuplicatedByteBuf(Recycler.Handle recyclerHandle) {
+        this.recyclerHandle = recyclerHandle;
+    }
+
+    @Override
+    public ByteBuf duplicate(boolean retain) {
+        return retain ? newInstance(this) : duplicate();
+    }
+
+    @Override
+    public ByteBuf slice(int index, int length, boolean retain) {
+        return retain ? PooledSlicedByteBuf.newInstance(this, index, length) : slice(index, length);
+    }
+
+    @Override
+    public ByteBuf slice(boolean retain) {
+        return slice(readerIndex(), readableBytes(), retain);
+    }
+
+    @Override
+    public ByteBuf readSlice(int length, boolean retain) {
+        ByteBuf slice = slice(readerIndex(), length, retain);
+        skipBytes(length);
+        return slice;
+    }
+
+    @Override
+    protected void deallocate() {
+        RECYCLER.recycle(this, recyclerHandle);
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/PooledSlicedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledSlicedByteBuf.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.Recycler;
+
+final class PooledSlicedByteBuf extends SlicedAbstractByteBuf {
+
+    private final Recycler.Handle recyclerHandle;
+
+    private static final Recycler<PooledSlicedByteBuf> RECYCLER = new Recycler<PooledSlicedByteBuf>() {
+        @Override
+        protected PooledSlicedByteBuf newObject(Handle handle) {
+            return new PooledSlicedByteBuf(handle);
+        }
+    };
+
+    static PooledSlicedByteBuf newInstance(ByteBuf buffer, int index, int length) {
+        PooledSlicedByteBuf buf = RECYCLER.get();
+        buf.init(buffer, index, length);
+        buffer.retain();
+        return buf;
+    }
+
+    private PooledSlicedByteBuf(Recycler.Handle recyclerHandle) {
+        this.recyclerHandle = recyclerHandle;
+    }
+
+    @Override
+    public ByteBuf duplicate(boolean retain) {
+        return retain ? PooledDuplicatedByteBuf.newInstance(this) : duplicate();
+    }
+
+    @Override
+    public ByteBuf slice(int index, int length, boolean retain) {
+        return retain ? newInstance(this, index, length) : slice(index, length);
+    }
+
+    @Override
+    public ByteBuf slice(boolean retain) {
+        return slice(readerIndex(), readableBytes(), retain);
+    }
+
+    @Override
+    public ByteBuf readSlice(int length, boolean retain) {
+        ByteBuf slice = slice(readerIndex(), length, retain);
+        skipBytes(length);
+        return slice;
+    }
+
+    @Override
+    protected void deallocate() {
+        RECYCLER.recycle(this, recyclerHandle);
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/SlicedAbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SlicedAbstractByteBuf.java
@@ -19,11 +19,13 @@ package io.netty.buffer;
  * A special {@link SlicedByteBuf} that can make optimizations because it knows the sliced buffer is of type
  * {@link AbstractByteBuf}.
  */
-final class SlicedAbstractByteBuf extends SlicedByteBuf {
+class SlicedAbstractByteBuf extends SlicedByteBuf {
 
     SlicedAbstractByteBuf(AbstractByteBuf buffer, int index, int length) {
         super(buffer, index, length);
     }
+
+    SlicedAbstractByteBuf() { }
 
     @Override
     protected byte _getByte(int index) {

--- a/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
@@ -32,12 +32,24 @@ import java.nio.channels.ScatteringByteChannel;
  */
 public class SlicedByteBuf extends AbstractDerivedByteBuf {
 
-    private final ByteBuf buffer;
-    private final int adjustment;
-    private final int length;
+    private ByteBuf buffer;
+    private int adjustment;
+    private int length;
 
     public SlicedByteBuf(ByteBuf buffer, int index, int length) {
         super(length);
+        init(buffer, index, length);
+    }
+
+    /**
+     * Special constructor for sub-classes. Be aware that {@link #init(ByteBuf, int, int)} needs to be called after
+     * construction.
+     */
+    SlicedByteBuf() {
+        super(Integer.MAX_VALUE);
+    }
+
+    final void init(ByteBuf buffer, int index, int length) {
         if (index < 0 || index > buffer.capacity() - length) {
             throw new IndexOutOfBoundsException(buffer + ".slice(" + index + ", " + length + ')');
         }
@@ -53,8 +65,8 @@ public class SlicedByteBuf extends AbstractDerivedByteBuf {
             adjustment = index;
         }
         this.length = length;
-
-        writerIndex(length);
+        maxCapacity(length);
+        setIndex0(0, length);
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/PooledDuplicatedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledDuplicatedByteBufTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class PooledDuplicatedByteBufTest extends DuplicateByteBufTest {
+    @Override
+    protected ByteBuf newBuffer(int length) {
+        ByteBuf wrapped = Unpooled.buffer(length);
+        ByteBuf buffer = PooledDuplicatedByteBuf.newInstance(wrapped);
+        assertEquals(wrapped.writerIndex(), buffer.writerIndex());
+        assertEquals(wrapped.readerIndex(), buffer.readerIndex());
+
+        assertEquals(2, buffer.refCnt());
+        assertEquals(2, buffer.unwrap().refCnt());
+        assertFalse(buffer.release());
+        assertEquals(1, buffer.refCnt());
+        assertEquals(1, buffer.unwrap().refCnt());
+        return buffer;
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/PooledSlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledSlicedByteBufTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import static org.junit.Assert.*;
+
+public class PooledSlicedByteBufTest extends SlicedByteBufTest {
+
+    @Override
+    protected ByteBuf newBuffer(int length) {
+        ByteBuf buffer = PooledSlicedByteBuf.newInstance(
+                Unpooled.buffer(length * 2), random.nextInt(length - 1) + 1, length);
+        assertEquals(length, buffer.writerIndex());
+        assertEquals(2, buffer.refCnt());
+        assertEquals(2, buffer.unwrap().refCnt());
+        assertFalse(buffer.release());
+        assertEquals(1, buffer.refCnt());
+        assertEquals(1, buffer.unwrap().refCnt());
+        return buffer;
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.*;
  */
 public class SlicedByteBufTest extends AbstractByteBufTest {
 
-    private final Random random = new Random();
+    final Random random = new Random();
 
     @Override
     protected ByteBuf newBuffer(int length) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -277,7 +277,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 // Keep reading data as a chunk until the end of connection is reached.
                 int toRead = Math.min(buffer.readableBytes(), maxChunkSize);
                 if (toRead > 0) {
-                    ByteBuf content = buffer.readSlice(toRead).retain();
+                    ByteBuf content = buffer.readSlice(toRead, true);
                     out.add(new DefaultHttpContent(content));
                 }
                 return;
@@ -299,7 +299,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 if (toRead > chunkSize) {
                     toRead = (int) chunkSize;
                 }
-                ByteBuf content = buffer.readSlice(toRead).retain();
+                ByteBuf content = buffer.readSlice(toRead, true);
                 chunkSize -= toRead;
 
                 if (chunkSize == 0) {
@@ -339,7 +339,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                 if (toRead == 0) {
                     return;
                 }
-                HttpContent chunk = new DefaultHttpContent(buffer.readSlice(toRead).retain());
+                HttpContent chunk = new DefaultHttpContent(buffer.readSlice(toRead, true));
                 chunkSize -= toRead;
 
                 out.add(chunk);

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
@@ -192,7 +192,7 @@ public class SpdySessionHandler
             if (newWindowSize < 0) {
                 while (spdyDataFrame.content().readableBytes() > initialReceiveWindowSize) {
                     SpdyDataFrame partialDataFrame = new DefaultSpdyDataFrame(streamId,
-                            spdyDataFrame.content().readSlice(initialReceiveWindowSize).retain());
+                            spdyDataFrame.content().readSlice(initialReceiveWindowSize, true));
                     ctx.writeAndFlush(partialDataFrame);
                 }
             }
@@ -499,7 +499,7 @@ public class SpdySessionHandler
 
                 // Create a partial data frame whose length is the current window size
                 SpdyDataFrame partialDataFrame = new DefaultSpdyDataFrame(streamId,
-                        spdyDataFrame.content().readSlice(sendWindowSize).retain());
+                        spdyDataFrame.content().readSlice(sendWindowSize, true));
 
                 // Enqueue the remaining data (will be the first frame queued)
                 spdySession.putPendingWrite(streamId, new SpdySession.PendingWrite(spdyDataFrame, promise));
@@ -780,7 +780,7 @@ public class SpdySessionHandler
 
                 // Create a partial data frame whose length is the current window size
                 SpdyDataFrame partialDataFrame = new DefaultSpdyDataFrame(writeStreamId,
-                        spdyDataFrame.content().readSlice(sendWindowSize).retain());
+                        spdyDataFrame.content().readSlice(sendWindowSize, true));
 
                 // The transfer window size is pre-decremented when sending a data frame downstream.
                 // Close the session on write failures that leave the transfer window in a corrupt state.

--- a/codec/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoder.java
@@ -268,13 +268,13 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoder {
             }
 
             if (stripDelimiter) {
-                frame = buffer.readSlice(minFrameLength);
+                frame = buffer.readSlice(minFrameLength, true);
                 buffer.skipBytes(minDelimLength);
             } else {
-                frame = buffer.readSlice(minFrameLength + minDelimLength);
+                frame = buffer.readSlice(minFrameLength + minDelimLength, true);
             }
 
-            return frame.retain();
+            return frame;
         } else {
             if (!discardingTooLongFrame) {
                 if (buffer.readableBytes() > maxFrameLength) {

--- a/codec/src/main/java/io/netty/handler/codec/FixedLengthFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/FixedLengthFrameDecoder.java
@@ -74,7 +74,7 @@ public class FixedLengthFrameDecoder extends ByteToMessageDecoder {
         if (in.readableBytes() < frameLength) {
             return null;
         } else {
-            return in.readSlice(frameLength).retain();
+            return in.readSlice(frameLength, true);
         }
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -491,7 +491,7 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
      * is overridden to avoid memory copy.
      */
     protected ByteBuf extractFrame(ChannelHandlerContext ctx, ByteBuf buffer, int index, int length) {
-        return buffer.slice(index, length).retain();
+        return buffer.slice(index, length, true);
     }
 
     private void fail(long frameLength) {

--- a/codec/src/main/java/io/netty/handler/codec/LineBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LineBasedFrameDecoder.java
@@ -100,13 +100,13 @@ public class LineBasedFrameDecoder extends ByteToMessageDecoder {
                 }
 
                 if (stripDelimiter) {
-                    frame = buffer.readSlice(length);
+                    frame = buffer.readSlice(length, true);
                     buffer.skipBytes(delimLength);
                 } else {
-                    frame = buffer.readSlice(length + delimLength);
+                    frame = buffer.readSlice(length + delimLength, true);
                 }
 
-                return frame.retain();
+                return frame;
             } else {
                 final int length = buffer.readableBytes();
                 if (length > maxLength) {

--- a/codec/src/main/java/io/netty/handler/codec/compression/SnappyFramedDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/SnappyFramedDecoder.java
@@ -153,7 +153,7 @@ public class SnappyFramedDecoder extends ByteToMessageDecoder {
                     } else {
                         in.skipBytes(4);
                     }
-                    out.add(in.readSlice(chunkLength - 4).retain());
+                    out.add(in.readSlice(chunkLength - 4, true));
                     break;
                 case COMPRESSED_DATA:
                     if (!started) {


### PR DESCRIPTION
Motivation:

Pooling ByteBufs for slice / duplicate operations can miminize object creation a lot. We should try to pool these if possible.

Modifications:

- Add new overloaded operations to ByteBuf that can be used to obtain a retained slice or duplicate. These can be pooled internally as optimization.
- Use optimized version in codecs.

Result:

Less object creation when using PooledByteBufAllocator.