### PR TITLE
Change 64 to 63 in Snappy.decodeLiteral

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
@@ -228,7 +228,7 @@ class Snappy {
      * @param out The output buffer to copy to
      * @param length The length of the literal to copy
      */
-    private static void encodeLiteral(ByteBuf in, ByteBuf out, int length) {
+    static void encodeLiteral(ByteBuf in, ByteBuf out, int length) {
         if (length < 61) {
             out.writeByte(length - 1 << 2);
         } else {
@@ -395,7 +395,7 @@ class Snappy {
      * @param out The output buffer to write the literal to
      * @return The number of bytes appended to the output buffer, or -1 to indicate "try again later"
      */
-    private static int decodeLiteral(byte tag, ByteBuf in, ByteBuf out) {
+    static int decodeLiteral(byte tag, ByteBuf in, ByteBuf out) {
         in.markReaderIndex();
         int length;
         switch(tag >> 2 & 0x3F) {
@@ -417,7 +417,7 @@ class Snappy {
             }
             length = in.readUnsignedMediumLE();
             break;
-        case 64:
+        case 63:
             if (in.readableBytes() < 4) {
                 return NOT_ENOUGH_INPUT;
             }

--- a/codec/src/test/java/io/netty/handler/codec/compression/SnappyTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/SnappyTest.java
@@ -195,4 +195,32 @@ public class SnappyTest {
 
         validateChecksum(maskChecksum(0xd6cb8b55), input);
     }
+
+    @Test
+    public void testEncodeLiteralAndDecodeLiteral() {
+        int[] lengths = new int[] {
+            0x11, // default
+            0x100, // case 60
+            0x1000, // case 61
+            0x100000, // case 62
+            0x1000001 // case 63
+        };
+        for (int len : lengths) {
+            ByteBuf in = Unpooled.wrappedBuffer(new byte[len]);
+            ByteBuf encoded = Unpooled.buffer(10);
+            ByteBuf decoded = Unpooled.buffer(10);
+            ByteBuf expected = Unpooled.wrappedBuffer(new byte[len]);
+            try {
+                Snappy.encodeLiteral(in, encoded, len);
+                byte tag = encoded.readByte();
+                Snappy.decodeLiteral(tag, encoded, decoded);
+                assertEquals("Encoded or decoded literal was incorrect", expected, decoded);
+            } finally {
+                in.release();
+                encoded.release();
+                decoded.release();
+                expected.release();
+            }
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

According to https://github.com/google/snappy/blob/master/format_description.txt#L55 , Snappy.decodeLiteral should handle the cases of 60, 61, 62 and 63. However right now it processes 64 instead of 63. I believe it's a typo since `tag >> 2 & 0x3F` must be less than 64.

Modifications:

Use the correct value 63.

Result:

Snappy.decodeLiteral handles the correct case.