### PR TITLE
ByteBufUtil.writeUtf8 Surrogate Support

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -15,19 +15,17 @@
  */
 package io.netty.buffer;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
-
-import java.util.Random;
-
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.charset.Charset;
+import java.util.Random;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ByteBufUtilTest {
     @Test
@@ -127,6 +125,21 @@ public class ByteBufUtilTest {
         buf.writeBytes(usAscii.getBytes(CharsetUtil.UTF_8));
         ByteBuf buf2 = ReferenceCountUtil.releaseLater(Unpooled.buffer(16));
         ByteBufUtil.writeUtf8(buf2, usAscii);
+
+        Assert.assertEquals(buf, buf2);
+    }
+
+    @Test
+    public void testWriteUtf8Surrogates() {
+        // leading surrogate + trailing surrogate
+        String surrogateString = new StringBuilder(2)
+                                .append('\uD800')
+                                .append('\uDC00')
+                                .toString();
+        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(16));
+        buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
+        ByteBuf buf2 = ReferenceCountUtil.releaseLater(Unpooled.buffer(16));
+        ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         Assert.assertEquals(buf, buf2);
     }

--- a/common/src/main/java/io/netty/util/internal/MathUtil.java
+++ b/common/src/main/java/io/netty/util/internal/MathUtil.java
@@ -60,9 +60,6 @@ public final class MathUtil {
      * </ul>
      */
     public static int compare(long x, long y) {
-        if (PlatformDependent.javaVersion() < 7) {
-            return (x < y) ? -1 : (x > y) ? 1 : 0;
-        }
-        return Long.compare(x, y);
+        return (x < y) ? -1 : (x > y) ? 1 : 0;
     }
 }

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -15,7 +15,6 @@
  */
 package io.netty.util.internal;
 
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Formatter;
@@ -389,6 +388,17 @@ public final class StringUtil {
      */
     public static boolean isNullOrEmpty(String s) {
         return s == null || s.isEmpty();
+    }
+
+    /**
+     * Determine if {@code c} lies within the range of values defined for
+     * <a href="http://unicode.org/glossary/#surrogate_code_point">Surrogate Code Point</a>.
+     * @param c the character to check.
+     * @return {@code true} if {@code c} lies within the range of values defined for
+     * <a href="http://unicode.org/glossary/#surrogate_code_point">Surrogate Code Point</a>. {@code false} otherwise.
+     */
+    public static boolean isSurrogate(char c) {
+        return c >= '\uD800' && c <= '\uDFFF';
     }
 
     private static boolean isDoubleQuote(char c) {

--- a/pom.xml
+++ b/pom.xml
@@ -1092,9 +1092,6 @@
             <ignore>java.security.AlgorithmConstraints</ignore>
 
             <ignore>java.util.concurrent.ConcurrentLinkedDeque</ignore>
-
-            <!-- Used in internal utilities (protected by conditional) -->
-            <ignore>java.lang.Long</ignore>
           </ignores>
         </configuration>
         <executions>


### PR DESCRIPTION
Motivation:
UTF-16 can not represent the full range of Unicode characters, and thus has the concept of Surrogate Pair (http://unicode.org/glossary/#surrogate_pair) where 2 16-bit code units can be used to represent the missing characters. ByteBufUtil.writeUtf8 is currently does not support this and is thus incomplete.

Modifications:
- Add support for surrogate pairs in ByteBufUtil.writeUtf8

Result:
ByteBufUtil.writeUtf8 now supports surrogate pairs and is correctly converting to UTF-8.