### PR TITLE
General API for compression codecs

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/AbstractClosableCompressionDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/AbstractClosableCompressionDecoder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+/**
+ * A skeletal {@link ClosableCompressionDecoder} implementation.
+ */
+public abstract class AbstractClosableCompressionDecoder extends AbstractCompressionDecoder
+        implements ClosableCompressionDecoder {
+
+    private static final InternalLogger logger =
+            InternalLoggerFactory.getInstance(AbstractClosableCompressionDecoder.class);
+
+    protected AbstractClosableCompressionDecoder(CompressionFormat format) {
+        super(format);
+    }
+
+    @Override
+    public abstract boolean isClosed();
+
+    @Override
+    protected void handlerRemoved0(ChannelHandlerContext ctx) throws Exception {
+        if (!isClosed()) {
+            logger.warn("ClosableCompressionDecoder is removed from a pipeline, "
+                    + "but the end of the compressed stream has not been reached.");
+        }
+    }
+}

--- a/codec/src/main/java/io/netty/handler/codec/compression/AbstractClosableCompressionEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/AbstractClosableCompressionEncoder.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.ChannelPromiseNotifier;
+import io.netty.util.concurrent.EventExecutor;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A skeletal {@link ClosableCompressionEncoder} implementation.
+ */
+public abstract class AbstractClosableCompressionEncoder extends AbstractCompressionEncoder
+        implements ClosableCompressionEncoder {
+
+    private static final long DEFAULT_LAST_WRITE_TIMEOUT = 10;
+    private static final TimeUnit DEFAULT_LAST_WRITE_TIMEOUT_UNIT = TimeUnit.MILLISECONDS;
+
+    private volatile long lastWriteTimeout;
+    private volatile TimeUnit lastWriteTimeoutUnit;
+
+    /**
+     * Used to interact with its {@link ChannelPipeline} and other handlers.
+     */
+    private volatile ChannelHandlerContext ctx;
+
+    /**
+     * Default constructor for {@link AbstractClosableCompressionEncoder} which will try to use a direct
+     * {@link ByteBuf} as a target for the encoded messages.
+     */
+    protected AbstractClosableCompressionEncoder(CompressionFormat format) {
+        this(format, true);
+    }
+
+    /**
+     * Creates an instance with specified preference of a target {@link ByteBuf} for the encoded messages.
+     * It uses if compression algorithm needs a byte array as a target.
+     *
+     * @param preferDirect {@code true} if a direct {@link ByteBuf} should be tried to be used as a target
+     *                     for the encoded messages. If {@code false} is used it will allocate a heap
+     *                     {@link ByteBuf}, which is backed by an byte array.
+     */
+    protected AbstractClosableCompressionEncoder(CompressionFormat format, boolean preferDirect) {
+        super(format, preferDirect);
+        lastWriteTimeout = DEFAULT_LAST_WRITE_TIMEOUT;
+        lastWriteTimeoutUnit = DEFAULT_LAST_WRITE_TIMEOUT_UNIT;
+    }
+
+    @Override
+    public final long lastWriteTimeoutMillis() {
+        return lastWriteTimeoutUnit.toMillis(lastWriteTimeout);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * The default value is {@value #DEFAULT_LAST_WRITE_TIMEOUT}, unit is {@value #DEFAULT_LAST_WRITE_TIMEOUT_UNIT}.
+     */
+    @Override
+    public final void setLastWriteTimeout(long timeout, TimeUnit unit) {
+        lastWriteTimeout = timeout;
+        lastWriteTimeoutUnit = unit;
+    }
+
+    @Override
+    public abstract boolean isClosed();
+
+    @Override
+    public final ChannelFuture close() {
+        return close(ctx().newPromise());
+    }
+
+    @Override
+    public final ChannelFuture close(final ChannelPromise promise) {
+        final ChannelHandlerContext ctx = ctx();
+        EventExecutor executor = ctx.executor();
+        if (executor.inEventLoop()) {
+            return finishEncode(ctx, promise);
+        } else {
+            final ChannelPromise p = ctx.newPromise();
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    ChannelFuture f = finishEncode(ctx(), p);
+                    f.addListener(new ChannelPromiseNotifier(promise));
+                }
+            });
+            return p;
+        }
+    }
+
+    @Override
+    public final void close(final ChannelHandlerContext ctx, final ChannelPromise promise) throws Exception {
+        ChannelFuture f = finishEncode(ctx, ctx.newPromise());
+        if (f.isDone()) {
+            ctx.close(promise);
+        } else {
+            f.addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture f) throws Exception {
+                    ctx.close(promise);
+                }
+            });
+            // Ensure the channel is closed even if the write operation completes in time
+            ctx.executor().schedule(new Runnable() {
+                @Override
+                public void run() {
+                    if (!promise.isDone()) {
+                        ctx.close(promise);
+                    }
+                }
+            }, lastWriteTimeout, lastWriteTimeoutUnit);
+        }
+    }
+
+    /**
+     * Finishes current encoding.
+     *
+     * Note: for some {@link CompressionFormat}'s which does not support finish operation
+     * this method could fail specified {@link ChannelPromise}.
+     */
+    protected abstract ChannelFuture finishEncode(ChannelHandlerContext ctx, ChannelPromise promise);
+
+    /**
+     * Holds link to current {@link ChannelHandlerContext}.
+     */
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+        this.ctx = ctx;
+    }
+
+    /**
+     * Discards link to current {@link ChannelHandlerContext}.
+     */
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        finishEncode(ctx, ctx.newPromise());
+        this.ctx = null;
+    }
+
+    /**
+     * Returns current {@link ChannelHandlerContext}.
+     */
+    private ChannelHandlerContext ctx() {
+        final ChannelHandlerContext ctx = this.ctx;
+        if (ctx == null) {
+            throw new IllegalStateException("not added to a pipeline");
+        }
+        return ctx;
+    }
+}

--- a/codec/src/main/java/io/netty/handler/codec/compression/AbstractCompressionDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/AbstractCompressionDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2017 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,19 +15,22 @@
  */
 package io.netty.handler.codec.compression;
 
-import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.util.internal.ObjectUtil;
 
 /**
- * Compresses a {@link ByteBuf} using the deflate algorithm.
+ * A skeletal {@link CompressionDecoder} implementation.
  */
