### PR TITLE
Added writeVoidPromise to reduce GC for Group Channel Writes.

### DIFF
--- a/transport/src/main/java/io/netty/channel/group/ChannelGroup.java
+++ b/transport/src/main/java/io/netty/channel/group/ChannelGroup.java
@@ -121,6 +121,22 @@ public interface ChannelGroup extends Set<Channel>, Comparable<ChannelGroup> {
 
     /**
      * Writes the specified {@code message} to all {@link Channel}s in this
+     * group. If the specified {@code message} is an instance of
+     * {@link ByteBuf}, it is automatically
+     * {@linkplain ByteBuf#duplicate() duplicated} to avoid a race
+     * condition. The same is true for {@link ByteBufHolder}. Please note that this operation is asynchronous as
+     * {@link Channel#write(Object)} is.
+     *
+     * To reduce GC use this method if you are not interested in {@link io.netty.channel.ChannelFuture}. Invoking
+     * this method will flag the {@link Channel} write to use {@link io.netty.channel.VoidChannelPromise} for each
+     * channel in the group.
+     *
+     * @return itself
+     */
+    ChannelGroupFuture writeVoidPromise(Object message);
+
+    /**
+     * Writes the specified {@code message} to all {@link Channel}s in this
      * group that match the given {@link ChannelMatcher}. If the specified {@code message} is an instance of
      * {@link ByteBuf}, it is automatically
      * {@linkplain ByteBuf#duplicate() duplicated} to avoid a race
@@ -131,6 +147,24 @@ public interface ChannelGroup extends Set<Channel>, Comparable<ChannelGroup> {
      *         the operation is done for all channels
      */
     ChannelGroupFuture write(Object message, ChannelMatcher matcher);
+
+
+    /**
+     * Writes the specified {@code message} to all {@link Channel}s in this
+     * group that match the given {@link ChannelMatcher}. If the specified {@code message} is an instance of
+     * {@link ByteBuf}, it is automatically
+     * {@linkplain ByteBuf#duplicate() duplicated} to avoid a race
+     * condition. The same is true for {@link ByteBufHolder}. Please note that this operation is asynchronous as
+     * {@link Channel#write(Object)} is.
+     *
+     * To reduce GC use this method if you are not interested in {@link io.netty.channel.ChannelFuture}. Invoking
+     * this method will flag the {@link Channel} write to use {@link io.netty.channel.VoidChannelPromise} for each
+     * channel in the group.
+     *
+     * @return the {@link ChannelGroupFuture} instance that notifies when
+     *         the operation is done for all channels
+     */
+    ChannelGroupFuture writeVoidPromise(Object message, ChannelMatcher matcher);
 
     /**
      * Flush all {@link Channel}s in this

--- a/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
+++ b/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
@@ -240,6 +240,11 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
         return write(message, ChannelMatchers.all());
     }
 
+    @Override
+    public ChannelGroupFuture writeVoidPromise(Object message) {
+        return writeVoidPromise(message, ChannelMatchers.all());
+    }
+
     // Create a safe duplicate of the message to write it to a channel but not affect other writes.
     // See https://github.com/netty/netty/issues/1461
     private static Object safeDuplicate(Object message) {
@@ -265,6 +270,26 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
         for (Channel c: nonServerChannels.values()) {
             if (matcher.matches(c)) {
                 futures.put(c, c.write(safeDuplicate(message)));
+            }
+        }
+
+        ReferenceCountUtil.release(message);
+        return new DefaultChannelGroupFuture(this, futures, executor);
+    }
+
+    @Override
+    public ChannelGroupFuture writeVoidPromise(Object message, ChannelMatcher matcher) {
+        if (message == null) {
+            throw new NullPointerException("message");
+        }
+        if (matcher == null) {
+            throw new NullPointerException("matcher");
+        }
+
+        Map<Channel, ChannelFuture> futures = new LinkedHashMap<Channel, ChannelFuture>(size());
+        for (Channel c: nonServerChannels.values()) {
+            if (matcher.matches(c)) {
+                futures.put(c, c.write(safeDuplicate(message), c.voidPromise()));
             }
         }
 


### PR DESCRIPTION
Added 2 methods to ChannelGroup & DefaultChannelGroup.

This will reduce GC by allowing voiding of promises to all channels.

Closes #3127.

Took a while learning Github.