### PR TITLE
PlatformDependent static initialization ExceptionInInitializerError

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -657,7 +657,7 @@ public final class PlatformDependent {
         try {
             Class.forName("android.app.Application", false, getSystemClassLoader());
             android = true;
-        } catch (Exception e) {
+        } catch (Throwable ignored) {
             // Failed to load the class uniquely available in Android.
             android = false;
         }
@@ -704,7 +704,7 @@ public final class PlatformDependent {
                         // Ignore
                     }
                 }
-            } catch (Exception e) {
+            } catch (Throwable ignored) {
                 // Failed to run the command.
                 uid = null;
             } finally {
@@ -785,7 +785,7 @@ public final class PlatformDependent {
                 Class.forName("java.time.Clock", false, getClassLoader(Object.class));
                 javaVersion = 8;
                 break;
-            } catch (Exception e) {
+            } catch (Throwable ignored) {
                 // Ignore
             }
 
@@ -793,7 +793,7 @@ public final class PlatformDependent {
                 Class.forName("java.util.concurrent.LinkedTransferQueue", false, getClassLoader(BlockingQueue.class));
                 javaVersion = 7;
                 break;
-            } catch (Exception e) {
+            } catch (Throwable ignored) {
                 // Ignore
             }
 
@@ -838,7 +838,7 @@ public final class PlatformDependent {
             boolean hasUnsafe = PlatformDependent0.hasUnsafe();
             logger.debug("sun.misc.Unsafe: {}", hasUnsafe ? "available" : "unavailable");
             return hasUnsafe;
-        } catch (Throwable t) {
+        } catch (Throwable ignored) {
             // Probably failed to initialize PlatformDependent0.
             return false;
         }
@@ -851,7 +851,7 @@ public final class PlatformDependent {
             Class<?> vmClass = Class.forName("sun.misc.VM", true, getSystemClassLoader());
             Method m = vmClass.getDeclaredMethod("maxDirectMemory");
             maxDirectMemory = ((Number) m.invoke(null)).longValue();
-        } catch (Throwable t) {
+        } catch (Throwable ignored) {
             // Ignore
         }
 
@@ -891,7 +891,7 @@ public final class PlatformDependent {
                 }
                 break;
             }
-        } catch (Throwable t) {
+        } catch (Throwable ignored) {
             // Ignore
         }
 
@@ -976,7 +976,7 @@ public final class PlatformDependent {
                     return f;
                 }
             }
-        } catch (Exception ignored) {
+        } catch (Throwable ignored) {
             // Environment variable inaccessible
         }
 

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -136,23 +136,29 @@ final class PlatformDependent0 {
             UNALIGNED = unaligned;
             logger.debug("java.nio.Bits.unaligned: {}", UNALIGNED);
 
-            Field stringValueField = AccessController.doPrivileged(new PrivilegedAction<Field>() {
-                @Override
-                public Field run() {
-                    try {
-                        Field f = String.class.getDeclaredField("value");
-                        f.setAccessible(true);
-                        return f;
-                    } catch (NoSuchFieldException e) {
-                        logger.warn("Failed to find String value array." +
-                                "String hash code optimizations are disabled.", e);
-                    } catch (SecurityException e) {
-                        logger.info("No permissions to get String value array." +
-                                "String hash code optimizations are disabled.", e);
+            Field stringValueField = null;
+            try {
+                stringValueField = AccessController.doPrivileged(new PrivilegedAction<Field>() {
+                    @Override
+                    public Field run() {
+                        try {
+                            Field f = String.class.getDeclaredField("value");
+                            f.setAccessible(true);
+                            return f;
+                        } catch (NoSuchFieldException e) {
+                            logger.info("Failed to find String value array (please report an issue)." +
+                                    "String hash code optimizations are disabled.", e);
+                        } catch (SecurityException e) {
+                            logger.debug("No permissions to get String value array." +
+                                    "String hash code optimizations are disabled.", e);
+                        }
+                        return null;
                     }
-                    return null;
-                }
-            });
+                });
+            } catch (Throwable t) {
+                logger.debug("AccessController.doPrivileged failed to get String value array." +
+                        "String hash code optimizations are disabled.", t);
+            }
             STRING_VALUE_FIELD_OFFSET = stringValueField == null ?
                     -1 : UNSAFE.objectFieldOffset(stringValueField);
         }


### PR DESCRIPTION
Motivation:
PlatformDependent allows some exceptions to escape during static initialization. If an exception escapes it will be translated into a java.lang.ExceptionInInitializerError and render the application unable to run.

Modifications:
- Make sure to catch Throwable during static initialization.

Result:
PlatformDependent static initialization doesn't result in java.lang.ExceptionInInitializerError.
Fixes https://github.com/netty/netty/issues/4730