### PR TITLE
Fix PlatformDependent.newAtomicReferenceFieldUpdater w/ generic classes

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -555,7 +555,7 @@ public final class PlatformDependent {
      * use {@link AtomicReferenceFieldUpdater#newUpdater(Class, Class, String)} as fallback.
      */
     public static <U, W> AtomicReferenceFieldUpdater<U, W> newAtomicReferenceFieldUpdater(
-            Class<U> tclass, String fieldName) {
+            Class<? super U> tclass, String fieldName) {
         if (hasUnsafe()) {
             try {
                 return PlatformDependent0.newAtomicReferenceFieldUpdater(tclass, fieldName);
@@ -572,7 +572,7 @@ public final class PlatformDependent {
      * use {@link AtomicIntegerFieldUpdater#newUpdater(Class, String)} as fallback.
      */
     public static <T> AtomicIntegerFieldUpdater<T> newAtomicIntegerFieldUpdater(
-            Class<?> tclass, String fieldName) {
+            Class<? super T> tclass, String fieldName) {
         if (hasUnsafe()) {
             try {
                 return PlatformDependent0.newAtomicIntegerFieldUpdater(tclass, fieldName);
@@ -589,7 +589,7 @@ public final class PlatformDependent {
      * use {@link AtomicLongFieldUpdater#newUpdater(Class, String)} as fallback.
      */
     public static <T> AtomicLongFieldUpdater<T> newAtomicLongFieldUpdater(
-            Class<?> tclass, String fieldName) {
+            Class<? super T> tclass, String fieldName) {
         if (hasUnsafe()) {
             try {
                 return PlatformDependent0.newAtomicLongFieldUpdater(tclass, fieldName);

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -484,17 +484,17 @@ final class PlatformDependent0 {
     }
 
     static <U, W> AtomicReferenceFieldUpdater<U, W> newAtomicReferenceFieldUpdater(
-            Class<U> tclass, String fieldName) throws Exception {
+            Class<? super U> tclass, String fieldName) throws Exception {
         return new UnsafeAtomicReferenceFieldUpdater<U, W>(UNSAFE, tclass, fieldName);
     }
 
     static <T> AtomicIntegerFieldUpdater<T> newAtomicIntegerFieldUpdater(
-            Class<?> tclass, String fieldName) throws Exception {
+            Class<? super T> tclass, String fieldName) throws Exception {
         return new UnsafeAtomicIntegerFieldUpdater<T>(UNSAFE, tclass, fieldName);
     }
 
     static <T> AtomicLongFieldUpdater<T> newAtomicLongFieldUpdater(
-            Class<?> tclass, String fieldName) throws Exception {
+            Class<? super T> tclass, String fieldName) throws Exception {
         return new UnsafeAtomicLongFieldUpdater<T>(UNSAFE, tclass, fieldName);
     }
 

--- a/common/src/main/java/io/netty/util/internal/UnsafeAtomicIntegerFieldUpdater.java
+++ b/common/src/main/java/io/netty/util/internal/UnsafeAtomicIntegerFieldUpdater.java
@@ -25,7 +25,8 @@ final class UnsafeAtomicIntegerFieldUpdater<T> extends AtomicIntegerFieldUpdater
     private final long offset;
     private final Unsafe unsafe;
 
-    UnsafeAtomicIntegerFieldUpdater(Unsafe unsafe, Class<?> tClass, String fieldName) throws NoSuchFieldException {
+    UnsafeAtomicIntegerFieldUpdater(Unsafe unsafe, Class<? super T> tClass, String fieldName)
+            throws NoSuchFieldException {
         Field field = tClass.getDeclaredField(fieldName);
         if (!Modifier.isVolatile(field.getModifiers())) {
             throw new IllegalArgumentException("Must be volatile");

--- a/common/src/main/java/io/netty/util/internal/UnsafeAtomicLongFieldUpdater.java
+++ b/common/src/main/java/io/netty/util/internal/UnsafeAtomicLongFieldUpdater.java
@@ -25,7 +25,8 @@ final class UnsafeAtomicLongFieldUpdater<T> extends AtomicLongFieldUpdater<T> {
     private final long offset;
     private final Unsafe unsafe;
 
-    UnsafeAtomicLongFieldUpdater(Unsafe unsafe, Class<?> tClass, String fieldName) throws NoSuchFieldException {
+    UnsafeAtomicLongFieldUpdater(Unsafe unsafe, Class<? super T> tClass, String fieldName)
+            throws NoSuchFieldException {
         Field field = tClass.getDeclaredField(fieldName);
         if (!Modifier.isVolatile(field.getModifiers())) {
             throw new IllegalArgumentException("Must be volatile");

--- a/common/src/main/java/io/netty/util/internal/UnsafeAtomicReferenceFieldUpdater.java
+++ b/common/src/main/java/io/netty/util/internal/UnsafeAtomicReferenceFieldUpdater.java
@@ -25,7 +25,8 @@ final class UnsafeAtomicReferenceFieldUpdater<U, M> extends AtomicReferenceField
     private final long offset;
     private final Unsafe unsafe;
 
-    UnsafeAtomicReferenceFieldUpdater(Unsafe unsafe, Class<U> tClass, String fieldName) throws NoSuchFieldException {
+    UnsafeAtomicReferenceFieldUpdater(Unsafe unsafe, Class<? super U> tClass, String fieldName)
+            throws NoSuchFieldException {
         Field field = tClass.getDeclaredField(fieldName);
         if (!Modifier.isVolatile(field.getModifiers())) {
             throw new IllegalArgumentException("Must be volatile");


### PR DESCRIPTION
Motivation:

On contrary to newAtomicIntegerFieldUpdater newAtomicLongFieldUpdater, newAtomicReferenceFieldUpdater forces the class parameter to be of the exact type.
This makes this method impossible to use with classes with a type parameter, as the updater has to be stored in a static field.

Modifications:

Take a Class<?> parameter instead of a Class<U> one.

Result:

PlatformDependent.newAtomicReferenceFieldUpdater works with generic classes.