### PR TITLE
Fix incorrect Serializable

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySession.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySession.java
@@ -323,9 +323,7 @@ final class SpdySession {
         }
     }
 
-    private final class StreamComparator implements Comparator<Integer>, Serializable {
-
-        private static final long serialVersionUID = 1161471649740544848L;
+    private final class StreamComparator implements Comparator<Integer> {
 
         StreamComparator() { }
 


### PR DESCRIPTION
Motivation:

SpdySession.StreamComparator should not be Serializable since SpdySession is not Serializable

Modifications:

Remove Serializable fom SpdySession.StreamComparator

Result:

StreamComparator is not Serializable any more