### PR TITLE
Added writeVoidPromise, writeAndFlushVoidPromise to ChannelGroup - Issue #3127

### DIFF
--- a/transport/src/main/java/io/netty/channel/group/ChannelGroup.java
+++ b/transport/src/main/java/io/netty/channel/group/ChannelGroup.java
@@ -121,6 +121,20 @@ public interface ChannelGroup extends Set<Channel>, Comparable<ChannelGroup> {
 
     /**
      * Writes the specified {@code message} to all {@link Channel}s in this
+     * group. If the specified {@code message} is an instance of
+     * {@link ByteBuf}, it is automatically
+     * {@linkplain ByteBuf#duplicate() duplicated} to avoid a race
+     * condition. The same is true for {@link ByteBufHolder}. Please note that this operation is asynchronous as
+     * {@link Channel#write(Object)} is. This method will reduce Object Allocation and thus reduce GC use this method
+     * if you are not interested in {@link io.netty.channel.ChannelFuture}. This method will write and use
+     * {@link io.netty.channel.VoidChannelPromise} for each channel that is written to.
+     *
+     * @return itself
+     */
+    ChannelGroupFuture writeVoidPromise(Object message);
+
+    /**
+     * Writes the specified {@code message} to all {@link Channel}s in this
      * group that match the given {@link ChannelMatcher}. If the specified {@code message} is an instance of
      * {@link ByteBuf}, it is automatically
      * {@linkplain ByteBuf#duplicate() duplicated} to avoid a race
@@ -131,6 +145,21 @@ public interface ChannelGroup extends Set<Channel>, Comparable<ChannelGroup> {
      *         the operation is done for all channels
      */
     ChannelGroupFuture write(Object message, ChannelMatcher matcher);
+
+    /**
+     * Writes the specified {@code message} to all {@link Channel}s in this
+     * group that match the given {@link ChannelMatcher}. If the specified {@code message} is an instance of
+     * {@link ByteBuf}, it is automatically
+     * {@linkplain ByteBuf#duplicate() duplicated} to avoid a race
+     * condition. The same is true for {@link ByteBufHolder}. Please note that this operation is asynchronous as
+     * {@link Channel#write(Object)} is. This method will reduce Object Allocation and thus reduce GC use this method
+     * if you are not interested in {@link io.netty.channel.ChannelFuture}. This method will write and use
+     * {@link io.netty.channel.VoidChannelPromise} for each channel that is written to.
+     *
+     * @return the {@link ChannelGroupFuture} instance that notifies when
+     *         the operation is done for all channels
+     */
+    ChannelGroupFuture writeVoidPromise(Object message, ChannelMatcher matcher);
 
     /**
      * Flush all {@link Channel}s in this
@@ -164,6 +193,11 @@ public interface ChannelGroup extends Set<Channel>, Comparable<ChannelGroup> {
     ChannelGroupFuture writeAndFlush(Object message);
 
     /**
+     * Shortcut for calling {@link #writeVoidPromise(Object)} and {@link #flush()}.
+     */
+    ChannelGroupFuture writeAndFlushVoidPromise(Object message);
+
+    /**
      * @deprecated Use {@link #writeAndFlush(Object)} instead.
      */
     @Deprecated
@@ -174,6 +208,12 @@ public interface ChannelGroup extends Set<Channel>, Comparable<ChannelGroup> {
      * {@link Channel}s that match the {@link ChannelMatcher}.
      */
     ChannelGroupFuture writeAndFlush(Object message, ChannelMatcher matcher);
+
+    /**
+     * Shortcut for calling {@link #writeVoidPromise(Object)} and {@link #flush()} and only act on
+     * {@link Channel}s that match the {@link ChannelMatcher}.
+     */
+    ChannelGroupFuture writeAndFlushVoidPromise(Object message, ChannelMatcher matcher);
 
     /**
      * @deprecated Use {@link #writeAndFlush(Object, ChannelMatcher)} instead.


### PR DESCRIPTION
Added ```writeVoidPromise```, ```writeAndFlushVoidPromise``` methods to ```ChannelGroup``` and ```DefaultChannelGroup```

#### Motivation:

Reduce Objects and GC by option. Give the option to developers to be able to choose to ```Channel.voidPromise()``` when making group writes. This will reduce object creation for ```ChannelGroup``` writes and writeAndFlush's by adding additional methods which add the ```Channel.voidPromise()``` into the ```Channel.write()``` portion of the method. 

#### Modifications:

ChannelGroup.class - Added new methods to the interface along with documentation to the regular method and addition documentation specificly the purpose of the new methods. 
> ChannelGroupFuture writeVoidPromise(Object message);
> ChannelGroupFuture writeAndFlushVoidPromise(Object message);
> ChannelGroupFuture writeVoidPromise(Object message, ChannelMatcher matcher); 
> ChannelGroupFuture  writeAndFlushVoidPromise(Object message, ChannelMatcher matcher);.

DefaultChannelGroup.class - Now implements these new interface methods in the utilizing the existing write and writeAndFlush method by coping them and then adding Channel.voidPromise() to the two methods that actually have the write logic.
> public ChannelGroupFuture writeVoidPromise(Object message);
> public ChannelGroupFuture writeAndFlushVoidPromise(Object message);
> public ChannelGroupFuture writeVoidPromise(Object message, ChannelMatcher matcher);
> public ChannelGroupFuture writeAndFlushVoidPromise(Object message, ChannelMatcher matcher);

#### Result:

Netty.io API users will now be able to use ```DefaultChannelGroup.writeVoidPromise();``` and ```DefaultChannelGroup.writeAndFlushVoidPromise();```, and be able to save on object creation and GC when not caring about the FuturePromise.

closes #3127