### PR TITLE
Make HttpHeaders.set(self) a no-op consistently

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -77,15 +77,14 @@ public class DefaultHttpHeaders extends HttpHeaders {
     @Override
     public HttpHeaders set(HttpHeaders headers) {
         if (headers instanceof DefaultHttpHeaders) {
-            if (headers == this) {
-                throw new IllegalArgumentException("can't add to itself.");
-            }
-            clear();
-            DefaultHttpHeaders defaultHttpHeaders = (DefaultHttpHeaders) headers;
-            HeaderEntry e = defaultHttpHeaders.head.after;
-            while (e != defaultHttpHeaders.head) {
-                add(e.key, e.value);
-                e = e.after;
+            if (headers != this) {
+                clear();
+                DefaultHttpHeaders defaultHttpHeaders = (DefaultHttpHeaders) headers;
+                HeaderEntry e = defaultHttpHeaders.head.after;
+                while (e != defaultHttpHeaders.head) {
+                    add(e.key, e.value);
+                    e = e.after;
+                }
             }
             return this;
         } else {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -1617,9 +1617,11 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
         if (headers == null) {
             throw new NullPointerException("headers");
         }
-        clear();
-        for (Map.Entry<String, String> e: headers) {
-            add(e.getKey(), e.getValue());
+        if (headers != this) {
+            clear();
+            for (Map.Entry<String, String> e : headers) {
+                add(e.getKey(), e.getValue());
+            }
         }
         return this;
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
@@ -74,9 +74,12 @@ public class HttpHeadersTest {
         headers.add(headers);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testSetSelf() {
+    @Test
+    public void testSetSelfIsNoOp() {
         HttpHeaders headers = new DefaultHttpHeaders(false);
+        headers.add("some", "thing");
         headers.set(headers);
+        Assert.assertEquals(1, headers.entries().size());
+        Assert.assertEquals("thing", headers.get("some"));
     }
 }


### PR DESCRIPTION
Existing implementations were inconsistently handling this. 

DefaultHttpHeaders would throw
HttpHeaders would unintentionally clear itself but not throw

Fixes #4442