### PR TITLE
Remove final to allow overriding behavior in SimpleChannelPool

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeoutException;
  * {@link ChannelPool} implementation that takes another {@link ChannelPool} implementation and enforce a maximum
  * number of concurrent connections.
  */
-public final class FixedChannelPool extends SimpleChannelPool {
+public class FixedChannelPool extends SimpleChannelPool {
     private static final IllegalStateException FULL_EXCEPTION =
             new IllegalStateException("Too many outstanding acquire operations");
     private static final TimeoutException TIMEOUT_EXCEPTION =


### PR DESCRIPTION
Netty version 4.0.33
I don't know if there is a reason to put final the class whereas there is some interesting behavior to override in the class io.netty.channel.pool.SimpleChannelPool and still using nice features offered by FixedChannelPool