### PR TITLE
Added when it's safe to call channel read

### DIFF
--- a/transport/src/main/java/io/netty/channel/Channel.java
+++ b/transport/src/main/java/io/netty/channel/Channel.java
@@ -404,6 +404,12 @@ public interface Channel extends AttributeMap, Comparable<Channel> {
      * {@link ChannelOutboundHandler#read(ChannelHandlerContext)}
      * method called of the next {@link ChannelOutboundHandler} contained in the  {@link ChannelPipeline} of the
      * {@link Channel}.
+     * <p>
+     * This may only be called after the channel is registered with the event loop, that is, when
+     * {@link #isRegistered()} returns true. This event can be received by adding a listener to the future returned by
+     * {@link EventLoopGroup#register(Channel)}. Alternatively, if {@link #isRegistered()} returns false when a
+     * {@link ChannelHandler} receives {@link ChannelHandler#handlerAdded(ChannelHandlerContext)}, the handler can call
+     * it when it receives {@link ChannelInboundHandler#channelRegistered(ChannelHandlerContext)}.
      */
     Channel read();
 

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
@@ -407,6 +407,12 @@ public interface ChannelHandlerContext extends AttributeMap {
      * {@link ChannelOutboundHandler#read(ChannelHandlerContext)}
      * method called of the next {@link ChannelOutboundHandler} contained in the {@link ChannelPipeline} of the
      * {@link Channel}.
+     * <p>
+     * This may only be called after the channel is registered with the event loop, that is, when
+     * {@link Channel#isRegistered()} returns true. This event can be received by adding a listener to the future
+     * returned by {@link EventLoopGroup#register(Channel)}. Alternatively, if {@link Channel#isRegistered()} returns
+     * false when a {@link ChannelHandler} receives {@link ChannelHandler#handlerAdded(ChannelHandlerContext)}, the
+     * handler can call it when it receives {@link ChannelInboundHandler#channelRegistered(ChannelHandlerContext)}.
      */
     ChannelHandlerContext read();
 


### PR DESCRIPTION
### Motivation:

I was reading the javadoc for Channel.read() just the other day to work out when the best time to first invoke it was, and it didn't say.  Coincidentally, in #4571, I found out in another project I was invoking it at a time that was illegal.
### Modifications:

This adds javadocs to Channel.read() and ChannelHandlerContext.read() to explain when it's legaal to invoke it.
### Result:

Hopefully other people won't make the same mistake I did in future.
