### PR TITLE
Use ByteBuf.*LE methods for write and read LE

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
 
 /**
  * Uncompresses an input {@link ByteBuf} encoded with Snappy compression into an
@@ -410,19 +409,19 @@ class Snappy {
             if (in.readableBytes() < 2) {
                 return NOT_ENOUGH_INPUT;
             }
-            length = ByteBufUtil.swapShort(in.readShort());
+            length = in.readShortLE();
             break;
         case 62:
             if (in.readableBytes() < 3) {
                 return NOT_ENOUGH_INPUT;
             }
-            length = ByteBufUtil.swapMedium(in.readUnsignedMedium());
+            length = in.readUnsignedMediumLE();
             break;
         case 64:
             if (in.readableBytes() < 4) {
                 return NOT_ENOUGH_INPUT;
             }
-            length = ByteBufUtil.swapInt(in.readInt());
+            length = in.readIntLE();
             break;
         default:
             length = tag >> 2 & 0x3F;
@@ -502,7 +501,7 @@ class Snappy {
 
         int initialIndex = out.writerIndex();
         int length = 1 + (tag >> 2 & 0x03f);
-        int offset = ByteBufUtil.swapShort(in.readShort());
+        int offset = in.readShortLE();
 
         validateOffset(offset, writtenSoFar);
 
@@ -546,7 +545,7 @@ class Snappy {
 
         int initialIndex = out.writerIndex();
         int length = 1 + (tag >> 2 & 0x03F);
-        int offset = ByteBufUtil.swapInt(in.readInt());
+        int offset = in.readIntLE();
 
         validateOffset(offset, writtenSoFar);
 

--- a/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 
@@ -95,7 +94,7 @@ public class SnappyFrameDecoder extends ByteToMessageDecoder {
 
             final int chunkTypeVal = in.getUnsignedByte(idx);
             final ChunkType chunkType = mapChunkType((byte) chunkTypeVal);
-            final int chunkLength = ByteBufUtil.swapMedium(in.getUnsignedMedium(idx + 1));
+            final int chunkLength = in.getUnsignedMediumLE(idx + 1);
 
             switch (chunkType) {
                 case STREAM_IDENTIFIER:
@@ -149,7 +148,7 @@ public class SnappyFrameDecoder extends ByteToMessageDecoder {
 
                     in.skipBytes(4);
                     if (validateChecksums) {
-                        int checksum = ByteBufUtil.swapInt(in.readInt());
+                        int checksum = in.readIntLE();
                         validateChecksum(checksum, in, in.readerIndex(), chunkLength - 4);
                     } else {
                         in.skipBytes(4);
@@ -166,7 +165,7 @@ public class SnappyFrameDecoder extends ByteToMessageDecoder {
                     }
 
                     in.skipBytes(4);
-                    int checksum = ByteBufUtil.swapInt(in.readInt());
+                    int checksum = in.readIntLE();
                     ByteBuf uncompressed = ctx.alloc().buffer(0);
                     if (validateChecksums) {
                         int oldWriterIndex = in.writerIndex();

--- a/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameEncoder.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
 
@@ -99,7 +98,7 @@ public class SnappyFrameEncoder extends MessageToByteEncoder<ByteBuf> {
         if (chunkLength >>> 24 != 0) {
             throw new CompressionException("compressed data too large: " + chunkLength);
         }
-        out.setMedium(lengthIdx, ByteBufUtil.swapMedium(chunkLength));
+        out.setMediumLE(lengthIdx, chunkLength);
     }
 
     /**
@@ -109,7 +108,7 @@ public class SnappyFrameEncoder extends MessageToByteEncoder<ByteBuf> {
      * @param chunkLength The length to write
      */
     private static void writeChunkLength(ByteBuf out, int chunkLength) {
-        out.writeMedium(ByteBufUtil.swapMedium(chunkLength));
+        out.writeMediumLE(chunkLength);
     }
 
     /**
@@ -119,6 +118,6 @@ public class SnappyFrameEncoder extends MessageToByteEncoder<ByteBuf> {
      * @param out The output buffer to write the checksum to
      */
     private static void calculateAndWriteChecksum(ByteBuf slice, ByteBuf out) {
-        out.writeInt(ByteBufUtil.swapInt(calculateChecksum(slice)));
+        out.writeIntLE(calculateChecksum(slice));
     }
 }


### PR DESCRIPTION
Motivation:

We recently added methods to ByteBuf to directly write and read LE values. We should use these in the Snappy implementation and so reduce duplication.

Modifications:

Replace manually swapping of values with LE write and read methods of ByteBuf.

Result:

Cleaner code with less duplication.