### PR TITLE
exist and fix the issue: can't null out the latter non-null entrys in array

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -353,6 +353,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     @Override
     protected void doDeregister() throws Exception {
         eventLoop().cancel(selectionKey());
+        selectionKey=null;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -353,7 +353,6 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     @Override
     protected void doDeregister() throws Exception {
         eventLoop().cancel(selectionKey());
-        selectionKey = null;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -353,7 +353,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     @Override
     protected void doDeregister() throws Exception {
         eventLoop().cancel(selectionKey());
-        selectionKey=null;
+        selectionKey = null;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -475,11 +475,11 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                 // null out entries in the array to allow to have it GC'ed once the Channel close
                 // See https://github.com/netty/netty/issues/2363
                 for (;;) {
+                    i++;
                     if (selectedKeys[i] == null) {
                         break;
                     }
                     selectedKeys[i] = null;
-                    i++;
                 }
 
                 selectAgain();


### PR DESCRIPTION
@normanmaurer   move i++ before "if";  the old fix can't null out entries in the array due to the " selectedKeys[i] = null" in the line 462  so that the "for loop" in line 477 is useless:

this will cause when we need select again due to cancel keys total number>256. we will leave some values in the keys' array with one null before them.
so if the new requests' size < the null's position, the latter values never be GCed. So in my applications' test. the memory can't down if no any requests existed.
my test is : connect->send only 3 requests> disconnect and keep one day and make sure the request handle speed< received request's speed so that the capacity is very big and the cancel keys is too much due to huge disconnect.

// See netty#2363
                for (;;) {
            
                    if (selectedKeys[i] == null) { 
                        break;  //must break due to 462 line had set the value to null. so the latter part can't be null.
                    }
                    selectedKeys[i] = null;
                }
           i++;