### PR TITLE
[#4564] Fix AsciiString.contentEqualsIgnoreCase

### DIFF
--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -530,7 +530,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
         if (string.getClass() == AsciiString.class) {
             AsciiString rhs = (AsciiString) string;
             for (int i = arrayOffset(), j = rhs.arrayOffset(); i < length(); ++i, ++j) {
-                if (!equalsIgnoreCase(value[i], value[j])) {
+                if (!equalsIgnoreCase(value[i], rhs.value[j])) {
                     return false;
                 }
             }

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -240,6 +240,16 @@ public class AsciiStringCharacterTest {
         assertThat(AsciiString.contentEqualsIgnoreCase(null, "foo"), is(false));
         assertThat(AsciiString.contentEqualsIgnoreCase("bar", null), is(false));
         assertThat(AsciiString.contentEqualsIgnoreCase("FoO", "fOo"), is(true));
+
+        // Test variations (Ascii + String, Ascii + Ascii, String + Ascii)
+        assertThat(AsciiString.contentEqualsIgnoreCase(new AsciiString("FoO"), "fOo"), is(true));
+        assertThat(AsciiString.contentEqualsIgnoreCase(new AsciiString("FoO"), new AsciiString("fOo")), is(true));
+        assertThat(AsciiString.contentEqualsIgnoreCase("FoO", new AsciiString("fOo")), is(true));
+
+        // Test variations (Ascii + String, Ascii + Ascii, String + Ascii)
+        assertThat(AsciiString.contentEqualsIgnoreCase(new AsciiString("FoO"), "bAr"), is(false));
+        assertThat(AsciiString.contentEqualsIgnoreCase(new AsciiString("FoO"), new AsciiString("bAr")), is(false));
+        assertThat(AsciiString.contentEqualsIgnoreCase("FoO", new AsciiString("bAr")), is(false));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Related to issue #4564.

```AsciiString.contentEqualsIgnoreCase``` fails when comparing two ```AsciiStrings``` of the same length

Modifications:

Compare the values of the first ```AsciiString``` to the second ```AsciiString```

Result:

```AsciiString.contentEqualsIgnoreCase``` works as expected