### PR TITLE
fix issue: selectionkeyimpl can't be gced.

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -353,6 +353,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     @Override
     protected void doDeregister() throws Exception {
         eventLoop().cancel(selectionKey());
+        selectionKey=null;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -353,7 +353,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     @Override
     protected void doDeregister() throws Exception {
         eventLoop().cancel(selectionKey());
-        selectionKey=null;
+        selectionKey = null;
     }
 
     @Override


### PR DESCRIPTION
4.0.33 final version:
selectionkeyimpl can't be gc due to exist loop reference:
selectionkeyimpl's attachment is the nio socket, but the nio socket's select key is itself so that the selection key can't be gced.
This will cause too much disconnetions will generated too much memory occupied can't be gced.
![gc](https://cloud.githubusercontent.com/assets/5654180/12136059/cc729246-b47e-11e5-8ca3-f907f41b4db8.png)
