### PR TITLE
[#4736] Clear disabled SSL protocols before enabling provided SSL pro…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -1076,21 +1076,29 @@ public final class OpenSslEngine extends SSLEngine {
                 // Enable all and then disable what we not want
                 SSL.setOptions(ssl, SSL.SSL_OP_ALL);
 
+                // Clear out options which disable protocols
+                SSL.clearOptions(ssl, SSL.SSL_OP_NO_SSLv2 | SSL.SSL_OP_NO_SSLv3 | SSL.SSL_OP_NO_TLSv1 |
+                    SSL.SSL_OP_NO_TLSv1_1 | SSL.SSL_OP_NO_TLSv1_2);
+
+                int opts = 0;
                 if (!sslv2) {
-                    SSL.setOptions(ssl, SSL.SSL_OP_NO_SSLv2);
+                    opts |= SSL.SSL_OP_NO_SSLv2;
                 }
                 if (!sslv3) {
-                    SSL.setOptions(ssl, SSL.SSL_OP_NO_SSLv3);
+                    opts |= SSL.SSL_OP_NO_SSLv3;
                 }
                 if (!tlsv1) {
-                    SSL.setOptions(ssl, SSL.SSL_OP_NO_TLSv1);
+                    opts |= SSL.SSL_OP_NO_TLSv1;
                 }
                 if (!tlsv1_1) {
-                    SSL.setOptions(ssl, SSL.SSL_OP_NO_TLSv1_1);
+                    opts |= SSL.SSL_OP_NO_TLSv1_1;
                 }
                 if (!tlsv1_2) {
-                    SSL.setOptions(ssl, SSL.SSL_OP_NO_TLSv1_2);
+                    opts |= SSL.SSL_OP_NO_TLSv1_2;
                 }
+
+                // Disable protocols we do not want
+                SSL.setOptions(ssl, opts);
             } else {
                 throw new IllegalStateException("failed to enable protocols: " + Arrays.asList(protocols));
             }

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -59,6 +59,8 @@ import static org.mockito.Mockito.verify;
 
 public abstract class SSLEngineTest {
 
+    protected static final String PROTOCOL_TLS_V1_2 = "TLSv1.2";
+
     @Mock
     protected MessageReceiver serverReceiver;
     @Mock

--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>netty-tcnative</artifactId>
-        <version>1.1.33.Fork10</version>
+        <version>1.1.33.Fork11</version>
         <classifier>${tcnative.classifier}</classifier>
         <scope>compile</scope>
         <optional>true</optional>


### PR DESCRIPTION
…tocols

Motivation:

Attempts to enable SSL protocols which are currently disable fail when using the OpenSslEngine. Related to https://github.com/netty/netty/issues/4736

Modifications:

Clear out all options that have disabled SSL protocols before attempting to enable any SSL protocol.

Result:

setEnabledProtocols works as expected.