### PR TITLE
HttpConversionUtil does not account for COOKIE compression

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -14,16 +14,15 @@
  */
 package io.netty.handler.codec.http2;
 
+import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
+import static io.netty.handler.codec.http2.Http2Exception.connectionError;
+import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
+import static io.netty.util.AsciiString.isUpperCase;
 import io.netty.handler.codec.CharSequenceValueConverter;
 import io.netty.handler.codec.DefaultHeaders;
 import io.netty.util.AsciiString;
 import io.netty.util.ByteProcessor;
 import io.netty.util.internal.PlatformDependent;
-
-import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
-import static io.netty.handler.codec.http2.Http2Exception.connectionError;
-import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
-import static io.netty.util.AsciiString.isUpperCase;
 
 public class DefaultHttp2Headers
         extends DefaultHeaders<CharSequence, CharSequence, Http2Headers> implements Http2Headers {
@@ -111,6 +110,20 @@ public class DefaultHttp2Headers
     public Http2Headers clear() {
         this.firstNonPseudo = head;
         return super.clear();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Http2Headers)) {
+            return false;
+        }
+
+        return equals((Http2Headers) o, CASE_SENSITIVE_HASHER);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode(CASE_SENSITIVE_HASHER);
     }
 
     @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -142,6 +142,27 @@ public class HttpToHttp2ConnectionHandlerTest {
     }
 
     @Test
