### PR TITLE
[memcache] More efficiently allocate header buffer.

### DIFF
--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheEncoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheEncoder.java
@@ -30,11 +30,12 @@ public abstract class AbstractBinaryMemcacheEncoder<M extends BinaryMemcacheMess
     /**
      * Every binary memcache message has at least a 24 bytes header.
      */
-    private static final int DEFAULT_BUFFER_SIZE = 24;
+    private static final int MINIMUM_HEADER_SIZE = 24;
 
     @Override
     protected ByteBuf encodeMessage(ChannelHandlerContext ctx, M msg) {
-        ByteBuf buf = ctx.alloc().buffer(DEFAULT_BUFFER_SIZE);
+        ByteBuf buf = ctx.alloc().buffer(MINIMUM_HEADER_SIZE + msg.extrasLength()
+            + msg.keyLength());
 
         encodeHeader(buf, msg);
         encodeExtras(buf, msg.extras());


### PR DESCRIPTION
Motivation
----------
Currently, only the fixed 24 bytes are allocated for the header and
then all the params as well as the optional extras and key are written
into the header section.

It is very likely that the buffer needs to expand at least two times
if either the extras and/or the key take up more space.

Modifications
-------------
Since at the point of allocation we know the key and extras length,
the buffer can be preallocated with the exact size, avoiding unnecessary
resizing and even allocating too much (since it uses power of two
internally).

Result
------
Less buffer resizing needed when encoding a memcache operation.