### PR TITLE
Add HTTP/2 local flow control option for auto refill

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -62,9 +62,9 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         this.encoder = checkNotNull(encoder, "encoder");
         this.requestVerifier = checkNotNull(requestVerifier, "requestVerifier");
         if (connection.local().flowController() == null) {
-            connection.local().flowController(
-                    new DefaultHttp2LocalFlowController(connection, encoder.frameWriter()));
+            connection.local().flowController(new DefaultHttp2LocalFlowController(connection));
         }
+        connection.local().flowController().frameWriter(encoder.frameWriter());
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -198,8 +198,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
             return promise.setFailure(t);
         }
 
-        ChannelFuture future = frameWriter.writePriority(ctx, streamId, streamDependency, weight, exclusive, promise);
-        return future;
+        return frameWriter.writePriority(ctx, streamId, streamDependency, weight, exclusive, promise);
     }
 
     @Override
@@ -222,20 +221,17 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
             return promise.setFailure(e);
         }
 
-        ChannelFuture future = frameWriter.writeSettings(ctx, settings, promise);
-        return future;
+        return frameWriter.writeSettings(ctx, settings, promise);
     }
 
     @Override
     public ChannelFuture writeSettingsAck(ChannelHandlerContext ctx, ChannelPromise promise) {
-        ChannelFuture future = frameWriter.writeSettingsAck(ctx, promise);
-        return future;
+        return frameWriter.writeSettingsAck(ctx, promise);
     }
 
     @Override
     public ChannelFuture writePing(ChannelHandlerContext ctx, boolean ack, ByteBuf data, ChannelPromise promise) {
-        ChannelFuture future = frameWriter.writePing(ctx, ack, data, promise);
-        return future;
+        return frameWriter.writePing(ctx, ack, data, promise);
     }
 
     @Override
@@ -253,8 +249,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
             return promise.setFailure(e);
         }
 
-        ChannelFuture future = frameWriter.writePushPromise(ctx, streamId, promisedStreamId, headers, padding, promise);
-        return future;
+        return frameWriter.writePushPromise(ctx, streamId, promisedStreamId, headers, padding, promise);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -14,14 +14,6 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http2.StreamByteDistributor.Writer;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
-
-import java.util.ArrayDeque;
-import java.util.Deque;
-
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_WINDOW_SIZE;
 import static io.netty.handler.codec.http2.Http2Error.FLOW_CONTROL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
@@ -31,6 +23,14 @@ import static io.netty.handler.codec.http2.Http2Stream.State.IDLE;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http2.StreamByteDistributor.Writer;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 /**
  * Basic implementation of {@link Http2RemoteFlowController}.
@@ -149,7 +149,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
      */
     @Override
     public void channelHandlerContext(ChannelHandlerContext ctx) throws Http2Exception {
-        this.ctx = ctx;
+        this.ctx = checkNotNull(ctx, "ctx");
 
         // Writing the pending bytes will not check writability change and instead a writability change notification
         // to be provided by an explicit call.
@@ -652,7 +652,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
     }
 
     /**
-     * Abstract class which provides common functionality for {@link WritabilityMonitorfoo} implementations.
+     * Abstract class which provides common functionality for writability monitor implementations.
      */
     private abstract class WritabilityMonitor {
         private long totalPendingBytes;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
@@ -295,6 +295,11 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
         }
 
         @Override
