### PR TITLE
Reduce memory footprint of DefaultChannelPipeline

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -22,7 +22,6 @@ import io.netty.util.DefaultAttributeMap;
 import io.netty.util.Recycler;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
-import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.OneTimeTask;
 import io.netty.util.internal.RecyclableMpscLinkedQueueNode;
@@ -64,7 +63,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
     private volatile Runnable invokeChannelWritableStateChangedTask;
     private volatile Runnable invokeFlushTask;
 
-    AbstractChannelHandlerContext(DefaultChannelPipeline pipeline, EventExecutorGroup group, String name,
+    AbstractChannelHandlerContext(DefaultChannelPipeline pipeline, EventExecutor executor, String name,
                                   boolean inbound, boolean outbound) {
 
         if (name == null) {
@@ -74,20 +73,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
         channel = pipeline.channel;
         this.pipeline = pipeline;
         this.name = name;
-
-        if (group != null) {
-            // Pin one of the child executors once and remember it so that the same child executor
-            // is used to fire events for the same channel.
-            EventExecutor childExecutor = pipeline.childExecutors.get(group);
-            if (childExecutor == null) {
-                childExecutor = group.next();
-                pipeline.childExecutors.put(group, childExecutor);
-            }
-            executor = childExecutor;
-        } else {
-            executor = null;
-        }
-
+        this.executor = executor;
         this.inbound = inbound;
         this.outbound = outbound;
     }

--- a/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
@@ -15,15 +15,15 @@
 */
 package io.netty.channel;
 
-import io.netty.util.concurrent.EventExecutorGroup;
+import io.netty.util.concurrent.EventExecutor;
 
 final class DefaultChannelHandlerContext extends AbstractChannelHandlerContext {
 
     private final ChannelHandler handler;
 
     DefaultChannelHandlerContext(
-            DefaultChannelPipeline pipeline, EventExecutorGroup group, String name, ChannelHandler handler) {
-        super(pipeline, group, name, isInbound(handler), isOutbound(handler));
+            DefaultChannelPipeline pipeline, EventExecutor executor, String name, ChannelHandler handler) {
+        super(pipeline, executor, name, isInbound(handler), isOutbound(handler));
         if (handler == null) {
             throw new NullPointerException("handler");
         }


### PR DESCRIPTION
Motivation:

If you need to handle a lot of concurrent connections (1M+) the memory footprint can be problem.

Modifications:

- Lazy create the IdentityHashMap that holds the EventExecutor mappings as this is not needed by most users anyway
- Use a sane initial capacity when creating the IdentityHashMap

Result:

Smaller memory footprint of DefaultChannelPipeline