### PR TITLE
Allow to create OpenSslEngine without finalizer

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/FinalizingOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/FinalizingOpenSslEngine.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.buffer.ByteBufAllocator;
+
+import java.security.cert.Certificate;
+
+/**
+ * Special {@link OpenSslEngine} which will ensure {@link #shutdown()} is called via finalizer.
+ */
+final class FinalizingOpenSslEngine extends OpenSslEngine {
+
+    FinalizingOpenSslEngine(long sslCtx, ByteBufAllocator alloc, boolean clientMode,
+                            OpenSslSessionContext sessionContext, OpenSslApplicationProtocolNegotiator apn,
+                            OpenSslEngineMap engineMap, boolean rejectRemoteInitiatedRenegation, String peerHost,
+                            int peerPort, Certificate[] localCerts, ClientAuth clientAuth) {
+        super(sslCtx, alloc, clientMode, sessionContext, apn, engineMap, rejectRemoteInitiatedRenegation, peerHost,
+                peerPort, localCerts, clientAuth);
+    }
+
+    @Override
+    @SuppressWarnings("FinalizeDeclaration")
+    protected void finalize() throws Throwable {
+        super.finalize();
+        // Call shutdown as the user may have created the OpenSslEngine and not used it at all.
+        shutdown();
+    }
+
+}

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -71,6 +71,10 @@ public abstract class OpenSslContext extends SslContext {
      */
     private static final boolean JDK_REJECT_CLIENT_INITIATED_RENEGOTIATION =
             SystemPropertyUtil.getBoolean("jdk.tls.rejectClientInitiatedRenegotiation", false);
+
+    private static final boolean OPEN_SSL_ENGINE_FINALIZER =
+            SystemPropertyUtil.getBoolean("io.netty.handler.ssl.opensslengine.finalizer", true);
+
     private static final List<String> DEFAULT_CIPHERS;
 
     // TODO: Maybe make configurable ?
@@ -306,6 +310,10 @@ public abstract class OpenSslContext extends SslContext {
 
     @Override
     public final SSLEngine newEngine(ByteBufAllocator alloc, String peerHost, int peerPort) {
+        if (OPEN_SSL_ENGINE_FINALIZER) {
+            return new FinalizingOpenSslEngine(ctx, alloc, isClient(), sessionContext(), apn, engineMap,
+                    rejectRemoteInitiatedRenegotiation, peerHost, peerPort, keyCertChain, clientAuth);
+        }
         return new OpenSslEngine(ctx, alloc, isClient(), sessionContext(), apn, engineMap,
                 rejectRemoteInitiatedRenegotiation, peerHost, peerPort, keyCertChain, clientAuth);
     }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -60,8 +60,10 @@ import static javax.net.ssl.SSLEngineResult.Status.*;
 /**
  * Implements a {@link SSLEngine} using
  * <a href="https://www.openssl.org/docs/crypto/BIO_s_bio.html#EXAMPLE">OpenSSL BIO abstractions</a>.
+ *
+ * <strong>Extending this class is strightly forbidden from external projects.</strong>
  */
-public final class OpenSslEngine extends SSLEngine {
+public class OpenSslEngine extends SSLEngine {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(OpenSslEngine.class);
 
@@ -575,7 +577,7 @@ public final class OpenSslEngine extends SSLEngine {
         return new SSLHandshakeException(err);
     }
 
-    public synchronized SSLEngineResult unwrap(
+    public final synchronized SSLEngineResult unwrap(
             final ByteBuffer[] srcs, int srcsOffset, final int srcsLength,
             final ByteBuffer[] dsts, final int dstsOffset, final int dstsLength) throws SSLException {
 
@@ -806,7 +808,7 @@ public final class OpenSslEngine extends SSLEngine {
         }
     }
 
-    public SSLEngineResult unwrap(final ByteBuffer[] srcs, final ByteBuffer[] dsts) throws SSLException {
+    public final SSLEngineResult unwrap(final ByteBuffer[] srcs, final ByteBuffer[] dsts) throws SSLException {
         return unwrap(srcs, 0, srcs.length, dsts, 0, dsts.length);
     }
 
@@ -829,7 +831,7 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public synchronized SSLEngineResult unwrap(
+    public final synchronized SSLEngineResult unwrap(
             final ByteBuffer src, final ByteBuffer[] dsts, final int offset, final int length) throws SSLException {
         try {
             return unwrap(singleSrcBuffer(src), 0, 1, dsts, offset, length);
@@ -839,7 +841,7 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public synchronized SSLEngineResult wrap(ByteBuffer src, ByteBuffer dst) throws SSLException {
+    public final synchronized SSLEngineResult wrap(ByteBuffer src, ByteBuffer dst) throws SSLException {
         try {
             return wrap(singleSrcBuffer(src), dst);
         } finally {
@@ -848,7 +850,7 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public synchronized SSLEngineResult unwrap(ByteBuffer src, ByteBuffer dst) throws SSLException {
+    public final synchronized SSLEngineResult unwrap(ByteBuffer src, ByteBuffer dst) throws SSLException {
         try {
             return unwrap(singleSrcBuffer(src), singleDstBuffer(dst));
         } finally {
@@ -858,7 +860,7 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public synchronized SSLEngineResult unwrap(ByteBuffer src, ByteBuffer[] dsts) throws SSLException {
+    public final synchronized SSLEngineResult unwrap(ByteBuffer src, ByteBuffer[] dsts) throws SSLException {
         try {
             return unwrap(singleSrcBuffer(src), dsts);
         } finally {
@@ -875,7 +877,7 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public synchronized void closeInbound() throws SSLException {
+    public final synchronized void closeInbound() throws SSLException {
         if (isInboundDone) {
             return;
         }
@@ -892,12 +894,12 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public synchronized boolean isInboundDone() {
+    public final synchronized boolean isInboundDone() {
         return isInboundDone || engineClosed;
     }
 
     @Override
-    public synchronized void closeOutbound() {
+    public final synchronized void closeOutbound() {
         if (isOutboundDone) {
             return;
         }
@@ -942,18 +944,18 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public synchronized boolean isOutboundDone() {
+    public final synchronized boolean isOutboundDone() {
         return isOutboundDone;
     }
 
     @Override
-    public String[] getSupportedCipherSuites() {
+    public final String[] getSupportedCipherSuites() {
         Set<String> availableCipherSuites = OpenSsl.availableCipherSuites();
         return availableCipherSuites.toArray(new String[availableCipherSuites.size()]);
     }
 
     @Override
-    public String[] getEnabledCipherSuites() {
+    public final String[] getEnabledCipherSuites() {
         final String[] enabled;
         synchronized (this) {
             if (!isDestroyed()) {
@@ -976,7 +978,7 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public void setEnabledCipherSuites(String[] cipherSuites) {
+    public final void setEnabledCipherSuites(String[] cipherSuites) {
         checkNotNull(cipherSuites, "cipherSuites");
 
         final StringBuilder buf = new StringBuilder();
@@ -1019,12 +1021,12 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public String[] getSupportedProtocols() {
+    public final String[] getSupportedProtocols() {
         return SUPPORTED_PROTOCOLS.clone();
     }
 
     @Override
-    public String[] getEnabledProtocols() {
+    public final String[] getEnabledProtocols() {
         List<String> enabled = InternalThreadLocalMap.get().arrayList();
         // Seems like there is no way to explict disable SSLv2Hello in openssl so it is always enabled
         enabled.add(PROTOCOL_SSL_V2_HELLO);
@@ -1056,7 +1058,7 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public void setEnabledProtocols(String[] protocols) {
+    public final void setEnabledProtocols(String[] protocols) {
         if (protocols == null) {
             // This is correct from the API docs
             throw new IllegalArgumentException();
@@ -1117,12 +1119,12 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public SSLSession getSession() {
+    public final SSLSession getSession() {
         return session;
     }
 
     @Override
-    public synchronized void beginHandshake() throws SSLException {
+    public final synchronized void beginHandshake() throws SSLException {
         switch (handshakeState) {
             case STARTED_IMPLICITLY:
                 checkEngineClosed();
@@ -1251,7 +1253,7 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public synchronized SSLEngineResult.HandshakeStatus getHandshakeStatus() {
+    public final synchronized SSLEngineResult.HandshakeStatus getHandshakeStatus() {
         // Check if we are in the initial handshake phase or shutdown phase
         return needPendingStatus() ? pendingStatus(SSL.pendingWrittenBytesInBIO(networkBIO)) : NOT_HANDSHAKING;
     }
@@ -1300,34 +1302,34 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public void setUseClientMode(boolean clientMode) {
+    public final void setUseClientMode(boolean clientMode) {
         if (clientMode != this.clientMode) {
             throw new UnsupportedOperationException();
         }
     }
 
     @Override
-    public boolean getUseClientMode() {
+    public final boolean getUseClientMode() {
         return clientMode;
     }
 
     @Override
-    public void setNeedClientAuth(boolean b) {
+    public final void setNeedClientAuth(boolean b) {
         setClientAuth(b ? ClientAuth.REQUIRE : ClientAuth.NONE);
     }
 
     @Override
-    public boolean getNeedClientAuth() {
+    public final boolean getNeedClientAuth() {
         return clientAuth == ClientAuth.REQUIRE;
     }
 
     @Override
-    public void setWantClientAuth(boolean b) {
+    public final void setWantClientAuth(boolean b) {
         setClientAuth(b ? ClientAuth.OPTIONAL : ClientAuth.NONE);
     }
 
     @Override
-    public boolean getWantClientAuth() {
+    public final boolean getWantClientAuth() {
         return clientAuth == ClientAuth.OPTIONAL;
     }
 
@@ -1356,19 +1358,19 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public void setEnableSessionCreation(boolean b) {
+    public final void setEnableSessionCreation(boolean b) {
         if (b) {
             throw new UnsupportedOperationException();
         }
     }
 
     @Override
-    public boolean getEnableSessionCreation() {
+    public final boolean getEnableSessionCreation() {
         return false;
     }
 
     @Override
-    public SSLParameters getSSLParameters() {
+    public final SSLParameters getSSLParameters() {
         SSLParameters sslParameters = super.getSSLParameters();
 
         if (PlatformDependent.javaVersion() >= 7) {
@@ -1379,21 +1381,13 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public void setSSLParameters(SSLParameters sslParameters) {
+    public final void setSSLParameters(SSLParameters sslParameters) {
         super.setSSLParameters(sslParameters);
 
         if (PlatformDependent.javaVersion() >= 7) {
             endPointIdentificationAlgorithm = sslParameters.getEndpointIdentificationAlgorithm();
             algorithmConstraints = sslParameters.getAlgorithmConstraints();
         }
-    }
-
-    @Override
-    @SuppressWarnings("FinalizeDeclaration")
-    protected void finalize() throws Throwable {
-        super.finalize();
-        // Call shutdown as the user may have created the OpenSslEngine and not used it at all.
-        shutdown();
     }
 
     private boolean isDestroyed() {


### PR DESCRIPTION
Motivation:

Whenever a new object is created that overrides finalize() some extra work must be done by the JVM which involved more object creation, more GC runs and other overhead. Our initial OpenSslEngine implementation did override finalize() to ensure we always release the native memory that was allocated before even if the user never used the OpenSslEngine at all. This is not really needed for the use-case of SslHandler in most cases, so we should allow the user to not create an OpenSslEngine with finalizer.

Modifications:

- Create FinalizedOpenSslEngine that extends OpenSslEngine and move the finalize() method from OpenSslEngine to FinalizedOpenSslEngine
- introduce new system property which allows the user to specify that the finalizer is not needed. In this case SslContext can create an OpenSslEngine that not override finalize().

Result:

Less overhead when OpenSslEngine is frequently allocated / deallocated.