### PR TITLE
Eliminate SniHandler's direct dependency on SslContext.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -25,14 +25,14 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
 import javax.crypto.Cipher;
 import javax.crypto.EncryptedPrivateKeyInfo;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
@@ -40,6 +40,7 @@ import javax.net.ssl.SSLSessionContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.security.auth.x500.X500Principal;
+
 import java.io.File;
 import java.io.IOException;
 import java.security.InvalidAlgorithmParameterException;
@@ -79,7 +80,7 @@ import java.util.List;
  * ...
  * </pre>
  */
-public abstract class SslContext {
+public abstract class SslContext implements SslHandlerFactory {
     static final CertificateFactory X509_CERT_FACTORY;
     static {
         try {
@@ -824,23 +825,18 @@ public abstract class SslContext {
      */
     public abstract SSLSessionContext sessionContext();
 
-    /**
-     * Creates a new {@link SslHandler}.
-     *
-     * @return a new {@link SslHandler}
-     */
+    @Deprecated
+    @Override
+    public final SslContext sslContext() {
+        return this;
+    }
+
+    @Override
     public final SslHandler newHandler(ByteBufAllocator alloc) {
         return newHandler(newEngine(alloc));
     }
 
-    /**
-     * Creates a new {@link SslHandler} with advisory peer information.
-     *
-     * @param peerHost the non-authoritative name of the host
-     * @param peerPort the non-authoritative port
-     *
-     * @return a new {@link SslHandler}
-     */
+    @Override
     public final SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort) {
         return newHandler(newEngine(alloc, peerHost, peerPort));
     }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandlerFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandlerFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.ssl;
+
+import io.netty.buffer.ByteBufAllocator;
+
+/**
+ * A factory for {@link SslHandler}s.
+ *
+ * @see SslContext
+ * @see SniHandler
+ */
+public interface SslHandlerFactory {
+
+    /**
+     * Returns the {@link SslContext} that is used by this factory.
+     *
+     * @return the {@link SslContext}
+     */
+    SslContext sslContext();
+
+    /**
+     * Creates a new {@link SslHandler}.
+     *
+     * @return a new {@link SslHandler}
+     */
+    SslHandler newHandler(ByteBufAllocator alloc);
+
+    /**
+     * Creates a new {@link SslHandler} with advisory peer information.
+     *
+     * @param peerHost the non-authoritative name of the host
+     * @param peerPort the non-authoritative port
+     *
+     * @return a new {@link SslHandler}
+     */
+    SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort);
+}


### PR DESCRIPTION
Eliminate SniHandler's direct dependency on SslContext.
    
    Motivation
    
    See https://github.com/netty/netty/issues/4470
    
    Modifications
    
    Extracted a new SslHandlerFactory interface from SslContext (which implements it for backwards compatibility) and changed SniHandler's ctor to depend on Mapper<String, SslHandlerFactory> rather than DomainNameMapper<SslContext> which assumes that SNI is a non-dynamic lookup.
    
    Result
    
    The SniHandler no longer depends directly on SslContext nor assumes the mapping is a predefined list. It's now possible to load SslContext instances on-demand and also release any associated resources if a custom SslHandlerFactory is being used.