### PR TITLE
Added raw 'deflate' (no wrap) support to JZlibDecoder

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JdkZlibDecoder.java
@@ -136,7 +136,7 @@ public class JdkZlibDecoder extends ZlibDecoder {
                 return;
             }
 
-            boolean nowrap = !looksLikeZlib(in.getShort(in.readerIndex()));
+            boolean nowrap = !ZlibUtil.looksLikeZlib(in.getShort(in.readerIndex()));
             inflater = new Inflater(nowrap);
             decideZlibOrNone = false;
         }
@@ -377,17 +377,5 @@ public class JdkZlibDecoder extends ZlibDecoder {
             throw new DecompressionException(
                     "CRC value missmatch. Expected: " + crcValue + ", Got: " + readCrc);
         }
-    }
-
-    /*
-     * Returns true if the cmf_flg parameter (think: first two bytes of a zlib stream)
-     * indicates that this is a zlib stream.
-     * <p>
-     * You can lookup the details in the ZLIB RFC:
-     * <a href="http://tools.ietf.org/html/rfc1950#section-2.2">RFC 1950</a>.
-     */
-    private static boolean looksLikeZlib(short cmf_flg) {
-        return (cmf_flg & 0x7800) == 0x7800 &&
-                cmf_flg % 31 == 0;
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibUtil.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibUtil.java
@@ -80,6 +80,18 @@ final class ZlibUtil {
         return overhead;
     }
 
+    /*
+     * Returns true if the cmf_flg parameter (think: first two bytes of a zlib stream)
+     * indicates that this is a zlib stream.
+     * <p>
+     * You can lookup the details in the ZLIB RFC:
+     * <a href="http://tools.ietf.org/html/rfc1950#section-2.2">RFC 1950</a>.
+     */
+    static boolean looksLikeZlib(short cmf_flg) {
+        return (cmf_flg & 0x7800) == 0x7800 &&
+                cmf_flg % 31 == 0;
+    }
+
     private ZlibUtil() {
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/JZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/JZlibTest.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.compression;
 
+import org.junit.Test;
+
 public class JZlibTest extends ZlibTest {
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/JdkZlibTest.java
@@ -29,10 +29,4 @@ public class JdkZlibTest extends ZlibTest {
     protected ZlibDecoder createDecoder(ZlibWrapper wrapper) {
         return new JdkZlibDecoder(wrapper);
     }
-
-    @Test(expected = DecompressionException.class)
-    @Override
-    public void testZLIB_OR_NONE3() throws Exception {
-        super.testZLIB_OR_NONE3();
-    }
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest1.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest1.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.compression;
 
+import org.junit.Test;
+
 public class ZlibCrossTest1 extends ZlibTest {
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest2.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZlibCrossTest2.java
@@ -28,10 +28,4 @@ public class ZlibCrossTest2 extends ZlibTest {
     protected ZlibDecoder createDecoder(ZlibWrapper wrapper) {
         return new JdkZlibDecoder(wrapper);
     }
-
-    @Test(expected = DecompressionException.class)
-    @Override
-    public void testZLIB_OR_NONE3() throws Exception {
-        super.testZLIB_OR_NONE3();
-    }
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
@@ -334,13 +334,6 @@ public abstract class ZlibTest {
         testCompressLarge(ZlibWrapper.ZLIB, ZlibWrapper.ZLIB_OR_NONE);
     }
 
-    @Test
-    public void testZLIB_OR_NONE3() throws Exception {
-        testCompressNone(ZlibWrapper.GZIP, ZlibWrapper.ZLIB_OR_NONE);
-        testCompressSmall(ZlibWrapper.GZIP, ZlibWrapper.ZLIB_OR_NONE);
-        testCompressLarge(ZlibWrapper.GZIP, ZlibWrapper.ZLIB_OR_NONE);
-    }
-
     private static byte[] gzip(byte[] bytes) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         GZIPOutputStream stream = new GZIPOutputStream(out);


### PR DESCRIPTION
Motivation:

Some servers use raw 'deflate' (no wrap) encoding instead of Zlib.
JdkZlibDecoder has support to detect this and fallback to raw
'deflate' encoding when the wrapper type is ZLIB_OR_NONE.
However JZlibDecoder does not have this support and fails when
raw 'deflate' encoding is used.

Modifications:

Modified JZlibDecoder to add this "fallback" feature similar to
JdkZlibDecoder when the wrapper type is ZLIB_OR_NONE. Before this
change, JZlibDecoder was able to handle gzip compression when
wrapper is ZLIB_OR_NONE. This has been removed now to make the
behavior same as JdkZlibDecoder. Since this is removed now,
I have removed the related test case - testZLIB_OR_NONE3().

Result:

JZlibDecoder now supports fallback to raw deflate (no wrap)
encoding similar to JdkZlibDecoder.