### PR TITLE
Fix build error on OSX.

### DIFF
--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -68,7 +68,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
       <version>${project.version}</version>
-      <classifier>${epoll.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1196,11 +1196,11 @@
           <archive>
             <manifestEntries>
               <Bundle-ManifestVersion>2</Bundle-ManifestVersion>
-              <Bundle-Name>${name}</Bundle-Name>
-              <Bundle-SymbolicName>${groupId}.${artifactId}.source</Bundle-SymbolicName>
-              <Bundle-Vendor>${organization.name}</Bundle-Vendor>
+              <Bundle-Name>${project.name}</Bundle-Name>
+              <Bundle-SymbolicName>${project.groupId}.${project.artifactId}.source</Bundle-SymbolicName>
+              <Bundle-Vendor>${project.organization.name}</Bundle-Vendor>
               <Bundle-Version>${parsedVersion.osgiVersion}</Bundle-Version>
-              <Eclipse-SourceBundle>${groupId}.${artifactId};version="${parsedVersion.osgiVersion}";roots:="."</Eclipse-SourceBundle>
+              <Eclipse-SourceBundle>${project.groupId}.${project.artifactId};version="${parsedVersion.osgiVersion}";roots:="."</Eclipse-SourceBundle>
             </manifestEntries>
           </archive>
         </configuration>


### PR DESCRIPTION
Motivation:

The build fails on OSX, due to it trying to pull in an epoll specific OSX dependency. See #4409.

Modifications:

Not sure. Removed a classifier tag, so that it would no longer pull in an OSX specific artifact, but a "general" dummy artifact?

Result:

Build succeeds.