### PR TITLE
Epoll Shutdown Input Exception Handling

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -366,8 +366,10 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
                         fd().shutdown(true, false);
                         clearEpollIn0();
                         pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
-                    } catch (IOException e) {
-                        pipeline().fireExceptionCaught(e);
+                    } catch (IOException ignored) {
+                        // We attempted to shutdown and failed, which means the input has already effectively been
+                        // shutdown.
+                        pipeline().fireUserEventTriggered(ChannelInputShutdownEvent.INSTANCE);
                         close(voidPromise());
                     }
                 } else {

--- a/transport-native-epoll/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/unix/Socket.java
@@ -49,17 +49,21 @@ public final class Socket extends FileDescriptor {
         super(fd);
     }
 
+    public void shutdown() throws IOException {
+        shutdown(!inputShutdown, !outputShutdown);
+    }
+
     public void shutdown(boolean read, boolean write) throws IOException {
         inputShutdown = read || inputShutdown;
         outputShutdown = write || outputShutdown;
+        shutdown0(read, write);
+    }
+
+    private void shutdown0(boolean read, boolean write) throws IOException {
         int res = shutdown(intValue(), read, write);
         if (res < 0) {
             ioResult("shutdown", res, CONNECTION_NOT_CONNECTED_SHUTDOWN_EXCEPTION);
         }
-    }
-
-    public void shutdown() throws IOException {
-        shutdown(true, true);
     }
 
     public boolean isShutdown() {


### PR DESCRIPTION
Motivation:
If ChannelOption.ALLOW_HALF_CLOSURE is true and the shutdown input operation fails we should not propagate this exception, and instead consider this socket's read as half closed.

Modifications:
- AbstractEpollChannel.shutdownInput should not propagate exceptions when attempting to shutdown the input, but instead should just close the socket

Result:
Users expecting a ChannelInputShutdownEvent will get this event even if the socket is already shutdown, and the shutdown operation fails.