### PR TITLE
Throw exception if KeyManagerFactory is used with OpenSslServerContext

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -321,6 +321,7 @@ public final class OpenSslServerContext extends OpenSslContext {
                 ClientAuth.NONE);
         OpenSsl.ensureAvailability();
 
+        checkKeyManagerFactory(keyManagerFactory);
         checkNotNull(keyCertChainFile, "keyCertChainFile");
         if (!keyCertChainFile.isFile()) {
             throw new IllegalArgumentException("keyCertChainFile is not a file: " + keyCertChainFile);
@@ -420,6 +421,7 @@ public final class OpenSslServerContext extends OpenSslContext {
                 clientAuth);
         OpenSsl.ensureAvailability();
 
+        checkKeyManagerFactory(keyManagerFactory);
         checkNotNull(keyCertChain, "keyCertChainFile");
         checkNotNull(key, "keyFile");
 
@@ -527,5 +529,12 @@ public final class OpenSslServerContext extends OpenSslContext {
     @Override
     public OpenSslServerSessionContext sessionContext() {
         return sessionContext;
+    }
+
+    private static void checkKeyManagerFactory(KeyManagerFactory keyManagerFactory) {
+        if (keyManagerFactory != null) {
+            throw new IllegalArgumentException(
+                    "KeyManagerFactory is currently not supported with OpenSslServerContext");
+        }
     }
 }


### PR DESCRIPTION
Motivation:

We currently not supported using KeyManagerFactory with OpenSslServerContext and so should throw an exception if the user tries to do so. This will at least not give suprising and hard to debug problems later.

Modifications:

Throw exception if a user tries to construct a OpenSslServerContext with a KeyManagerFactory

Result:

Fail fast if the user tries to use something that is not supported.