### PR TITLE
Fix for #4658

### DIFF
--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-15"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright 2014 The Netty Project
   ~


### PR DESCRIPTION
Motivation:

transport-native-epoll has its pom.xml encoding attribute set to ISO-8859-15. Because
of this gradle, and other dependency management systems, can't correctly resolve this
library from wherever it happens to be published.

Modifications:

netty/transport-native-epoll/pom.xml had its xml encoding changed to UTF-8

Result:

Gradle, and other dependency management systems, will now be able to correctly resolve this module.