### PR TITLE
Avoid unnecessary boxing/unboxing

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieDecoder.java
@@ -233,7 +233,7 @@ public final class ClientCookieDecoder extends CookieDecoder {
 
         private void setMaxAge(String value) {
             try {
-                maxAge = Math.max(Long.valueOf(value), 0L);
+                maxAge = Math.max(Long.parseLong(value), 0L);
             } catch (NumberFormatException e1) {
                 // ignore failure to parse -> treat as session cookie
             }

--- a/example/src/main/java/io/netty/example/http2/Http2ExampleUtil.java
+++ b/example/src/main/java/io/netty/example/http2/Http2ExampleUtil.java
@@ -47,7 +47,7 @@ public final class Http2ExampleUtil {
      */
     public static int toInt(String string, int defaultValue) {
         if (string != null && !string.isEmpty()) {
-            return Integer.valueOf(string);
+            return Integer.parseInt(string);
         }
         return defaultValue;
     }

--- a/example/src/main/java/io/netty/example/http2/tiles/Http2RequestHandler.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/Http2RequestHandler.java
@@ -24,7 +24,7 @@ import static io.netty.handler.codec.http.HttpUtil.setContentLength;
 import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
-import static java.lang.Integer.valueOf;
+import static java.lang.Integer.parseInt;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -77,7 +77,7 @@ public class Http2RequestHandler extends SimpleChannelInboundHandler<FullHttpReq
 
     private void handleImage(String x, String y, ChannelHandlerContext ctx, String streamId, int latency,
             FullHttpRequest request) {
-        ByteBuf image = ImageCache.INSTANCE.image(valueOf(x), valueOf(y));
+        ByteBuf image = ImageCache.INSTANCE.image(parseInt(x), parseInt(y));
         FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, OK, image.duplicate());
         response.headers().set(CONTENT_TYPE, "image/jpeg");
         sendResponse(ctx, streamId, latency, response, request);

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -184,7 +184,7 @@ public class SimpleChannelPool implements ChannelPool {
         assert ch.eventLoop().inEventLoop();
 
         if (future.isSuccess()) {
-            if (future.getNow() == Boolean.TRUE) {
+            if (future.getNow()) {
                 try {
                     ch.attr(POOL_KEY).set(this);
                     handler.channelAcquired(ch);


### PR DESCRIPTION
Motivation:

Boxing/unboxing can be avoided.

Modifications:

Use parseInt/parseLong to avoid unnecessary boxing/unboxing.

Result:

Remove unnecessary boxing/unboxing.