-public abstract class ZlibEncoder extends AbstractClosableCompressionEncoder {
+public abstract class AbstractCompressionDecoder extends ByteToMessageDecoder implements CompressionDecoder {
 
-    protected ZlibEncoder(CompressionFormat format) {
-        super(format, false);
-        if (format == CompressionFormat.ZLIB_OR_NONE) {
-            throw new IllegalArgumentException(
-                    "format '" + CompressionFormat.ZLIB_OR_NONE + "' is not " +
-                    "allowed for compression.");
-        }
+    private final CompressionFormat format;
+
+    protected AbstractCompressionDecoder(CompressionFormat format) {
+        this.format = ObjectUtil.checkNotNull(format, "format");
+    }
+
+    @Override
+    public final CompressionFormat format() {
+        return format;
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/AbstractCompressionEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/AbstractCompressionEncoder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.MessageToByteEncoder;
+import io.netty.util.internal.ObjectUtil;
+
+/**
+ * A skeletal {@link CompressionEncoder} implementation.
+ */
+public abstract class AbstractCompressionEncoder extends MessageToByteEncoder<ByteBuf> implements CompressionEncoder {
+
+    private final CompressionFormat format;
+
+    /**
+     * Default constructor for {@link AbstractCompressionEncoder} which will try to use a direct
+     * {@link ByteBuf} as a target for the encoded messages.
+     */
+    protected AbstractCompressionEncoder(CompressionFormat format) {
+        this(format, true);
+    }
+
+    /**
+     * Creates an instance with specified preference of a target {@link ByteBuf} for the encoded messages.
+     * It uses if compression algorithm needs a byte array as a target.
+     *
+     * @param preferDirect {@code true} if a direct {@link ByteBuf} should be tried to be used as a target
+     *                     for the encoded messages. If {@code false} is used it will allocate a heap
+     *                     {@link ByteBuf}, which is backed by an byte array.
+     */
+    protected AbstractCompressionEncoder(CompressionFormat format, boolean preferDirect) {
+        super(preferDirect);
+        this.format = ObjectUtil.checkNotNull(format, "format");
+    }
+
+    @Override
+    public final CompressionFormat format() {
+        return format;
+    }
+}

--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Decoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Decoder.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
@@ -28,7 +27,7 @@ import static io.netty.handler.codec.compression.Bzip2Constants.*;
  *
  * See <a href="http://en.wikipedia.org/wiki/Bzip2">Bzip2</a>.
  */
-public class Bzip2Decoder extends ByteToMessageDecoder {
+public class Bzip2Decoder extends AbstractClosableCompressionDecoder {
     /**
      * Current state of stream.
      */
@@ -75,6 +74,10 @@ public class Bzip2Decoder extends ByteToMessageDecoder {
      * The merged CRC of all blocks decompressed so far.
      */
     private int streamCRC;
+
+    public Bzip2Decoder() {
+        super(CompressionFormat.BZIP2);
+    }
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
@@ -320,10 +323,7 @@ public class Bzip2Decoder extends ByteToMessageDecoder {
         }
     }
 
-    /**
-     * Returns {@code true} if and only if the end of the compressed stream
-     * has been reached.
-     */
+    @Override
     public boolean isClosed() {
         return currentState == State.EOF;
     }

--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2Encoder.java
@@ -17,15 +17,8 @@ package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.ChannelPromiseNotifier;
-import io.netty.handler.codec.MessageToByteEncoder;
-import io.netty.util.concurrent.EventExecutor;
-
-import java.util.concurrent.TimeUnit;
 
 import static io.netty.handler.codec.compression.Bzip2Constants.*;
 
@@ -34,7 +27,7 @@ import static io.netty.handler.codec.compression.Bzip2Constants.*;
  *
  * See <a href="http://en.wikipedia.org/wiki/Bzip2">Bzip2</a>.
  */
-public class Bzip2Encoder extends MessageToByteEncoder<ByteBuf> {
+public class Bzip2Encoder extends AbstractClosableCompressionEncoder {
     /**
      * Current state of stream.
      */
@@ -73,11 +66,6 @@ public class Bzip2Encoder extends MessageToByteEncoder<ByteBuf> {
     private volatile boolean finished;
 
     /**
-     * Used to interact with its {@link ChannelPipeline} and other handlers.
-     */
-    private volatile ChannelHandlerContext ctx;
-
-    /**
      * Creates a new bzip2 encoder with the maximum (900,000 byte) block size.
      */
     public Bzip2Encoder() {
@@ -92,6 +80,8 @@ public class Bzip2Encoder extends MessageToByteEncoder<ByteBuf> {
      *        but give better compression ratios. {@code 9} will usually be the best value to use.
      */
     public Bzip2Encoder(final int blockSizeMultiplier) {
+        super(CompressionFormat.BZIP2);
+
         if (blockSizeMultiplier < MIN_BLOCK_SIZE || blockSizeMultiplier > MAX_BLOCK_SIZE) {
             throw new IllegalArgumentException(
                     "blockSizeMultiplier: " + blockSizeMultiplier + " (expected: 1-9)");
@@ -157,66 +147,13 @@ public class Bzip2Encoder extends MessageToByteEncoder<ByteBuf> {
         }
     }
 
-    /**
-     * Returns {@code true} if and only if the end of the compressed stream has been reached.
-     */
+    @Override
     public boolean isClosed() {
         return finished;
     }
 
-    /**
-     * Close this {@link Bzip2Encoder} and so finish the encoding.
-     *
-     * The returned {@link ChannelFuture} will be notified once the operation completes.
-     */
-    public ChannelFuture close() {
-        return close(ctx().newPromise());
-    }
-
-    /**
-     * Close this {@link Bzip2Encoder} and so finish the encoding.
-     * The given {@link ChannelFuture} will be notified once the operation
-     * completes and will also be returned.
-     */
-    public ChannelFuture close(final ChannelPromise promise) {
-        ChannelHandlerContext ctx = ctx();
-        EventExecutor executor = ctx.executor();
-        if (executor.inEventLoop()) {
-            return finishEncode(ctx, promise);
-        } else {
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    ChannelFuture f = finishEncode(ctx(), promise);
-                    f.addListener(new ChannelPromiseNotifier(promise));
-                }
-            });
-            return promise;
-        }
-    }
-
     @Override
-    public void close(final ChannelHandlerContext ctx, final ChannelPromise promise) throws Exception {
-        ChannelFuture f = finishEncode(ctx, ctx.newPromise());
-        f.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture f) throws Exception {
-                ctx.close(promise);
-            }
-        });
-
-        if (!f.isDone()) {
-            // Ensure the channel is closed even if the write operation completes in time.
-            ctx.executor().schedule(new Runnable() {
-                @Override
-                public void run() {
-                    ctx.close(promise);
-                }
-            }, 10, TimeUnit.SECONDS); // FIXME: Magic number
-        }
-    }
-
-    private ChannelFuture finishEncode(final ChannelHandlerContext ctx, ChannelPromise promise) {
+    protected final ChannelFuture finishEncode(final ChannelHandlerContext ctx, ChannelPromise promise) {
         if (finished) {
             promise.setSuccess();
             return promise;
@@ -237,18 +174,5 @@ public class Bzip2Encoder extends MessageToByteEncoder<ByteBuf> {
             blockCompressor = null;
         }
         return ctx.writeAndFlush(footer, promise);
-    }
-
-    private ChannelHandlerContext ctx() {
-        ChannelHandlerContext ctx = this.ctx;
-        if (ctx == null) {
-            throw new IllegalStateException("not added to a pipeline");
-        }
-        return ctx;
-    }
-
-    @Override
-    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-        this.ctx = ctx;
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/ClosableCompressionDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ClosableCompressionDecoder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+/**
+ * A {@link CompressionDecoder} which decodes compressed streams with end of stream flag.
+ * <p/>
+ * If the end of the compressed stream is reached all new inbound bytes will be skipped.
+ * Note, that all closable compression decoders are not reusable. You have to create and add a new
+ * {@link ClosableCompressionDecoder} to a pipeline if current decoder is closed.
+ * <p/>
+ * Note, that you can safely remove current handler from a pipeline only if it is already closed.
+ */
+public interface ClosableCompressionDecoder extends CompressionDecoder {
+
+    /**
+     * Returns {@code true} if and only if the end of the compressed stream has been reached.
+     */
+    boolean isClosed();
+}

--- a/codec/src/main/java/io/netty/handler/codec/compression/ClosableCompressionEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ClosableCompressionEncoder.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link CompressionEncoder} which may be closed.
+ */
+public interface ClosableCompressionEncoder extends CompressionEncoder {
+
+    /**
+     * Amount of time to be delayed before the ensuring that the channel is closed
+     * after the call of {@link #close(ChannelHandlerContext, ChannelPromise)}.
+     */
+    long lastWriteTimeoutMillis();
+
+    /**
+     * Set amount of time to be delayed before the ensuring that the channel is closed
+     * after the call of {@link #close(ChannelHandlerContext, ChannelPromise)}.
+     *
+     * @param timeout value of time.
+     * @param unit    unit of time.
+     */
+    void setLastWriteTimeout(long timeout, TimeUnit unit);
+
+    /**
+     * Returns {@code true} if and only if the end of the compressed stream has been reached.
+     */
+    boolean isClosed();
+
+    /**
+     * Close this {@link AbstractClosableCompressionEncoder} and so finish the encoding.
+     *
+     * The returned {@link ChannelFuture} will be notified once the operation completes.
+     *
+     * Note: for some {@link CompressionFormat}'s which does not support close operation
+     * this method could return failed {@link ChannelFuture}.
+     */
+    ChannelFuture close();
+
+    /**
+     * Close this {@link AbstractClosableCompressionEncoder} and so finish the encoding.
+     * The given {@link ChannelFuture} will be notified once the operation
+     * completes and will also be returned.
+     *
+     * Note: for some {@link CompressionFormat}'s which does not support close operation
+     * this method could return failed {@link ChannelFuture}.
+     */
+    ChannelFuture close(ChannelPromise promise);
+}

--- a/codec/src/main/java/io/netty/handler/codec/compression/CompressionDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/CompressionDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2017 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,18 +16,17 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelInboundHandler;
 
 /**
- * Compresses a {@link ByteBuf} using the deflate algorithm.
+ * Decompresses a {@link ByteBuf} using one of compression algorithms.
+ * <p/>
+ * Note that stream may be corrupted if you remove current handler from a pipeline.
  */
-public abstract class ZlibEncoder extends AbstractClosableCompressionEncoder {
+public interface CompressionDecoder extends ChannelInboundHandler {
 
-    protected ZlibEncoder(CompressionFormat format) {
-        super(format, false);
-        if (format == CompressionFormat.ZLIB_OR_NONE) {
-            throw new IllegalArgumentException(
-                    "format '" + CompressionFormat.ZLIB_OR_NONE + "' is not " +
-                    "allowed for compression.");
-        }
-    }
+    /**
+     * Returns a format of current compression algorithm.
+     */
+    CompressionFormat format();
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/CompressionEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/CompressionEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2017 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,18 +16,15 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelOutboundHandler;
 
 /**
- * Compresses a {@link ByteBuf} using the deflate algorithm.
+ * Compresses a {@link ByteBuf} using one of compression algorithms.
  */
-public abstract class ZlibEncoder extends AbstractClosableCompressionEncoder {
+public interface CompressionEncoder extends ChannelOutboundHandler {
 
-    protected ZlibEncoder(CompressionFormat format) {
-        super(format, false);
-        if (format == CompressionFormat.ZLIB_OR_NONE) {
-            throw new IllegalArgumentException(
-                    "format '" + CompressionFormat.ZLIB_OR_NONE + "' is not " +
-                    "allowed for compression.");
-        }
-    }
+    /**
+     * Returns a format of current compression algorithm.
+     */
+    CompressionFormat format();
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/CompressionFormat.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/CompressionFormat.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.compression;
+
+/**
+ * Enumeration of possible compression formats.
+ */
+public enum CompressionFormat {
+    /**
+     * The ZLIB Compressed Data Format as specified in <a href="https://tools.ietf.org/html/rfc1950">RFC 1950</a>.
+     *
+     * For more information about {@code zlib} compression format
+     * see <a href="http://en.wikipedia.org/wiki/Zlib">zlib</a> wiki-page.
+     */
+    ZLIB,
+    /**
+     * The GZIP file format as specified in <a href="https://tools.ietf.org/html/rfc1952">RFC 1952</a>.
+     *
+     * For more information about {@code gzip} compression format
+     * see <a href="http://en.wikipedia.org/wiki/Gzip">gzip</a> wiki-page.
+     */
+    GZIP,
+    /**
+     * The DEFLATE Compressed Data Format as specified in <a href="https://tools.ietf.org/html/rfc1951">RFC 1951</a>.
+     *
+     * For more information about {@code DEFLATE} compression format
+     * see <a href="https://en.wikipedia.org/wiki/DEFLATE">DEFLATE</a> wiki-page.
+     */
+    DEFLATE,
+    /**
+     * Try {@link #ZLIB} first and then {@link #DEFLATE} if the first attempt fails.
+     * Please note that you can specify this wrapper type only when decompressing.
+     */
+    ZLIB_OR_NONE,
+    /**
+     * For more information about {@code gzip} compression format
+     * see <a href="http://google.github.io/snappy/">Snappy</a> official website.
+     */
+    SNAPPY,
+    /**
+     * For more information about {@code bzip2} compression format
+     * see <a href="http://en.wikipedia.org/wiki/Bzip2">bzip2</a> wiki-page.
+     */
+    BZIP2,
+    /**
+     * For more information about {@code LZF} compression format
+     * see <a href="https://github.com/ning/compress/wiki">LZF</a> official repository.
+     */
+    LZF,
+    /**
+     * For more information about {@code LZ4} compression format
+     * see <a href="http://en.wikipedia.org/wiki/LZ4_%28compression_algorithm%29">LZ4</a> wiki-page.
+     */
+    LZ4,
+    /**
+     * For more information about {@code FastLZ} compression format
+     * see <a href="http://fastlz.org/">FastLZ</a> wiki-page.
+     */
+    FASTLZ,
+    /**
+     * For more information about {@code LZMA} compression format
+     * see <a href="http://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Markov_chain_algorithm">LZMA</a> wiki-page.
+     */
+    LZMA
+}

--- a/codec/src/main/java/io/netty/handler/codec/compression/FastLzFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/FastLzFrameDecoder.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.util.internal.EmptyArrays;
 
 import java.util.List;
@@ -27,11 +26,11 @@ import java.util.zip.Checksum;
 import static io.netty.handler.codec.compression.FastLz.*;
 
 /**
- * Uncompresses a {@link ByteBuf} encoded by {@link FastLzFrameEncoder} using the FastLZ algorithm.
+ * Decompresses a {@link ByteBuf} encoded by {@link FastLzFrameEncoder} using the FastLZ algorithm.
  *
  * See <a href="https://github.com/netty/netty/issues/2750">FastLZ format</a>.
  */
-public class FastLzFrameDecoder extends ByteToMessageDecoder {
+public class FastLzFrameDecoder extends AbstractCompressionDecoder {
     /**
      * Current state of decompression.
      */
@@ -104,6 +103,7 @@ public class FastLzFrameDecoder extends ByteToMessageDecoder {
      *        You may set {@code null} if you do not want to validate checksum of each block.
      */
     public FastLzFrameDecoder(Checksum checksum) {
+        super(CompressionFormat.FASTLZ);
         this.checksum = checksum;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/compression/FastLzFrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/FastLzFrameEncoder.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToByteEncoder;
 
 import java.util.zip.Adler32;
 import java.util.zip.Checksum;
@@ -29,7 +28,7 @@ import static io.netty.handler.codec.compression.FastLz.*;
  *
  * See <a href="https://github.com/netty/netty/issues/2750">FastLZ format</a>.
  */
-public class FastLzFrameEncoder extends MessageToByteEncoder<ByteBuf> {
+public class FastLzFrameEncoder extends AbstractCompressionEncoder {
     /**
      * Compression level.
      */
@@ -60,8 +59,8 @@ public class FastLzFrameEncoder extends MessageToByteEncoder<ByteBuf> {
     }
 
     /**
-     * Creates a FastLZ encoder with auto detection of compression
-     * level and calculation of checksums as specified.
+     * Creates a FastLZ encoder with auto detection of compression level
+     * and calculation of checksums as specified.
      *
      * @param validateChecksums
      *        If true, the checksum of each block will be calculated and this value
@@ -85,7 +84,8 @@ public class FastLzFrameEncoder extends MessageToByteEncoder<ByteBuf> {
      *        You may set {@code null} if you don't want to validate checksum of each block.
      */
     public FastLzFrameEncoder(int level, Checksum checksum) {
-        super(false);
+        super(CompressionFormat.FASTLZ, false);
+
         if (level != LEVEL_AUTO && level != LEVEL_1 && level != LEVEL_2) {
             throw new IllegalArgumentException(String.format(
                     "level: %d (expected: %d or %d or %d)", level, LEVEL_AUTO, LEVEL_1, LEVEL_2));

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
@@ -22,6 +22,9 @@ import io.netty.channel.ChannelHandlerContext;
 
 import java.util.List;
 
+/**
+ * Decompress a {@link ByteBuf} using the inflate algorithm.
+ */
 public class JZlibDecoder extends ZlibDecoder {
 
     private final Inflater z = new Inflater();
@@ -43,9 +46,7 @@ public class JZlibDecoder extends ZlibDecoder {
      * @throws DecompressionException if failed to initialize zlib
      */
     public JZlibDecoder(ZlibWrapper wrapper) {
-        if (wrapper == null) {
-            throw new NullPointerException("wrapper");
-        }
+        super(wrapper.asCompressionFormat());
 
         int resultCode = z.init(ZlibUtil.convertWrapperType(wrapper));
         if (resultCode != JZlib.Z_OK) {
@@ -61,6 +62,8 @@ public class JZlibDecoder extends ZlibDecoder {
      * @throws DecompressionException if failed to initialize zlib
      */
     public JZlibDecoder(byte[] dictionary) {
+        super(CompressionFormat.ZLIB);
+
         if (dictionary == null) {
             throw new NullPointerException("dictionary");
         }
@@ -71,15 +74,6 @@ public class JZlibDecoder extends ZlibDecoder {
         if (resultCode != JZlib.Z_OK) {
             ZlibUtil.fail(z, "initialization failure", resultCode);
         }
-    }
-
-    /**
-     * Returns {@code true} if and only if the end of the compressed stream
-     * has been reached.
-     */
-    @Override
-    public boolean isClosed() {
-        return finished;
     }
 
     @Override
@@ -169,5 +163,10 @@ public class JZlibDecoder extends ZlibDecoder {
             z.next_in = null;
             z.next_out = null;
         }
+    }
+
+    @Override
+    public boolean isClosed() {
+        return finished;
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibEncoder.java
@@ -20,14 +20,9 @@ import com.jcraft.jzlib.JZlib;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.ChannelPromiseNotifier;
-import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.internal.EmptyArrays;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * Compresses a {@link ByteBuf} using the deflate algorithm.
@@ -37,7 +32,6 @@ public class JZlibEncoder extends ZlibEncoder {
     private final int wrapperOverhead;
     private final Deflater z = new Deflater();
     private volatile boolean finished;
-    private volatile ChannelHandlerContext ctx;
 
     /**
      * Creates a new zlib encoder with the default compression level ({@code 6}),
@@ -116,6 +110,7 @@ public class JZlibEncoder extends ZlibEncoder {
      * @throws CompressionException if failed to initialize zlib
      */
     public JZlibEncoder(ZlibWrapper wrapper, int compressionLevel, int windowBits, int memLevel) {
+        super(wrapper.asCompressionFormat());
 
         if (compressionLevel < 0 || compressionLevel > 9) {
             throw new IllegalArgumentException(
@@ -129,14 +124,6 @@ public class JZlibEncoder extends ZlibEncoder {
         if (memLevel < 1 || memLevel > 9) {
             throw new IllegalArgumentException(
                     "memLevel: " + memLevel + " (expected: 1-9)");
-        }
-        if (wrapper == null) {
-            throw new NullPointerException("wrapper");
-        }
-        if (wrapper == ZlibWrapper.ZLIB_OR_NONE) {
-            throw new IllegalArgumentException(
-                    "wrapper '" + ZlibWrapper.ZLIB_OR_NONE + "' is not " +
-                    "allowed for compression.");
         }
 
         int resultCode = z.init(
@@ -209,6 +196,8 @@ public class JZlibEncoder extends ZlibEncoder {
      * @throws CompressionException if failed to initialize zlib
      */
     public JZlibEncoder(int compressionLevel, int windowBits, int memLevel, byte[] dictionary) {
+        super(CompressionFormat.ZLIB);
+
         if (compressionLevel < 0 || compressionLevel > 9) {
             throw new IllegalArgumentException("compressionLevel: " + compressionLevel + " (expected: 0-9)");
         }
@@ -237,38 +226,6 @@ public class JZlibEncoder extends ZlibEncoder {
         }
 
         wrapperOverhead = ZlibUtil.wrapperOverhead(ZlibWrapper.ZLIB);
-    }
-
-    @Override
-    public ChannelFuture close() {
-        return close(ctx().channel().newPromise());
-    }
-
-    @Override
-    public ChannelFuture close(final ChannelPromise promise) {
-        ChannelHandlerContext ctx = ctx();
-        EventExecutor executor = ctx.executor();
-        if (executor.inEventLoop()) {
-            return finishEncode(ctx, promise);
-        } else {
-            final ChannelPromise p = ctx.newPromise();
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    ChannelFuture f = finishEncode(ctx(), p);
-                    f.addListener(new ChannelPromiseNotifier(promise));
-                }
-            });
-            return p;
-        }
-    }
-
-    private ChannelHandlerContext ctx() {
-        ChannelHandlerContext ctx = this.ctx;
-        if (ctx == null) {
-            throw new IllegalStateException("not added to a pipeline");
-        }
-        return ctx;
     }
 
     @Override
@@ -338,29 +295,7 @@ public class JZlibEncoder extends ZlibEncoder {
     }
 
     @Override
-    public void close(
-            final ChannelHandlerContext ctx,
-            final ChannelPromise promise) {
-        ChannelFuture f = finishEncode(ctx, ctx.newPromise());
-        f.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture f) throws Exception {
-                ctx.close(promise);
-            }
-        });
-
-        if (!f.isDone()) {
-            // Ensure the channel is closed even if the write operation completes in time.
-            ctx.executor().schedule(new Runnable() {
-                @Override
-                public void run() {
-                    ctx.close(promise);
-                }
-            }, 10, TimeUnit.SECONDS); // FIXME: Magic number
-        }
-    }
-
-    private ChannelFuture finishEncode(ChannelHandlerContext ctx, ChannelPromise promise) {
+    protected final ChannelFuture finishEncode(ChannelHandlerContext ctx, ChannelPromise promise) {
         if (finished) {
             promise.setSuccess();
             return promise;
@@ -401,10 +336,5 @@ public class JZlibEncoder extends ZlibEncoder {
             z.next_out = null;
         }
         return ctx.writeAndFlush(footer, promise);
-    }
-
-    @Override
-    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-        this.ctx = ctx;
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
@@ -85,9 +85,8 @@ public class JdkZlibDecoder extends ZlibDecoder {
     }
 
     private JdkZlibDecoder(ZlibWrapper wrapper, byte[] dictionary) {
-        if (wrapper == null) {
-            throw new NullPointerException("wrapper");
-        }
+        super(wrapper.asCompressionFormat());
+
         switch (wrapper) {
             case GZIP:
                 inflater = new Inflater(true);
@@ -110,11 +109,6 @@ public class JdkZlibDecoder extends ZlibDecoder {
                 throw new IllegalArgumentException("Only GZIP or ZLIB is supported, but you used " + wrapper);
         }
         this.dictionary = dictionary;
-    }
-
-    @Override
-    public boolean isClosed() {
-        return finished;
     }
 
     @Override
@@ -383,5 +377,10 @@ public class JdkZlibDecoder extends ZlibDecoder {
     private static boolean looksLikeZlib(short cmf_flg) {
         return (cmf_flg & 0x7800) == 0x7800 &&
                 cmf_flg % 31 == 0;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return finished;
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibEncoder.java
@@ -17,13 +17,9 @@ package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.ChannelPromiseNotifier;
-import io.netty.util.concurrent.EventExecutor;
 
-import java.util.concurrent.TimeUnit;
 import java.util.zip.CRC32;
 import java.util.zip.Deflater;
 
@@ -35,7 +31,6 @@ public class JdkZlibEncoder extends ZlibEncoder {
     private final ZlibWrapper wrapper;
     private final Deflater deflater;
     private volatile boolean finished;
-    private volatile ChannelHandlerContext ctx;
 
     /*
      * GZIP support
@@ -91,17 +86,11 @@ public class JdkZlibEncoder extends ZlibEncoder {
      * @throws CompressionException if failed to initialize zlib
      */
     public JdkZlibEncoder(ZlibWrapper wrapper, int compressionLevel) {
+        super(wrapper.asCompressionFormat());
+
         if (compressionLevel < 0 || compressionLevel > 9) {
             throw new IllegalArgumentException(
                     "compressionLevel: " + compressionLevel + " (expected: 0-9)");
-        }
-        if (wrapper == null) {
-            throw new NullPointerException("wrapper");
-        }
-        if (wrapper == ZlibWrapper.ZLIB_OR_NONE) {
-            throw new IllegalArgumentException(
-                    "wrapper '" + ZlibWrapper.ZLIB_OR_NONE + "' is not " +
-                    "allowed for compression.");
         }
 
         this.wrapper = wrapper;
@@ -137,6 +126,8 @@ public class JdkZlibEncoder extends ZlibEncoder {
      * @throws CompressionException if failed to initialize zlib
      */
     public JdkZlibEncoder(int compressionLevel, byte[] dictionary) {
+        super(CompressionFormat.ZLIB);
+
         if (compressionLevel < 0 || compressionLevel > 9) {
             throw new IllegalArgumentException(
                     "compressionLevel: " + compressionLevel + " (expected: 0-9)");
@@ -148,38 +139,6 @@ public class JdkZlibEncoder extends ZlibEncoder {
         wrapper = ZlibWrapper.ZLIB;
         deflater = new Deflater(compressionLevel);
         deflater.setDictionary(dictionary);
-    }
-
-    @Override
-    public ChannelFuture close() {
-        return close(ctx().newPromise());
-    }
-
-    @Override
-    public ChannelFuture close(final ChannelPromise promise) {
-        ChannelHandlerContext ctx = ctx();
-        EventExecutor executor = ctx.executor();
-        if (executor.inEventLoop()) {
-            return finishEncode(ctx, promise);
-        } else {
-            final ChannelPromise p = ctx.newPromise();
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    ChannelFuture f = finishEncode(ctx(), p);
-                    f.addListener(new ChannelPromiseNotifier(promise));
-                }
-            });
-            return p;
-        }
-    }
-
-    private ChannelHandlerContext ctx() {
-        ChannelHandlerContext ctx = this.ctx;
-        if (ctx == null) {
-            throw new IllegalStateException("not added to a pipeline");
-        }
-        return ctx;
     }
 
     @Override
@@ -230,6 +189,16 @@ public class JdkZlibEncoder extends ZlibEncoder {
         }
     }
 
+    private void deflate(ByteBuf out) {
+        int numBytes;
+        do {
+            int writerIndex = out.writerIndex();
+            numBytes = deflater.deflate(
+                    out.array(), out.arrayOffset() + writerIndex, out.writableBytes(), Deflater.SYNC_FLUSH);
+            out.writerIndex(writerIndex + numBytes);
+        } while (numBytes > 0);
+    }
+
     @Override
     protected final ByteBuf allocateBuffer(ChannelHandlerContext ctx, ByteBuf msg,
                                            boolean preferDirect) throws Exception {
@@ -250,27 +219,7 @@ public class JdkZlibEncoder extends ZlibEncoder {
     }
 
     @Override
-    public void close(final ChannelHandlerContext ctx, final ChannelPromise promise) throws Exception {
-        ChannelFuture f = finishEncode(ctx, ctx.newPromise());
-        f.addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture f) throws Exception {
-                ctx.close(promise);
-            }
-        });
-
-        if (!f.isDone()) {
-            // Ensure the channel is closed even if the write operation completes in time.
-            ctx.executor().schedule(new Runnable() {
-                @Override
-                public void run() {
-                    ctx.close(promise);
-                }
-            }, 10, TimeUnit.SECONDS); // FIXME: Magic number
-        }
-    }
-
-    private ChannelFuture finishEncode(final ChannelHandlerContext ctx, ChannelPromise promise) {
+    protected final ChannelFuture finishEncode(final ChannelHandlerContext ctx, ChannelPromise promise) {
         if (finished) {
             promise.setSuccess();
             return promise;
@@ -308,20 +257,5 @@ public class JdkZlibEncoder extends ZlibEncoder {
         }
         deflater.end();
         return ctx.writeAndFlush(footer, promise);
-    }
-
-    private void deflate(ByteBuf out) {
-        int numBytes;
-        do {
-            int writerIndex = out.writerIndex();
-            numBytes = deflater.deflate(
-                    out.array(), out.arrayOffset() + writerIndex, out.writableBytes(), Deflater.SYNC_FLUSH);
-            out.writerIndex(writerIndex + numBytes);
-        } while (numBytes > 0);
-    }
-
-    @Override
-    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-        this.ctx = ctx;
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4Constants.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4Constants.java
@@ -15,6 +15,9 @@
  */
 package io.netty.handler.codec.compression;
 
+/**
+ * Constants for both the {@link Lz4FrameEncoder} and the {@link Lz4FrameDecoder}.
+ */
 final class Lz4Constants {
     /**
      * Magic number of LZ4 block.

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoder.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.ByteToMessageDecoder;
 import net.jpountz.lz4.LZ4Exception;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.lz4.LZ4FastDecompressor;
@@ -29,7 +28,7 @@ import java.util.zip.Checksum;
 import static io.netty.handler.codec.compression.Lz4Constants.*;
 
 /**
- * Uncompresses a {@link ByteBuf} encoded with the LZ4 format.
+ * Decompresses a {@link ByteBuf} encoded with the LZ4 format.
  *
  * See original <a href="https://github.com/Cyan4973/lz4">LZ4 Github project</a>
  * and <a href="http://fastcompression.blogspot.ru/2011/05/lz4-explained.html">LZ4 block format</a>
@@ -44,7 +43,7 @@ import static io.netty.handler.codec.compression.Lz4Constants.*;
  *  *       *       *    length   *     length    *           *     *      block      *
  *  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *     * * * * * * * * * *
  */
-public class Lz4FrameDecoder extends ByteToMessageDecoder {
+public class Lz4FrameDecoder extends AbstractClosableCompressionDecoder {
     /**
      * Current state of stream.
      */
@@ -139,6 +138,8 @@ public class Lz4FrameDecoder extends ByteToMessageDecoder {
      *                  You may set {@code null} if you do not want to validate checksum of each block
      */
     public Lz4FrameDecoder(LZ4Factory factory, Checksum checksum) {
+        super(CompressionFormat.LZ4);
+
         if (factory == null) {
             throw new NullPointerException("factory");
         }
@@ -266,10 +267,7 @@ public class Lz4FrameDecoder extends ByteToMessageDecoder {
         }
     }
 
-    /**
-     * Returns {@code true} if and only if the end of the compressed stream
-     * has been reached.
-     */
+    @Override
     public boolean isClosed() {
         return currentState == State.FINISHED;
     }

--- a/codec/src/main/java/io/netty/handler/codec/compression/LzfDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/LzfDecoder.java
@@ -20,7 +20,6 @@ import com.ning.compress.lzf.ChunkDecoder;
 import com.ning.compress.lzf.util.ChunkDecoderFactory;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
@@ -31,12 +30,12 @@ import static com.ning.compress.lzf.LZFChunk.BYTE_Z;
 import static com.ning.compress.lzf.LZFChunk.HEADER_LEN_NOT_COMPRESSED;
 
 /**
- * Uncompresses a {@link ByteBuf} encoded with the LZF format.
+ * Decompresses a {@link ByteBuf} encoded with the LZF format.
  *
  * See original <a href="http://oldhome.schmorp.de/marc/liblzf.html">LZF package</a>
  * and <a href="https://github.com/ning/compress/wiki/LZFFormat">LZF format</a> for full description.
  */
-public class LzfDecoder extends ByteToMessageDecoder {
+public class LzfDecoder extends AbstractCompressionDecoder {
     /**
      * Current state of decompression.
      */
@@ -100,6 +99,8 @@ public class LzfDecoder extends ByteToMessageDecoder {
      *        Sun JDK's {@link sun.misc.Unsafe} class (which may be included by other JDK's as well).
      */
     public LzfDecoder(boolean safeInstance) {
+        super(CompressionFormat.LZF);
+
         decoder = safeInstance ?
                 ChunkDecoderFactory.safeInstance()
               : ChunkDecoderFactory.optimalInstance();

--- a/codec/src/main/java/io/netty/handler/codec/compression/LzfEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/LzfEncoder.java
@@ -21,7 +21,6 @@ import com.ning.compress.lzf.LZFEncoder;
 import com.ning.compress.lzf.util.ChunkEncoderFactory;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToByteEncoder;
 
 import static com.ning.compress.lzf.LZFChunk.*;
 
@@ -31,7 +30,7 @@ import static com.ning.compress.lzf.LZFChunk.*;
  * See original <a href="http://oldhome.schmorp.de/marc/liblzf.html">LZF package</a>
  * and <a href="https://github.com/ning/compress/wiki/LZFFormat">LZF format</a> for full description.
  */
-public class LzfEncoder extends MessageToByteEncoder<ByteBuf> {
+public class LzfEncoder extends AbstractCompressionEncoder {
     /**
      * Minimum block size ready for compression. Blocks with length
      * less than {@link #MIN_BLOCK_TO_COMPRESS} will write as uncompressed.
@@ -96,7 +95,7 @@ public class LzfEncoder extends MessageToByteEncoder<ByteBuf> {
      *        than maximum chunk size (64k), to optimize encoding hash tables.
      */
     public LzfEncoder(boolean safeInstance, int totalLength) {
-        super(false);
+        super(CompressionFormat.LZF, false);
         if (totalLength < MIN_BLOCK_TO_COMPRESS || totalLength > MAX_CHUNK_LEN) {
             throw new IllegalArgumentException("totalLength: " + totalLength +
                     " (expected: " + MIN_BLOCK_TO_COMPRESS + '-' + MAX_CHUNK_LEN + ')');

--- a/codec/src/main/java/io/netty/handler/codec/compression/LzmaFrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/LzmaFrameEncoder.java
@@ -19,7 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import lzma.sdk.lzma.Base;
@@ -36,7 +35,7 @@ import static lzma.sdk.lzma.Encoder.*;
  * and <a href="http://svn.python.org/projects/external/xz-5.0.5/doc/lzma-file-format.txt">LZMA format</a>
  * or documents in <a href="http://www.7-zip.org/sdk.html">LZMA SDK</a> archive.
  */
-public class LzmaFrameEncoder extends MessageToByteEncoder<ByteBuf> {
+public class LzmaFrameEncoder extends AbstractCompressionEncoder {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(LzmaFrameEncoder.class);
 
@@ -135,6 +134,7 @@ public class LzmaFrameEncoder extends MessageToByteEncoder<ByteBuf> {
      *        available values [{@value #MIN_FAST_BYTES}, {@value #MAX_FAST_BYTES}].
      */
     public LzmaFrameEncoder(int lc, int lp, int pb, int dictionarySize, boolean endMarkerMode, int numFastBytes) {
+        super(CompressionFormat.LZMA, false);
         if (lc < 0 || lc > 8) {
             throw new IllegalArgumentException("lc: " + lc + " (expected: 0-8)");
         }

--- a/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
@@ -18,7 +18,7 @@ package io.netty.handler.codec.compression;
 import io.netty.buffer.ByteBuf;
 
 /**
- * Uncompresses an input {@link ByteBuf} encoded with Snappy compression into an
+ * Decompresses an input {@link ByteBuf} encoded with Snappy compression into an
  * output {@link ByteBuf}.
  *
  * See <a href="https://github.com/google/snappy/blob/master/format_description.txt">snappy format</a>.

--- a/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java
@@ -17,14 +17,13 @@ package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
 import static io.netty.handler.codec.compression.Snappy.validateChecksum;
 
 /**
- * Uncompresses a {@link ByteBuf} encoded with the Snappy framing format.
+ * Decompresses a {@link ByteBuf} encoded with the Snappy framing format.
  *
  * See <a href="https://github.com/google/snappy/blob/master/framing_format.txt">Snappy framing format</a>.
  *
@@ -34,7 +33,7 @@ import static io.netty.handler.codec.compression.Snappy.validateChecksum;
  * use the {@link #SnappyFrameDecoder(boolean)} constructor with the argument
  * set to {@code true}.
  */
-public class SnappyFrameDecoder extends ByteToMessageDecoder {
+public class SnappyFrameDecoder extends AbstractCompressionDecoder {
 
     private enum ChunkType {
         STREAM_IDENTIFIER,
@@ -72,6 +71,7 @@ public class SnappyFrameDecoder extends ByteToMessageDecoder {
      *        {@link DecompressionException} will be thrown
      */
     public SnappyFrameDecoder(boolean validateChecksums) {
+        super(CompressionFormat.SNAPPY);
         this.validateChecksums = validateChecksums;
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameEncoder.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToByteEncoder;
 
 import static io.netty.handler.codec.compression.Snappy.*;
 
@@ -26,7 +25,7 @@ import static io.netty.handler.codec.compression.Snappy.*;
  *
  * See <a href="https://github.com/google/snappy/blob/master/framing_format.txt">Snappy framing format</a>.
  */
-public class SnappyFrameEncoder extends MessageToByteEncoder<ByteBuf> {
+public class SnappyFrameEncoder extends AbstractCompressionEncoder {
     /**
      * The minimum amount that we'll consider actually attempting to compress.
      * This value is preamble + the minimum length our Snappy service will
@@ -44,6 +43,10 @@ public class SnappyFrameEncoder extends MessageToByteEncoder<ByteBuf> {
 
     private final Snappy snappy = new Snappy();
     private boolean started;
+
+    public SnappyFrameEncoder() {
+        super(CompressionFormat.SNAPPY);
+    }
 
     @Override
     protected void encode(ChannelHandlerContext ctx, ByteBuf in, ByteBuf out) throws Exception {

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibDecoder.java
@@ -16,16 +16,13 @@
 package io.netty.handler.codec.compression;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.handler.codec.ByteToMessageDecoder;
 
 /**
  * Decompresses a {@link ByteBuf} using the deflate algorithm.
  */
-public abstract class ZlibDecoder extends ByteToMessageDecoder {
+public abstract class ZlibDecoder extends AbstractClosableCompressionDecoder {
 
-    /**
-     * Returns {@code true} if and only if the end of the compressed stream
-     * has been reached.
-     */
-    public abstract boolean isClosed();
+    protected ZlibDecoder(CompressionFormat format) {
+        super(format);
+    }
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibWrapper.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibWrapper.java
@@ -16,25 +16,37 @@
 package io.netty.handler.codec.compression;
 
 /**
- * The container file formats that wrap the stream compressed by the DEFLATE
- * algorithm.
+ * The container file formats that wrap the stream compressed by the DEFLATE algorithm.
  */
 public enum ZlibWrapper {
     /**
      * The ZLIB wrapper as specified in <a href="http://tools.ietf.org/html/rfc1950">RFC 1950</a>.
      */
-    ZLIB,
+    ZLIB(CompressionFormat.ZLIB),
     /**
      * The GZIP wrapper as specified in <a href="http://tools.ietf.org/html/rfc1952">RFC 1952</a>.
      */
-    GZIP,
+    GZIP(CompressionFormat.GZIP),
     /**
      * Raw DEFLATE stream only (no header and no footer).
      */
-    NONE,
+    NONE(CompressionFormat.DEFLATE),
     /**
      * Try {@link #ZLIB} first and then {@link #NONE} if the first attempt fails.
      * Please note that you can specify this wrapper type only when decompressing.
      */
-    ZLIB_OR_NONE
+    ZLIB_OR_NONE(CompressionFormat.ZLIB_OR_NONE);
+
+    private final CompressionFormat compressionFormat;
+
+    ZlibWrapper(CompressionFormat compressionFormat) {
+        this.compressionFormat = compressionFormat;
+    }
+
+    /**
+     * Returns a {@link CompressionFormat} of current {@link ZlibWrapper}.
+     */
+    public CompressionFormat asCompressionFormat() {
+        return compressionFormat;
+    }
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/package-info.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/package-info.java
@@ -15,9 +15,17 @@
  */
 
 /**
- * Encoder and decoder which compresses and decompresses {@link io.netty.buffer.ByteBuf}s
- * in a compression format such as <a href="http://en.wikipedia.org/wiki/Zlib">zlib</a>,
- * <a href="http://en.wikipedia.org/wiki/Gzip">gzip</a>, and
- * <a href="https://github.com/google/snappy">Snappy</a>.
+ * <p>Encoder and decoder which compresses and decompresses {@link io.netty.buffer.ByteBuf}s
+ * in a compression format such as:</p>
+ * <ul>
+ *      <li><a href="http://en.wikipedia.org/wiki/Zlib">zlib</a></li>
+ *      <li><a href="http://en.wikipedia.org/wiki/Gzip">gzip</a></li>
+ *      <li><a href="http://google.github.io/snappy/">Snappy</a></li>
+ *      <li><a href="http://en.wikipedia.org/wiki/Bzip2">bzip2</a></li>
+ *      <li><a href="https://github.com/ning/compress/wiki">LZF</a></li>
+ *      <li><a href="http://en.wikipedia.org/wiki/LZ4_%28compression_algorithm%29">LZ4</a></li>
+ *      <li><a href="http://fastlz.org/">FastLZ</a></li>
+ *      <li><a href="http://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Markov_chain_algorithm">LZMA</a></li>
+ * </ul>
  */
 package io.netty.handler.codec.compression;

--- a/codec/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Lz4FrameEncoderTest.java
@@ -114,7 +114,7 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
     }
 
     @Test
-    public void testAllocateDirectBuffer() {
+    public void testAllocateDirectBuffer() throws Exception {
         final int blockSize = 100;
         testAllocateBuffer(blockSize, blockSize - 13, true);
         testAllocateBuffer(blockSize, blockSize * 5, true);
@@ -122,14 +122,14 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
     }
 
     @Test
-    public void testAllocateHeapBuffer() {
+    public void testAllocateHeapBuffer() throws Exception {
         final int blockSize = 100;
         testAllocateBuffer(blockSize, blockSize - 13, false);
         testAllocateBuffer(blockSize, blockSize * 5, false);
         testAllocateBuffer(blockSize, NONALLOCATABLE_SIZE, false);
     }
 
-    private void testAllocateBuffer(int blockSize, int bufSize, boolean preferDirect) {
+    private void testAllocateBuffer(int blockSize, int bufSize, boolean preferDirect) throws Exception {
         // allocate the input buffer to an arbitrary size less than the blockSize
         ByteBuf in = ByteBufAllocator.DEFAULT.buffer(bufSize, bufSize);
         in.writerIndex(in.capacity());
@@ -157,8 +157,8 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
         }
     }
 
-    @Test (expected = EncoderException.class)
-    public void testAllocateDirectBufferExceedMaxEncodeSize() {
+    @Test(expected = EncoderException.class)
+    public void testAllocateDirectBufferExceedMaxEncodeSize() throws Exception {
         final int maxEncodeSize = 1024;
         Lz4FrameEncoder encoder = newEncoder(Lz4Constants.DEFAULT_BLOCK_SIZE, maxEncodeSize);
         int inputBufferSize = maxEncodeSize * 10;
@@ -171,7 +171,7 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
         }
     }
 
-    private Lz4FrameEncoder newEncoder(int blockSize, int maxEncodeSize) {
+    private Lz4FrameEncoder newEncoder(int blockSize, int maxEncodeSize) throws Exception {
         Checksum checksum = XXHashFactory.fastestInstance().newStreamingHash32(DEFAULT_SEED).asChecksum();
         Lz4FrameEncoder encoder = new Lz4FrameEncoder(LZ4Factory.fastestInstance(), true,
                                                       blockSize,
@@ -186,8 +186,8 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
      * {@link Lz4FrameEncoder#allocateBuffer(ChannelHandlerContext, ByteBuf, boolean)}, but this is safest way
      * of testing the overflow conditions as allocating the huge buffers fails in many CI environments.
      */
-    @Test (expected = EncoderException.class)
-    public void testAllocateOnHeapBufferOverflowsOutputSize() {
+    @Test(expected = EncoderException.class)
+    public void testAllocateOnHeapBufferOverflowsOutputSize() throws Exception {
         final int maxEncodeSize = Integer.MAX_VALUE;
         Lz4FrameEncoder encoder = newEncoder(Lz4Constants.DEFAULT_BLOCK_SIZE, maxEncodeSize);
         when(buffer.readableBytes()).thenReturn(maxEncodeSize);
@@ -213,7 +213,7 @@ public class Lz4FrameEncoderTest extends AbstractEncoderTest {
     }
 
     @Test
-    public void testAllocatingAroundBlockSize() {
+    public void testAllocatingAroundBlockSize() throws Exception {
         int blockSize = 100;
         Lz4FrameEncoder encoder = newEncoder(blockSize, Lz4FrameEncoder.DEFAULT_MAX_ENCODE_SIZE);
         EmbeddedChannel channel = new EmbeddedChannel(encoder);


### PR DESCRIPTION
Motivation:

Each compression codec is presented as its own class. It's difficult to switch one compression codec to another one without significant code modifications.

Modifications:

* `CompressionFormat` - enum with all available compression formats;
* `CompressionDecoder` - common interface for all compression decoders;
* `CompressionEncoder` - common interface for all compression encoders;
* `ClosableCompressionDecoder` - common interface for compression decoders which could reach the end of the compression stream.
* `ClosableCompressionEncoder` - common interface for compression encoders which could be closed by request.
* New abstract classes which implement basic functionality of described interfaces.
* Extend all compression encoders and decoders to use new abstract classes.

Result:

General API for all compression codecs.