### PR TITLE
Extract SocketAdress logic from NameResolver

### DIFF
--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
@@ -36,7 +36,7 @@ import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
-import io.netty.resolver.NoopNameResolverGroup;
+import io.netty.resolver.NoopAddressResolverGroup;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
@@ -523,7 +523,7 @@ public class ProxyHandlerTest {
             Bootstrap b = new Bootstrap();
             b.group(group);
             b.channel(NioSocketChannel.class);
-            b.resolver(NoopNameResolverGroup.INSTANCE);
+            b.resolver(NoopAddressResolverGroup.INSTANCE);
             b.handler(new ChannelInitializer<SocketChannel>() {
                 @Override
                 protected void initChannel(SocketChannel ch) throws Exception {
@@ -571,7 +571,7 @@ public class ProxyHandlerTest {
             Bootstrap b = new Bootstrap();
             b.group(group);
             b.channel(NioSocketChannel.class);
-            b.resolver(NoopNameResolverGroup.INSTANCE);
+            b.resolver(NoopAddressResolverGroup.INSTANCE);
             b.handler(new ChannelInitializer<SocketChannel>() {
                 @Override
                 protected void initChannel(SocketChannel ch) throws Exception {
@@ -616,7 +616,7 @@ public class ProxyHandlerTest {
             Bootstrap b = new Bootstrap();
             b.group(group);
             b.channel(NioSocketChannel.class);
-            b.resolver(NoopNameResolverGroup.INSTANCE);
+            b.resolver(NoopAddressResolverGroup.INSTANCE);
             b.handler(new ChannelInitializer<SocketChannel>() {
                 @Override
                 protected void initChannel(SocketChannel ch) throws Exception {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
@@ -20,8 +20,8 @@ import io.netty.channel.ChannelFactory;
 import io.netty.channel.EventLoop;
 import io.netty.channel.ReflectiveChannelFactory;
 import io.netty.channel.socket.DatagramChannel;
-import io.netty.resolver.NameResolver;
-import io.netty.resolver.NameResolverGroup;
+import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.internal.StringUtil;
 
@@ -30,31 +30,31 @@ import java.net.InetSocketAddress;
 import static io.netty.resolver.dns.DnsNameResolver.ANY_LOCAL_ADDR;
 
 /**
- * A {@link NameResolverGroup} of {@link DnsNameResolver}s.
+ * A {@link AddressResolverGroup} of {@link DnsNameResolver}s.
  */
-public class DnsNameResolverGroup extends NameResolverGroup<InetSocketAddress> {
+public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddress> {
 
     private final ChannelFactory<? extends DatagramChannel> channelFactory;
     private final InetSocketAddress localAddress;
     private final DnsServerAddresses nameServerAddresses;
 
-    public DnsNameResolverGroup(
+    public DnsAddressResolverGroup(
             Class<? extends DatagramChannel> channelType, DnsServerAddresses nameServerAddresses) {
         this(channelType, ANY_LOCAL_ADDR, nameServerAddresses);
     }
 
-    public DnsNameResolverGroup(
+    public DnsAddressResolverGroup(
             Class<? extends DatagramChannel> channelType,
             InetSocketAddress localAddress, DnsServerAddresses nameServerAddresses) {
         this(new ReflectiveChannelFactory<DatagramChannel>(channelType), localAddress, nameServerAddresses);
     }
 
-    public DnsNameResolverGroup(
+    public DnsAddressResolverGroup(
             ChannelFactory<? extends DatagramChannel> channelFactory, DnsServerAddresses nameServerAddresses) {
         this(channelFactory, ANY_LOCAL_ADDR, nameServerAddresses);
     }
 
-    public DnsNameResolverGroup(
+    public DnsAddressResolverGroup(
             ChannelFactory<? extends DatagramChannel> channelFactory,
             InetSocketAddress localAddress, DnsServerAddresses nameServerAddresses) {
         this.channelFactory = channelFactory;
@@ -63,7 +63,7 @@ public class DnsNameResolverGroup extends NameResolverGroup<InetSocketAddress> {
     }
 
     @Override
-    protected final NameResolver<InetSocketAddress> newResolver(EventExecutor executor) throws Exception {
+    protected final AddressResolver<InetSocketAddress> newResolver(EventExecutor executor) throws Exception {
         if (!(executor instanceof EventLoop)) {
             throw new IllegalStateException(
                     "unsupported executor type: " + StringUtil.simpleClassName(executor) +
@@ -77,11 +77,11 @@ public class DnsNameResolverGroup extends NameResolverGroup<InetSocketAddress> {
      * Creates a new {@link DnsNameResolver}. Override this method to create an alternative {@link DnsNameResolver}
      * implementation or override the default configuration.
      */
-    protected DnsNameResolver newResolver(
+    protected AddressResolver<InetSocketAddress> newResolver(
             EventLoop eventLoop, ChannelFactory<? extends DatagramChannel> channelFactory,
             InetSocketAddress localAddress, DnsServerAddresses nameServerAddresses) throws Exception {
 
-        return new DnsNameResolver(
-                eventLoop, channelFactory, localAddress, nameServerAddresses);
+        return new DnsNameResolver(eventLoop, channelFactory, localAddress, nameServerAddresses)
+                .asAddressResolver();
     }
 }

--- a/resolver/src/main/java/io/netty/resolver/AbstractAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/AbstractAddressResolver.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.resolver;
+
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.TypeParameterMatcher;
+
+import java.net.SocketAddress;
+import java.nio.channels.UnsupportedAddressTypeException;
+import java.util.Collections;
+import java.util.List;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * A skeletal {@link AddressResolver} implementation.
+ */
+public abstract class AbstractAddressResolver<T extends SocketAddress> implements AddressResolver<T> {
+
+    private final EventExecutor executor;
+    private final TypeParameterMatcher matcher;
+
+    /**
+     * @param executor the {@link EventExecutor} which is used to notify the listeners of the {@link Future} returned
+     *                 by {@link #resolve(SocketAddress)}
+     */
+    protected AbstractAddressResolver(EventExecutor executor) {
+        this.executor = checkNotNull(executor, "executor");
+        matcher = TypeParameterMatcher.find(this, AbstractAddressResolver.class, "T");
+    }
+
+    /**
+     * @param executor the {@link EventExecutor} which is used to notify the listeners of the {@link Future} returned
+     *                 by {@link #resolve(SocketAddress)}
+     * @param addressType the type of the {@link SocketAddress} supported by this resolver
+     */
+    protected AbstractAddressResolver(EventExecutor executor, Class<? extends T> addressType) {
+        this.executor = checkNotNull(executor, "executor");
+        matcher = TypeParameterMatcher.get(addressType);
+    }
+
+    /**
+     * Returns the {@link EventExecutor} which is used to notify the listeners of the {@link Future} returned
+     * by {@link #resolve(SocketAddress)}.
+     */
+    protected EventExecutor executor() {
+        return executor;
+    }
+
+    @Override
+    public boolean isSupported(SocketAddress address) {
+        return matcher.match(address);
+    }
+
+    @Override
+    public final boolean isResolved(SocketAddress address) {
+        if (!isSupported(address)) {
+            throw new UnsupportedAddressTypeException();
+        }
+
+        @SuppressWarnings("unchecked")
+        final T castAddress = (T) address;
+        return doIsResolved(castAddress);
+    }
+
+    /**
+     * Invoked by {@link #isResolved(SocketAddress)} to check if the specified {@code address} has been resolved
+     * already.
+     */
+    protected abstract boolean doIsResolved(T address);
+
+    @Override
+    public final Future<T> resolve(SocketAddress address) {
+        if (!isSupported(checkNotNull(address, "address"))) {
+            // Address type not supported by the resolver
+            return executor().newFailedFuture(new UnsupportedAddressTypeException());
+        }
+
+        if (isResolved(address)) {
+            // Resolved already; no need to perform a lookup
+            @SuppressWarnings("unchecked")
+            final T cast = (T) address;
+            return executor.newSucceededFuture(cast);
+        }
+
+        try {
+            @SuppressWarnings("unchecked")
+            final T cast = (T) address;
+            final Promise<T> promise = executor().newPromise();
+            doResolve(cast, promise);
+            return promise;
+        } catch (Exception e) {
+            return executor().newFailedFuture(e);
+        }
+    }
+
+    @Override
+    public final Future<T> resolve(SocketAddress address, Promise<T> promise) {
+        checkNotNull(address, "address");
+        checkNotNull(promise, "promise");
+
+        if (!isSupported(address)) {
+            // Address type not supported by the resolver
+            return promise.setFailure(new UnsupportedAddressTypeException());
+        }
+
+        if (isResolved(address)) {
+            // Resolved already; no need to perform a lookup
+            @SuppressWarnings("unchecked")
+            final T cast = (T) address;
+            return promise.setSuccess(cast);
+        }
+
+        try {
+            @SuppressWarnings("unchecked")
+            final T cast = (T) address;
+            doResolve(cast, promise);
+            return promise;
+        } catch (Exception e) {
+            return promise.setFailure(e);
+        }
+    }
+
+    @Override
+    public final Future<List<T>> resolveAll(SocketAddress address) {
+        if (!isSupported(checkNotNull(address, "address"))) {
+            // Address type not supported by the resolver
+            return executor().newFailedFuture(new UnsupportedAddressTypeException());
+        }
+
+        if (isResolved(address)) {
+            // Resolved already; no need to perform a lookup
+            @SuppressWarnings("unchecked")
+            final T cast = (T) address;
+            return executor.newSucceededFuture(Collections.singletonList(cast));
+        }
+
+        try {
+            @SuppressWarnings("unchecked")
+            final T cast = (T) address;
+            final Promise<List<T>> promise = executor().newPromise();
+            doResolveAll(cast, promise);
+            return promise;
+        } catch (Exception e) {
+            return executor().newFailedFuture(e);
+        }
+    }
+
+    @Override
+    public final Future<List<T>> resolveAll(SocketAddress address, Promise<List<T>> promise) {
+        checkNotNull(address, "address");
+        checkNotNull(promise, "promise");
+
+        if (!isSupported(address)) {
+            // Address type not supported by the resolver
+            return promise.setFailure(new UnsupportedAddressTypeException());
+        }
+
+        if (isResolved(address)) {
+            // Resolved already; no need to perform a lookup
+            @SuppressWarnings("unchecked")
+            final T cast = (T) address;
+            return promise.setSuccess(Collections.singletonList(cast));
+        }
+
+        try {
+            @SuppressWarnings("unchecked")
+            final T cast = (T) address;
+            doResolveAll(cast, promise);
+            return promise;
+        } catch (Exception e) {
+            return promise.setFailure(e);
+        }
+    }
+
+    /**
+     * Invoked by {@link #resolve(SocketAddress)} to perform the actual name
+     * resolution.
+     */
+    protected abstract void doResolve(T unresolvedAddress, Promise<T> promise) throws Exception;
+
+    /**
+     * Invoked by {@link #resolveAll(SocketAddress)} to perform the actual name
+     * resolution.
+     */
+    protected abstract void doResolveAll(T unresolvedAddress, Promise<List<T>> promise) throws Exception;
+
+    @Override
+    public void close() { }
+}

--- a/resolver/src/main/java/io/netty/resolver/AddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/AddressResolver.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver;
+
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+
+import java.io.Closeable;
+import java.net.SocketAddress;
+import java.nio.channels.UnsupportedAddressTypeException;
+import java.util.List;
+
+/**
+ * Resolves a possibility unresolved {@link {@link SocketAddress}}.
+ */
+public interface AddressResolver<T extends SocketAddress> extends Closeable {
+
+  /**
+   * Returns {@code true} if and only if the specified address is supported by this resolved.
+   */
+  boolean isSupported(SocketAddress address);
+
+  /**
+   * Returns {@code true} if and only if the specified address has been resolved.
+   *
+   * @throws UnsupportedAddressTypeException if the specified address is not supported by this resolver
+   */
+  boolean isResolved(SocketAddress address);
+
+  /**
+   * Resolves the specified address. If the specified address is resolved already, this method does nothing
+   * but returning the original address.
+   *
+   * @param address the address to resolve
+   *
+   * @return the {@link SocketAddress} as the result of the resolution
+   */
+  Future<T> resolve(SocketAddress address);
+
+  /**
+   * Resolves the specified address. If the specified address is resolved already, this method does nothing
+   * but returning the original address.
+   *
+   * @param address the address to resolve
+   * @param promise the {@link Promise} which will be fulfilled when the name resolution is finished
+   *
+   * @return the {@link SocketAddress} as the result of the resolution
+   */
+  Future<T> resolve(SocketAddress address, Promise<T> promise);
+
+  /**
+   * Resolves the specified address. If the specified address is resolved already, this method does nothing
+   * but returning the original address.
+   *
+   * @param address the address to resolve
+   *
+   * @return the list of the {@link SocketAddress}es as the result of the resolution
+   */
+  Future<List<T>> resolveAll(SocketAddress address);
+
+  /**
+   * Resolves the specified address. If the specified address is resolved already, this method does nothing
+   * but returning the original address.
+   *
+   * @param address the address to resolve
+   * @param promise the {@link Promise} which will be fulfilled when the name resolution is finished
+   *
+   * @return the list of the {@link SocketAddress}es as the result of the resolution
+   */
+  Future<List<T>> resolveAll(SocketAddress address, Promise<List<T>> promise);
+
+  /**
+   * Closes all the resources allocated and used by this resolver.
+   */
+  @Override
+  void close();
+}

--- a/resolver/src/main/java/io/netty/resolver/AddressResolverGroup.java
+++ b/resolver/src/main/java/io/netty/resolver/AddressResolverGroup.java
@@ -31,25 +31,25 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * Creates and manages {@link NameResolver}s so that each {@link EventExecutor} has its own resolver instance.
  */
-public abstract class NameResolverGroup<T extends SocketAddress> implements Closeable {
+public abstract class AddressResolverGroup<T extends SocketAddress> implements Closeable {
 
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(NameResolverGroup.class);
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(AddressResolverGroup.class);
 
     /**
      * Note that we do not use a {@link ConcurrentMap} here because it is usually expensive to instantiate a resolver.
      */
-    private final Map<EventExecutor, NameResolver<T>> resolvers =
-            new IdentityHashMap<EventExecutor, NameResolver<T>>();
+    private final Map<EventExecutor, AddressResolver<T>> resolvers =
+            new IdentityHashMap<EventExecutor, AddressResolver<T>>();
 
-    protected NameResolverGroup() { }
+    protected AddressResolverGroup() { }
 
     /**
-     * Returns the {@link NameResolver} associated with the specified {@link EventExecutor}.  If there's no associated
+     * Returns the {@link AddressResolver} associated with the specified {@link EventExecutor}. If there's no associated
      * resolved found, this method creates and returns a new resolver instance created by
      * {@link #newResolver(EventExecutor)} so that the new resolver is reused on another
      * {@link #getResolver(EventExecutor)} call with the same {@link EventExecutor}.
      */
-    public NameResolver<T> getResolver(final EventExecutor executor) {
+    public AddressResolver<T> getResolver(final EventExecutor executor) {
         if (executor == null) {
             throw new NullPointerException("executor");
         }
@@ -58,11 +58,11 @@ public abstract class NameResolverGroup<T extends SocketAddress> implements Clos
             throw new IllegalStateException("executor not accepting a task");
         }
 
-        NameResolver<T> r;
+        AddressResolver<T> r;
         synchronized (resolvers) {
             r = resolvers.get(executor);
             if (r == null) {
-                final NameResolver<T> newResolver;
+                final AddressResolver<T> newResolver;
                 try {
                     newResolver = newResolver(executor);
                 } catch (Exception e) {
@@ -86,9 +86,9 @@ public abstract class NameResolverGroup<T extends SocketAddress> implements Clos
     }
 
     /**
-     * Invoked by {@link #getResolver(EventExecutor)} to create a new {@link NameResolver}.
+     * Invoked by {@link #getResolver(EventExecutor)} to create a new {@link AddressResolver}.
      */
-    protected abstract NameResolver<T> newResolver(EventExecutor executor) throws Exception;
+    protected abstract AddressResolver<T> newResolver(EventExecutor executor) throws Exception;
 
     /**
      * Closes all {@link NameResolver}s created by this group.
@@ -96,13 +96,13 @@ public abstract class NameResolverGroup<T extends SocketAddress> implements Clos
     @Override
     @SuppressWarnings({ "unchecked", "SuspiciousToArrayCall" })
     public void close() {
-        final NameResolver<T>[] rArray;
+        final AddressResolver<T>[] rArray;
         synchronized (resolvers) {
-            rArray = (NameResolver<T>[]) resolvers.values().toArray(new NameResolver[resolvers.size()]);
+            rArray = (AddressResolver<T>[]) resolvers.values().toArray(new AddressResolver[resolvers.size()]);
             resolvers.clear();
         }
 
-        for (NameResolver<T> r: rArray) {
+        for (AddressResolver<T> r: rArray) {
             try {
                 r.close();
             } catch (Throwable t) {

--- a/resolver/src/main/java/io/netty/resolver/DefaultAddressResolverGroup.java
+++ b/resolver/src/main/java/io/netty/resolver/DefaultAddressResolverGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Netty Project
+ * Copyright 2015 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,19 +18,19 @@ package io.netty.resolver;
 
 import io.netty.util.concurrent.EventExecutor;
 
-import java.net.SocketAddress;
+import java.net.InetSocketAddress;
 
 /**
- * A {@link NameResolverGroup} of {@link NoopNameResolver}s.
+ * A {@link AddressResolverGroup} of {@link DefaultNameResolver}s.
  */
-public final class NoopNameResolverGroup extends NameResolverGroup<SocketAddress> {
+public final class DefaultAddressResolverGroup extends AddressResolverGroup<InetSocketAddress> {
 
-    public static final NoopNameResolverGroup INSTANCE = new NoopNameResolverGroup();
+    public static final DefaultAddressResolverGroup INSTANCE = new DefaultAddressResolverGroup();
 
-    private NoopNameResolverGroup() { }
+    private DefaultAddressResolverGroup() { }
 
     @Override
-    protected NameResolver<SocketAddress> newResolver(EventExecutor executor) throws Exception {
-        return new NoopNameResolver(executor);
+    protected AddressResolver<InetSocketAddress> newResolver(EventExecutor executor) throws Exception {
+        return new DefaultNameResolver(executor).asAddressResolver();
     }
 }

--- a/resolver/src/main/java/io/netty/resolver/DefaultNameResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/DefaultNameResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Netty Project
+ * Copyright 2015 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -22,49 +22,32 @@ import io.netty.util.concurrent.Promise;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
- * A {@link NameResolver} that resolves an {@link InetSocketAddress} using JDK's built-in domain name lookup mechanism.
+ * A {@link InetNameResolver} that resolves using JDK's built-in domain name lookup mechanism.
  * Note that this resolver performs a blocking name lookup from the caller thread.
  */
-public class DefaultNameResolver extends SimpleNameResolver<InetSocketAddress> {
+public class DefaultNameResolver extends InetNameResolver {
 
     public DefaultNameResolver(EventExecutor executor) {
         super(executor);
     }
 
     @Override
-    protected boolean doIsResolved(InetSocketAddress address) {
-        return !address.isUnresolved();
-    }
-
-    @Override
-    protected void doResolve(InetSocketAddress unresolvedAddress, Promise<InetSocketAddress> promise) throws Exception {
+    protected void doResolve(String inetHost, Promise<InetAddress> promise) throws Exception {
         try {
-            // Note that InetSocketAddress.getHostName() will never incur a reverse lookup here,
-            // because an unresolved address always has a host name.
-            promise.setSuccess(new InetSocketAddress(
-                    InetAddress.getByName(unresolvedAddress.getHostName()), unresolvedAddress.getPort()));
+            promise.setSuccess(InetAddress.getByName(inetHost));
         } catch (UnknownHostException e) {
             promise.setFailure(e);
         }
     }
 
     @Override
-    protected void doResolveAll(
-            InetSocketAddress unresolvedAddress, Promise<List<InetSocketAddress>> promise) throws Exception {
-
+    protected void doResolveAll(String inetHost, Promise<List<InetAddress>> promise) throws Exception {
         try {
-            // Note that InetSocketAddress.getHostName() will never incur a reverse lookup here,
-            // because an unresolved address always has a host name.
-            final InetAddress[] resolved = InetAddress.getAllByName(unresolvedAddress.getHostName());
-            final List<InetSocketAddress> result = new ArrayList<InetSocketAddress>(resolved.length);
-            for (InetAddress a: resolved) {
-                result.add(new InetSocketAddress(a, unresolvedAddress.getPort()));
-            }
-            promise.setSuccess(result);
+            promise.setSuccess(Arrays.asList(InetAddress.getAllByName(inetHost)));
         } catch (UnknownHostException e) {
             promise.setFailure(e);
         }

--- a/resolver/src/main/java/io/netty/resolver/InetNameResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/InetNameResolver.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver;
+
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+/**
+ * A skeletal {@link NameResolver} implementation that resolves {@link InetAddress}.
+ */
+public abstract class InetNameResolver extends SimpleNameResolver<InetAddress> {
+
+    private volatile AddressResolver<InetSocketAddress> addressResolver;
+
+    /**
+     * @param executor the {@link EventExecutor} which is used to notify the listeners of the {@link Future} returned
+     *                 by {@link #resolve(String)}
+     */
+    protected InetNameResolver(EventExecutor executor) {
+        super(executor);
+    }
+
+    /**
+     * Creates a new {@link AddressResolver} that will use this name resolver underneath.
+     */
+    public AddressResolver<InetSocketAddress> asAddressResolver() {
+        AddressResolver<InetSocketAddress> result = addressResolver;
+        if (result == null) {
+            synchronized (this) {
+                result = addressResolver;
+                if (result == null) {
+                    addressResolver = result = new InetSocketAddressResolver(executor(), this);
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver;
+
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.Promise;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A {@link AbstractAddressResolver} that resolves {@link InetAddress}.
+ */
+public class InetSocketAddressResolver extends AbstractAddressResolver<InetSocketAddress> {
+
+    private final NameResolver<InetAddress> nameResolver;
+
+    /**
+     * @param executor the {@link EventExecutor} which is used to notify the listeners of the {@link Future} returned
+     *                 by {@link #resolve(java.net.SocketAddress)}
+     * @param nameResolver the {@link NameResolver} used for name resolution
+     */
+    public InetSocketAddressResolver(EventExecutor executor, NameResolver<InetAddress> nameResolver) {
+        super(executor, InetSocketAddress.class);
+        this.nameResolver = nameResolver;
+    }
+
+    @Override
+    protected boolean doIsResolved(InetSocketAddress address) {
+        return !address.isUnresolved();
+    }
+
+    @Override
+    protected void doResolve(final InetSocketAddress unresolvedAddress, final Promise<InetSocketAddress> promise)
+            throws Exception {
+        // Note that InetSocketAddress.getHostName() will never incur a reverse lookup here,
+        // because an unresolved address always has a host name.
+        nameResolver.resolve(unresolvedAddress.getHostName())
+                .addListener(new GenericFutureListener<Future<InetAddress>>() {
+                    @Override
+                    public void operationComplete(Future<InetAddress> future) throws Exception {
+                        if (future.isSuccess()) {
+                            promise.setSuccess(new InetSocketAddress(future.getNow(), unresolvedAddress.getPort()));
+                        } else {
+                            promise.setFailure(future.cause());
+                        }
+                    }
+                });
+    }
+
+    @Override
+    protected void doResolveAll(final InetSocketAddress unresolvedAddress,
+                                final Promise<List<InetSocketAddress>> promise) throws Exception {
+        // Note that InetSocketAddress.getHostName() will never incur a reverse lookup here,
+        // because an unresolved address always has a host name.
+        nameResolver.resolveAll(unresolvedAddress.getHostName())
+                .addListener(new GenericFutureListener<Future<List<InetAddress>>>() {
+                    @Override
+                    public void operationComplete(Future<List<InetAddress>> future) throws Exception {
+                        if (future.isSuccess()) {
+                            List<InetAddress> inetAddresses = future.getNow();
+                            List<InetSocketAddress> socketAddresses =
+                                    new ArrayList<InetSocketAddress>(inetAddresses.size());
+                            for (InetAddress inetAddress : inetAddresses) {
+                                socketAddresses.add(new InetSocketAddress(inetAddress, unresolvedAddress.getPort()));
+                            }
+                            promise.setSuccess(socketAddresses);
+                        } else {
+                            promise.setFailure(future.cause());
+                        }
+                    }
+                });
+    }
+}

--- a/resolver/src/main/java/io/netty/resolver/NameResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/NameResolver.java
@@ -20,110 +20,50 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 
 import java.io.Closeable;
-import java.net.SocketAddress;
-import java.nio.channels.UnsupportedAddressTypeException;
 import java.util.List;
 
 /**
- * Resolves an arbitrary string that represents the name of an endpoint into a {@link SocketAddress}.
+ * Resolves an arbitrary string that represents the name of an endpoint into an address.
  */
-public interface NameResolver<T extends SocketAddress> extends Closeable {
+public interface NameResolver<T> extends Closeable {
 
     /**
-     * Returns {@code true} if and only if the specified address is supported by this resolved.
-     */
-    boolean isSupported(SocketAddress address);
-
-    /**
-     * Returns {@code true} if and only if the specified address has been resolved.
-     *
-     * @throws UnsupportedAddressTypeException if the specified address is not supported by this resolver
-     */
-    boolean isResolved(SocketAddress address);
-
-    /**
-     * Resolves the specified name into a {@link SocketAddress}.
+     * Resolves the specified name into an address.
      *
      * @param inetHost the name to resolve
-     * @param inetPort the port number
      *
-     * @return the {@link SocketAddress} as the result of the resolution
+     * @return the address as the result of the resolution
      */
-    Future<T> resolve(String inetHost, int inetPort);
+    Future<T> resolve(String inetHost);
 
     /**
-     * Resolves the specified name into a {@link SocketAddress}.
+     * Resolves the specified name into an address.
      *
      * @param inetHost the name to resolve
-     * @param inetPort the port number
      * @param promise the {@link Promise} which will be fulfilled when the name resolution is finished
      *
-     * @return the {@link SocketAddress} as the result of the resolution
+     * @return the address as the result of the resolution
      */
-    Future<T> resolve(String inetHost, int inetPort, Promise<T> promise);
+    Future<T> resolve(String inetHost, Promise<T> promise);
 
     /**
-     * Resolves the specified address. If the specified address is resolved already, this method does nothing
-     * but returning the original address.
-     *
-     * @param address the address to resolve
-     *
-     * @return the {@link SocketAddress} as the result of the resolution
-     */
-    Future<T> resolve(SocketAddress address);
-
-    /**
-     * Resolves the specified address. If the specified address is resolved already, this method does nothing
-     * but returning the original address.
-     *
-     * @param address the address to resolve
-     * @param promise the {@link Promise} which will be fulfilled when the name resolution is finished
-     *
-     * @return the {@link SocketAddress} as the result of the resolution
-     */
-    Future<T> resolve(SocketAddress address, Promise<T> promise);
-
-    /**
-     * Resolves the specified host name and port into a list of {@link SocketAddress}es.
+     * Resolves the specified host name and port into a list of address.
      *
      * @param inetHost the name to resolve
-     * @param inetPort the port number
      *
-     * @return the list of the {@link SocketAddress}es as the result of the resolution
+     * @return the list of the address as the result of the resolution
      */
-    Future<List<T>> resolveAll(String inetHost, int inetPort);
+    Future<List<T>> resolveAll(String inetHost);
 
     /**
-     * Resolves the specified host name and port into a list of {@link SocketAddress}es.
+     * Resolves the specified host name and port into a list of address.
      *
      * @param inetHost the name to resolve
-     * @param inetPort the port number
      * @param promise the {@link Promise} which will be fulfilled when the name resolution is finished
      *
-     * @return the list of the {@link SocketAddress}es as the result of the resolution
+     * @return the list of the address as the result of the resolution
      */
-    Future<List<T>> resolveAll(String inetHost, int inetPort, Promise<List<T>> promise);
-
-    /**
-     * Resolves the specified address. If the specified address is resolved already, this method does nothing
-     * but returning the original address.
-     *
-     * @param address the address to resolve
-     *
-     * @return the list of the {@link SocketAddress}es as the result of the resolution
-     */
-    Future<List<T>> resolveAll(SocketAddress address);
-
-    /**
-     * Resolves the specified address. If the specified address is resolved already, this method does nothing
-     * but returning the original address.
-     *
-     * @param address the address to resolve
-     * @param promise the {@link Promise} which will be fulfilled when the name resolution is finished
-     *
-     * @return the list of the {@link SocketAddress}es as the result of the resolution
-     */
-    Future<List<T>> resolveAll(SocketAddress address, Promise<List<T>> promise);
+    Future<List<T>> resolveAll(String inetHost, Promise<List<T>> promise);
 
     /**
      * Closes all the resources allocated and used by this resolver.

--- a/resolver/src/main/java/io/netty/resolver/NoopAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/NoopAddressResolver.java
@@ -24,12 +24,12 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * A {@link NameResolver} that does not perform any resolution but always reports successful resolution.
+ * A {@link AddressResolver} that does not perform any resolution but always reports successful resolution.
  * This resolver is useful when name resolution is performed by a handler in a pipeline, such as a proxy handler.
  */
-public class NoopNameResolver extends SimpleNameResolver<SocketAddress> {
+public class NoopAddressResolver extends AbstractAddressResolver<SocketAddress> {
 
-    public NoopNameResolver(EventExecutor executor) {
+    public NoopAddressResolver(EventExecutor executor) {
         super(executor);
     }
 

--- a/resolver/src/main/java/io/netty/resolver/NoopAddressResolverGroup.java
+++ b/resolver/src/main/java/io/netty/resolver/NoopAddressResolverGroup.java
@@ -18,19 +18,19 @@ package io.netty.resolver;
 
 import io.netty.util.concurrent.EventExecutor;
 
-import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 
 /**
- * A {@link NameResolverGroup} of {@link DefaultNameResolver}s.
+ * A {@link AddressResolverGroup} of {@link NoopAddressResolver}s.
  */
-public final class DefaultNameResolverGroup extends NameResolverGroup<InetSocketAddress> {
+public final class NoopAddressResolverGroup extends AddressResolverGroup<SocketAddress> {
 
-    public static final DefaultNameResolverGroup INSTANCE = new DefaultNameResolverGroup();
+    public static final NoopAddressResolverGroup INSTANCE = new NoopAddressResolverGroup();
 
-    private DefaultNameResolverGroup() { }
+    private NoopAddressResolverGroup() { }
 
     @Override
-    protected NameResolver<InetSocketAddress> newResolver(EventExecutor executor) throws Exception {
-        return new DefaultNameResolver(executor);
+    protected AddressResolver<SocketAddress> newResolver(EventExecutor executor) throws Exception {
+        return new NoopAddressResolver(executor);
     }
 }

--- a/resolver/src/main/java/io/netty/resolver/package-info.java
+++ b/resolver/src/main/java/io/netty/resolver/package-info.java
@@ -15,6 +15,6 @@
  */
 
 /**
- * Resolves an arbitrary string that represents the name of an endpoint into a {@link java.net.SocketAddress}.
+ * Resolves an arbitrary string that represents the name of an endpoint into an address.
  */
 package io.netty.resolver;

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -23,9 +23,10 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
-import io.netty.resolver.DefaultNameResolverGroup;
+import io.netty.resolver.AddressResolver;
+import io.netty.resolver.DefaultAddressResolverGroup;
 import io.netty.resolver.NameResolver;
-import io.netty.resolver.NameResolverGroup;
+import io.netty.resolver.AddressResolverGroup;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
@@ -50,10 +51,11 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Bootstrap.class);
 
-    private static final NameResolverGroup<?> DEFAULT_RESOLVER = DefaultNameResolverGroup.INSTANCE;
+    private static final AddressResolverGroup<?> DEFAULT_RESOLVER = DefaultAddressResolverGroup.INSTANCE;
 
     @SuppressWarnings("unchecked")
-    private volatile NameResolverGroup<SocketAddress> resolver = (NameResolverGroup<SocketAddress>) DEFAULT_RESOLVER;
+    private volatile AddressResolverGroup<SocketAddress> resolver =
+            (AddressResolverGroup<SocketAddress>) DEFAULT_RESOLVER;
     private volatile SocketAddress remoteAddress;
 
     public Bootstrap() { }
@@ -68,11 +70,11 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
      * Sets the {@link NameResolver} which will resolve the address of the unresolved named address.
      */
     @SuppressWarnings("unchecked")
-    public Bootstrap resolver(NameResolverGroup<?> resolver) {
+    public Bootstrap resolver(AddressResolverGroup<?> resolver) {
         if (resolver == null) {
             throw new NullPointerException("resolver");
         }
-        this.resolver = (NameResolverGroup<SocketAddress>) resolver;
+        this.resolver = (AddressResolverGroup<SocketAddress>) resolver;
         return this;
     }
 
@@ -162,7 +164,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
 
         final Channel channel = regFuture.channel();
         final EventLoop eventLoop = channel.eventLoop();
-        final NameResolver<SocketAddress> resolver = this.resolver.getResolver(eventLoop);
+        final AddressResolver<SocketAddress> resolver = this.resolver.getResolver(eventLoop);
 
         if (!resolver.isSupported(remoteAddress) || resolver.isResolved(remoteAddress)) {
             // Resolver has no idea about what to do with the specified remote address or it's resolved already.

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -30,9 +30,9 @@ import io.netty.channel.ServerChannel;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalServerChannel;
-import io.netty.resolver.NameResolver;
-import io.netty.resolver.NameResolverGroup;
-import io.netty.resolver.SimpleNameResolver;
+import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.AbstractAddressResolver;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
@@ -223,7 +223,7 @@ public class BootstrapTest {
         final Bootstrap bootstrapA = new Bootstrap();
         bootstrapA.group(groupA);
         bootstrapA.channel(LocalChannel.class);
-        bootstrapA.resolver(new TestNameResolverGroup(true));
+        bootstrapA.resolver(new TestAddressResolverGroup(true));
         bootstrapA.handler(dummyHandler);
 
         final ServerBootstrap bootstrapB = new ServerBootstrap();
@@ -242,7 +242,7 @@ public class BootstrapTest {
         final Bootstrap bootstrapA = new Bootstrap();
         bootstrapA.group(groupA);
         bootstrapA.channel(LocalChannel.class);
-        bootstrapA.resolver(new TestNameResolverGroup(false));
+        bootstrapA.resolver(new TestAddressResolverGroup(false));
         bootstrapA.handler(dummyHandler);
 
         final ServerBootstrap bootstrapB = new ServerBootstrap();
@@ -284,17 +284,17 @@ public class BootstrapTest {
     @Sharable
     private static final class DummyHandler extends ChannelInboundHandlerAdapter { }
 
-    private static final class TestNameResolverGroup extends NameResolverGroup<SocketAddress> {
+    private static final class TestAddressResolverGroup extends AddressResolverGroup<SocketAddress> {
 
         private final boolean success;
 
-        TestNameResolverGroup(boolean success) {
+        TestAddressResolverGroup(boolean success) {
             this.success = success;
         }
 
         @Override
-        protected NameResolver<SocketAddress> newResolver(EventExecutor executor) throws Exception {
-            return new SimpleNameResolver<SocketAddress>(executor) {
+        protected AddressResolver<SocketAddress> newResolver(EventExecutor executor) throws Exception {
+            return new AbstractAddressResolver<SocketAddress>(executor) {
 
                 @Override
                 protected boolean doIsResolved(SocketAddress address) {


### PR DESCRIPTION
Motivation:

As discussed in #4529, NameResolver design shouldn't be resolving SocketAddresses (or String name + port) and return InetSocketAddresses. It should resolve String names and return InetAddresses.
This SocketAddress to InetSocketAddresses resolution is actually a different concern, used by Bootstrap.   

Modifications:

Extract SocketAddress to InetSocketAddresses resolution concern to a new class hierarchy named `AddressResolver`.
These `AddressResolver`s delegate to `NameResolver`s.

Result:

Better separation of concerns.

Note that new `AddressResolver`s generate a bit more allocations because of the intermediate `Promise` and `List<InetAddress>`.