### PR TITLE
Fix javadoc links and tags

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufProcessor.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufProcessor.java
@@ -24,7 +24,7 @@ import io.netty.util.ByteProcessor;
 public interface ByteBufProcessor extends ByteProcessor {
 
     /**
-     * @deprecated Use {@link ByteProcessor#FIND_NULL}.
+     * @deprecated Use {@link ByteProcessor#FIND_NUL}.
      */
     ByteBufProcessor FIND_NUL = new ByteBufProcessor() {
         @Override

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -590,7 +590,7 @@ public final class ByteBufUtil {
     }
 
     /**
-     * Create a copy of the underlying storage from {@link value} into a byte array.
+     * Create a copy of the underlying storage from {@code buf} into a byte array.
      * The copy will start at {@link ByteBuf#readerIndex()} and copy {@link ByteBuf#readableBytes()} bytes.
      */
     public static byte[] getBytes(ByteBuf buf) {
@@ -598,7 +598,7 @@ public final class ByteBufUtil {
     }
 
     /**
-     * Create a copy of the underlying storage from {@link buf} into a byte array.
+     * Create a copy of the underlying storage from {@code buf} into a byte array.
      * The copy will start at {@code start} and copy {@code length} bytes.
      */
     public static byte[] getBytes(ByteBuf buf, int start, int length) {
@@ -606,7 +606,7 @@ public final class ByteBufUtil {
     }
 
     /**
-     * Return an array of the underlying storage from {@link buf} into a byte array.
+     * Return an array of the underlying storage from {@code buf} into a byte array.
      * The copy will start at {@code start} and copy {@code length} bytes.
      * If {@code copy} is true a copy will be made of the memory.
      * If {@code copy} is false the underlying storage will be shared, if possible.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/ClientCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/ClientCookieEncoder.java
@@ -50,7 +50,7 @@ public final class ClientCookieEncoder {
     /**
      * Encodes the specified cookie into a Cookie header value.
      *
-     * @param specified the cookie
+     * @param cookie the specified cookie
      * @return a Rfc6265 style Cookie header value
      */
     @Deprecated

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -1135,7 +1135,7 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     }
 
     /**
-     * @deprecated Use {@link AsciiString#equalsIgnoreCase(CharSequence, CharSequence)} instead.
+     * @deprecated Use {@link AsciiString#contentEqualsIgnoreCase(CharSequence, CharSequence)} instead.
      */
     @Deprecated
     public static boolean equalsIgnoreCase(CharSequence name1, CharSequence name2) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
@@ -81,8 +81,7 @@ public final class ClientCookieEncoder extends CookieEncoder {
     /**
      * Encodes the specified cookie into a Cookie header value.
      *
-     * @param specified
-     *            the cookie
+     * @param cookie the specified cookie
      * @return a Rfc6265 style Cookie header value
      */
     public String encode(Cookie cookie) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamByteDistributor.java
@@ -35,7 +35,7 @@ public interface StreamByteDistributor {
          * Get the amount of bytes this stream has pending to send. The actual amount written must not exceed
          * {@link #windowSize()}!
          * @return The amount of bytes this stream has pending to send.
-         * @see {@link #io.netty.handler.codec.http2.Http2CodecUtil.streamableBytes(StreamState)}
+         * @see {@link io.netty.handler.codec.http2.Http2CodecUtil#streamableBytes(StreamState)}
          */
         int pendingBytes();
 
@@ -51,7 +51,7 @@ public interface StreamByteDistributor {
          * an stream has been given a chance to write an empty frame, and also enables optimizations like not writing
          * empty frames in some situations (don't write headers until data can also be written).
          * @return the size of the stream's flow control window.
-         * @see {@link #io.netty.handler.codec.http2.Http2CodecUtil.streamableBytes(StreamState)}
+         * @see {@link io.netty.handler.codec.http2.Http2CodecUtil#streamableBytes(StreamState)}
          */
         int windowSize();
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
@@ -134,7 +134,7 @@ public final class WeightedFairQueueByteDistributor implements StreamByteDistrib
 
     /**
      * Sets the amount of bytes that will be allocated to each stream. Defaults to 1KiB.
-     * @param minAllocationChunk the amount of bytes that will be allocated to each stream. Must be > 0.
+     * @param allocationQuantum the amount of bytes that will be allocated to each stream. Must be > 0.
      */
     public void allocationQuantum(int allocationQuantum) {
         if (allocationQuantum <= 0) {

--- a/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
+++ b/codec/src/main/java/io/netty/handler/codec/MessageAggregator.java
@@ -346,7 +346,7 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
 
     /**
      * Determine if the channel should be closed after the result of {@link #newContinueResponse(Object)} is written.
-     * @param The return value from {@link #newContinueResponse(Object)}.
+     * @param msg The return value from {@link #newContinueResponse(Object)}.
      * @return {@code true} if the channel should be closed after the result of {@link #newContinueResponse(Object)}
      * is written. {@code false} otherwise.
      */
@@ -356,7 +356,7 @@ public abstract class MessageAggregator<I, S, C extends ByteBufHolder, O extends
      * Determine if all objects for the current request/response should be ignored or not.
      * Messages will stop being ignored the next time {@link #isContentMessage(Object)} returns {@code true}.
      *
-     * @param The return value from {@link #newContinueResponse(Object)}.
+     * @param msg The return value from {@link #newContinueResponse(Object)}.
      * @return {@code true} if all objects for the current request/response should be ignored or not.
      * {@code false} otherwise.
      */

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -108,7 +108,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
     }
 
     /**
-     * Create a copy of the underlying storage from {@link value}.
+     * Create a copy of the underlying storage from {@code value}.
      * The copy will start at {@link ByteBuffer#position()} and copy {@link ByteBuffer#remaining()} bytes.
      */
     public AsciiString(ByteBuffer value) {
@@ -116,7 +116,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
     }
 
     /**
-     * Initialize a instance based upon the underlying storage from {@link value}.
+     * Initialize an instance based upon the underlying storage from {@code value}.
      * There is a potential to share the underlying array storage if {@link ByteBuffer#hasArray()} is {@code true}.
      * if {@code copy} is {@code true} a copy will be made of the memory.
      * if {@code copy} is {@code false} the underlying storage will be shared, if possible.
@@ -126,7 +126,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
     }
 
     /**
-     * Initialize a {@link ByteString} based upon the underlying storage from {@link value}.
+     * Initialize an {@link AsciiString} based upon the underlying storage from {@code value}.
      * There is a potential to share the underlying array storage if {@link ByteBuffer#hasArray()} is {@code true}.
      * if {@code copy} is {@code true} a copy will be made of the memory.
      * if {@code copy} is {@code false} the underlying storage will be shared, if possible.
@@ -182,14 +182,14 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
     }
 
     /**
-     * Create a copy of {@link value} into this instance using the encoding type of {@code charset}.
+     * Create a copy of {@code value} into this instance using the encoding type of {@code charset}.
      */
     public AsciiString(char[] value, Charset charset) {
         this(value, charset, 0, value.length);
     }
 
     /**
-     * Create a copy of {@link value} into a this instance using the encoding type of {@code charset}.
+     * Create a copy of {@code value} into a this instance using the encoding type of {@code charset}.
      * The copy will start at index {@code start} and copy {@code length} bytes.
      */
     public AsciiString(char[] value, Charset charset, int start, int length) {
@@ -229,14 +229,14 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
     }
 
     /**
-     * Create a copy of {@link value} into this instance using the encoding type of {@code charset}.
+     * Create a copy of {@code value} into this instance using the encoding type of {@code charset}.
      */
     public AsciiString(CharSequence value, Charset charset) {
         this(value, charset, 0, value.length());
     }
 
     /**
-     * Create a copy of {@link value} into this instance using the encoding type of {@code charset}.
+     * Create a copy of {@code value} into this instance using the encoding type of {@code charset}.
      * The copy will start at index {@code start} and copy {@code length} bytes.
      */
     public AsciiString(CharSequence value, Charset charset, int start, int length) {
@@ -349,7 +349,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
     }
 
     /**
-     * During normal use cases the {@link ByteString} should be immutable, but if the underlying array is shared,
+     * During normal use cases the {@link AsciiString} should be immutable, but if the underlying array is shared,
      * and changes then this needs to be called.
      */
     public void arrayChanged() {
@@ -1137,7 +1137,6 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
 
     /**
      * Translates the [{@code start}, {@code end}) range of this byte string to a {@link String}.
-     * @see {@link #toString(int, int)}
      */
     public String toString(int start, int end) {
         int length = end - start;

--- a/common/src/main/java/io/netty/util/HashingStrategy.java
+++ b/common/src/main/java/io/netty/util/HashingStrategy.java
@@ -57,8 +57,8 @@ public interface HashingStrategy<T> {
     boolean equals(T a, T b);
 
     /**
-     * A {@link HashingStrategy} which delegates to java's {@link ObjectUtil#hashCode(Object)}
-     * and {@link ObjectUtil#equals(Object, Object)}.
+     * A {@link HashingStrategy} which delegates to java's {@link Object#hashCode()}
+     * and {@link Object#equals(Object)}.
      */
     @SuppressWarnings("rawtypes")
     HashingStrategy JAVA_HASHER = new HashingStrategy() {

--- a/common/src/main/java/io/netty/util/concurrent/PromiseAggregator.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseAggregator.java
@@ -24,8 +24,8 @@ import java.util.Set;
  * into one, by listening to individual {@link Future}s and producing an aggregated result
  * (success/failure) when all {@link Future}s have completed.
  *
- * @param V the type of value returned by the {@link Future}
- * @param F the type of {@link Future}
+ * @tparam V the type of value returned by the {@link Future}
+ * @tparam F the type of {@link Future}
  */
 public class PromiseAggregator<V, F extends Future<V>> implements GenericFutureListener<F> {
 

--- a/handler/src/main/java/io/netty/handler/stream/ChunkedInput.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedInput.java
@@ -57,7 +57,7 @@ public interface ChunkedInput<B> {
      * and thus the stream has reached at its end, any subsequent {@link #isEndOfInput()}
      * call must return {@code true}.
      *
-     * @param a {@link ByteBufAllocator} if buffer allocation is necessary.
+     * @param allocator {@link ByteBufAllocator} if buffer allocation is necessary.
      * @return the fetched chunk.
      *         {@code null} if there is no data left in the stream.
      *         Please note that {@code null} does not necessarily mean that the

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -278,7 +278,6 @@ public final class DnsNameResolverBuilder {
     /**
      * @param hostsFileEntriesResolver the {@link HostsFileEntriesResolver} used to first check
      *                                 if the hostname is locally aliased.
-     * @param hostsFileEntriesResolver the {@link HostsFileEntriesResolver}
      * @return {@code this}
      */
     public DnsNameResolverBuilder hostsFileEntriesResolver(HostsFileEntriesResolver hostsFileEntriesResolver) {

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -293,7 +293,6 @@ public class DefaultChannelConfig implements ChannelConfig {
      * @param allocator the allocator to set.
      * @param metadata Used to set the {@link ChannelMetadata#defaultMaxMessagesPerRead()} if {@code allocator}
      * is of type {@link MaxMessagesRecvByteBufAllocator}.
-     * @return this
      */
     private void setRecvByteBufAllocator(RecvByteBufAllocator allocator, ChannelMetadata metadata) {
         if (allocator instanceof MaxMessagesRecvByteBufAllocator) {

--- a/transport/src/main/java/io/netty/channel/RecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/RecvByteBufAllocator.java
@@ -91,8 +91,6 @@ public interface RecvByteBufAllocator {
 
         /**
          * Determine if the current read loop should should continue.
-         * @param totalMessages The total number of messages read so far by this read loop.
-         * @param lastReadBytes The number of bytes read from the previous read operation.
          * @return {@code true} if the read loop should continue reading. {@code false} if the read loop is complete.
          */
         boolean continueReading();


### PR DESCRIPTION
Motivation:

There are some wrong links and tags in javadoc.

Modifications:

Fix the wrong links and tags in javadoc.

Result:

These links will work correctly in javadoc.