### PR TITLE
Fix testResolveIp to make it work in some special environment

### DIFF
--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -499,7 +499,7 @@ public class DnsNameResolverTest {
         try {
             InetAddress address = resolver.resolve("10.0.0.1").syncUninterruptibly().getNow();
 
-            assertEquals("10.0.0.1", address.getHostName());
+            assertEquals("10.0.0.1", address.getHostAddress());
         } finally {
             resolver.close();
         }


### PR DESCRIPTION
Motivation:

As "getHostName" may do a reverse name lookup and return a host name based on the system configured name lookup service, testResolveIp may fail in some special environment. See #4720

Modifications:

Use getHostAddress instead of getHostName

Result:

testResolveIp works in all environments