### PR TITLE
Log the current channel in Http2FrameLogger

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
@@ -20,6 +20,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.logging.LogLevel;
 import io.netty.util.internal.logging.InternalLogLevel;
 import io.netty.util.internal.logging.InternalLogger;
@@ -56,97 +57,102 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
         this.logger = checkNotNull(logger, "logger");
     }
 
-    public void logData(Direction direction, int streamId, ByteBuf data, int padding,
+    public void logData(Direction direction, ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
             boolean endStream) {
         if (enabled()) {
             log(direction,
-                    "DATA: streamId=%d, padding=%d, endStream=%b, length=%d, bytes=%s",
-                    streamId, padding, endStream, data.readableBytes(), toString(data));
+                    "%s DATA: streamId=%d, padding=%d, endStream=%b, length=%d, bytes=%s",
+                    ctx.channel(), streamId, padding, endStream, data.readableBytes(), toString(data));
         }
     }
 
-    public void logHeaders(Direction direction, int streamId, Http2Headers headers, int padding,
-            boolean endStream) {
+    public void logHeaders(Direction direction, ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+            int padding, boolean endStream) {
         if (enabled()) {
-            log(direction, "HEADERS: streamId=%d, headers=%s, padding=%d, endStream=%b",
-                    streamId, headers, padding, endStream);
+            log(direction, "%s HEADERS: streamId=%d, headers=%s, padding=%d, endStream=%b",
+                    ctx.channel(), streamId, headers, padding, endStream);
         }
     }
 
-    public void logHeaders(Direction direction, int streamId, Http2Headers headers,
+    public void logHeaders(Direction direction, ChannelHandlerContext ctx, int streamId, Http2Headers headers,
             int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) {
         if (enabled()) {
             log(direction,
-                    "HEADERS: streamId=%d, headers=%s, streamDependency=%d, weight=%d, exclusive=%b, "
-                            + "padding=%d, endStream=%b", streamId, headers,
-                    streamDependency, weight, exclusive, padding, endStream);
+                    "%s HEADERS: streamId=%d, headers=%s, streamDependency=%d, weight=%d, "
+                            + "exclusive=%b, padding=%d, endStream=%b",
+                    ctx.channel(), streamId, headers, streamDependency, weight, exclusive, padding, endStream);
         }
     }
 
-    public void logPriority(Direction direction, int streamId, int streamDependency, short weight,
-            boolean exclusive) {
+    public void logPriority(Direction direction, ChannelHandlerContext ctx, int streamId, int streamDependency,
+            short weight, boolean exclusive) {
         if (enabled()) {
-            log(direction, "PRIORITY: streamId=%d, streamDependency=%d, weight=%d, exclusive=%b",
-                    streamId, streamDependency, weight, exclusive);
+            log(direction, "%s PRIORITY: streamId=%d, streamDependency=%d, weight=%d, exclusive=%b",
+                    ctx.channel(), streamId, streamDependency, weight, exclusive);
         }
     }
 
-    public void logRstStream(Direction direction, int streamId, long errorCode) {
+    public void logRstStream(Direction direction, ChannelHandlerContext ctx, int streamId, long errorCode) {
         if (enabled()) {
-            log(direction, "RST_STREAM: streamId=%d, errorCode=%d", streamId, errorCode);
+            log(direction, "%s RST_STREAM: streamId=%d, errorCode=%d", ctx.channel(), streamId, errorCode);
         }
     }
 
-    public void logSettingsAck(Direction direction) {
+    public void logSettingsAck(Direction direction, ChannelHandlerContext ctx) {
         if (enabled()) {
-            log(direction, "SETTINGS ack=true");
+            log(direction, "%s SETTINGS: ack=true", ctx.channel());
         }
     }
 
-    public void logSettings(Direction direction, Http2Settings settings) {
+    public void logSettings(Direction direction, ChannelHandlerContext ctx, Http2Settings settings) {
         if (enabled()) {
-            log(direction, "SETTINGS: ack=false, settings=%s", settings);
+            log(direction, "%s SETTINGS: ack=false, settings=%s", ctx.channel(), settings);
         }
     }
 
-    public void logPing(Direction direction, ByteBuf data) {
+    public void logPing(Direction direction, ChannelHandlerContext ctx, ByteBuf data) {
         if (enabled()) {
-            log(direction, "PING: ack=false, length=%d, bytes=%s", data.readableBytes(), toString(data));
+            log(direction, "%s PING: ack=false, length=%d, bytes=%s", ctx.channel(),
+                    data.readableBytes(), toString(data));
         }
     }
 
-    public void logPingAck(Direction direction, ByteBuf data) {
+    public void logPingAck(Direction direction, ChannelHandlerContext ctx, ByteBuf data) {
         if (enabled()) {
-            log(direction, "PING: ack=true, length=%d, bytes=%s", data.readableBytes(), toString(data));
+            log(direction, "%s PING: ack=true, length=%d, bytes=%s",
+                    ctx.channel(), data.readableBytes(), toString(data));
         }
     }
 
-    public void logPushPromise(Direction direction, int streamId, int promisedStreamId,
+    public void logPushPromise(Direction direction, ChannelHandlerContext ctx, int streamId, int promisedStreamId,
             Http2Headers headers, int padding) {
         if (enabled()) {
-            log(direction, "PUSH_PROMISE: streamId=%d, promisedStreamId=%d, headers=%s, padding=%d",
-                    streamId, promisedStreamId, headers, padding);
+            log(direction, "%s PUSH_PROMISE: streamId=%d, promisedStreamId=%d, headers=%s, padding=%d",
+                    ctx.channel(), streamId, promisedStreamId, headers, padding);
         }
     }
 
-    public void logGoAway(Direction direction, int lastStreamId, long errorCode, ByteBuf debugData) {
+    public void logGoAway(Direction direction, ChannelHandlerContext ctx, int lastStreamId, long errorCode,
+            ByteBuf debugData) {
         if (enabled()) {
-            log(direction, "GO_AWAY: lastStreamId=%d, errorCode=%d, length=%d, bytes=%s", lastStreamId,
-                    errorCode, debugData.readableBytes(), toString(debugData));
+            log(direction, "%s GO_AWAY: lastStreamId=%d, errorCode=%d, length=%d, bytes=%s",
+                    ctx.channel(), lastStreamId, errorCode, debugData.readableBytes(), toString(debugData));
         }
     }
 
-    public void logWindowsUpdate(Direction direction, int streamId, int windowSizeIncrement) {
+    public void logWindowsUpdate(Direction direction, ChannelHandlerContext ctx, int streamId,
+            int windowSizeIncrement) {
         if (enabled()) {
-            log(direction, "WINDOW_UPDATE: streamId=%d, windowSizeIncrement=%d", streamId,
-                    windowSizeIncrement);
+            log(direction, "%s WINDOW_UPDATE: streamId=%d, windowSizeIncrement=%d",
+                    ctx.channel(), streamId, windowSizeIncrement);
         }
     }
 
-    public void logUnknownFrame(Direction direction, byte frameType, int streamId, Http2Flags flags, ByteBuf data) {
+    public void logUnknownFrame(Direction direction, ChannelHandlerContext ctx, byte frameType, int streamId,
+            Http2Flags flags, ByteBuf data) {
         if (enabled()) {
-            log(direction, "UNKNOWN: frameType=%d, streamId=%d, flags=%d, length=%d, bytes=%s",
-                    frameType & 0xFF, streamId, flags.value(), data.readableBytes(), toString(data));
+            log(direction, "%s UNKNOWN: frameType=%d, streamId=%d, flags=%d, length=%d, bytes=%s",
+                    ctx.channel(), frameType & 0xFF, streamId, flags.value(), data.readableBytes(), toString(data));
         }
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2InboundFrameLogger.java
@@ -42,7 +42,7 @@ public class Http2InboundFrameLogger implements Http2FrameReader {
             public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data,
                     int padding, boolean endOfStream)
                     throws Http2Exception {
-                logger.logData(INBOUND, streamId, data, padding, endOfStream);
+                logger.logData(INBOUND, ctx, streamId, data, padding, endOfStream);
                 return listener.onDataRead(ctx, streamId, data, padding, endOfStream);
             }
 
@@ -50,7 +50,7 @@ public class Http2InboundFrameLogger implements Http2FrameReader {
             public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
                     Http2Headers headers, int padding, boolean endStream)
                     throws Http2Exception {
-                logger.logHeaders(INBOUND, streamId, headers, padding, endStream);
+                logger.logHeaders(INBOUND, ctx, streamId, headers, padding, endStream);
                 listener.onHeadersRead(ctx, streamId, headers, padding, endStream);
             }
 
@@ -58,7 +58,7 @@ public class Http2InboundFrameLogger implements Http2FrameReader {
             public void onHeadersRead(ChannelHandlerContext ctx, int streamId,
                     Http2Headers headers, int streamDependency, short weight, boolean exclusive,
                     int padding, boolean endStream) throws Http2Exception {
-                logger.logHeaders(INBOUND, streamId, headers, streamDependency, weight, exclusive,
+                logger.logHeaders(INBOUND, ctx, streamId, headers, streamDependency, weight, exclusive,
                         padding, endStream);
                 listener.onHeadersRead(ctx, streamId, headers, streamDependency, weight, exclusive,
                         padding, endStream);
@@ -67,67 +67,67 @@ public class Http2InboundFrameLogger implements Http2FrameReader {
             @Override
             public void onPriorityRead(ChannelHandlerContext ctx, int streamId,
                     int streamDependency, short weight, boolean exclusive) throws Http2Exception {
-                logger.logPriority(INBOUND, streamId, streamDependency, weight, exclusive);
+                logger.logPriority(INBOUND, ctx, streamId, streamDependency, weight, exclusive);
                 listener.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
             }
 
             @Override
             public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode)
                     throws Http2Exception {
-                logger.logRstStream(INBOUND, streamId, errorCode);
+                logger.logRstStream(INBOUND, ctx, streamId, errorCode);
                 listener.onRstStreamRead(ctx, streamId, errorCode);
             }
 
             @Override
             public void onSettingsAckRead(ChannelHandlerContext ctx) throws Http2Exception {
-                logger.logSettingsAck(INBOUND);
+                logger.logSettingsAck(INBOUND, ctx);
                 listener.onSettingsAckRead(ctx);
             }
 
             @Override
             public void onSettingsRead(ChannelHandlerContext ctx, Http2Settings settings)
                     throws Http2Exception {
-                logger.logSettings(INBOUND, settings);
+                logger.logSettings(INBOUND, ctx, settings);
                 listener.onSettingsRead(ctx, settings);
             }
 
             @Override
             public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
-                logger.logPing(INBOUND, data);
+                logger.logPing(INBOUND, ctx, data);
                 listener.onPingRead(ctx, data);
             }
 
             @Override
             public void onPingAckRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
-                logger.logPingAck(INBOUND, data);
+                logger.logPingAck(INBOUND, ctx, data);
                 listener.onPingAckRead(ctx, data);
             }
 
             @Override
             public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId,
                     int promisedStreamId, Http2Headers headers, int padding) throws Http2Exception {
-                logger.logPushPromise(INBOUND, streamId, promisedStreamId, headers, padding);
+                logger.logPushPromise(INBOUND, ctx, streamId, promisedStreamId, headers, padding);
                 listener.onPushPromiseRead(ctx, streamId, promisedStreamId, headers, padding);
             }
 
             @Override
             public void onGoAwayRead(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
                     ByteBuf debugData) throws Http2Exception {
-                logger.logGoAway(INBOUND, lastStreamId, errorCode, debugData);
+                logger.logGoAway(INBOUND, ctx, lastStreamId, errorCode, debugData);
                 listener.onGoAwayRead(ctx, lastStreamId, errorCode, debugData);
             }
 
             @Override
             public void onWindowUpdateRead(ChannelHandlerContext ctx, int streamId, int windowSizeIncrement)
                     throws Http2Exception {
-                logger.logWindowsUpdate(INBOUND, streamId, windowSizeIncrement);
+                logger.logWindowsUpdate(INBOUND, ctx, streamId, windowSizeIncrement);
                 listener.onWindowUpdateRead(ctx, streamId, windowSizeIncrement);
             }
 
             @Override
             public void onUnknownFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
                     Http2Flags flags, ByteBuf payload) throws Http2Exception {
-                logger.logUnknownFrame(INBOUND, frameType, streamId, flags, payload);
+                logger.logUnknownFrame(INBOUND, ctx, frameType, streamId, flags, payload);
                 listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
             }
         });

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2OutboundFrameLogger.java
@@ -38,14 +38,14 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
     @Override
     public ChannelFuture writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
             int padding, boolean endStream, ChannelPromise promise) {
-        logger.logData(OUTBOUND, streamId, data, padding, endStream);
+        logger.logData(OUTBOUND, ctx, streamId, data, padding, endStream);
         return writer.writeData(ctx, streamId, data, padding, endStream, promise);
     }
 
     @Override
     public ChannelFuture writeHeaders(ChannelHandlerContext ctx, int streamId,
             Http2Headers headers, int padding, boolean endStream, ChannelPromise promise) {
-        logger.logHeaders(OUTBOUND, streamId, headers, padding, endStream);
+        logger.logHeaders(OUTBOUND, ctx, streamId, headers, padding, endStream);
         return writer.writeHeaders(ctx, streamId, headers, padding, endStream, promise);
     }
 
@@ -53,7 +53,7 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
     public ChannelFuture writeHeaders(ChannelHandlerContext ctx, int streamId,
             Http2Headers headers, int streamDependency, short weight, boolean exclusive,
             int padding, boolean endStream, ChannelPromise promise) {
-        logger.logHeaders(OUTBOUND, streamId, headers, streamDependency, weight, exclusive,
+        logger.logHeaders(OUTBOUND, ctx, streamId, headers, streamDependency, weight, exclusive,
                 padding, endStream);
         return writer.writeHeaders(ctx, streamId, headers, streamDependency, weight,
                 exclusive, padding, endStream, promise);
@@ -62,27 +62,27 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
     @Override
     public ChannelFuture writePriority(ChannelHandlerContext ctx, int streamId,
             int streamDependency, short weight, boolean exclusive, ChannelPromise promise) {
-        logger.logPriority(OUTBOUND, streamId, streamDependency, weight, exclusive);
+        logger.logPriority(OUTBOUND, ctx, streamId, streamDependency, weight, exclusive);
         return writer.writePriority(ctx, streamId, streamDependency, weight, exclusive, promise);
     }
 
     @Override
     public ChannelFuture writeRstStream(ChannelHandlerContext ctx,
             int streamId, long errorCode, ChannelPromise promise) {
-        logger.logRstStream(OUTBOUND, streamId, errorCode);
+        logger.logRstStream(OUTBOUND, ctx, streamId, errorCode);
         return writer.writeRstStream(ctx, streamId, errorCode, promise);
     }
 
     @Override
     public ChannelFuture writeSettings(ChannelHandlerContext ctx,
             Http2Settings settings, ChannelPromise promise) {
-        logger.logSettings(OUTBOUND, settings);
+        logger.logSettings(OUTBOUND, ctx, settings);
         return writer.writeSettings(ctx, settings, promise);
     }
 
     @Override
     public ChannelFuture writeSettingsAck(ChannelHandlerContext ctx, ChannelPromise promise) {
-        logger.logSettingsAck(OUTBOUND);
+        logger.logSettingsAck(OUTBOUND, ctx);
         return writer.writeSettingsAck(ctx, promise);
     }
 
@@ -90,9 +90,9 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
     public ChannelFuture writePing(ChannelHandlerContext ctx, boolean ack,
             ByteBuf data, ChannelPromise promise) {
         if (ack) {
-            logger.logPingAck(OUTBOUND, data);
+            logger.logPingAck(OUTBOUND, ctx, data);
         } else {
-            logger.logPing(OUTBOUND, data);
+            logger.logPing(OUTBOUND, ctx, data);
         }
         return writer.writePing(ctx, ack, data, promise);
     }
@@ -100,28 +100,28 @@ public class Http2OutboundFrameLogger implements Http2FrameWriter {
     @Override
     public ChannelFuture writePushPromise(ChannelHandlerContext ctx, int streamId,
             int promisedStreamId, Http2Headers headers, int padding, ChannelPromise promise) {
-        logger.logPushPromise(OUTBOUND, streamId, promisedStreamId, headers, padding);
+        logger.logPushPromise(OUTBOUND, ctx, streamId, promisedStreamId, headers, padding);
         return writer.writePushPromise(ctx, streamId, promisedStreamId, headers, padding, promise);
     }
 
     @Override
     public ChannelFuture writeGoAway(ChannelHandlerContext ctx, int lastStreamId, long errorCode,
             ByteBuf debugData, ChannelPromise promise) {
-        logger.logGoAway(OUTBOUND, lastStreamId, errorCode, debugData);
+        logger.logGoAway(OUTBOUND, ctx, lastStreamId, errorCode, debugData);
         return writer.writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
     }
 
     @Override
     public ChannelFuture writeWindowUpdate(ChannelHandlerContext ctx,
             int streamId, int windowSizeIncrement, ChannelPromise promise) {
-        logger.logWindowsUpdate(OUTBOUND, streamId, windowSizeIncrement);
+        logger.logWindowsUpdate(OUTBOUND, ctx, streamId, windowSizeIncrement);
         return writer.writeWindowUpdate(ctx, streamId, windowSizeIncrement, promise);
     }
 
     @Override
     public ChannelFuture writeFrame(ChannelHandlerContext ctx, byte frameType, int streamId,
             Http2Flags flags, ByteBuf payload, ChannelPromise promise) {
-        logger.logUnknownFrame(OUTBOUND, frameType, streamId, flags, payload);
+        logger.logUnknownFrame(OUTBOUND, ctx, frameType, streamId, flags, payload);
         return writer.writeFrame(ctx, frameType, streamId, flags, payload, promise);
     }
 


### PR DESCRIPTION
Motivation:
Currently it's impossible to distinguish which connection the corresponding logged message is related to.

Modifications:
Http2FrameLogger is extended to support channel id logging, usages in Inbound/Outbound Frame  Loggers are adjusted accordingly. 

Result:
Logger outputs the channel id.

Originally discussed at #4719 

Log format is changed in a way similar to LoggingHandler (starting with channel id)