### PR TITLE
Fix NPE bug when "channelActive" is called before "handlerAdded"

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1454,6 +1454,8 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      */
     @Override
     public void channelActive(final ChannelHandlerContext ctx) throws Exception {
+        this.ctx = ctx;
+
         if (!startTls && engine.getUseClientMode()) {
             // Begin the initial handshake
             handshake(null);


### PR DESCRIPTION
Motivation:

#4705

Modifications:

Set "this.ctx" in "channelActive"

Result:

NPE is gone