### PR TITLE
SslHandler: Avoid unchecked exception on write

### DIFF
--- a/src/main/java/org/jboss/netty/handler/ssl/SslHandler.java
+++ b/src/main/java/org/jboss/netty/handler/ssl/SslHandler.java
@@ -1005,8 +1005,9 @@ public class SslHandler extends FrameDecoder
             }
 
             if (!success) {
-                IllegalStateException cause =
-                    new IllegalStateException("SSLEngine already closed");
+                Exception cause = channel.isOpen()
+                        ? new SSLException("SSLEngine already closed")
+                        : new ClosedChannelException();
 
                 // Check if we had a pendingWrite in process, if so we need to also notify as otherwise
                 // the ChannelFuture will never get notified


### PR DESCRIPTION
Motivation
----------

Channels.write() is advertised to be thread-safe, however
if one thread starts a write and another closes the channel,
the first thread can find itself with a closed SSLEngine.

Throwing an unchecked exception will cause most programs to
crash, which is not acceptable for such an inconsequential
race.

Solution
--------

Throw SSLException or ClosedChannelException instead, which
are checked exceptions and should therefore be handled in a
non-crashy fashion by most applications.