### PR TITLE
Exclude native transport related test and dependency when not running…

### DIFF
--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -45,6 +45,26 @@
       <properties>
         <epoll.arch>${os.detected.arch}</epoll.arch>
       </properties>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
+          <classifier>${epoll.classifier}</classifier>
+        </dependency>
+      </dependencies>
+      <build>
+      	<plugins>
+      	  <plugin>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                  <includes>
+                      <include>**/*.java</include>
+                  </includes>
+               </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 
@@ -63,12 +83,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-http2</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${project.version}</version>
-      <classifier>${epoll.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -95,8 +109,15 @@
 
   <build>
     <plugins>
+  	  <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/Http2FrameWriterBenchmark.java</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <testSourceDirectory>${project.build.sourceDirectory}</testSourceDirectory>


### PR DESCRIPTION
… under Linux, close #4409

Motivation:

The build fails on OSX, due to it trying to pull in an epoll specific OSX dependency. See #4409.

Modifications:

* move netty-transport-native-epoll to linux profile
* exclude Http2FrameWriterBenchmark from compiler
* include Http2FrameWriterBenchmark back only in linux profile (please check)

Result:

Build succeeds on OSX.