### PR TITLE
Fix the last value in AsciiString.trim

### DIFF
--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -983,7 +983,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
      * @return a new string with characters {@code <= \\u0020} removed from the beginning and the end.
      */
     public AsciiString trim() {
-        int start = arrayOffset(), last = arrayOffset() + length();
+        int start = arrayOffset(), last = arrayOffset() + length() - 1;
         int end = last;
         while (start <= end && value[start] <= ' ') {
             start++;

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -282,4 +282,12 @@ public class AsciiStringCharacterTest {
         assertEquals(2, AsciiString.indexOfIgnoreCaseAscii("aabaabaa", "", 2));
         assertEquals(-1, AsciiString.indexOfIgnoreCaseAscii("abc", "", 9));
     }
+
+    @Test
+    public void testTrim() {
+        assertEquals("", AsciiString.EMPTY_STRING.trim().toString());
+        assertEquals("abc", new AsciiString("  abc").trim().toString());
+        assertEquals("abc", new AsciiString("abc  ").trim().toString());
+        assertEquals("abc", new AsciiString("  abc  ").trim().toString());
+    }
 }


### PR DESCRIPTION
Motivation:

In AsciiString.trim, last should be `arrayOffset() + length() - 1`. See #4741.

Modifications:

Fix the last value.

Result:

AsciiString.trim works correctly.