### PR TITLE
Only call ReferenceCountUtil.touch(...) if ResourceLeakDetection was …

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -18,7 +18,6 @@ package io.netty.channel;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
-import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ResourceLeakHint;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.internal.StringUtil;
@@ -153,8 +152,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     @Override
     public ChannelHandlerContext fireChannelRead(Object msg) {
         AbstractChannelHandlerContext next = findContextInbound();
-        ReferenceCountUtil.touch(msg, next);
-        next.invoker().invokeChannelRead(next, msg);
+        next.invoker().invokeChannelRead(next, pipeline.touch(msg, next));
         return this;
     }
 
@@ -261,8 +259,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     @Override
     public ChannelFuture write(Object msg, ChannelPromise promise) {
         AbstractChannelHandlerContext next = findContextOutbound();
-        ReferenceCountUtil.touch(msg, next);
-        next.invoker().invokeWrite(next, msg, promise);
+        next.invoker().invokeWrite(next, pipeline.touch(msg, next), promise);
         return promise;
     }
 
@@ -276,9 +273,8 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     @Override
     public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
         AbstractChannelHandlerContext next = findContextOutbound();
-        ReferenceCountUtil.touch(msg, next);
         ChannelHandlerInvoker invoker = next.invoker();
-        invoker.invokeWrite(next, msg, promise);
+        invoker.invokeWrite(next, pipeline.touch(msg, next) , promise);
         invoker.invokeFlush(next);
         return promise;
     }

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -17,6 +17,7 @@ package io.netty.channel;
 
 import io.netty.channel.Channel.Unsafe;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ResourceLeakDetector;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.internal.OneTimeTask;
@@ -63,6 +64,7 @@ final class DefaultChannelPipeline implements ChannelPipeline {
 
     private final Map<String, AbstractChannelHandlerContext> name2ctx =
         new HashMap<String, AbstractChannelHandlerContext>(4);
+    private final boolean touch = ResourceLeakDetector.isEnabled();
 
     /**
      * @see #findInvoker(EventExecutorGroup)
@@ -80,6 +82,10 @@ final class DefaultChannelPipeline implements ChannelPipeline {
 
         head.next = tail;
         tail.prev = head;
+    }
+
+    Object touch(Object msg, AbstractChannelHandlerContext next) {
+        return touch ? ReferenceCountUtil.touch(msg, next) : msg;
     }
 
     @Override


### PR DESCRIPTION
…enabled when Channel was created.

Motivation:

We should only call ReferenceCountUtil.touch(...) if needed as otherwise we pay the overhead of instanceof and cast
everytime.

Modifications:

Add boolean flag which indicates if touch(...) should be called.

Result:

Less overhead when leak detection is not enabled.