### PR TITLE
OpenSslEngine skip ALPN tests if OpenSsl version doesn't support ALPN

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -40,6 +40,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @Test
     public void testAlpn() throws Exception {
         assumeTrue(OpenSsl.isAvailable());
+        assumeTrue(OpenSsl.isAlpnSupported());
         ApplicationProtocolConfig apn = acceptingNegotiator(Protocol.ALPN,
                 PREFERRED_APPLICATION_LEVEL_PROTOCOL);
         setupHandlers(apn);
@@ -49,6 +50,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @Test
     public void testAlpnCompatibleProtocolsDifferentClientOrder() throws Exception {
         assumeTrue(OpenSsl.isAvailable());
+        assumeTrue(OpenSsl.isAlpnSupported());
         ApplicationProtocolConfig clientApn = acceptingNegotiator(Protocol.ALPN,
                 FALLBACK_APPLICATION_LEVEL_PROTOCOL, PREFERRED_APPLICATION_LEVEL_PROTOCOL);
         ApplicationProtocolConfig serverApn = acceptingNegotiator(Protocol.ALPN,


### PR DESCRIPTION
Motivation:
OpenSslEngine now tests ALPN behavior. However it is possible that OpenSSL is present, but the version does not support ALPN. This will result in test failures instead of just skipping the test.

Modifications:
- Skip ALPN tests in OpenSslEngineTest if the version of OpenSSL does not support ALPN

Result:
Tests don't fail due to unsupported feature in OpenSSL.