### PR TITLE
Fix memory leak in DefaultHttp2Headers

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -91,6 +91,12 @@ public class DefaultHttp2Headers
     }
 
     @Override
+    public Http2Headers clear() {
+        this.firstNonPseudo = head;
+        return super.clear();
+    }
+
+    @Override
     public Http2Headers method(CharSequence value) {
         set(PseudoHeaderName.METHOD.value(), value);
         return this;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import java.util.Map.Entry;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -72,6 +73,16 @@ public class DefaultHttp2HeadersTest {
         Http2Headers headers = newHeaders();
 
         headers.add(of("Foo"), of("foo"));
+    }
+
+    @Test
+    public void testClearResetsPseudoHeaderDivision() {
+        DefaultHttp2Headers http2Headers = new DefaultHttp2Headers();
+        http2Headers.method("POST");
+        http2Headers.set("some", "value");
+        http2Headers.clear();
+        http2Headers.method("GET");
+        assertEquals(1, http2Headers.names().size());
     }
 
     private static void verifyAllPseudoHeadersPresent(Http2Headers headers) {


### PR DESCRIPTION
Motivation:

Memory leak makes headers non-reusable.

Modifications:

Correctly reset firstNonPseudo header reference

Result:

No leak