### PR TITLE
[#4637] More helpful exception message when a non PKCS#8 key is used.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/PemReader.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemReader.java
@@ -125,7 +125,8 @@ final class PemReader {
 
         Matcher m = KEY_PATTERN.matcher(content);
         if (!m.find()) {
-            throw new KeyException("found no private key in input stream");
+            throw new KeyException("could not find a PKCS #8 private key in input stream" +
+                    " (see http://netty.io/wiki/sslcontextbuilder-and-private-key.html for more information)");
         }
 
         ByteBuf base64 = Unpooled.copiedBuffer(m.group(1), CharsetUtil.US_ASCII);


### PR DESCRIPTION
Motivation:

We should throw a more helpful exception when a non PKCS#8 key is used by the user.

Modifications:

Change exception message to give a hint what is wrong.

Result:

Easier for user to understand whats wrong with their used key.