+        public Http2LocalFlowController frameWriter(Http2FrameWriter frameWriter) {
+            return flowController.frameWriter(frameWriter);
+        }
+
+        @Override
         public void channelHandlerContext(ChannelHandlerContext ctx) throws Http2Exception {
             flowController.channelHandlerContext(ctx);
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -14,23 +14,6 @@
  */
 package io.netty.handler.codec.http2;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPromise;
-import io.netty.handler.codec.ByteToMessageDecoder;
-import io.netty.handler.codec.http2.Http2Exception.CompositeStreamException;
-import io.netty.handler.codec.http2.Http2Exception.StreamException;
-import io.netty.util.concurrent.ScheduledFuture;
-import io.netty.util.internal.OneTimeTask;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
-
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 import static io.netty.buffer.ByteBufUtil.hexDump;
 import static io.netty.handler.codec.http2.Http2CodecUtil.HTTP_UPGRADE_STREAM_ID;
 import static io.netty.handler.codec.http2.Http2CodecUtil.connectionPrefaceBuf;
@@ -47,6 +30,23 @@ import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.codec.http2.Http2Exception.CompositeStreamException;
+import io.netty.handler.codec.http2.Http2Exception.StreamException;
+import io.netty.util.concurrent.ScheduledFuture;
+import io.netty.util.internal.OneTimeTask;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Provides the default implementation for processing inbound frame events and delegates to a
@@ -738,7 +738,8 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
      * @param cause the exception that was caught
      * @param http2Ex the {@link StreamException} that is embedded in the causality chain.
      */
-    protected void onStreamError(ChannelHandlerContext ctx, Throwable cause, StreamException http2Ex) {
+    protected void onStreamError(ChannelHandlerContext ctx, @SuppressWarnings("unused") Throwable cause,
+                                 StreamException http2Ex) {
         resetStream(ctx, http2Ex.streamId(), http2Ex.error().code(), ctx.newPromise());
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
@@ -20,6 +20,13 @@ import io.netty.buffer.ByteBuf;
  * A {@link Http2FlowController} for controlling the inbound flow of {@code DATA} frames from the remote endpoint.
  */
 public interface Http2LocalFlowController extends Http2FlowController {
+    /**
+     * Sets the writer to be use for sending {@code WINDOW_UPDATE} frames. This must be called before any flow
+     * controlled data is received.
+     *
+     * @param frameWriter the HTTP/2 frame writer.
+     */
+    Http2LocalFlowController frameWriter(Http2FrameWriter frameWriter);
 
     /**
      * Receives an inbound {@code DATA} frame from the remote endpoint and applies flow control policies to it for both
@@ -29,7 +36,6 @@ public interface Http2LocalFlowController extends Http2FlowController {
      * If {@code stream} is {@code null} or closed, flow control should only be applied to the connection window and the
      * bytes are immediately consumed.
      *
-     * @param ctx the context from the handler where the frame was read.
      * @param stream the subject stream for the received frame. The connection stream object must not be used. If {@code
      * stream} is {@code null} or closed, flow control should only be applied to the connection window and the bytes are
      * immediately consumed.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
@@ -90,8 +90,8 @@ public interface Http2RemoteFlowController extends Http2FlowController {
         /**
          * Called to indicate that an error occurred before this object could be completely written.
          * <p>
-         * The {@link Http2RemoteFlowController} will make exactly one call to either {@link #error(Throwable)} or
-         * {@link #writeComplete()}.
+         * The {@link Http2RemoteFlowController} will make exactly one call to either
+         * this method or {@link #writeComplete()}.
          * </p>
          *
          * @param ctx The context to use if any communication needs to occur as a result of the error.
@@ -103,8 +103,8 @@ public interface Http2RemoteFlowController extends Http2FlowController {
         /**
          * Called after this object has been successfully written.
          * <p>
-         * The {@link Http2RemoteFlowController} will make exactly one call to either {@link #error(Throwable)} or
-         * {@link #writeComplete()}.
+         * The {@link Http2RemoteFlowController} will make exactly one call to either
+         * this method or {@link #error(ChannelHandlerContext, Throwable)}.
          * </p>
          */
         void writeComplete();
@@ -116,7 +116,7 @@ public interface Http2RemoteFlowController extends Http2FlowController {
          * the payload is fully written, i.e it's size after the write is 0.
          * <p>
          * When an exception is thrown the {@link Http2RemoteFlowController} will make a call to
-         * {@link #error(Throwable)}.
+         * {@link #error(ChannelHandlerContext, Throwable)}.
          * </p>
          *
          * @param ctx The context to use for writing.

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -296,8 +296,13 @@ public class DataCompressionHttp2Test {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 ChannelPipeline p = ch.pipeline();
+                Http2FrameWriter frameWriter = new DefaultHttp2FrameWriter();
+                serverConnection.remote().flowController(
+                        new DefaultHttp2RemoteFlowController(serverConnection));
+                serverConnection.local().flowController(
+                        new DefaultHttp2LocalFlowController(serverConnection).frameWriter(frameWriter));
                 Http2ConnectionEncoder encoder = new CompressorHttp2ConnectionEncoder(
-                        new DefaultHttp2ConnectionEncoder(serverConnection, new DefaultHttp2FrameWriter()));
+                        new DefaultHttp2ConnectionEncoder(serverConnection, frameWriter));
                 Http2ConnectionDecoder decoder =
                         new DefaultHttp2ConnectionDecoder(serverConnection, encoder, new DefaultHttp2FrameReader());
                 Http2ConnectionHandler connectionHandler = new Http2ConnectionHandler.Builder()
@@ -314,8 +319,14 @@ public class DataCompressionHttp2Test {
             @Override
             protected void initChannel(Channel ch) throws Exception {
                 ChannelPipeline p = ch.pipeline();
+                Http2FrameWriter frameWriter = new DefaultHttp2FrameWriter();
+                clientConnection.remote().flowController(
+                        new DefaultHttp2RemoteFlowController(clientConnection));
+                clientConnection.local().flowController(
+                        new DefaultHttp2LocalFlowController(clientConnection).frameWriter(frameWriter));
                 clientEncoder = new CompressorHttp2ConnectionEncoder(
-                        new DefaultHttp2ConnectionEncoder(clientConnection, new DefaultHttp2FrameWriter()));
+                        new DefaultHttp2ConnectionEncoder(clientConnection, frameWriter));
+
                 Http2ConnectionDecoder decoder =
                         new DefaultHttp2ConnectionDecoder(clientConnection, clientEncoder,
                                 new DefaultHttp2FrameReader());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -221,6 +221,7 @@ public class DefaultHttp2ConnectionDecoderTest {
                 verify(localFlow)
                         .receiveFlowControlledFrame(eq((Http2Stream) null), eq(data), eq(padding), eq(true));
                 verify(localFlow).consumeBytes(eq((Http2Stream) null), eq(processedBytes));
+                verify(localFlow).frameWriter(any(Http2FrameWriter.class));
                 verifyNoMoreInteractions(localFlow);
                 verify(listener, never()).onDataRead(eq(ctx), anyInt(), any(ByteBuf.class), anyInt(), anyBoolean());
             } finally {
@@ -240,6 +241,7 @@ public class DefaultHttp2ConnectionDecoderTest {
             verify(localFlow)
                     .receiveFlowControlledFrame(eq((Http2Stream) null), eq(data), eq(padding), eq(true));
             verify(localFlow).consumeBytes(eq((Http2Stream) null), eq(processedBytes));
+            verify(localFlow).frameWriter(any(Http2FrameWriter.class));
             verifyNoMoreInteractions(localFlow);
 
             // Verify that the event was absorbed and not propagated to the observer.

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -105,6 +105,8 @@ public class StreamBufferingEncoderTest {
                 .thenAnswer(successAnswer());
 
         connection = new DefaultHttp2Connection(false);
+        connection.remote().flowController(new DefaultHttp2RemoteFlowController(connection));
+        connection.local().flowController(new DefaultHttp2LocalFlowController(connection).frameWriter(writer));
 
         DefaultHttp2ConnectionEncoder defaultEncoder =
                 new DefaultHttp2ConnectionEncoder(connection, writer);

--- a/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2LocalFlowController.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2LocalFlowController.java
@@ -19,6 +19,7 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.MAX_INITIAL_WINDOW_SIZ
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http2.Http2Exception;
+import io.netty.handler.codec.http2.Http2FrameWriter;
 import io.netty.handler.codec.http2.Http2LocalFlowController;
 import io.netty.handler.codec.http2.Http2Stream;
 
@@ -67,5 +68,10 @@ public final class NoopHttp2LocalFlowController implements Http2LocalFlowControl
 
     @Override
     public void channelHandlerContext(ChannelHandlerContext ctx) throws Http2Exception {
+    }
+
+    @Override
+    public Http2LocalFlowController frameWriter(Http2FrameWriter frameWriter) {
+        return this;
     }
 }


### PR DESCRIPTION
Motivation:

For many HTTP/2 applications (such as gRPC) it is necessary to autorefill the connection window in order to prevent application-level deadlocking.

Consider an application with 2 streams, A and B.  A receives a stream of messages and the application pops off one message at a time and makes a request on stream B. However, if receiving of data on A has caused the connection window to collapse, B will not be able to receive any data and the application will deadlock.  The only way (currently) to get around this is 1) use multiple connections, or 2) manually refill the connection window.  Both are undesirable and could needlessly complicate the application code.

Modifications:

Add a configuration option to DefaultHttp2LocalFlowController, allowing it to autorefill the connection window.

Result:

Applications can configure HTTP/2 to avoid inter-stream deadlocking.