### PR TITLE
Improve SctpMessage.hashCode method

### DIFF
--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
@@ -142,6 +142,8 @@ public final class SctpMessage extends DefaultByteBufHolder {
     public int hashCode() {
         int result = streamIdentifier;
         result = 31 * result + protocolIdentifier;
+        // values 1231 and 1237 are referenced in the javadocs of Boolean#hashCode()
+        result = 31 * result + (unordered ? 1231 : 1237);
         result = 31 * result + content().hashCode();
         return result;
     }


### PR DESCRIPTION
Motivation:

Not all fields of SctpMessage which used to check message equality are used
to generate hashcode.

Modifications:

Use value of 'unordered' field in hashCode method.

Result:

Better hash function of SctpMessage.