### PR TITLE
ApplicationProtocolNegotiationHandler failure behavior

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiationHandler.java
@@ -99,8 +99,7 @@ public abstract class ApplicationProtocolNegotiationHandler extends ChannelInbou
                 String protocol = sslHandler.applicationProtocol();
                 configurePipeline(ctx, protocol != null? protocol : fallbackProtocol);
             } else {
-                logger.warn("{} TLS handshake failed:", ctx.channel(), handshakeEvent.cause());
-                ctx.close();
+                handshakeFailure(ctx, handshakeEvent.cause());
             }
         }
 
@@ -116,6 +115,14 @@ public abstract class ApplicationProtocolNegotiationHandler extends ChannelInbou
      *                 isn't aware of ALPN/NPN extension
      */
     protected abstract void configurePipeline(ChannelHandlerContext ctx, String protocol) throws Exception;
+
+    /**
+     * Invoked on failed initial SSL/TLS handshake.
+     */
+    protected void handshakeFailure(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        logger.warn("{} TLS handshake failed:", ctx.channel(), cause);
+        ctx.close();
+    }
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {


### PR DESCRIPTION
Motivation:
Child classes of ApplicationProtocolNegotiationHandler may want to override the behavior when a handshake failure is detected.

Modifications:
- Provide a method which can be overriden when a handshake failure is detected.

Result:
Child classes can override ApplicationProtocolNegotiationHandler handshake failure behavior.