### PR TITLE
Add first-class Little Endian support for Int to ByteBuf and descendants

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -349,8 +349,21 @@ public abstract class AbstractByteBuf extends ByteBuf {
     protected abstract short _getShort(int index);
 
     @Override
+    public short getShortLE(int index) {
+        checkIndex(index, 2);
+        return _getShortLE(index);
+    }
+
+    protected abstract short _getShortLE(int index);
+
+    @Override
     public int getUnsignedShort(int index) {
         return getShort(index) & 0xFFFF;
+    }
+
+    @Override
+    public int getUnsignedShortLE(int index) {
+        return getShortLE(index) & 0xFFFF;
     }
 
     @Override
@@ -362,8 +375,25 @@ public abstract class AbstractByteBuf extends ByteBuf {
     protected abstract int _getUnsignedMedium(int index);
 
     @Override
+    public int getUnsignedMediumLE(int index) {
+        checkIndex(index, 3);
+        return _getUnsignedMediumLE(index);
+    }
+
+    protected abstract int _getUnsignedMediumLE(int index);
+
+    @Override
     public int getMedium(int index) {
         int value = getUnsignedMedium(index);
+        if ((value & 0x800000) != 0) {
+            value |= 0xff000000;
+        }
+        return value;
+    }
+
+    @Override
+    public int getMediumLE(int index) {
+        int value = getUnsignedMediumLE(index);
         if ((value & 0x800000) != 0) {
             value |= 0xff000000;
         }
@@ -379,8 +409,21 @@ public abstract class AbstractByteBuf extends ByteBuf {
     protected abstract int _getInt(int index);
 
     @Override
+    public int getIntLE(int index) {
+        checkIndex(index, 4);
+        return _getIntLE(index);
+    }
+
+    protected abstract int _getIntLE(int index);
+
+    @Override
     public long getUnsignedInt(int index) {
         return getInt(index) & 0xFFFFFFFFL;
+    }
+
+    @Override
+    public long getUnsignedIntLE(int index) {
+        return getIntLE(index) & 0xFFFFFFFFL;
     }
 
     @Override
@@ -390,6 +433,14 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     protected abstract long _getLong(int index);
+
+    @Override
+    public long getLongLE(int index) {
+        checkIndex(index, 8);
+        return _getLongLE(index);
+    }
+
+    protected abstract long _getLongLE(int index);
 
     @Override
     public char getChar(int index) {
@@ -450,6 +501,15 @@ public abstract class AbstractByteBuf extends ByteBuf {
     protected abstract void _setShort(int index, int value);
 
     @Override
+    public ByteBuf setShortLE(int index, int value) {
+        checkIndex(index, 2);
+        _setShortLE(index, value);
+        return this;
+    }
+
+    protected abstract void _setShortLE(int index, int value);
+
+    @Override
     public ByteBuf setChar(int index, int value) {
         setShort(index, value);
         return this;
@@ -465,6 +525,15 @@ public abstract class AbstractByteBuf extends ByteBuf {
     protected abstract void _setMedium(int index, int value);
 
     @Override
+    public ByteBuf setMediumLE(int index, int value) {
+        checkIndex(index, 3);
+        _setMediumLE(index, value);
+        return this;
+    }
+
+    protected abstract void _setMediumLE(int index, int value);
+
+    @Override
     public ByteBuf setInt(int index, int value) {
         checkIndex(index, 4);
         _setInt(index, value);
@@ -472,6 +541,15 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     protected abstract void _setInt(int index, int value);
+
+    @Override
+    public ByteBuf setIntLE(int index, int value) {
+        checkIndex(index, 4);
+        _setIntLE(index, value);
+        return this;
+    }
+
+    protected abstract void _setIntLE(int index, int value);
 
     @Override
     public ByteBuf setFloat(int index, float value) {
@@ -487,6 +565,15 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     protected abstract void _setLong(int index, long value);
+
+    @Override
+    public ByteBuf setLongLE(int index, long value) {
+        checkIndex(index, 8);
+        _setLongLE(index, value);
+        return this;
+    }
+
+    protected abstract void _setLongLE(int index, long value);
 
     @Override
     public ByteBuf setDouble(int index, double value) {
@@ -583,13 +670,35 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     @Override
+    public short readShortLE() {
+        checkReadableBytes0(2);
+        short v = _getShortLE(readerIndex);
+        readerIndex += 2;
+        return v;
+    }
+
+    @Override
     public int readUnsignedShort() {
         return readShort() & 0xFFFF;
     }
 
     @Override
+    public int readUnsignedShortLE() {
+        return readShortLE() & 0xFFFF;
+    }
+
+    @Override
     public int readMedium() {
         int value = readUnsignedMedium();
+        if ((value & 0x800000) != 0) {
+            value |= 0xff000000;
+        }
+        return value;
+    }
+
+    @Override
+    public int readMediumLE() {
+        int value = readUnsignedMediumLE();
         if ((value & 0x800000) != 0) {
             value |= 0xff000000;
         }
@@ -605,9 +714,25 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     @Override
+    public int readUnsignedMediumLE() {
+        checkReadableBytes0(3);
+        int v = _getUnsignedMediumLE(readerIndex);
+        readerIndex += 3;
+        return v;
+    }
+
+    @Override
     public int readInt() {
         checkReadableBytes0(4);
         int v = _getInt(readerIndex);
+        readerIndex += 4;
+        return v;
+    }
+
+    @Override
+    public int readIntLE() {
+        checkReadableBytes0(4);
+        int v = _getIntLE(readerIndex);
         readerIndex += 4;
         return v;
     }
@@ -618,9 +743,22 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     @Override
+    public long readUnsignedIntLE() {
+        return readIntLE() & 0xFFFFFFFFL;
+    }
+
+    @Override
     public long readLong() {
         checkReadableBytes0(8);
         long v = _getLong(readerIndex);
+        readerIndex += 8;
+        return v;
+    }
+
+    @Override
+    public long readLongLE() {
+        checkReadableBytes0(8);
+        long v = _getLongLE(readerIndex);
         readerIndex += 8;
         return v;
     }
@@ -757,10 +895,28 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf writeShortLE(int value) {
+        ensureAccessible();
+        ensureWritable0(2);
+        _setShortLE(writerIndex, value);
+        writerIndex += 2;
+        return this;
+    }
+
+    @Override
     public ByteBuf writeMedium(int value) {
         ensureAccessible();
         ensureWritable0(3);
         _setMedium(writerIndex, value);
+        writerIndex += 3;
+        return this;
+    }
+
+    @Override
+    public ByteBuf writeMediumLE(int value) {
+        ensureAccessible();
+        ensureWritable0(3);
+        _setMediumLE(writerIndex, value);
         writerIndex += 3;
         return this;
     }
@@ -775,10 +931,28 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf writeIntLE(int value) {
+        ensureAccessible();
+        ensureWritable0(4);
+        _setIntLE(writerIndex, value);
+        writerIndex += 4;
+        return this;
+    }
+
+    @Override
     public ByteBuf writeLong(long value) {
         ensureAccessible();
         ensureWritable0(8);
         _setLong(writerIndex, value);
+        writerIndex += 8;
+        return this;
+    }
+
+    @Override
+    public ByteBuf writeLongLE(long value) {
+        ensureAccessible();
+        ensureWritable0(8);
+        _setLongLE(writerIndex, value);
         writerIndex += 8;
         return this;
     }

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -262,6 +262,9 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     /**
      * Returns the <a href="http://en.wikipedia.org/wiki/Endianness">endianness</a>
      * of this buffer.
+     *
+     * @deprecated use the Little Endian accessors, e.g. {@code getShortLE}, {@code getIntLE}
+     * instead of creating a buffer with swapped {@code endianness}.
      */
     public abstract ByteOrder order();
 
@@ -272,6 +275,9 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * specified {@code endianness} is identical to this buffer's byte order, this method can
      * return {@code this}.  This method does not modify {@code readerIndex} or {@code writerIndex}
      * of this buffer.
+     *
+     * @deprecated use the Little Endian accessors, e.g. {@code getShortLE}, {@code getIntLE}
+     * instead of creating a buffer with swapped {@code endianness}.
      */
     public abstract ByteBuf order(ByteOrder endianness);
 
@@ -558,6 +564,17 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract short getShort(int index);
 
     /**
+     * Gets a 16-bit short integer at the specified absolute {@code index} in
+     * this buffer in Little Endian Byte Order. This method does not modify
+     * {@code readerIndex} or {@code writerIndex} of this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if the specified {@code index} is less than {@code 0} or
+     *         {@code index + 2} is greater than {@code this.capacity}
+     */
+    public abstract short getShortLE(int index);
+
+    /**
      * Gets an unsigned 16-bit short integer at the specified absolute
      * {@code index} in this buffer.  This method does not modify
      * {@code readerIndex} or {@code writerIndex} of this buffer.
@@ -567,6 +584,18 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         {@code index + 2} is greater than {@code this.capacity}
      */
     public abstract int getUnsignedShort(int index);
+
+    /**
+     * Gets an unsigned 16-bit short integer at the specified absolute
+     * {@code index} in this buffer in Little Endian Byte Order.
+     * This method does not modify {@code readerIndex} or
+     * {@code writerIndex} of this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if the specified {@code index} is less than {@code 0} or
+     *         {@code index + 2} is greater than {@code this.capacity}
+     */
+    public abstract int getUnsignedShortLE(int index);
 
     /**
      * Gets a 24-bit medium integer at the specified absolute {@code index} in
@@ -580,6 +609,17 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract int   getMedium(int index);
 
     /**
+     * Gets a 24-bit medium integer at the specified absolute {@code index} in
+     * this buffer in the Little Endian Byte Order. This method does not
+     * modify {@code readerIndex} or {@code writerIndex} of this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if the specified {@code index} is less than {@code 0} or
+     *         {@code index + 3} is greater than {@code this.capacity}
+     */
+    public abstract int getMediumLE(int index);
+
+    /**
      * Gets an unsigned 24-bit medium integer at the specified absolute
      * {@code index} in this buffer.  This method does not modify
      * {@code readerIndex} or {@code writerIndex} of this buffer.
@@ -589,6 +629,18 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         {@code index + 3} is greater than {@code this.capacity}
      */
     public abstract int   getUnsignedMedium(int index);
+
+    /**
+     * Gets an unsigned 24-bit medium integer at the specified absolute
+     * {@code index} in this buffer in Little Endian Byte Order.
+     * This method does not modify {@code readerIndex} or
+     * {@code writerIndex} of this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if the specified {@code index} is less than {@code 0} or
+     *         {@code index + 3} is greater than {@code this.capacity}
+     */
+    public abstract int   getUnsignedMediumLE(int index);
 
     /**
      * Gets a 32-bit integer at the specified absolute {@code index} in
@@ -602,6 +654,17 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract int   getInt(int index);
 
     /**
+     * Gets a 32-bit integer at the specified absolute {@code index} in
+     * this buffer with Little Endian Byte Order. This method does not
+     * modify {@code readerIndex} or {@code writerIndex} of this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if the specified {@code index} is less than {@code 0} or
+     *         {@code index + 4} is greater than {@code this.capacity}
+     */
+    public abstract int   getIntLE(int index);
+
+    /**
      * Gets an unsigned 32-bit integer at the specified absolute {@code index}
      * in this buffer.  This method does not modify {@code readerIndex} or
      * {@code writerIndex} of this buffer.
@@ -613,6 +676,17 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract long  getUnsignedInt(int index);
 
     /**
+     * Gets an unsigned 32-bit integer at the specified absolute {@code index}
+     * in this buffer in Little Endian Byte Order. This method does not
+     * modify {@code readerIndex} or {@code writerIndex} of this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if the specified {@code index} is less than {@code 0} or
+     *         {@code index + 4} is greater than {@code this.capacity}
+     */
+    public abstract long  getUnsignedIntLE(int index);
+
+    /**
      * Gets a 64-bit long integer at the specified absolute {@code index} in
      * this buffer.  This method does not modify {@code readerIndex} or
      * {@code writerIndex} of this buffer.
@@ -622,6 +696,17 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         {@code index + 8} is greater than {@code this.capacity}
      */
     public abstract long  getLong(int index);
+
+    /**
+     * Gets a 64-bit long integer at the specified absolute {@code index} in
+     * this buffer in Little Endian Byte Order. This method does not
+     * modify {@code readerIndex} or {@code writerIndex} of this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if the specified {@code index} is less than {@code 0} or
+     *         {@code index + 8} is greater than {@code this.capacity}
+     */
+    public abstract long  getLongLE(int index);
 
     /**
      * Gets a 2-byte UTF-16 character at the specified absolute
@@ -833,6 +918,19 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract ByteBuf setShort(int index, int value);
 
     /**
+     * Sets the specified 16-bit short integer at the specified absolute
+     * {@code index} in this buffer with the Little Endian Byte Order.
+     * The 16 high-order bits of the specified value are ignored.
+     * This method does not modify {@code readerIndex} or {@code writerIndex} of
+     * this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if the specified {@code index} is less than {@code 0} or
+     *         {@code index + 2} is greater than {@code this.capacity}
+     */
+    public abstract ByteBuf setShortLE(int index, int value);
+
+    /**
      * Sets the specified 24-bit medium integer at the specified absolute
      * {@code index} in this buffer.  Please note that the most significant
      * byte is ignored in the specified value.
@@ -844,6 +942,20 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         {@code index + 3} is greater than {@code this.capacity}
      */
     public abstract ByteBuf setMedium(int index, int   value);
+
+    /**
+     * Sets the specified 24-bit medium integer at the specified absolute
+     * {@code index} in this buffer in the Little Endian Byte Order.
+     * Please note that the most significant byte is ignored in the
+     * specified value.
+     * This method does not modify {@code readerIndex} or {@code writerIndex} of
+     * this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if the specified {@code index} is less than {@code 0} or
+     *         {@code index + 3} is greater than {@code this.capacity}
+     */
+    public abstract ByteBuf setMediumLE(int index, int   value);
 
     /**
      * Sets the specified 32-bit integer at the specified absolute
@@ -858,6 +970,19 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract ByteBuf setInt(int index, int   value);
 
     /**
+     * Sets the specified 32-bit integer at the specified absolute
+     * {@code index} in this buffer with Little Endian byte order
+     * .
+     * This method does not modify {@code readerIndex} or {@code writerIndex} of
+     * this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if the specified {@code index} is less than {@code 0} or
+     *         {@code index + 4} is greater than {@code this.capacity}
+     */
+    public abstract ByteBuf setIntLE(int index, int value);
+
+    /**
      * Sets the specified 64-bit long integer at the specified absolute
      * {@code index} in this buffer.
      * This method does not modify {@code readerIndex} or {@code writerIndex} of
@@ -868,6 +993,18 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         {@code index + 8} is greater than {@code this.capacity}
      */
     public abstract ByteBuf setLong(int index, long  value);
+
+    /**
+     * Sets the specified 64-bit long integer at the specified absolute
+     * {@code index} in this buffer in Little Endian Byte Order.
+     * This method does not modify {@code readerIndex} or {@code writerIndex} of
+     * this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if the specified {@code index} is less than {@code 0} or
+     *         {@code index + 8} is greater than {@code this.capacity}
+     */
+    public abstract ByteBuf setLongLE(int index, long  value);
 
     /**
      * Sets the specified 2-byte UTF-16 character at the specified absolute
@@ -1094,6 +1231,16 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract short readShort();
 
     /**
+     * Gets a 16-bit short integer at the current {@code readerIndex}
+     * in the Little Endian Byte Order and increases the {@code readerIndex}
+     * by {@code 2} in this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code this.readableBytes} is less than {@code 2}
+     */
+    public abstract short readShortLE();
+
+    /**
      * Gets an unsigned 16-bit short integer at the current {@code readerIndex}
      * and increases the {@code readerIndex} by {@code 2} in this buffer.
      *
@@ -1101,6 +1248,16 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         if {@code this.readableBytes} is less than {@code 2}
      */
     public abstract int   readUnsignedShort();
+
+    /**
+     * Gets an unsigned 16-bit short integer at the current {@code readerIndex}
+     * in the Little Endian Byte Order and increases the {@code readerIndex}
+     * by {@code 2} in this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code this.readableBytes} is less than {@code 2}
+     */
+    public abstract int   readUnsignedShortLE();
 
     /**
      * Gets a 24-bit medium integer at the current {@code readerIndex}
@@ -1112,6 +1269,16 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract int   readMedium();
 
     /**
+     * Gets a 24-bit medium integer at the current {@code readerIndex}
+     * in the Little Endian Byte Order and increases the
+     * {@code readerIndex} by {@code 3} in this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code this.readableBytes} is less than {@code 3}
+     */
+    public abstract int   readMediumLE();
+
+    /**
      * Gets an unsigned 24-bit medium integer at the current {@code readerIndex}
      * and increases the {@code readerIndex} by {@code 3} in this buffer.
      *
@@ -1119,6 +1286,16 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         if {@code this.readableBytes} is less than {@code 3}
      */
     public abstract int   readUnsignedMedium();
+
+    /**
+     * Gets an unsigned 24-bit medium integer at the current {@code readerIndex}
+     * in the Little Endian Byte Order and increases the {@code readerIndex}
+     * by {@code 3} in this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code this.readableBytes} is less than {@code 3}
+     */
+    public abstract int   readUnsignedMediumLE();
 
     /**
      * Gets a 32-bit integer at the current {@code readerIndex}
@@ -1130,6 +1307,16 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract int   readInt();
 
     /**
+     * Gets a 32-bit integer at the current {@code readerIndex}
+     * in the Little Endian Byte Order and increases the {@code readerIndex}
+     * by {@code 4} in this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code this.readableBytes} is less than {@code 4}
+     */
+    public abstract int   readIntLE();
+
+    /**
      * Gets an unsigned 32-bit integer at the current {@code readerIndex}
      * and increases the {@code readerIndex} by {@code 4} in this buffer.
      *
@@ -1139,6 +1326,16 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract long  readUnsignedInt();
 
     /**
+     * Gets an unsigned 32-bit integer at the current {@code readerIndex}
+     * in the Little Endian Byte Order and increases the {@code readerIndex}
+     * by {@code 4} in this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code this.readableBytes} is less than {@code 4}
+     */
+    public abstract long  readUnsignedIntLE();
+
+    /**
      * Gets a 64-bit integer at the current {@code readerIndex}
      * and increases the {@code readerIndex} by {@code 8} in this buffer.
      *
@@ -1146,6 +1343,16 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         if {@code this.readableBytes} is less than {@code 8}
      */
     public abstract long  readLong();
+
+    /**
+     * Gets a 64-bit integer at the current {@code readerIndex}
+     * in the Little Endian Byte Order and increases the {@code readerIndex}
+     * by {@code 8} in this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code this.readableBytes} is less than {@code 8}
+     */
+    public abstract long  readLongLE();
 
     /**
      * Gets a 2-byte UTF-16 character at the current {@code readerIndex}
@@ -1358,6 +1565,17 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract ByteBuf writeShort(int value);
 
     /**
+     * Sets the specified 16-bit short integer in the Little Endian Byte
+     * Order at the current {@code writerIndex} and increases the
+     * {@code writerIndex} by {@code 2} in this buffer.
+     * The 16 high-order bits of the specified value are ignored.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code this.writableBytes} is less than {@code 2}
+     */
+    public abstract ByteBuf writeShortLE(int value);
+
+    /**
      * Sets the specified 24-bit medium integer at the current
      * {@code writerIndex} and increases the {@code writerIndex} by {@code 3}
      * in this buffer.
@@ -1366,6 +1584,17 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         if {@code this.writableBytes} is less than {@code 3}
      */
     public abstract ByteBuf writeMedium(int   value);
+
+    /**
+     * Sets the specified 24-bit medium integer at the current
+     * {@code writerIndex} in the Little Endian Byte Order and
+     * increases the {@code writerIndex} by {@code 3} in this
+     * buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code this.writableBytes} is less than {@code 3}
+     */
+    public abstract ByteBuf writeMediumLE(int   value);
 
     /**
      * Sets the specified 32-bit integer at the current {@code writerIndex}
@@ -1377,6 +1606,16 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract ByteBuf writeInt(int   value);
 
     /**
+     * Sets the specified 32-bit integer at the current {@code writerIndex}
+     * in the Little Endian Byte Order and increases the {@code writerIndex}
+     * by {@code 4} in this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code this.writableBytes} is less than {@code 4}
+     */
+    public abstract ByteBuf writeIntLE(int   value);
+
+    /**
      * Sets the specified 64-bit long integer at the current
      * {@code writerIndex} and increases the {@code writerIndex} by {@code 8}
      * in this buffer.
@@ -1385,6 +1624,17 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         if {@code this.writableBytes} is less than {@code 8}
      */
     public abstract ByteBuf writeLong(long  value);
+
+    /**
+     * Sets the specified 64-bit long integer at the current
+     * {@code writerIndex} in the Little Endian Byte Order and
+     * increases the {@code writerIndex} by {@code 8}
+     * in this buffer.
+     *
+     * @throws IndexOutOfBoundsException
+     *         if {@code this.writableBytes} is less than {@code 8}
+     */
+    public abstract ByteBuf writeLongLE(long  value);
 
     /**
      * Sets the specified 2-byte UTF-16 character at the current

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -636,6 +636,18 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
     }
 
     @Override
+    protected short _getShortLE(int index) {
+        Component c = findComponent(index);
+        if (index + 2 <= c.endOffset) {
+            return c.buf.getShortLE(index - c.offset);
+        } else if (order() == ByteOrder.BIG_ENDIAN) {
+            return (short) (_getByte(index) & 0xff | (_getByte(index + 1) & 0xff) << 8);
+        } else {
+            return (short) ((_getByte(index) & 0xff) << 8 | _getByte(index + 1) & 0xff);
+        }
+    }
+
+    @Override
     protected int _getUnsignedMedium(int index) {
         Component c = findComponent(index);
         if (index + 3 <= c.endOffset) {
@@ -644,6 +656,18 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
             return (_getShort(index) & 0xffff) << 8 | _getByte(index + 2) & 0xff;
         } else {
             return _getShort(index) & 0xFFFF | (_getByte(index + 2) & 0xFF) << 16;
+        }
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        Component c = findComponent(index);
+        if (index + 3 <= c.endOffset) {
+            return c.buf.getUnsignedMediumLE(index - c.offset);
+        } else if (order() == ByteOrder.BIG_ENDIAN) {
+            return _getShortLE(index) & 0xffff | (_getByte(index + 2) & 0xff) << 16;
+        } else {
+            return (_getShortLE(index) & 0xffff) << 8 | _getByte(index + 2) & 0xff;
         }
     }
 
@@ -660,6 +684,18 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
     }
 
     @Override
+    protected int _getIntLE(int index) {
+        Component c = findComponent(index);
+        if (index + 4 <= c.endOffset) {
+            return c.buf.getIntLE(index - c.offset);
+        } else if (order() == ByteOrder.BIG_ENDIAN) {
+            return _getShortLE(index) & 0xffff | (_getShortLE(index + 2) & 0xffff) << 16;
+        } else {
+            return (_getShortLE(index) & 0xffff) << 16 | _getShortLE(index + 2) & 0xffff;
+        }
+    }
+
+    @Override
     protected long _getLong(int index) {
         Component c = findComponent(index);
         if (index + 8 <= c.endOffset) {
@@ -668,6 +704,18 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
             return (_getInt(index) & 0xffffffffL) << 32 | _getInt(index + 4) & 0xffffffffL;
         } else {
             return _getInt(index) & 0xFFFFFFFFL | (_getInt(index + 4) & 0xFFFFFFFFL) << 32;
+        }
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        Component c = findComponent(index);
+        if (index + 8 <= c.endOffset) {
+            return c.buf.getLongLE(index - c.offset);
+        } else if (order() == ByteOrder.BIG_ENDIAN) {
+            return _getIntLE(index) & 0xffffffffL | (_getIntLE(index + 4) & 0xffffffffL) << 32;
+        } else {
+            return (_getIntLE(index) & 0xffffffffL) << 32 | _getIntLE(index + 4) & 0xffffffffL;
         }
     }
 
@@ -813,6 +861,20 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
     }
 
     @Override
+    protected void _setShortLE(int index, int value) {
+        Component c = findComponent(index);
+        if (index + 2 <= c.endOffset) {
+            c.buf.setShortLE(index - c.offset, value);
+        } else if (order() == ByteOrder.BIG_ENDIAN) {
+            _setByte(index, (byte) value);
+            _setByte(index + 1, (byte) (value >>> 8));
+        } else {
+            _setByte(index, (byte) (value >>> 8));
+            _setByte(index + 1, (byte) value);
+        }
+    }
+
+    @Override
     public CompositeByteBuf setMedium(int index, int value) {
         return (CompositeByteBuf) super.setMedium(index, value);
     }
@@ -828,6 +890,20 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         } else {
             _setShort(index, (short) value);
             _setByte(index + 2, (byte) (value >>> 16));
+        }
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        Component c = findComponent(index);
+        if (index + 3 <= c.endOffset) {
+            c.buf.setMediumLE(index - c.offset, value);
+        } else if (order() == ByteOrder.BIG_ENDIAN) {
+            _setShortLE(index, (short) value);
+            _setByte(index + 2, (byte) (value >>> 16));
+        } else {
+            _setShortLE(index, (short) (value >> 8));
+            _setByte(index + 2, (byte) value);
         }
     }
 
@@ -851,6 +927,20 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
     }
 
     @Override
+    protected void _setIntLE(int index, int value) {
+        Component c = findComponent(index);
+        if (index + 4 <= c.endOffset) {
+            c.buf.setIntLE(index - c.offset, value);
+        } else if (order() == ByteOrder.BIG_ENDIAN) {
+            _setShortLE(index, (short) value);
+            _setShortLE(index + 2, (short) (value >>> 16));
+        } else {
+            _setShortLE(index, (short) (value >>> 16));
+            _setShortLE(index + 2, (short) value);
+        }
+    }
+
+    @Override
     public CompositeByteBuf setLong(int index, long value) {
         return (CompositeByteBuf) super.setLong(index, value);
     }
@@ -866,6 +956,20 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         } else {
             _setInt(index, (int) value);
             _setInt(index + 4, (int) (value >>> 32));
+        }
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
+        Component c = findComponent(index);
+        if (index + 8 <= c.endOffset) {
+            c.buf.setLongLE(index - c.offset, value);
+        } else if (order() == ByteOrder.BIG_ENDIAN) {
+            _setIntLE(index, (int) value);
+            _setIntLE(index + 4, (int) (value >>> 32));
+        } else {
+            _setIntLE(index, (int) (value >>> 32));
+            _setIntLE(index + 4, (int) value);
         }
     }
 

--- a/buffer/src/main/java/io/netty/buffer/DuplicatedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DuplicatedByteBuf.java
@@ -126,6 +126,11 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    protected short _getShortLE(int index) {
+        return buffer.getShortLE(index);
+    }
+
+    @Override
     public int getUnsignedMedium(int index) {
         return buffer.getUnsignedMedium(index);
     }
@@ -133,6 +138,11 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
     @Override
     protected int _getUnsignedMedium(int index) {
         return buffer.getUnsignedMedium(index);
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return buffer.getUnsignedMediumLE(index);
     }
 
     @Override
@@ -146,6 +156,11 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    protected int _getIntLE(int index) {
+        return buffer.getIntLE(index);
+    }
+
+    @Override
     public long getLong(int index) {
         return buffer.getLong(index);
     }
@@ -153,6 +168,11 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
     @Override
     protected long _getLong(int index) {
         return buffer.getLong(index);
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return buffer.getLongLE(index);
     }
 
     @Override
@@ -206,6 +226,11 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    protected void _setShortLE(int index, int value) {
+        buffer.setShortLE(index, value);
+    }
+
+    @Override
     public ByteBuf setMedium(int index, int value) {
         buffer.setMedium(index, value);
         return this;
@@ -214,6 +239,11 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
     @Override
     protected void _setMedium(int index, int value) {
         buffer.setMedium(index, value);
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        buffer.setMediumLE(index, value);
     }
 
     @Override
@@ -228,6 +258,11 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    protected void _setIntLE(int index, int value) {
+        buffer.setIntLE(index, value);
+    }
+
+    @Override
     public ByteBuf setLong(int index, long value) {
         buffer.setLong(index, value);
         return this;
@@ -236,6 +271,11 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
     @Override
     protected void _setLong(int index, long value) {
         buffer.setLong(index, value);
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
+        buffer.setLongLE(index, value);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -254,7 +254,17 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public short getShortLE(int index) {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
     public int getUnsignedShort(int index) {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
+    public int getUnsignedShortLE(int index) {
         throw new IndexOutOfBoundsException();
     }
 
@@ -264,7 +274,17 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public int getMediumLE(int index) {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
     public int getUnsignedMedium(int index) {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
         throw new IndexOutOfBoundsException();
     }
 
@@ -274,12 +294,27 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public int getIntLE(int index) {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
     public long getUnsignedInt(int index) {
         throw new IndexOutOfBoundsException();
     }
 
     @Override
+    public long getUnsignedIntLE(int index) {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
     public long getLong(int index) {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
+    public long getLongLE(int index) {
         throw new IndexOutOfBoundsException();
     }
 
@@ -355,7 +390,17 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf setShortLE(int index, int value) {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
     public ByteBuf setMedium(int index, int value) {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
+    public ByteBuf setMediumLE(int index, int value) {
         throw new IndexOutOfBoundsException();
     }
 
@@ -365,7 +410,17 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf setIntLE(int index, int value) {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
     public ByteBuf setLong(int index, long value) {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
+    public ByteBuf setLongLE(int index, long value) {
         throw new IndexOutOfBoundsException();
     }
 
@@ -452,7 +507,17 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public short readShortLE() {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
     public int readUnsignedShort() {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
+    public int readUnsignedShortLE() {
         throw new IndexOutOfBoundsException();
     }
 
@@ -462,7 +527,17 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public int readMediumLE() {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
     public int readUnsignedMedium() {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
+    public int readUnsignedMediumLE() {
         throw new IndexOutOfBoundsException();
     }
 
@@ -472,12 +547,27 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public int readIntLE() {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
     public long readUnsignedInt() {
         throw new IndexOutOfBoundsException();
     }
 
     @Override
+    public long readUnsignedIntLE() {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
     public long readLong() {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
+    public long readLongLE() {
         throw new IndexOutOfBoundsException();
     }
 
@@ -568,7 +658,17 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf writeShortLE(int value) {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
     public ByteBuf writeMedium(int value) {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
+    public ByteBuf writeMediumLE(int value) {
         throw new IndexOutOfBoundsException();
     }
 
@@ -578,7 +678,17 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf writeIntLE(int value) {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
     public ByteBuf writeLong(long value) {
+        throw new IndexOutOfBoundsException();
+    }
+
+    @Override
+    public ByteBuf writeLongLE(long value) {
         throw new IndexOutOfBoundsException();
     }
 

--- a/buffer/src/main/java/io/netty/buffer/FixedCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/FixedCompositeByteBuf.java
@@ -128,12 +128,22 @@ final class FixedCompositeByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected void _setShortLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     public ByteBuf setMedium(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
     protected void _setMedium(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -148,12 +158,22 @@ final class FixedCompositeByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected void _setIntLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     public ByteBuf setLong(int index, long value) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
     protected void _setLong(int index, long value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -266,6 +286,18 @@ final class FixedCompositeByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected short _getShortLE(int index) {
+        Component c = findComponent(index);
+        if (index + 2 <= c.endOffset) {
+            return c.buf.getShortLE(index - c.offset);
+        } else if (order() == ByteOrder.BIG_ENDIAN) {
+            return (short) (_getByte(index) & 0xff | (_getByte(index + 1) & 0xff) << 8);
+        } else {
+            return (short) ((_getByte(index) & 0xff) << 8 | _getByte(index + 1) & 0xff);
+        }
+    }
+
+    @Override
     protected int _getUnsignedMedium(int index) {
         Component c = findComponent(index);
         if (index + 3 <= c.endOffset) {
@@ -274,6 +306,18 @@ final class FixedCompositeByteBuf extends AbstractReferenceCountedByteBuf {
             return (_getShort(index) & 0xffff) << 8 | _getByte(index + 2) & 0xff;
         } else {
             return _getShort(index) & 0xFFFF | (_getByte(index + 2) & 0xFF) << 16;
+        }
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        Component c = findComponent(index);
+        if (index + 3 <= c.endOffset) {
+            return c.buf.getUnsignedMediumLE(index - c.offset);
+        } else if (order() == ByteOrder.BIG_ENDIAN) {
+            return _getShortLE(index) & 0xffff | (_getByte(index + 2) & 0xff) << 16;
+        } else {
+            return (_getShortLE(index) & 0xffff) << 8 | _getByte(index + 2) & 0xff;
         }
     }
 
@@ -290,6 +334,18 @@ final class FixedCompositeByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected int _getIntLE(int index) {
+        Component c = findComponent(index);
+        if (index + 4 <= c.endOffset) {
+            return c.buf.getIntLE(index - c.offset);
+        } else if (order() == ByteOrder.BIG_ENDIAN) {
+            return _getShortLE(index) & 0xFFFF | (_getShortLE(index + 2) & 0xFFFF) << 16;
+        } else {
+            return (_getShortLE(index) & 0xffff) << 16 | _getShortLE(index + 2) & 0xffff;
+        }
+    }
+
+    @Override
     protected long _getLong(int index) {
         Component c = findComponent(index);
         if (index + 8 <= c.endOffset) {
@@ -298,6 +354,18 @@ final class FixedCompositeByteBuf extends AbstractReferenceCountedByteBuf {
             return (_getInt(index) & 0xffffffffL) << 32 | _getInt(index + 4) & 0xffffffffL;
         } else {
             return _getInt(index) & 0xFFFFFFFFL | (_getInt(index + 4) & 0xFFFFFFFFL) << 32;
+        }
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        Component c = findComponent(index);
+        if (index + 8 <= c.endOffset) {
+            return c.buf.getLongLE(index - c.offset);
+        } else if (order() == ByteOrder.BIG_ENDIAN) {
+            return _getIntLE(index) & 0xffffffffL | (_getIntLE(index + 4) & 0xffffffffL) << 32;
+        } else {
+            return (_getIntLE(index) & 0xffffffffL) << 32 | _getIntLE(index + 4) & 0xffffffffL;
         }
     }
 

--- a/buffer/src/main/java/io/netty/buffer/HeapByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/HeapByteBufUtil.java
@@ -28,10 +28,20 @@ final class HeapByteBufUtil {
         return (short) (memory[index] << 8 | memory[index + 1] & 0xFF);
     }
 
+    static short getShortLE(byte[] memory, int index) {
+        return (short) (memory[index] & 0xff | memory[index + 1] << 8);
+    }
+
     static int getUnsignedMedium(byte[] memory, int index) {
         return  (memory[index]     & 0xff) << 16 |
                 (memory[index + 1] & 0xff) <<  8 |
                 memory[index + 2] & 0xff;
+    }
+
+    static int getUnsignedMediumLE(byte[] memory, int index) {
+        return  memory[index]     & 0xff         |
+                (memory[index + 1] & 0xff) <<  8 |
+                (memory[index + 2] & 0xff) << 16;
     }
 
     static int getInt(byte[] memory, int index) {
@@ -39,6 +49,13 @@ final class HeapByteBufUtil {
                 (memory[index + 1] & 0xff) << 16 |
                 (memory[index + 2] & 0xff) <<  8 |
                 memory[index + 3] & 0xff;
+    }
+
+    static int getIntLE(byte[] memory, int index) {
+        return  memory[index]      & 0xff        |
+                (memory[index + 1] & 0xff) << 8  |
+                (memory[index + 2] & 0xff) << 16 |
+                (memory[index + 3] & 0xff) << 24;
     }
 
     static long getLong(byte[] memory, int index) {
@@ -52,6 +69,17 @@ final class HeapByteBufUtil {
                 (long) memory[index + 7] & 0xff;
     }
 
+    static long getLongLE(byte[] memory, int index) {
+        return  (long) memory[index]      & 0xff        |
+                ((long) memory[index + 1] & 0xff) <<  8 |
+                ((long) memory[index + 2] & 0xff) << 16 |
+                ((long) memory[index + 3] & 0xff) << 24 |
+                ((long) memory[index + 4] & 0xff) << 32 |
+                ((long) memory[index + 5] & 0xff) << 40 |
+                ((long) memory[index + 6] & 0xff) << 48 |
+                ((long) memory[index + 7] & 0xff) << 56;
+    }
+
     static void setByte(byte[] memory, int index, int value) {
         memory[index] = (byte) value;
     }
@@ -61,10 +89,21 @@ final class HeapByteBufUtil {
         memory[index + 1] = (byte) value;
     }
 
+    static void setShortLE(byte[] memory, int index, int value) {
+        memory[index]     = (byte) value;
+        memory[index + 1] = (byte) (value >>> 8);
+    }
+
     static void setMedium(byte[] memory, int index, int value) {
         memory[index]     = (byte) (value >>> 16);
         memory[index + 1] = (byte) (value >>> 8);
         memory[index + 2] = (byte) value;
+    }
+
+    static void setMediumLE(byte[] memory, int index, int value) {
+        memory[index]     = (byte) value;
+        memory[index + 1] = (byte) (value >>> 8);
+        memory[index + 2] = (byte) (value >>> 16);
     }
 
     static void setInt(byte[] memory, int index, int value) {
@@ -72,6 +111,13 @@ final class HeapByteBufUtil {
         memory[index + 1] = (byte) (value >>> 16);
         memory[index + 2] = (byte) (value >>> 8);
         memory[index + 3] = (byte) value;
+    }
+
+    static void setIntLE(byte[] memory, int index, int value) {
+        memory[index]     = (byte) value;
+        memory[index + 1] = (byte) (value >>> 8);
+        memory[index + 2] = (byte) (value >>> 16);
+        memory[index + 3] = (byte) (value >>> 24);
     }
 
     static void setLong(byte[] memory, int index, long value) {
@@ -83,6 +129,17 @@ final class HeapByteBufUtil {
         memory[index + 5] = (byte) (value >>> 16);
         memory[index + 6] = (byte) (value >>> 8);
         memory[index + 7] = (byte) value;
+    }
+
+    static void setLongLE(byte[] memory, int index, long value) {
+        memory[index]     = (byte) value;
+        memory[index + 1] = (byte) (value >>> 8);
+        memory[index + 2] = (byte) (value >>> 16);
+        memory[index + 3] = (byte) (value >>> 24);
+        memory[index + 4] = (byte) (value >>> 32);
+        memory[index + 5] = (byte) (value >>> 40);
+        memory[index + 6] = (byte) (value >>> 48);
+        memory[index + 7] = (byte) (value >>> 56);
     }
 
     private HeapByteBufUtil() { }

--- a/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
@@ -66,9 +66,24 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
     }
 
     @Override
+    protected short _getShortLE(int index) {
+        return ByteBufUtil.swapShort(_getShort(index));
+    }
+
+    @Override
     protected int _getUnsignedMedium(int index) {
         index = idx(index);
-        return (memory.get(index) & 0xff) << 16 | (memory.get(index + 1) & 0xff) << 8 | memory.get(index + 2) & 0xff;
+        return (memory.get(index) & 0xff)     << 16 |
+               (memory.get(index + 1) & 0xff) << 8  |
+               memory.get(index + 2) & 0xff;
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        index = idx(index);
+        return memory.get(index)      & 0xff        |
+               (memory.get(index + 1) & 0xff) << 8  |
+               (memory.get(index + 2) & 0xff) << 16;
     }
 
     @Override
@@ -77,8 +92,18 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
     }
 
     @Override
+    protected int _getIntLE(int index) {
+        return ByteBufUtil.swapInt(_getInt(index));
+    }
+
+    @Override
     protected long _getLong(int index) {
         return memory.getLong(idx(index));
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return ByteBufUtil.swapLong(_getLong(index));
     }
 
     @Override
@@ -227,6 +252,11 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
     }
 
     @Override
+    protected void _setShortLE(int index, int value) {
+        _setShort(index, ByteBufUtil.swapShort((short) value));
+    }
+
+    @Override
     protected void _setMedium(int index, int value) {
         index = idx(index);
         memory.put(index, (byte) (value >>> 16));
@@ -235,13 +265,31 @@ final class PooledDirectByteBuf extends PooledByteBuf<ByteBuffer> {
     }
 
     @Override
+    protected void _setMediumLE(int index, int value) {
+        index = idx(index);
+        memory.put(index, (byte) value);
+        memory.put(index + 1, (byte) (value >>> 8));
+        memory.put(index + 2, (byte) (value >>> 16));
+    }
+
+    @Override
     protected void _setInt(int index, int value) {
         memory.putInt(idx(index), value);
     }
 
     @Override
+    protected void _setIntLE(int index, int value) {
+        _setInt(index, ByteBufUtil.swapInt(value));
+    }
+
+    @Override
     protected void _setLong(int index, long value) {
         memory.putLong(idx(index), value);
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
+        _setLong(index, ByteBufUtil.swapLong(value));
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
@@ -60,8 +60,18 @@ class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
     }
 
     @Override
+    protected short _getShortLE(int index) {
+        return HeapByteBufUtil.getShortLE(memory, idx(index));
+    }
+
+    @Override
     protected int _getUnsignedMedium(int index) {
         return HeapByteBufUtil.getUnsignedMedium(memory, idx(index));
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return HeapByteBufUtil.getUnsignedMediumLE(memory, idx(index));
     }
 
     @Override
@@ -70,8 +80,18 @@ class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
     }
 
     @Override
+    protected int _getIntLE(int index) {
+        return HeapByteBufUtil.getIntLE(memory, idx(index));
+    }
+
+    @Override
     protected long _getLong(int index) {
         return HeapByteBufUtil.getLong(memory, idx(index));
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return HeapByteBufUtil.getLongLE(memory, idx(index));
     }
 
     @Override
@@ -144,8 +164,18 @@ class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
     }
 
     @Override
+    protected void _setShortLE(int index, int value) {
+        HeapByteBufUtil.setShortLE(memory, idx(index), value);
+    }
+
+    @Override
     protected void _setMedium(int index, int   value) {
         HeapByteBufUtil.setMedium(memory, idx(index), value);
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        HeapByteBufUtil.setMediumLE(memory, idx(index), value);
     }
 
     @Override
@@ -154,8 +184,18 @@ class PooledHeapByteBuf extends PooledByteBuf<byte[]> {
     }
 
     @Override
+    protected void _setIntLE(int index, int value) {
+        HeapByteBufUtil.setIntLE(memory, idx(index), value);
+    }
+
+    @Override
     protected void _setLong(int index, long  value) {
         HeapByteBufUtil.setLong(memory, idx(index), value);
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
+        HeapByteBufUtil.setLongLE(memory, idx(index), value);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
@@ -85,8 +85,18 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
     }
 
     @Override
+    protected short _getShortLE(int index) {
+        return UnsafeByteBufUtil.getShortLE(addr(index));
+    }
+
+    @Override
     protected int _getUnsignedMedium(int index) {
         return UnsafeByteBufUtil.getUnsignedMedium(addr(index));
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return UnsafeByteBufUtil.getUnsignedMediumLE(addr(index));
     }
 
     @Override
@@ -95,8 +105,18 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
     }
 
     @Override
+    protected int _getIntLE(int index) {
+        return UnsafeByteBufUtil.getIntLE(addr(index));
+    }
+
+    @Override
     protected long _getLong(int index) {
         return UnsafeByteBufUtil.getLong(addr(index));
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return UnsafeByteBufUtil.getLongLE(addr(index));
     }
 
     @Override
@@ -174,8 +194,18 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
     }
 
     @Override
+    protected void _setShortLE(int index, int value) {
+        UnsafeByteBufUtil.setShortLE(addr(index), value);
+    }
+
+    @Override
     protected void _setMedium(int index, int value) {
         UnsafeByteBufUtil.setMedium(addr(index), value);
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        UnsafeByteBufUtil.setMediumLE(addr(index), value);
     }
 
     @Override
@@ -184,8 +214,18 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
     }
 
     @Override
+    protected void _setIntLE(int index, int value) {
+        UnsafeByteBufUtil.setIntLE(addr(index), value);
+    }
+
+    @Override
     protected void _setLong(int index, long value) {
         UnsafeByteBufUtil.setLong(addr(index), value);
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
+        UnsafeByteBufUtil.setLongLE(addr(index), value);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
@@ -142,12 +142,22 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    protected void _setShortLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     public ByteBuf setMedium(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
     protected void _setMedium(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -162,12 +172,22 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    protected void _setIntLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     public ByteBuf setLong(int index, long value) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
     protected void _setLong(int index, long value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -248,6 +268,11 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    protected short _getShortLE(int index) {
+        return buffer.getShortLE(index);
+    }
+
+    @Override
     public int getUnsignedMedium(int index) {
         return _getUnsignedMedium(index);
     }
@@ -255,6 +280,11 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     @Override
     protected int _getUnsignedMedium(int index) {
         return buffer.getUnsignedMedium(index);
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return buffer.getUnsignedMediumLE(index);
     }
 
     @Override
@@ -268,6 +298,11 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    protected int _getIntLE(int index) {
+        return buffer.getIntLE(index);
+    }
+
+    @Override
     public long getLong(int index) {
         return _getLong(index);
     }
@@ -275,6 +310,11 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     @Override
     protected long _getLong(int index) {
         return buffer.getLong(index);
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return buffer.getLongLE(index);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -73,6 +73,11 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected short _getShortLE(int index) {
+        return ByteBufUtil.swapShort(buffer.getShort(index));
+    }
+
+    @Override
     public int getUnsignedMedium(int index) {
         ensureAccessible();
         return _getUnsignedMedium(index);
@@ -80,7 +85,16 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected int _getUnsignedMedium(int index) {
-        return (getByte(index) & 0xff) << 16 | (getByte(index + 1) & 0xff) << 8 | getByte(index + 2) & 0xff;
+        return (getByte(index) & 0xff)     << 16 |
+               (getByte(index + 1) & 0xff) << 8  |
+               getByte(index + 2) & 0xff;
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return getByte(index)      & 0xff       |
+               (getByte(index + 1) & 0xff) << 8 |
+               (getByte(index + 2) & 0xff) << 16;
     }
 
     @Override
@@ -95,6 +109,11 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected int _getIntLE(int index) {
+        return ByteBufUtil.swapInt(buffer.getInt(index));
+    }
+
+    @Override
     public long getLong(int index) {
         ensureAccessible();
         return _getLong(index);
@@ -103,6 +122,11 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected long _getLong(int index) {
         return buffer.getLong(index);
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return ByteBufUtil.swapLong(buffer.getLong(index));
     }
 
     @Override
@@ -162,7 +186,17 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected void _setShortLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setMedium(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -172,7 +206,17 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected void _setIntLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setLong(int index, long value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
         throw new ReadOnlyBufferException();
     }
 

--- a/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
@@ -125,8 +125,18 @@ public class SlicedByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    protected short _getShortLE(int index) {
+        return buffer.getShortLE(idx(index));
+    }
+
+    @Override
     protected int _getUnsignedMedium(int index) {
         return buffer.getUnsignedMedium(idx(index));
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return buffer.getUnsignedMediumLE(idx(index));
     }
 
     @Override
@@ -135,8 +145,18 @@ public class SlicedByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    protected int _getIntLE(int index) {
+        return buffer.getIntLE(idx(index));
+    }
+
+    @Override
     protected long _getLong(int index) {
         return buffer.getLong(idx(index));
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return buffer.getLongLE(idx(index));
     }
 
     @Override
@@ -190,8 +210,18 @@ public class SlicedByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    protected void _setShortLE(int index, int value) {
+        buffer.setShortLE(idx(index), value);
+    }
+
+    @Override
     protected void _setMedium(int index, int value) {
         buffer.setMedium(idx(index), value);
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        buffer.setMediumLE(idx(index), value);
     }
 
     @Override
@@ -200,8 +230,18 @@ public class SlicedByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    protected void _setIntLE(int index, int value) {
+        buffer.setIntLE(idx(index), value);
+    }
+
+    @Override
     protected void _setLong(int index, long value) {
         buffer.setLong(idx(index), value);
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
+        buffer.setLongLE(idx(index), value);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -28,6 +28,9 @@ import java.nio.charset.Charset;
 
 /**
  * Wrapper which swap the {@link ByteOrder} of a {@link ByteBuf}.
+ *
+ * @deprecated use the Little Endian accessors, e.g. {@code getShortLE}, {@code getIntLE}
+ * instead.
  */
 public class SwappedByteBuf extends ByteBuf {
 
@@ -230,8 +233,18 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public short getShortLE(int index) {
+        return buf.getShort(index);
+    }
+
+    @Override
     public int getUnsignedShort(int index) {
         return getShort(index) & 0xFFFF;
+    }
+
+    @Override
+    public int getUnsignedShortLE(int index) {
+        return getShortLE(index) & 0xFFFF;
     }
 
     @Override
@@ -240,8 +253,18 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public int getMediumLE(int index) {
+        return buf.getMedium(index);
+    }
+
+    @Override
     public int getUnsignedMedium(int index) {
         return getMedium(index) & 0xFFFFFF;
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
+        return getMediumLE(index) & 0xFFFFFF;
     }
 
     @Override
@@ -250,13 +273,28 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public int getIntLE(int index) {
+        return buf.getInt(index);
+    }
+
+    @Override
     public long getUnsignedInt(int index) {
         return getInt(index) & 0xFFFFFFFFL;
     }
 
     @Override
+    public long getUnsignedIntLE(int index) {
+        return getIntLE(index) & 0xFFFFFFFFL;
+    }
+
+    @Override
     public long getLong(int index) {
         return ByteBufUtil.swapLong(buf.getLong(index));
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        return buf.getLong(index);
     }
 
     @Override
@@ -340,8 +378,20 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf setShortLE(int index, int value) {
+        buf.setShort(index, (short) value);
+        return this;
+    }
+
+    @Override
     public ByteBuf setMedium(int index, int value) {
         buf.setMedium(index, ByteBufUtil.swapMedium(value));
+        return this;
+    }
+
+    @Override
+    public ByteBuf setMediumLE(int index, int value) {
+        buf.setMedium(index, value);
         return this;
     }
 
@@ -352,8 +402,20 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf setIntLE(int index, int value) {
+        buf.setInt(index, value);
+        return this;
+    }
+
+    @Override
     public ByteBuf setLong(int index, long value) {
         buf.setLong(index, ByteBufUtil.swapLong(value));
+        return this;
+    }
+
+    @Override
+    public ByteBuf setLongLE(int index, long value) {
+        buf.setLong(index, value);
         return this;
     }
 
@@ -448,8 +510,18 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public short readShortLE() {
+        return buf.readShort();
+    }
+
+    @Override
     public int readUnsignedShort() {
         return readShort() & 0xFFFF;
+    }
+
+    @Override
+    public int readUnsignedShortLE() {
+        return readShortLE() & 0xFFFF;
     }
 
     @Override
@@ -458,8 +530,18 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public int readMediumLE() {
+        return buf.readMedium();
+    }
+
+    @Override
     public int readUnsignedMedium() {
         return readMedium() & 0xFFFFFF;
+    }
+
+    @Override
+    public int readUnsignedMediumLE() {
+        return readMediumLE() & 0xFFFFFF;
     }
 
     @Override
@@ -468,13 +550,28 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public int readIntLE() {
+        return buf.readInt();
+    }
+
+    @Override
     public long readUnsignedInt() {
         return readInt() & 0xFFFFFFFFL;
     }
 
     @Override
+    public long readUnsignedIntLE() {
+        return readIntLE() & 0xFFFFFFFFL;
+    }
+
+    @Override
     public long readLong() {
         return ByteBufUtil.swapLong(buf.readLong());
+    }
+
+    @Override
+    public long readLongLE() {
+        return buf.readLong();
     }
 
     @Override
@@ -574,8 +671,20 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf writeShortLE(int value) {
+        buf.writeShort((short) value);
+        return this;
+    }
+
+    @Override
     public ByteBuf writeMedium(int value) {
         buf.writeMedium(ByteBufUtil.swapMedium(value));
+        return this;
+    }
+
+    @Override
+    public ByteBuf writeMediumLE(int value) {
+        buf.writeMedium(value);
         return this;
     }
 
@@ -586,8 +695,20 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf writeIntLE(int value) {
+        buf.writeInt(value);
+        return this;
+    }
+
+    @Override
     public ByteBuf writeLong(long value) {
         buf.writeLong(ByteBufUtil.swapLong(value));
+        return this;
+    }
+
+    @Override
+    public ByteBuf writeLongLE(long value) {
+        buf.writeLong(value);
         return this;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -233,6 +233,11 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected short _getShortLE(int index) {
+        return ByteBufUtil.swapShort(buffer.getShort(index));
+    }
+
+    @Override
     public int getUnsignedMedium(int index) {
         ensureAccessible();
         return _getUnsignedMedium(index);
@@ -240,7 +245,16 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected int _getUnsignedMedium(int index) {
-        return (getByte(index) & 0xff) << 16 | (getByte(index + 1) & 0xff) << 8 | getByte(index + 2) & 0xff;
+        return (getByte(index) & 0xff)     << 16 |
+               (getByte(index + 1) & 0xff) << 8  |
+               getByte(index + 2) & 0xff;
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return getByte(index) & 0xff             |
+               (getByte(index + 1) & 0xff) << 8  |
+               (getByte(index + 2) & 0xff) << 16;
     }
 
     @Override
@@ -255,6 +269,11 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected int _getIntLE(int index) {
+        return ByteBufUtil.swapInt(buffer.getInt(index));
+    }
+
+    @Override
     public long getLong(int index) {
         ensureAccessible();
         return _getLong(index);
@@ -263,6 +282,11 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected long _getLong(int index) {
         return buffer.getLong(index);
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return ByteBufUtil.swapLong(buffer.getLong(index));
     }
 
     @Override
@@ -366,6 +390,11 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected void _setShortLE(int index, int value) {
+        buffer.putShort(index, ByteBufUtil.swapShort((short) value));
+    }
+
+    @Override
     public ByteBuf setMedium(int index, int value) {
         ensureAccessible();
         _setMedium(index, value);
@@ -377,6 +406,13 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
         setByte(index, (byte) (value >>> 16));
         setByte(index + 1, (byte) (value >>> 8));
         setByte(index + 2, (byte) value);
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        setByte(index, (byte) value);
+        setByte(index + 1, (byte) (value >>> 8));
+        setByte(index + 2, (byte) (value >>> 16));
     }
 
     @Override
@@ -392,6 +428,11 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected void _setIntLE(int index, int value) {
+        buffer.putInt(index, ByteBufUtil.swapInt(value));
+    }
+
+    @Override
     public ByteBuf setLong(int index, long value) {
         ensureAccessible();
         _setLong(index, value);
@@ -401,6 +442,11 @@ public class UnpooledDirectByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void _setLong(int index, long value) {
         buffer.putLong(index, value);
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
+        buffer.putLong(index, ByteBufUtil.swapLong(value));
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -304,6 +304,11 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected short _getShortLE(int index) {
+        return HeapByteBufUtil.getShortLE(array, index);
+    }
+
+    @Override
     public int getUnsignedMedium(int index) {
         ensureAccessible();
         return _getUnsignedMedium(index);
@@ -312,6 +317,11 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected int _getUnsignedMedium(int index) {
         return HeapByteBufUtil.getUnsignedMedium(array, index);
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return HeapByteBufUtil.getUnsignedMediumLE(array, index);
     }
 
     @Override
@@ -326,6 +336,11 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected int _getIntLE(int index) {
+        return HeapByteBufUtil.getIntLE(array, index);
+    }
+
+    @Override
     public long getLong(int index) {
         ensureAccessible();
         return _getLong(index);
@@ -334,6 +349,11 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected long _getLong(int index) {
         return HeapByteBufUtil.getLong(array, index);
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return HeapByteBufUtil.getLongLE(array, index);
     }
 
     @Override
@@ -361,6 +381,11 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected void _setShortLE(int index, int value) {
+        HeapByteBufUtil.setShortLE(array, index, value);
+    }
+
+    @Override
     public ByteBuf setMedium(int index, int   value) {
         ensureAccessible();
         _setMedium(index, value);
@@ -370,6 +395,11 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void _setMedium(int index, int value) {
         HeapByteBufUtil.setMedium(array, index, value);
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        HeapByteBufUtil.setMediumLE(array, index, value);
     }
 
     @Override
@@ -385,6 +415,11 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    protected void _setIntLE(int index, int value) {
+        HeapByteBufUtil.setIntLE(array, index, value);
+    }
+
+    @Override
     public ByteBuf setLong(int index, long  value) {
         ensureAccessible();
         _setLong(index, value);
@@ -394,6 +429,11 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void _setLong(int index, long value) {
         HeapByteBufUtil.setLong(array, index, value);
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
+        HeapByteBufUtil.setLongLE(array, index, value);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
@@ -224,8 +224,18 @@ public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf
     }
 
     @Override
+    protected short _getShortLE(int index) {
+        return UnsafeByteBufUtil.getShortLE(addr(index));
+    }
+
+    @Override
     protected int _getUnsignedMedium(int index) {
         return UnsafeByteBufUtil.getUnsignedMedium(addr(index));
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return UnsafeByteBufUtil.getUnsignedMediumLE(addr(index));
     }
 
     @Override
@@ -234,8 +244,18 @@ public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf
     }
 
     @Override
+    protected int _getIntLE(int index) {
+        return UnsafeByteBufUtil.getIntLE(addr(index));
+    }
+
+    @Override
     protected long _getLong(int index) {
         return UnsafeByteBufUtil.getLong(addr(index));
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return UnsafeByteBufUtil.getLongLE(addr(index));
     }
 
     @Override
@@ -276,8 +296,18 @@ public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf
     }
 
     @Override
+    protected void _setShortLE(int index, int value) {
+        UnsafeByteBufUtil.setShortLE(addr(index), value);
+    }
+
+    @Override
     protected void _setMedium(int index, int value) {
         UnsafeByteBufUtil.setMedium(addr(index), value);
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        UnsafeByteBufUtil.setMediumLE(addr(index), value);
     }
 
     @Override
@@ -286,8 +316,18 @@ public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf
     }
 
     @Override
+    protected void _setIntLE(int index, int value) {
+        UnsafeByteBufUtil.setIntLE(addr(index), value);
+    }
+
+    @Override
     protected void _setLong(int index, long value) {
         UnsafeByteBufUtil.setLong(addr(index), value);
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
+        UnsafeByteBufUtil.setLongLE(addr(index), value);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
@@ -45,6 +45,14 @@ final class UnsafeByteBufUtil {
         return (short) (PlatformDependent.getByte(address) << 8 | PlatformDependent.getByte(address + 1) & 0xff);
     }
 
+    static short getShortLE(long address) {
+        if (UNALIGNED) {
+            short v = PlatformDependent.getShort(address);
+            return BIG_ENDIAN_NATIVE_ORDER ? Short.reverseBytes(v) : v;
+        }
+        return (short) (PlatformDependent.getByte(address) & 0xff | PlatformDependent.getByte(address + 1) << 8);
+    }
+
     static int getUnsignedMedium(long address) {
         if (UNALIGNED) {
             if (BIG_ENDIAN_NATIVE_ORDER) {
@@ -59,6 +67,20 @@ final class UnsafeByteBufUtil {
                PlatformDependent.getByte(address + 2) & 0xff;
     }
 
+    static int getUnsignedMediumLE(long address) {
+        if (UNALIGNED) {
+            if (BIG_ENDIAN_NATIVE_ORDER) {
+                return (Short.reverseBytes(PlatformDependent.getShort(address)) & 0xffff) << 8 |
+                       PlatformDependent.getByte(address + 2) & 0xff;
+            }
+            return (PlatformDependent.getByte(address)      & 0xff) |
+                   (PlatformDependent.getShort(address + 1) & 0xffff) << 8;
+        }
+        return PlatformDependent.getByte(address)      & 0xff       |
+               (PlatformDependent.getByte(address + 1) & 0xff) << 8 |
+               (PlatformDependent.getByte(address + 1) & 0xff) << 16 ;
+    }
+
     static int getInt(long address) {
         if (UNALIGNED) {
             int v = PlatformDependent.getInt(address);
@@ -68,6 +90,17 @@ final class UnsafeByteBufUtil {
                (PlatformDependent.getByte(address + 1) & 0xff) << 16 |
                (PlatformDependent.getByte(address + 2) & 0xff) <<  8 |
                PlatformDependent.getByte(address + 3) & 0xff;
+    }
+
+    static int getIntLE(long address) {
+        if (UNALIGNED) {
+            int v = PlatformDependent.getInt(address);
+            return BIG_ENDIAN_NATIVE_ORDER ? Integer.reverseBytes(v) : v;
+        }
+        return PlatformDependent.getByte(address) & 0xff |
+               (PlatformDependent.getByte(address + 1) & 0xff) <<  8 |
+               (PlatformDependent.getByte(address + 2) & 0xff) << 16 |
+               PlatformDependent.getByte(address + 3) << 24;
     }
 
     static long getLong(long address) {
@@ -85,6 +118,21 @@ final class UnsafeByteBufUtil {
                (long) PlatformDependent.getByte(address + 7) & 0xff;
     }
 
+    static long getLongLE(long address) {
+        if (UNALIGNED) {
+            long v = PlatformDependent.getLong(address);
+            return BIG_ENDIAN_NATIVE_ORDER ? Long.reverseBytes(v) : v;
+        }
+        return (long) PlatformDependent.getByte(address)      & 0xff        |
+               ((long) PlatformDependent.getByte(address + 1) & 0xff) <<  8 |
+               ((long) PlatformDependent.getByte(address + 2) & 0xff) << 16 |
+               ((long) PlatformDependent.getByte(address + 3) & 0xff) << 24 |
+               ((long) PlatformDependent.getByte(address + 4) & 0xff) << 32 |
+               ((long) PlatformDependent.getByte(address + 5) & 0xff) << 40 |
+               ((long) PlatformDependent.getByte(address + 6) & 0xff) << 48 |
+               (long) PlatformDependent.getByte(address  + 7)         << 56;
+    }
+
     static void setByte(long address, int value) {
         PlatformDependent.putByte(address, (byte) value);
     }
@@ -96,6 +144,16 @@ final class UnsafeByteBufUtil {
         } else {
             PlatformDependent.putByte(address, (byte) (value >>> 8));
             PlatformDependent.putByte(address + 1, (byte) value);
+        }
+    }
+
+    static void setShortLE(long address, int value) {
+        if (UNALIGNED) {
+            PlatformDependent.putShort(
+                address, BIG_ENDIAN_NATIVE_ORDER ? Short.reverseBytes((short) value) : (short) value);
+        } else {
+            PlatformDependent.putByte(address, (byte) value);
+            PlatformDependent.putByte(address + 1, (byte) (value >>> 8));
         }
     }
 
@@ -115,6 +173,22 @@ final class UnsafeByteBufUtil {
         }
     }
 
+    static void setMediumLE(long address, int value) {
+        if (UNALIGNED) {
+            if (BIG_ENDIAN_NATIVE_ORDER) {
+                PlatformDependent.putShort(address, Short.reverseBytes((short) (value >>> 8)));
+                PlatformDependent.putByte(address + 2, (byte) value);
+            } else {
+                PlatformDependent.putByte(address, (byte) value);
+                PlatformDependent.putShort(address + 1, (short) (value >>> 8));
+            }
+        } else {
+            PlatformDependent.putByte(address, (byte) value);
+            PlatformDependent.putByte(address + 1, (byte) (value >>> 8));
+            PlatformDependent.putByte(address + 2, (byte) (value >>> 16));
+        }
+    }
+
     static void setInt(long address, int value) {
         if (UNALIGNED) {
             PlatformDependent.putInt(address, BIG_ENDIAN_NATIVE_ORDER ? value : Integer.reverseBytes(value));
@@ -123,6 +197,17 @@ final class UnsafeByteBufUtil {
             PlatformDependent.putByte(address + 1, (byte) (value >>> 16));
             PlatformDependent.putByte(address + 2, (byte) (value >>> 8));
             PlatformDependent.putByte(address + 3, (byte) value);
+        }
+    }
+
+    static void setIntLE(long address, int value) {
+        if (UNALIGNED) {
+            PlatformDependent.putInt(address, BIG_ENDIAN_NATIVE_ORDER ? Integer.reverseBytes(value) : value);
+        } else {
+            PlatformDependent.putByte(address, (byte) value);
+            PlatformDependent.putByte(address + 1, (byte) (value >>> 8));
+            PlatformDependent.putByte(address + 2, (byte) (value >>> 16));
+            PlatformDependent.putByte(address + 3, (byte) (value >>> 24));
         }
     }
 
@@ -141,6 +226,21 @@ final class UnsafeByteBufUtil {
         }
     }
 
+    static void setLongLE(long address, long value) {
+        if (UNALIGNED) {
+            PlatformDependent.putLong(address, BIG_ENDIAN_NATIVE_ORDER ? Long.reverseBytes(value) : value);
+        } else {
+            PlatformDependent.putByte(address, (byte) value);
+            PlatformDependent.putByte(address + 1, (byte) (value >>> 8));
+            PlatformDependent.putByte(address + 2, (byte) (value >>> 16));
+            PlatformDependent.putByte(address + 3, (byte) (value >>> 24));
+            PlatformDependent.putByte(address + 4, (byte) (value >>> 32));
+            PlatformDependent.putByte(address + 5, (byte) (value >>> 40));
+            PlatformDependent.putByte(address + 6, (byte) (value >>> 48));
+            PlatformDependent.putByte(address + 7, (byte) (value >>> 56));
+        }
+    }
+
     static byte getByte(byte[] array, int index) {
         return PlatformDependent.getByte(array, index);
     }
@@ -151,6 +251,14 @@ final class UnsafeByteBufUtil {
             return BIG_ENDIAN_NATIVE_ORDER ? v : Short.reverseBytes(v);
         }
         return (short) (PlatformDependent.getByte(index) << 8 | PlatformDependent.getByte(index + 1) & 0xff);
+    }
+
+    static short getShortLE(byte[] array, int index) {
+        if (UNALIGNED) {
+            short v = PlatformDependent.getShort(array, index);
+            return BIG_ENDIAN_NATIVE_ORDER ? Short.reverseBytes(v) : v;
+        }
+        return (short) (PlatformDependent.getByte(index) & 0xff | PlatformDependent.getByte(index + 1) << 8);
     }
 
     static int getUnsignedMedium(byte[] array, int index) {
@@ -167,6 +275,20 @@ final class UnsafeByteBufUtil {
                 PlatformDependent.getByte(array, index + 2) & 0xff;
     }
 
+    static int getUnsignedMediumLE(byte[] array, int index) {
+        if (UNALIGNED) {
+            if (BIG_ENDIAN_NATIVE_ORDER) {
+                return (Short.reverseBytes(PlatformDependent.getShort(array, index)) & 0xffff) << 8 |
+                       PlatformDependent.getByte(array, index + 2) & 0xff;
+            }
+            return (PlatformDependent.getByte(array, index) & 0xff) |
+                   (PlatformDependent.getShort(array, index + 1) & 0xffff) << 8;
+        }
+        return  PlatformDependent.getByte(array, index) & 0xff         |
+                (PlatformDependent.getByte(array, index + 1) & 0xff) <<  8 |
+                (PlatformDependent.getByte(array, index + 2) & 0xff) << 16;
+    }
+
     static int getInt(byte[] array, int index) {
         if (UNALIGNED) {
             int v = PlatformDependent.getInt(array, index);
@@ -178,9 +300,20 @@ final class UnsafeByteBufUtil {
                 PlatformDependent.getByte(array, index + 3) & 0xff;
     }
 
+    static int getIntLE(byte[] array, int index) {
+        if (UNALIGNED) {
+            int v = PlatformDependent.getInt(array, index);
+            return BIG_ENDIAN_NATIVE_ORDER ? Integer.reverseBytes(v) : v;
+        }
+        return PlatformDependent.getByte(array, index)      & 0xff        |
+               (PlatformDependent.getByte(array, index + 1) & 0xff) <<  8 |
+               (PlatformDependent.getByte(array, index + 2) & 0xff) << 16 |
+               PlatformDependent.getByte(array,  index + 3) << 24;
+    }
+
     static long getLong(byte[] array, int index) {
         if (UNALIGNED) {
-            long v =  PlatformDependent.getLong(array, index);
+            long v = PlatformDependent.getLong(array, index);
             return BIG_ENDIAN_NATIVE_ORDER ? v : Long.reverseBytes(v);
         }
         return (long) PlatformDependent.getByte(array, index) << 56 |
@@ -191,6 +324,21 @@ final class UnsafeByteBufUtil {
                 ((long) PlatformDependent.getByte(array, index + 5) & 0xff) << 16 |
                 ((long) PlatformDependent.getByte(array, index + 6) & 0xff) <<  8 |
                 (long) PlatformDependent.getByte(array, index + 7) & 0xff;
+    }
+
+    static long getLongLE(byte[] array, int index) {
+        if (UNALIGNED) {
+            long v = PlatformDependent.getLong(array, index);
+            return BIG_ENDIAN_NATIVE_ORDER ? Long.reverseBytes(v) : v;
+        }
+        return (long) PlatformDependent.getByte(array, index)      & 0xff        |
+               ((long) PlatformDependent.getByte(array, index + 1) & 0xff) <<  8 |
+               ((long) PlatformDependent.getByte(array, index + 2) & 0xff) << 16 |
+               ((long) PlatformDependent.getByte(array, index + 3) & 0xff) << 24 |
+               ((long) PlatformDependent.getByte(array, index + 4) & 0xff) << 32 |
+               ((long) PlatformDependent.getByte(array, index + 5) & 0xff) << 40 |
+               ((long) PlatformDependent.getByte(array, index + 6) & 0xff) << 48 |
+               (long) PlatformDependent.getByte(array,  index + 7) << 56;
     }
 
     static void setByte(byte[] array, int index, int value) {
@@ -204,6 +352,16 @@ final class UnsafeByteBufUtil {
         } else {
             PlatformDependent.putByte(array, index, (byte) (value >>> 8));
             PlatformDependent.putByte(array, index + 1, (byte) value);
+        }
+    }
+
+    static void setShortLE(byte[] array, int index, int value) {
+        if (UNALIGNED) {
+            PlatformDependent.putShort(
+                array, index, BIG_ENDIAN_NATIVE_ORDER ? Short.reverseBytes((short) value) : (short) value);
+        } else {
+            PlatformDependent.putByte(array, index, (byte) value);
+            PlatformDependent.putByte(array, index + 1, (byte) (value >>> 8));
         }
     }
 
@@ -223,6 +381,22 @@ final class UnsafeByteBufUtil {
         }
     }
 
+    static void setMediumLE(byte[] array, int index, int   value) {
+        if (UNALIGNED) {
+            if (BIG_ENDIAN_NATIVE_ORDER) {
+                PlatformDependent.putShort(array, index, Short.reverseBytes((short) (value >>> 8)));
+                PlatformDependent.putByte(array, index + 2, (byte) value);
+            } else {
+                PlatformDependent.putByte(array, index, (byte) value);
+                PlatformDependent.putShort(array, index + 1, (short) (value >>> 8));
+            }
+        } else {
+            PlatformDependent.putByte(array, index, (byte) value);
+            PlatformDependent.putByte(array, index + 1, (byte) (value >>> 8));
+            PlatformDependent.putByte(array, index + 2, (byte) (value >>> 16));
+        }
+    }
+
     static void setInt(byte[] array, int index, int   value) {
         if (UNALIGNED) {
             PlatformDependent.putInt(array, index, BIG_ENDIAN_NATIVE_ORDER ? value : Integer.reverseBytes(value));
@@ -231,6 +405,17 @@ final class UnsafeByteBufUtil {
             PlatformDependent.putByte(array, index + 1, (byte) (value >>> 16));
             PlatformDependent.putByte(array, index + 2, (byte) (value >>> 8));
             PlatformDependent.putByte(array, index + 3, (byte) value);
+        }
+    }
+
+    static void setIntLE(byte[] array, int index, int   value) {
+        if (UNALIGNED) {
+            PlatformDependent.putInt(array, index, BIG_ENDIAN_NATIVE_ORDER ? Integer.reverseBytes(value) : value);
+        } else {
+            PlatformDependent.putByte(array, index, (byte) value);
+            PlatformDependent.putByte(array, index + 1, (byte) (value >>> 8));
+            PlatformDependent.putByte(array, index + 2, (byte) (value >>> 16));
+            PlatformDependent.putByte(array, index + 3, (byte) (value >>> 24));
         }
     }
 
@@ -246,6 +431,21 @@ final class UnsafeByteBufUtil {
             PlatformDependent.putByte(array, index + 5, (byte) (value >>> 16));
             PlatformDependent.putByte(array, index + 6, (byte) (value >>> 8));
             PlatformDependent.putByte(array, index + 7, (byte) value);
+        }
+    }
+
+    static void setLongLE(byte[] array, int index, long  value) {
+        if (UNALIGNED) {
+            PlatformDependent.putLong(array, index, BIG_ENDIAN_NATIVE_ORDER ? Long.reverseBytes(value) : value);
+        } else {
+            PlatformDependent.putByte(array, index, (byte) value);
+            PlatformDependent.putByte(array, index + 1, (byte) (value >>> 8));
+            PlatformDependent.putByte(array, index + 2, (byte) (value >>> 16));
+            PlatformDependent.putByte(array, index + 3, (byte) (value >>> 24));
+            PlatformDependent.putByte(array, index + 4, (byte) (value >>> 32));
+            PlatformDependent.putByte(array, index + 5, (byte) (value >>> 40));
+            PlatformDependent.putByte(array, index + 6, (byte) (value >>> 48));
+            PlatformDependent.putByte(array, index + 7, (byte) (value >>> 56));
         }
     }
 

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -224,8 +224,18 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public short getShortLE(int index) {
+        return buf.getShortLE(index);
+    }
+
+    @Override
     public int getUnsignedShort(int index) {
         return buf.getUnsignedShort(index);
+    }
+
+    @Override
+    public int getUnsignedShortLE(int index) {
+        return buf.getUnsignedShortLE(index);
     }
 
     @Override
@@ -234,8 +244,18 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public int getMediumLE(int index) {
+        return buf.getMediumLE(index);
+    }
+
+    @Override
     public int getUnsignedMedium(int index) {
         return buf.getUnsignedMedium(index);
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
+        return buf.getUnsignedMediumLE(index);
     }
 
     @Override
@@ -244,13 +264,28 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public int getIntLE(int index) {
+        return buf.getIntLE(index);
+    }
+
+    @Override
     public long getUnsignedInt(int index) {
         return buf.getUnsignedInt(index);
     }
 
     @Override
+    public long getUnsignedIntLE(int index) {
+        return buf.getUnsignedIntLE(index);
+    }
+
+    @Override
     public long getLong(int index) {
         return buf.getLong(index);
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        return buf.getLongLE(index);
     }
 
     @Override
@@ -334,8 +369,20 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf setShortLE(int index, int value) {
+        buf.setShortLE(index, value);
+        return this;
+    }
+
+    @Override
     public ByteBuf setMedium(int index, int value) {
         buf.setMedium(index, value);
+        return this;
+    }
+
+    @Override
+    public ByteBuf setMediumLE(int index, int value) {
+        buf.setMediumLE(index, value);
         return this;
     }
 
@@ -346,8 +393,20 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf setIntLE(int index, int value) {
+        buf.setIntLE(index, value);
+        return this;
+    }
+
+    @Override
     public ByteBuf setLong(int index, long value) {
         buf.setLong(index, value);
+        return this;
+    }
+
+    @Override
+    public ByteBuf setLongLE(int index, long value) {
+        buf.setLongLE(index, value);
         return this;
     }
 
@@ -442,8 +501,18 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public short readShortLE() {
+        return buf.readShortLE();
+    }
+
+    @Override
     public int readUnsignedShort() {
         return buf.readUnsignedShort();
+    }
+
+    @Override
+    public int readUnsignedShortLE() {
+        return buf.readUnsignedShortLE();
     }
 
     @Override
@@ -452,8 +521,18 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public int readMediumLE() {
+        return buf.readMediumLE();
+    }
+
+    @Override
     public int readUnsignedMedium() {
         return buf.readUnsignedMedium();
+    }
+
+    @Override
+    public int readUnsignedMediumLE() {
+        return buf.readUnsignedMediumLE();
     }
 
     @Override
@@ -462,13 +541,28 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public int readIntLE() {
+        return buf.readIntLE();
+    }
+
+    @Override
     public long readUnsignedInt() {
         return buf.readUnsignedInt();
     }
 
     @Override
+    public long readUnsignedIntLE() {
+        return buf.readUnsignedIntLE();
+    }
+
+    @Override
     public long readLong() {
         return buf.readLong();
+    }
+
+    @Override
+    public long readLongLE() {
+        return buf.readLongLE();
     }
 
     @Override
@@ -568,8 +662,20 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf writeShortLE(int value) {
+        buf.writeShortLE(value);
+        return this;
+    }
+
+    @Override
     public ByteBuf writeMedium(int value) {
         buf.writeMedium(value);
+        return this;
+    }
+
+    @Override
+    public ByteBuf writeMediumLE(int value) {
+        buf.writeMediumLE(value);
         return this;
     }
 
@@ -580,8 +686,20 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf writeIntLE(int value) {
+        buf.writeIntLE(value);
+        return this;
+    }
+
+    @Override
     public ByteBuf writeLong(long value) {
         buf.writeLong(value);
+        return this;
+    }
+
+    @Override
+    public ByteBuf writeLongLE(long value) {
+        buf.writeLongLE(value);
         return this;
     }
 

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -394,99 +394,245 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testRandomShortAccess() {
+        testRandomShortAccess(true);
+    }
+    @Test
+    public void testRandomShortLEAccess() {
+        testRandomShortAccess(false);
+    }
+
+    private void testRandomShortAccess(boolean testBigEndian) {
         for (int i = 0; i < buffer.capacity() - 1; i += 2) {
             short value = (short) random.nextInt();
-            buffer.setShort(i, value);
+            if (testBigEndian) {
+                buffer.setShort(i, value);
+            } else {
+                buffer.setShortLE(i, value);
+            }
         }
 
         random.setSeed(seed);
         for (int i = 0; i < buffer.capacity() - 1; i += 2) {
             short value = (short) random.nextInt();
-            assertEquals(value, buffer.getShort(i));
+            if (testBigEndian) {
+                assertEquals(value, buffer.getShort(i));
+            } else {
+                assertEquals(value, buffer.getShortLE(i));
+            }
         }
     }
 
     @Test
     public void testRandomUnsignedShortAccess() {
+        testRandomUnsignedShortAccess(true);
+    }
+
+    @Test
+    public void testRandomUnsignedShortLEAccess() {
+        testRandomUnsignedShortAccess(false);
+    }
+
+    private void testRandomUnsignedShortAccess(boolean testBigEndian) {
         for (int i = 0; i < buffer.capacity() - 1; i += 2) {
             short value = (short) random.nextInt();
-            buffer.setShort(i, value);
+            if (testBigEndian) {
+                buffer.setShort(i, value);
+            } else {
+                buffer.setShortLE(i, value);
+            }
         }
 
         random.setSeed(seed);
         for (int i = 0; i < buffer.capacity() - 1; i += 2) {
             int value = random.nextInt() & 0xFFFF;
-            assertEquals(value, buffer.getUnsignedShort(i));
+            if (testBigEndian) {
+                assertEquals(value, buffer.getUnsignedShort(i));
+            } else {
+                assertEquals(value, buffer.getUnsignedShortLE(i));
+            }
         }
     }
 
     @Test
     public void testRandomMediumAccess() {
+        testRandomMediumAccess(true);
+    }
+
+    @Test
+    public void testRandomMediumLEAccess() {
+        testRandomMediumAccess(false);
+    }
+
+    private void testRandomMediumAccess(boolean testBigEndian) {
         for (int i = 0; i < buffer.capacity() - 2; i += 3) {
             int value = random.nextInt();
-            buffer.setMedium(i, value);
+            if (testBigEndian) {
+                buffer.setMedium(i, value);
+            } else {
+                buffer.setMediumLE(i, value);
+            }
         }
 
         random.setSeed(seed);
         for (int i = 0; i < buffer.capacity() - 2; i += 3) {
             int value = random.nextInt() << 8 >> 8;
-            assertEquals(value, buffer.getMedium(i));
+            if (testBigEndian) {
+                assertEquals(value, buffer.getMedium(i));
+            } else {
+                assertEquals(value, buffer.getMediumLE(i));
+            }
         }
     }
 
     @Test
     public void testRandomUnsignedMediumAccess() {
+        testRandomUnsignedMediumAccess(true);
+    }
+
+    @Test
+    public void testRandomUnsignedMediumLEAccess() {
+        testRandomUnsignedMediumAccess(false);
+    }
+
+    private void testRandomUnsignedMediumAccess(boolean testBigEndian) {
         for (int i = 0; i < buffer.capacity() - 2; i += 3) {
             int value = random.nextInt();
-            buffer.setMedium(i, value);
+            if (testBigEndian) {
+                buffer.setMedium(i, value);
+            } else {
+                buffer.setMediumLE(i, value);
+            }
         }
 
         random.setSeed(seed);
         for (int i = 0; i < buffer.capacity() - 2; i += 3) {
             int value = random.nextInt() & 0x00FFFFFF;
-            assertEquals(value, buffer.getUnsignedMedium(i));
+            if (testBigEndian) {
+                assertEquals(value, buffer.getUnsignedMedium(i));
+            } else {
+                assertEquals(value, buffer.getUnsignedMediumLE(i));
+            }
         }
     }
 
     @Test
     public void testRandomIntAccess() {
+        testRandomIntAccess(true);
+    }
+
+    @Test
+    public void testRandomIntLEAccess() {
+        testRandomIntAccess(false);
+    }
+
+    private void testRandomIntAccess(boolean testBigEndian) {
         for (int i = 0; i < buffer.capacity() - 3; i += 4) {
             int value = random.nextInt();
-            buffer.setInt(i, value);
+            if (testBigEndian) {
+                buffer.setInt(i, value);
+            } else {
+                buffer.setIntLE(i, value);
+            }
         }
 
         random.setSeed(seed);
         for (int i = 0; i < buffer.capacity() - 3; i += 4) {
             int value = random.nextInt();
-            assertEquals(value, buffer.getInt(i));
+            if (testBigEndian) {
+                assertEquals(value, buffer.getInt(i));
+            } else {
+                assertEquals(value, buffer.getIntLE(i));
+            }
         }
     }
 
     @Test
     public void testRandomUnsignedIntAccess() {
+        testRandomUnsignedIntAccess(true);
+    }
+
+    @Test
+    public void testRandomUnsignedIntLEAccess() {
+        testRandomUnsignedIntAccess(false);
+    }
+
+    private void testRandomUnsignedIntAccess(boolean testBigEndian) {
         for (int i = 0; i < buffer.capacity() - 3; i += 4) {
             int value = random.nextInt();
-            buffer.setInt(i, value);
+            if (testBigEndian) {
+                buffer.setInt(i, value);
+            } else {
+                buffer.setIntLE(i, value);
+            }
         }
 
         random.setSeed(seed);
         for (int i = 0; i < buffer.capacity() - 3; i += 4) {
             long value = random.nextInt() & 0xFFFFFFFFL;
-            assertEquals(value, buffer.getUnsignedInt(i));
+            if (testBigEndian) {
+                assertEquals(value, buffer.getUnsignedInt(i));
+            } else {
+                assertEquals(value, buffer.getUnsignedIntLE(i));
+            }
         }
     }
 
     @Test
     public void testRandomLongAccess() {
+        testRandomLongAccess(true);
+    }
+
+    @Test
+    public void testRandomLongLEAccess() {
+        testRandomLongAccess(false);
+    }
+
+    private void testRandomLongAccess(boolean testBigEndian) {
         for (int i = 0; i < buffer.capacity() - 7; i += 8) {
             long value = random.nextLong();
-            buffer.setLong(i, value);
+            if (testBigEndian) {
+                buffer.setLong(i, value);
+            } else {
+                buffer.setLongLE(i, value);
+            }
         }
 
         random.setSeed(seed);
         for (int i = 0; i < buffer.capacity() - 7; i += 8) {
             long value = random.nextLong();
-            assertEquals(value, buffer.getLong(i));
+            if (testBigEndian) {
+                assertEquals(value, buffer.getLong(i));
+            } else {
+                assertEquals(value, buffer.getLongLE(i));
+            }
+        }
+    }
+
+    @Test
+    public void testRandomFloatAccess() {
+        for (int i = 0; i < buffer.capacity() - 7; i += 8) {
+            float value = random.nextFloat();
+            buffer.setFloat(i, value);
+        }
+
+        random.setSeed(seed);
+        for (int i = 0; i < buffer.capacity() - 7; i += 8) {
+            float value = random.nextFloat();
+            assertEquals(value, buffer.getFloat(i), 0.01);
+        }
+    }
+
+    @Test
+    public void testRandomDoubleAccess() {
+        for (int i = 0; i < buffer.capacity() - 7; i += 8) {
+            double value = random.nextDouble();
+            buffer.setDouble(i, value);
+        }
+
+        random.setSeed(seed);
+        for (int i = 0; i < buffer.capacity() - 7; i += 8) {
+            double value = random.nextDouble();
+            assertEquals(value, buffer.getDouble(i), 0.01);
         }
     }
 
@@ -566,12 +712,25 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testSequentialShortAccess() {
+        testSequentialShortAccess(true);
+    }
+
+    @Test
+    public void testSequentialShortLEAccess() {
+        testSequentialShortAccess(false);
+    }
+
+    private void testSequentialShortAccess(boolean testBigEndian) {
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity(); i += 2) {
             short value = (short) random.nextInt();
             assertEquals(i, buffer.writerIndex());
             assertTrue(buffer.isWritable());
-            buffer.writeShort(value);
+            if (testBigEndian) {
+                buffer.writeShort(value);
+            } else {
+                buffer.writeShortLE(value);
+            }
         }
 
         assertEquals(0, buffer.readerIndex());
@@ -583,7 +742,11 @@ public abstract class AbstractByteBufTest {
             short value = (short) random.nextInt();
             assertEquals(i, buffer.readerIndex());
             assertTrue(buffer.isReadable());
-            assertEquals(value, buffer.readShort());
+            if (testBigEndian) {
+                assertEquals(value, buffer.readShort());
+            } else {
+                assertEquals(value, buffer.readShortLE());
+            }
         }
 
         assertEquals(buffer.capacity(), buffer.readerIndex());
@@ -594,12 +757,25 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testSequentialUnsignedShortAccess() {
+        testSequentialUnsignedShortAccess(true);
+    }
+
+    @Test
+    public void testSequentialUnsignedShortLEAccess() {
+        testSequentialUnsignedShortAccess(true);
+    }
+
+    private void testSequentialUnsignedShortAccess(boolean testBigEndian) {
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity(); i += 2) {
             short value = (short) random.nextInt();
             assertEquals(i, buffer.writerIndex());
             assertTrue(buffer.isWritable());
-            buffer.writeShort(value);
+            if (testBigEndian) {
+                buffer.writeShort(value);
+            } else {
+                buffer.writeShortLE(value);
+            }
         }
 
         assertEquals(0, buffer.readerIndex());
@@ -611,7 +787,11 @@ public abstract class AbstractByteBufTest {
             int value = random.nextInt() & 0xFFFF;
             assertEquals(i, buffer.readerIndex());
             assertTrue(buffer.isReadable());
-            assertEquals(value, buffer.readUnsignedShort());
+            if (testBigEndian) {
+                assertEquals(value, buffer.readUnsignedShort());
+            } else {
+                assertEquals(value, buffer.readUnsignedShortLE());
+            }
         }
 
         assertEquals(buffer.capacity(), buffer.readerIndex());
@@ -622,12 +802,24 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testSequentialMediumAccess() {
+        testSequentialMediumAccess(true);
+    }
+    @Test
+    public void testSequentialMediumLEAccess() {
+        testSequentialMediumAccess(false);
+    }
+
+    private void testSequentialMediumAccess(boolean testBigEndian) {
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity() / 3 * 3; i += 3) {
             int value = random.nextInt();
             assertEquals(i, buffer.writerIndex());
             assertTrue(buffer.isWritable());
-            buffer.writeMedium(value);
+            if (testBigEndian) {
+                buffer.writeMedium(value);
+            } else {
+                buffer.writeMediumLE(value);
+            }
         }
 
         assertEquals(0, buffer.readerIndex());
@@ -639,7 +831,11 @@ public abstract class AbstractByteBufTest {
             int value = random.nextInt() << 8 >> 8;
             assertEquals(i, buffer.readerIndex());
             assertTrue(buffer.isReadable());
-            assertEquals(value, buffer.readMedium());
+            if (testBigEndian) {
+                assertEquals(value, buffer.readMedium());
+            } else {
+                assertEquals(value, buffer.readMediumLE());
+            }
         }
 
         assertEquals(buffer.capacity() / 3 * 3, buffer.readerIndex());
@@ -650,12 +846,25 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testSequentialUnsignedMediumAccess() {
+        testSequentialUnsignedMediumAccess(true);
+    }
+
+    @Test
+    public void testSequentialUnsignedMediumLEAccess() {
+        testSequentialUnsignedMediumAccess(false);
+    }
+
+    private void testSequentialUnsignedMediumAccess(boolean testBigEndian) {
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity() / 3 * 3; i += 3) {
             int value = random.nextInt() & 0x00FFFFFF;
             assertEquals(i, buffer.writerIndex());
             assertTrue(buffer.isWritable());
-            buffer.writeMedium(value);
+            if (testBigEndian) {
+                buffer.writeMedium(value);
+            } else {
+                buffer.writeMediumLE(value);
+            }
         }
 
         assertEquals(0, buffer.readerIndex());
@@ -667,7 +876,11 @@ public abstract class AbstractByteBufTest {
             int value = random.nextInt() & 0x00FFFFFF;
             assertEquals(i, buffer.readerIndex());
             assertTrue(buffer.isReadable());
-            assertEquals(value, buffer.readUnsignedMedium());
+            if (testBigEndian) {
+                assertEquals(value, buffer.readUnsignedMedium());
+            } else {
+                assertEquals(value, buffer.readUnsignedMediumLE());
+            }
         }
 
         assertEquals(buffer.capacity() / 3 * 3, buffer.readerIndex());
@@ -678,12 +891,25 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testSequentialIntAccess() {
+        testSequentialIntAccess(true);
+    }
+
+    @Test
+    public void testSequentialIntLEAccess() {
+        testSequentialIntAccess(false);
+    }
+
+    private void testSequentialIntAccess(boolean testBigEndian) {
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity(); i += 4) {
             int value = random.nextInt();
             assertEquals(i, buffer.writerIndex());
             assertTrue(buffer.isWritable());
-            buffer.writeInt(value);
+            if (testBigEndian) {
+                buffer.writeInt(value);
+            } else {
+                buffer.writeIntLE(value);
+            }
         }
 
         assertEquals(0, buffer.readerIndex());
@@ -695,7 +921,11 @@ public abstract class AbstractByteBufTest {
             int value = random.nextInt();
             assertEquals(i, buffer.readerIndex());
             assertTrue(buffer.isReadable());
-            assertEquals(value, buffer.readInt());
+            if (testBigEndian) {
+                assertEquals(value, buffer.readInt());
+            } else {
+                assertEquals(value, buffer.readIntLE());
+            }
         }
 
         assertEquals(buffer.capacity(), buffer.readerIndex());
@@ -706,12 +936,25 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testSequentialUnsignedIntAccess() {
+        testSequentialUnsignedIntAccess(true);
+    }
+
+    @Test
+    public void testSequentialUnsignedIntLEAccess() {
+        testSequentialUnsignedIntAccess(false);
+    }
+
+    private void testSequentialUnsignedIntAccess(boolean testBigEndian) {
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity(); i += 4) {
             int value = random.nextInt();
             assertEquals(i, buffer.writerIndex());
             assertTrue(buffer.isWritable());
-            buffer.writeInt(value);
+            if (testBigEndian) {
+                buffer.writeInt(value);
+            } else {
+                buffer.writeIntLE(value);
+            }
         }
 
         assertEquals(0, buffer.readerIndex());
@@ -723,7 +966,11 @@ public abstract class AbstractByteBufTest {
             long value = random.nextInt() & 0xFFFFFFFFL;
             assertEquals(i, buffer.readerIndex());
             assertTrue(buffer.isReadable());
-            assertEquals(value, buffer.readUnsignedInt());
+            if (testBigEndian) {
+                assertEquals(value, buffer.readUnsignedInt());
+            } else {
+                assertEquals(value, buffer.readUnsignedIntLE());
+            }
         }
 
         assertEquals(buffer.capacity(), buffer.readerIndex());
@@ -734,12 +981,25 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testSequentialLongAccess() {
+        testSequentialLongAccess(true);
+    }
+
+    @Test
+    public void testSequentialLongLEAccess() {
+        testSequentialLongAccess(false);
+    }
+
+    private void testSequentialLongAccess(boolean testBigEndian) {
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity(); i += 8) {
             long value = random.nextLong();
             assertEquals(i, buffer.writerIndex());
             assertTrue(buffer.isWritable());
-            buffer.writeLong(value);
+            if (testBigEndian) {
+                buffer.writeLong(value);
+            } else {
+                buffer.writeLongLE(value);
+            }
         }
 
         assertEquals(0, buffer.readerIndex());
@@ -751,7 +1011,11 @@ public abstract class AbstractByteBufTest {
             long value = random.nextLong();
             assertEquals(i, buffer.readerIndex());
             assertTrue(buffer.isReadable());
-            assertEquals(value, buffer.readLong());
+            if (testBigEndian) {
+                assertEquals(value, buffer.readLong());
+            } else {
+                assertEquals(value, buffer.readLongLE());
+            }
         }
 
         assertEquals(buffer.capacity(), buffer.readerIndex());
@@ -1997,13 +2261,28 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testGetShortLEAfterRelease() {
+        releasedBuffer().getShortLE(0);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testGetUnsignedShortAfterRelease() {
         releasedBuffer().getUnsignedShort(0);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testGetUnsignedShortLEAfterRelease() {
+        releasedBuffer().getUnsignedShortLE(0);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testGetMediumAfterRelease() {
         releasedBuffer().getMedium(0);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testGetMediumLEAfterRelease() {
+        releasedBuffer().getMediumLE(0);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2017,13 +2296,28 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testGetIntLEAfterRelease() {
+        releasedBuffer().getIntLE(0);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testGetUnsignedIntAfterRelease() {
         releasedBuffer().getUnsignedInt(0);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testGetUnsignedIntLEAfterRelease() {
+        releasedBuffer().getUnsignedIntLE(0);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testGetLongAfterRelease() {
         releasedBuffer().getLong(0);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testGetLongLEAfterRelease() {
+        releasedBuffer().getLongLE(0);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2097,8 +2391,18 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testSetShortLEAfterRelease() {
+        releasedBuffer().setShortLE(0, 1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testSetMediumAfterRelease() {
         releasedBuffer().setMedium(0, 1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testSetMediumLEAfterRelease() {
+        releasedBuffer().setMediumLE(0, 1);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2107,8 +2411,18 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testSetIntLEAfterRelease() {
+        releasedBuffer().setIntLE(0, 1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testSetLongAfterRelease() {
         releasedBuffer().setLong(0, 1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testSetLongLEAfterRelease() {
+        releasedBuffer().setLongLE(0, 1);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2192,8 +2506,18 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testReadShortLEAfterRelease() {
+        releasedBuffer().readShortLE();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testReadUnsignedShortAfterRelease() {
         releasedBuffer().readUnsignedShort();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testReadUnsignedShortLEAfterRelease() {
+        releasedBuffer().readUnsignedShortLE();
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2202,8 +2526,18 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testReadMediumLEAfterRelease() {
+        releasedBuffer().readMediumLE();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testReadUnsignedMediumAfterRelease() {
         releasedBuffer().readUnsignedMedium();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testReadUnsignedMediumLEAfterRelease() {
+        releasedBuffer().readUnsignedMediumLE();
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2212,13 +2546,28 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testReadIntLEAfterRelease() {
+        releasedBuffer().readIntLE();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testReadUnsignedIntAfterRelease() {
         releasedBuffer().readUnsignedInt();
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testReadUnsignedIntLEAfterRelease() {
+        releasedBuffer().readUnsignedIntLE();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testReadLongAfterRelease() {
         releasedBuffer().readLong();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testReadLongLEAfterRelease() {
+        releasedBuffer().readLongLE();
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2302,8 +2651,18 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testWriteShortLEAfterRelease() {
+        releasedBuffer().writeShortLE(1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testWriteMediumAfterRelease() {
         releasedBuffer().writeMedium(1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testWriteMediumLEAfterRelease() {
+        releasedBuffer().writeMediumLE(1);
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2312,8 +2671,18 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test(expected = IllegalReferenceCountException.class)
+    public void testWriteIntLEAfterRelease() {
+        releasedBuffer().writeIntLE(1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
     public void testWriteLongAfterRelease() {
         releasedBuffer().writeLong(1);
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testWriteLongLEAfterRelease() {
+        releasedBuffer().writeLongLE(1);
     }
 
     @Test(expected = IllegalReferenceCountException.class)

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
@@ -246,9 +246,21 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    public int getIntLE(int index) {
+        checkIndex(index, 4);
+        return buffer.getIntLE(index);
+    }
+
+    @Override
     public long getUnsignedInt(int index) {
         checkIndex(index, 4);
         return buffer.getUnsignedInt(index);
+    }
+
+    @Override
+    public long getUnsignedIntLE(int index) {
+        checkIndex(index, 4);
+        return buffer.getUnsignedIntLE(index);
     }
 
     @Override
@@ -258,9 +270,21 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    public long getLongLE(int index) {
+        checkIndex(index, 8);
+        return buffer.getLongLE(index);
+    }
+
+    @Override
     public int getMedium(int index) {
         checkIndex(index, 3);
         return buffer.getMedium(index);
+    }
+
+    @Override
+    public int getMediumLE(int index) {
+        checkIndex(index, 3);
+        return buffer.getMediumLE(index);
     }
 
     @Override
@@ -270,15 +294,33 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    public int getUnsignedMediumLE(int index) {
+        checkIndex(index, 3);
+        return buffer.getUnsignedMediumLE(index);
+    }
+
+    @Override
     public short getShort(int index) {
         checkIndex(index, 2);
         return buffer.getShort(index);
     }
 
     @Override
+    public short getShortLE(int index) {
+        checkIndex(index, 2);
+        return buffer.getShortLE(index);
+    }
+
+    @Override
     public int getUnsignedShort(int index) {
         checkIndex(index, 2);
         return buffer.getUnsignedShort(index);
+    }
+
+    @Override
+    public int getUnsignedShortLE(int index) {
+        checkIndex(index, 2);
+        return buffer.getUnsignedShortLE(index);
     }
 
     @Override
@@ -551,9 +593,21 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    public int readIntLE() {
+        checkReadableBytes(4);
+        return buffer.readIntLE();
+    }
+
+    @Override
     public long readUnsignedInt() {
         checkReadableBytes(4);
         return buffer.readUnsignedInt();
+    }
+
+    @Override
+    public long readUnsignedIntLE() {
+        checkReadableBytes(4);
+        return buffer.readUnsignedIntLE();
     }
 
     @Override
@@ -563,9 +617,21 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    public long readLongLE() {
+        checkReadableBytes(8);
+        return buffer.readLongLE();
+    }
+
+    @Override
     public int readMedium() {
         checkReadableBytes(3);
         return buffer.readMedium();
+    }
+
+    @Override
+    public int readMediumLE() {
+        checkReadableBytes(3);
+        return buffer.readMediumLE();
     }
 
     @Override
@@ -575,15 +641,33 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    public int readUnsignedMediumLE() {
+        checkReadableBytes(3);
+        return buffer.readUnsignedMediumLE();
+    }
+
+    @Override
     public short readShort() {
         checkReadableBytes(2);
         return buffer.readShort();
     }
 
     @Override
+    public short readShortLE() {
+        checkReadableBytes(2);
+        return buffer.readShortLE();
+    }
+
+    @Override
     public int readUnsignedShort() {
         checkReadableBytes(2);
         return buffer.readUnsignedShort();
+    }
+
+    @Override
+    public int readUnsignedShortLE() {
+        checkReadableBytes(2);
+        return buffer.readUnsignedShortLE();
     }
 
     @Override
@@ -695,7 +779,19 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf setIntLE(int index, int value) {
+        reject();
+        return this;
+    }
+
+    @Override
     public ByteBuf setLong(int index, long value) {
+        reject();
+        return this;
+    }
+
+    @Override
+    public ByteBuf setLongLE(int index, long value) {
         reject();
         return this;
     }
@@ -707,7 +803,19 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf setMediumLE(int index, int value) {
+        reject();
+        return this;
+    }
+
+    @Override
     public ByteBuf setShort(int index, int value) {
+        reject();
+        return this;
+    }
+
+    @Override
+    public ByteBuf setShortLE(int index, int value) {
         reject();
         return this;
     }
@@ -894,13 +1002,31 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf writeIntLE(int value) {
+        reject();
+        return this;
+    }
+
+    @Override
     public ByteBuf writeLong(long value) {
         reject();
         return this;
     }
 
     @Override
+    public ByteBuf writeLongLE(long value) {
+        reject();
+        return this;
+    }
+
+    @Override
     public ByteBuf writeMedium(int value) {
+        reject();
+        return this;
+    }
+
+    @Override
+    public ByteBuf writeMediumLE(int value) {
         reject();
         return this;
     }
@@ -924,6 +1050,12 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf writeShort(int value) {
+        reject();
+        return this;
+    }
+
+    @Override
+    public ByteBuf writeShortLE(int value) {
         reject();
         return this;
     }


### PR DESCRIPTION
As discussed in #3209, this PR adds Little Endian accessors 
to ByteBuf and descendants.

Corresponding accessors were added to UnsafeByteBufUtil,
HeapByteBufferUtil to avoid calling `Integer.reverseBytes`. 