+    public void testMultipleCookieEntriesAreCombined() throws Exception {
+        bootstrapEnv(2, 1, 0);
+        final FullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET,
+                "http://my-user_name@www.example.org:5555/example");
+        final HttpHeaders httpHeaders = request.headers();
+        httpHeaders.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 5);
+        httpHeaders.set(HttpHeaderNames.HOST, "my-user_name@www.example.org:5555");
+        httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "http");
+        httpHeaders.set(HttpHeaderNames.COOKIE, "a=b; c=d; e=f");
+        final Http2Headers http2Headers =
+                new DefaultHttp2Headers().method(new AsciiString("GET")).path(new AsciiString("/example"))
+                .authority(new AsciiString("www.example.org:5555")).scheme(new AsciiString("http"))
+                .add(HttpHeaderNames.COOKIE, "a=b")
+                .add(HttpHeaderNames.COOKIE, "c=d")
+                .add(HttpHeaderNames.COOKIE, "e=f");
+
+        ChannelPromise writePromise = newPromise();
+        verifyHeadersOnly(http2Headers, writePromise, clientChannel.writeAndFlush(request, writePromise));
+    }
+
+    @Test
     public void testOriginFormRequestTargetHandled() throws Exception {
         bootstrapEnv(2, 1, 0);
         final FullHttpRequest request = new DefaultFullHttpRequest(HTTP_1_1, GET, "/where?q=now&f=then#section1");

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -159,6 +159,75 @@ public class InboundHttp2ToHttpAdapterTest {
     }
 
     @Test
+    public void clientRequestSingleHeaderCookieSplitIntoMultipleEntries() throws Exception {
+        boostrapEnv(1, 1, 1);
+        final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                "/some/path/resource2", true);
+        try {
+            HttpHeaders httpHeaders = request.headers();
+            httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "https");
+            httpHeaders.set(HttpHeaderNames.HOST, "example.org");
+            httpHeaders.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 3);
+            httpHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
+            httpHeaders.set(HttpHeaderNames.COOKIE, "a=b; c=d; e=f");
+            final Http2Headers http2Headers = new DefaultHttp2Headers().method(new AsciiString("GET")).
+                    scheme(new AsciiString("https")).authority(new AsciiString("example.org"))
+                    .path(new AsciiString("/some/path/resource2"))
+                    .add(HttpHeaderNames.COOKIE, "a=b")
+                    .add(HttpHeaderNames.COOKIE, "c=d")
+                    .add(HttpHeaderNames.COOKIE, "e=f");
+            runInChannel(clientChannel, new Http2Runnable() {
+                @Override
+                public void run() {
+                    frameWriter.writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
+                    ctxClient().flush();
+                }
+            });
+            awaitRequests();
+            ArgumentCaptor<FullHttpMessage> requestCaptor = ArgumentCaptor.forClass(FullHttpMessage.class);
+            verify(serverListener).messageReceived(requestCaptor.capture());
+            capturedRequests = requestCaptor.getAllValues();
+            assertEquals(request, capturedRequests.get(0));
+        } finally {
+            request.release();
+        }
+    }
+
+    @Test
+    public void clientRequestSingleHeaderCookieSplitIntoMultipleEntries2() throws Exception {
+        boostrapEnv(1, 1, 1);
+        final FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                "/some/path/resource2", true);
+        try {
+            HttpHeaders httpHeaders = request.headers();
+            httpHeaders.set(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), "https");
+            httpHeaders.set(HttpHeaderNames.HOST, "example.org");
+            httpHeaders.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), 3);
+            httpHeaders.setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
+            httpHeaders.set(HttpHeaderNames.COOKIE, "a=b; c=d; e=f");
+            final Http2Headers http2Headers = new DefaultHttp2Headers().method(new AsciiString("GET")).
+                    scheme(new AsciiString("https")).authority(new AsciiString("example.org"))
+                    .path(new AsciiString("/some/path/resource2"))
+                    .add(HttpHeaderNames.COOKIE, "a=b; c=d")
+                    .add(HttpHeaderNames.COOKIE, "e=f");
+            runInChannel(clientChannel, new Http2Runnable() {
+                @Override
+                public void run() {
+                    frameWriter.writeHeaders(ctxClient(), 3, http2Headers, 0, true, newPromiseClient());
+                    ctxClient().flush();
+                }
+            });
+            awaitRequests();
+            ArgumentCaptor<FullHttpMessage> requestCaptor = ArgumentCaptor.forClass(FullHttpMessage.class);
+            verify(serverListener).messageReceived(requestCaptor.capture());
+            capturedRequests = requestCaptor.getAllValues();
+            assertEquals(request, capturedRequests.get(0));
+        } finally {
+            request.release();
+        }
+    }
+
+    @Test
     public void clientRequestSingleHeaderNonAsciiShouldThrow() throws Exception {
         boostrapEnv(1, 1, 1);
         final Http2Headers http2Headers = new DefaultHttp2Headers()

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -276,7 +276,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
     }
 
     private int forEachByte0(int index, int length, ByteProcessor visitor) throws Exception {
-        final int len = offset + length;
+        final int len = offset + index + length;
         for (int i = offset + index; i < len; ++i) {
             if (!visitor.process(value[i])) {
                 return i - offset;

--- a/common/src/main/java/io/netty/util/ByteProcessor.java
+++ b/common/src/main/java/io/netty/util/ByteProcessor.java
@@ -121,6 +121,16 @@ public interface ByteProcessor {
     };
 
     /**
+     * Aborts on a {@code CR (';')}.
+     */
+    ByteProcessor FIND_SEMI_COLON = new ByteProcessor() {
+        @Override
+        public boolean process(byte value) throws Exception {
+            return value != ';';
+        }
+    };
+
+    /**
      * @return {@code true} if the processor wants to continue the loop and handle the next byte in the buffer.
      *         {@code false} if the processor wants to stop handling bytes and abort the loop.
      */

--- a/common/src/test/java/io/netty/util/AsciiStringMemoryTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringMemoryTest.java
@@ -17,6 +17,7 @@ package io.netty.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import io.netty.util.ByteProcessor.IndexOfProcessor;
 
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
@@ -103,6 +104,18 @@ public class AsciiStringMemoryTest {
     }
 
     @Test
+    public void forEachWithIndexEndTest() throws Exception {
+        assertNotEquals(-1, aAsciiString.forEachByte(aAsciiString.length() - 1,
+                1, new IndexOfProcessor(aAsciiString.byteAt(aAsciiString.length() - 1))));
+    }
+
+    @Test
+    public void forEachWithIndexBeginTest() throws Exception {
+        assertNotEquals(-1, aAsciiString.forEachByte(0,
+                1, new IndexOfProcessor(aAsciiString.byteAt(0))));
+    }
+
+    @Test
     public void forEachDescTest() throws Exception {
         final AtomicReference<Integer> aCount = new AtomicReference<Integer>(0);
         final AtomicReference<Integer> bCount = new AtomicReference<Integer>(0);
@@ -126,6 +139,18 @@ public class AsciiStringMemoryTest {
         });
         assertEquals(aAsciiString.length(), aCount.get().intValue());
         assertEquals(bAsciiString.length(), bCount.get().intValue());
+    }
+
+    @Test
+    public void forEachDescWithIndexEndTest() throws Exception {
+        assertNotEquals(-1, bAsciiString.forEachByteDesc(bAsciiString.length() - 1,
+                1, new IndexOfProcessor(bAsciiString.byteAt(bAsciiString.length() - 1))));
+    }
+
+    @Test
+    public void forEachDescWithIndexBeginTest() throws Exception {
+        assertNotEquals(-1, bAsciiString.forEachByteDesc(0,
+                1, new IndexOfProcessor(bAsciiString.byteAt(0))));
     }
 
     @Test


### PR DESCRIPTION
Motivation:
The HTTP/2 RFC allows for COOKIE values to be split into individual header elements to get more benefit from compression (https://tools.ietf.org/html/rfc7540#section-8.1.2.5). HttpConversionUtil was not accounting for this behavior.

Modifications:
- Modify HttpConversionUtil to support compressing and decompressing the COOKIE values

Result:
HttpConversionUtil is compatible with https://tools.ietf.org/html/rfc7540#section-8.1.2.5)
Fixes https://github.com/netty/netty/issues/4457