### PR TITLE
Http2ConnectionHandler.BaseBuilder exception cleanup

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -191,6 +191,8 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             Http2ConnectionEncoder encoder = new DefaultHttp2ConnectionEncoder(connection, writer);
             if (encoderEnforceMaxConcurrentStreams) {
                 if (connection.isServer()) {
+                    encoder.close();
+                    reader.close();
                     throw new IllegalArgumentException(
                             "encoderEnforceMaxConcurrentStreams: " + encoderEnforceMaxConcurrentStreams +
                             " not supported for server");
@@ -210,8 +212,15 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
          * {@link #encoderEnforceMaxConcurrentStreams(boolean)} (int)}</li></ul>
          */
         public final T build(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder) {
-            // Call the abstract build method
-            T handler = build0(decoder, encoder);
+            final T handler;
+            try {
+                // Call the abstract build method
+                handler = build0(decoder, encoder);
+            } catch (RuntimeException e) {
+                encoder.close();
+                decoder.close();
+                throw e;
+            }
 
             // Setup post build options
             handler.gracefulShutdownTimeoutMillis(gracefulShutdownTimeoutMillis);


### PR DESCRIPTION
Motivation:
Http2ConnectionHandler.BaseBuilder is constructing objects which have 'close' methods, but is not calling these methods in the event of an exception.

Modifications:
- Objects which implement 'close' should have this method called if an exception is thrown and the build operation can not complete normally.

Result:
Objects are closed even if the build process encounters an error.