### PR TITLE
PriorityStreamByteDistributor distribute reentry

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -64,6 +64,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
                                             StreamByteDistributor streamByteDistributor) {
         this.connection = checkNotNull(connection, "connection");
         this.streamByteDistributor = checkNotNull(streamByteDistributor, "streamWriteDistributor");
+        streamByteDistributor.writer(writer);
 
         // Add a flow state for the connection.
         stateKey = connection.newKey();
@@ -283,7 +284,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
         // bytesToWrite or not. This ensures that zero-length frames will always be written.
         do {
             // Distribute the connection window across the streams and write the data.
-            haveUnwrittenBytes = streamByteDistributor.distribute(bytesToWrite, writer);
+            haveUnwrittenBytes = streamByteDistributor.distribute(bytesToWrite);
         } while (haveUnwrittenBytes && (bytesToWrite = writableBytes()) > 0 && ctx.channel().isWritable());
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamByteDistributor.java
@@ -66,6 +66,12 @@ public interface StreamByteDistributor {
     void updateStreamableBytes(StreamState state);
 
     /**
+     * Set the object which is to be used during the {@link #distribute(int)} operations.
+     * @param writer Used to actually write the bytes after they are distributed.
+     */
+    void writer(Writer writer);
+
+    /**
      * Distributes up to {@code maxBytes} to those streams containing streamable bytes and
      * iterates across those streams to write the appropriate bytes. Criteria for
      * traversing streams is undefined and it is up to the implementation to determine when to stop
@@ -79,5 +85,5 @@ public interface StreamByteDistributor {
      * @return {@code true} if there are still streamable bytes that have not yet been written,
      * otherwise {@code false}.
      */
-    boolean distribute(int maxBytes, Writer writer);
+    boolean distribute(int maxBytes) throws Http2Exception;
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/PriorityStreamByteDistributorTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/PriorityStreamByteDistributorTest.java
@@ -69,6 +69,7 @@ public class PriorityStreamByteDistributorTest {
 
         connection = new DefaultHttp2Connection(false);
         distributor = new PriorityStreamByteDistributor(connection);
+        distributor.writer(writer);
 
         // Assume we always write all the allocated bytes.
         doAnswer(new Answer<Void>() {
@@ -91,7 +92,7 @@ public class PriorityStreamByteDistributorTest {
     }
 
     @Test
-    public void bytesUnassignedAfterProcessing() {
+    public void bytesUnassignedAfterProcessing() throws Http2Exception {
         updateStream(STREAM_A, 1, true);
         updateStream(STREAM_B, 2, true);
         updateStream(STREAM_C, 3, true);
@@ -111,7 +112,7 @@ public class PriorityStreamByteDistributorTest {
     }
 
     @Test
-    public void bytesUnassignedAfterProcessingWithException() {
+    public void bytesUnassignedAfterProcessingWithException() throws Http2Exception {
         updateStream(STREAM_A, 1, true);
         updateStream(STREAM_B, 2, true);
         updateStream(STREAM_C, 3, true);
@@ -123,8 +124,8 @@ public class PriorityStreamByteDistributorTest {
         try {
             write(10);
             fail("Expected an exception");
-        } catch (RuntimeException e) {
-            assertSame(fakeException, e);
+        } catch (Http2Exception e) {
+            assertSame(fakeException, e.getCause());
         }
 
         verifyWrite(atMost(1), STREAM_A, 1);
@@ -665,8 +666,8 @@ public class PriorityStreamByteDistributorTest {
         return distributor.unallocatedStreamableBytesForTree(stream);
     }
 
-    private boolean write(int numBytes) {
-        return distributor.distribute(numBytes, writer);
+    private boolean write(int numBytes) throws Http2Exception {
+        return distributor.distribute(numBytes);
     }
 
     private void verifyWrite(int streamId, int numBytes) {


### PR DESCRIPTION
Motivation:
PriorityStreamByteDistributor's iterator during distribute keeps state which may get corrupted during reentry.

Modifications:
- Remove the state in PriorityStreamByteDistributor.distribute's allocation process which may cause a reentry issue

Result:
Reentry will now not corrupt state in PriorityStreamByteDistributor.