### PR TITLE
Fix buffer leak introduced by 693633eeff106febf4403208f9eed2117931f45a

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateDecoderTest.java
@@ -143,9 +143,7 @@ public class PerMessageDeflateDecoderTest {
         byte[] finalPayload = new byte[300];
         finalPayloadWrapped.readBytes(finalPayload);
         assertTrue(Arrays.equals(finalPayload, payload));
-        uncompressedFrame1.release();
-        uncompressedFrame2.release();
-        uncompressedFrame3.release();
+        finalPayloadWrapped.release();
     }
 
     @Test

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -488,7 +488,9 @@ public abstract class OpenSslContext extends SslContext {
         ByteBuf buffer = Unpooled.directBuffer();
         try {
             buffer.writeBytes(BEGIN_PRIVATE_KEY);
-            buffer.writeBytes(Base64.encode(Unpooled.wrappedBuffer(key.getEncoded()), true));
+            ByteBuf encoded = Base64.encode(Unpooled.wrappedBuffer(key.getEncoded()), true);
+            buffer.writeBytes(encoded);
+            encoded.release();
             buffer.writeBytes(END_PRIVATE_KEY);
             return newBIO(buffer);
         } finally {
@@ -508,7 +510,9 @@ public abstract class OpenSslContext extends SslContext {
         try {
             for (X509Certificate cert: certChain) {
                 buffer.writeBytes(BEGIN_CERT);
-                buffer.writeBytes(Base64.encode(Unpooled.wrappedBuffer(cert.getEncoded()), true));
+                ByteBuf encoded = Base64.encode(Unpooled.wrappedBuffer(cert.getEncoded()), true);
+                buffer.writeBytes(encoded);
+                encoded.release();
                 buffer.writeBytes(END_CERT);
             }
             return newBIO(buffer);

--- a/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/SelfSignedCertificate.java
@@ -16,6 +16,7 @@
 
 package io.netty.handler.ssl.util;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.base64.Base64;
 import io.netty.util.CharsetUtil;
@@ -217,11 +218,11 @@ public final class SelfSignedCertificate {
 
     static String[] newSelfSignedCertificate(
             String fqdn, PrivateKey key, X509Certificate cert) throws IOException, CertificateEncodingException {
-
         // Encode the private key into a file.
-        String keyText = "-----BEGIN PRIVATE KEY-----\n" +
-                Base64.encode(Unpooled.wrappedBuffer(key.getEncoded()), true).toString(CharsetUtil.US_ASCII) +
+        ByteBuf enc = Base64.encode(Unpooled.wrappedBuffer(key.getEncoded()), true);
+        String keyText = "-----BEGIN PRIVATE KEY-----\n" + enc.toString(CharsetUtil.US_ASCII) +
                 "\n-----END PRIVATE KEY-----\n";
+        enc.release();
 
         File keyFile = File.createTempFile("keyutil_" + fqdn + '_', ".key");
         keyFile.deleteOnExit();
@@ -238,10 +239,12 @@ public final class SelfSignedCertificate {
             }
         }
 
+        ByteBuf encoded = Base64.encode(Unpooled.wrappedBuffer(cert.getEncoded()), true);
         // Encode the certificate into a CRT file.
         String certText = "-----BEGIN CERTIFICATE-----\n" +
-                Base64.encode(Unpooled.wrappedBuffer(cert.getEncoded()), true).toString(CharsetUtil.US_ASCII) +
+                encoded.toString(CharsetUtil.US_ASCII) +
                 "\n-----END CERTIFICATE-----\n";
+        encoded.release();
 
         File certFile = File.createTempFile("keyutil_" + fqdn + '_', ".crt");
         certFile.deleteOnExit();


### PR DESCRIPTION
Motivation:

As we not used Unpooled anymore for allocate buffers in Base64.* methods we need to ensure we realease all the buffers.

Modifications:

Correctly release buffers

Result:

No more buffer leaks