### PR TITLE
Fix InternalAttribute.equals

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/InternalAttribute.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/InternalAttribute.java
@@ -79,10 +79,10 @@ final class InternalAttribute extends AbstractReferenceCounted implements Interf
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Attribute)) {
+        if (!(o instanceof InternalAttribute)) {
             return false;
         }
-        Attribute attribute = (Attribute) o;
+        InternalAttribute attribute = (InternalAttribute) o;
         return getName().equalsIgnoreCase(attribute.getName());
     }
 


### PR DESCRIPTION
Motivation:

InternalAttribute doesn't extend Attribute, but its equals only returns true when it compares with an Attribute. So it will return false when comparing with itself.

Modifications:

Make sure InternalAttribute return false for non InternalAttribute objects.

Result:

InternalAttribute's equals works correctly.