### PR TITLE
Fix race when changing channel writability

### DIFF
--- a/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioWorker.java
+++ b/src/main/java/org/jboss/netty/channel/socket/nio/AbstractNioWorker.java
@@ -19,6 +19,7 @@ import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelFuture;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.channel.socket.Worker;
+import org.jboss.netty.channel.socket.nio.AbstractNioChannel.WriteRequestQueue;
 import org.jboss.netty.channel.socket.nio.SocketSendBufferPool.SendBuffer;
 import org.jboss.netty.util.ThreadNameDeterminer;
 import org.jboss.netty.util.ThreadRenamingRunnable;
@@ -34,7 +35,6 @@ import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.Executor;
 
@@ -170,7 +170,7 @@ abstract class AbstractNioWorker extends AbstractNioSelector implements Worker {
 
         final SocketSendBufferPool sendBufferPool = this.sendBufferPool;
         final WritableByteChannel ch = channel.channel;
-        final Queue<MessageEvent> writeBuffer = channel.writeBufferQueue;
+        final WriteRequestQueue writeBuffer = channel.writeBufferQueue;
         final int writeSpinCount = channel.getConfig().getWriteSpinCount();
         List<Throwable> causes = null;
 
@@ -418,7 +418,7 @@ abstract class AbstractNioWorker extends AbstractNioSelector implements Worker {
                 fireExceptionCaught = true;
             }
 
-            Queue<MessageEvent> writeBuffer = channel.writeBufferQueue;
+            WriteRequestQueue writeBuffer = channel.writeBufferQueue;
             for (;;) {
                 evt = writeBuffer.poll();
                 if (evt == null) {

--- a/src/main/java/org/jboss/netty/channel/socket/nio/NioDatagramWorker.java
+++ b/src/main/java/org/jboss/netty/channel/socket/nio/NioDatagramWorker.java
@@ -22,6 +22,7 @@ import org.jboss.netty.channel.ChannelException;
 import org.jboss.netty.channel.ChannelFuture;
 import org.jboss.netty.channel.MessageEvent;
 import org.jboss.netty.channel.ReceiveBufferSizePredictor;
+import org.jboss.netty.channel.socket.nio.AbstractNioChannel.WriteRequestQueue;
 
 import java.io.IOException;
 import java.net.SocketAddress;
@@ -240,7 +241,7 @@ public class NioDatagramWorker extends AbstractNioWorker {
 
         final SocketSendBufferPool sendBufferPool = this.sendBufferPool;
         final DatagramChannel ch = ((NioDatagramChannel) channel).getDatagramChannel();
-        final Queue<MessageEvent> writeBuffer = channel.writeBufferQueue;
+        final WriteRequestQueue writeBuffer = channel.writeBufferQueue;
         final int writeSpinCount = channel.getConfig().getWriteSpinCount();
         synchronized (channel.writeLock) {
             // inform the channel that write is in-progress


### PR DESCRIPTION
Motivation:

A rare issue was seen wherein a channel would become
persistently unwritable, even though the underlying
connection was working fine, as evidenced by the fact
that heartbeats were still being received from the
other side.

Examination of WriteRequestQueue and the threading
model around it revealed the following race:

T1: offer MessageEvent
    go over high water mark
    context switch before calling setUnwritable()

T2: poll multiple MessageEvent
    go under low water mark
    call setWritable()

T1: call setUnwritable()

At which point the channel is incorrectly marked as
unwritable and will remain so until another back-and-forth
across the low water mark, which may never happen if
the application uses writability to apply backpressure
on the writer.

The commit log shows that this issue has been present
since commit 2127c8eafef61a27e40c66479552febb2f042847
i.e. version 3.10, when the introduction of user-defined
writability decoupled isWritable from the bufferSize.

Solution:

The use of a mutex was decided against due to the serious
performance implications.

To avoid subtle breakage in backward-compat, deferring the
call to setUnwritable() in the io thread was also decided
against.

Instead, the buffer size is re-checked against the water
mark immediately before firing the interestChanged event
and the writability change is rolled back if necessary.

In addition, a stronger invariant is enforced on poll()
to make it easier to reason about the possible water
mark/writability transitions. This requires minor changes
to NioChannelTest which manually calls poll().