### PR TITLE
Use ByteBufAllocator to allocate ByteBuf for FullHttpMessage

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientUpgradeHandler.java
@@ -62,6 +62,13 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator implements Ch
      * The source codec that is used in the pipeline initially.
      */
     public interface SourceCodec {
+
+        /**
+         * Removes or disables the encoder of this codec so that the {@link UpgradeCodec} can send an initial greeting
+         * (if any).
+         */
+        void prepareUpgradeFrom(ChannelHandlerContext ctx);
+
         /**
          * Removes this codec (i.e. all associated handlers) from the pipeline.
          */
@@ -222,8 +229,9 @@ public class HttpClientUpgradeHandler extends HttpObjectAggregator implements Ch
             }
 
             // Upgrade to the new protocol.
-            sourceCodec.upgradeFrom(ctx);
+            sourceCodec.prepareUpgradeFrom(ctx);
             upgradeCodec.upgradeTo(ctx, response);
+            sourceCodec.upgradeFrom(ctx);
 
             // Notify that the upgrade to the new protocol completed successfully.
             ctx.fireUserEventTriggered(UpgradeEvent.UPGRADE_SUCCESSFUL);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -114,13 +114,13 @@ public class HttpObjectAggregator
 
     @Override
     protected boolean isContentLengthInvalid(HttpMessage start, int maxContentLength) {
-        return getContentLength(start, -1) > maxContentLength;
+        return getContentLength(start, -1L) > maxContentLength;
     }
 
     @Override
     protected Object newContinueResponse(HttpMessage start, int maxContentLength, ChannelPipeline pipeline) {
         if (HttpUtil.is100ContinueExpected(start)) {
-            if (getContentLength(start, -1) <= maxContentLength) {
+            if (getContentLength(start, -1L) <= maxContentLength) {
                 return CONTINUE.duplicate().retain();
             }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -602,7 +602,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
     private long contentLength() {
         if (contentLength == Long.MIN_VALUE) {
-            contentLength = HttpUtil.getContentLength(message, -1);
+            contentLength = HttpUtil.getContentLength(message, -1L);
         }
         return contentLength;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
@@ -22,8 +22,8 @@ import static io.netty.handler.codec.http.cookie.CookieUtil.stripTrailingSeparat
 import static io.netty.handler.codec.http.cookie.CookieUtil.stripTrailingSeparatorOrNull;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.util.internal.InternalThreadLocalMap;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -196,7 +196,7 @@ public final class ClientCookieEncoder extends CookieEncoder {
             if (!cookiesIt.hasNext()) {
                 encode(buf, firstCookie);
             } else {
-                List<Cookie> cookiesList = new ArrayList<Cookie>();
+                List<Cookie> cookiesList = InternalThreadLocalMap.get().arrayList();
                 cookiesList.add(firstCookie);
                 while (cookiesIt.hasNext()) {
                     cookiesList.add(cookiesIt.next());

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -30,6 +30,7 @@ import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder.ErrorDataDec
 import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder.MultiPartStatus;
 import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder.NotEnoughDataDecoderException;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.StringUtil;
 
 import java.io.IOException;
@@ -1836,7 +1837,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
      * @return an array of String where values that were separated by ';' or ','
      */
     private static String[] splitMultipartHeaderValues(String svalue) {
-        List<String> values = new ArrayList<String>(1);
+        List<String> values = InternalThreadLocalMap.get().arrayList(1);
         boolean inQuote = false;
         boolean escapeNext = false;
         int start = 0;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -82,12 +82,12 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
     private static final byte OPCODE_PONG = 0xA;
 
     /**
-     * The size treshold for gathering writes. Non-Masked messages bigger than this size will be be sent fragmented as
+     * The size threshold for gathering writes. Non-Masked messages bigger than this size will be be sent fragmented as
      * a header and a content ByteBuf whereas messages smaller than the size will be merged into a single buffer and
      * sent at once.<br>
      * Masked messages will always be sent at once.
      */
-    private static final int GATHERING_WRITE_TRESHOLD = 1024;
+    private static final int GATHERING_WRITE_THRESHOLD = 1024;
 
     private final boolean maskPayload;
 
@@ -148,7 +148,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
             int maskLength = maskPayload ? 4 : 0;
             if (length <= 125) {
                 int size = 2 + maskLength;
-                if (maskPayload || length <= GATHERING_WRITE_TRESHOLD) {
+                if (maskPayload || length <= GATHERING_WRITE_THRESHOLD) {
                     size += length;
                 }
                 buf = ctx.alloc().buffer(size);
@@ -157,7 +157,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                 buf.writeByte(b);
             } else if (length <= 0xFFFF) {
                 int size = 4 + maskLength;
-                if (maskPayload || length <= GATHERING_WRITE_TRESHOLD) {
+                if (maskPayload || length <= GATHERING_WRITE_THRESHOLD) {
                     size += length;
                 }
                 buf = ctx.alloc().buffer(size);
@@ -167,7 +167,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                 buf.writeByte(length & 0xFF);
             } else {
                 int size = 10 + maskLength;
-                if (maskPayload || length <= GATHERING_WRITE_TRESHOLD) {
+                if (maskPayload || length <= GATHERING_WRITE_THRESHOLD) {
                     size += length;
                 }
                 buf = ctx.alloc().buffer(size);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketClientCompressionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketClientCompressionHandler.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.http.websocketx.extensions.compression;
 
+import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandler;
 
 /**
@@ -23,12 +24,12 @@ import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensio
  *
  * See <tt>io.netty.example.http.websocketx.client.WebSocketClient</tt> for usage.
  */
-public class WebSocketClientCompressionHandler extends WebSocketClientExtensionHandler {
+@ChannelHandler.Sharable
+public final class WebSocketClientCompressionHandler extends WebSocketClientExtensionHandler {
 
-    /**
-     * Constructor with default configuration.
-     */
-    public WebSocketClientCompressionHandler() {
+    public static final WebSocketClientCompressionHandler INSTANCE = new WebSocketClientCompressionHandler();
+
+    private WebSocketClientCompressionHandler() {
         super(new PerMessageDeflateClientExtensionHandshaker(),
                 new DeflateFrameClientExtensionHandshaker(false),
                 new DeflateFrameClientExtensionHandshaker(true));

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpDecoder.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.spdy;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import io.netty.handler.codec.TooLongFrameException;
@@ -165,7 +166,8 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
                 }
 
                 try {
-                    FullHttpRequest httpRequestWithEntity = createHttpRequest(spdyVersion, spdySynStreamFrame);
+                    FullHttpRequest httpRequestWithEntity =
+                       createHttpRequest(spdyVersion, spdySynStreamFrame, ctx.alloc());
 
                     // Set the Stream-ID, Associated-To-Stream-ID, iand Priority as headers
                     httpRequestWithEntity.headers().setInt(Names.STREAM_ID, streamId);
@@ -195,7 +197,8 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
                 }
 
                 try {
-                    FullHttpRequest httpRequestWithEntity = createHttpRequest(spdyVersion, spdySynStreamFrame);
+                    FullHttpRequest httpRequestWithEntity =
+                       createHttpRequest(spdyVersion, spdySynStreamFrame, ctx.alloc());
 
                     // Set the Stream-ID as a header
                     httpRequestWithEntity.headers().setInt(Names.STREAM_ID, streamId);
@@ -346,7 +349,8 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
         }
     }
 
-    private static FullHttpRequest createHttpRequest(int spdyVersion, SpdyHeadersFrame requestFrame)
+    private static FullHttpRequest createHttpRequest(int spdyVersion, SpdyHeadersFrame requestFrame,
+                                                     ByteBufAllocator alloc)
             throws Exception {
         // Create the first line of the request from the name/value pairs
         SpdyHeaders headers     = requestFrame.headers();
@@ -357,7 +361,7 @@ public class SpdyHttpDecoder extends MessageToMessageDecoder<SpdyFrame> {
         headers.remove(PATH);
         headers.remove(VERSION);
 
-        FullHttpRequest req = new DefaultFullHttpRequest(httpVersion, method, url);
+        FullHttpRequest req = new DefaultFullHttpRequest(httpVersion, method, url, alloc.buffer());
 
         // Remove the scheme header
         headers.remove(SCHEME);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -14,12 +14,6 @@
  */
 package io.netty.handler.codec.http2;
 
-import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
-import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
-import static io.netty.handler.codec.http2.Http2Exception.connectionError;
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
-import static java.lang.Math.min;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -29,6 +23,12 @@ import io.netty.channel.CoalescingBufferQueue;
 import io.netty.handler.codec.http2.Http2Exception.ClosedStreamCreationException;
 
 import java.util.ArrayDeque;
+
+import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;
+import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
+import static io.netty.handler.codec.http2.Http2Exception.connectionError;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static java.lang.Math.min;
 
 /**
  * Default implementation of {@link Http2ConnectionEncoder}.
@@ -167,11 +167,29 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
                 }
             }
 
-            // Pass headers to the flow-controller so it can maintain their sequence relative to DATA frames.
-            flowController().addFlowControlled(stream,
-                    new FlowControlledHeaders(stream, headers, streamDependency, weight, exclusive, padding,
-                            endOfStream, promise));
-            return promise;
+            // Trailing headers must go through flow control if there are other frames queued in flow control
+            // for this stream.
+            Http2RemoteFlowController flowController = flowController();
+            if (!endOfStream || !flowController.hasFlowControlled(stream)) {
+                ChannelFuture future = frameWriter.writeHeaders(ctx, streamId, headers, streamDependency, weight,
+                                                                exclusive, padding, endOfStream, promise);
+                if (endOfStream) {
+                    final Http2Stream finalStream = stream;
+                    future.addListener(new ChannelFutureListener() {
+                        @Override
+                        public void operationComplete(ChannelFuture future) throws Exception {
+                            lifecycleManager.closeStreamLocal(finalStream, promise);
+                        }
+                    });
+                }
+                return future;
+            } else {
+                // Pass headers to the flow-controller so it can maintain their sequence relative to DATA frames.
+                flowController.addFlowControlled(stream,
+                        new FlowControlledHeaders(stream, headers, streamDependency, weight, exclusive, padding,
+                                                 endOfStream, promise));
+                return promise;
+            }
         } catch (Http2NoMoreStreamIdsException e) {
             lifecycleManager.onError(ctx, e);
             return promise.setFailure(e);
@@ -357,10 +375,11 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
 
         @Override
         public boolean merge(ChannelHandlerContext ctx, Http2RemoteFlowController.FlowControlled next) {
-            if (FlowControlledData.class != next.getClass()) {
+            FlowControlledData nextData;
+            if (FlowControlledData.class != next.getClass() ||
+                Integer.MAX_VALUE - (nextData = (FlowControlledData) next).size() < size()) {
                 return false;
             }
-            FlowControlledData nextData = (FlowControlledData) next;
             nextData.queue.copyTo(queue);
             // Given that we're merging data into a frame it doesn't really make sense to accumulate padding.
             padding = Math.max(padding, nextData.padding);
@@ -409,7 +428,6 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
             }
             promise.addListener(this);
 
-            stream.headerSent();
             frameWriter.writeHeaders(ctx, stream.id(), headers, streamDependency, weight, exclusive,
                     padding, endOfStream, promise);
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -152,7 +152,15 @@ public final class Http2CodecUtil {
 
         // Create the debug message. `* 3` because UTF-8 max character consumes 3 bytes.
         ByteBuf debugData = ctx.alloc().buffer(cause.getMessage().length() * 3);
-        ByteBufUtil.writeUtf8(debugData, cause.getMessage());
+        boolean shouldRelease = true;
+        try {
+            ByteBufUtil.writeUtf8(debugData, cause.getMessage());
+            shouldRelease = false;
+        } finally {
+            if (shouldRelease) {
+                debugData.release();
+            }
+        }
         return debugData;
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -138,12 +138,11 @@ public interface Http2Connection {
      * A view of the connection from one endpoint (local or remote).
      */
     interface Endpoint<F extends Http2FlowController> {
-
         /**
-         * Returns the next valid streamId for this endpoint. If negative, the stream IDs are
+         * Increment and get the next generated stream id this endpoint. If negative, the stream IDs are
          * exhausted for this endpoint an no further streams may be created.
          */
-        int nextStreamId();
+        int incrementAndGetNextStreamId();
 
         /**
          * Indicates whether the given streamId is from the set of IDs used by this endpoint to
@@ -161,13 +160,6 @@ public interface Http2Connection {
          * Indicates whether or not this endpoint created the given stream.
          */
         boolean created(Http2Stream stream);
-
-        /**
-         * Indicates whether or not the stream IDs for this endpoint have been exhausted
-         * (i.e. {@link #nextStreamId()} < 0). If {@code true}, any attempt to create new streams
-         * on this endpoint will fail.
-         */
-        boolean isExhausted();
 
         /**
          * Indicates whether or a stream created by this endpoint can be opened without violating

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Error.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Error.java
@@ -35,6 +35,16 @@ public enum Http2Error {
     HTTP_1_1_REQUIRED(0xD);
 
     private final long code;
+    private static final Http2Error[] INT_TO_ENUM_MAP;
+    static {
+        Http2Error[] errors = Http2Error.values();
+        Http2Error[] map = new Http2Error[errors.length];
+        for (int i = 0; i < errors.length; ++i) {
+            Http2Error error = errors[i];
+            map[(int) error.code()] = error;
+        }
+        INT_TO_ENUM_MAP = map;
+    }
 
     Http2Error(long code) {
         this.code = code;
@@ -45,5 +55,9 @@ public enum Http2Error {
      */
     public long code() {
         return code;
+    }
+
+    public static Http2Error valueOf(long value) {
+        return value >= INT_TO_ENUM_MAP.length || value < 0 ? null : INT_TO_ENUM_MAP[(int) value];
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
@@ -42,6 +42,13 @@ public interface Http2RemoteFlowController extends Http2FlowController {
     void addFlowControlled(Http2Stream stream, FlowControlled payload);
 
     /**
+     * Determine if {@code stream} has any {@link FlowControlled} frames currently queued.
+     * @param stream the stream to check if it has flow controlled frames.
+     * @return {@code true} if {@code stream} has any {@link FlowControlled} frames currently queued.
+     */
+    boolean hasFlowControlled(Http2Stream stream);
+
+    /**
      * Write all data pending in the flow controller up to the flow-control limits.
      *
      * @throws Http2Exception throws if a protocol-related error occurred.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -111,18 +111,6 @@ public interface Http2Stream {
     Http2Stream resetSent();
 
     /**
-     * Indicates whether or not at least one {@code HEADERS} frame has been sent from the local endpoint
-     * for this stream.
-     */
-    boolean isHeaderSent();
-
-    /**
-     * Sets the flag indicating that a {@code HEADERS} frame has been sent from the local endpoint
-     * for this stream. This does not affect the stream state.
-     */
-    Http2Stream headerSent();
-
-    /**
      * Associates the application-defined data with this stream.
      * @return The value that was previously associated with {@code key}, or {@code null} if there was none.
      */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -14,6 +14,7 @@
  */
 package io.netty.handler.codec.http2;
 
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpMessage;
@@ -186,6 +187,7 @@ public final class HttpConversionUtil {
      *
      * @param streamId The stream associated with the response
      * @param http2Headers The initial set of HTTP/2 headers to create the response with
+     * @param alloc The {@link ByteBufAllocator} to use to generate the content of the message
      * @param validateHttpHeaders <ul>
      *        <li>{@code true} to validate HTTP headers in the http-codec</li>
      *        <li>{@code false} not to validate HTTP headers in the http-codec</li>
@@ -193,13 +195,23 @@ public final class HttpConversionUtil {
      * @return A new response object which represents headers/data
      * @throws Http2Exception see {@link #addHttp2ToHttpHeaders(int, Http2Headers, FullHttpMessage, boolean)}
      */
-    public static FullHttpResponse toHttpResponse(int streamId, Http2Headers http2Headers, boolean validateHttpHeaders)
+    public static FullHttpResponse toHttpResponse(int streamId, Http2Headers http2Headers, ByteBufAllocator alloc,
+                                                  boolean validateHttpHeaders)
                     throws Http2Exception {
         HttpResponseStatus status = parseStatus(http2Headers.status());
         // HTTP/2 does not define a way to carry the version or reason phrase that is included in an
         // HTTP/1.1 status line.
-        FullHttpResponse msg = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status, validateHttpHeaders);
-        addHttp2ToHttpHeaders(streamId, http2Headers, msg, false);
+        FullHttpResponse msg = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status, alloc.buffer(),
+                                                           validateHttpHeaders);
+        try {
+            addHttp2ToHttpHeaders(streamId, http2Headers, msg, false);
+        } catch (Http2Exception e) {
+            msg.release();
+            throw e;
+        } catch (Throwable t) {
+            msg.release();
+            throw streamError(streamId, PROTOCOL_ERROR, t, "HTTP/2 to HTTP/1.x headers conversion error");
+        }
         return msg;
     }
 
@@ -208,6 +220,7 @@ public final class HttpConversionUtil {
      *
      * @param streamId The stream associated with the request
      * @param http2Headers The initial set of HTTP/2 headers to create the request with
+     * @param alloc The {@link ByteBufAllocator} to use to generate the content of the message
      * @param validateHttpHeaders <ul>
      *        <li>{@code true} to validate HTTP headers in the http-codec</li>
      *        <li>{@code false} not to validate HTTP headers in the http-codec</li>
@@ -215,7 +228,8 @@ public final class HttpConversionUtil {
      * @return A new request object which represents headers/data
      * @throws Http2Exception see {@link #addHttp2ToHttpHeaders(int, Http2Headers, FullHttpMessage, boolean)}
      */
-    public static FullHttpRequest toHttpRequest(int streamId, Http2Headers http2Headers, boolean validateHttpHeaders)
+    public static FullHttpRequest toHttpRequest(int streamId, Http2Headers http2Headers, ByteBufAllocator alloc,
+                                                boolean validateHttpHeaders)
                     throws Http2Exception {
         // HTTP/2 does not define a way to carry the version identifier that is included in the HTTP/1.1 request line.
         final CharSequence method = checkNotNull(http2Headers.method(),
@@ -223,8 +237,16 @@ public final class HttpConversionUtil {
         final CharSequence path = checkNotNull(http2Headers.path(),
                 "path header cannot be null in conversion to HTTP/1.x");
         FullHttpRequest msg = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf(method
-                        .toString()), path.toString(), validateHttpHeaders);
-        addHttp2ToHttpHeaders(streamId, http2Headers, msg, false);
+                        .toString()), path.toString(), alloc.buffer(), validateHttpHeaders);
+        try {
+            addHttp2ToHttpHeaders(streamId, http2Headers, msg, false);
+        } catch (Http2Exception e) {
+            msg.release();
+            throw e;
+        } catch (Throwable t) {
+            msg.release();
+            throw streamError(streamId, PROTOCOL_ERROR, t, "HTTP/2 to HTTP/1.x headers conversion error");
+        }
         return msg;
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
@@ -51,7 +51,7 @@ public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
      */
     private int getStreamId(HttpHeaders httpHeaders) throws Exception {
         return httpHeaders.getInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(),
-                                  connection().local().nextStreamId());
+                                  connection().local().incrementAndGetNextStreamId());
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -15,6 +15,7 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -22,8 +23,6 @@ import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.HttpUtil;
-import io.netty.util.collection.IntObjectHashMap;
-import io.netty.util.collection.IntObjectMap;
 
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
@@ -61,11 +60,11 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
     };
 
     private final int maxContentLength;
+    private final ImmediateSendDetector sendDetector;
+    private final Http2Connection.PropertyKey messageKey;
+    private final boolean propagateSettings;
     protected final Http2Connection connection;
     protected final boolean validateHttpHeaders;
-    private final ImmediateSendDetector sendDetector;
-    protected final IntObjectMap<FullHttpMessage> messageMap;
-    private final boolean propagateSettings;
 
     protected InboundHttp2ToHttpAdapter(Http2Connection connection, int maxContentLength,
                                         boolean validateHttpHeaders, boolean propagateSettings) {
@@ -79,20 +78,45 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
         this.validateHttpHeaders = validateHttpHeaders;
         this.propagateSettings = propagateSettings;
         sendDetector = DEFAULT_SEND_DETECTOR;
-        messageMap = new IntObjectHashMap<FullHttpMessage>();
+        messageKey = connection.newKey();
     }
 
     /**
-     * The streamId is out of scope for the HTTP message flow and will no longer be tracked
-     * @param streamId The stream id to remove associated state with
+     * The stream is out of scope for the HTTP message flow and will no longer be tracked
+     * @param stream The stream to remove associated state with
+     * @param release {@code true} to call release on the value if it is present. {@code false} to not call release.
      */
-    protected void removeMessage(int streamId) {
-        messageMap.remove(streamId);
+    protected final void removeMessage(Http2Stream stream, boolean release) {
+        FullHttpMessage msg = stream.removeProperty(messageKey);
+        if (release && msg != null) {
+            msg.release();
+        }
+    }
+
+    /**
+     * Get the {@link FullHttpMessage} associated with {@code stream}.
+     * @param stream The stream to get the associated state from
+     * @return The {@link FullHttpMessage} associated with {@code stream}.
+     */
+    protected final FullHttpMessage getMessage(Http2Stream stream) {
+        return (FullHttpMessage) stream.getProperty(messageKey);
+    }
+
+    /**
+     * Make {@code message} be the state associated with {@code stream}.
+     * @param stream The stream which {@code message} is associated with.
+     * @param message The message which contains the HTTP semantics.
+     */
+    protected final void putMessage(Http2Stream stream, FullHttpMessage message) {
+        FullHttpMessage previous = stream.setProperty(messageKey, message);
+        if (previous != message && previous != null) {
+            previous.release();
+        }
     }
 
     @Override
     public void onStreamRemoved(Http2Stream stream) {
-        removeMessage(stream.id());
+        removeMessage(stream, true);
     }
 
     /**
@@ -100,10 +124,12 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
      *
      * @param ctx The context to fire the event on
      * @param msg The message to send
-     * @param streamId the streamId of the message which is being fired
+     * @param release {@code true} to release if present in {@link #messageMap}. {@code false} otherwise.
+     * @param stream the stream of the message which is being fired
      */
-    protected void fireChannelRead(ChannelHandlerContext ctx, FullHttpMessage msg, int streamId) {
-        removeMessage(streamId);
+    protected void fireChannelRead(ChannelHandlerContext ctx, FullHttpMessage msg, boolean release,
+                                   Http2Stream stream) {
+        removeMessage(stream, release);
         HttpUtil.setContentLength(msg, msg.content().readableBytes());
         ctx.fireChannelRead(msg);
     }
@@ -111,19 +137,22 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
     /**
      * Create a new {@link FullHttpMessage} based upon the current connection parameters
      *
-     * @param streamId The stream id to create a message for
-     * @param headers The headers associated with {@code streamId}
+     * @param stream The stream to create a message for
+     * @param headers The headers associated with {@code stream}
      * @param validateHttpHeaders
      * <ul>
      * <li>{@code true} to validate HTTP headers in the http-codec</li>
      * <li>{@code false} not to validate HTTP headers in the http-codec</li>
      * </ul>
+     * @param alloc The {@link ByteBufAllocator} to use to generate the content of the message
      * @throws Http2Exception
      */
-    protected FullHttpMessage newMessage(int streamId, Http2Headers headers, boolean validateHttpHeaders)
+    protected FullHttpMessage newMessage(Http2Stream stream, Http2Headers headers, boolean validateHttpHeaders,
+                                         ByteBufAllocator alloc)
             throws Http2Exception {
-        return connection.isServer() ? HttpConversionUtil.toHttpRequest(streamId, headers,
-                validateHttpHeaders) : HttpConversionUtil.toHttpResponse(streamId, headers, validateHttpHeaders);
+        return connection.isServer() ? HttpConversionUtil.toHttpRequest(stream.id(), headers, alloc,
+                validateHttpHeaders) : HttpConversionUtil.toHttpResponse(stream.id(), headers, alloc,
+                                                                         validateHttpHeaders);
     }
 
     /**
@@ -132,9 +161,9 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
      *
      * @param ctx The context for which this message has been received.
      * Used to send informational header if detected.
-     * @param streamId The stream id the {@code headers} apply to
+     * @param stream The stream the {@code headers} apply to
      * @param headers The headers to process
-     * @param endOfStream {@code true} if the {@code streamId} has received the end of stream flag
+     * @param endOfStream {@code true} if the {@code stream} has received the end of stream flag
      * @param allowAppend
      * <ul>
      * <li>{@code true} if headers will be appended if the stream already exists.</li>
@@ -142,27 +171,25 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
      * </ul>
      * @param appendToTrailer
      * <ul>
-     * <li>{@code true} if a message {@code streamId} already exists then the headers
+     * <li>{@code true} if a message {@code stream} already exists then the headers
      * should be added to the trailing headers.</li>
      * <li>{@code false} then appends will be done to the initial headers.</li>
      * </ul>
-     * @return The object used to track the stream corresponding to {@code streamId}. {@code null} if
+     * @return The object used to track the stream corresponding to {@code stream}. {@code null} if
      *         {@code allowAppend} is {@code false} and the stream already exists.
      * @throws Http2Exception If the stream id is not in the correct state to process the headers request
      */
-    protected FullHttpMessage processHeadersBegin(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+    protected FullHttpMessage processHeadersBegin(ChannelHandlerContext ctx, Http2Stream stream, Http2Headers headers,
                 boolean endOfStream, boolean allowAppend, boolean appendToTrailer) throws Http2Exception {
-        FullHttpMessage msg = messageMap.get(streamId);
+        FullHttpMessage msg = getMessage(stream);
+        boolean release = true;
         if (msg == null) {
-            msg = newMessage(streamId, headers, validateHttpHeaders);
+            msg = newMessage(stream, headers, validateHttpHeaders, ctx.alloc());
         } else if (allowAppend) {
-            try {
-                HttpConversionUtil.addHttp2ToHttpHeaders(streamId, headers, msg, appendToTrailer);
-            } catch (Http2Exception e) {
-                removeMessage(streamId);
-                throw e;
-            }
+            release = false;
+            HttpConversionUtil.addHttp2ToHttpHeaders(stream.id(), headers, msg, appendToTrailer);
         } else {
+            release = false;
             msg = null;
         }
 
@@ -170,7 +197,7 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
             // Copy the message (if necessary) before sending. The content is not expected to be copied (or used) in
             // this operation but just in case it is used do the copy before sending and the resource may be released
             final FullHttpMessage copy = endOfStream ? null : sendDetector.copyIfNeeded(msg);
-            fireChannelRead(ctx, msg, streamId);
+            fireChannelRead(ctx, msg, release, stream);
             return copy;
         }
 
@@ -182,23 +209,25 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
      * sends the result up the pipeline or retains the message for future processing.
      *
      * @param ctx The context for which this message has been received
-     * @param streamId The stream id the {@code objAccumulator} corresponds to
-     * @param msg The object which represents all headers/data for corresponding to {@code streamId}
+     * @param stream The stream the {@code objAccumulator} corresponds to
+     * @param msg The object which represents all headers/data for corresponding to {@code stream}
      * @param endOfStream {@code true} if this is the last event for the stream
      */
-    private void processHeadersEnd(ChannelHandlerContext ctx, int streamId,
-            FullHttpMessage msg, boolean endOfStream) {
+    private void processHeadersEnd(ChannelHandlerContext ctx, Http2Stream stream, FullHttpMessage msg,
+                                   boolean endOfStream) {
         if (endOfStream) {
-            fireChannelRead(ctx, msg, streamId);
+            // Release if the msg from the map is different from the object being forwarded up the pipeline.
+            fireChannelRead(ctx, msg, getMessage(stream) != msg, stream);
         } else {
-            messageMap.put(streamId, msg);
+            putMessage(stream, msg);
         }
     }
 
     @Override
     public int onDataRead(ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding, boolean endOfStream)
                     throws Http2Exception {
-        FullHttpMessage msg = messageMap.get(streamId);
+        Http2Stream stream = connection.stream(streamId);
+        FullHttpMessage msg = getMessage(stream);
         if (msg == null) {
             throw connectionError(PROTOCOL_ERROR, "Data Frame received for unknown stream id %d", streamId);
         }
@@ -213,7 +242,7 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
         content.writeBytes(data, data.readerIndex(), dataReadableBytes);
 
         if (endOfStream) {
-            fireChannelRead(ctx, msg, streamId);
+            fireChannelRead(ctx, msg, false, stream);
         }
 
         // All bytes have been processed.
@@ -223,34 +252,40 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
     @Override
     public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int padding,
                     boolean endOfStream) throws Http2Exception {
-        FullHttpMessage msg = processHeadersBegin(ctx, streamId, headers, endOfStream, true, true);
+        Http2Stream stream = connection.stream(streamId);
+        FullHttpMessage msg = processHeadersBegin(ctx, stream, headers, endOfStream, true, true);
         if (msg != null) {
-            processHeadersEnd(ctx, streamId, msg, endOfStream);
+            processHeadersEnd(ctx, stream, msg, endOfStream);
         }
     }
 
     @Override
     public void onHeadersRead(ChannelHandlerContext ctx, int streamId, Http2Headers headers, int streamDependency,
                     short weight, boolean exclusive, int padding, boolean endOfStream) throws Http2Exception {
-        FullHttpMessage msg = processHeadersBegin(ctx, streamId, headers, endOfStream, true, true);
+        Http2Stream stream = connection.stream(streamId);
+        FullHttpMessage msg = processHeadersBegin(ctx, stream, headers, endOfStream, true, true);
         if (msg != null) {
-            processHeadersEnd(ctx, streamId, msg, endOfStream);
+            processHeadersEnd(ctx, stream, msg, endOfStream);
         }
     }
 
     @Override
     public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) throws Http2Exception {
-        FullHttpMessage msg = messageMap.get(streamId);
+        Http2Stream stream = connection.stream(streamId);
+        FullHttpMessage msg = getMessage(stream);
         if (msg != null) {
-            fireChannelRead(ctx, msg, streamId);
+            onRstStreamRead(stream, msg);
         }
+        ctx.fireExceptionCaught(Http2Exception.streamError(streamId, Http2Error.valueOf(errorCode),
+                "HTTP/2 to HTTP layer caught stream reset"));
     }
 
     @Override
     public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
             Http2Headers headers, int padding) throws Http2Exception {
         // A push promise should not be allowed to add headers to an existing stream
-        FullHttpMessage msg = processHeadersBegin(ctx, promisedStreamId, headers, false, false, false);
+        Http2Stream promisedStream = connection.stream(promisedStreamId);
+        FullHttpMessage msg = processHeadersBegin(ctx, promisedStream, headers, false, false, false);
         if (msg == null) {
             throw connectionError(PROTOCOL_ERROR, "Push Promise Frame received for pre-existing stream id %d",
                             promisedStreamId);
@@ -258,7 +293,7 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
 
         msg.headers().setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_PROMISE_ID.text(), streamId);
 
-        processHeadersEnd(ctx, promisedStreamId, msg, false);
+        processHeadersEnd(ctx, promisedStream, msg, false);
     }
 
     @Override
@@ -267,6 +302,13 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
             // Provide an interface for non-listeners to capture settings
             ctx.fireChannelRead(settings);
         }
+    }
+
+    /**
+     * Called if a {@code RST_STREAM} is received but we have some data for that stream.
+     */
+    protected void onRstStreamRead(Http2Stream stream, FullHttpMessage msg) {
+        removeMessage(stream, true);
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpPriorityAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpPriorityAdapter.java
@@ -19,8 +19,6 @@ import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.util.AsciiString;
-import io.netty.util.collection.IntObjectHashMap;
-import io.netty.util.collection.IntObjectMap;
 
 import java.util.Iterator;
 import java.util.Map.Entry;
@@ -41,20 +39,25 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
             HttpConversionUtil.OUT_OF_MESSAGE_SEQUENCE_PATH);
     private static final AsciiString OUT_OF_MESSAGE_SEQUENCE_RETURN_CODE = new AsciiString(
             HttpConversionUtil.OUT_OF_MESSAGE_SEQUENCE_RETURN_CODE.toString());
-    private final IntObjectMap<HttpHeaders> outOfMessageFlowHeaders;
+    private final Http2Connection.PropertyKey outOfMessageFlowHeadersKey;
 
     InboundHttp2ToHttpPriorityAdapter(Http2Connection connection, int maxContentLength,
                                       boolean validateHttpHeaders,
                                       boolean propagateSettings) {
-
         super(connection, maxContentLength, validateHttpHeaders, propagateSettings);
-        outOfMessageFlowHeaders = new IntObjectHashMap<HttpHeaders>();
+        outOfMessageFlowHeadersKey = connection.newKey();
     }
 
-    @Override
-    protected void removeMessage(int streamId) {
-        super.removeMessage(streamId);
-        outOfMessageFlowHeaders.remove(streamId);
+    private HttpHeaders getOutOfMessageFlowHeaders(Http2Stream stream) {
+        return stream.getProperty(outOfMessageFlowHeadersKey);
+    }
+
+    private void putOutOfMessageFlowHeaders(Http2Stream stream, HttpHeaders headers) {
+        stream.setProperty(outOfMessageFlowHeadersKey, headers);
+    }
+
+    private HttpHeaders removeOutOfMessageFlowHeaders(Http2Stream stream) {
+        return stream.removeProperty(outOfMessageFlowHeadersKey);
     }
 
     /**
@@ -68,13 +71,13 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
 
     /**
      * This method will add the {@code headers} to the out of order headers map
-     * @param streamId The stream id associated with {@code headers}
+     * @param stream The stream associated with {@code headers}
      * @param headers Newly encountered out of order headers which must be stored for future use
      */
-    private void importOutOfMessageFlowHeaders(int streamId, HttpHeaders headers) {
-        final HttpHeaders outOfMessageFlowHeader = outOfMessageFlowHeaders.get(streamId);
+    private void importOutOfMessageFlowHeaders(Http2Stream stream, HttpHeaders headers) {
+        final HttpHeaders outOfMessageFlowHeader = getOutOfMessageFlowHeaders(stream);
         if (outOfMessageFlowHeader == null) {
-            outOfMessageFlowHeaders.put(streamId, headers);
+            putOutOfMessageFlowHeaders(stream, headers);
         } else {
             outOfMessageFlowHeader.setAll(headers);
         }
@@ -82,11 +85,11 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
 
     /**
      * Take any saved out of order headers and export them to {@code headers}
-     * @param streamId The stream id to search for out of order headers for
-     * @param headers If any out of order headers exist for {@code streamId} they will be added to this object
+     * @param stream The stream to search for out of order headers for
+     * @param headers If any out of order headers exist for {@code stream} they will be added to this object
      */
-    private void exportOutOfMessageFlowHeaders(int streamId, final HttpHeaders headers) {
-        final HttpHeaders outOfMessageFlowHeader = outOfMessageFlowHeaders.get(streamId);
+    private void exportOutOfMessageFlowHeaders(Http2Stream stream, final HttpHeaders headers) {
+        final HttpHeaders outOfMessageFlowHeader = getOutOfMessageFlowHeaders(stream);
         if (outOfMessageFlowHeader != null) {
             headers.setAll(outOfMessageFlowHeader);
         }
@@ -127,18 +130,19 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
     }
 
     @Override
-    protected void fireChannelRead(ChannelHandlerContext ctx, FullHttpMessage msg, int streamId) {
-        exportOutOfMessageFlowHeaders(streamId, getActiveHeaders(msg));
-        super.fireChannelRead(ctx, msg, streamId);
+    protected void fireChannelRead(ChannelHandlerContext ctx, FullHttpMessage msg, boolean release,
+                                   Http2Stream stream) {
+        exportOutOfMessageFlowHeaders(stream, getActiveHeaders(msg));
+        super.fireChannelRead(ctx, msg, release, stream);
     }
 
     @Override
-    protected FullHttpMessage processHeadersBegin(ChannelHandlerContext ctx, int streamId, Http2Headers headers,
+    protected FullHttpMessage processHeadersBegin(ChannelHandlerContext ctx, Http2Stream stream, Http2Headers headers,
             boolean endOfStream, boolean allowAppend, boolean appendToTrailer) throws Http2Exception {
-        FullHttpMessage msg = super.processHeadersBegin(ctx, streamId, headers,
+        FullHttpMessage msg = super.processHeadersBegin(ctx, stream, headers,
                 endOfStream, allowAppend, appendToTrailer);
         if (msg != null) {
-            exportOutOfMessageFlowHeaders(streamId, getActiveHeaders(msg));
+            exportOutOfMessageFlowHeaders(stream, getActiveHeaders(msg));
         }
         return msg;
     }
@@ -146,15 +150,15 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
     @Override
     public void onPriorityTreeParentChanged(Http2Stream stream, Http2Stream oldParent) {
         Http2Stream parent = stream.parent();
-        FullHttpMessage msg = messageMap.get(stream.id());
+        FullHttpMessage msg = getMessage(stream);
         if (msg == null) {
-            // msg may be null if a HTTP/2 frame event in received outside the HTTP message flow
-            // For example a PRIORITY frame can be received in any state
-            // and the HTTP message flow exists in OPEN.
+            // msg may be null if a HTTP/2 frame event is received outside the HTTP message flow
+            // For example a PRIORITY frame can be received in any state but the HTTP message flow
+            // takes place while the stream is OPEN.
             if (parent != null && !parent.equals(connection.connectionStream())) {
                 HttpHeaders headers = new DefaultHttpHeaders();
                 headers.setInt(HttpConversionUtil.ExtensionHeaderNames.STREAM_DEPENDENCY_ID.text(), parent.id());
-                importOutOfMessageFlowHeaders(stream.id(), headers);
+                importOutOfMessageFlowHeaders(stream, headers);
             }
         } else {
             if (parent == null) {
@@ -169,14 +173,14 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
 
     @Override
     public void onWeightChanged(Http2Stream stream, short oldWeight) {
-        FullHttpMessage msg = messageMap.get(stream.id());
+        FullHttpMessage msg = getMessage(stream);
         final HttpHeaders headers;
         if (msg == null) {
             // msg may be null if a HTTP/2 frame event in received outside the HTTP message flow
             // For example a PRIORITY frame can be received in any state
             // and the HTTP message flow exists in OPEN.
             headers = new DefaultHttpHeaders();
-            importOutOfMessageFlowHeaders(stream.id(), headers);
+            importOutOfMessageFlowHeaders(stream, headers);
         } else {
             headers = getActiveHeaders(msg);
         }
@@ -186,9 +190,13 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
     @Override
     public void onPriorityRead(ChannelHandlerContext ctx, int streamId, int streamDependency, short weight,
                     boolean exclusive) throws Http2Exception {
-        FullHttpMessage msg = messageMap.get(streamId);
+        Http2Stream stream = connection.stream(streamId);
+        if (stream == null) {
+            return;
+        }
+        FullHttpMessage msg = getMessage(stream);
         if (msg == null) {
-            HttpHeaders httpHeaders = outOfMessageFlowHeaders.remove(streamId);
+            HttpHeaders httpHeaders = removeOutOfMessageFlowHeaders(stream);
             if (httpHeaders == null) {
                 throw connectionError(PROTOCOL_ERROR, "Priority Frame recieved for unknown stream id %d", streamId);
             }
@@ -196,8 +204,8 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
             Http2Headers http2Headers = new DefaultHttp2Headers(validateHttpHeaders, httpHeaders.size());
             initializePseudoHeaders(http2Headers);
             addHttpHeadersToHttp2Headers(httpHeaders, http2Headers);
-            msg = newMessage(streamId, http2Headers, validateHttpHeaders);
-            fireChannelRead(ctx, msg, streamId);
+            msg = newMessage(stream, http2Headers, validateHttpHeaders, ctx.alloc());
+            fireChannelRead(ctx, msg, false, stream);
         }
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -265,8 +265,9 @@ public class DefaultHttp2ConnectionEncoderTest {
     public void dataFramesDontMergeWithHeaders() throws Exception {
         createStream(STREAM_ID, false);
         final ByteBuf data = dummyData().retain();
-        encoder.writeData(ctx, STREAM_ID, data, 0, true, newPromise());
-        encoder.writeHeaders(ctx, STREAM_ID, EmptyHttp2Headers.INSTANCE, 0, false, newPromise());
+        encoder.writeData(ctx, STREAM_ID, data, 0, false, newPromise());
+        when(remoteFlow.hasFlowControlled(any(Http2Stream.class))).thenReturn(true);
+        encoder.writeHeaders(ctx, STREAM_ID, EmptyHttp2Headers.INSTANCE, 0, true, newPromise());
         List<FlowControlled> capturedWrites = payloadCaptor.getAllValues();
         assertFalse(capturedWrites.get(0).merge(ctx, capturedWrites.get(1)));
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -315,7 +315,6 @@ public class Http2ConnectionHandlerTest {
         when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID),
                 anyLong(), any(ChannelPromise.class))).thenReturn(future);
         when(stream.state()).thenReturn(CLOSED);
-        when(stream.isHeaderSent()).thenReturn(true);
         // The stream is "closed" but is still known about by the connection (connection().stream(..)
         // will return the stream). We should still write a RST_STREAM frame in this scenario.
         handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code(), promise);

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObject.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObject.java
@@ -16,11 +16,12 @@
 package io.netty.handler.codec.memcache;
 
 import io.netty.handler.codec.DecoderResult;
+import io.netty.util.AbstractReferenceCounted;
 
 /**
  * The default {@link MemcacheObject} implementation.
  */
-public abstract class AbstractMemcacheObject implements MemcacheObject {
+public abstract class AbstractMemcacheObject extends AbstractReferenceCounted implements MemcacheObject {
 
     private DecoderResult decoderResult = DecoderResult.SUCCESS;
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
@@ -51,25 +51,20 @@ public class DefaultMemcacheContent extends AbstractMemcacheObject implements Me
     }
 
     @Override
-    public int refCnt() {
-        return content.refCnt();
-    }
-
-    @Override
     public MemcacheContent retain() {
-        content.retain();
+        super.retain();
         return this;
     }
 
     @Override
     public MemcacheContent retain(int increment) {
-        content.retain(increment);
+        super.retain(increment);
         return this;
     }
 
     @Override
     public MemcacheContent touch() {
-        content.touch();
+        super.touch();
         return this;
     }
 
@@ -80,13 +75,8 @@ public class DefaultMemcacheContent extends AbstractMemcacheObject implements Me
     }
 
     @Override
-    public boolean release() {
-        return content.release();
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        return content.release(decrement);
+    protected void deallocate() {
+        content.release();
     }
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheMessage.java
@@ -166,48 +166,28 @@ public abstract class AbstractBinaryMemcacheMessage
     }
 
     @Override
-    public int refCnt() {
-        if (extras != null) {
-            return extras.refCnt();
-        }
-        return 1;
-    }
-
-    @Override
     public BinaryMemcacheMessage retain() {
-        if (extras != null) {
-            extras.retain();
-        }
+        super.retain();
         return this;
     }
 
     @Override
     public BinaryMemcacheMessage retain(int increment) {
-        if (extras != null) {
-            extras.retain(increment);
-        }
+        super.retain(increment);
         return this;
     }
 
     @Override
-    public boolean release() {
+    protected void deallocate() {
         if (extras != null) {
-            return extras.release();
+            extras.release();
         }
-        return false;
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        if (extras != null) {
-            return extras.release(decrement);
-        }
-        return false;
     }
 
     @Override
     public BinaryMemcacheMessage touch() {
-        return touch(null);
+        super.touch();
+        return this;
     }
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregator.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregator.java
@@ -53,8 +53,9 @@ public class BinaryMemcacheObjectAggregator extends AbstractMemcacheObjectAggreg
     }
 
     private static FullBinaryMemcacheRequest toFullRequest(BinaryMemcacheRequest request, ByteBuf content) {
+        ByteBuf extras = request.extras() == null ? null : request.extras().retain();
         FullBinaryMemcacheRequest fullRequest =
-                new DefaultFullBinaryMemcacheRequest(request.key(), request.extras(), content);
+                new DefaultFullBinaryMemcacheRequest(request.key(), extras, content);
 
         fullRequest.setMagic(request.magic());
         fullRequest.setOpcode(request.opcode());
@@ -70,8 +71,9 @@ public class BinaryMemcacheObjectAggregator extends AbstractMemcacheObjectAggreg
     }
 
     private static FullBinaryMemcacheResponse toFullResponse(BinaryMemcacheResponse response, ByteBuf content) {
+        ByteBuf extras = response.extras() == null ? null : response.extras().retain();
         FullBinaryMemcacheResponse fullResponse =
-                new DefaultFullBinaryMemcacheResponse(response.key(), response.extras(), content);
+                new DefaultFullBinaryMemcacheResponse(response.key(), extras, content);
 
         fullResponse.setMagic(response.magic());
         fullResponse.setOpcode(response.opcode());

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
@@ -59,28 +59,20 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
     }
 
     @Override
-    public int refCnt() {
-        return content.refCnt();
-    }
-
-    @Override
     public FullBinaryMemcacheRequest retain() {
         super.retain();
-        content.retain();
         return this;
     }
 
     @Override
     public FullBinaryMemcacheRequest retain(int increment) {
         super.retain(increment);
-        content.retain(increment);
         return this;
     }
 
     @Override
     public FullBinaryMemcacheRequest touch() {
         super.touch();
-        content.touch();
         return this;
     }
 
@@ -92,15 +84,9 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
     }
 
     @Override
-    public boolean release() {
-        super.release();
-        return content.release();
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        super.release(decrement);
-        return content.release(decrement);
+    protected void deallocate() {
+        super.deallocate();
+        content.release();
     }
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
@@ -59,28 +59,20 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
     }
 
     @Override
-    public int refCnt() {
-        return content.refCnt();
-    }
-
-    @Override
     public FullBinaryMemcacheResponse retain() {
         super.retain();
-        content.retain();
         return this;
     }
 
     @Override
     public FullBinaryMemcacheResponse retain(int increment) {
         super.retain(increment);
-        content.retain(increment);
         return this;
     }
 
     @Override
     public FullBinaryMemcacheResponse touch() {
         super.touch();
-        content.touch();
         return this;
     }
 
@@ -92,15 +84,9 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
     }
 
     @Override
-    public boolean release() {
-        super.release();
-        return content.release();
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        super.release(decrement);
-        return content.release(decrement);
+    protected void deallocate() {
+        super.deallocate();
+        content.release();
     }
 
     @Override

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -17,13 +17,13 @@ package io.netty.util;
 
 import io.netty.util.ByteProcessor.IndexOfProcessor;
 import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.PlatformDependent;
 
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -1050,7 +1050,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
      * Splits the specified {@link String} with the specified delimiter..
      */
     public AsciiString[] split(char delim) {
-        final List<AsciiString> res = new ArrayList<AsciiString>();
+        final List<AsciiString> res = InternalThreadLocalMap.get().arrayList();
 
         int start = 0;
         final int length = length();

--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -22,6 +22,7 @@ import io.netty.util.concurrent.FastThreadLocalThread;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -33,6 +34,8 @@ import java.util.WeakHashMap;
  * unless you know what you are doing.
  */
 public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap {
+
+    private static final int DEFAULT_ARRAY_LIST_INITIAL_CAPACITY = 8;
 
     public static final Object UNSET = new Object();
 
@@ -160,6 +163,9 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
         if (charsetDecoderCache != null) {
             count ++;
         }
+        if (arrayList != null) {
+            count ++;
+        }
 
         for (Object o: indexedVariables) {
             if (o != UNSET) {
@@ -196,6 +202,21 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
             charsetDecoderCache = cache = new IdentityHashMap<Charset, CharsetDecoder>();
         }
         return cache;
+    }
+
+    public <E> ArrayList<E> arrayList() {
+        return arrayList(DEFAULT_ARRAY_LIST_INITIAL_CAPACITY);
+    }
+
+    public <E> ArrayList<E> arrayList(int minCapacity) {
+        ArrayList<E> list = (ArrayList<E>) arrayList;
+        if (list == null) {
+            list = (ArrayList<E>) new ArrayList<Object>(minCapacity);
+        } else {
+            list.clear();
+            list.ensureCapacity(minCapacity);
+        }
+        return list;
     }
 
     public int futureListenerStackDepth() {

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -16,7 +16,6 @@
 package io.netty.util.internal;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Formatter;
 import java.util.List;
 
@@ -94,7 +93,7 @@ public final class StringUtil {
      */
     public static String[] split(String value, char delim) {
         final int end = value.length();
-        final List<String> res = new ArrayList<String>();
+        final List<String> res = InternalThreadLocalMap.get().arrayList();
 
         int start = 0;
         for (int i = 0; i < end; i ++) {
@@ -136,7 +135,7 @@ public final class StringUtil {
      */
     public static String[] split(String value, char delim, int maxParts) {
         final int end = value.length();
-        final List<String> res = new ArrayList<String>();
+        final List<String> res = InternalThreadLocalMap.get().arrayList();
 
         int start = 0;
         int cpt = 1;

--- a/common/src/main/java/io/netty/util/internal/UnpaddedInternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/UnpaddedInternalThreadLocalMap.java
@@ -21,6 +21,7 @@ import io.netty.util.concurrent.FastThreadLocal;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -50,6 +51,9 @@ class UnpaddedInternalThreadLocalMap {
     StringBuilder stringBuilder;
     Map<Charset, CharsetEncoder> charsetEncoderCache;
     Map<Charset, CharsetDecoder> charsetDecoderCache;
+
+    // ArrayList-related thread-locals
+    ArrayList<Object> arrayList;
 
     UnpaddedInternalThreadLocalMap(Object[] indexedVariables) {
         this.indexedVariables = indexedVariables;

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -81,8 +81,8 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-tcnative</artifactId>
-        <classifier>${tcnative.classifier}</classifier>
+      <artifactId>${tcnative.artifactId}</artifactId>
+      <classifier>${tcnative.classifier}</classifier>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.npn</groupId>

--- a/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
@@ -113,7 +113,7 @@ public final class WebSocketClient {
                      p.addLast(
                              new HttpClientCodec(),
                              new HttpObjectAggregator(8192),
-                             new WebSocketClientCompressionHandler(),
+                             WebSocketClientCompressionHandler.INSTANCE,
                              handler);
                  }
              });

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-tcnative</artifactId>
+      <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
       <optional>true</optional>
     </dependency>

--- a/handler/src/main/java/io/netty/handler/ssl/IdentityCipherSuiteFilter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/IdentityCipherSuiteFilter.java
@@ -15,7 +15,8 @@
  */
 package io.netty.handler.ssl;
 
-import java.util.ArrayList;
+import io.netty.util.internal.InternalThreadLocalMap;
+
 import java.util.List;
 import java.util.Set;
 
@@ -33,7 +34,7 @@ public final class IdentityCipherSuiteFilter implements CipherSuiteFilter {
         if (ciphers == null) {
             return defaultCiphers.toArray(new String[defaultCiphers.size()]);
         } else {
-            List<String> newCiphers = new ArrayList<String>(supportedCiphers.size());
+            List<String> newCiphers = InternalThreadLocalMap.get().arrayList(supportedCiphers.size());
             for (String c : ciphers) {
                 if (c == null) {
                     break;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -196,6 +196,11 @@ public abstract class OpenSslContext extends SslContext {
                 SSLContext.setOptions(ctx, SSL.SSL_OP_SINGLE_DH_USE);
                 SSLContext.setOptions(ctx, SSL.SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION);
 
+                // We need to enable SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER as the memory address may change between
+                // calling OpenSSLEngine.wrap(...).
+                // See https://github.com/netty/netty-tcnative/issues/100
+                SSLContext.setMode(ctx, SSLContext.getMode(ctx) | SSL.SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+
                 /* List the ciphers that are permitted to negotiate. */
                 try {
                     SSLContext.setCipherSuite(ctx, CipherSuiteConverter.toOpenSsl(unmodifiableCiphers));

--- a/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
@@ -108,19 +108,25 @@ public class SniHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
-        if (!suppressRead && !handshakeFailed && in.readableBytes() >= SslUtils.SSL_RECORD_HEADER_LENGTH) {
-            int writerIndex = in.writerIndex();
-            int readerIndex = in.readerIndex();
+        if (!suppressRead && !handshakeFailed) {
+            final int writerIndex = in.writerIndex();
             try {
                 loop:
                 for (int i = 0; i < MAX_SSL_RECORDS; i++) {
-                    int command = in.getUnsignedByte(readerIndex);
+                    final int readerIndex = in.readerIndex();
+                    final int readableBytes = writerIndex - readerIndex;
+                    if (readableBytes < SslUtils.SSL_RECORD_HEADER_LENGTH) {
+                        // Not enough data to determine the record type and length.
+                        return;
+                    }
+
+                    final int command = in.getUnsignedByte(readerIndex);
 
                     // tls, but not handshake command
                     switch (command) {
                         case SslUtils.SSL_CONTENT_TYPE_CHANGE_CIPHER_SPEC:
                         case SslUtils.SSL_CONTENT_TYPE_ALERT:
-                            int len = SslUtils.getEncryptedPacketLength(in, readerIndex);
+                            final int len = SslUtils.getEncryptedPacketLength(in, readerIndex);
 
                             // Not an SSL/TLS packet
                             if (len == -1) {
@@ -138,20 +144,21 @@ public class SniHandler extends ByteToMessageDecoder implements ChannelOutboundH
                                 return;
                             }
                             // increase readerIndex and try again.
-                            readerIndex += len;
+                            in.skipBytes(len);
                             continue;
                         case SslUtils.SSL_CONTENT_TYPE_HANDSHAKE:
-                            int majorVersion = in.getUnsignedByte(readerIndex + 1);
+                            final int majorVersion = in.getUnsignedByte(readerIndex + 1);
 
                             // SSLv3 or TLS
                             if (majorVersion == 3) {
-                                int packetLength = in.getUnsignedShort(readerIndex + 3)
-                                        + SslUtils.SSL_RECORD_HEADER_LENGTH;
+                                final int packetLength = in.getUnsignedShort(readerIndex + 3) +
+                                                         SslUtils.SSL_RECORD_HEADER_LENGTH;
 
-                                if (in.readableBytes() < packetLength) {
-                                    // client hello incomplete try again to decode once more data is ready.
+                                if (readableBytes < packetLength) {
+                                    // client hello incomplete; try again to decode once more data is ready.
                                     return;
                                 }
+
                                 // See https://tools.ietf.org/html/rfc5246#section-7.4.1.2
                                 //
                                 // Decode the ssl client hello packet.
@@ -171,39 +178,71 @@ public class SniHandler extends ByteToMessageDecoder implements ChannelOutboundH
                                 //    };
                                 // } ClientHello;
                                 //
+
+                                final int endOffset = readerIndex + packetLength;
                                 int offset = readerIndex + 43;
 
-                                int sessionIdLength = in.getUnsignedByte(offset);
+                                if (endOffset - offset < 6) {
+                                    break loop;
+                                }
+
+                                final int sessionIdLength = in.getUnsignedByte(offset);
                                 offset += sessionIdLength + 1;
 
-                                int cipherSuitesLength = in.getUnsignedShort(offset);
+                                final int cipherSuitesLength = in.getUnsignedShort(offset);
                                 offset += cipherSuitesLength + 2;
 
-                                int compressionMethodLength = in.getUnsignedByte(offset);
+                                final int compressionMethodLength = in.getUnsignedByte(offset);
                                 offset += compressionMethodLength + 1;
 
-                                int extensionsLength = in.getUnsignedShort(offset);
+                                final int extensionsLength = in.getUnsignedShort(offset);
                                 offset += 2;
-                                int extensionsLimit = offset + extensionsLength;
+                                final int extensionsLimit = offset + extensionsLength;
 
-                                while (offset < extensionsLimit) {
-                                    int extensionType = in.getUnsignedShort(offset);
+                                if (extensionsLimit > endOffset) {
+                                    // Extensions should never exceed the record boundary.
+                                    break loop;
+                                }
+
+                                for (;;) {
+                                    if (extensionsLimit - offset < 4) {
+                                        break loop;
+                                    }
+
+                                    final int extensionType = in.getUnsignedShort(offset);
                                     offset += 2;
 
-                                    int extensionLength = in.getUnsignedShort(offset);
+                                    final int extensionLength = in.getUnsignedShort(offset);
                                     offset += 2;
+
+                                    if (extensionsLimit - offset < extensionLength) {
+                                        break loop;
+                                    }
 
                                     // SNI
                                     // See https://tools.ietf.org/html/rfc6066#page-6
                                     if (extensionType == 0) {
-                                        int serverNameType = in.getUnsignedByte(offset + 2);
+                                        offset += 2;
+                                        if (extensionsLimit - offset < 3) {
+                                            break loop;
+                                        }
+
+                                        final int serverNameType = in.getUnsignedByte(offset);
+                                        offset++;
+
                                         if (serverNameType == 0) {
-                                            int serverNameLength = in.getUnsignedShort(offset + 3);
-                                            String hostname = in.toString(offset + 5, serverNameLength,
-                                                    CharsetUtil.UTF_8);
+                                            final int serverNameLength = in.getUnsignedShort(offset);
+                                            offset += 2;
+
+                                            if (extensionsLimit - offset < serverNameLength) {
+                                                break loop;
+                                            }
+
+                                            final String hostname = in.toString(offset, serverNameLength,
+                                                                                CharsetUtil.UTF_8);
 
                                             select(ctx, IDN.toASCII(hostname,
-                                                    IDN.ALLOW_UNASSIGNED).toLowerCase(Locale.US));
+                                                                    IDN.ALLOW_UNASSIGNED).toLowerCase(Locale.US));
                                             return;
                                         } else {
                                             // invalid enum value

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1351,6 +1351,10 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             }
 
             handshakePromise = p = newHandshakePromise;
+        } else if (engine.getHandshakeStatus() != HandshakeStatus.NOT_HANDSHAKING) {
+            // Not all SSLEngine implementations support calling beginHandshake multiple times while a handshake
+            // is in progress. See https://github.com/netty/netty/issues/4718.
+            return;
         } else {
             // Forced to reuse the old handshake.
             p = handshakePromise;

--- a/handler/src/main/java/io/netty/handler/ssl/SupportedCipherSuiteFilter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SupportedCipherSuiteFilter.java
@@ -15,8 +15,9 @@
  */
 package io.netty.handler.ssl;
 
+import io.netty.util.internal.InternalThreadLocalMap;
+
 import javax.net.ssl.SSLEngine;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -40,10 +41,10 @@ public final class SupportedCipherSuiteFilter implements CipherSuiteFilter {
 
         final List<String> newCiphers;
         if (ciphers == null) {
-            newCiphers = new ArrayList<String>(defaultCiphers.size());
+            newCiphers = InternalThreadLocalMap.get().arrayList(defaultCiphers.size());
             ciphers = defaultCiphers;
         } else {
-            newCiphers = new ArrayList<String>(supportedCiphers.size());
+            newCiphers = InternalThreadLocalMap.get().arrayList(supportedCiphers.size());
         }
         for (String c : ciphers) {
             if (c == null) {

--- a/handler/src/main/java/io/netty/handler/ssl/util/FingerprintTrustManagerFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/FingerprintTrustManagerFactory.java
@@ -20,6 +20,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.concurrent.FastThreadLocal;
+import io.netty.util.internal.InternalThreadLocalMap;
 
 import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.TrustManager;
@@ -31,7 +32,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -151,7 +151,7 @@ public final class FingerprintTrustManagerFactory extends SimpleTrustManagerFact
             throw new NullPointerException("fingerprints");
         }
 
-        List<byte[]> list = new ArrayList<byte[]>();
+        List<byte[]> list = InternalThreadLocalMap.get().arrayList();
         for (byte[] f: fingerprints) {
             if (f == null) {
                 break;
@@ -171,7 +171,7 @@ public final class FingerprintTrustManagerFactory extends SimpleTrustManagerFact
             throw new NullPointerException("fingerprints");
         }
 
-        List<byte[]> list = new ArrayList<byte[]>();
+        List<byte[]> list = InternalThreadLocalMap.get().arrayList();
         for (String f: fingerprints) {
             if (f == null) {
                 break;

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -15,13 +15,22 @@
  */
 package io.netty.handler.ssl;
 
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.internal.ThreadLocalRandom;
 import org.junit.Test;
 
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import java.nio.ByteBuffer;
+
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assume.assumeTrue;
 
 public class OpenSslEngineTest extends SSLEngineTest {
@@ -101,6 +110,32 @@ public class OpenSslEngineTest extends SSLEngineTest {
     public void testSessionInvalidate() throws Exception {
         assumeTrue(OpenSsl.isAvailable());
         super.testSessionInvalidate();
+    }
+
+    @Test
+    public void testWrapHeapBuffersNoWritePendingError() throws Exception {
+        assumeTrue(OpenSsl.isAvailable());
+        final SslContext clientContext = SslContextBuilder.forClient()
+                .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                .sslProvider(sslProvider())
+                .build();
+        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        SslContext serverContext = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
+                .sslProvider(sslProvider())
+                .build();
+        SSLEngine clientEngine = clientContext.newEngine(UnpooledByteBufAllocator.DEFAULT);
+        SSLEngine serverEngine = serverContext.newEngine(UnpooledByteBufAllocator.DEFAULT);
+        handshake(clientEngine, serverEngine);
+
+        ByteBuffer src = ByteBuffer.allocate(1024 * 10);
+        ThreadLocalRandom.current().nextBytes(src.array());
+        ByteBuffer dst = ByteBuffer.allocate(1);
+        // Try to wrap multiple times so we are more likely to hit the issue.
+        for (int i = 0; i < 100; i++) {
+            src.position(0);
+            dst.position(0);
+            assertSame(SSLEngineResult.Status.BUFFER_OVERFLOW, clientEngine.wrap(src, dst).getStatus());
+        }
     }
 
     @Override

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -366,7 +366,7 @@ public abstract class SSLEngineTest {
         }
     }
 
-    private static void handshake(SSLEngine clientEngine, SSLEngine serverEngine) throws SSLException {
+    protected static void handshake(SSLEngine clientEngine, SSLEngine serverEngine) throws SSLException {
         int netBufferSize = 17 * 1024;
         ByteBuffer cTOs = ByteBuffer.allocateDirect(netBufferSize);
         ByteBuffer sTOc = ByteBuffer.allocateDirect(netBufferSize);

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.local.LocalAddress;
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalServerChannel;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.Mapping;
+import io.netty.util.concurrent.Promise;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+public class SniClientTest {
+
+    @Test
+    public void testSniClientJdkSslServerJdkSsl() throws Exception {
+        testSniClient(SslProvider.JDK, SslProvider.JDK);
+    }
+
+    @Test
+    public void testSniClientOpenSslServerOpenSsl() throws Exception {
+        Assume.assumeTrue(OpenSsl.isAvailable());
+        testSniClient(SslProvider.OPENSSL, SslProvider.OPENSSL);
+    }
+
+    @Test
+    public void testSniClientJdkSslServerOpenSsl() throws Exception {
+        Assume.assumeTrue(OpenSsl.isAvailable());
+        testSniClient(SslProvider.JDK, SslProvider.OPENSSL);
+    }
+
+    @Test
+    public void testSniClientOpenSslServerJdkSsl() throws Exception {
+        Assume.assumeTrue(OpenSsl.isAvailable());
+        testSniClient(SslProvider.OPENSSL, SslProvider.JDK);
+    }
+
+    private static void testSniClient(SslProvider sslClientProvider, SslProvider sslServerProvider) throws Exception {
+        final String sniHost = "sni.netty.io";
+        LocalAddress address = new LocalAddress("test");
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
+        Channel sc = null;
+        Channel cc = null;
+        try {
+            SelfSignedCertificate cert = new SelfSignedCertificate();
+            final SslContext sslServerContext = SslContextBuilder.forServer(cert.key(), cert.cert())
+                    .sslProvider(sslServerProvider).build();
+
+            final Promise<String> promise = group.next().newPromise();
+            ServerBootstrap sb = new ServerBootstrap();
+            sc = sb.group(group).channel(LocalServerChannel.class).childHandler(new ChannelInitializer<Channel>() {
+                @Override
+                protected void initChannel(Channel ch) throws Exception {
+                    ch.pipeline().addFirst(new SniHandler(new Mapping<String, SslContext>() {
+                        @Override
+                        public SslContext map(String input) {
+                            promise.setSuccess(input);
+                            return sslServerContext;
+                        }
+                    }));
+                }
+            }).bind(address).syncUninterruptibly().channel();
+
+            SslContext sslContext = SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE)
+                    .sslProvider(sslClientProvider).build();
+            Bootstrap cb = new Bootstrap();
+            cc = cb.group(group).channel(LocalChannel.class).handler(new SslHandler(
+                    sslContext.newEngine(ByteBufAllocator.DEFAULT, sniHost, -1)))
+                    .connect(address).syncUninterruptibly().channel();
+            Assert.assertEquals(sniHost, promise.syncUninterruptibly().getNow());
+        } finally {
+            if (cc != null) {
+                cc.close();
+            }
+            if (sc != null) {
+                sc.close();
+            }
+            group.shutdownGracefully();
+        }
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
@@ -72,6 +72,11 @@ public final class NoopHttp2RemoteFlowController implements Http2RemoteFlowContr
     }
 
     @Override
+    public boolean hasFlowControlled(Http2Stream stream) {
+        return false;
+    }
+
+    @Override
     public void channelHandlerContext(ChannelHandlerContext ctx) throws Http2Exception {
         this.ctx = ctx;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,8 @@
     <!-- Configure the os-maven-plugin extension to expand the classifier on                  -->
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
+    <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
+    <tcnative.version>1.1.33.Fork12</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <epoll.classifier>${os.detected.name}-${os.detected.arch}</epoll.classifier>
   </properties>
@@ -297,8 +299,8 @@
       <!-- Our own Tomcat Native fork - completely optional, used for acclerating SSL with OpenSSL. -->
       <dependency>
         <groupId>${project.groupId}</groupId>
-        <artifactId>netty-tcnative</artifactId>
-        <version>1.1.33.Fork11</version>
+        <artifactId>${tcnative.artifactId}</artifactId>
+        <version>${tcnative.version}</version>
         <classifier>${tcnative.classifier}</classifier>
         <scope>compile</scope>
         <optional>true</optional>

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -23,9 +23,9 @@ import io.netty.channel.ReflectiveChannelFactory;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.resolver.HostsFileEntriesResolver;
+import io.netty.util.internal.InternalThreadLocalMap;
 
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
 import java.util.List;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -170,7 +170,7 @@ public final class DnsNameResolverBuilder {
         checkNotNull(resolvedAddressTypes, "resolvedAddressTypes");
 
         final List<InternetProtocolFamily> list =
-                new ArrayList<InternetProtocolFamily>(InternetProtocolFamily.values().length);
+                InternalThreadLocalMap.get().arrayList(InternetProtocolFamily.values().length);
 
         for (InternetProtocolFamily f : resolvedAddressTypes) {
             if (f == null) {
@@ -207,7 +207,7 @@ public final class DnsNameResolverBuilder {
         checkNotNull(resolvedAddressTypes, "resolveAddressTypes");
 
         final List<InternetProtocolFamily> list =
-                new ArrayList<InternetProtocolFamily>(InternetProtocolFamily.values().length);
+                InternalThreadLocalMap.get().arrayList(InternetProtocolFamily.values().length);
 
         for (InternetProtocolFamily f : resolvedAddressTypes) {
             if (f == null) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddresses.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddresses.java
@@ -16,6 +16,7 @@
 
 package io.netty.resolver.dns;
 
+import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -241,7 +242,7 @@ public abstract class DnsServerAddresses {
             throw new NullPointerException("addresses");
         }
 
-        List<InetSocketAddress> list = new ArrayList<InetSocketAddress>(addresses.length);
+        List<InetSocketAddress> list = InternalThreadLocalMap.get().arrayList(addresses.length);
         for (InetSocketAddress a: addresses) {
             if (a == null) {
                 break;

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-tcnative</artifactId>
+      <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
       <optional>true</optional>
     </dependency>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-tcnative</artifactId>
+      <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
       <scope>test</scope>
     </dependency>

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
@@ -54,7 +54,7 @@ public class EpollSocketTcpMd5Test {
         server = (EpollServerSocketChannel) bootstrap.group(GROUP)
                 .channel(EpollServerSocketChannel.class)
                 .handler(new ChannelInboundHandlerAdapter())
-                .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                .bind(new InetSocketAddress(NetUtil.LOCALHOST4, 0)).syncUninterruptibly().channel();
     }
 
     @After

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
@@ -54,7 +54,7 @@ public class OioSctpServerChannel extends AbstractOioMessageChannel
     private static final InternalLogger logger =
             InternalLoggerFactory.getInstance(OioSctpServerChannel.class);
 
-    private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
+    private static final ChannelMetadata METADATA = new ChannelMetadata(false, 1);
 
     private static SctpServerChannel newServerSocket() {
         try {

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -78,7 +78,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      */
     protected AbstractChannel(Channel parent) {
         this.parent = parent;
-        id = DefaultChannelId.newInstance();
+        id = newId();
         unsafe = newUnsafe();
         pipeline = new DefaultChannelPipeline(this);
     }
@@ -99,6 +99,14 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     @Override
     public final ChannelId id() {
         return id;
+    }
+
+    /**
+     * Returns a new {@link DefaultChannelId} instance. Subclasses may override this method to assign custom
+     * {@link ChannelId}s to {@link Channel}s that use the {@link AbstractChannel#AbstractChannel(Channel)} constructor.
+     */
+    protected ChannelId newId() {
+        return DefaultChannelId.newInstance();
     }
 
     @Override
@@ -360,30 +368,21 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         SocketAddress remoteAddr = remoteAddress();
         SocketAddress localAddr = localAddress();
         if (remoteAddr != null) {
-            SocketAddress srcAddr;
-            SocketAddress dstAddr;
-            if (parent == null) {
-                srcAddr = localAddr;
-                dstAddr = remoteAddr;
-            } else {
-                srcAddr = remoteAddr;
-                dstAddr = localAddr;
-            }
-
             StringBuilder buf = new StringBuilder(96)
                 .append("[id: 0x")
                 .append(id.asShortText())
-                .append(", ")
-                .append(srcAddr)
-                .append(active? " => " : " :> ")
-                .append(dstAddr)
+                .append(", L:")
+                .append(localAddr)
+                .append(active? " - " : " ! ")
+                .append("R:")
+                .append(remoteAddr)
                 .append(']');
             strVal = buf.toString();
         } else if (localAddr != null) {
             StringBuilder buf = new StringBuilder(64)
                 .append("[id: 0x")
                 .append(id.asShortText())
-                .append(", ")
+                .append(", L:")
                 .append(localAddr)
                 .append(']');
             strVal = buf.toString();

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
@@ -44,7 +44,7 @@ public class OioServerSocketChannel extends AbstractOioMessageChannel
     private static final InternalLogger logger =
         InternalLoggerFactory.getInstance(OioServerSocketChannel.class);
 
-    private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
+    private static final ChannelMetadata METADATA = new ChannelMetadata(false, 1);
 
     private static ServerSocket newServerSocket() {
         try {

--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -22,6 +22,8 @@ import org.easymock.IAnswer;
 import org.junit.Test;
 
 import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
 
 public class AbstractChannelTest {
 
@@ -88,6 +90,13 @@ public class AbstractChannelTest {
 
         checkForHandlerException(throwable);
         verify(handler);
+    }
+
+    @Test
+    public void ensureDefaultChannelId() {
+        TestChannel channel = new TestChannel();
+        final ChannelId channelId = channel.id();
+        assertThat(channelId, instanceOf(DefaultChannelId.class));
     }
 
     private static void registerChannel(EventLoop eventLoop, Channel channel) throws Exception {


### PR DESCRIPTION
Motivation:
When converting SPDY or HTTP/2 frames to HTTP/1.x, netty always used an unpooled heap ```ByteBuf```.

Modifications:
When constructing the ```FullHttpMessage``` pass in the ```ByteBuf``` to use via the ```ByteBufAllocator``` assigned via the context.

Result:
The ```ByteBuf``` assigned to the ```FullHttpMessage``` can now be configured as a pooled/unpooled, direct/heap based ```ByteBuf``` via the ```ByteBufAllocator``` used.