### PR TITLE
Add FileRegion support for HTTP/2

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
@@ -17,12 +17,15 @@ package io.netty.handler.codec.http;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.AbstractFileRegion;
 import io.netty.channel.FileRegion;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
+
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.channels.FileChannel;
 import java.nio.channels.WritableByteChannel;
 
 import static org.hamcrest.Matchers.*;
@@ -64,7 +67,7 @@ public class HttpResponseEncoderTest {
         assertFalse(channel.finish());
     }
 
-    private static class DummyLongFileRegion implements FileRegion {
+    private static class DummyLongFileRegion extends AbstractFileRegion {
 
         @Override
         public long position() {
@@ -83,6 +86,11 @@ public class HttpResponseEncoderTest {
 
         @Override
         public long transferTo(WritableByteChannel target, long position) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long transferBytesTo(WritableByteChannel target, long position, long length) throws IOException {
             throw new UnsupportedOperationException();
         }
 
@@ -119,6 +127,16 @@ public class HttpResponseEncoderTest {
         @Override
         public boolean release(int decrement) {
             return false;
+        }
+
+        @Override
+        public FileRegion unwrap() {
+            return null;
+        }
+
+        @Override
+        public FileChannel channel() throws IOException {
+            return null;
         }
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CompressorHttp2ConnectionEncoder.java
@@ -20,11 +20,12 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.ChannelPromiseAggregator;
+import io.netty.channel.FileRegion;
+import io.netty.channel.ReadableCollection;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.compression.ZlibWrapper;
-
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_ENCODING;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderValues.DEFLATE;
@@ -142,6 +143,22 @@ public class CompressorHttp2ConnectionEncoder extends DecoratingHttp2ConnectionE
                 cleanup(stream, channel);
             }
         }
+    }
+
+    @Override
+    public ChannelFuture writeData(ChannelHandlerContext ctx, int streamId, FileRegion data, int padding,
+            boolean endStream, ChannelPromise promise) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ChannelFuture writeData(ChannelHandlerContext ctx, int streamId, ReadableCollection data, int padding,
+            boolean endStream, ChannelPromise promise) {
+        ByteBuf buf = data.unbox();
+        if (buf == null) {
+            throw new UnsupportedOperationException();
+        }
+        return writeData(ctx, streamId, buf, padding, endStream, promise);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DecoratingHttp2FrameWriter.java
@@ -15,11 +15,12 @@
 package io.netty.handler.codec.http2;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.FileRegion;
+import io.netty.channel.ReadableCollection;
 
 /**
  * Decorator around another {@link Http2FrameWriter} instance.
@@ -34,6 +35,18 @@ public class DecoratingHttp2FrameWriter implements Http2FrameWriter {
     @Override
     public ChannelFuture writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
                                    boolean endStream, ChannelPromise promise) {
+        return delegate.writeData(ctx, streamId, data, padding, endStream, promise);
+    }
+
+    @Override
+    public ChannelFuture writeData(ChannelHandlerContext ctx, int streamId, FileRegion data, int padding,
+            boolean endStream, ChannelPromise promise) {
+        return delegate.writeData(ctx, streamId, data, padding, endStream, promise);
+    }
+
+    @Override
+    public ChannelFuture writeData(ChannelHandlerContext ctx, int streamId, ReadableCollection data, int padding,
+            boolean endStream, ChannelPromise promise) {
         return delegate.writeData(ctx, streamId, data, padding, endStream, promise);
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -334,7 +334,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
                         break;
                     }
                     writeOccurred = true;
-                    int initialFrameSize = frame.size();
+                    long initialFrameSize = frame.size();
                     try {
                         frame.write(ctx, max(0, maxBytes));
                         if (frame.size() == 0) {
@@ -346,7 +346,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
                         }
                     } finally {
                         // Decrement allocated by how much was actually written.
-                        allocated -= initialFrameSize - frame.size();
+                        allocated -= (int) (initialFrameSize - frame.size());
                     }
                 }
 
@@ -455,7 +455,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
          * Increments the number of pending bytes for this node and optionally updates the
          * {@link StreamByteDistributor}.
          */
-        private void incrementPendingBytes(int numBytes, boolean updateStreamableBytes) {
+        private void incrementPendingBytes(long numBytes, boolean updateStreamableBytes) {
             pendingBytes += numBytes;
             monitor.incrementPendingBytes(numBytes);
             if (updateStreamableBytes) {
@@ -466,7 +466,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
         /**
          * If this frame is in the pending queue, decrements the number of pending bytes for the stream.
          */
-        private void decrementPendingBytes(int bytes, boolean updateStreamableBytes) {
+        private void decrementPendingBytes(long bytes, boolean updateStreamableBytes) {
             incrementPendingBytes(-bytes, updateStreamableBytes);
         }
 
@@ -673,7 +673,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
          * method should be called.
          * @param delta The amount to increment by.
          */
-        public final void incrementPendingBytes(int delta) {
+        public final void incrementPendingBytes(long delta) {
             totalPendingBytes += delta;
 
             // Notification of writibilty change should be delayed until the end of the top level event.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataWriter.java
@@ -18,6 +18,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.FileRegion;
+import io.netty.channel.ReadableCollection;
 
 /**
  * Interface that defines an object capable of producing HTTP/2 data frames.
@@ -37,4 +39,35 @@ public interface Http2DataWriter {
      */
     ChannelFuture writeData(ChannelHandlerContext ctx, int streamId,
             ByteBuf data, int padding, boolean endStream, ChannelPromise promise);
+
+    /**
+     * Writes a {@code DATA} frame to the remote endpoint. This will result in one or more
+     * frames being written to the context.
+     *
+     * @param ctx the context to use for writing.
+     * @param streamId the stream for which to send the frame.
+     * @param data the payload of the frame. This will be released by this method.
+     * @param padding the amount of padding to be added to the end of the frame
+     * @param endStream indicates if this is the last frame to be sent for the stream.
+     * @param promise the promise for the write.
+     * @return the future for the write.
+     */
+    ChannelFuture writeData(ChannelHandlerContext ctx, int streamId, FileRegion data, int padding, boolean endStream,
+            ChannelPromise promise);
+
+    /**
+     * Writes a {@code DATA} frame to the remote endpoint. This will result in one or more frames being written to the
+     * context.
+     *
+     * @param ctx the context to use for writing.
+     * @param streamId the stream for which to send the frame.
+     * @param data the payload of the frame. This will be released by this method.
+     * @param padding the amount of padding to be added to the end of the frame
+     * @param endStream indicates if this is the last frame to be sent for the stream.
+     * @param promise the promise for the write.
+     * @return the future for the write.
+     */
+    ChannelFuture writeData(ChannelHandlerContext ctx, int streamId, ReadableCollection data, int padding,
+            boolean endStream, ChannelPromise promise);
+
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
@@ -16,10 +16,11 @@
 package io.netty.handler.codec.http2;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.FileRegion;
+import io.netty.channel.ReadableCollection;
 import io.netty.handler.logging.LogLevel;
 import io.netty.util.internal.logging.InternalLogLevel;
 import io.netty.util.internal.logging.InternalLogger;
@@ -62,6 +63,24 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
             log(direction,
                     "DATA: streamId=%d, padding=%d, endStream=%b, length=%d, bytes=%s",
                     streamId, padding, endStream, data.readableBytes(), toString(data));
+        }
+    }
+
+    public void logData(Direction direction, int streamId, FileRegion data, int padding,
+            boolean endStream) {
+        if (enabled()) {
+            log(direction,
+                    "DATA: streamId=%d, padding=%d, endStream=%b, length=%d, FileRegion",
+                    streamId, padding, endStream, data.transferableBytes());
+        }
+    }
+
+    public void logData(Direction direction, int streamId, ReadableCollection data, int padding,
+            boolean endStream) {
+        if (enabled()) {
+            log(direction,
+                    "DATA: streamId=%d, padding=%d, endStream=%b, length=%d, ReadableCollection",
+                    streamId, padding, endStream, data.readableBytes());
         }
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
@@ -21,6 +21,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.FileRegion;
+import io.netty.channel.ReadableCollection;
 
 /**
  * Decorator around a {@link Http2FrameWriter} that logs all outbound frames before calling the
@@ -38,6 +40,20 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
     @Override
     public ChannelFuture writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
             int padding, boolean endStream, ChannelPromise promise) {
+        logger.logData(OUTBOUND, streamId, data, padding, endStream);
+        return writer.writeData(ctx, streamId, data, padding, endStream, promise);
+    }
+
+    @Override
+    public ChannelFuture writeData(ChannelHandlerContext ctx, int streamId, FileRegion data, int padding,
+            boolean endStream, ChannelPromise promise) {
+        logger.logData(OUTBOUND, streamId, data, padding, endStream);
+        return writer.writeData(ctx, streamId, data, padding, endStream, promise);
+    }
+
+    @Override
+    public ChannelFuture writeData(ChannelHandlerContext ctx, int streamId, ReadableCollection data, int padding,
+            boolean endStream, ChannelPromise promise) {
         logger.logData(OUTBOUND, streamId, data, padding, endStream);
         return writer.writeData(ctx, streamId, data, padding, endStream, promise);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
@@ -85,7 +85,7 @@ public interface Http2RemoteFlowController extends Http2FlowController {
          * the wire. Other frames like {@code DATA} frames have both their payload and padding count
          * against flow-control.
          */
-        int size();
+        long size();
 
         /**
          * Called to indicate that an error occurred before this object could be completely written.

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -783,7 +783,7 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
         final Http2RemoteFlowController.FlowControlled flowControlled =
                 mock(Http2RemoteFlowController.FlowControlled.class);
         final Http2Stream stream = stream(STREAM_A);
-        when(flowControlled.size()).thenReturn(100);
+        when(flowControlled.size()).thenReturn(100L);
         doThrow(new RuntimeException("write failed"))
             .when(flowControlled).write(any(ChannelHandlerContext.class), anyInt());
         doAnswer(new Answer<Void>() {
@@ -905,12 +905,12 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
     private static Http2RemoteFlowController.FlowControlled mockedFlowControlledThatThrowsOnWrite() throws Exception {
         final Http2RemoteFlowController.FlowControlled flowControlled =
                 mock(Http2RemoteFlowController.FlowControlled.class);
-        when(flowControlled.size()).thenReturn(100);
+        when(flowControlled.size()).thenReturn(100L);
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock in) throws Throwable {
                 // Write most of the bytes and then fail
-                when(flowControlled.size()).thenReturn(10);
+                when(flowControlled.size()).thenReturn(10L);
                 throw new RuntimeException("Write failed");
             }
         }).when(flowControlled).write(any(ChannelHandlerContext.class), anyInt());
@@ -975,7 +975,7 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
         }
 
         @Override
-        public int size() {
+        public long size() {
             return currentSize;
         }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
@@ -46,9 +45,14 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.ReadableCollection;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ImmediateEventExecutor;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,9 +62,6 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockito.verification.VerificationMode;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Tests for {@link StreamBufferingEncoder}.
@@ -159,7 +160,7 @@ public class StreamBufferingEncoderTest {
 
         writeVerifyWriteHeaders(times(2), 3);
         // Contiguous data writes are coalesced
-        ArgumentCaptor<ByteBuf> bufCaptor = ArgumentCaptor.forClass(ByteBuf.class);
+        ArgumentCaptor<ReadableCollection> bufCaptor = ArgumentCaptor.forClass(ReadableCollection.class);
         verify(writer, times(1))
                 .writeData(eq(ctx), eq(3), bufCaptor.capture(), eq(0), eq(false), any(ChannelPromise.class));
         assertEquals(expectedBytes, bufCaptor.getValue().readableBytes());

--- a/microbench/src/main/java/io/netty/microbench/http2/NoPriorityByteDistributionBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/NoPriorityByteDistributionBenchmark.java
@@ -185,7 +185,7 @@ public class NoPriorityByteDistributionBenchmark extends AbstractMicrobenchmark 
             int size = dataSize;
 
             @Override
-            public int size() {
+            public long size() {
                 return size;
             }
 
@@ -207,12 +207,7 @@ public class NoPriorityByteDistributionBenchmark extends AbstractMicrobenchmark 
             @Override
             public boolean merge(ChannelHandlerContext ctx,
                                  Http2RemoteFlowController.FlowControlled next) {
-                int nextSize = next.size();
-                if (Integer.MAX_VALUE - nextSize < size) {
-                    // Disallow merge to avoid integer overflow.
-                    return false;
-                }
-
+                long nextSize = next.size();
                 // Merge.
                 size += nextSize;
                 return true;

--- a/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.h
+++ b/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.h
@@ -45,7 +45,7 @@ jint Java_io_netty_channel_epoll_Native_epollCtlDel0(JNIEnv* env, jclass clazz, 
 jint Java_io_netty_channel_epoll_Native_sendmmsg(JNIEnv* env, jclass clazz, jint fd, jobjectArray packets, jint offset, jint len);
 jint Java_io_netty_channel_epoll_Native_recvFd0(JNIEnv* env, jclass clazz, jint fd);
 jint Java_io_netty_channel_epoll_Native_sendFd0(JNIEnv* env, jclass clazz, jint socketFd, jint fd);
-jlong Java_io_netty_channel_epoll_Native_sendfile0(JNIEnv* env, jclass clazz, jint fd, jobject fileRegion, jlong base_off, jlong off, jlong len);
+jlong Java_io_netty_channel_epoll_Native_sendfile0(JNIEnv* env, jclass clazz, jint fd, jobject fileChannel, jlong base_off, jlong off, jlong len);
 
 void Java_io_netty_channel_epoll_Native_setReuseAddress(JNIEnv* env, jclass clazz, jint fd, jint optval);
 void Java_io_netty_channel_epoll_Native_setReusePort(JNIEnv* env, jclass clazz, jint fd, jint optval);

--- a/transport/src/main/java/io/netty/channel/AbstractFileRegion.java
+++ b/transport/src/main/java/io/netty/channel/AbstractFileRegion.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import java.io.IOException;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * Base class for {@link FileRegion} implementation.
+ *
+ */
+public abstract class AbstractFileRegion implements FileRegion {
+
+    private long transferIndex;
+
+    @Override
+    public long transferBytesTo(WritableByteChannel target, long length) throws IOException {
+        long written = transferBytesTo(target, transferIndex, length);
+        if (written > 0) {
+            transferIndex += written;
+        }
+        return written;
+    }
+
+    @Override
+    public long transferIndex() {
+        return transferIndex;
+    }
+
+    @Override
+    public FileRegion transferIndex(long index) {
+        if (index < 0 || index > count()) {
+            throw new IndexOutOfBoundsException(String.format(
+                    "transferIndex: %d (expected: 0 <= transferIndex <= count(%d))", index, count()));
+        }
+        this.transferIndex = index;
+        return this;
+    }
+
+    @Override
+    public boolean isTransferable() {
+        return transferIndex < count();
+    }
+
+    @Override
+    public long transferableBytes() {
+        return count() - transferIndex;
+    }
+
+    @Override
+    public long transferBytesTo(WritableByteChannel target, long position, long length) throws IOException {
+        if (position < 0 || position > count()) {
+            throw new IllegalArgumentException("position out of range: " + position + " (expected: 0 - "
+                    + (this.count() - 1) + ')');
+        }
+        if (length < 0) {
+            throw new IllegalArgumentException("negative length " + length);
+        }
+        length = Math.min(count() - position, length);
+        if (length == 0) {
+            return 0L;
+        }
+        return channel().transferTo(position() + position, length, target);
+    }
+
+    @Override
+    public FileRegion slice(long index, long length) {
+        return new SlicedFileRegion(this, index, length);
+    }
+
+    @Override
+    public FileRegion transferSlice(long length) {
+        FileRegion sliced = slice(transferIndex(), length);
+        transferIndex += length;
+        return sliced;
+    }
+}

--- a/transport/src/main/java/io/netty/channel/CoalescingReadableQueue.java
+++ b/transport/src/main/java/io/netty/channel/CoalescingReadableQueue.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.channel;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.ObjectUtil;
+
+import java.util.ArrayDeque;
+
+/**
+ * A FIFO queue of bytes where producers add bytes by repeatedly adding {@link ByteBuf} or {@link FileRegion} and
+ * consumers take bytes in arbitrary lengths. This allows producers to add lots of small buffers and the consumer to
+ * take all the bytes out in a single buffer. Conversely the producer may add larger buffers and the consumer could take
+ * the bytes in many small buffers.
+ *
+ * <p>
+ * Bytes are added and removed with promises. If the last byte of a buffer added with a promise is removed then that
+ * promise will complete when the promise passed to {@link #remove} completes.
+ *
+ * <p>
+ * This functionality is useful for aggregating or partitioning writes into fixed size buffers for framing protocols
+ * such as HTTP2.
+ */
+public final class CoalescingReadableQueue {
+
+    private final Channel channel;
+    private final ArrayDeque<Object> bufAndListenerPairs = new ArrayDeque<Object>();
+    private long readableBytes;
+
+    public CoalescingReadableQueue(Channel channel) {
+        this.channel = ObjectUtil.checkNotNull(channel, "channel");
+    }
+
+    /**
+     * Add a buffer to the end of the queue.
+     */
+    public void add(Object obj) {
+        add(obj, (ChannelFutureListener) null);
+    }
+
+    /**
+     * Add a buffer to the end of the queue and associate a promise with it that should be completed when all the
+     * buffers bytes have been consumed from the queue and written.
+     *
+     * @param obj
+     *            to add to the tail of the queue
+     * @param promise
+     *            to complete when all the bytes have been consumed and written, can be void.
+     */
+    public void add(Object obj, ChannelPromise promise) {
+        // buffers are added before promises so that we naturally 'consume' the entire buffer during removal
+        // before we complete it's promise.
+        ObjectUtil.checkNotNull(promise, "promise");
+        add(obj, promise.isVoid() ? null : new ChannelPromiseNotifier(promise));
+    }
+
+    /**
+     * Add a buffer to the end of the queue and associate a listener with it that should be completed when all the
+     * buffers bytes have been consumed from the queue and written.
+     *
+     * @param obj
+     *            to add to the tail of the queue
+     * @param listener
+     *            to notify when all the bytes have been consumed and written, can be {@code null}.
+     */
+    public void add(Object obj, ChannelFutureListener listener) {
+        // buffers are added before promises so that we naturally 'consume' the entire buffer during removal
+        // before we complete it's promise.
+        ObjectUtil.checkNotNull(obj, "buffer");
+        long addedBytes;
+        if (obj instanceof ByteBuf) {
+            addedBytes = ((ByteBuf) obj).readableBytes();
+        } else if (obj instanceof FileRegion) {
+            addedBytes = ((FileRegion) obj).transferableBytes();
+        } else if (obj instanceof ReadableCollection) {
+            addedBytes = ((ReadableCollection) obj).readableBytes();
+        } else {
+            throw new IllegalArgumentException("Unsupported buffer type: " + obj.getClass());
+        }
+        bufAndListenerPairs.add(obj);
+        if (listener != null) {
+            bufAndListenerPairs.add(listener);
+        }
+        readableBytes += addedBytes;
+    }
+
+    /**
+     * Remove a {@link ReadableCollection} from the queue with the specified number of bytes. Any added buffer who's
+     * bytes are fully consumed during removal will have it's promise completed when the passed aggregate
+     * {@link ChannelPromise} completes.
+     *
+     * @param bytes
+     *            the maximum number of readable bytes in the returned {@link ByteBuf}, if {@code bytes} is greater than
+     *            {@link #readableBytes} then a buffer of length {@link #readableBytes} is returned.
+     * @param aggregatePromise
+     *            used to aggregate the promises and listeners for the constituent buffers.
+     * @return a {@link ReadableCollection} composed of the enqueued buffers.
+     */
+    public ReadableCollection remove(long bytes, ChannelPromise aggregatePromise) {
+        if (bytes < 0) {
+            throw new IllegalArgumentException("bytes (expected >= 0): " + bytes);
+        }
+        ObjectUtil.checkNotNull(aggregatePromise, "aggregatePromise");
+
+        // Use isEmpty rather than readableBytes==0 as we may have a promise associated with an empty buffer.
+        if (bufAndListenerPairs.isEmpty()) {
+            return ReadableCollection.EMPTY;
+        }
+        bytes = Math.min(bytes, readableBytes);
+        readableBytes -= bytes;
+        ReadableCollection.Builder builder = ReadableCollection.create(channel.alloc(), bufAndListenerPairs.size() / 2);
+        for (long remaining = bytes;;) {
+            Object entry = bufAndListenerPairs.poll();
+            if (entry == null) {
+                break;
+            }
+            if (entry instanceof ChannelFutureListener) {
+                aggregatePromise.addListener((ChannelFutureListener) entry);
+                continue;
+            }
+            if (entry instanceof ByteBuf) {
+                ByteBuf entryBuffer = (ByteBuf) entry;
+                if (entryBuffer.readableBytes() > remaining) {
+                    // Add the buffer back to the queue as we can't consume all of it.
+                    bufAndListenerPairs.addFirst(entryBuffer);
+                    if (remaining > 0) {
+                        // Take a slice of what we can consume and retain it.
+                        builder.add(entryBuffer.readSlice((int) remaining).retain());
+                    }
+                    break;
+                } else {
+                    remaining -= entryBuffer.readableBytes();
+                    builder.add(entryBuffer);
+                }
+            } else if (entry instanceof FileRegion) {
+                FileRegion entryRegion = (FileRegion) entry;
+                if (entryRegion.transferableBytes() > remaining) {
+                    // Add the buffer back to the queue as we can't consume all of it.
+                    bufAndListenerPairs.addFirst(entryRegion);
+                    if (remaining > 0) {
+                        // Take a slice of what we can consume and retain it.
+                        builder.add(entryRegion.transferSlice(remaining).retain());
+                    }
+                    break;
+                } else {
+                    remaining -= entryRegion.transferableBytes();
+                    builder.add(entryRegion);
+                }
+            } else { // ReadableCollection
+                ReadableCollection entryRc = (ReadableCollection) entry;
+                if (entryRc.readableBytes() > remaining) {
+                    // Add the buffer back to the queue as we can't consume all of it.
+                    bufAndListenerPairs.addFirst(entryRc);
+                    if (remaining > 0) {
+                        // Take a slice of what we can consume and retain it.
+                        builder.add(entryRc, remaining);
+                    }
+                    break;
+                } else {
+                    remaining -= entryRc.readableBytes();
+                    builder.add(entryRc, entryRc.readableBytes());
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    /**
+     * The number of readable bytes.
+     */
+    public long readableBytes() {
+        return readableBytes;
+    }
+
+    /**
+     * Are there pending buffers in the queue.
+     */
+    public boolean isEmpty() {
+        return bufAndListenerPairs.isEmpty();
+    }
+
+    /**
+     * Release all buffers in the queue and complete all listeners and promises.
+     */
+    public void releaseAndFailAll(Throwable cause) {
+        releaseAndCompleteAll(channel.newFailedFuture(cause));
+    }
+
+    private void releaseAndCompleteAll(ChannelFuture future) {
+        readableBytes = 0;
+        Throwable pending = null;
+        for (;;) {
+            Object entry = bufAndListenerPairs.poll();
+            if (entry == null) {
+                break;
+            }
+            try {
+                if (entry instanceof ChannelFutureListener) {
+                    ((ChannelFutureListener) entry).operationComplete(future);
+                } else if (entry instanceof ReadableCollection) {
+                    ((ReadableCollection) entry).clear();
+                } else {
+                    ReferenceCountUtil.safeRelease(entry);
+                }
+            } catch (Throwable t) {
+                pending = t;
+            }
+        }
+        if (pending != null) {
+            throw new IllegalStateException(pending);
+        }
+    }
+
+    /**
+     * Copy all pending entries in this queue into the destination queue.
+     *
+     * @param dest
+     *            to copy pending buffers to.
+     */
+    public void copyTo(CoalescingReadableQueue dest) {
+        dest.bufAndListenerPairs.addAll(bufAndListenerPairs);
+        dest.readableBytes += readableBytes;
+    }
+}

--- a/transport/src/main/java/io/netty/channel/ReadableCollection.java
+++ b/transport/src/main/java/io/netty/channel/ReadableCollection.java
@@ -1,0 +1,463 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.channel;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ReferenceCounted;
+import io.netty.util.internal.ObjectUtil;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * A wrapper class which can combine several {@link ByteBuf}s and {@link FileRegion}s together.
+ */
+public final class ReadableCollection {
+
+    public static final ReadableCollection EMPTY = new ReadableCollection(new ArrayDeque<Component>(), 0L);
+
+    private static final class Component {
+        ReferenceCounted obj;
+        long length;
+        final boolean isByteBuf;
+
+        public Component(ReferenceCounted obj, long length, boolean isByteBuf) {
+            this.obj = obj;
+            this.length = length;
+            this.isByteBuf = isByteBuf;
+        }
+    }
+
+    private final Deque<Component> components;
+
+    private long readableBytes;
+
+    private ReadableCollection(Deque<Component> components, long readableBytes) {
+        this.components = components;
+        this.readableBytes = readableBytes;
+    }
+
+    /**
+     * Return a {@link ByteBuf} if it is the only element in this collection.
+     * <p>
+     * Usually you should call this first because lots of netty's modules are optimized for {@link ByteBuf}.
+     */
+    public ByteBuf unbox() {
+        if (components.size() == 1) {
+            Component c = components.peekFirst();
+            if (c.isByteBuf) {
+                return (ByteBuf) c.obj;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Return true iff {@link #readableBytes()} {@code > 0}
+     */
+    public boolean isReadable() {
+        return readableBytes > 0;
+    }
+
+    /**
+     * The number of readable bytes.
+     */
+    public long readableBytes() {
+        return readableBytes;
+    }
+
+    private Object slice(Component c, long length) {
+        c.length -= length;
+        if (c.isByteBuf) {
+            ByteBuf buf = (ByteBuf) c.obj;
+            return buf.readSlice((int) length).retain();
+        } else {
+            FileRegion region = (FileRegion) c.obj;
+            return region.transferSlice(length).retain();
+        }
+    }
+
+    private long checkLength(long length) {
+        if (length < 0) {
+            throw new IllegalArgumentException("length (expected >= 0): " + length);
+        }
+        return Math.min(length, readableBytes);
+    }
+
+    private interface WriteTarget {
+
+        ChannelFuture newSucceededFuture();
+
+        ChannelPromise newPromise();
+
+        ChannelFuture write(Object msg);
+
+        ChannelFuture write(Object msg, ChannelPromise promise);
+    }
+
+    private ChannelFuture writeMultiTo(WriteTarget target, ChannelPromise promise, long length) throws IOException {
+        List<ChannelPromise> pendingPromiseList = new ArrayList<ChannelPromise>();
+        for (long remaining = length;;) {
+            Component c = components.peekFirst();
+            if (c.length > remaining) {
+                ChannelPromise p = target.newPromise();
+                target.write(slice(c, remaining), p);
+                pendingPromiseList.add(p);
+                break;
+            } else {
+                ChannelPromise p = target.newPromise();
+                target.write(c.obj, p);
+                pendingPromiseList.add(p);
+                components.pollFirst();
+                remaining -= c.length;
+                if (remaining == 0) {
+                    break;
+                }
+            }
+        }
+        ChannelPromiseAggregator aggregator = new ChannelPromiseAggregator(promise);
+        aggregator.add(pendingPromiseList.toArray(new ChannelPromise[0]));
+        return promise;
+    }
+
+    private ChannelFuture writeTo(WriteTarget target, long length) throws IOException {
+        length = checkLength(length);
+        if (length == 0) {
+            return target.newSucceededFuture();
+        }
+        readableBytes -= length;
+        Component c = components.peekFirst();
+        if (c.length == length) {
+            components.pollFirst();
+            return target.write(c.obj);
+        }
+        if (c.length > length) {
+            return target.write(slice(c, length));
+        }
+        return writeMultiTo(target, target.newPromise(), length);
+    }
+
+    private ChannelFuture writeTo(WriteTarget target, ChannelPromise promise, long length) throws IOException {
+        length = checkLength(length);
+        if (length == 0) {
+            return target.newSucceededFuture();
+        }
+        readableBytes -= length;
+        Component c = components.peekFirst();
+        if (c.length == length) {
+            components.pollFirst();
+            return target.write(c.obj, promise);
+        }
+        if (c.length > length) {
+            return target.write(slice(c, length), promise);
+        }
+        return writeMultiTo(target, promise, length);
+    }
+
+    private static final class ChannelWriteTarget implements WriteTarget {
+
+        private final Channel ch;
+
+        public ChannelWriteTarget(Channel ch) {
+            this.ch = ch;
+        }
+
+        @Override
+        public ChannelFuture write(Object msg, ChannelPromise promise) {
+            return ch.write(msg, promise);
+        }
+
+        @Override
+        public ChannelFuture write(Object msg) {
+            return ch.write(msg);
+        }
+
+        @Override
+        public ChannelFuture newSucceededFuture() {
+            return ch.newSucceededFuture();
+        }
+
+        @Override
+        public ChannelPromise newPromise() {
+            return ch.newPromise();
+        }
+    }
+
+    /**
+     * Call {@link Channel#write(Object)}.
+     *
+     * @param length
+     *            the maximum number of bytes to transfer, if larger than {@link #readableBytes()}, then only
+     *            {@link #readableBytes()} bytes will be write out.
+     */
+    public ChannelFuture writeTo(final Channel ch, long length) throws IOException {
+        return writeTo(new ChannelWriteTarget(ch), length);
+    }
+
+    /**
+     * Call {@link Channel#write(Object, ChannelPromise)}.
+     *
+     * @param length
+     *            the maximum number of bytes to transfer, if larger than {@link #readableBytes()}, then only
+     *            {@link #readableBytes()} bytes will be write out.
+     */
+    public ChannelFuture writeTo(Channel ch, ChannelPromise promise, long length) throws IOException {
+        return writeTo(new ChannelWriteTarget(ch), promise, length);
+    }
+
+    private static final class ContextWriteTarget implements WriteTarget {
+
+        private final ChannelHandlerContext ctx;
+
+        public ContextWriteTarget(ChannelHandlerContext ctx) {
+            this.ctx = ctx;
+        }
+
+        @Override
+        public ChannelFuture write(Object msg, ChannelPromise promise) {
+            return ctx.write(msg, promise);
+        }
+
+        @Override
+        public ChannelFuture write(Object msg) {
+            return ctx.write(msg);
+        }
+
+        @Override
+        public ChannelFuture newSucceededFuture() {
+            return ctx.newSucceededFuture();
+        }
+
+        @Override
+        public ChannelPromise newPromise() {
+            return ctx.newPromise();
+        }
+    }
+
+    /**
+     * Call {@link ChannelHandlerContext#write(Object)}.
+     *
+     * @param length
+     *            the maximum number of bytes to transfer, if larger than {@link #readableBytes()}, then only
+     *            {@link #readableBytes()} bytes will be write out.
+     */
+    public ChannelFuture writeTo(ChannelHandlerContext ctx, long length) throws IOException {
+        return writeTo(new ContextWriteTarget(ctx), length);
+    }
+
+    /**
+     * Call {@link ChannelHandlerContext#write(Object, ChannelPromise)}.
+     *
+     * @param length
+     *            the maximum number of bytes to transfer, if larger than {@link #readableBytes()}, then only
+     *            {@link #readableBytes()} bytes will be write out.
+     */
+    public ChannelFuture writeTo(ChannelHandlerContext ctx, ChannelPromise promise, long length) throws IOException {
+        return writeTo(new ContextWriteTarget(ctx), promise, length);
+    }
+
+    private static final class PipelineWriteTarget implements WriteTarget {
+
+        private final ChannelPipeline pipeline;
+
+        public PipelineWriteTarget(ChannelPipeline pipeline) {
+            this.pipeline = pipeline;
+        }
+
+        @Override
+        public ChannelFuture write(Object msg, ChannelPromise promise) {
+            return pipeline.write(msg, promise);
+        }
+
+        @Override
+        public ChannelFuture write(Object msg) {
+            return pipeline.write(msg);
+        }
+
+        @Override
+        public ChannelFuture newSucceededFuture() {
+            return pipeline.channel().newSucceededFuture();
+        }
+
+        @Override
+        public ChannelPromise newPromise() {
+            return pipeline.channel().newPromise();
+        }
+    }
+
+    /**
+     * Call {@link ChannelPipeline#write(Object)}.
+     *
+     * @param length
+     *            the maximum number of bytes to transfer, if larger than {@link #readableBytes()}, then only
+     *            {@link #readableBytes()} bytes will be write out.
+     */
+    public ChannelFuture writeTo(ChannelPipeline pipeline, long length) throws IOException {
+        return writeTo(new PipelineWriteTarget(pipeline), length);
+    }
+
+    /**
+     * Call {@link ChannelPipeline#write(Object, ChannelPromise)}.
+     *
+     * @param length
+     *            the maximum number of bytes to transfer, if larger than {@link #readableBytes()}, then only
+     *            {@link #readableBytes()} bytes will be write out.
+     */
+    public ChannelFuture writeTo(ChannelPipeline pipeline, ChannelPromise promise, long length) throws IOException {
+        return writeTo(new PipelineWriteTarget(pipeline), promise, length);
+    }
+
+    /**
+     * Release all readable objects and set {@link #readableBytes()} to {@code 0}.
+     */
+    public void clear() {
+        for (Component c; (c = components.poll()) != null;) {
+            c.obj.release();
+        }
+        this.readableBytes = 0;
+    }
+
+    /**
+     * Similar to {@link #clear()} but use {@link ReferenceCountUtil#safeRelease(Object)} when releasing object.
+     */
+    public void safeClear() {
+        for (Component c; (c = components.poll()) != null;) {
+            ReferenceCountUtil.safeRelease(c.obj);
+        }
+        this.readableBytes = 0;
+    }
+
+    /**
+     * Fast path to create a {@link ReadableCollection} which only contains on FileRegion as its elements.
+     */
+    public static ReadableCollection of(FileRegion region) {
+        Deque<Component> components = new ArrayDeque<Component>();
+        components.addLast(new Component(region, region.transferableBytes(), false));
+        return new ReadableCollection(components, region.transferableBytes());
+    }
+
+    /**
+     * Get a Builder to build {@link ReadableCollection}.
+     */
+    public static Builder create(ByteBufAllocator alloc, int maxNumComponents) {
+        return new Builder(alloc, maxNumComponents);
+    }
+
+    public static final class Builder {
+
+        private final ByteBufAllocator alloc;
+
+        private final int maxNumComponents;
+
+        private final Deque<Component> components = new ArrayDeque<Component>();
+
+        private long readableBytes;
+
+        private Builder(ByteBufAllocator alloc, int maxNumComponents) {
+            this.alloc = alloc;
+            this.maxNumComponents = maxNumComponents;
+        }
+
+        private ByteBuf compose(ByteBuf current, ByteBuf next) {
+            return CoalescingBufferQueue.compose(alloc, maxNumComponents, current, next);
+        }
+
+        private void addComponent(ByteBuf buf) {
+            int readableBytes = buf.readableBytes();
+            Component last = components.peekLast();
+            if (last != null && last.isByteBuf) {
+                last.length += readableBytes;
+                last.obj = compose((ByteBuf) last.obj, buf);
+            } else {
+                components.addLast(new Component(buf, readableBytes, true));
+            }
+        }
+
+        /**
+         * Add a {@link ByteBuf}.
+         */
+        public Builder add(ByteBuf buf) {
+            this.readableBytes += ObjectUtil.checkNotNull(buf, "buf").readableBytes();
+            addComponent(buf);
+            return this;
+        }
+
+        /**
+         * Add a {@link FileRegion}
+         */
+        public Builder add(FileRegion region) {
+            long transferableBytes = ObjectUtil.checkNotNull(region, "region").transferableBytes();
+            this.readableBytes += transferableBytes;
+            components.addLast(new Component(region, transferableBytes, false));
+            return this;
+        }
+
+        /**
+         * Add a {@link ReadableCollection} with maximum {@code length} data.
+         */
+        public Builder add(ReadableCollection rc, long length) {
+            long readableBytes = ObjectUtil.checkNotNull(rc, "ReadableCollection").readableBytes();
+            if (length > readableBytes) {
+                throw new IndexOutOfBoundsException("max " + readableBytes + ", got " + length);
+            }
+            for (long remaining = length;;) {
+                Component c = rc.components.peekFirst();
+                if (c.isByteBuf) {
+                    if (c.length > remaining) {
+                        c.length -= remaining;
+                        addComponent(((ByteBuf) c.obj).readSlice((int) remaining).retain());
+                        break;
+                    } else {
+                        addComponent((ByteBuf) c.obj);
+                        rc.components.pollFirst();
+                        remaining -= c.length;
+                        if (remaining == 0) {
+                            break;
+                        }
+                    }
+                } else { // FileRegion
+                    if (c.length > remaining) {
+                        c.length -= remaining;
+                        components.addLast(new Component(((FileRegion) c.obj).transferSlice(remaining).retain(),
+                                remaining, false));
+                        break;
+                    } else {
+                        components.addLast(c);
+                        rc.components.pollFirst();
+                        remaining -= c.length;
+                        if (remaining == 0) {
+                            break;
+                        }
+                    }
+                }
+            }
+            this.readableBytes += length;
+            rc.readableBytes -= length;
+            return this;
+        }
+
+        /**
+         * Create the {@link ReadableCollection} instance.
+         */
+        public ReadableCollection build() {
+            return new ReadableCollection(components, readableBytes);
+        }
+    }
+}

--- a/transport/src/main/java/io/netty/channel/SlicedFileRegion.java
+++ b/transport/src/main/java/io/netty/channel/SlicedFileRegion.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * A derived {@link FileRegion} which shares reference counting with its parent.
+ */
+public class SlicedFileRegion extends AbstractFileRegion {
+
+    private final FileRegion parent;
+
+    private final long offset;
+
+    private final long count;
+
+    public SlicedFileRegion(FileRegion parent, long index, long count) {
+        if (index < 0 || index > parent.count() - count) {
+            throw new IndexOutOfBoundsException(parent + ".slice(" + index + ", " + count + ')');
+        }
+
+        if (parent instanceof SlicedFileRegion) {
+            SlicedFileRegion sliced = (SlicedFileRegion) parent;
+            this.parent = sliced.parent;
+            this.offset = sliced.offset + index;
+        } else {
+            this.parent = parent;
+            this.offset = index;
+        }
+        this.count = count;
+    }
+
+    @Override
+    public long position() {
+        return parent.position() + offset;
+    }
+
+    @Override
+    public long transfered() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long count() {
+        return count;
+    }
+
+    @Override
+    public long transferTo(WritableByteChannel target, long position) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SlicedFileRegion retain() {
+        parent.retain();
+        return this;
+    }
+
+    @Override
+    public SlicedFileRegion retain(int increment) {
+        parent.retain(increment);
+        return this;
+    }
+
+    @Override
+    public SlicedFileRegion touch() {
+        parent.touch();
+        return this;
+    }
+
+    @Override
+    public SlicedFileRegion touch(Object hint) {
+        parent.touch(hint);
+        return this;
+    }
+
+    @Override
+    public int refCnt() {
+        return parent.refCnt();
+    }
+
+    @Override
+    public boolean release() {
+        return parent.release();
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        return parent.release(decrement);
+    }
+
+    @Override
+    public FileRegion unwrap() {
+        return parent;
+    }
+
+    @Override
+    public FileChannel channel() throws IOException {
+        return parent.channel();
+    }
+}

--- a/transport/src/main/java/io/netty/channel/oio/AbstractOioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/AbstractOioByteChannel.java
@@ -208,9 +208,9 @@ public abstract class AbstractOioByteChannel extends AbstractOioChannel {
                 in.remove();
             } else if (msg instanceof FileRegion) {
                 FileRegion region = (FileRegion) msg;
-                long transfered = region.transfered();
+                long transferIndex = region.transferIndex();
                 doWriteFileRegion(region);
-                in.progress(region.transfered() - transfered);
+                in.progress(region.transferIndex() - transferIndex);
                 in.remove();
             } else {
                 in.remove(new UnsupportedOperationException(

--- a/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
@@ -128,25 +128,23 @@ public abstract class OioByteStreamChannel extends AbstractOioByteChannel {
             outChannel = Channels.newChannel(os);
         }
 
-        long written = 0;
         for (;;) {
-            long localWritten = region.transferTo(outChannel, written);
+            long localWritten = region.transferBytesTo(outChannel, region.transferableBytes());
             if (localWritten == -1) {
                 checkEOF(region);
                 return;
             }
-            written += localWritten;
 
-            if (written >= region.count()) {
+            if (!region.isTransferable()) {
                 return;
             }
         }
     }
 
     private static void checkEOF(FileRegion region) throws IOException {
-        if (region.transfered() < region.count()) {
+        if (region.transferIndex() < region.count()) {
             throw new EOFException("Expected to be able to write " + region.count() + " bytes, " +
-                                   "but only wrote " + region.transfered());
+                                   "but only wrote " + region.transferIndex());
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -253,8 +253,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
 
     @Override
     protected long doWriteFileRegion(FileRegion region) throws Exception {
-        final long position = region.transfered();
-        return region.transferTo(javaChannel(), position);
+        return region.transferBytesTo(javaChannel(), region.transferableBytes());
     }
 
     @Override

--- a/transport/src/test/java/io/netty/channel/CoalescingReadableQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/CoalescingReadableQueueTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.channel;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link CoalescingReadableQueue}.
+ */
+public class CoalescingReadableQueueTest {
+
+    private ByteBuf cat;
+    private FileRegion mouse;
+    private ReadableCollection dog;
+
+    private ChannelPromise catPromise, emptyPromise;
+    private ChannelPromise voidPromise;
+    private ChannelFutureListener mouseListener;
+
+    private boolean mouseDone;
+    private boolean mouseSuccess;
+
+    private Channel channel = new EmbeddedChannel();
+
+    private CoalescingReadableQueue writeQueue = new CoalescingReadableQueue(channel);
+
+    private DefaultFileRegion createFileRegion(String str) throws IOException {
+        File file = File.createTempFile("netty-", ".tmp");
+        file.deleteOnExit();
+        FileOutputStream out = new FileOutputStream(file);
+        try {
+            out.write(str.getBytes(CharsetUtil.US_ASCII));
+        } finally {
+            out.close();
+        }
+        return new DefaultFileRegion(file, 0, file.length());
+    }
+
+    @Before
+    public void setup() throws IOException {
+        MockitoAnnotations.initMocks(this);
+        catPromise = newPromise();
+        mouseListener = new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) throws Exception {
+                mouseDone = true;
+                mouseSuccess = future.isSuccess();
+            }
+        };
+        emptyPromise = newPromise();
+        voidPromise = channel.voidPromise();
+
+        cat = Unpooled.wrappedBuffer("cat".getBytes(CharsetUtil.US_ASCII));
+        mouse = createFileRegion("mouse");
+        dog = ReadableCollection.of(createFileRegion("dog"));
+    }
+
+    @Test
+    public void testAggregateWithFullRead() throws IOException {
+        writeQueue.add(cat, catPromise);
+        assertQueueSize(3, false);
+        writeQueue.add(mouse, mouseListener);
+        assertQueueSize(8, false);
+        writeQueue.add(dog);
+        assertQueueSize(11, false);
+        DefaultChannelPromise aggregatePromise = newPromise();
+        assertEquals("catmouse", dequeue(8, aggregatePromise));
+        assertQueueSize(3, false);
+        assertFalse(catPromise.isSuccess());
+        assertFalse(mouseDone);
+        assertEquals("dog", dequeue(3, aggregatePromise));
+        assertQueueSize(0, true);
+        aggregatePromise.setSuccess();
+        assertTrue(catPromise.isSuccess());
+        assertTrue(mouseSuccess);
+        assertEquals(0, cat.refCnt());
+        assertEquals(0, mouse.refCnt());
+        assertFalse(dog.isReadable());
+    }
+
+    @Test
+    public void testWithVoidPromise() throws IOException {
+        writeQueue.add(cat, voidPromise);
+        writeQueue.add(mouse, voidPromise);
+        writeQueue.add(dog, voidPromise);
+        assertQueueSize(11, false);
+        assertEquals("catm", dequeue(4, newPromise()));
+        assertQueueSize(7, false);
+        assertEquals("oused", dequeue(5, newPromise()));
+        assertQueueSize(2, false);
+        assertEquals("og", dequeue(2, newPromise()));
+        assertQueueSize(0, true);
+        assertEquals(0, cat.refCnt());
+        assertEquals(0, mouse.refCnt());
+        assertFalse(dog.isReadable());
+    }
+
+    @Test
+    public void testAggregateWithPartialRead() throws IOException {
+        writeQueue.add(cat, catPromise);
+        writeQueue.add(mouse, mouseListener);
+        DefaultChannelPromise aggregatePromise = newPromise();
+        assertEquals("catm", dequeue(4, aggregatePromise));
+        assertQueueSize(4, false);
+        assertFalse(catPromise.isSuccess());
+        assertFalse(mouseDone);
+        aggregatePromise.setSuccess();
+        assertTrue(catPromise.isSuccess());
+        assertFalse(mouseDone);
+
+        aggregatePromise = newPromise();
+        assertEquals("ouse", dequeue(Integer.MAX_VALUE, aggregatePromise));
+        assertQueueSize(0, true);
+        assertFalse(mouseDone);
+        aggregatePromise.setSuccess();
+        assertTrue(mouseSuccess);
+        assertEquals(0, cat.refCnt());
+        assertEquals(0, mouse.refCnt());
+    }
+
+    @Test
+    public void testReadExactAddedBufferSizeReturnsOriginal() throws IOException {
+        writeQueue.add(cat, catPromise);
+        writeQueue.add(mouse, mouseListener);
+
+        DefaultChannelPromise aggregatePromise = newPromise();
+        assertSame(cat, writeQueue.remove(3, aggregatePromise).unbox());
+        assertFalse(catPromise.isSuccess());
+        aggregatePromise.setSuccess();
+        assertTrue(catPromise.isSuccess());
+        assertEquals(1, cat.refCnt());
+        cat.release();
+
+        aggregatePromise = newPromise();
+        assertEquals("mouse", dequeue(5, aggregatePromise));
+        assertFalse(mouseDone);
+        aggregatePromise.setSuccess();
+        assertTrue(mouseSuccess);
+    }
+
+    @Test
+    public void testReadEmptyQueueReturnsEmptyBuffer() throws IOException {
+        // Not used in this test.
+        cat.release();
+        mouse.release();
+
+        assertQueueSize(0, true);
+        DefaultChannelPromise aggregatePromise = newPromise();
+        assertEquals("", dequeue(Integer.MAX_VALUE, aggregatePromise));
+        assertQueueSize(0, true);
+    }
+
+    @Test
+    public void testReleaseAndFailAll() throws IOException {
+        writeQueue.add(cat, catPromise);
+        writeQueue.add(mouse, mouseListener);
+        writeQueue.add(dog);
+        RuntimeException cause = new RuntimeException("ooops");
+        writeQueue.releaseAndFailAll(cause);
+        DefaultChannelPromise aggregatePromise = newPromise();
+        assertQueueSize(0, true);
+        assertEquals(0, cat.refCnt());
+        assertEquals(0, mouse.refCnt());
+        assertFalse(dog.isReadable());
+        assertSame(cause, catPromise.cause());
+        assertEquals("", dequeue(Integer.MAX_VALUE, aggregatePromise));
+        assertQueueSize(0, true);
+    }
+
+    @Test
+    public void testEmptyBuffersAreCoalesced() throws IOException {
+        ByteBuf empty = Unpooled.buffer(0, 1);
+        assertQueueSize(0, true);
+        writeQueue.add(cat, catPromise);
+        writeQueue.add(empty, emptyPromise);
+        assertQueueSize(3, false);
+        DefaultChannelPromise aggregatePromise = newPromise();
+        assertEquals("cat", dequeue(3, aggregatePromise));
+        assertQueueSize(0, true);
+        assertFalse(catPromise.isSuccess());
+        assertFalse(emptyPromise.isSuccess());
+        aggregatePromise.setSuccess();
+        assertTrue(catPromise.isSuccess());
+        assertTrue(emptyPromise.isSuccess());
+        assertEquals(0, cat.refCnt());
+        assertEquals(0, empty.refCnt());
+    }
+
+    @Test
+    public void testMerge() throws IOException {
+        writeQueue.add(cat, catPromise);
+        CoalescingReadableQueue otherQueue = new CoalescingReadableQueue(channel);
+        otherQueue.add(mouse, mouseListener);
+        otherQueue.copyTo(writeQueue);
+        assertQueueSize(8, false);
+        DefaultChannelPromise aggregatePromise = newPromise();
+        assertEquals("catmouse", dequeue(8, aggregatePromise));
+        assertQueueSize(0, true);
+        assertFalse(catPromise.isSuccess());
+        assertFalse(mouseDone);
+        aggregatePromise.setSuccess();
+        assertTrue(catPromise.isSuccess());
+        assertTrue(mouseSuccess);
+        assertEquals(0, cat.refCnt());
+        assertEquals(0, mouse.refCnt());
+    }
+
+    private DefaultChannelPromise newPromise() {
+        return new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
+    }
+
+    private void assertQueueSize(int size, boolean isEmpty) {
+        assertEquals(size, writeQueue.readableBytes());
+        if (isEmpty) {
+            assertTrue(writeQueue.isEmpty());
+        } else {
+            assertFalse(writeQueue.isEmpty());
+        }
+    }
+
+    private byte[] toBytes(ReadableCollection rc) throws IOException {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        rc.writeTo(channel, rc.readableBytes());
+        channel.flush();
+        return ReadableCollectionTest.toBytes(channel.outboundMessages());
+    }
+
+    private String dequeue(int numBytes, ChannelPromise aggregatePromise) throws IOException {
+        ReadableCollection removed = writeQueue.remove(numBytes, aggregatePromise);
+        String result = new String(toBytes(removed), CharsetUtil.US_ASCII);
+        ReferenceCountUtil.safeRelease(removed);
+        return result;
+    }
+}

--- a/transport/src/test/java/io/netty/channel/ReadableCollectionTest.java
+++ b/transport/src/test/java/io/netty/channel/ReadableCollectionTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.channel;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.ThreadLocalRandom;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.util.Arrays;
+import java.util.Queue;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests for {@link ReadableCollection}.
+ */
+public class ReadableCollectionTest {
+
+    private static byte[] TEST_FILE_DATA = new byte[10];
+
+    private static File TEST_FILE;
+
+    private static ByteBufAllocator ALLOC = UnpooledByteBufAllocator.DEFAULT;
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+        ThreadLocalRandom.current().nextBytes(TEST_FILE_DATA);
+        TEST_FILE = File.createTempFile("netty-", ".tmp");
+        TEST_FILE.deleteOnExit();
+        FileOutputStream out = new FileOutputStream(TEST_FILE);
+        try {
+            out.write(TEST_FILE_DATA);
+        } finally {
+            out.close();
+        }
+    }
+
+    private byte[] toBytes(FileRegion region) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            WritableByteChannel channel = Channels.newChannel(out);
+            while (region.isTransferable()) {
+                region.transferBytesTo(channel, region.transferableBytes());
+            }
+        } finally {
+            region.release();
+        }
+        return out.toByteArray();
+    }
+
+    @Test
+    public void testCompose() throws IOException {
+        ReadableCollection.Builder builder = ReadableCollection.create(ALLOC, 100);
+        for (int i = 0; i < 5; i++) {
+            builder.add(Unpooled.wrappedBuffer(Integer.toString(i).getBytes(CharsetUtil.US_ASCII)));
+        }
+        ReadableCollection rc = builder.build();
+        assertTrue(rc.isReadable());
+        assertEquals(5, rc.readableBytes());
+        ByteBuf buf = rc.unbox();
+        assertNotNull(buf);
+        assertEquals("01234", buf.toString(CharsetUtil.US_ASCII));
+        assertTrue(buf.release());
+        builder = ReadableCollection.create(ALLOC, 100);
+        builder.add(new DefaultFileRegion(TEST_FILE, 0, TEST_FILE_DATA.length));
+        for (int i = 5; i < 10; i++) {
+            builder.add(Unpooled.wrappedBuffer(Integer.toString(i).getBytes(CharsetUtil.US_ASCII)));
+        }
+        rc = builder.build();
+        assertNull(rc.unbox());
+        assertEquals(5 + TEST_FILE_DATA.length, rc.readableBytes());
+        EmbeddedChannel channel = new EmbeddedChannel();
+        rc.writeTo(channel, channel.newPromise(), TEST_FILE_DATA.length);
+        assertEquals(5, rc.readableBytes());
+        channel.flush();
+        FileRegion region = (FileRegion) channel.outboundMessages().poll();
+        assertArrayEquals(TEST_FILE_DATA, toBytes(region));
+        buf = rc.unbox();
+        assertNotNull(buf);
+        assertEquals("56789", buf.toString(CharsetUtil.US_ASCII));
+        assertTrue(buf.release());
+    }
+
+    static byte[] toBytes(Queue<Object> queue) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        WritableByteChannel channel = Channels.newChannel(out);
+        for (Object obj; (obj = queue.poll()) != null;) {
+            try {
+                if (obj instanceof ByteBuf) {
+                    ByteBuf buf = (ByteBuf) obj;
+                    buf.readBytes(out, buf.readableBytes());
+                } else {
+                    FileRegion region = (FileRegion) obj;
+                    while (region.isTransferable()) {
+                        region.transferBytesTo(channel, region.transferableBytes());
+                    }
+                }
+            } finally {
+                ReferenceCountUtil.release(obj);
+            }
+        }
+        return out.toByteArray();
+    }
+
+    @Test
+    public void testWriteTo() throws IOException {
+        ReadableCollection.Builder builder = ReadableCollection.create(ALLOC, 100);
+        for (int i = 0; i < 5; i++) {
+            builder.add(Unpooled.wrappedBuffer(TEST_FILE_DATA)).add(
+                    new DefaultFileRegion(TEST_FILE, 0, TEST_FILE_DATA.length));
+        }
+        ReadableCollection rc = builder.build();
+        assertEquals(TEST_FILE_DATA.length * 10, rc.readableBytes());
+        byte[] expected = new byte[TEST_FILE_DATA.length * 10];
+        for (int i = 0; i < 10; i++) {
+            System.arraycopy(TEST_FILE_DATA, 0, expected, i * TEST_FILE_DATA.length, TEST_FILE_DATA.length);
+        }
+        EmbeddedChannel channel = new EmbeddedChannel();
+        for (int removed = 0, step = 12; removed < expected.length;) {
+            rc.writeTo(channel, step);
+            channel.flush();
+            int expectedLength = Math.min(step, expected.length - removed);
+            assertArrayEquals(Arrays.copyOfRange(expected, removed, removed + expectedLength),
+                    toBytes(channel.outboundMessages()));
+            removed += expectedLength;
+        }
+    }
+
+    @Test
+    public void testAddReadableCollection() throws IOException {
+        ReadableCollection.Builder builder0 = ReadableCollection.create(ALLOC, 100);
+        ReadableCollection.Builder builder1 = ReadableCollection.create(ALLOC, 100);
+        for (int i = 0; i < 5; i++) {
+            builder0.add(Unpooled.wrappedBuffer(TEST_FILE_DATA)).add(
+                    new DefaultFileRegion(TEST_FILE, 0, TEST_FILE_DATA.length));
+        }
+        ReadableCollection rc0 = builder0.build();
+        byte[] expected = new byte[TEST_FILE_DATA.length * 10];
+        for (int i = 0; i < 10; i++) {
+            System.arraycopy(TEST_FILE_DATA, 0, expected, i * TEST_FILE_DATA.length, TEST_FILE_DATA.length);
+        }
+        for (int added = 0, step = 12; added < expected.length; added += step) {
+            builder1.add(rc0, Math.min(step, expected.length - added));
+        }
+        ReadableCollection rc1 = builder1.build();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        rc1.writeTo(channel, rc1.readableBytes());
+        channel.flush();
+        assertArrayEquals(expected, toBytes(channel.outboundMessages()));
+    }
+}

--- a/transport/src/test/java/io/netty/channel/SlicedFileRegionTest.java
+++ b/transport/src/test/java/io/netty/channel/SlicedFileRegionTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.channel;
+
+import static org.junit.Assert.*;
+import io.netty.util.internal.ThreadLocalRandom;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.util.Arrays;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test for {@link SlicedFileRegion}.
+ */
+public class SlicedFileRegionTest {
+
+    private static byte[] TEST_DATA = new byte[1024 * 64];
+
+    private static File TEST_FILE;
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+        ThreadLocalRandom.current().nextBytes(TEST_DATA);
+        TEST_FILE = File.createTempFile("netty-", ".tmp");
+        TEST_FILE.deleteOnExit();
+        FileOutputStream out = new FileOutputStream(TEST_FILE);
+        try {
+            out.write(TEST_DATA);
+        } finally {
+            out.close();
+        }
+    }
+
+    @Test
+    public void test() throws IOException {
+        DefaultFileRegion region = new DefaultFileRegion(TEST_FILE, 0, TEST_DATA.length);
+        assertEquals(0, region.position());
+        assertTrue(region.isTransferable());
+        assertEquals(TEST_DATA.length, region.transferableBytes());
+        assertEquals(0, region.transferIndex());
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        WritableByteChannel ch = Channels.newChannel(bos);
+        while (region.transferableBytes() > TEST_DATA.length / 2) {
+            region.transferBytesTo(ch, TEST_DATA.length / 2 - region.transferIndex());
+        }
+        assertArrayEquals(Arrays.copyOf(TEST_DATA, TEST_DATA.length / 2), bos.toByteArray());
+
+        FileRegion subRegion1 = region.transferSlice(TEST_DATA.length / 2).retain();
+        assertFalse(region.isTransferable());
+        assertEquals(0, region.transferableBytes());
+        assertEquals(TEST_DATA.length, region.transferIndex());
+        region.release();
+
+        assertEquals(TEST_DATA.length / 2, subRegion1.position());
+        assertTrue(subRegion1.isTransferable());
+        assertEquals(TEST_DATA.length / 2, subRegion1.transferableBytes());
+        assertEquals(0, subRegion1.transferIndex());
+
+        bos.reset();
+        while (subRegion1.transferableBytes() > TEST_DATA.length / 4) {
+            subRegion1.transferBytesTo(ch, TEST_DATA.length / 4 - subRegion1.transferIndex());
+        }
+        assertArrayEquals(Arrays.copyOfRange(TEST_DATA, TEST_DATA.length / 2, TEST_DATA.length - TEST_DATA.length / 4),
+                bos.toByteArray());
+
+        FileRegion subRegion2 = subRegion1.transferSlice(TEST_DATA.length / 4).retain();
+        assertFalse(subRegion1.isTransferable());
+        assertEquals(0, subRegion1.transferableBytes());
+        assertEquals(TEST_DATA.length / 2, subRegion1.transferIndex());
+        subRegion1.release();
+
+        assertEquals(TEST_DATA.length - TEST_DATA.length / 4, subRegion2.position());
+        bos.reset();
+        while (subRegion2.isTransferable()) {
+            subRegion2.transferBytesTo(ch, subRegion2.transferableBytes());
+        }
+        assertArrayEquals(Arrays.copyOfRange(TEST_DATA, TEST_DATA.length - TEST_DATA.length / 4, TEST_DATA.length),
+                bos.toByteArray());
+        subRegion2.release();
+    }
+}


### PR DESCRIPTION
The implementaton of #3927.

No testcase yet, will add later.

And I think maybe I should split the patch into 3 pieces?
1. Add slice support for `FileRegion`. This requires changing the c code of `epoll-transport` project.
2. Add `ReadableCollection` and `CoalescingReadableQueue`. This makes it possible to combine `ByteBuf` and `FileRegion` together.
3. Add `FileRegion` support for HTTP/2.

@nmittler  @Scottmitch WDYT? Thanks.
