### PR TITLE
Don't cycle dns servers while cycling dns record types. Each server s…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -100,6 +100,7 @@ abstract class DnsNameResolverContext<T> {
     }
 
     void resolve() {
+        InetSocketAddress nameServerAddrToTry = nameServerAddrs.next();
         for (InternetProtocolFamily f: resolveAddressTypes) {
             final DnsRecordType type;
             switch (f) {
@@ -113,7 +114,7 @@ abstract class DnsNameResolverContext<T> {
                 throw new Error();
             }
 
-            query(nameServerAddrs.next(), new DefaultDnsQuestion(hostname, type));
+            query(nameServerAddrToTry, new DefaultDnsQuestion(hostname, type));
         }
     }
 


### PR DESCRIPTION
…hould be checked for every record type. Currently, if there are only two configured servers and the first is down, it is impossible to query for IPv4 addresses because the second server is only ever queried for type AAAA.