### PR TITLE
Introduce DnsCache API + DnsResolver extensibility

### DIFF
--- a/common/src/main/java/io/netty/util/internal/ObjectUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectUtil.java
@@ -76,4 +76,24 @@ public final class ObjectUtil {
         checkPositive(array.length, name + ".length");
         return array;
     }
+
+    /**
+     * Resolves a possibly null Integer to a primitive int, using a default value.
+     * @param wrapper the wrapper
+     * @param defaultValue the default value
+     * @return the primitive value
+     */
+    public static int intValue(Integer wrapper, int defaultValue) {
+        return wrapper != null ? wrapper.intValue() : defaultValue;
+    }
+
+    /**
+     * Resolves a possibly null Long to a primitive long, using a default value.
+     * @param wrapper the wrapper
+     * @param defaultValue the default value
+     * @return the primitive value
+     */
+    public static long longValue(Long wrapper, long defaultValue) {
+        return wrapper != null ? wrapper.longValue() : defaultValue;
+    }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.EventLoop;
+import io.netty.util.internal.OneTimeTask;
+import io.netty.util.internal.PlatformDependent;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
+
+/**
+ * Default implementation of {@link DnsCache}, backed by a {@link ConcurrentMap}.
+ */
+public class DefaultDnsCache implements DnsCache {
+
+    private final ConcurrentMap<String, List<DnsCacheEntry>> resolveCache = PlatformDependent.newConcurrentHashMap();
+    private final int minTtl;
+    private final int maxTtl;
+    private final int negativeTtl;
+
+    /**
+     * Create a cache that respects the TTL returned by the DNS server
+     * and doesn't cache negative responses.
+     */
+    public DefaultDnsCache() {
+        this(0, Integer.MAX_VALUE, 0);
+    }
+
+    /**
+     * Create a cache.
+     * @param minTtl the minimum TTL
+     * @param maxTtl the maximum TTL
+     * @param negativeTtl the TTL for failed queries
+     */
+    public DefaultDnsCache(int minTtl, int maxTtl, int negativeTtl) {
+        this.minTtl = checkPositiveOrZero(minTtl, "minTtl");
+        this.maxTtl = checkPositiveOrZero(maxTtl, "maxTtl");
+        if (minTtl > maxTtl) {
+            throw new IllegalArgumentException(
+                    "minTtl: " + minTtl + ", maxTtl: " + maxTtl + " (expected: 0 <= minTtl <= maxTtl)");
+        }
+        this.negativeTtl = checkPositiveOrZero(negativeTtl, "negativeTtl");
+    }
+
+    /**
+     * Returns the minimum TTL of the cached DNS resource records (in seconds).
+     *
+     * @see #maxTtl()
+     */
+    public int minTtl() {
+        return minTtl;
+    }
+
+    /**
+     * Returns the maximum TTL of the cached DNS resource records (in seconds).
+     *
+     * @see #minTtl()
+     */
+    public int maxTtl() {
+        return maxTtl;
+    }
+
+    /**
+     * Returns the TTL of the cache for the failed DNS queries (in seconds). The default value is {@code 0}, which
+     * disables the cache for negative results.
+     */
+    public int negativeTtl() {
+        return negativeTtl;
+    }
+
+    @Override
+    public void clear() {
+        for (Iterator<Map.Entry<String, List<DnsCacheEntry>>> i = resolveCache.entrySet().iterator(); i.hasNext();) {
+            final Map.Entry<String, List<DnsCacheEntry>> e = i.next();
+            i.remove();
+            cancelExpiration(e.getValue());
+        }
+    }
+
+    @Override
+    public boolean clear(String hostname) {
+        checkNotNull(hostname, "hostname");
+        boolean removed = false;
+        for (Iterator<Map.Entry<String, List<DnsCacheEntry>>> i = resolveCache.entrySet().iterator(); i.hasNext();) {
+            final Map.Entry<String, List<DnsCacheEntry>> e = i.next();
+            if (e.getKey().equals(hostname)) {
+                i.remove();
+                cancelExpiration(e.getValue());
+                removed = true;
+            }
+        }
+        return removed;
+    }
+
+    @Override
+    public List<DnsCacheEntry> get(String hostname) {
+        checkNotNull(hostname, "hostname");
+        return resolveCache.get(hostname);
+    }
+
+    private List<DnsCacheEntry> cachedEntries(String hostname) {
+        List<DnsCacheEntry> oldEntries = resolveCache.get(hostname);
+        final List<DnsCacheEntry> entries;
+        if (oldEntries == null) {
+            List<DnsCacheEntry> newEntries = new ArrayList<DnsCacheEntry>(8);
+            oldEntries = resolveCache.putIfAbsent(hostname, newEntries);
+            entries = oldEntries != null? oldEntries : newEntries;
+        } else {
+            entries = oldEntries;
+        }
+        return entries;
+    }
+
+    @Override
+    public void cache(String hostname, InetAddress address, long originalTtl, EventLoop loop) {
+        if (maxTtl == 0) {
+            return;
+        }
+        checkNotNull(hostname, "hostname");
+        checkNotNull(address, "address");
+        checkNotNull(loop, "loop");
+
+        final int ttl = Math.max(minTtl, (int) Math.min(maxTtl, originalTtl));
+        final List<DnsCacheEntry> entries = cachedEntries(hostname);
+        final DnsCacheEntry e = new DnsCacheEntry(hostname, address);
+
+        synchronized (entries) {
+            if (!entries.isEmpty()) {
+                final DnsCacheEntry firstEntry = entries.get(0);
+                if (firstEntry.cause() != null) {
+                    assert entries.size() == 1;
+                    firstEntry.cancelExpiration();
+                    entries.clear();
+                }
+            }
+            entries.add(e);
+        }
+
+        scheduleCacheExpiration(entries, e, ttl, loop);
+    }
+
+    @Override
+    public void cache(String hostname, Throwable cause, EventLoop loop) {
+        if (negativeTtl == 0) {
+            return;
+        }
+        checkNotNull(hostname, "hostname");
+        checkNotNull(cause, "cause");
+        checkNotNull(loop, "loop");
+
+        final List<DnsCacheEntry> entries = cachedEntries(hostname);
+        final DnsCacheEntry e = new DnsCacheEntry(hostname, cause);
+
+        synchronized (entries) {
+            final int numEntries = entries.size();
+            for (int i = 0; i < numEntries; i ++) {
+                entries.get(i).cancelExpiration();
+            }
+            entries.clear();
+            entries.add(e);
+        }
+
+        scheduleCacheExpiration(entries, e, negativeTtl, loop);
+    }
+
+    private static void cancelExpiration(List<DnsCacheEntry> entries) {
+        final int numEntries = entries.size();
+        for (int i = 0; i < numEntries; i++) {
+            entries.get(i).cancelExpiration();
+        }
+    }
+
+    private void scheduleCacheExpiration(final List<DnsCacheEntry> entries,
+                                         final DnsCacheEntry e,
+                                         int ttl,
+                                         EventLoop loop) {
+        e.scheduleExpiration(loop, new OneTimeTask() {
+                    @Override
+                    public void run() {
+                        synchronized (entries) {
+                            entries.remove(e);
+                            if (entries.isEmpty()) {
+                                resolveCache.remove(e.hostname());
+                            }
+                        }
+                    }
+                }, ttl, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder()
+                .append("DefaultDnsCache(minTtl=")
+                .append(minTtl).append(", maxTtl=")
+                .append(maxTtl).append(", negativeTtl=")
+                .append(negativeTtl).append(", cached resolved hostname=")
+                .append(resolveCache.size()).append(")")
+                .toString();
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCache.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.EventLoop;
+
+import java.net.InetAddress;
+import java.util.List;
+
+/**
+ * A cache for DNS resolution entries.
+ */
+public interface DnsCache {
+
+    /**
+     * Clears all the resolved addresses cached by this resolver.
+     *
+     * @return {@code this}
+     *
+     * @see #clear(String)
+     */
+    void clear();
+
+    /**
+     * Clears the resolved addresses of the specified host name from the cache of this resolver.
+     *
+     * @return {@code true} if and only if there was an entry for the specified host name in the cache and
+     *         it has been removed by this method
+     */
+    boolean clear(String hostname);
+
+    /**
+     * Return the cached entries for the given hostname.
+     * @param hostname the hostname
+     * @return the cached entries
+     */
+    List<DnsCacheEntry> get(String hostname);
+
+    /**
+     * Cache a resolved address for a given hostname.
+     * @param hostname the hostname
+     * @param address the resolved adresse
+     * @param originalTtl the TLL as returned by the DNS server
+     * @param loop the {@link EventLoop} used to register the TTL timeout
+     */
+    void cache(String hostname, InetAddress address, long originalTtl, EventLoop loop);
+
+    /**
+     * Cache the resolution failure for a given hostname.
+     * @param hostname the hostname
+     * @param cause the resolution failure
+     * @param loop the {@link EventLoop} used to register the TTL timeout
+     */
+    void cache(String hostname, Throwable cause, EventLoop loop);
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCacheEntry.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCacheEntry.java
@@ -16,40 +16,45 @@
 
 package io.netty.resolver.dns;
 
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
 import io.netty.channel.EventLoop;
 import io.netty.util.concurrent.ScheduledFuture;
 
 import java.net.InetAddress;
 import java.util.concurrent.TimeUnit;
 
-final class DnsCacheEntry {
+/**
+ * Entry in {@link DnsCache}.
+ */
+public final class DnsCacheEntry {
 
     private final String hostname;
     private final InetAddress address;
     private final Throwable cause;
     private volatile ScheduledFuture<?> expirationFuture;
 
-    DnsCacheEntry(String hostname, InetAddress address) {
-        this.hostname = hostname;
-        this.address = address;
+    public DnsCacheEntry(String hostname, InetAddress address) {
+        this.hostname = checkNotNull(hostname, "hostname");
+        this.address = checkNotNull(address, "address");
         cause = null;
     }
 
-    DnsCacheEntry(String hostname, Throwable cause) {
-        this.hostname = hostname;
-        this.cause = cause;
+    public DnsCacheEntry(String hostname, Throwable cause) {
+        this.hostname = checkNotNull(hostname, "hostname");
+        this.cause = checkNotNull(cause, "cause");
         address = null;
     }
 
-    String hostname() {
+    public String hostname() {
         return hostname;
     }
 
-    InetAddress address() {
+    public InetAddress address() {
         return address;
     }
 
-    Throwable cause() {
+    public Throwable cause() {
         return cause;
     }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/NoopDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/NoopDnsCache.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.EventLoop;
+
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A noop DNS cache that actually never caches anything.
+ */
+public final class NoopDnsCache implements DnsCache {
+
+    public static final NoopDnsCache INSTANCE = new NoopDnsCache();
+
+    /**
+     * Private singleton constructor.
+     */
+    private NoopDnsCache() {
+    }
+
+    @Override
+    public void clear() {
+    }
+
+    @Override
+    public boolean clear(String hostname) {
+        return false;
+    }
+
+    @Override
+    public List<DnsCacheEntry> get(String hostname) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void cache(String hostname, InetAddress address, long originalTtl, EventLoop loop) {
+    }
+
+    @Override
+    public void cache(String hostname, Throwable cause, EventLoop loop) {
+    }
+
+    @Override
+    public String toString() {
+        return NoopDnsCache.class.getSimpleName();
+    }
+}


### PR DESCRIPTION
Motivation:
Caching is currently nested in DnsResolver.
It should also be possible to extend DnsResolver to ba able to pass a different cache on each resolution attemp.

Modifications:
* Introduce DnsCache, NoopDnsCache and DefaultDnsCache. The latter contains all the current caching logic that was extracted.
* Introduce protected versions of doResolve and doResolveAll that can be used as extension points to build resolvers that bypass the main cache and use a different one on each resolution.

Result:
Isolated caching logic. Better extensibility.