### PR TITLE
Fix unnecessary boxing and incorrect Serializable

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySession.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySession.java
@@ -323,9 +323,7 @@ final class SpdySession {
         }
     }
 
-    private final class StreamComparator implements Comparator<Integer>, Serializable {
-
-        private static final long serialVersionUID = 1161471649740544848L;
+    private final class StreamComparator implements Comparator<Integer> {
 
         StreamComparator() { }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2ConnectionHandlerBuilder.java
@@ -94,7 +94,7 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
     // * OK to use with server() and connection()
     private Http2FrameLogger frameLogger;
     private SensitivityDetector headerSensitivityDetector;
-    private Boolean encoderEnforceMaxConcurrentStreams;
+    private boolean encoderEnforceMaxConcurrentStreams;
 
     /**
      * Returns if HTTP headers should be validated according to
@@ -268,7 +268,7 @@ public abstract class AbstractHttp2ConnectionHandlerBuilder<T extends Http2Conne
      * would otherwise be exceeded.
      */
     protected boolean encoderEnforceMaxConcurrentStreams() {
-        return encoderEnforceMaxConcurrentStreams != null ? encoderEnforceMaxConcurrentStreams : false;
+        return encoderEnforceMaxConcurrentStreams;
     }
 
     /**


### PR DESCRIPTION
Motivation:

- AbstractHttp2ConnectionHandlerBuilder.encoderEnforceMaxConcurrentStreams can be the primitive boolean
- SpdySession.StreamComparator should not be Serializable since the outer SpdySession is not Serializable

Modifications:

Use boolean instead and remove Serializable

Result:

- Minor improvement for AbstractHttp2ConnectionHandlerBuilder
- StreamComparator is not Serializable any more