### PR TITLE
Make headers.set(self) a no-op instead of throwing

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpHeadersTest.java
@@ -76,9 +76,11 @@ public class HttpHeadersTest {
         headers.add(headers);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testSetSelf() {
+    @Test
+    public void testSetSelfIsNoOp() {
         HttpHeaders headers = new DefaultHttpHeaders(false);
+        headers.add("name", "value");
         headers.set(headers);
+        assertEquals(1, headers.size());
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -539,7 +539,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     public T set(Headers<? extends K, ? extends V, ?> headers) {
         checkNotNull(headers, "headers");
         if (headers == this) {
-            throw new IllegalArgumentException("can't add to itself.");
+            return thisT();
         }
         clear();
         if (headers instanceof DefaultHeaders) {

--- a/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
@@ -390,9 +390,11 @@ public class DefaultHeadersTest {
         headers.add(headers);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testSetSelf() {
+    @Test
+    public void testSetSelfIsNoOp() {
         TestDefaultHeaders headers = newInstance();
+        headers.add("name", "value");
         headers.set(headers);
+        assertEquals(1, headers.size());
     }
 }


### PR DESCRIPTION
Fixes #4446

Make headers.set(self) a no-op instead of throwing. Makes it consistent with setAll

Motivation:

Makes the API contract of headers more consistent and simpler.

Modifications:

If self is passed to set then simply return

Result:

set and setAll will be consistent