### PR TITLE
refactory AbstractChannelHandlerContext and DefaultChannelPipeline to avoid tight coupling

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -31,7 +31,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
 
     private final boolean inbound;
     private final boolean outbound;
-    private final DefaultChannelPipeline pipeline;
+    private final ChannelPipeline pipeline;
     private final String name;
     private boolean removed;
 
@@ -47,7 +47,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     volatile Runnable invokeFlushTask;
 
     AbstractChannelHandlerContext(
-            DefaultChannelPipeline pipeline, ChannelHandlerInvoker invoker,
+            ChannelPipeline pipeline, ChannelHandlerInvoker invoker,
             String name, boolean inbound, boolean outbound) {
 
         if (name == null) {

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -18,6 +18,8 @@ package io.netty.channel;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakHint;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.internal.StringUtil;
@@ -25,6 +27,8 @@ import io.netty.util.internal.StringUtil;
 import java.net.SocketAddress;
 
 abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, ResourceLeakHint {
+
+    private final boolean touch = ResourceLeakDetector.isEnabled();
 
     volatile AbstractChannelHandlerContext next;
     volatile AbstractChannelHandlerContext prev;
@@ -150,7 +154,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     @Override
     public ChannelHandlerContext fireChannelRead(Object msg) {
         AbstractChannelHandlerContext next = findContextInbound();
-        next.invoker().invokeChannelRead(next, pipeline.touch(msg, next));
+        next.invoker().invokeChannelRead(next, touch(msg, next));
         return this;
     }
 
@@ -257,7 +261,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     @Override
     public ChannelFuture write(Object msg, ChannelPromise promise) {
         AbstractChannelHandlerContext next = findContextOutbound();
-        next.invoker().invokeWrite(next, pipeline.touch(msg, next), promise);
+        next.invoker().invokeWrite(next, touch(msg, next), promise);
         return promise;
     }
 
@@ -272,7 +276,7 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
         AbstractChannelHandlerContext next = findContextOutbound();
         ChannelHandlerInvoker invoker = next.invoker();
-        invoker.invokeWrite(next, pipeline.touch(msg, next) , promise);
+        invoker.invokeWrite(next, touch(msg, next) , promise);
         invoker.invokeFlush(next);
         return promise;
     }
@@ -320,6 +324,10 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
             ctx = ctx.prev;
         } while (!ctx.outbound);
         return ctx;
+    }
+
+    private Object touch(Object msg, ChannelHandlerContext next) {
+        return touch ? ReferenceCountUtil.touch(msg, next) : msg;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
@@ -18,7 +18,6 @@ package io.netty.channel;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.AttributeMap;
 import io.netty.util.concurrent.EventExecutor;

--- a/transport/src/main/java/io/netty/channel/ChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPipeline.java
@@ -957,13 +957,4 @@ public interface ChannelPipeline extends Iterable<Entry<String, ChannelHandler>>
      * Shortcut for call {@link #write(Object)} and {@link #flush()}.
      */
     ChannelFuture writeAndFlush(Object msg);
-
-    /**
-     *
-     * touch the msg.
-     *
-     * Note that this method is only meant to be called from with in the
-     * {@link ChannelHandlerContext}.
-     */
-    Object touch(Object msg, ChannelHandlerContext next);
 }

--- a/transport/src/main/java/io/netty/channel/ChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPipeline.java
@@ -957,4 +957,13 @@ public interface ChannelPipeline extends Iterable<Entry<String, ChannelHandler>>
      * Shortcut for call {@link #write(Object)} and {@link #flush()}.
      */
     ChannelFuture writeAndFlush(Object msg);
+
+    /**
+     *
+     * touch the msg.
+     *
+     * Note that this method is only meant to be called from with in the
+     * {@link ChannelHandlerContext}.
+     */
+    Object touch(Object msg, ChannelHandlerContext next);
 }

--- a/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelHandlerContext.java
@@ -20,7 +20,7 @@ final class DefaultChannelHandlerContext extends AbstractChannelHandlerContext {
     private final ChannelHandler handler;
 
     DefaultChannelHandlerContext(
-            DefaultChannelPipeline pipeline, ChannelHandlerInvoker invoker, String name, ChannelHandler handler) {
+            ChannelPipeline pipeline, ChannelHandlerInvoker invoker, String name, ChannelHandler handler) {
         super(pipeline, invoker, name, isInbound(handler), isOutbound(handler));
         if (handler == null) {
             throw new NullPointerException("handler");

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -80,7 +80,8 @@ final class DefaultChannelPipeline implements ChannelPipeline {
         tail.prev = head;
     }
 
-    Object touch(Object msg, AbstractChannelHandlerContext next) {
+    @Override
+    public Object touch(Object msg, ChannelHandlerContext next) {
         return touch ? ReferenceCountUtil.touch(msg, next) : msg;
     }
 

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -60,7 +60,6 @@ final class DefaultChannelPipeline implements ChannelPipeline {
     final AbstractChannelHandlerContext head;
     final AbstractChannelHandlerContext tail;
 
-    private final boolean touch = ResourceLeakDetector.isEnabled();
 
     /**
      * @see #findInvoker(EventExecutorGroup)
@@ -78,11 +77,6 @@ final class DefaultChannelPipeline implements ChannelPipeline {
 
         head.next = tail;
         tail.prev = head;
-    }
-
-    @Override
-    public Object touch(Object msg, ChannelHandlerContext next) {
-        return touch ? ReferenceCountUtil.touch(msg, next) : msg;
     }
 
     @Override


### PR DESCRIPTION
In the code of class AbstractChannelHandlerContext and DefaultChannelHandlerContext, DefaultChannelPipeline is used directly, not the interface ChannelPipeline.

I tried to replace DefaultChannelPipeline with interface ChannelPipeline, but found that in AbstractChannelHandlerContext the method DefaultChannelPipeline.touch() is invoked, which is not defined in the interface ChannelPipeline.

The way to resolve this is add the touch() method in the interface ChannelPipeline, then we can safely replace all the DefaultChannelPipeline with ChannelPipeline. --- This is what I do in the first commit.

Yet here it is still a question: should the touch() method be a part of ChannelPipeline? Of cause not.

So I tried to do the second update: I found that the implementation of touch() method is independent to the actual implementation of ChannelPipeline, and only class AbstractChannelHandlerContext invokes the touch() method. It is reasonable to move the touch() logic from ChannelPipeline to AbstractChannelHandlerContext. 

The final result of above two commit:

1. the touch() method and touch attribute are moved from class DefaultChannelPipeline to class AbstractChannelHandlerContext.

2. AbstractChannelHandlerContext and DefaultChannelHandlerContext now use pure interface ChannelPipeline, not implementation DefaultChannelPipeline any more.

3. interface ChannelPipeline is not changed.

It seems more clear and less coupling now. Do you like this refactory? 
