### PR TITLE
Allow to do async mappings in the SniHandler

### DIFF
--- a/common/src/main/java/io/netty/util/AsyncMapping.java
+++ b/common/src/main/java/io/netty/util/AsyncMapping.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util;
+
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+
+public interface AsyncMapping<IN, OUT> {
+
+    /**
+     * Returns the {@link Future} that will provide the result of the mapping.
+     */
+    Future<OUT> map(IN input, Promise<OUT> promise);
+}


### PR DESCRIPTION
Motivation:

Sometimes a user want to do async mappings in the SniHandler as it is not possible to populate a Mapping up front.

Modifications:

Add AsyncMapping interface and make SniHandler work with it.

Result:

It is possible to do async mappings for SNI