### PR TITLE
[#4694] Ensure native transport can also be compiled on 32bit systems.

### DIFF
--- a/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.c
+++ b/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.c
@@ -15,6 +15,7 @@
  */
 #define _GNU_SOURCE
 #include <jni.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
@@ -270,7 +271,7 @@ JNIEXPORT jint JNICALL Java_io_netty_channel_epoll_Native_epollCreate(JNIEnv* en
 }
 
 JNIEXPORT jint JNICALL Java_io_netty_channel_epoll_Native_epollWait0(JNIEnv* env, jclass clazz, jint efd, jlong address, jint len, jint timeout) {
-    struct epoll_event *ev = (struct epoll_event*) address;
+    struct epoll_event *ev = (struct epoll_event*) (intptr_t) address;
     int ready;
     int err;
 
@@ -337,7 +338,7 @@ JNIEXPORT jint JNICALL Java_io_netty_channel_epoll_Native_sendmmsg0(JNIEnv* env,
         msg[i].msg_hdr.msg_name = &addr;
         msg[i].msg_hdr.msg_namelen = sizeof(addr);
 
-        msg[i].msg_hdr.msg_iov = (struct iovec*) (*env)->GetLongField(env, packet, packetMemoryAddressFieldId);
+        msg[i].msg_hdr.msg_iov = (struct iovec*) (intptr_t) (*env)->GetLongField(env, packet, packetMemoryAddressFieldId);
         msg[i].msg_hdr.msg_iovlen = (*env)->GetIntField(env, packet, packetCountFieldId);;
     }
 

--- a/transport-native-epoll/src/main/c/io_netty_channel_unix_FileDescriptor.c
+++ b/transport-native-epoll/src/main/c/io_netty_channel_unix_FileDescriptor.c
@@ -15,6 +15,7 @@
  */
 #include <errno.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/uio.h>
@@ -158,12 +159,12 @@ JNIEXPORT jint JNICALL Java_io_netty_channel_unix_FileDescriptor_write(JNIEnv* e
 }
 
 JNIEXPORT jint JNICALL Java_io_netty_channel_unix_FileDescriptor_writeAddress(JNIEnv* env, jclass clazz, jint fd, jlong address, jint pos, jint limit) {
-    return _write(env, clazz, fd, (void*) address, pos, limit);
+    return _write(env, clazz, fd, (void*) (intptr_t) address, pos, limit);
 }
 
 
 JNIEXPORT jlong JNICALL Java_io_netty_channel_unix_FileDescriptor_writevAddresses(JNIEnv* env, jclass clazz, jint fd, jlong memoryAddress, jint length) {
-    struct iovec* iov = (struct iovec*) memoryAddress;
+    struct iovec* iov = (struct iovec*) (intptr_t) memoryAddress;
     return _writev(env, clazz, fd, iov, length);
 }
 
@@ -211,7 +212,7 @@ JNIEXPORT jint JNICALL Java_io_netty_channel_unix_FileDescriptor_read(JNIEnv* en
 }
 
 JNIEXPORT jint JNICALL Java_io_netty_channel_unix_FileDescriptor_readAddress(JNIEnv* env, jclass clazz, jint fd, jlong address, jint pos, jint limit) {
-    return _read(env, clazz, fd, (void*) address, pos, limit);
+    return _read(env, clazz, fd, (void*) (intptr_t) address, pos, limit);
 }
 
 JNIEXPORT jlong JNICALL Java_io_netty_channel_unix_FileDescriptor_newPipe(JNIEnv* env, jclass clazz) {

--- a/transport-native-epoll/src/main/c/io_netty_channel_unix_Socket.c
+++ b/transport-native-epoll/src/main/c/io_netty_channel_unix_Socket.c
@@ -16,8 +16,8 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <unistd.h>
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/un.h>
 #include <sys/socket.h>
@@ -538,7 +538,7 @@ JNIEXPORT jint JNICALL Java_io_netty_channel_unix_Socket_sendTo(JNIEnv* env, jcl
 }
 
 JNIEXPORT jint JNICALL Java_io_netty_channel_unix_Socket_sendToAddress(JNIEnv* env, jclass clazz, jint fd, jlong memoryAddress, jint pos, jint limit ,jbyteArray address, jint scopeId, jint port) {
-    return _sendTo(env, fd, (void*) memoryAddress, pos, limit, address, scopeId, port);
+    return _sendTo(env, fd, (void *) (intptr_t) memoryAddress, pos, limit, address, scopeId, port);
 }
 
 JNIEXPORT jint JNICALL Java_io_netty_channel_unix_Socket_sendToAddresses(JNIEnv* env, jclass clazz, jint fd, jlong memoryAddress, jint length, jbyteArray address, jint scopeId, jint port) {
@@ -551,7 +551,7 @@ JNIEXPORT jint JNICALL Java_io_netty_channel_unix_Socket_sendToAddresses(JNIEnv*
     struct msghdr m;
     m.msg_name = (void*) &addr;
     m.msg_namelen = (socklen_t) sizeof(struct sockaddr_storage);
-    m.msg_iov = (struct iovec*) memoryAddress;
+    m.msg_iov = (struct iovec*) (intptr_t) memoryAddress;
     m.msg_iovlen = length;
 
     ssize_t res;
@@ -573,7 +573,7 @@ JNIEXPORT jobject JNICALL Java_io_netty_channel_unix_Socket_recvFrom(JNIEnv* env
 }
 
 JNIEXPORT jobject JNICALL Java_io_netty_channel_unix_Socket_recvFromAddress(JNIEnv* env, jclass clazz, jint fd, jlong address, jint pos, jint limit) {
-    return _recvFrom(env, fd, (void*) address, pos, limit);
+    return _recvFrom(env, fd, (void *) (intptr_t) address, pos, limit);
 }
 
 JNIEXPORT jint JNICALL Java_io_netty_channel_unix_Socket_bindDomainSocket(JNIEnv* env, jclass clazz, jint fd, jbyteArray socketPath) {


### PR DESCRIPTION
Motivation:

We should also be able to compile the native transport on 32bit systems.

Modifications:

Add cast to intptr_t for pointers

Result:

It's possible now to also compile on 32bit.