### PR TITLE
set default CONTENT_TYPE when it is absent in multipart request body.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -844,9 +844,11 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
                 size = 0;
             }
             try {
-                String contentType = HttpPostBodyUtil.DEFAULT_BINARY_CONTENT_TYPE;
+                String contentType;
                 if (contentTypeAttribute != null) {
                     contentType = contentTypeAttribute.getValue();
+                } else {
+                    contentType = HttpPostBodyUtil.DEFAULT_BINARY_CONTENT_TYPE;
                 }
                 currentFileUpload = factory.createFileUpload(request,
                         cleanString(nameAttribute.getValue()), cleanString(filenameAttribute.getValue()),

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -834,9 +834,6 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
             Attribute filenameAttribute = currentFieldAttributes.get(HttpPostBodyUtil.FILENAME);
             Attribute nameAttribute = currentFieldAttributes.get(HttpPostBodyUtil.NAME);
             Attribute contentTypeAttribute = currentFieldAttributes.get(HttpHeaders.Names.CONTENT_TYPE);
-            if (contentTypeAttribute == null) {
-                throw new ErrorDataDecoderException("Content-Type is absent but required");
-            }
             Attribute lengthAttribute = currentFieldAttributes.get(HttpHeaders.Names.CONTENT_LENGTH);
             long size;
             try {
@@ -847,9 +844,13 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
                 size = 0;
             }
             try {
+                String contentType = HttpPostBodyUtil.DEFAULT_BINARY_CONTENT_TYPE;
+                if (contentTypeAttribute != null) {
+                    contentType = contentTypeAttribute.getValue();
+                }
                 currentFileUpload = factory.createFileUpload(request,
                         cleanString(nameAttribute.getValue()), cleanString(filenameAttribute.getValue()),
-                        contentTypeAttribute.getValue(), mechanism.value(), localCharset,
+                        contentType, mechanism.value(), localCharset,
                         size);
             } catch (NullPointerException e) {
                 throw new ErrorDataDecoderException(e);


### PR DESCRIPTION
Set default CONTENT_TYPE when it is absent in multipart request body

Motivation:

I am use netty as a http server, it fail to decode some POST request when the request absent Content-Type in the multipart/form-data body.

for example: I use this code (base on python `requests` library) to produce some http request,
```python
r = requests.post('http://testserverxxx/post', files={'file': open('Pink_Birkin_bag.jpg', 'rb')})
```

It will lead this decoder exception and can’t decode the request successfuly
```java
io.netty.handler.codec.http.multipart.HttpPostRequestDecoder$ErrorDataDecoderException: Content-Type is absent but required
    at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.getFileUpload(HttpPostMultipartRequestDecoder.java:838) ~[dependency-all-1.2.2-shaded.jar:na]
    at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.decodeMultipart(HttpPostMultipartRequestDecoder.java:532) ~[dependency-all-1.2.2-shaded.jar:na]
    at io.netty.handler.codec.http.multipart.HttpPostMultipartRequestDecoder.findMultipartDisposition(HttpPostMultipartRequestDecoder.java:771) ~[dependency-all-1.2.2-shaded.jar:na]
```

Modifications:

Set content_type with default `application/octet-stream` to parse the uploaded file data when the Content-Type is absent in multipart request body

Result:

Can decode the http request as normal.