### PR TITLE
Fixing OsgiBundleTest

### DIFF
--- a/testsuite-osgi/src/test/java/io/netty/osgitests/OsgiBundleTest.java
+++ b/testsuite-osgi/src/test/java/io/netty/osgitests/OsgiBundleTest.java
@@ -90,7 +90,6 @@ public class OsgiBundleTest {
         options.addAll(Arrays.asList(junitBundles()));
 
         options.add(mavenBundle("com.barchart.udt", "barchart-udt-bundle").versionAsInProject());
-        options.add(mavenBundle("com.twitter", "hpack").versionAsInProject());
         options.add(wrappedBundle(mavenBundle("org.rxtx", "rxtx").versionAsInProject()));
 
         for (String name : BUNDLES) {


### PR DESCRIPTION
Motivation:

Twitter hpack is no longer a dependency so the test fails.

Modifications:

Removed the reference to twitter hpack.

Result:

It builds.