### PR TITLE
Have hosts file support for DnsNameResolver, close #4074

### DIFF
--- a/common/src/main/java/io/netty/util/internal/ObjectUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectUtil.java
@@ -32,4 +32,48 @@ public final class ObjectUtil {
         }
         return arg;
     }
+
+    /**
+     * Checks that the given argument is strictly positive. If it is, throws {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static int checkPositive(int i, String name) {
+        if (i <= 0) {
+            throw new IllegalArgumentException(name + ": " + i + " (expected: > 0)");
+        }
+        return i;
+    }
+
+    /**
+     * Checks that the given argument is strictly positive. If it is, throws {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static long checkPositive(long i, String name) {
+        if (i <= 0) {
+            throw new IllegalArgumentException(name + ": " + i + " (expected: > 0)");
+        }
+        return i;
+    }
+
+    /**
+     * Checks that the given argument is positive or zero. If it is, throws {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static int checkPositiveOrZero(int i, String name) {
+        if (i < 0) {
+            throw new IllegalArgumentException(name + ": " + i + " (expected: >= 0)");
+        }
+        return i;
+    }
+
+    /**
+     * Checks that the given argument is neither null nor empty.
+     * If it is, throws {@link NullPointerException} or {@link IllegalArgumentException}.
+     * Otherwise, returns the argument.
+     */
+    public static <T> T[] checkNonEmpty(T[] array, String name) {
+        checkNotNull(array, name);
+        checkPositive(array.length, name + ".length");
+        return array;
+    }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
@@ -81,7 +81,11 @@ public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddr
             EventLoop eventLoop, ChannelFactory<? extends DatagramChannel> channelFactory,
             InetSocketAddress localAddress, DnsServerAddresses nameServerAddresses) throws Exception {
 
-        return new DnsNameResolver(eventLoop, channelFactory, localAddress, nameServerAddresses)
+        return new DnsNameResolverBuilder(eventLoop)
+                .channelFactory(channelFactory)
+                .localAddress(localAddress)
+                .nameServerAddresses(nameServerAddresses)
+                .build()
                 .asAddressResolver();
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.ChannelFactory;
+import io.netty.channel.EventLoop;
+import io.netty.channel.ReflectiveChannelFactory;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.InternetProtocolFamily;
+import io.netty.resolver.HostsFileEntriesResolver;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * A {@link DnsNameResolver} builder.
+ */
+public final class DnsNameResolverBuilder {
+
+    private final EventLoop eventLoop;
+    private ChannelFactory<? extends DatagramChannel> channelFactory;
+    private InetSocketAddress localAddress = DnsNameResolver.ANY_LOCAL_ADDR;
+    private DnsServerAddresses nameServerAddresses;
+    private int minTtl;
+    private int maxTtl = Integer.MAX_VALUE;
+    private int negativeTtl;
+    private long queryTimeoutMillis = 5000;
+    private InternetProtocolFamily[] resolvedAddressTypes = DnsNameResolver.DEFAULT_RESOLVE_ADDRESS_TYPES;
+    private boolean recursionDesired = true;
+    private int maxQueriesPerResolve = 3;
+    private boolean traceEnabled;
+    private int maxPayloadSize = 4096;
+    private boolean optResourceEnabled = true;
+    private HostsFileEntriesResolver hostsFileEntriesResolver = HostsFileEntriesResolver.DEFAULT;
+
+    /**
+     * Creates a new builder.
+     *
+     * @param eventLoop the {@link EventLoop} the {@link EventLoop} which will perform the communication with the DNS
+     * servers.
+     */
+    public DnsNameResolverBuilder(EventLoop eventLoop) {
+        this.eventLoop = eventLoop;
+    }
+
+    /**
+     * Sets the {@link ChannelFactory} that will create a {@link DatagramChannel}.
+     *
+     * @param channelFactory the {@link ChannelFactory}
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder channelFactory(ChannelFactory<? extends DatagramChannel> channelFactory) {
+        this.channelFactory = channelFactory;
+        return this;
+    }
+
+    /**
+     * Sets the {@link ChannelFactory} as a {@link ReflectiveChannelFactory} of this type.
+     * Use as an alternative to {@link #channelFactory(ChannelFactory)}.
+     *
+     * @param channelType
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder channelType(Class<? extends DatagramChannel> channelType) {
+        return channelFactory(new ReflectiveChannelFactory<DatagramChannel>(channelType));
+    }
+
+    /**
+     * Sets the local address of the {@link DatagramChannel}
+     *
+     * @param localAddress the local address
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder localAddress(InetSocketAddress localAddress) {
+        this.localAddress = localAddress;
+        return this;
+    }
+
+    /**
+     * Sets the addresses of the DNS server.
+     *
+     * @param nameServerAddresses the DNS server addresses
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder nameServerAddresses(DnsServerAddresses nameServerAddresses) {
+        this.nameServerAddresses = nameServerAddresses;
+        return this;
+    }
+
+    /**
+     * Sets the minimum and maximum TTL of the cached DNS resource records (in seconds). If the TTL of the DNS
+     * resource record returned by the DNS server is less than the minimum TTL or greater than the maximum TTL,
+     * this resolver will ignore the TTL from the DNS server and use the minimum TTL or the maximum TTL instead
+     * respectively.
+     * The default value is {@code 0} and {@link Integer#MAX_VALUE}, which practically tells this resolver to
+     * respect the TTL from the DNS server.
+     *
+     * @param minTtl the minimum TTL
+     * @param maxTtl the maximum TTL
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder ttl(int minTtl, int maxTtl) {
+        this.maxTtl = maxTtl;
+        this.minTtl = minTtl;
+        return this;
+    }
+
+    /**
+     * Sets the TTL of the cache for the failed DNS queries (in seconds).
+     *
+     * @param negativeTtl the TTL for failed cached queries
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder negativeTtl(int negativeTtl) {
+        this.negativeTtl = negativeTtl;
+        return this;
+    }
+
+    /**
+     * Sets the timeout of each DNS query performed by this resolver (in milliseconds).
+     *
+     * @param queryTimeoutMillis the query timeout
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder queryTimeoutMillis(long queryTimeoutMillis) {
+        this.queryTimeoutMillis = queryTimeoutMillis;
+        return this;
+    }
+
+    /**
+     * Sets the list of the protocol families of the address resolved.
+     * Usually, both {@link InternetProtocolFamily#IPv4} and {@link InternetProtocolFamily#IPv6} are specified in
+     * the order of preference.  To enforce the resolve to retrieve the address of a specific protocol family,
+     * specify only a single {@link InternetProtocolFamily}.
+     *
+     * @param resolvedAddressTypes the address types
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder resolvedAddressTypes(InternetProtocolFamily... resolvedAddressTypes) {
+        checkNotNull(resolvedAddressTypes, "resolvedAddressTypes");
+
+        final List<InternetProtocolFamily> list =
+                new ArrayList<InternetProtocolFamily>(InternetProtocolFamily.values().length);
+
+        for (InternetProtocolFamily f : resolvedAddressTypes) {
+            if (f == null) {
+                break;
+            }
+
+            // Avoid duplicate entries.
+            if (list.contains(f)) {
+                continue;
+            }
+
+            list.add(f);
+        }
+
+        if (list.isEmpty()) {
+            throw new IllegalArgumentException("no protocol family specified");
+        }
+
+        this.resolvedAddressTypes = list.toArray(new InternetProtocolFamily[list.size()]);
+
+        return this;
+    }
+
+    /**
+     * Sets the list of the protocol families of the address resolved.
+     * Usually, both {@link InternetProtocolFamily#IPv4} and {@link InternetProtocolFamily#IPv6} are specified in
+     * the order of preference.  To enforce the resolve to retrieve the address of a specific protocol family,
+     * specify only a single {@link InternetProtocolFamily}.
+     *
+     * @param resolvedAddressTypes the address types
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder resolvedAddressTypes(Iterable<InternetProtocolFamily> resolvedAddressTypes) {
+        checkNotNull(resolvedAddressTypes, "resolveAddressTypes");
+
+        final List<InternetProtocolFamily> list =
+                new ArrayList<InternetProtocolFamily>(InternetProtocolFamily.values().length);
+
+        for (InternetProtocolFamily f : resolvedAddressTypes) {
+            if (f == null) {
+                break;
+            }
+
+            // Avoid duplicate entries.
+            if (list.contains(f)) {
+                continue;
+            }
+
+            list.add(f);
+        }
+
+        if (list.isEmpty()) {
+            throw new IllegalArgumentException("no protocol family specified");
+        }
+
+        this.resolvedAddressTypes = list.toArray(new InternetProtocolFamily[list.size()]);
+
+        return this;
+    }
+
+    /**
+     * Sets if this resolver has to send a DNS query with the RD (recursion desired) flag set.
+     *
+     * @param recursionDesired true if recursion is desired
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder recursionDesired(boolean recursionDesired) {
+        this.recursionDesired = recursionDesired;
+        return this;
+    }
+
+    /**
+     * Sets the maximum allowed number of DNS queries to send when resolving a host name.
+     *
+     * @param maxQueriesPerResolve the max number of queries
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder maxQueriesPerResolve(int maxQueriesPerResolve) {
+        this.maxQueriesPerResolve = maxQueriesPerResolve;
+        return this;
+    }
+
+    /**
+     * Sets if this resolver should generate the detailed trace information in an exception message so that
+     * it is easier to understand the cause of resolution failure.
+     *
+     * @param traceEnabled true if trace is enabled
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder traceEnabled(boolean traceEnabled) {
+        this.traceEnabled = traceEnabled;
+        return this;
+    }
+
+    /**
+     * Sets the capacity of the datagram packet buffer (in bytes).  The default value is {@code 4096} bytes.
+     *
+     * @param maxPayloadSize the capacity of the datagram packet buffer
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder maxPayloadSize(int maxPayloadSize) {
+        this.maxPayloadSize = maxPayloadSize;
+        return this;
+    }
+
+    /**
+     * Enable the automatic inclusion of a optional records that tries to give the remote DNS server a hint about
+     * how much data the resolver can read per response. Some DNSServer may not support this and so fail to answer
+     * queries. If you find problems you may want to disable this.
+     *
+     * @param optResourceEnabled if optional records inclusion is enabled
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder optResourceEnabled(boolean optResourceEnabled) {
+        this.optResourceEnabled = optResourceEnabled;
+        return this;
+    }
+
+    /**
+     * @param hostsFileEntriesResolver the {@link HostsFileEntriesResolver} used to first check
+     *                                 if the hostname is locally aliased.
+     * @param hostsFileEntriesResolver the {@link HostsFileEntriesResolver}
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder hostsFileEntriesResolver(HostsFileEntriesResolver hostsFileEntriesResolver) {
+        this.hostsFileEntriesResolver = hostsFileEntriesResolver;
+        return this;
+    }
+
+    /**
+     * Returns a new {@link DnsNameResolver} instance.
+     *
+     * @return a {@link DnsNameResolver}
+     */
+    public DnsNameResolver build() {
+        return new DnsNameResolver(
+                eventLoop,
+                channelFactory,
+                localAddress,
+                nameServerAddresses,
+                minTtl,
+                maxTtl,
+                negativeTtl,
+                queryTimeoutMillis,
+                resolvedAddressTypes,
+                recursionDesired,
+                maxQueriesPerResolve,
+                traceEnabled,
+                maxPayloadSize,
+                optResourceEnabled,
+                hostsFileEntriesResolver);
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverException.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverException.java
@@ -31,11 +31,6 @@ public final class DnsNameResolverException extends RuntimeException {
     private final InetSocketAddress remoteAddress;
     private final DnsQuestion question;
 
-    public DnsNameResolverException(InetSocketAddress remoteAddress, DnsQuestion question) {
-        this.remoteAddress = validateRemoteAddress(remoteAddress);
-        this.question = validateQuestion(question);
-    }
-
     public DnsNameResolverException(InetSocketAddress remoteAddress, DnsQuestion question, String message) {
         super(message);
         this.remoteAddress = validateRemoteAddress(remoteAddress);
@@ -49,18 +44,19 @@ public final class DnsNameResolverException extends RuntimeException {
         this.question = validateQuestion(question);
     }
 
-    public DnsNameResolverException(InetSocketAddress remoteAddress, DnsQuestion question, Throwable cause) {
-        super(cause);
-        this.remoteAddress = validateRemoteAddress(remoteAddress);
-        this.question = validateQuestion(question);
-    }
-
     private static InetSocketAddress validateRemoteAddress(InetSocketAddress remoteAddress) {
         return ObjectUtil.checkNotNull(remoteAddress, "remoteAddress");
     }
 
     private static DnsQuestion validateQuestion(DnsQuestion question) {
         return ObjectUtil.checkNotNull(question, "question");
+    }
+
+    /**
+     * Returns the {@link InetSocketAddress} of the DNS query that has failed.
+     */
+    public InetSocketAddress remoteAddress() {
+        return remoteAddress;
     }
 
     /**

--- a/resolver/src/main/java/io/netty/resolver/CompositeNameResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/CompositeNameResolver.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver;
+
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.Promise;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static io.netty.util.internal.ObjectUtil.*;
+
+/**
+ * A composite {@link SimpleNameResolver} that resolves a host name against a sequence of {@link NameResolver}s.
+ *
+ * In case of a failure, only the last one will be reported.
+ */
+public final class CompositeNameResolver<T> extends SimpleNameResolver<T> {
+
+    private final NameResolver<T>[] resolvers;
+
+    /**
+     * @param executor the {@link EventExecutor} which is used to notify the listeners of the {@link Future} returned
+     *                 by {@link #resolve(String)}
+     * @param resolvers the {@link NameResolver}s to be tried sequentially
+     */
+    public CompositeNameResolver(EventExecutor executor, NameResolver<T>... resolvers) {
+        super(executor);
+        checkNotNull(resolvers, "resolvers");
+        for (int i = 0; i < resolvers.length; i++) {
+            if (resolvers[i] == null) {
+                throw new NullPointerException("resolvers[" + i + ']');
+            }
+        }
+        if (resolvers.length < 2) {
+            throw new IllegalArgumentException("resolvers: " + Arrays.asList(resolvers) +
+                    " (expected: at least 2 resolvers)");
+        }
+        this.resolvers = resolvers.clone();
+    }
+
+    @Override
+    protected void doResolve(String inetHost, Promise<T> promise) throws Exception {
+        doResolveRec(inetHost, promise, 0, null);
+    }
+
+    private void doResolveRec(final String inetHost,
+                              final Promise<T> promise,
+                              final int resolverIndex,
+                              Throwable lastFailure) throws Exception {
+        if (resolverIndex >= resolvers.length) {
+            promise.setFailure(lastFailure);
+        } else {
+            NameResolver resolver = resolvers[resolverIndex];
+            resolver.resolve(inetHost).addListener(new FutureListener<T>() {
+                @Override
+                public void operationComplete(Future<T> future) throws Exception {
+                    if (future.isSuccess()) {
+                        promise.setSuccess(future.getNow());
+                    } else {
+                        doResolveRec(inetHost, promise, resolverIndex + 1, future.cause());
+                    }
+                }
+            });
+        }
+    }
+
+    @Override
+    protected void doResolveAll(String inetHost, Promise<List<T>> promise) throws Exception {
+        doResolveAllRec(inetHost, promise, 0, null);
+    }
+
+    private void doResolveAllRec(final String inetHost,
+                              final Promise<List<T>> promise,
+                              final int resolverIndex,
+                              Throwable lastFailure) throws Exception {
+        if (resolverIndex >= resolvers.length) {
+            promise.setFailure(lastFailure);
+        } else {
+            NameResolver resolver = resolvers[resolverIndex];
+            resolver.resolveAll(inetHost).addListener(new FutureListener<List<T>>() {
+                @Override
+                public void operationComplete(Future<List<T>> future) throws Exception {
+                    if (future.isSuccess()) {
+                        promise.setSuccess(future.getNow());
+                    } else {
+                        doResolveAllRec(inetHost, promise, resolverIndex + 1, future.cause());
+                    }
+                }
+            });
+        }
+    }
+}

--- a/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver;
+
+import java.net.InetAddress;
+import java.util.Map;
+
+/**
+ * Default {@link HostsFileEntriesResolver} that resolves hosts file entries only once.
+ */
+public final class DefaultHostsFileEntriesResolver implements HostsFileEntriesResolver {
+
+    private final Map<String, InetAddress> entries = HostsFileParser.parseSilently();
+
+    @Override
+    public InetAddress address(String inetHost) {
+        return entries.get(inetHost);
+    }
+}

--- a/resolver/src/main/java/io/netty/resolver/DefaultNameResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/DefaultNameResolver.java
@@ -20,7 +20,6 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Promise;
 
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;

--- a/resolver/src/main/java/io/netty/resolver/HostsFileEntriesResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/HostsFileEntriesResolver.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver;
+
+import java.net.InetAddress;
+
+/**
+ * Resolves a hostname against the hosts file entries.
+ */
+public interface HostsFileEntriesResolver {
+
+    /**
+     * Default instance: a {@link DefaultHostsFileEntriesResolver}.
+     */
+    HostsFileEntriesResolver DEFAULT = new DefaultHostsFileEntriesResolver();
+
+    InetAddress address(String inetHost);
+}

--- a/resolver/src/main/java/io/netty/resolver/HostsFileParser.java
+++ b/resolver/src/main/java/io/netty/resolver/HostsFileParser.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver;
+
+import io.netty.util.NetUtil;
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.netty.util.internal.ObjectUtil.*;
+
+/**
+ * A parser for hosts files.
+ */
+public final class HostsFileParser {
+
+    private static final String WINDOWS_DEFAULT_SYSTEM_ROOT = "C:\\Windows";
+    private static final String WINDOWS_HOSTS_FILE_RELATIVE_PATH = "\\system32\\drivers\\etc\\hosts";
+    private static final String X_PLATFORMS_HOSTS_FILE_PATH = "/etc/hosts";
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(HostsFileParser.class);
+
+    private static File locateHostsFile() {
+        File hostsFile;
+        if (PlatformDependent.isWindows()) {
+            hostsFile = new File(System.getenv("SystemRoot") + WINDOWS_HOSTS_FILE_RELATIVE_PATH);
+            if (!hostsFile.exists()) {
+                hostsFile = new File(WINDOWS_DEFAULT_SYSTEM_ROOT + WINDOWS_HOSTS_FILE_RELATIVE_PATH);
+            }
+        } else {
+            hostsFile = new File(X_PLATFORMS_HOSTS_FILE_PATH);
+        }
+        return hostsFile;
+    }
+
+    /**
+     * Parse hosts file at standard OS location.
+     *
+     * @return a map of hostname or alias to {@link InetAddress}
+     */
+    public static Map<String, InetAddress> parseSilently() {
+        File hostsFile = locateHostsFile();
+        try {
+            return parse(hostsFile);
+        } catch (IOException e) {
+            logger.warn("Failed to load and parse hosts file at " + hostsFile.getPath(), e);
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Parse hosts file at standard OS location.
+     *
+     * @return a map of hostname or alias to {@link InetAddress}
+     * @throws IOException file could not be read
+     */
+    public static Map<String, InetAddress> parse() throws IOException {
+        return parse(locateHostsFile());
+    }
+
+    /**
+     * Parse a hosts file.
+     *
+     * @param file the file to be parsed
+     * @return a map of hostname or alias to {@link InetAddress}
+     * @throws IOException file could not be read
+     */
+    public static Map<String, InetAddress> parse(File file) throws IOException {
+        checkNotNull(file, "file");
+        if (file.exists() && file.isFile()) {
+            return parse(new BufferedReader(new FileReader(file)));
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    /**
+     * Parse a reader of hosts file format.
+     *
+     * @param reader the file to be parsed
+     * @return a map of hostname or alias to {@link InetAddress}
+     * @throws IOException file could not be read
+     */
+    public static Map<String, InetAddress> parse(Reader reader) throws IOException {
+        checkNotNull(reader, "reader");
+        BufferedReader buff = new BufferedReader(reader);
+        try {
+            Map<String, InetAddress> entries = new HashMap<String, InetAddress>();
+            String line;
+            while ((line = buff.readLine()) != null) {
+                // remove comment
+                int commentPosition = line.indexOf('#');
+                if (commentPosition != -1) {
+                    line = line.substring(0, commentPosition);
+                }
+                // skip empty lines
+                line = line.trim();
+                if (line.isEmpty()) {
+                    continue;
+                }
+
+                // split
+                List<String> lineParts = new ArrayList<String>();
+                for (String s: line.split("[ \t]+")) {
+                    if (!s.isEmpty()) {
+                        lineParts.add(s);
+                    }
+                }
+
+                // a valid line should be [IP, hostname, alias*]
+                if (lineParts.size() < 2) {
+                    // skip invalid line
+                    continue;
+                }
+
+                byte[] ipBytes = NetUtil.createByteArrayFromIpAddressString(lineParts.get(0));
+
+                if (ipBytes == null) {
+                    // skip invalid IP
+                    continue;
+                }
+
+                InetAddress inetAddress = InetAddress.getByAddress(ipBytes);
+
+                // loop over hostname and aliases
+                for (int i = 1; i < lineParts.size(); i ++) {
+                    String hostname = lineParts.get(i);
+                    if (!entries.containsKey(hostname)) {
+                        // trying to map a host to multiple IPs is wrong
+                        // only the first entry is honored
+                        entries.put(hostname, inetAddress);
+                    }
+                }
+            }
+            return entries;
+        } finally {
+            buff.close();
+        }
+    }
+
+    /**
+     * Can't be instantiated.
+     */
+    private HostsFileParser() {
+    }
+}

--- a/resolver/src/main/java/io/netty/resolver/InetNameResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/InetNameResolver.java
@@ -37,7 +37,8 @@ public abstract class InetNameResolver extends SimpleNameResolver<InetAddress> {
     }
 
     /**
-     * Creates a new {@link AddressResolver} that will use this name resolver underneath.
+     * Return a {@link AddressResolver} that will use this name resolver underneath.
+     * It's cached internally, so the same instance is always returned.
      */
     public AddressResolver<InetSocketAddress> asAddressResolver() {
         AddressResolver<InetSocketAddress> result = addressResolver;

--- a/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
@@ -17,7 +17,7 @@ package io.netty.resolver;
 
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 
 import java.net.InetAddress;
@@ -53,7 +53,7 @@ public class InetSocketAddressResolver extends AbstractAddressResolver<InetSocke
         // Note that InetSocketAddress.getHostName() will never incur a reverse lookup here,
         // because an unresolved address always has a host name.
         nameResolver.resolve(unresolvedAddress.getHostName())
-                .addListener(new GenericFutureListener<Future<InetAddress>>() {
+                .addListener(new FutureListener<InetAddress>() {
                     @Override
                     public void operationComplete(Future<InetAddress> future) throws Exception {
                         if (future.isSuccess()) {
@@ -71,7 +71,7 @@ public class InetSocketAddressResolver extends AbstractAddressResolver<InetSocke
         // Note that InetSocketAddress.getHostName() will never incur a reverse lookup here,
         // because an unresolved address always has a host name.
         nameResolver.resolveAll(unresolvedAddress.getHostName())
-                .addListener(new GenericFutureListener<Future<List<InetAddress>>>() {
+                .addListener(new FutureListener<List<InetAddress>>() {
                     @Override
                     public void operationComplete(Future<List<InetAddress>> future) throws Exception {
                         if (future.isSuccess()) {

--- a/resolver/src/test/java/io/netty/resolver/HostsFileParserTest.java
+++ b/resolver/src/test/java/io/netty/resolver/HostsFileParserTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.InetAddress;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class HostsFileParserTest {
+
+    @Test
+    public void testParse() throws IOException {
+        String hostsString = new StringBuilder()
+                .append("127.0.0.1 host1").append("\n") // single hostname, separated with blanks
+                .append("\n") // empty line
+                .append("192.168.0.1\thost2").append("\n") // single hostname, separated with tabs
+                .append("#comment").append("\n") // comment at the beginning of the line
+                .append(" #comment  ").append("\n") // comment in the middle of the line
+                .append("192.168.0.2  host3  #comment").append("\n") // comment after hostname
+                .append("192.168.0.3  host4  host5 host6").append("\n") // multiple aliases
+                .append("192.168.0.4  host4").append("\n") // host mapped to a second address, must be ignored
+                .toString();
+
+        Map<String, InetAddress> entries = HostsFileParser.parse(new BufferedReader(new StringReader(hostsString)));
+
+        assertEquals("Expected 6 entries", 6, entries.size());
+        assertEquals("127.0.0.1", entries.get("host1").getHostAddress());
+        assertEquals("192.168.0.1", entries.get("host2").getHostAddress());
+        assertEquals("192.168.0.2", entries.get("host3").getHostAddress());
+        assertEquals("192.168.0.3", entries.get("host4").getHostAddress());
+        assertEquals("192.168.0.3", entries.get("host5").getHostAddress());
+        assertEquals("192.168.0.3", entries.get("host6").getHostAddress());
+    }
+}


### PR DESCRIPTION
Motivation:

On contrary to `DefaultNameResolver`, `DnsNameResolver` doesn't currently honor hosts file.

Modifications:

* Introduce `HostsFileParser` that parses `/etc/hosts` or `C:\Windows\system32\drivers\etc\hosts` depending on the platform
* Introduce `HostsFileEntriesResolver` that uses the former to resolve host names
* Make `DnsNameResolver` check his `HostsFileEntriesResolver` prior to trying to resolve names against the DNS server
* Introduce `DnsNameResolverBuilder` so we now have a builder for `DnsNameResolver`s
* Additionally introduce a `CompositeNameResolver` that takes several `NameResolver`s and tries to resolve names by delegating sequentially
* Change `DnsNameResolver.asAddressResolver` to return a composite and honor hosts file

Result:

Hosts file support when using `DnsNameResolver`.
Consistent behavior with JDK implementation.