### PR TITLE
Ensure we retain the original InetSocketAddress when connect to a rem…

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -759,7 +759,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel {
         /**
          * Finish the connect
          */
-        private boolean doFinishConnect() throws Exception {
+        boolean doFinishConnect() throws Exception {
             if (fd().finishConnect()) {
                 clearFlag(Native.EPOLLOUT);
                 return true;


### PR DESCRIPTION
…ote peer when using epoll transport.

Motivation:

We should retain the original InetSocketAddress when connecto to a remote peer so the user can still query the origin hostname if getHostString() is used.

Modifications:

Store a reference to the origin InetSocketAddress and use it once the chnannel becomes active.

Result:

Same behavior when using epoll transport and nio transport.