### PR TITLE
Fix SSLEngineTest handshake method.

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -397,7 +397,7 @@ public abstract class SSLEngineTest {
             runDelegatedTasks(serverResult, serverEngine);
             cTOs.compact();
             sTOc.compact();
-        } while (isHandshaking(clientResult) && isHandshaking(serverResult));
+        } while (isHandshaking(clientResult) || isHandshaking(serverResult));
     }
 
     private static boolean isHandshaking(SSLEngineResult result) {


### PR DESCRIPTION
Motivation:

We used && in the handshake method of SSLEngineTest but it must be ||.

Modifications:

Changed && to ||

Result:

Correctly check condition