### PR TITLE
SslHandler should call beginHanshake once for the initial handshake

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -148,7 +148,6 @@ public final class OpenSslEngine extends SSLEngine {
 
     private HandshakeState handshakeState = HandshakeState.NOT_STARTED;
     private boolean receivedShutdown;
-    @SuppressWarnings("UnusedDeclaration")
     private volatile int destroyed;
 
     private volatile ClientAuth clientAuth = ClientAuth.NONE;
@@ -226,13 +225,18 @@ public final class OpenSslEngine extends SSLEngine {
     }
 
     @Override
-    public SSLSession getHandshakeSession() {
-        if (handshakeState != HandshakeState.NOT_STARTED) {
-            // handshake started we are able to return the session.
+    public synchronized SSLSession getHandshakeSession() {
+        // Javadocs state return value should be:
+        // null if this instance is not currently handshaking, or if the current handshake has not
+        // progressed far enough to create a basic SSLSession. Otherwise, this method returns the
+        // SSLSession currently being negotiated.
+        switch(handshakeState) {
+        case NOT_STARTED:
+        case FINISHED:
+            return null;
+        default:
             return session;
         }
-        // As stated by the javadocs of getHandshakeSession() we should return null if the handshake not started yet.
-        return null;
     }
 
     /**
@@ -1242,18 +1246,12 @@ public final class OpenSslEngine extends SSLEngine {
     @Override
     public synchronized SSLEngineResult.HandshakeStatus getHandshakeStatus() {
         // Check if we are in the initial handshake phase or shutdown phase
-        if (needPendingStatus()) {
-            return pendingStatus(SSL.pendingWrittenBytesInBIO(networkBIO));
-        }
-        return NOT_HANDSHAKING;
+        return needPendingStatus() ? pendingStatus(SSL.pendingWrittenBytesInBIO(networkBIO)) : NOT_HANDSHAKING;
     }
 
     private SSLEngineResult.HandshakeStatus getHandshakeStatus(int pending) {
         // Check if we are in the initial handshake phase or shutdown phase
-        if (needPendingStatus()) {
-            return pendingStatus(pending);
-        }
-        return NOT_HANDSHAKING;
+        return needPendingStatus() ? pendingStatus(pending) : NOT_HANDSHAKING;
     }
 
     private boolean needPendingStatus() {

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1338,6 +1338,10 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             }
 
             handshakePromise = p = newHandshakePromise;
+        } else if (engine.getHandshakeStatus() != HandshakeStatus.NOT_HANDSHAKING) {
+            // Not all SSLEngine implementations support calling beginHandshake multiple times while a handshake
+            // is in progress. See https://github.com/netty/netty/issues/4718.
+            return;
         } else {
             // Forced to reuse the old handshake.
             p = handshakePromise;


### PR DESCRIPTION
Motivation:
Not all SSLEngine implementations permit beginHandshake being called while a handshake is in progress during the initial handshake. We should ensure we only go through the initial handshake code once to prevent unexpected exceptions from being thrown.

Modifications:
- Only call beginHandshake if there is not currently a handshake in progress

Result:
SslHandler's handshake method is compatible with OpenSSLEngineImpl in Android 5.0+ and 6.0+.
Fixes https://github.com/netty/netty/issues/4718