### PR TITLE
[#4755] Make WebSocketClientCompressionHandler @Sharable

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketClientCompressionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketClientCompressionHandler.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.http.websocketx.extensions.compression;
 
+import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler;
 
 /**
@@ -23,12 +24,12 @@ import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensio
  *
  * See <tt>io.netty.example.http.websocketx.client.WebSocketClient</tt> for usage.
  */
-public class WebSocketClientCompressionHandler extends WebSocketClientExtensionHandler {
+@ChannelHandler.Sharable
+public final class WebSocketClientCompressionHandler extends WebSocketClientExtensionHandler {
 
-    /**
-     * Constructor with default configuration.
-     */
-    public WebSocketClientCompressionHandler() {
+    public static final WebSocketClientCompressionHandler INSTANCE = new WebSocketClientCompressionHandler();
+
+    private WebSocketClientCompressionHandler() {
         super(new PerMessageDeflateClientExtensionHandshaker(),
                 new DeflateFrameClientExtensionHandshaker(false),
                 new DeflateFrameClientExtensionHandshaker(true));

--- a/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
@@ -113,7 +113,7 @@ public final class WebSocketClient {
                      p.addLast(
                              new HttpClientCodec(),
                              new HttpObjectAggregator(8192),
-                             new WebSocketClientCompressionHandler(),
+                             WebSocketClientCompressionHandler.INSTANCE,
                              handler);
                  }
              });


### PR DESCRIPTION
    Motivation:

    WebSocketClientCompressionHandler is stateless so it should be @Sharable.

    Modifications:

    Add @Sharable annotation to WebSocketClientCompressionHandler, make constructor private and add static field to get the instance.

    Result:

    Less object creation.