### PR TITLE
HTTP/2 Data Padding

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -197,7 +197,7 @@ public class Http2FrameRoundtripTest {
         for (int framePadding : paddingCaptor.getAllValues()) {
             totalReadPadding += framePadding;
         }
-        assertEquals(originalPadding, totalReadPadding);
+        assertEquals(originalPadding * paddingCaptor.getAllValues().size(), totalReadPadding);
     }
 
     @Test


### PR DESCRIPTION
Motivation:
Currently we apply padding on either the last frame, or potentially the last 2 frames if the padding overflows over the max frame size. If there is a large payload then the majority of the frames will not have any padding applied, and the length of these frames will not be obfuscated as discussed in https://tools.ietf.org/html/rfc7540#section-10.7.

Modifications:
- Apply padding to all frames if data must be split amongst multiple frames.

Result:
- Padding is no longer only applied to the last (or last 2) frames.