### PR TITLE
Remove synchronization overhead on generateName.

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -19,6 +19,7 @@ import io.netty.channel.Channel.Unsafe;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.OneTimeTask;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
@@ -46,15 +47,13 @@ final class DefaultChannelPipeline implements ChannelPipeline {
 
     static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultChannelPipeline.class);
 
-    @SuppressWarnings("unchecked")
-    private static final WeakHashMap<Class<?>, String>[] nameCaches =
-            new WeakHashMap[Runtime.getRuntime().availableProcessors()];
-
-    static {
-        for (int i = 0; i < nameCaches.length; i ++) {
-            nameCaches[i] = new WeakHashMap<Class<?>, String>();
+    private static final FastThreadLocal<Map<Class<?>, String>> nameCaches =
+            new FastThreadLocal<Map<Class<?>, String>>() {
+        @Override
+        protected Map<Class<?>, String> initialValue() throws Exception {
+            return new WeakHashMap<Class<?>, String>();
         }
-    }
+    };
 
     final AbstractChannel channel;
 
@@ -360,15 +359,12 @@ final class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     String generateName(ChannelHandler handler) {
-        WeakHashMap<Class<?>, String> cache = nameCaches[(int) (Thread.currentThread().getId() % nameCaches.length)];
+        Map<Class<?>, String> cache = nameCaches.get();
         Class<?> handlerType = handler.getClass();
-        String name;
-        synchronized (cache) {
-            name = cache.get(handlerType);
-            if (name == null) {
-                name = generateName0(handlerType);
-                cache.put(handlerType, name);
-            }
+        String name = cache.get(handlerType);
+        if (name == null) {
+            name = generateName0(handlerType);
+            cache.put(handlerType, name);
         }
 
         synchronized (this) {


### PR DESCRIPTION
Motivation:

Changing the chache of generated names to use a cache per thread. This will remove the bottleneck when many eventloops are used and names need to generate.

Modifications:

Use a FastThreadLocal to store the cached names.

Result:

Less locking between threads.