### PR TITLE
Cleanup ChannelOption.AUTO_CLOSE javadocs

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -33,7 +33,6 @@ import java.net.NetworkInterface;
 public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
 
     private static final ConstantPool<ChannelOption<Object>> pool = new ConstantPool<ChannelOption<Object>>() {
-        @SuppressWarnings("deprecation")
         @Override
         protected ChannelOption<Object> newConstant(int id, String name) {
             return new ChannelOption<Object>(id, name);
@@ -91,8 +90,8 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
     /**
      * @deprecated From version 5.0, {@link Channel} will not be closed on write failure.
      *
-     * {@code true} if and only if the {@link Channel} is closed automatically and immediately on write failure.
-     * The default is {@code false}.
+     * If {@code true} then the {@link Channel} is closed automatically and immediately on write failure.
+     * The default value is {@code true}.
      */
     @Deprecated
     public static final ChannelOption<Boolean> AUTO_CLOSE = valueOf("AUTO_CLOSE");


### PR DESCRIPTION
Motivation:
The javadocs for ChannelOption.AUTO_CLOSE say the default is false, but the default is currently true.

Modifications:
- Make javadocs consistent with code

Result:
Less confusing docs.