### PR TITLE
Fix a bug where DefaultPromise.toString() says 'incomplete' when it's done

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -817,12 +817,17 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
         } else if (result == UNCANCELLABLE) {
             buf.append("(uncancellable)");
         } else if (result instanceof CauseHolder) {
-            buf.append("(failure(")
+            buf.append("(failure: ")
                .append(((CauseHolder) result).cause)
+               .append(')');
+        } else if (result != null) {
+            buf.append("(success: ")
+               .append(result)
                .append(')');
         } else {
             buf.append("(incomplete)");
         }
+
         return buf;
     }
 


### PR DESCRIPTION
Motivation:

DefaultPromise.toString() returns 'DefaultPromise(incomplete)' when it's
actually complete with non-null result.

Modifications:

Handle the case where the promise is done and its result is non-null in
toString()

Result:

The String returned by DefaultPromise.toString() is not confusing
anymore.