### PR TITLE
HTTP/2 DefaultHttp2RemoteFlowController Stream writability notificati…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -30,6 +30,8 @@ import static io.netty.buffer.Unpooled.directBuffer;
 import static io.netty.buffer.Unpooled.unmodifiableBuffer;
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
 import static io.netty.util.CharsetUtil.UTF_8;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 
 /**
  * Constants and utility method used for encoding/decoding HTTP2 frames.
@@ -187,6 +189,13 @@ public final class Http2CodecUtil {
             Http2Flags flags, int streamId) {
         out.ensureWritable(FRAME_HEADER_LENGTH + payloadLength);
         writeFrameHeaderInternal(out, payloadLength, type, flags, streamId);
+    }
+
+    /**
+     * Calculate the amount of bytes that can be sent by {@code state}. The lower bound is {@code 0}.
+     */
+    public static int streamableBytes(StreamByteDistributor.StreamState state) {
+        return max(0, min(state.pendingBytes(), state.windowSize()));
     }
 
     static void writeFrameHeaderInternal(ByteBuf out, int payloadLength, byte type,

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/PriorityStreamByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/PriorityStreamByteDistributor.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http2;
 
 import java.util.Arrays;
 
+import static io.netty.handler.codec.http2.Http2CodecUtil.streamableBytes;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -78,7 +79,7 @@ public final class PriorityStreamByteDistributor implements StreamByteDistributo
 
     @Override
     public void updateStreamableBytes(StreamState streamState) {
-        state(streamState.stream()).updateStreamableBytes(streamState.streamableBytes(),
+        state(streamState.stream()).updateStreamableBytes(streamableBytes(streamState),
                 streamState.hasFrame());
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
@@ -21,6 +21,7 @@ import io.netty.util.internal.PriorityQueueNode;
 import java.util.Queue;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.CONNECTION_STREAM_ID;
+import static io.netty.handler.codec.http2.Http2CodecUtil.streamableBytes;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -104,8 +105,8 @@ public final class WeightedFairQueueByteDistributor implements StreamByteDistrib
 
     @Override
     public void updateStreamableBytes(StreamState state) {
-        state(state.stream()).updateStreamableBytes(state.streamableBytes(),
-                                                    state.hasFrame() && state.isWriteAllowed());
+        state(state.stream()).updateStreamableBytes(streamableBytes(state),
+                                                    state.hasFrame() && state.windowSize() >= 0);
     }
 
     @Override
@@ -204,7 +205,7 @@ public final class WeightedFairQueueByteDistributor implements StreamByteDistrib
     /**
      * For testing only!
      */
-    int streamableBytes(Http2Stream stream) {
+    int streamableBytes0(Http2Stream stream) {
         return state(stream).streamableBytes;
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -58,7 +58,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Tests for {@link DefaultHttp2RemoteFlowController}.
  */
-public class DefaultHttp2RemoteFlowControllerTest {
+public abstract class DefaultHttp2RemoteFlowControllerTest {
     private static final int STREAM_A = 1;
     private static final int STREAM_B = 3;
     private static final int STREAM_C = 5;
@@ -114,9 +114,11 @@ public class DefaultHttp2RemoteFlowControllerTest {
         reset(listener);
     }
 
+    protected abstract StreamByteDistributor newDistributor(Http2Connection connection);
+
     private void initConnectionAndController() throws Http2Exception {
         connection = new DefaultHttp2Connection(false);
-        controller = new DefaultHttp2RemoteFlowController(connection, listener);
+        controller = new DefaultHttp2RemoteFlowController(connection, newDistributor(connection), listener);
         connection.remote().flowController(controller);
 
         connection.local().createStream(STREAM_A, false);
@@ -926,7 +928,6 @@ public class DefaultHttp2RemoteFlowControllerTest {
                 mock(Http2RemoteFlowController.FlowControlled.class);
         when(flowControlled.size()).thenReturn(100);
         doAnswer(new Answer<Void>() {
-            private int invocationCount;
             @Override
             public Void answer(InvocationOnMock in) throws Throwable {
                 // Write most of the bytes and then fail

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/PriorityStreamByteDistributorTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/PriorityStreamByteDistributorTest.java
@@ -639,7 +639,7 @@ public class PriorityStreamByteDistributorTest {
         return connection.stream(streamId);
     }
 
-    private void updateStream(final int streamId, final int streamableBytes, final boolean hasFrame) {
+    private void updateStream(final int streamId, final int pendingBytes, final boolean hasFrame) {
         final Http2Stream stream = stream(streamId);
         distributor.updateStreamableBytes(new StreamByteDistributor.StreamState() {
             @Override
@@ -648,8 +648,8 @@ public class PriorityStreamByteDistributorTest {
             }
 
             @Override
-            public int streamableBytes() {
-                return streamableBytes;
+            public int pendingBytes() {
+                return pendingBytes;
             }
 
             @Override
@@ -658,8 +658,8 @@ public class PriorityStreamByteDistributorTest {
             }
 
             @Override
-            public boolean isWriteAllowed() {
-                return hasFrame;
+            public int windowSize() {
+                return pendingBytes;
             }
         });
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/UniformStreamByteDistributorFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/UniformStreamByteDistributorFlowControllerTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+public class UniformStreamByteDistributorFlowControllerTest extends DefaultHttp2RemoteFlowControllerTest {
+    @Override
+    protected StreamByteDistributor newDistributor(Http2Connection connection) {
+        return new UniformStreamByteDistributor(connection);
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributorTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributorTest.java
@@ -82,7 +82,7 @@ public class WeightedFairQueueByteDistributorTest {
             public Void answer(InvocationOnMock in) throws Throwable {
                 Http2Stream stream = in.getArgumentAt(0, Http2Stream.class);
                 int numBytes = in.getArgumentAt(1, Integer.class);
-                int streamableBytes = distributor.streamableBytes(stream) - numBytes;
+                int streamableBytes = distributor.streamableBytes0(stream) - numBytes;
                 updateStream(stream.id(), streamableBytes, streamableBytes > 0);
                 return null;
             }
@@ -913,7 +913,7 @@ public class WeightedFairQueueByteDistributorTest {
         updateStream(streamId, streamableBytes, hasFrame, hasFrame);
     }
 
-    private void updateStream(final int streamId, final int streamableBytes, final boolean hasFrame,
+    private void updateStream(final int streamId, final int pendingBytes, final boolean hasFrame,
             final boolean isWriteAllowed) {
         final Http2Stream stream = stream(streamId);
         distributor.updateStreamableBytes(new StreamByteDistributor.StreamState() {
@@ -923,8 +923,8 @@ public class WeightedFairQueueByteDistributorTest {
             }
 
             @Override
-            public int streamableBytes() {
-                return streamableBytes;
+            public int pendingBytes() {
+                return pendingBytes;
             }
 
             @Override
@@ -933,8 +933,8 @@ public class WeightedFairQueueByteDistributorTest {
             }
 
             @Override
-            public boolean isWriteAllowed() {
-                return isWriteAllowed;
+            public int windowSize() {
+                return isWriteAllowed ? pendingBytes : -1;
             }
         });
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/WeightedFairQueueRemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/WeightedFairQueueRemoteFlowControllerTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+public class WeightedFairQueueRemoteFlowControllerTest extends DefaultHttp2RemoteFlowControllerTest {
+    @Override
+    protected StreamByteDistributor newDistributor(Http2Connection connection) {
+        return new WeightedFairQueueByteDistributor(connection);
+    }
+}


### PR DESCRIPTION
…on broken

Motivation:
DefaultHttp2RemoteFlowController.ListenerWritabilityMonitor no longer reliably detects when a stream's writability change occurs.

Modifications:
- Ensure writiability is reliabily reported by DefaultHttp2RemoteFlowController.ListenerWritabilityMonitor
- Fix infinite loop issue (https://github.com/netty/netty/issues/4588) detected when consolidating unit tests

Result:
Reliable stream writability change notification, and 1 less infinite loop in UniformStreamByteDistributor.
Fixes https://github.com/netty/netty/issues/4587