### PR TITLE
Fix the incorrect usage/value of 'Connection: upgrade'

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
@@ -266,7 +266,7 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator implements Ch
             builder.append(part);
             builder.append(',');
         }
-        builder.append(HttpHeaderNames.UPGRADE);
+        builder.append(HttpHeaderValues.UPGRADE);
         request.headers().set(HttpHeaderNames.CONNECTION, builder.toString());
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
@@ -193,9 +193,9 @@ public final class HttpHeaderValues {
      */
     public static final AsciiString TRAILERS = new AsciiString("trailers");
     /**
-     * {@code "Upgrade"}
+     * {@code "upgrade"}
      */
-    public static final AsciiString UPGRADE = new AsciiString("Upgrade");
+    public static final AsciiString UPGRADE = new AsciiString("upgrade");
     /**
      * {@code "websocket"}
      */


### PR DESCRIPTION
Motivation:

HttpClientUpgradeHandler uses HttpHeaderNames.UPGRADE as the value of
the 'Connection' header, which is incorrect. It should use
HttpHeaderValues.UPGRADE instead (note Names vs Values.)

Also, HttpHeaderValues.UPGRADE should be 'upgrade' rather than
'Upgrade', as defined in:

- https://tools.ietf.org/html/rfc7230#section-6.7

Modifications:

- Use HttpHeaderValues.UPGRADE for a 'Connection' header
- Lowercase the value of HttpHeaderValues.UPGRADE

Result:

- Fixes #4508
- Correct behavior