### PR TITLE
Mark ChannelHandler.exceptionCaught(...) as deprected.

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandler.java
@@ -192,7 +192,10 @@ public interface ChannelHandler {
 
     /**
      * Gets called if a {@link Throwable} was thrown.
+     *
+     * @deprecated is part of {@link ChannelInboundHandler}
      */
+    @Deprecated
     void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception;
 
     /**

--- a/transport/src/main/java/io/netty/channel/ChannelInboundHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelInboundHandler.java
@@ -70,5 +70,6 @@ public interface ChannelInboundHandler extends ChannelHandler {
      * Gets called if a {@link Throwable} was thrown.
      */
     @Override
+    @SuppressWarnings("deprecated")
     void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception;
 }


### PR DESCRIPTION
Motivation:

exceptionCaught(...) will only handle inbound exceptions which means it makes not much sense to have it also on ChannelOutboundHandler. Because of this we should move it to ChannelInboundHandler.

Modifications:

Add @deprecated annotation to ChannelHandler.exceptionCaught(...).

Result:

Preapre to cleanup the API in later release.