### PR TITLE
Fix for HttpObjectDecoder message content handling

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -465,6 +465,10 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             case 204: case 205: case 304:
                 return true;
             }
+        } else { // assume it is HttpRequest, what else ?
+            if (((HttpRequest) msg).method().equals(HttpMethod.HEAD)) {
+                return true;
+            }
         }
         return false;
     }
@@ -587,7 +591,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
         State nextState;
 
-        if (isContentAlwaysEmpty(message)) {
+        if (isContentAlwaysEmpty(message) || HttpUtil.hasEmptyContent(message)) {
             HttpUtil.setTransferEncodingChunked(message, false);
             nextState = State.SKIP_CONTROL_CHARS;
         } else if (HttpUtil.isTransferEncodingChunked(message)) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -299,6 +299,17 @@ public final class HttpUtil {
     }
 
     /**
+     * Checks to see if {@link HttpMessage} has empty content.
+     *
+     * @param message The message to check
+     * @return True if headers indicate empty content
+     */
+    public static boolean hasEmptyContent(HttpMessage message) {
+        return !message.headers().contains(HttpHeaderNames.TRANSFER_ENCODING)
+                && getContentLength(message, 0) == 0;
+    }
+
+    /**
      * Set the {@link HttpHeaderNames#TRANSFER_ENCODING} to either include {@link HttpHeaderValues#CHUNKED} if
      * {@code chunked} is {@code true}, or remove {@link HttpHeaderValues#CHUNKED} if {@code chunked} is {@code false}.
      * @param m The message which contains the headers to modify.

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseDecoderTest.java
@@ -67,9 +67,9 @@ public class HttpResponseDecoderTest {
         assertNull(res.decoderResult().cause());
         assertTrue(res.decoderResult().isSuccess());
 
-        assertNull(ch.readInbound());
         assertTrue(ch.finish());
         assertThat(ch.readInbound(), instanceOf(LastHttpContent.class));
+        assertNull(ch.readInbound());
     }
 
     /**
@@ -202,7 +202,6 @@ public class HttpResponseDecoderTest {
         HttpResponse res = ch.readInbound();
         assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
         assertThat(res.status(), is(HttpResponseStatus.OK));
-        assertThat(ch.readInbound(), is(nullValue()));
 
         // Close the connection without sending anything.
         assertTrue(ch.finish());
@@ -221,7 +220,8 @@ public class HttpResponseDecoderTest {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
 
         // Write the partial response.
-        ch.writeInbound(Unpooled.copiedBuffer("HTTP/1.1 200 OK\r\n\r\n12345678", CharsetUtil.US_ASCII));
+        ch.writeInbound(Unpooled.copiedBuffer("HTTP/1.1 200 OK\r\nTransfer-Encoding: identity\r\n\r\n12345678",
+                CharsetUtil.US_ASCII));
 
         // Read the response headers.
         HttpResponse res = ch.readInbound();
@@ -304,7 +304,6 @@ public class HttpResponseDecoderTest {
         HttpResponse res = ch.readInbound();
         assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
         assertThat(res.status(), is(HttpResponseStatus.OK));
-        assertThat(ch.readInbound(), is(nullValue()));
 
         assertThat(ch.finish(), is(true));
 
@@ -316,9 +315,30 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
+    public void testLastResponseWithZeroContentLengthHeader() {
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
+        ch.writeInbound(Unpooled.copiedBuffer("HTTP/1.1 404 Not found\r\n" +
+                "Content-Length: 0\r\n\r\n" , CharsetUtil.US_ASCII));
+
+        HttpResponse res = ch.readInbound();
+        assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
+        assertThat(res.status(), is(HttpResponseStatus.NOT_FOUND));
+        assertThat(res.headers().get(HttpHeaderNames.CONTENT_LENGTH), is("0"));
+
+        assertThat(ch.finish(), is(true));
+
+        LastHttpContent lastContent = ch.readInbound();
+        assertThat(lastContent.content().isReadable(), is(false));
+        lastContent.release();
+
+        assertThat(ch.readInbound(), is(nullValue()));
+    }
+
+    @Test
     public void testLastResponseWithoutContentLengthHeader() {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
-        ch.writeInbound(Unpooled.copiedBuffer("HTTP/1.1 200 OK\r\n\r\n", CharsetUtil.US_ASCII));
+        ch.writeInbound(Unpooled.copiedBuffer("HTTP/1.1 200 OK\r\n" +
+                "Transfer-Encoding: identity\r\n\r\n" , CharsetUtil.US_ASCII));
 
         HttpResponse res = ch.readInbound();
         assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
@@ -340,10 +360,30 @@ public class HttpResponseDecoderTest {
     }
 
     @Test
+    public void testTemporaryRedirectResponse() {
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
+        ch.writeInbound(Unpooled.copiedBuffer("HTTP/1.1 302 Found\r\nlocation: /tmp\r\n\r\n", CharsetUtil.US_ASCII));
+
+        HttpResponse res = ch.readInbound();
+        assertThat(res.protocolVersion(), sameInstance(HttpVersion.HTTP_1_1));
+        assertThat(res.status(), is(HttpResponseStatus.FOUND));
+
+        assertThat(ch.finish(), is(true));
+
+        LastHttpContent lastContent = ch.readInbound();
+        assertThat(lastContent.content().isReadable(), is(false));
+        lastContent.release();
+
+        assertThat(ch.readInbound(), is(nullValue()));
+    }
+
+    @Test
     public void testLastResponseWithHeaderRemoveTrailingSpaces() {
         EmbeddedChannel ch = new EmbeddedChannel(new HttpResponseDecoder());
         ch.writeInbound(Unpooled.copiedBuffer(
-                "HTTP/1.1 200 OK\r\nX-Header: h2=h2v2; Expires=Wed, 09-Jun-2021 10:18:14 GMT       \r\n\r\n",
+                "HTTP/1.1 200 OK\r\n" +
+                        "Transfer-Encoding: identity\r\n" +
+                        "X-Header: h2=h2v2; Expires=Wed, 09-Jun-2021 10:18:14 GMT       \r\n\r\n",
                 CharsetUtil.US_ASCII));
 
         HttpResponse res = ch.readInbound();


### PR DESCRIPTION
Motivation:
To fix pipelining of http response messages when some
of the responses are treated as http content i.e. following 302 redirect
message.

Modifications:
Modified HttpObjectDecoder behaviour to properly handle messages with
empty content introducing hasEmptyContent method in HttpUtil. Also
modified some tests to take into account this new behaviour.

Result:
Assume zero length content if no transfer-encoding or content-length header
fields are present