### PR TITLE
Init DnsNameResolverBuilder#nameServerAddresses

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -38,7 +38,7 @@ public final class DnsNameResolverBuilder {
     private final EventLoop eventLoop;
     private ChannelFactory<? extends DatagramChannel> channelFactory;
     private InetSocketAddress localAddress = DnsNameResolver.ANY_LOCAL_ADDR;
-    private DnsServerAddresses nameServerAddresses;
+    private DnsServerAddresses nameServerAddresses = DefaultDnsServerAddresses.defaultAddresses();
     private DnsCache resolveCache;
     private Integer minTtl;
     private Integer maxTtl;


### PR DESCRIPTION
Motivation:

DnsNameResolverBuilder#nameServerAddresses isn’t initialized with a
default value. In most cases, user will want
DefaultDnsServerAddresses#defaultAddresses.

Modifications:

Initialize DnsNameResolverBuilder#nameServerAddresses with
DefaultDnsServerAddresses#defaultAddresses

Result:

DnsNameResolverBuilder more convenient usage.