### PR TITLE
Close FileInputStream after consuming it in SelfSignedCertificate

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
@@ -162,11 +162,20 @@ public final class SelfSignedCertificate {
         certificate = new File(paths[0]);
         privateKey = new File(paths[1]);
         key = keypair.getPrivate();
+        FileInputStream certificateInput = null;
         try {
-            cert = (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(
-                    new FileInputStream(certificate));
+            certificateInput = new FileInputStream(certificate);
+            cert = (X509Certificate) CertificateFactory.getInstance("X509").generateCertificate(certificateInput);
         } catch (Exception e) {
             throw new CertificateEncodingException(e);
+        } finally {
+            if (certificateInput != null) {
+                try {
+                    certificateInput.close();
+                } catch (IOException e) {
+                    logger.warn("Failed to close a file: " + certificate, e);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Motivation:

FileInputStream opened by SelfSignedCertificate wasn't closed.

Modifications:

Use a try-finally to close the opened FileInputStream.

Result:

FileInputStream will be closed properly.