### PR TITLE
fix SctpMessage duplicate behavior

### DIFF
--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
@@ -160,7 +160,7 @@ public final class SctpMessage extends DefaultByteBufHolder {
         if (msgInfo == null) {
             return new SctpMessage(protocolIdentifier, streamIdentifier, unordered, content().duplicate());
         } else {
-            return new SctpMessage(msgInfo, content().copy());
+            return new SctpMessage(msgInfo, content().duplicate());
         }
     }
 


### PR DESCRIPTION
duplicate content of ByteBufHolder instead of copying