### PR TITLE
[#4528] Make ChannelHandlerAppender sub-types compatible with previou…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
@@ -100,6 +100,7 @@ public final class HttpClientCodec extends ChannelHandlerAppender implements Htt
             @Override
             public void run() {
                 p.remove(decoder());
+                p.remove(HttpClientCodec.this);
             }
         });
         p.remove(encoder());

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
@@ -41,7 +41,8 @@ public final class HttpServerCodec extends ChannelHandlerAppender implements
      * Creates a new instance with the specified decoder options.
      */
     public HttpServerCodec(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
-        super(new HttpRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize), new HttpResponseEncoder());
+        super(new HttpRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize),
+              new HttpResponseEncoder());
     }
 
     /**
@@ -49,7 +50,7 @@ public final class HttpServerCodec extends ChannelHandlerAppender implements
      */
     public HttpServerCodec(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders) {
         super(new HttpRequestDecoder(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders),
-                new HttpResponseEncoder());
+              new HttpResponseEncoder());
     }
 
     /**
@@ -58,8 +59,7 @@ public final class HttpServerCodec extends ChannelHandlerAppender implements
      */
     @Override
     public void upgradeFrom(ChannelHandlerContext ctx) {
-        ctx.pipeline().remove(HttpRequestDecoder.class);
-        ctx.pipeline().remove(HttpResponseEncoder.class);
+        remove(ctx);
     }
 
     /**


### PR DESCRIPTION
…s ChannelDuplexHandler sub-types

Motivation:

ChannelHandlerAppender did remove itself from the pipeline and so changed the sematic of HttpClientCodec and HttpServerCodec compared to 4.0 in which a user could just remove one of these and so remove all handlers that where part of the codec. This leads to an API-breakage when upgrade from 4.0 to 4.1

Modifications:

- Don't remove ChannelHandlerAppender by default from pipeline
- When a ChannelHandlerAppender is removed from the pipeline by a user it will also remove all the handler that where append as part of the ChannelAppender

Result:

Remove HttpClientCodec or HttpServerCodec from the pipeline has the same sematic as in 4.0.