### PR TITLE
Make cookie encoding conform better to RFC 6265

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
@@ -15,16 +15,24 @@
  */
 package io.netty.handler.codec.http.cookie;
 
-import static io.netty.handler.codec.http.cookie.CookieUtil.*;
+import static io.netty.handler.codec.http.cookie.CookieUtil.add;
+import static io.netty.handler.codec.http.cookie.CookieUtil.addQuoted;
+import static io.netty.handler.codec.http.cookie.CookieUtil.stringBuilder;
+import static io.netty.handler.codec.http.cookie.CookieUtil.stripTrailingSeparator;
+import static io.netty.handler.codec.http.cookie.CookieUtil.stripTrailingSeparatorOrNull;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
-
-import java.util.Iterator;
-
 import io.netty.handler.codec.http.HttpRequest;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
 /**
- * A <a href="http://tools.ietf.org/html/rfc6265">RFC6265</a> compliant cookie encoder to be used client side,
- * so only name=value pairs are sent.
+ * A <a href="http://tools.ietf.org/html/rfc6265">RFC6265</a> compliant cookie encoder to be used client side, so
+ * only name=value pairs are sent.
  *
  * User-Agents are not supposed to interpret cookies, so, if present, {@link Cookie#rawValue()} will be used.
  * Otherwise, {@link Cookie#value()} will be used unquoted.
@@ -42,13 +50,14 @@ import io.netty.handler.codec.http.HttpRequest;
 public final class ClientCookieEncoder extends CookieEncoder {
 
     /**
-     * Strict encoder that validates that name and value chars are in the valid scope
-     * defined in RFC6265
+     * Strict encoder that validates that name and value chars are in the valid scope and (for methods that accept
+     * multiple cookies) sorts cookies into order of decreasing path length, as specified in RFC6265.
      */
     public static final ClientCookieEncoder STRICT = new ClientCookieEncoder(true);
 
     /**
-     * Lax instance that doesn't validate name and value
+     * Lax instance that doesn't validate name and value, and (for methods that accept multiple cookies) keeps
+     * cookies in the order in which they were given.
      */
     public static final ClientCookieEncoder LAX = new ClientCookieEncoder(false);
 
