### PR TITLE
Clear selectedKeys in OioSctpChannel.doReadMessages

### DIFF
--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpChannel.java
@@ -183,7 +183,12 @@ public class OioSctpChannel extends AbstractOioMessageChannel
         if (!keysSelected) {
             return readMessages;
         }
-
+        // We must clear the selectedKeys because the Selector will never do it. If we do not clear it, the selectionKey
+        // will always be returned even if there is no data can be read which causes performance issue. And in some
+        // implementation of Selector, the select method may return 0 if the selectionKey which is ready for process has
+        // already been in the selectedKeys and cause the keysSelected above to be false even if we actually have
+        // something to read.
+        readSelector.selectedKeys().clear();
         final RecvByteBufAllocator.Handle allocHandle = unsafe().recvBufAllocHandle();
         ByteBuf buffer = allocHandle.allocate(config().getAllocator());
         boolean free = true;


### PR DESCRIPTION
Motivation:
The fix for https://github.com/netty/netty/issues/3884 breaks SctpEchoTest because Selector.select will always return 0 if you do not clear last selectedKeys.

Modifications:
Clear readSelector.selectedKeys() if it is not empty.

Result:
SctpEchoTest is green again.