### PR TITLE
Add Http2HeadersEncoder.ALWAYS_SENSITIVE instance

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersEncoder.java
@@ -63,12 +63,22 @@ public interface Http2HeadersEncoder {
     Configuration configuration();
 
     /**
-     * Always return {@code false} for {@link SensitivityDetector#isSensitive(ByteString, ByteString)}.
+     * Always return {@code false} for {@link SensitivityDetector#isSensitive(CharSequence, CharSequence)}.
      */
     SensitivityDetector NEVER_SENSITIVE = new SensitivityDetector() {
         @Override
         public boolean isSensitive(CharSequence name, CharSequence value) {
             return false;
+        }
+    };
+
+    /**
+     * Always return {@code true} for {@link SensitivityDetector#isSensitive(CharSequence, CharSequence)}.
+     */
+    SensitivityDetector ALWAYS_SENSITIVE = new SensitivityDetector() {
+        @Override
+        public boolean isSensitive(CharSequence name, CharSequence value) {
+            return true;
         }
     };
 }


### PR DESCRIPTION
Motivation:

We already provide a NEVER_SENSITIVE instance,we should add ALWAYS_SENSITIVE as well.

Modifications:

Add ALWAYS_SENSITIVE instance which will always return true when check for sesitive.

Result:

User can reuse code.