@@ -59,8 +68,10 @@ public final class ClientCookieEncoder extends CookieEncoder {
     /**
      * Encodes the specified cookie into a Cookie header value.
      *
-     * @param name the cookie name
-     * @param value the cookie value
+     * @param name
+     *            the cookie name
+     * @param value
+     *            the cookie value
      * @return a Rfc6265 style Cookie header value
      */
     public String encode(String name, String value) {
@@ -70,7 +81,8 @@ public final class ClientCookieEncoder extends CookieEncoder {
     /**
      * Encodes the specified cookie into a Cookie header value.
      *
-     * @param specified the cookie
+     * @param specified
+     *            the cookie
      * @return a Rfc6265 style Cookie header value
      */
     public String encode(Cookie cookie) {
@@ -80,9 +92,36 @@ public final class ClientCookieEncoder extends CookieEncoder {
     }
 
     /**
+     * Sort cookies into decreasing order of path length, breaking ties by sorting into increasing chronological
+     * order of creation time, as recommended by RFC 6265.
+     */
+    private static final Comparator<Cookie> COOKIE_COMPARATOR = new Comparator<Cookie>() {
+        @Override
+        public int compare(Cookie c1, Cookie c2) {
+            String path1 = c1.path();
+            String path2 = c2.path();
+            // Cookies with unspecified path default to the path of the request. We don't
+            // know the request path here, but we assume that the length of an unspecified
+            // path is longer than any specified path (i.e. pathless cookies come first),
+            // because setting cookies with a path longer than the request path is of
+            // limited use.
+            int len1 = path1 == null ? Integer.MAX_VALUE : path1.length();
+            int len2 = path2 == null ? Integer.MAX_VALUE : path2.length();
+            int diff = len2 - len1;
+            if (diff != 0) {
+                return diff;
+            }
+            // Rely on Java's sort stability to retain creation order in cases where
+            // cookies have same path length.
+            return -1;
+        }
+    };
+
+    /**
      * Encodes the specified cookies into a single Cookie header value.
      *
-     * @param cookies some cookies
+     * @param cookies
+     *            some cookies
      * @return a Rfc6265 style Cookie header value, null if no cookies are passed.
      */
     public String encode(Cookie... cookies) {
@@ -91,12 +130,51 @@ public final class ClientCookieEncoder extends CookieEncoder {
         }
 
         StringBuilder buf = stringBuilder();
-        for (Cookie c : cookies) {
-            if (c == null) {
-                break;
+        if (strict) {
+            if (cookies.length == 1) {
+                encode(buf, cookies[0]);
+            } else {
+                Cookie[] cookiesSorted = Arrays.copyOf(cookies, cookies.length);
+                Arrays.sort(cookiesSorted, COOKIE_COMPARATOR);
+                for (Cookie c : cookiesSorted) {
+                    encode(buf, c);
+                }
             }
+        } else {
+            for (Cookie c : cookies) {
+                encode(buf, c);
+            }
+        }
+        return stripTrailingSeparatorOrNull(buf);
+    }
 
-            encode(buf, c);
+    /**
+     * Encodes the specified cookies into a single Cookie header value.
+     *
+     * @param cookies
+     *            some cookies
+     * @return a Rfc6265 style Cookie header value, null if no cookies are passed.
+     */
+    public String encode(Collection<? extends Cookie> cookies) {
+        if (checkNotNull(cookies, "cookies").isEmpty()) {
+            return null;
+        }
+
+        StringBuilder buf = stringBuilder();
+        if (strict) {
+            if (cookies.size() == 1) {
+                encode(buf, cookies.iterator().next());
+            } else {
+                Cookie[] cookiesSorted = cookies.toArray(new Cookie[cookies.size()]);
+                Arrays.sort(cookiesSorted, COOKIE_COMPARATOR);
+                for (Cookie c : cookiesSorted) {
+                    encode(buf, c);
+                }
+            }
+        } else {
+            for (Cookie c : cookies) {
+                encode(buf, c);
+            }
         }
         return stripTrailingSeparatorOrNull(buf);
     }
@@ -114,13 +192,26 @@ public final class ClientCookieEncoder extends CookieEncoder {
         }
 
         StringBuilder buf = stringBuilder();
-        while (cookiesIt.hasNext()) {
-            Cookie c = cookiesIt.next();
-            if (c == null) {
-                break;
+        if (strict) {
+            Cookie firstCookie = cookiesIt.next();
+            if (!cookiesIt.hasNext()) {
+                encode(buf, firstCookie);
+            } else {
+                List<Cookie> cookiesList = new ArrayList<Cookie>();
+                cookiesList.add(firstCookie);
+                while (cookiesIt.hasNext()) {
+                    cookiesList.add(cookiesIt.next());
+                }
+                Cookie[] cookiesSorted = cookiesList.toArray(new Cookie[cookiesList.size()]);
+                Arrays.sort(cookiesSorted, COOKIE_COMPARATOR);
+                for (Cookie c : cookiesSorted) {
+                    encode(buf, c);
+                }
             }
-
-            encode(buf, c);
+        } else {
+            while (cookiesIt.hasNext()) {
+                encode(buf, cookiesIt.next());
+            }
         }
         return stripTrailingSeparatorOrNull(buf);
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieEncoder.java
@@ -24,7 +24,7 @@ import static io.netty.handler.codec.http.cookie.CookieUtil.unwrapValue;
  */
 public abstract class CookieEncoder {
 
-    private final boolean strict;
+    protected final boolean strict;
 
     protected CookieEncoder(boolean strict) {
         this.strict = strict;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ClientCookieEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ClientCookieEncoderTest.java
@@ -23,21 +23,23 @@ public class ClientCookieEncoderTest {
 
     @Test
     public void testEncodingMultipleClientCookies() {
-        String c1 = "myCookie=myValue; ";
-        String c2 = "myCookie2=myValue2; ";
+        String c1 = "myCookie=myValue";
+        String c2 = "myCookie2=myValue2";
         String c3 = "myCookie3=myValue3";
-        Cookie cookie = new DefaultCookie("myCookie", "myValue");
-        cookie.setDomain(".adomainsomewhere");
-        cookie.setMaxAge(50);
-        cookie.setPath("/apathsomewhere");
-        cookie.setSecure(true);
+        Cookie cookie1 = new DefaultCookie("myCookie", "myValue");
+        cookie1.setDomain(".adomainsomewhere");
+        cookie1.setMaxAge(50);
+        cookie1.setPath("/apathsomewhere");
+        cookie1.setSecure(true);
         Cookie cookie2 = new DefaultCookie("myCookie2", "myValue2");
         cookie2.setDomain(".anotherdomainsomewhere");
         cookie2.setPath("/anotherpathsomewhere");
         cookie2.setSecure(false);
         Cookie cookie3 = new DefaultCookie("myCookie3", "myValue3");
-        String encodedCookie = ClientCookieEncoder.STRICT.encode(cookie, cookie2, cookie3);
-        assertEquals(c1 + c2 + c3, encodedCookie);
+        String encodedCookie = ClientCookieEncoder.STRICT.encode(cookie1, cookie2, cookie3);
+        // Cookies should be sorted into decreasing order of path length, as per RFC6265.
+        // When no path is provided, we assume maximum path length (so cookie3 comes first).
+        assertEquals(c3 + "; " + c2 + "; " + c1, encodedCookie);
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieEncoderTest.java
@@ -15,17 +15,20 @@
  */
 package io.netty.handler.codec.http.cookie;
 
-import org.junit.Test;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import io.netty.handler.codec.http.HttpHeaderDateFormat;
 
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
 
 public class ServerCookieEncoderTest {
 
@@ -59,5 +62,30 @@ public class ServerCookieEncoderTest {
         assertNull(encodedCookie1);
         assertNotNull(encodedCookie2);
         assertTrue(encodedCookie2.isEmpty());
+    }
+
+    @Test
+    public void testEncodingMultipleCookiesStrict() {
+        List<String> result = new ArrayList<String>();
+        result.add("cookie2=value2");
+        result.add("cookie1=value3");
+        Cookie cookie1 = new DefaultCookie("cookie1", "value1");
+        Cookie cookie2 = new DefaultCookie("cookie2", "value2");
+        Cookie cookie3 = new DefaultCookie("cookie1", "value3");
+        List<String> encodedCookies = ServerCookieEncoder.STRICT.encode(cookie1, cookie2, cookie3);
+        assertEquals(result, encodedCookies);
+    }
+
+    @Test
+    public void testEncodingMultipleCookiesLax() {
+        List<String> result = new ArrayList<String>();
+        result.add("cookie1=value1");
+        result.add("cookie2=value2");
+        result.add("cookie1=value3");
+        Cookie cookie1 = new DefaultCookie("cookie1", "value1");
+        Cookie cookie2 = new DefaultCookie("cookie2", "value2");
+        Cookie cookie3 = new DefaultCookie("cookie1", "value3");
+        List<String> encodedCookies = ServerCookieEncoder.LAX.encode(cookie1, cookie2, cookie3);
+        assertEquals(result, encodedCookies);
     }
 }


### PR DESCRIPTION
Applies two changes to cookie encoding in strict mode:

1. ClientCookieEncoder will sort cookies in decreasing order of path length.
2. ServerCookieEncoder will only send one cookie of a given name (arbitrarily chosen as the last cookie set with the given name, ignoring path -- which cookie to send in the case of multiple cookies with the same name is not specified in the spec).

(Please double-check everything looks right, I admittedly have not tested this, as I don't have the bandwith right now to figure out how to build and incorporate a modified version of Netty into my project.)