### PR TITLE
fix the issue netty#2363 in 4.1 entries in the array can't null out for GC

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -475,11 +475,11 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                 // null out entries in the array to allow to have it GC'ed once the Channel close
                 // See https://github.com/netty/netty/issues/2363
                 for (;;) {
+                    i++;
                     if (selectedKeys[i] == null) {
                         break;
                     }
                     selectedKeys[i] = null;
-                    i++;
                 }
 
                 selectAgain();


### PR DESCRIPTION
fix the issue netty#2363

Motivation:

this fix codes of netty#2363 exist issue so that the entry can't be null out.

Modifications:

move the i++ from end of loop to beginning of loop

Result:

after the fix, entries in the array will be null out so allow to have it GC'ed once the Channel close