### PR TITLE
Guard against false-sharing when allocate from PooledByteBufAllocator

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -105,6 +105,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
     final PoolArena<T> arena;
     final T memory;
     final boolean unpooled;
+    final int offset;
 
     private final byte[] memoryMap;
     private final byte[] depthMap;
@@ -129,7 +130,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
     // TODO: Test if adding padding helps under contention
     //private long pad0, pad1, pad2, pad3, pad4, pad5, pad6, pad7;
 
-    PoolChunk(PoolArena<T> arena, T memory, int pageSize, int maxOrder, int pageShifts, int chunkSize) {
+    PoolChunk(PoolArena<T> arena, T memory, int pageSize, int maxOrder, int pageShifts, int chunkSize, int offset) {
         unpooled = false;
         this.arena = arena;
         this.memory = memory;
@@ -137,6 +138,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
         this.pageShifts = pageShifts;
         this.maxOrder = maxOrder;
         this.chunkSize = chunkSize;
+        this.offset = offset;
         unusable = (byte) (maxOrder + 1);
         log2ChunkSize = log2(chunkSize);
         subpageOverflowMask = ~(pageSize - 1);
@@ -163,10 +165,11 @@ final class PoolChunk<T> implements PoolChunkMetric {
     }
 
     /** Creates a special chunk that is not pooled. */
-    PoolChunk(PoolArena<T> arena, T memory, int size) {
+    PoolChunk(PoolArena<T> arena, T memory, int size, int offset) {
         unpooled = true;
         this.arena = arena;
         this.memory = memory;
+        this.offset = offset;
         memoryMap = null;
         depthMap = null;
         subpages = null;
@@ -369,7 +372,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
         if (bitmapIdx == 0) {
             byte val = value(memoryMapIdx);
             assert val == unusable : String.valueOf(val);
-            buf.init(this, handle, runOffset(memoryMapIdx), reqCapacity, runLength(memoryMapIdx),
+            buf.init(this, handle, runOffset(memoryMapIdx) + offset, reqCapacity, runLength(memoryMapIdx),
                      arena.parent.threadCache());
         } else {
             initBufWithSubpage(buf, handle, bitmapIdx, reqCapacity);
@@ -391,8 +394,8 @@ final class PoolChunk<T> implements PoolChunkMetric {
 
         buf.init(
             this, handle,
-            runOffset(memoryMapIdx) + (bitmapIdx & 0x3FFFFFFF) * subpage.elemSize, reqCapacity, subpage.elemSize,
-            arena.parent.threadCache());
+            runOffset(memoryMapIdx) + (bitmapIdx & 0x3FFFFFFF) * subpage.elemSize + offset, reqCapacity,
+            subpage.elemSize, arena.parent.threadCache());
     }
 
     private byte value(int id) {

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -61,7 +61,7 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
         this.chunk = chunk;
         handle = 0;
         memory = chunk.memory;
-        offset = 0;
+        offset = chunk.offset;
         this.length = maxLength = length;
         tmpNioBuf = null;
         cache = null;

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -151,11 +151,18 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator {
 
     public PooledByteBufAllocator(boolean preferDirect, int nHeapArena, int nDirectArena, int pageSize, int maxOrder) {
         this(preferDirect, nHeapArena, nDirectArena, pageSize, maxOrder,
-                DEFAULT_TINY_CACHE_SIZE, DEFAULT_SMALL_CACHE_SIZE, DEFAULT_NORMAL_CACHE_SIZE);
+                DEFAULT_TINY_CACHE_SIZE, DEFAULT_SMALL_CACHE_SIZE, DEFAULT_NORMAL_CACHE_SIZE, true);
     }
 
     public PooledByteBufAllocator(boolean preferDirect, int nHeapArena, int nDirectArena, int pageSize, int maxOrder,
                                   int tinyCacheSize, int smallCacheSize, int normalCacheSize) {
+        this(preferDirect, nHeapArena, nDirectArena, pageSize, maxOrder,
+                tinyCacheSize, smallCacheSize, normalCacheSize, true);
+    }
+
+    public PooledByteBufAllocator(boolean preferDirect, int nHeapArena, int nDirectArena, int pageSize, int maxOrder,
+                                  int tinyCacheSize, int smallCacheSize, int normalCacheSize,
+                                  boolean preventFalseSharing) {
         super(preferDirect);
         threadCache = new PoolThreadLocalCache();
         this.tinyCacheSize = tinyCacheSize;
@@ -176,7 +183,8 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator {
             heapArenas = newArenaArray(nHeapArena);
             List<PoolArenaMetric> metrics = new ArrayList<PoolArenaMetric>(heapArenas.length);
             for (int i = 0; i < heapArenas.length; i ++) {
-                PoolArena.HeapArena arena = new PoolArena.HeapArena(this, pageSize, maxOrder, pageShifts, chunkSize);
+                PoolArena.HeapArena arena = new PoolArena.HeapArena(
+                        this, pageSize, maxOrder, pageShifts, chunkSize, preventFalseSharing);
                 heapArenas[i] = arena;
                 metrics.add(arena);
             }
@@ -191,7 +199,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator {
             List<PoolArenaMetric> metrics = new ArrayList<PoolArenaMetric>(directArenas.length);
             for (int i = 0; i < directArenas.length; i ++) {
                 PoolArena.DirectArena arena = new PoolArena.DirectArena(
-                        this, pageSize, maxOrder, pageShifts, chunkSize);
+                        this, pageSize, maxOrder, pageShifts, chunkSize, preventFalseSharing);
                 directArenas[i] = arena;
                 metrics.add(arena);
             }

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -25,7 +25,7 @@ public class PoolArenaTest {
 
     @Test
     public void testNormalizeCapacity() throws Exception {
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, 0, 0, 9, 999999);
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, 0, 0, 9, 999999, true);
         int[] reqCapacities = {0, 15, 510, 1024, 1023, 1025};
         int[] expectedResult = {0, 16, 512, 1024, 1024, 2048};
         for (int i = 0; i < reqCapacities.length; i ++) {

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -42,7 +42,7 @@ public class PooledByteBufAllocatorTest {
 
         // We use no caches and only one arena to maximize the chance of hitting the race-condition we
         // had before.
-        ByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 1, 8192, 11, 0, 0, 0);
+        ByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 1, 8192, 11, 0, 0, 0, true);
         List<AllocationThread> threads = new ArrayList<AllocationThread>();
         try {
             for (int i = 0; i < 512; i++) {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -23,6 +23,7 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
@@ -31,6 +32,8 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Deque;
 import java.util.List;
 import java.util.Locale;
@@ -71,6 +74,9 @@ public final class PlatformDependent {
 
     private static final boolean IS_ANDROID = isAndroid0();
     private static final boolean IS_WINDOWS = isWindows0();
+    private static final boolean IS_LINUX = isLinux0();
+    private static final boolean IS_OSX = isOsx0();
+
     private static volatile Boolean IS_ROOT;
 
     private static final int JAVA_VERSION = javaVersion0();
@@ -92,6 +98,8 @@ public final class PlatformDependent {
     private static final int BIT_MODE = bitMode0();
 
     private static final int ADDRESS_SIZE = addressSize0();
+    private static final int CACHE_LINE_SIZE = cacheLineSize0();
+
     public static final boolean BIG_ENDIAN_NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
 
     static {
@@ -652,6 +660,14 @@ public final class PlatformDependent {
         }
     }
 
+    /**
+     * Return the size of a cache line for the running platform or {@code -1} if is unknown
+     * or could not be detected.
+     */
+    public static int cacheLineSize() {
+        return CACHE_LINE_SIZE;
+    }
+
     private static boolean isAndroid0() {
         boolean android;
         try {
@@ -668,12 +684,108 @@ public final class PlatformDependent {
         return android;
     }
 
+    private static boolean isOs(String os) {
+        return SystemPropertyUtil.get("os.name", "").toLowerCase(Locale.US).contains(os);
+    }
+
     private static boolean isWindows0() {
-        boolean windows = SystemPropertyUtil.get("os.name", "").toLowerCase(Locale.US).contains("win");
+        boolean windows = isOs("win");
         if (windows) {
             logger.debug("Platform: Windows");
         }
         return windows;
+    }
+
+    private static boolean isLinux0() {
+        boolean linux = isOs("linux");
+        if (linux) {
+            logger.debug("Platform: Linux");
+        }
+        return linux;
+    }
+
+    private static boolean isOsx0() {
+        boolean osx = isOs("os x") || isOs("osx");
+        if (osx) {
+            logger.debug("Platform: OSX");
+        }
+        return osx;
+    }
+
+    private static int cacheLineSize0() {
+        return AccessController.doPrivileged(new PrivilegedAction<Integer>() {
+            @Override
+            public Integer run() {
+                if (IS_LINUX) {
+                    BufferedReader in = null;
+                    try {
+                        in = new BufferedReader(new InputStreamReader(new FileInputStream("/proc/cpuinfo")));
+                        String line;
+                        while ((line = in.readLine()) != null) {
+                            if (line.startsWith("cache_alignment")) {
+                                String[] parts = StringUtil.split(line, ':');
+                                return Integer.parseInt(parts[1].trim());
+                            }
+                        }
+                    } catch (Throwable cause) {
+                        logger.debug("Failed to retrieve cache line size", cause);
+                        return -1;
+                    } finally {
+                        if (in != null) {
+                            try {
+                                in.close();
+                            } catch (IOException ignore) {
+                                // ignore on close
+                            }
+                        }
+                    }
+                } else if (IS_OSX) {
+                    Process p = null;
+                    BufferedReader in = null;
+                    try {
+                        p = Runtime.getRuntime().exec(new String[] { "sysctl", "hw.cachelinesize" });
+                        in = new BufferedReader(new InputStreamReader(p.getInputStream(), CharsetUtil.US_ASCII));
+                        String line = in.readLine();
+                        in.close();
+                        try {
+                            int exitCode = p.waitFor();
+                            if (exitCode != 0) {
+                                logger.debug("Failed to retrieve cache line size," +
+                                        " 'sysctl hw.cachelinesize' did exit with code " + exitCode);
+                                return -1;
+                            }
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        if (line != null) {
+                            String[] parts = StringUtil.split(line, ':');
+                            return Integer.parseInt(parts[1].trim());
+                        }
+                    } catch (Exception e) {
+                        // Failed to run the command.
+                        logger.debug("Failed to retrieve cache line size", e);
+                        return -1;
+                    } finally {
+                        if (in != null) {
+                            try {
+                                in.close();
+                            } catch (IOException e) {
+                                // Ignore
+                            }
+                        }
+                        if (p != null) {
+                            try {
+                                p.destroy();
+                            } catch (Exception ignore) {
+                                // Just ignore
+                            }
+                        }
+                    }
+                }
+                logger.debug("Failed to retrieve cache line size");
+                return -1;
+            }
+        });
     }
 
     private static boolean isRoot0() {

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
@@ -35,7 +35,7 @@ public class ByteBufAllocatorBenchmark extends AbstractMicrobenchmark {
 
     private static final ByteBufAllocator unpooledAllocator = new UnpooledByteBufAllocator(true);
     private static final ByteBufAllocator pooledAllocator =
-            new PooledByteBufAllocator(true, 4, 4, 8192, 11, 0, 0, 0); // Disable thread-local cache
+            new PooledByteBufAllocator(true, 4, 4, 8192, 11, 0, 0, 0, false); // Disable thread-local cache
 
     private static final int MAX_LIVE_BUFFERS = 8192;
     private static final Random rand = new Random();

--- a/microbench/src/main/java/io/netty/microbench/buffer/PooledByteBufAllocatorFalseSharingBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/PooledByteBufAllocatorFalseSharingBenchmark.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.buffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+@Threads(4)
+public class PooledByteBufAllocatorFalseSharingBenchmark extends AbstractMicrobenchmark {
+    private static final byte BYTE = 'a';
+
+    private PooledByteBufAllocator allocator;
+    private PooledByteBufAllocator allocator2;
+
+    @Setup
+    public void setup() {
+        allocator = new PooledByteBufAllocator(true, 2, 2, 8192, 11, 0, 0, 0, false);
+        allocator2 = new PooledByteBufAllocator(true, 2, 2, 8192, 11, 0, 0, 0, true);
+    }
+
+    @Param({ "00512", "01024", "02048", "04096", "08192" })
+    public int size;
+
+    @Benchmark
+    public void falseSharing(Blackhole hole) {
+        alloc(allocator, size, hole);
+    }
+
+    @Benchmark
+    public void noFalseSharing(Blackhole hole) {
+        alloc(allocator2, size, hole);
+    }
+
+    private static void alloc(ByteBufAllocator allocator, int size, Blackhole hole) {
+        ByteBuf buffer = allocator.directBuffer(size);
+        for (int a = 0; a < size; a++) {
+            buffer.setByte(a, BYTE);
+            hole.consume(buffer.getByte(a));
+        }
+        buffer.release();
+    }
+}


### PR DESCRIPTION
Motivation:

Because we not took care to allign allocations on the cacheline size it could produce false-sharing effects.

Modifications:

- Ensure we correctly use a offset when slice out buffers so we not share cache lines

Result:

Better performance

```
Benchmark                                                   (size)   Mode  Cnt       Score       Error  Units
PooledByteBufAllocatorFalseSharingBenchmark.falseSharing     00512  thrpt   20  685296.357 ± 30092.225  ops/s
PooledByteBufAllocatorFalseSharingBenchmark.falseSharing     01024  thrpt   20  370008.716 ±  3509.795  ops/s
PooledByteBufAllocatorFalseSharingBenchmark.falseSharing     02048  thrpt   20  185731.575 ±  4806.616  ops/s
PooledByteBufAllocatorFalseSharingBenchmark.falseSharing     04096  thrpt   20   90603.308 ±  3860.461  ops/s
PooledByteBufAllocatorFalseSharingBenchmark.falseSharing     08192  thrpt   20   43513.344 ±  3038.603  ops/s
PooledByteBufAllocatorFalseSharingBenchmark.noFalseSharing   00512  thrpt   20  719899.937 ± 10043.278  ops/s
PooledByteBufAllocatorFalseSharingBenchmark.noFalseSharing   01024  thrpt   20  370943.544 ± 10816.982  ops/s
PooledByteBufAllocatorFalseSharingBenchmark.noFalseSharing   02048  thrpt   20  188452.511 ±  4935.453  ops/s
PooledByteBufAllocatorFalseSharingBenchmark.noFalseSharing   04096  thrpt   20   94369.012 ±  3636.229  ops/s
PooledByteBufAllocatorFalseSharingBenchmark.noFalseSharing   08192  thrpt   20   47478.232 ±  2165.613  ops/s
```