### PR TITLE
Add a possibility to create HttpMessage instances with pre-existing Headers

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
@@ -28,7 +28,7 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
 
     private final ByteBuf content;
     private final HttpHeaders trailingHeaders;
-    private final boolean validateHeaders;
+
     /**
      * Used to cache the value of the hash code and avoid {@link IllegalRefCountException}.
      */
@@ -62,7 +62,13 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
         this.content = checkNotNull(content, "content");
         this.trailingHeaders = singleFieldHeaders ? new CombinedHttpHeaders(validateHeaders)
                                                   : new DefaultHttpHeaders(validateHeaders);
-        this.validateHeaders = validateHeaders;
+    }
+
+    public DefaultFullHttpResponse(HttpVersion version, HttpResponseStatus status,
+            ByteBuf content, HttpHeaders headers, HttpHeaders trailingHeaders) {
+        super(version, status, headers);
+        this.content = checkNotNull(content, "content");
+        this.trailingHeaders = checkNotNull(trailingHeaders, "trailingHeaders");
     }
 
     @Override
@@ -142,13 +148,12 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
      * @return A copy of this object
      */
     private FullHttpResponse copy(boolean copyContent, ByteBuf newContent) {
-        DefaultFullHttpResponse copy = new DefaultFullHttpResponse(
+        return new DefaultFullHttpResponse(
                 protocolVersion(), status(),
                 copyContent ? content().copy() :
-                        newContent == null ? Unpooled.buffer(0) : newContent);
-        copy.headers().set(headers());
-        copy.trailingHeaders().set(trailingHeaders());
-        return copy;
+                        newContent == null ? Unpooled.buffer(0) : newContent,
+                headers(),
+                trailingHeaders());
     }
 
     @Override
@@ -163,11 +168,8 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
 
     @Override
     public FullHttpResponse duplicate() {
-        DefaultFullHttpResponse duplicate = new DefaultFullHttpResponse(protocolVersion(), status(),
-                content().duplicate(), validateHeaders);
-        duplicate.headers().set(headers());
-        duplicate.trailingHeaders().set(trailingHeaders());
-        return duplicate;
+        return new DefaultFullHttpResponse(protocolVersion(), status(),
+                content().duplicate(), headers(), trailingHeaders());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpMessage.java
@@ -36,9 +36,17 @@ public abstract class DefaultHttpMessage extends DefaultHttpObject implements Ht
      * Creates a new instance.
      */
     protected DefaultHttpMessage(final HttpVersion version, boolean validateHeaders, boolean singleFieldHeaders) {
+        this(version,
+                singleFieldHeaders ? new CombinedHttpHeaders(validateHeaders)
+                                   : new DefaultHttpHeaders(validateHeaders));
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    protected DefaultHttpMessage(final HttpVersion version, HttpHeaders headers) {
         this.version = checkNotNull(version, "version");
-        headers = singleFieldHeaders ? new CombinedHttpHeaders(validateHeaders)
-                                     : new DefaultHttpHeaders(validateHeaders);
+        this.headers = checkNotNull(headers, "headers");
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpRequest.java
@@ -29,7 +29,7 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
      * Creates a new instance.
      *
      * @param httpVersion the HTTP version of the request
-     * @param method      the HTTP getMethod of the request
+     * @param method      the HTTP method of the request
      * @param uri         the URI or path of the request
      */
     public DefaultHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri) {
@@ -40,12 +40,26 @@ public class DefaultHttpRequest extends DefaultHttpMessage implements HttpReques
      * Creates a new instance.
      *
      * @param httpVersion       the HTTP version of the request
-     * @param method            the HTTP getMethod of the request
+     * @param method            the HTTP method of the request
      * @param uri               the URI or path of the request
      * @param validateHeaders   validate the header names and values when adding them to the {@link HttpHeaders}
      */
     public DefaultHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, boolean validateHeaders) {
         super(httpVersion, validateHeaders, false);
+        this.method = checkNotNull(method, "method");
+        this.uri = checkNotNull(uri, "uri");
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param httpVersion       the HTTP version of the request
+     * @param method            the HTTP method of the request
+     * @param uri               the URI or path of the request
+     * @param headers           the Headers for this Request
+     */
+    public DefaultHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri, HttpHeaders headers) {
+        super(httpVersion, headers);
         this.method = checkNotNull(method, "method");
         this.uri = checkNotNull(uri, "uri");
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.http;
 
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * The default {@link HttpResponse} implementation.
@@ -27,7 +28,7 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
      * Creates a new instance.
      *
      * @param version the HTTP version of this response
-     * @param status  the getStatus of this response
+     * @param status  the status of this response
      */
     public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status) {
         this(version, status, true, false);
@@ -37,7 +38,7 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
      * Creates a new instance.
      *
      * @param version           the HTTP version of this response
-     * @param status            the getStatus of this response
+     * @param status            the status of this response
      * @param validateHeaders   validate the header names and values when adding them to the {@link HttpHeaders}
      */
     public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders) {
@@ -48,7 +49,7 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
      * Creates a new instance.
      *
      * @param version           the HTTP version of this response
-     * @param status            the getStatus of this response
+     * @param status            the status of this response
      * @param validateHeaders   validate the header names and values when adding them to the {@link HttpHeaders}
      * @param singleFieldHeaders {@code true} to check and enforce that headers with the same name are appended
      * to the same entry and comma separated.
@@ -59,10 +60,19 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
     public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status, boolean validateHeaders,
                                boolean singleFieldHeaders) {
         super(version, validateHeaders, singleFieldHeaders);
-        if (status == null) {
-            throw new NullPointerException("status");
-        }
-        this.status = status;
+        this.status = checkNotNull(status, "status");
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param version           the HTTP version of this response
+     * @param status            the status of this response
+     * @param headers           the headers for this HTTP Response
+     */
+    public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status, HttpHeaders headers) {
+        super(version, headers);
+        this.status = checkNotNull(status, "status");
     }
 
     @Override


### PR DESCRIPTION
Addressing issue #4315 

Allow passing HttpHeaders instance to DefaultHttpMessage in order to avoid eager creation of Headers to allow users reuse their Headers instance.

Modifications:

Added a constructor with HttpHeaders to DefaultHttpMessage, Modified DefaultHttpResponse and DefaultHttpRequest to receive HttpHeaders instances. 

Result:

Users can now pass HttpHeaders instance when  constructing Http Requests and Responses.