### PR TITLE
Enable Handlers to be added to EmbeddedChannel post creation.

### DIFF
--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannelPipeline.java
@@ -1,0 +1,470 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.embedded;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelHandlerInvoker;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel.LastInboundHandler;
+import io.netty.util.concurrent.EventExecutorGroup;
+
+import java.net.SocketAddress;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static io.netty.channel.embedded.EmbeddedChannel.LAST_HANDLER_NAME;
+
+/**
+ * A {@link ChannelPipeline} implementation used by {@link EmbeddedChannel}. This pipeline implementation assures that
+ * the {@link io.netty.channel.embedded.EmbeddedChannel.LastInboundHandler} in the embedded channel is always the last
+ * irrespective of the fact if the channel pipeline is modified post channel creation.
+ */
+final class EmbeddedChannelPipeline implements ChannelPipeline {
+
+    private final ChannelPipeline delegate;
+
+    public EmbeddedChannelPipeline(ChannelPipeline delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ChannelPipeline addFirst(String name, ChannelHandler handler) {
+        delegate.addFirst(name, handler);
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addFirst(EventExecutorGroup group, String name,
+                                    ChannelHandler handler) {
+        delegate.addFirst(group, name, handler);
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addFirst(ChannelHandlerInvoker invoker, String name,
+                                    ChannelHandler handler) {
+        delegate.addFirst(invoker, name, handler);
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addLast(String name, ChannelHandler handler) {
+        if (hasLastInboundHandler()) {
+            delegate.addBefore(LAST_HANDLER_NAME, name, handler);
+        } else {
+            delegate.addLast(name, handler);
+        }
+        return this;
+    }
+
+    private boolean hasLastInboundHandler() {
+        return delegate.get(LAST_HANDLER_NAME) != null;
+    }
+
+    @Override
+    public ChannelPipeline addLast(EventExecutorGroup group, String name,
+                                   ChannelHandler handler) {
+        if (hasLastInboundHandler()) {
+            delegate.addBefore(group, LAST_HANDLER_NAME, name, handler);
+        } else {
+            delegate.addLast(group, name, handler);
+        }
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addLast(ChannelHandlerInvoker invoker, String name,
+                                   ChannelHandler handler) {
+        if (hasLastInboundHandler()) {
+            delegate.addBefore(invoker, LAST_HANDLER_NAME, name, handler);
+        } else {
+            delegate.addLast(invoker, name, handler);
+        }
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addBefore(String baseName, String name, ChannelHandler handler) {
+        delegate.addBefore(baseName, name, handler);
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addBefore(EventExecutorGroup group, String baseName,
+                                     String name, ChannelHandler handler) {
+        delegate.addBefore(group, baseName, name, handler);
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addBefore(ChannelHandlerInvoker invoker, String baseName, String name,
+                                     ChannelHandler handler) {
+        delegate.addBefore(invoker, baseName, name, handler);
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addAfter(String baseName, String name, ChannelHandler handler) {
+        delegate.addAfter(baseName, name, handler);
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addAfter(EventExecutorGroup group, String baseName,
+                                    String name, ChannelHandler handler) {
+        delegate.addAfter(group, baseName, name, handler);
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addAfter(ChannelHandlerInvoker invoker, String baseName, String name,
+                                    ChannelHandler handler) {
+        delegate.addAfter(invoker, baseName, name, handler);
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addFirst(ChannelHandler... handlers) {
+        delegate.addFirst(handlers);
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addFirst(EventExecutorGroup group,
+                                    ChannelHandler... handlers) {
+        delegate.addFirst(group, handlers);
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addFirst(ChannelHandlerInvoker invoker,
+                                    ChannelHandler... handlers) {
+        delegate.addFirst(invoker, handlers);
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addLast(ChannelHandler... handlers) {
+        if (hasLastInboundHandler()) {
+            for (ChannelHandler handler : handlers) {
+                delegate.addBefore(LAST_HANDLER_NAME, null, handler);
+            }
+        } else {
+            delegate.addLast(handlers);
+        }
+
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addLast(EventExecutorGroup group, ChannelHandler... handlers) {
+        if (hasLastInboundHandler()) {
+            for (ChannelHandler handler : handlers) {
+                delegate.addBefore(group, LAST_HANDLER_NAME, null, handler);
+            }
+        } else {
+            delegate.addLast(handlers);
+        }
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline addLast(ChannelHandlerInvoker invoker, ChannelHandler... handlers) {
+        if (hasLastInboundHandler()) {
+            for (ChannelHandler handler : handlers) {
+                delegate.addBefore(invoker, LAST_HANDLER_NAME, null, handler);
+            }
+        } else {
+            delegate.addLast(handlers);
+        }
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline remove(ChannelHandler handler) {
+        delegate.remove(handler);
+        return this;
+    }
+
+    @Override
+    public ChannelHandler remove(String name) {
+        return delegate.remove(name);
+    }
+
+    @Override
+    public <T extends ChannelHandler> T remove(Class<T> handlerType) {
+        return delegate.remove(handlerType);
+    }
+
+    @Override
+    public ChannelHandler removeFirst() {
+        return delegate.removeFirst();
+    }
+
+    @Override
+    public ChannelHandler removeLast() {
+        ChannelHandler lastHandler = delegate.last();
+        if (lastHandler instanceof LastInboundHandler) {
+            /*Since there is no easy way to remove the second last handler, this code removes the last two handlers and
+            * then add back LastInboundHandler.*/
+            delegate.removeLast(); /*Remove the LIH*/
+            ChannelHandler actualLast = delegate.removeLast(); /*Remove the actual last handler*/
+            delegate.addLast(LAST_HANDLER_NAME, lastHandler);
+            return actualLast;
+        } else {
+            return delegate.removeLast();
+        }
+    }
+
+    @Override
+    public ChannelPipeline replace(ChannelHandler oldHandler, String newName,
+                                   ChannelHandler newHandler) {
+        delegate.replace(oldHandler, newName, newHandler);
+        return this;
+    }
+
+    @Override
+    public ChannelHandler replace(String oldName, String newName,
+                                  ChannelHandler newHandler) {
+        return delegate.replace(oldName, newName, newHandler);
+    }
+
+    @Override
+    public <T extends ChannelHandler> T replace(Class<T> oldHandlerType, String newName,
+                                                ChannelHandler newHandler) {
+        return delegate.replace(oldHandlerType, newName, newHandler);
+    }
+
+    @Override
+    public ChannelHandler first() {
+        return delegate.first();
+    }
+
+    @Override
+    public ChannelHandlerContext firstContext() {
+        return delegate.firstContext();
+    }
+
+    @Override
+    public ChannelHandler last() {
+        return delegate.last();
+    }
+
+    @Override
+    public ChannelHandlerContext lastContext() {
+        return delegate.lastContext();
+    }
+
+    @Override
+    public ChannelHandler get(String name) {
+        return delegate.get(name);
+    }
+
+    @Override
+    public <T extends ChannelHandler> T get(Class<T> handlerType) {
+        return delegate.get(handlerType);
+    }
+
+    @Override
+    public ChannelHandlerContext context(ChannelHandler handler) {
+        return delegate.context(handler);
+    }
+
+    @Override
+    public ChannelHandlerContext context(String name) {
+        return delegate.context(name);
+    }
+
+    @Override
+    public ChannelHandlerContext context(
+            Class<? extends ChannelHandler> handlerType) {
+        return delegate.context(handlerType);
+    }
+
+    @Override
+    public Channel channel() {
+        return delegate.channel();
+    }
+
+    @Override
+    public List<String> names() {
+        return delegate.names();
+    }
+
+    @Override
+    public Map<String, ChannelHandler> toMap() {
+        return delegate.toMap();
+    }
+
+    @Override
+    public ChannelPipeline fireChannelRegistered() {
+        delegate.fireChannelRegistered();
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline fireChannelUnregistered() {
+        delegate.fireChannelUnregistered();
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline fireChannelActive() {
+        delegate.fireChannelActive();
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline fireChannelInactive() {
+        delegate.fireChannelInactive();
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline fireExceptionCaught(Throwable cause) {
+        delegate.fireExceptionCaught(cause);
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline fireUserEventTriggered(Object event) {
+        delegate.fireUserEventTriggered(event);
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline fireChannelRead(Object msg) {
+        delegate.fireChannelRead(msg);
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline fireChannelReadComplete() {
+        delegate.fireChannelReadComplete();
+        return this;
+    }
+
+    @Override
+    public ChannelPipeline fireChannelWritabilityChanged() {
+        delegate.fireChannelWritabilityChanged();
+        return this;
+    }
+
+    @Override
+    public ChannelFuture bind(SocketAddress localAddress) {
+        return delegate.bind(localAddress);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress) {
+        return delegate.connect(remoteAddress);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress) {
+        return delegate.connect(remoteAddress, localAddress);
+    }
+
+    @Override
+    public ChannelFuture disconnect() {
+        return delegate.disconnect();
+    }
+
+    @Override
+    public ChannelFuture close() {
+        return delegate.close();
+    }
+
+    @Override
+    public ChannelFuture deregister() {
+        return delegate.deregister();
+    }
+
+    @Override
+    public ChannelFuture bind(SocketAddress localAddress, ChannelPromise promise) {
+        return delegate.bind(localAddress, promise);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress,
+                                 ChannelPromise promise) {
+        return delegate.connect(remoteAddress, promise);
+    }
+
+    @Override
+    public ChannelFuture connect(SocketAddress remoteAddress, SocketAddress localAddress,
+                                 ChannelPromise promise) {
+        return delegate.connect(remoteAddress, localAddress, promise);
+    }
+
+    @Override
+    public ChannelFuture disconnect(ChannelPromise promise) {
+        return delegate.disconnect(promise);
+    }
+
+    @Override
+    public ChannelFuture close(ChannelPromise promise) {
+        return delegate.close(promise);
+    }
+
+    @Override
+    public ChannelFuture deregister(ChannelPromise promise) {
+        return delegate.deregister(promise);
+    }
+
+    @Override
+    public ChannelPipeline read() {
+        delegate.read();
+        return this;
+    }
+
+    @Override
+    public ChannelFuture write(Object msg) {
+        return delegate.write(msg);
+    }
+
+    @Override
+    public ChannelFuture write(Object msg, ChannelPromise promise) {
+        return delegate.write(msg, promise);
+    }
+
+    @Override
+    public ChannelPipeline flush() {
+        delegate.flush();
+        return this;
+    }
+
+    @Override
+    public ChannelFuture writeAndFlush(Object msg, ChannelPromise promise) {
+        return delegate.writeAndFlush(msg, promise);
+    }
+
+    @Override
+    public ChannelFuture writeAndFlush(Object msg) {
+        return delegate.writeAndFlush(msg);
+    }
+
+    @Override
+    public Iterator<Entry<String, ChannelHandler>> iterator() {
+        return delegate.iterator();
+    }
+}

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelPipelineTestRealChannel.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelPipelineTestRealChannel.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */package io.netty.channel.embedded;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerInvoker;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.embedded.EmbeddedChannel.LastInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.concurrent.EventExecutorGroup;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.mockito.Mockito;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+public class EmbeddedChannelPipelineTestRealChannel {
+
+    @Rule
+    public final EmbeddedChannelRule channelRule = new EmbeddedChannelRule();
+
+    @Test(timeout = 60000)
+    public void testAddLast() throws Exception {
+        ChannelPipeline pipeline = channelRule.embeddedPipeline.addLast("last-handler", channelRule.mockHandler);
+        assertThat("Unexpected pipeline instance returned.", pipeline, is(instanceOf(EmbeddedChannelPipeline.class)));
+        assertThat("Unexpected last handler in the pipeline.", pipeline.last(),
+                   is(instanceOf(LastInboundHandler.class)));
+    }
+
+    @Test(timeout = 60000)
+    public void testAddLastWithGroup() throws Exception {
+        ChannelPipeline pipeline = channelRule.embeddedPipeline.addLast(channelRule.group, "last-handler",
+                                                                        channelRule.mockHandler);
+        assertThat("Unexpected pipeline instance returned.", pipeline, is(instanceOf(EmbeddedChannelPipeline.class)));
+        assertThat("Unexpected last handler in the pipeline.", pipeline.last(),
+                   is(instanceOf(LastInboundHandler.class)));
+    }
+
+    @Test(timeout = 60000)
+    public void testAddLastWithInvoker() throws Exception {
+        ChannelPipeline pipeline = channelRule.embeddedPipeline.addLast(channelRule.invoker, "last-handler",
+                                                                        channelRule.mockHandler);
+        assertThat("Unexpected pipeline instance returned.", pipeline, is(instanceOf(EmbeddedChannelPipeline.class)));
+        assertThat("Unexpected last handler in the pipeline.", pipeline.last(),
+                   is(instanceOf(LastInboundHandler.class)));
+    }
+
+    @Test(timeout = 60000)
+    public void testAddLastMulti() throws Exception {
+        ChannelPipeline pipeline = channelRule.embeddedPipeline.addLast(channelRule.invoker,
+                                                                        channelRule.mockHandler);
+        assertThat("Unexpected pipeline instance returned.", pipeline, is(instanceOf(EmbeddedChannelPipeline.class)));
+        assertThat("Unexpected last handler in the pipeline.", pipeline.last(),
+                   is(instanceOf(LastInboundHandler.class)));
+    }
+
+    @Test(timeout = 60000)
+    public void testAddLastMultiWithGroup() throws Exception {
+        ChannelPipeline pipeline = channelRule.embeddedPipeline.addLast(channelRule.group, channelRule.mockHandler,
+                                                                        channelRule.mockHandler);
+        assertThat("Unexpected pipeline instance returned.", pipeline, is(instanceOf(EmbeddedChannelPipeline.class)));
+        assertThat("Unexpected last handler in the pipeline.", pipeline.last(),
+                   is(instanceOf(LastInboundHandler.class)));
+    }
+
+    @Test(timeout = 60000)
+    public void testAddLastMultiWithInvoker() throws Exception {
+        ChannelPipeline pipeline = channelRule.embeddedPipeline.addLast(channelRule.invoker,
+                                                                        channelRule.mockHandler,
+                                                                        channelRule.mockHandler);
+        assertThat("Unexpected pipeline instance returned.", pipeline, is(instanceOf(EmbeddedChannelPipeline.class)));
+        assertThat("Unexpected last handler in the pipeline.", pipeline.last(),
+                   is(instanceOf(LastInboundHandler.class)));
+    }
+
+    public static class EmbeddedChannelRule extends ExternalResource {
+
+        private EventExecutorGroup group;
+        private ChannelHandler mockHandler;
+        private ChannelHandlerInvoker invoker;
+        private EmbeddedChannel embeddedChannel;
+        private EmbeddedChannelPipeline embeddedPipeline;
+
+        @Override
+        public Statement apply(final Statement base, Description description) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    embeddedChannel = new EmbeddedChannel();
+                    embeddedPipeline = (EmbeddedChannelPipeline) embeddedChannel.pipeline();
+                    group = new NioEventLoopGroup();
+                    invoker = embeddedChannel.eventLoop().asInvoker();
+                    mockHandler = Mockito.mock(ChannelHandler.class);
+                    base.evaluate();
+                }
+            };
+        }
+    }
+}

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelPipelineTestWithMockDelegate.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelPipelineTestWithMockDelegate.java
@@ -1,0 +1,634 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */package io.netty.channel.embedded;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerInvoker;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel.LastInboundHandler;
+import io.netty.util.concurrent.EventExecutorGroup;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.net.InetSocketAddress;
+
+import static io.netty.channel.embedded.EmbeddedChannel.LAST_HANDLER_NAME;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EmbeddedChannelPipelineTestWithMockDelegate {
+
+    private static final String HANDLER_NAME = "handler";
+    private static final String HANDLER_NAME_DUMMY = "dummy-handler";
+
+    @Mock
+    private ChannelPipeline delegate;
+    @Mock
+    private EventExecutorGroup mockGroup;
+    @Mock
+    private ChannelHandler mockHandler;
+    @Mock
+    private ChannelHandlerInvoker mockInvoker;
+    @Mock
+    private ChannelPromise mockPromise;
+
+    @Test(timeout = 60000)
+    public void testAddFirst() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addFirst(HANDLER_NAME, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).addFirst(HANDLER_NAME, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddFirstWithGroup() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addFirst(mockGroup, HANDLER_NAME, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).addFirst(mockGroup, HANDLER_NAME, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddFirstWithInvoker() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addFirst(mockInvoker, HANDLER_NAME, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).addFirst(mockInvoker, HANDLER_NAME, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddLast() throws Exception {
+        Mockito.when(delegate.get(LAST_HANDLER_NAME)).thenReturn(mockHandler);
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addLast(HANDLER_NAME, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).get(LAST_HANDLER_NAME);
+        Mockito.verify(delegate).addBefore(LAST_HANDLER_NAME, HANDLER_NAME,  mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddLastWithGroup() throws Exception {
+        Mockito.when(delegate.get(LAST_HANDLER_NAME)).thenReturn(mockHandler);
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addLast(mockGroup, HANDLER_NAME, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).get(LAST_HANDLER_NAME);
+        Mockito.verify(delegate).addBefore(mockGroup, LAST_HANDLER_NAME, HANDLER_NAME,  mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddLastWithInvoker() throws Exception {
+        Mockito.when(delegate.get(LAST_HANDLER_NAME)).thenReturn(mockHandler);
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addLast(mockInvoker, HANDLER_NAME, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).get(LAST_HANDLER_NAME);
+        Mockito.verify(delegate).addBefore(mockInvoker, LAST_HANDLER_NAME, HANDLER_NAME,  mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddBefore() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addBefore(HANDLER_NAME_DUMMY, HANDLER_NAME, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).addBefore(HANDLER_NAME_DUMMY, HANDLER_NAME, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddBeforeWithGroup() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addBefore(mockGroup, HANDLER_NAME_DUMMY, HANDLER_NAME, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).addBefore(mockGroup, HANDLER_NAME_DUMMY, HANDLER_NAME, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddBeforeWithInvoker() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addBefore(mockInvoker, HANDLER_NAME_DUMMY, HANDLER_NAME, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).addBefore(mockInvoker, HANDLER_NAME_DUMMY, HANDLER_NAME, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddAfter() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addAfter(HANDLER_NAME_DUMMY, HANDLER_NAME, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).addAfter(HANDLER_NAME_DUMMY, HANDLER_NAME, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddAfterWithGroup() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addAfter(mockGroup, HANDLER_NAME_DUMMY, HANDLER_NAME, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).addAfter(mockGroup, HANDLER_NAME_DUMMY, HANDLER_NAME, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddAfterWithInvoker() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addAfter(mockInvoker, HANDLER_NAME_DUMMY, HANDLER_NAME, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).addAfter(mockInvoker, HANDLER_NAME_DUMMY, HANDLER_NAME, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddFirstMulti() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addFirst(mockHandler, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).addFirst(mockHandler, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddFirstMultiWithGroup() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addFirst(mockGroup, mockHandler, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).addFirst(mockGroup, mockHandler, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddFirstMultiWithInvoker() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addFirst(mockInvoker, mockHandler, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).addFirst(mockInvoker, mockHandler, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddLastMulti() throws Exception {
+        Mockito.when(delegate.get(LAST_HANDLER_NAME)).thenReturn(mockHandler);
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addLast(mockHandler, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate, times(2)).addBefore(LAST_HANDLER_NAME, null, mockHandler);
+        Mockito.verify(delegate).get(LAST_HANDLER_NAME);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddLastMultiWithGroup() throws Exception {
+        Mockito.when(delegate.get(LAST_HANDLER_NAME)).thenReturn(mockHandler);
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addLast(mockGroup, mockHandler, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).get(LAST_HANDLER_NAME);
+        Mockito.verify(delegate, times(2)).addBefore(mockGroup, LAST_HANDLER_NAME, null, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testAddLastMultiWithInvoker() throws Exception {
+        Mockito.when(delegate.get(LAST_HANDLER_NAME)).thenReturn(mockHandler);
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.addLast(mockInvoker, mockHandler, mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).get(LAST_HANDLER_NAME);
+        Mockito.verify(delegate, times(2)).addBefore(mockInvoker, LAST_HANDLER_NAME, null, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testRemove() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.remove(mockHandler);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).remove(mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testRemoveByName() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.remove(HANDLER_NAME);
+        Mockito.verify(delegate).remove(HANDLER_NAME);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testRemoveByClass() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.remove(mockHandler.getClass());
+        Mockito.verify(delegate).remove(mockHandler.getClass());
+    }
+
+    @Test(timeout = 60000)
+    public void testRemoveFirst() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.removeFirst();
+        Mockito.verify(delegate).removeFirst();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testRemoveLast() throws Exception {
+        EmbeddedChannel ec = new EmbeddedChannel();
+        LastInboundHandler lih = ec.new LastInboundHandler();
+
+        Mockito.when(delegate.last()).thenReturn(lih);
+
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelHandler removed = ecp.removeLast();
+        assertThat("Last Inbound Handler removed.", removed, is(nullValue()));
+        Mockito.verify(delegate, times(2)).removeLast();
+        Mockito.verify(delegate).addLast(LAST_HANDLER_NAME, lih);
+    }
+
+    @Test(timeout = 60000)
+    public void testReplace() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.replace(mockHandler, HANDLER_NAME, mockHandler);
+        Mockito.verify(delegate).replace(mockHandler, HANDLER_NAME, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testReplaceByName() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.replace(HANDLER_NAME, HANDLER_NAME, mockHandler);
+        Mockito.verify(delegate).replace(HANDLER_NAME, HANDLER_NAME, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testReplaceByClass() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.replace(mockHandler.getClass(), HANDLER_NAME, mockHandler);
+        Mockito.verify(delegate).replace(mockHandler.getClass(), HANDLER_NAME, mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testFirst() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.first();
+        Mockito.verify(delegate).first();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testFirstContext() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.firstContext();
+        Mockito.verify(delegate).firstContext();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testLast() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.last();
+        Mockito.verify(delegate).last();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testLastContext() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.lastContext();
+        Mockito.verify(delegate).lastContext();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testGetByName() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.get(HANDLER_NAME);
+        Mockito.verify(delegate).get(HANDLER_NAME);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testGetByClass() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.get(mockHandler.getClass());
+        Mockito.verify(delegate).get(mockHandler.getClass());
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testContextByName() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.context(HANDLER_NAME);
+        Mockito.verify(delegate).context(HANDLER_NAME);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testContextByClass() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.context(mockHandler.getClass());
+        Mockito.verify(delegate).context(mockHandler.getClass());
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testContextByHandler() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.context(mockHandler);
+        Mockito.verify(delegate).context(mockHandler);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testChannel() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.channel();
+        Mockito.verify(delegate).channel();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testNames() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.names();
+        Mockito.verify(delegate).names();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testToMap() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.toMap();
+        Mockito.verify(delegate).toMap();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testFireChannelRegistered() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.fireChannelRegistered();
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).fireChannelRegistered();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testFireChannelUnregistered() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.fireChannelUnregistered();
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).fireChannelUnregistered();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testFireChannelActive() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.fireChannelActive();
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).fireChannelActive();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testFireChannelInactive() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.fireChannelInactive();
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).fireChannelInactive();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testFireExceptionCaught() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        Throwable t = new IllegalStateException();
+        ChannelPipeline cp = ecp.fireExceptionCaught(t);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).fireExceptionCaught(t);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testFireUserEventTriggered() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        Throwable t = new IllegalStateException();
+        ChannelPipeline cp = ecp.fireUserEventTriggered(t);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).fireUserEventTriggered(t);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testFireChannelRead() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        Throwable t = new IllegalStateException();
+        ChannelPipeline cp = ecp.fireChannelRead(t);
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).fireChannelRead(t);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testFireChannelReadComplete() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.fireChannelReadComplete();
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).fireChannelReadComplete();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testFireChannelWritabilityChanged() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ChannelPipeline cp = ecp.fireChannelWritabilityChanged();
+        assertThat("Unexpected returned pipeline instance.", cp, is(ecp));
+        Mockito.verify(delegate).fireChannelWritabilityChanged();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testBind() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        InetSocketAddress address = new InetSocketAddress(0);
+        ecp.bind(address);
+        Mockito.verify(delegate).bind(address);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testConnect() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        InetSocketAddress address = new InetSocketAddress(0);
+        ecp.connect(address);
+        Mockito.verify(delegate).connect(address);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testConnectWithLocalAndRemote() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        InetSocketAddress address = new InetSocketAddress(0);
+        ecp.connect(address, address);
+        Mockito.verify(delegate).connect(address, address);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testDisconnect() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.disconnect();
+        Mockito.verify(delegate).disconnect();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testClose() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.close();
+        Mockito.verify(delegate).close();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testDeregister() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.deregister();
+        Mockito.verify(delegate).deregister();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testBindWithPromise() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        InetSocketAddress address = new InetSocketAddress(0);
+        ecp.bind(address, mockPromise);
+        Mockito.verify(delegate).bind(address, mockPromise);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testConnectWithPromise() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        InetSocketAddress address = new InetSocketAddress(0);
+        ecp.connect(address, mockPromise);
+        Mockito.verify(delegate).connect(address, mockPromise);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testConnectWithRemoteAndPromise() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        InetSocketAddress address = new InetSocketAddress(0);
+        ecp.connect(address, address, mockPromise);
+        Mockito.verify(delegate).connect(address, address, mockPromise);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testDisconnectWithPromise() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.disconnect(mockPromise);
+        Mockito.verify(delegate).disconnect(mockPromise);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testCloseWithPromise() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.close(mockPromise);
+        Mockito.verify(delegate).close(mockPromise);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testDeregisterWithPromise() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.deregister(mockPromise);
+        Mockito.verify(delegate).deregister(mockPromise);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testRead() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.read();
+        Mockito.verify(delegate).read();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testWrite() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.write("");
+        Mockito.verify(delegate).write("");
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testWriteWithPromise() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.write("", mockPromise);
+        Mockito.verify(delegate).write("", mockPromise);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testFlush() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.flush();
+        Mockito.verify(delegate).flush();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testWriteAndFlush() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.writeAndFlush("");
+        Mockito.verify(delegate).writeAndFlush("");
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testWriteAndFlushWithPromise() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.writeAndFlush("", mockPromise);
+        Mockito.verify(delegate).writeAndFlush("", mockPromise);
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+
+    @Test(timeout = 60000)
+    public void testIterator() throws Exception {
+        ChannelPipeline ecp = new EmbeddedChannelPipeline(delegate);
+        ecp.iterator();
+        Mockito.verify(delegate).iterator();
+        Mockito.verifyNoMoreInteractions(delegate);
+    }
+}


### PR DESCRIPTION
##### Motivation

Today EmbeddedChannel adds a `LastInboundHandler` which is always expected to be the last inbound handler as it does not propagate any messages read, further in the pipeline.
This expectation is broken if the channel's pipeline is modified (specially if a handler is added to the end) after creation. The result of this breakage is that any handler added after the `LastInboundHandler` never receive any messages read on the channel.

##### Modifications

This change uses a specialized `ChannelPipeline` implementation that makes sure that the `LastInboundHandler` is always at the end, unless explicitly modified by handler name, class, etc.
This pipeline implementation uses a delegating pipeline which is created by the original channel.

##### Result

Embedded channel pipeline can be modified post creation without breaking the functionality of the inbound messages.

I have opted for a delegation approach for the `EmbeddedChannelPipeline` because `DefaultChannelPipeline` is package private. So, it does have one more object allocation per channel. If it is ok to make `DefaultChannelPipeline` public, I can redo this change by making `AbstractChannel` in such a way to take a `ChannelPipeline` instance and hence this extra allocation can be reduced.