### PR TITLE
Remote flow controller incorrectly updates stream state

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -460,7 +460,6 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
          * Increments the number of pending bytes for this node and optionally updates the
          * {@link StreamByteDistributor}.
          */
-        // TODO(nmittler): consider updating streamable bytes elsewhere.
         private void incrementPendingBytes(int numBytes, boolean updateStreamableBytes) {
             pendingBytes += numBytes;
             monitor.incrementPendingBytes(numBytes);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/PriorityStreamByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/PriorityStreamByteDistributor.java
@@ -346,6 +346,9 @@ public final class PriorityStreamByteDistributor implements StreamByteDistributo
         }
 
         void updateStreamableBytes(int newStreamableBytes, boolean hasFrame) {
+            if (!hasFrame && newStreamableBytes > 0) {
+                throw new IllegalArgumentException("Streamable bytes must be zero when !hasFrame.");
+            }
             this.hasFrame = hasFrame;
 
             int delta = newStreamableBytes - streamableBytes;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/PriorityStreamByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/PriorityStreamByteDistributor.java
@@ -346,9 +346,7 @@ public final class PriorityStreamByteDistributor implements StreamByteDistributo
         }
 
         void updateStreamableBytes(int newStreamableBytes, boolean hasFrame) {
-            if (!hasFrame && newStreamableBytes > 0) {
-                throw new IllegalArgumentException("Streamable bytes must be zero when !hasFrame.");
-            }
+            assert hasFrame || newStreamableBytes == 0;
             this.hasFrame = hasFrame;
 
             int delta = newStreamableBytes - streamableBytes;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/PriorityStreamByteDistributorTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/PriorityStreamByteDistributorTest.java
@@ -136,10 +136,10 @@ public class PriorityStreamByteDistributorTest {
 
         doNothing().when(writer).write(same(stream(STREAM_C)), eq(3));
         write(10);
-        verifyWrite(atMost(1), STREAM_A, 1);
-        verifyWrite(atMost(1), STREAM_B, 2);
+        verifyWrite(STREAM_A, 1);
+        verifyWrite(STREAM_B, 2);
         verifyWrite(times(2), STREAM_C, 3);
-        verifyWrite(atMost(1), STREAM_D, 4);
+        verifyWrite(STREAM_D, 4);
     }
 
     /**


### PR DESCRIPTION
Motivation:

The `DefaultHttp2RemoteFlowController` does not correctly determine `hasFrame` when updating the stream state for the distributor. Adding a check to enforce `hasFrame` when `streamableBytes > 0` causes several test failures.

Modifications:

Modified `DefaultHttp2RemoteFlowController` to simplify the writing logic and to correct the bookkeeping for `hasFrame`.

Result:

The distributors are always called with valid arguments.