### PR TITLE
[#4736] Clear disabled SSL protocols before enabling provided SSL pro…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -1076,21 +1076,29 @@ public final class OpenSslEngine extends SSLEngine {
                 // Enable all and then disable what we not want
                 SSL.setOptions(ssl, SSL.SSL_OP_ALL);
 
+                // Clear out options which disable protocols
+                SSL.clearOptions(ssl, SSL.SSL_OP_NO_SSLv2 | SSL.SSL_OP_NO_SSLv3 | SSL.SSL_OP_NO_TLSv1 |
+                    SSL.SSL_OP_NO_TLSv1_1 | SSL.SSL_OP_NO_TLSv1_2);
+
+                int opts = 0;
                 if (!sslv2) {
-                    SSL.setOptions(ssl, SSL.SSL_OP_NO_SSLv2);
+                    opts |= SSL.SSL_OP_NO_SSLv2;
                 }
                 if (!sslv3) {
-                    SSL.setOptions(ssl, SSL.SSL_OP_NO_SSLv3);
+                    opts |= SSL.SSL_OP_NO_SSLv3;
                 }
                 if (!tlsv1) {
-                    SSL.setOptions(ssl, SSL.SSL_OP_NO_TLSv1);
+                    opts |= SSL.SSL_OP_NO_TLSv1;
                 }
                 if (!tlsv1_1) {
-                    SSL.setOptions(ssl, SSL.SSL_OP_NO_TLSv1_1);
+                    opts |= SSL.SSL_OP_NO_TLSv1_1;
                 }
                 if (!tlsv1_2) {
-                    SSL.setOptions(ssl, SSL.SSL_OP_NO_TLSv1_2);
+                    opts |= SSL.SSL_OP_NO_TLSv1_2;
                 }
+
+                // Disable protocols we do not want
+                SSL.setOptions(ssl, opts);
             } else {
                 throw new IllegalStateException("failed to enable protocols: " + Arrays.asList(protocols));
             }

--- a/handler/src/test/java/io/netty/handler/ssl/JdkSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkSslEngineTest.java
@@ -15,25 +15,24 @@
  */
 package io.netty.handler.ssl;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeNoException;
-import io.netty.handler.ssl.JdkApplicationProtocolNegotiator.ProtocolSelector;
-import io.netty.handler.ssl.JdkApplicationProtocolNegotiator.ProtocolSelectorFactory;
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
+import io.netty.handler.ssl.JdkApplicationProtocolNegotiator.ProtocolSelector;
+import io.netty.handler.ssl.JdkApplicationProtocolNegotiator.ProtocolSelectorFactory;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import org.junit.Test;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLHandshakeException;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLHandshakeException;
-
-import org.junit.Test;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeNoException;
 
 public class JdkSslEngineTest extends SSLEngineTest {
     private static final String PREFERRED_APPLICATION_LEVEL_PROTOCOL = "my-protocol-http2";
@@ -261,6 +260,11 @@ public class JdkSslEngineTest extends SSLEngineTest {
             // java version incompatibility don't fail the test, but instead just skip the test
             assumeNoException(e);
         }
+    }
+
+    @Test
+    public void testEnablingAnAlreadyDisabledSslProtocol() throws Exception {
+        testEnablingAnAlreadyDisabledSslProtocol(new String[]{}, new String[]{PROTOCOL_TLS_V1_2});
     }
 
     private void runTest() throws Exception {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -60,6 +60,13 @@ public class OpenSslEngineTest extends SSLEngineTest {
         runTest(PREFERRED_APPLICATION_LEVEL_PROTOCOL);
     }
 
+    @Test
+    public void testEnablingAnAlreadyDisabledSslProtocol() throws Exception {
+        assumeTrue(OpenSsl.isAvailable());
+        testEnablingAnAlreadyDisabledSslProtocol(new String[]{PROTOCOL_SSL_V2_HELLO},
+            new String[]{PROTOCOL_SSL_V2_HELLO, PROTOCOL_TLS_V1_2});
+    }
+
     @Override
     public void testMutualAuthSameCerts() throws Exception {
         assumeTrue(OpenSsl.isAvailable());

--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>1.1.33.Fork10</version>
+        <version>1.1.33.Fork11</version>
         <classifier>${tcnative.classifier}</classifier>
         <scope>compile</scope>
         <optional>true</optional>


### PR DESCRIPTION
…tocols

Motivation:

Attempts to enable SSL protocols which are currently disabled fail when using the OpenSslEngine. Related to https://github.com/netty/netty/issues/4736

Modifications:

Clear out all options that have disabled SSL protocols before attempting to enable any SSL protocol.

Result:

setEnabledProtocols works as expected.