### PR TITLE
Remove final from EpollEventLoopGroup

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ThreadFactory;
  * {@link EventLoopGroup} which uses epoll under the covers. Because of this
  * it only works on linux.
  */
-public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
+public class EpollEventLoopGroup extends MultithreadEventLoopGroup {
 
     /**
      * Create a new instance using the default number of threads and the default {@link ThreadFactory}.


### PR DESCRIPTION
Motivation:
NioEventLoopGroup is not final and is able to be extended. EpollEventLoopGroup should be consistent.

Modifications:
- Remove the final keyword from EpollEventLoopGroup class definition.

Result:
EpollEventLoopGroup can be extended.