### PR TITLE
Correctly handle wildcard address when bind to socket and using nativ…

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
@@ -54,7 +54,7 @@ public class EpollSocketTcpMd5Test {
         server = (EpollServerSocketChannel) bootstrap.group(GROUP)
                 .channel(EpollServerSocketChannel.class)
                 .handler(new ChannelInboundHandlerAdapter())
-                .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                .bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0)).syncUninterruptibly().channel();
     }
 
     @After


### PR DESCRIPTION
…e transport

Motivation:

When a wildcard address is used to bind a socket and ipv4 and ipv6 are usable we should accept both (just like JDK IO/NIO does).

Modifications:

Detect wildcard address and if so use in6addr_any

Result:

Correctly accept ipv4 and ipv6