### PR TITLE
Native Transport Netty Class Package Prefix

### DIFF
--- a/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.c
+++ b/transport-native-epoll/src/main/c/io_netty_channel_epoll_Native.c
@@ -37,6 +37,7 @@
 #include "netty_unix_filedescriptor.h"
 #include "netty_unix_socket.h"
 #include "netty_unix_errors.h"
+#include "netty_unix_util.h"
 
 // TCP_NOTSENT_LOWAT is defined in linux 3.12. We define this here so older kernels can compile.
 #ifndef TCP_NOTSENT_LOWAT
@@ -83,6 +84,9 @@ jfieldID packetScopeIdFieldId = NULL;
 jfieldID packetPortFieldId = NULL;
 jfieldID packetMemoryAddressFieldId = NULL;
 jfieldID packetCountFieldId = NULL;
+static jstring nettyPackagePrefixJString = NULL;
+static const char* nettyPackagePrefix = NULL;
+static char* nettyClassName = NULL;
 
 // util methods
 static int getSysctlValue(const char * property, int* returnValue) {
@@ -115,17 +119,35 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     if ((*vm)->GetEnv(vm, (void**) &env, JNI_VERSION_1_6) != JNI_OK) {
         return JNI_ERR;
     } else {
-        if (netty_unix_errors_JNI_OnLoad(env) == JNI_ERR) {
+        // Load the prefix to use when looking for Netty classes
+        jclass systemCls = (*env)->FindClass(env, "java/lang/System");
+        if (systemCls == NULL) {
             return JNI_ERR;
         }
-        if (netty_unix_filedescriptor_JNI_OnLoad(env) == JNI_ERR) {
+        jmethodID getPropertyMethod = (*env)->GetStaticMethodID(env, systemCls, "getProperty", "(Ljava/lang/String;)Ljava/lang/String;");
+        if (getPropertyMethod == NULL) {
             return JNI_ERR;
         }
-        if (netty_unix_socket_JNI_OnLoad(env) == JNI_ERR) {
+        jstring propertyName = (*env)->NewStringUTF(env, "io.netty.native.epoll.nettyPackagePrefix");
+        nettyPackagePrefixJString = (*env)->CallStaticObjectMethod(env, systemCls, getPropertyMethod, propertyName);
+        if (nettyPackagePrefixJString != NULL) {
+            nettyPackagePrefix = (*env)->GetStringUTFChars(env, nettyPackagePrefixJString, 0);
+        }
+
+        if (netty_unix_errors_JNI_OnLoad(env, nettyPackagePrefix) == JNI_ERR) {
+            return JNI_ERR;
+        }
+        if (netty_unix_filedescriptor_JNI_OnLoad(env, nettyPackagePrefix) == JNI_ERR) {
+            return JNI_ERR;
+        }
+        if (netty_unix_socket_JNI_OnLoad(env, nettyPackagePrefix) == JNI_ERR) {
             return JNI_ERR;
         }
 
-        jclass fileRegionCls = (*env)->FindClass(env, "io/netty/channel/DefaultFileRegion");
+        nettyClassName = netty_unix_util_prepend(nettyPackagePrefix, "io/netty/channel/DefaultFileRegion");
+        jclass fileRegionCls = (*env)->FindClass(env, nettyClassName);
+        free(nettyClassName);
+        nettyClassName = NULL;
         if (fileRegionCls == NULL) {
             // pending exception...
             return JNI_ERR;
@@ -163,7 +185,10 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
             return JNI_ERR;
         }
 
-        jclass nativeDatagramPacketCls = (*env)->FindClass(env, "io/netty/channel/epoll/NativeDatagramPacketArray$NativeDatagramPacket");
+        nettyClassName = netty_unix_util_prepend(nettyPackagePrefix, "io/netty/channel/epoll/NativeDatagramPacketArray$NativeDatagramPacket");
+        jclass nativeDatagramPacketCls = (*env)->FindClass(env, nettyClassName);
+        free(nettyClassName);
+        nettyClassName = NULL;
         if (nativeDatagramPacketCls == NULL) {
             // pending exception...
             return JNI_ERR;
@@ -196,6 +221,12 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
             return JNI_ERR;
         }
 
+        if (nettyPackagePrefixJString != NULL) {
+            (*env)->ReleaseStringUTFChars(env, nettyPackagePrefixJString, nettyPackagePrefix);
+            nettyPackagePrefix = NULL;
+            nettyPackagePrefixJString = NULL;
+        }
+
         return JNI_VERSION_1_6;
     }
 }
@@ -207,6 +238,15 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
         return;
     } else {
         // delete global references so the GC can collect them
+        if (nettyPackagePrefixJString != NULL) {
+            (*env)->ReleaseStringUTFChars(env, nettyPackagePrefixJString, nettyPackagePrefix);
+            nettyPackagePrefix = NULL;
+            nettyPackagePrefixJString = NULL;
+        }
+        if (nettyClassName != NULL) {
+            free(nettyClassName);
+            nettyClassName = NULL;
+        }
         netty_unix_errors_JNI_OnUnLoad(env);
         netty_unix_filedescriptor_JNI_OnUnLoad(env);
         netty_unix_socket_JNI_OnUnLoad(env);

--- a/transport-native-epoll/src/main/c/io_netty_channel_unix_FileDescriptor.c
+++ b/transport-native-epoll/src/main/c/io_netty_channel_unix_FileDescriptor.c
@@ -73,7 +73,7 @@ static jint _read(JNIEnv* env, jclass clazz, jint fd, void* buffer, jint pos, ji
     return (jint) res;
 }
 
-jint netty_unix_filedescriptor_JNI_OnLoad(JNIEnv* env) {
+jint netty_unix_filedescriptor_JNI_OnLoad(JNIEnv* env, const char* nettyPackagePrefix) {
     void* mem = malloc(1);
     if (mem == NULL) {
         netty_unix_errors_throwOutOfMemoryError(env);

--- a/transport-native-epoll/src/main/c/netty_unix_errors.h
+++ b/transport-native-epoll/src/main/c/netty_unix_errors.h
@@ -27,7 +27,7 @@ void netty_unix_errors_throwClosedChannelException(JNIEnv* env);
 void netty_unix_errors_throwOutOfMemoryError(JNIEnv* env);
 
 // JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
-jint netty_unix_errors_JNI_OnLoad(JNIEnv* env);
+jint netty_unix_errors_JNI_OnLoad(JNIEnv* env, const char* nettyPackagePrefix);
 void netty_unix_errors_JNI_OnUnLoad(JNIEnv* env);
 
 #endif /* NETTY_UNIX_ERRORS_H_ */

--- a/transport-native-epoll/src/main/c/netty_unix_socket.h
+++ b/transport-native-epoll/src/main/c/netty_unix_socket.h
@@ -25,7 +25,7 @@ int netty_unix_socket_getOption(JNIEnv* env, jint fd, int level, int optname, vo
 int netty_unix_socket_setOption(JNIEnv* env, jint fd, int level, int optname, const void* optval, socklen_t len);
 
 // JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
-jint netty_unix_socket_JNI_OnLoad(JNIEnv* env);
+jint netty_unix_socket_JNI_OnLoad(JNIEnv* env, const char* nettyPackagePrefix);
 void netty_unix_socket_JNI_OnUnLoad(JNIEnv* env);
 
 #endif /* NETTY_UNIX_SOCKET_H_ */

--- a/transport-native-epoll/src/main/c/netty_unix_util.c
+++ b/transport-native-epoll/src/main/c/netty_unix_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,13 +13,18 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-#ifndef NETTY_UNIX_FILEDESCRIPTOR_H_
-#define NETTY_UNIX_FILEDESCRIPTOR_H_
 
-#include <jni.h>
+#include <string.h>
+#include "netty_unix_util.h"
 
-// JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
-jint netty_unix_filedescriptor_JNI_OnLoad(JNIEnv* env, const char* nettyPackagePrefix);
-void netty_unix_filedescriptor_JNI_OnUnLoad(JNIEnv* env);
-
-#endif /* NETTY_UNIX_FILEDESCRIPTOR_H_ */
+char* netty_unix_util_prepend(const char* prefix, const char* str) {
+    if (prefix == NULL) {
+        char* result = (char*) malloc(sizeof(char) * (strlen(str) + 1));
+        strcpy(result, str);
+        return result;
+    }
+    char* result = (char*) malloc(sizeof(char) * (strlen(prefix) + strlen(str) + 1));
+    strcpy(result, prefix);
+    strcat(result, str);
+    return result;
+}

--- a/transport-native-epoll/src/main/c/netty_unix_util.h
+++ b/transport-native-epoll/src/main/c/netty_unix_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,13 +13,15 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-#ifndef NETTY_UNIX_FILEDESCRIPTOR_H_
-#define NETTY_UNIX_FILEDESCRIPTOR_H_
 
-#include <jni.h>
+#ifndef NETTY_UNIX_UTIL_H_
+#define NETTY_UNIX_UTIL_H_
 
-// JNI initialization hooks. Users of this file are responsible for calling these in the JNI_OnLoad and JNI_OnUnload methods.
-jint netty_unix_filedescriptor_JNI_OnLoad(JNIEnv* env, const char* nettyPackagePrefix);
-void netty_unix_filedescriptor_JNI_OnUnLoad(JNIEnv* env);
+/**
+ * Return a new string (caller must free this string) which is equivalent to <pre>prefix + str</pre>.
+ *
+ * Caller must free the return value!
+ */
+char* netty_unix_util_prepend(const char* prefix, const char* str);
 
-#endif /* NETTY_UNIX_FILEDESCRIPTOR_H_ */
+#endif /* NETTY_UNIX_UTIL_H_ */


### PR DESCRIPTION
Motivation:
transport-native-epoll finds java classes from JNI using fully qualified class names. If a shaded version of Netty is used then these lookups will fail.

Modifications:
- Allow a prefix to be appended to Netty class names in JNI code.

Result:
JNI code can be used with shaded version of Netty.