### PR TITLE
[codec-memcache] ByteBuf for Key instead of String

### DIFF
--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObject.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObject.java
@@ -16,11 +16,12 @@
 package io.netty.handler.codec.memcache;
 
 import io.netty.handler.codec.DecoderResult;
+import io.netty.util.AbstractReferenceCounted;
 
 /**
  * The default {@link MemcacheObject} implementation.
  */
-public abstract class AbstractMemcacheObject implements MemcacheObject {
+public abstract class AbstractMemcacheObject extends AbstractReferenceCounted implements MemcacheObject {
 
     private DecoderResult decoderResult = DecoderResult.SUCCESS;
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultLastMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultLastMemcacheContent.java
@@ -33,36 +33,12 @@ public class DefaultLastMemcacheContent extends DefaultMemcacheContent implement
     }
 
     @Override
-    public LastMemcacheContent retain() {
-        super.retain();
-        return this;
-    }
-
-    @Override
-    public LastMemcacheContent retain(int increment) {
-        super.retain(increment);
-        return this;
-    }
-
-    @Override
-    public LastMemcacheContent touch() {
-        super.touch();
-        return this;
-    }
-
-    @Override
-    public LastMemcacheContent touch(Object hint) {
-        super.touch(hint);
-        return this;
-    }
-
-    @Override
-    public LastMemcacheContent copy() {
+    public DefaultLastMemcacheContent copy() {
         return new DefaultLastMemcacheContent(content().copy());
     }
 
     @Override
-    public LastMemcacheContent duplicate() {
+    public DefaultLastMemcacheContent duplicate() {
         return new DefaultLastMemcacheContent(content().duplicate());
     }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
@@ -41,57 +41,47 @@ public class DefaultMemcacheContent extends AbstractMemcacheObject implements Me
     }
 
     @Override
-    public MemcacheContent copy() {
+    public DefaultMemcacheContent copy() {
         return new DefaultMemcacheContent(content.copy());
     }
 
     @Override
-    public MemcacheContent duplicate() {
+    public DefaultMemcacheContent duplicate() {
         return new DefaultMemcacheContent(content.duplicate());
     }
 
     @Override
-    public int refCnt() {
-        return content.refCnt();
-    }
-
-    @Override
-    public MemcacheContent retain() {
-        content.retain();
+    public DefaultMemcacheContent retain() {
+        super.retain();
         return this;
     }
 
     @Override
-    public MemcacheContent retain(int increment) {
-        content.retain(increment);
+    public DefaultMemcacheContent retain(int increment) {
+        super.retain(increment);
         return this;
     }
 
     @Override
-    public MemcacheContent touch() {
-        content.touch();
+    public DefaultMemcacheContent touch() {
+        super.touch();
         return this;
     }
 
     @Override
-    public MemcacheContent touch(Object hint) {
+    public DefaultMemcacheContent touch(Object hint) {
         content.touch(hint);
         return this;
-    }
-
-    @Override
-    public boolean release() {
-        return content.release();
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        return content.release(decrement);
     }
 
     @Override
     public String toString() {
         return StringUtil.simpleClassName(this) +
                "(data: " + content() + ", decoderResult: " + decoderResult() + ')';
+    }
+
+    @Override
+    protected void deallocate() {
+        content.release();
     }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/FullMemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/FullMemcacheMessage.java
@@ -20,22 +20,4 @@ package io.netty.handler.codec.memcache;
  * message. So it represent a <i>complete</i> memcache message.
  */
 public interface FullMemcacheMessage extends MemcacheMessage, LastMemcacheContent {
-
-    @Override
-    FullMemcacheMessage copy();
-
-    @Override
-    FullMemcacheMessage retain(int increment);
-
-    @Override
-    FullMemcacheMessage retain();
-
-    @Override
-    FullMemcacheMessage touch();
-
-    @Override
-    FullMemcacheMessage touch(Object hint);
-
-    @Override
-    FullMemcacheMessage duplicate();
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/LastMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/LastMemcacheContent.java
@@ -90,22 +90,4 @@ public interface LastMemcacheContent extends MemcacheContent {
             return false;
         }
     };
-
-    @Override
-    LastMemcacheContent copy();
-
-    @Override
-    LastMemcacheContent retain(int increment);
-
-    @Override
-    LastMemcacheContent retain();
-
-    @Override
-    LastMemcacheContent touch();
-
-    @Override
-    LastMemcacheContent touch(Object hint);
-
-    @Override
-    LastMemcacheContent duplicate();
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheContent.java
@@ -27,22 +27,4 @@ import io.netty.channel.ChannelPipeline;
  * in the {@link ChannelPipeline}.
  */
 public interface MemcacheContent extends MemcacheObject, ByteBufHolder {
-
-    @Override
-    MemcacheContent copy();
-
-    @Override
-    MemcacheContent duplicate();
-
-    @Override
-    MemcacheContent retain();
-
-    @Override
-    MemcacheContent retain(int increment);
-
-    @Override
-    MemcacheContent touch();
-
-    @Override
-    MemcacheContent touch(Object hint);
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheMessage.java
@@ -21,22 +21,4 @@ import io.netty.util.ReferenceCounted;
  * Marker interface for both ascii and binary messages.
  */
 public interface MemcacheMessage extends MemcacheObject, ReferenceCounted {
-
-    /**
-     * Increases the reference count by {@code 1}.
-     */
-    @Override
-    MemcacheMessage retain();
-
-    /**
-     * Increases the reference count by the specified {@code increment}.
-     */
-    @Override
-    MemcacheMessage retain(int increment);
-
-    @Override
-    MemcacheMessage touch();
-
-    @Override
-    MemcacheMessage touch(Object hint);
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheEncoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheEncoder.java
@@ -64,12 +64,12 @@ public abstract class AbstractBinaryMemcacheEncoder<M extends BinaryMemcacheMess
      * @param buf the {@link ByteBuf} to write into.
      * @param key the key to encode.
      */
-    private static void encodeKey(ByteBuf buf, String key) {
-        if (key == null || key.isEmpty()) {
+    private static void encodeKey(ByteBuf buf, ByteBuf key) {
+        if (key == null || !key.isReadable()) {
             return;
         }
 
-        buf.writeBytes(key.getBytes(CharsetUtil.UTF_8));
+        buf.writeBytes(key);
     }
 
     /**

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheMessage.java
@@ -28,7 +28,7 @@ public abstract class AbstractBinaryMemcacheMessage
     /**
      * Contains the optional key.
      */
-    private String key;
+    private ByteBuf key;
 
     /**
      * Contains the optional extras.
@@ -50,13 +50,13 @@ public abstract class AbstractBinaryMemcacheMessage
      * @param key    the message key.
      * @param extras the message extras.
      */
-    protected AbstractBinaryMemcacheMessage(String key, ByteBuf extras) {
+    protected AbstractBinaryMemcacheMessage(ByteBuf key, ByteBuf extras) {
         this.key = key;
         this.extras = extras;
     }
 
     @Override
-    public String key() {
+    public ByteBuf key() {
         return key;
     }
 
@@ -66,7 +66,7 @@ public abstract class AbstractBinaryMemcacheMessage
     }
 
     @Override
-    public BinaryMemcacheMessage setKey(String key) {
+    public BinaryMemcacheMessage setKey(ByteBuf key) {
         this.key = key;
         return this;
     }
@@ -166,55 +166,24 @@ public abstract class AbstractBinaryMemcacheMessage
     }
 
     @Override
-    public int refCnt() {
-        if (extras != null) {
-            return extras.refCnt();
+    public AbstractBinaryMemcacheMessage touch(Object hint) {
+        if (key != null) {
+            key.touch(hint);
         }
-        return 1;
-    }
-
-    @Override
-    public BinaryMemcacheMessage retain() {
-        if (extras != null) {
-            extras.retain();
-        }
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheMessage retain(int increment) {
-        if (extras != null) {
-            extras.retain(increment);
-        }
-        return this;
-    }
-
-    @Override
-    public boolean release() {
-        if (extras != null) {
-            return extras.release();
-        }
-        return false;
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        if (extras != null) {
-            return extras.release(decrement);
-        }
-        return false;
-    }
-
-    @Override
-    public BinaryMemcacheMessage touch() {
-        return touch(null);
-    }
-
-    @Override
-    public BinaryMemcacheMessage touch(Object hint) {
         if (extras != null) {
             extras.touch(hint);
         }
         return this;
     }
+
+    @Override
+    protected void deallocate() {
+        if (key != null) {
+            key.release();
+        }
+        if (extras != null) {
+            extras.release();
+        }
+    }
+
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheMessage.java
@@ -160,14 +160,14 @@ public interface BinaryMemcacheMessage extends MemcacheMessage {
      *
      * @return the key of the document.
      */
-    String key();
+    ByteBuf key();
 
     /**
      * Sets the key of the document.
      *
      * @param key the key of the message.
      */
-    BinaryMemcacheMessage setKey(String key);
+    BinaryMemcacheMessage setKey(ByteBuf key);
 
     /**
      * Returns a {@link ByteBuf} representation of the optional extras.
@@ -182,22 +182,4 @@ public interface BinaryMemcacheMessage extends MemcacheMessage {
      * @param extras the extras buffer of the document.
      */
     BinaryMemcacheMessage setExtras(ByteBuf extras);
-
-    /**
-     * Increases the reference count by {@code 1}.
-     */
-    @Override
-    BinaryMemcacheMessage retain();
-
-    /**
-     * Increases the reference count by the specified {@code increment}.
-     */
-    @Override
-    BinaryMemcacheMessage retain(int increment);
-
-    @Override
-    BinaryMemcacheMessage touch();
-
-    @Override
-    BinaryMemcacheMessage touch(Object hint);
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregator.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregator.java
@@ -53,8 +53,9 @@ public class BinaryMemcacheObjectAggregator extends AbstractMemcacheObjectAggreg
     }
 
     private static FullBinaryMemcacheRequest toFullRequest(BinaryMemcacheRequest request, ByteBuf content) {
-        FullBinaryMemcacheRequest fullRequest =
-                new DefaultFullBinaryMemcacheRequest(request.key(), request.extras(), content);
+        ByteBuf key = request.key() == null ? null : request.key().retain();
+        ByteBuf extras = request.extras() == null ? null : request.extras().retain();
+        FullBinaryMemcacheRequest fullRequest = new DefaultFullBinaryMemcacheRequest(key, extras, content);
 
         fullRequest.setMagic(request.magic());
         fullRequest.setOpcode(request.opcode());
@@ -70,8 +71,9 @@ public class BinaryMemcacheObjectAggregator extends AbstractMemcacheObjectAggreg
     }
 
     private static FullBinaryMemcacheResponse toFullResponse(BinaryMemcacheResponse response, ByteBuf content) {
-        FullBinaryMemcacheResponse fullResponse =
-                new DefaultFullBinaryMemcacheResponse(response.key(), response.extras(), content);
+        ByteBuf key = response.key() == null ? null : response.key().retain();
+        ByteBuf extras = response.extras() == null ? null : response.extras().retain();
+        FullBinaryMemcacheResponse fullResponse = new DefaultFullBinaryMemcacheResponse(key, extras, content);
 
         fullResponse.setMagic(response.magic());
         fullResponse.setOpcode(response.opcode());

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequest.java
@@ -33,16 +33,4 @@ public interface BinaryMemcacheRequest extends BinaryMemcacheMessage {
      * @param reserved the reserved field value.
      */
     BinaryMemcacheRequest setReserved(short reserved);
-
-    @Override
-    BinaryMemcacheRequest retain();
-
-    @Override
-    BinaryMemcacheRequest retain(int increment);
-
-    @Override
-    BinaryMemcacheRequest touch();
-
-    @Override
-    BinaryMemcacheRequest touch(Object hint);
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequestDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequestDecoder.java
@@ -49,6 +49,6 @@ public class BinaryMemcacheRequestDecoder
 
     @Override
     protected BinaryMemcacheRequest buildInvalidMessage() {
-        return new DefaultBinaryMemcacheRequest("", Unpooled.EMPTY_BUFFER);
+        return new DefaultBinaryMemcacheRequest(Unpooled.EMPTY_BUFFER, Unpooled.EMPTY_BUFFER);
     }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponse.java
@@ -33,16 +33,4 @@ public interface BinaryMemcacheResponse extends BinaryMemcacheMessage {
      * @param status the status to set.
      */
     BinaryMemcacheResponse setStatus(short status);
-
-    @Override
-    BinaryMemcacheResponse retain();
-
-    @Override
-    BinaryMemcacheResponse retain(int increment);
-
-    @Override
-    BinaryMemcacheResponse touch();
-
-    @Override
-    BinaryMemcacheResponse touch(Object hint);
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponseDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponseDecoder.java
@@ -49,6 +49,6 @@ public class BinaryMemcacheResponseDecoder
 
     @Override
     protected BinaryMemcacheResponse buildInvalidMessage() {
-        return new DefaultBinaryMemcacheResponse("", Unpooled.EMPTY_BUFFER);
+        return new DefaultBinaryMemcacheResponse(Unpooled.EMPTY_BUFFER, Unpooled.EMPTY_BUFFER);
     }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheRequest.java
@@ -41,17 +41,8 @@ public class DefaultBinaryMemcacheRequest extends AbstractBinaryMemcacheMessage 
      *
      * @param key    the key to use.
      */
-    public DefaultBinaryMemcacheRequest(String key) {
+    public DefaultBinaryMemcacheRequest(ByteBuf key) {
         this(key, null);
-    }
-
-    /**
-     * Create a new {@link DefaultBinaryMemcacheRequest} with the header and extras.
-     *
-     * @param extras the extras to use.
-     */
-    public DefaultBinaryMemcacheRequest(ByteBuf extras) {
-        this(null, extras);
     }
 
     /**
@@ -60,7 +51,7 @@ public class DefaultBinaryMemcacheRequest extends AbstractBinaryMemcacheMessage 
      * @param key    the key to use.
      * @param extras the extras to use.
      */
-    public DefaultBinaryMemcacheRequest(String key, ByteBuf extras) {
+    public DefaultBinaryMemcacheRequest(ByteBuf key, ByteBuf extras) {
         super(key, extras);
         setMagic(REQUEST_MAGIC_BYTE);
     }
@@ -73,30 +64,6 @@ public class DefaultBinaryMemcacheRequest extends AbstractBinaryMemcacheMessage 
     @Override
     public BinaryMemcacheRequest setReserved(short reserved) {
         this.reserved = reserved;
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheRequest retain() {
-        super.retain();
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheRequest retain(int increment) {
-        super.retain(increment);
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheRequest touch() {
-        super.touch();
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheRequest touch(Object hint) {
-        super.touch(hint);
         return this;
     }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheResponse.java
@@ -41,17 +41,8 @@ public class DefaultBinaryMemcacheResponse extends AbstractBinaryMemcacheMessage
      *
      * @param key    the key to use
      */
-    public DefaultBinaryMemcacheResponse(String key) {
+    public DefaultBinaryMemcacheResponse(ByteBuf key) {
         this(key, null);
-    }
-
-    /**
-     * Create a new {@link DefaultBinaryMemcacheResponse} with the header and extras.
-     *
-     * @param extras the extras to use.
-     */
-    public DefaultBinaryMemcacheResponse(ByteBuf extras) {
-        this(null, extras);
     }
 
     /**
@@ -60,7 +51,7 @@ public class DefaultBinaryMemcacheResponse extends AbstractBinaryMemcacheMessage
      * @param key    the key to use.
      * @param extras the extras to use.
      */
-    public DefaultBinaryMemcacheResponse(String key, ByteBuf extras) {
+    public DefaultBinaryMemcacheResponse(ByteBuf key, ByteBuf extras) {
         super(key, extras);
         setMagic(RESPONSE_MAGIC_BYTE);
     }
@@ -71,32 +62,8 @@ public class DefaultBinaryMemcacheResponse extends AbstractBinaryMemcacheMessage
     }
 
     @Override
-    public BinaryMemcacheResponse setStatus(short status) {
+    public DefaultBinaryMemcacheResponse setStatus(short status) {
         this.status = status;
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheResponse retain() {
-        super.retain();
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheResponse retain(int increment) {
-        super.retain(increment);
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheResponse touch() {
-        super.touch();
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheResponse touch(Object hint) {
-        super.touch(hint);
         return this;
     }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
@@ -32,7 +32,7 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
      * @param key    the key to use.
      * @param extras the extras to use.
      */
-    public DefaultFullBinaryMemcacheRequest(String key, ByteBuf extras) {
+    public DefaultFullBinaryMemcacheRequest(ByteBuf key, ByteBuf extras) {
         this(key, extras, Unpooled.buffer(0));
     }
 
@@ -43,7 +43,7 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
      * @param extras  the extras to use.
      * @param content the content of the full request.
      */
-    public DefaultFullBinaryMemcacheRequest(String key, ByteBuf extras,
+    public DefaultFullBinaryMemcacheRequest(ByteBuf key, ByteBuf extras,
                                             ByteBuf content) {
         super(key, extras);
         if (content == null) {
@@ -59,65 +59,59 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
     }
 
     @Override
-    public int refCnt() {
-        return content.refCnt();
-    }
-
-    @Override
-    public FullBinaryMemcacheRequest retain() {
+    public DefaultFullBinaryMemcacheRequest retain() {
         super.retain();
-        content.retain();
         return this;
     }
 
     @Override
-    public FullBinaryMemcacheRequest retain(int increment) {
+    public DefaultFullBinaryMemcacheRequest retain(int increment) {
         super.retain(increment);
-        content.retain(increment);
         return this;
     }
 
     @Override
-    public FullBinaryMemcacheRequest touch() {
+    public DefaultFullBinaryMemcacheRequest touch() {
         super.touch();
-        content.touch();
         return this;
     }
 
     @Override
-    public FullBinaryMemcacheRequest touch(Object hint) {
+    public DefaultFullBinaryMemcacheRequest touch(Object hint) {
         super.touch(hint);
         content.touch(hint);
         return this;
     }
 
     @Override
-    public boolean release() {
-        super.release();
-        return content.release();
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        super.release(decrement);
-        return content.release(decrement);
-    }
-
-    @Override
-    public FullBinaryMemcacheRequest copy() {
+    public DefaultFullBinaryMemcacheRequest copy() {
+        ByteBuf key = key();
+        if (key != null) {
+            key = key.copy();
+        }
         ByteBuf extras = extras();
         if (extras != null) {
             extras = extras.copy();
         }
-        return new DefaultFullBinaryMemcacheRequest(key(), extras, content().copy());
+        return new DefaultFullBinaryMemcacheRequest(key, extras, content().copy());
     }
 
     @Override
-    public FullBinaryMemcacheRequest duplicate() {
+    public DefaultFullBinaryMemcacheRequest duplicate() {
+        ByteBuf key = key();
+        if (key != null) {
+            key = key.duplicate();
+        }
         ByteBuf extras = extras();
         if (extras != null) {
             extras = extras.duplicate();
         }
-        return new DefaultFullBinaryMemcacheRequest(key(), extras, content().duplicate());
+        return new DefaultFullBinaryMemcacheRequest(key, extras, content().duplicate());
+    }
+
+    @Override
+    protected void deallocate() {
+        super.deallocate();
+        content.release();
     }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
@@ -32,7 +32,7 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
      * @param key    the key to use.
      * @param extras the extras to use.
      */
-    public DefaultFullBinaryMemcacheResponse(String key, ByteBuf extras) {
+    public DefaultFullBinaryMemcacheResponse(ByteBuf key, ByteBuf extras) {
         this(key, extras, Unpooled.buffer(0));
     }
 
@@ -43,7 +43,7 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
      * @param extras  the extras to use.
      * @param content the content of the full request.
      */
-    public DefaultFullBinaryMemcacheResponse(String key, ByteBuf extras,
+    public DefaultFullBinaryMemcacheResponse(ByteBuf key, ByteBuf extras,
         ByteBuf content) {
         super(key, extras);
         if (content == null) {
@@ -59,48 +59,28 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
     }
 
     @Override
-    public int refCnt() {
-        return content.refCnt();
-    }
-
-    @Override
-    public FullBinaryMemcacheResponse retain() {
+    public DefaultFullBinaryMemcacheResponse retain() {
         super.retain();
-        content.retain();
         return this;
     }
 
     @Override
-    public FullBinaryMemcacheResponse retain(int increment) {
+    public DefaultFullBinaryMemcacheResponse retain(int increment) {
         super.retain(increment);
-        content.retain(increment);
         return this;
     }
 
     @Override
-    public FullBinaryMemcacheResponse touch() {
+    public DefaultFullBinaryMemcacheResponse touch() {
         super.touch();
-        content.touch();
         return this;
     }
 
     @Override
-    public FullBinaryMemcacheResponse touch(Object hint) {
+    public DefaultFullBinaryMemcacheResponse touch(Object hint) {
         super.touch(hint);
         content.touch(hint);
         return this;
-    }
-
-    @Override
-    public boolean release() {
-        super.release();
-        return content.release();
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        super.release(decrement);
-        return content.release(decrement);
     }
 
     @Override
@@ -119,5 +99,11 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
             extras = extras.duplicate();
         }
         return new DefaultFullBinaryMemcacheResponse(key(), extras, content().duplicate());
+    }
+
+    @Override
+    protected void deallocate() {
+        super.deallocate();
+        content.release();
     }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheRequest.java
@@ -21,22 +21,4 @@ import io.netty.handler.codec.memcache.FullMemcacheMessage;
  * A {@link BinaryMemcacheRequest} that also includes the content.
  */
 public interface FullBinaryMemcacheRequest extends BinaryMemcacheRequest, FullMemcacheMessage {
-
-    @Override
-    FullBinaryMemcacheRequest copy();
-
-    @Override
-    FullBinaryMemcacheRequest retain(int increment);
-
-    @Override
-    FullBinaryMemcacheRequest retain();
-
-    @Override
-    FullBinaryMemcacheRequest touch();
-
-    @Override
-    FullBinaryMemcacheRequest touch(Object hint);
-
-    @Override
-    FullBinaryMemcacheRequest duplicate();
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheResponse.java
@@ -21,22 +21,4 @@ import io.netty.handler.codec.memcache.FullMemcacheMessage;
  * A {@link BinaryMemcacheResponse} that also includes the content.
  */
 public interface FullBinaryMemcacheResponse extends BinaryMemcacheResponse, FullMemcacheMessage {
-
-    @Override
-    FullBinaryMemcacheResponse copy();
-
-    @Override
-    FullBinaryMemcacheResponse retain(int increment);
-
-    @Override
-    FullBinaryMemcacheResponse retain();
-
-    @Override
-    FullBinaryMemcacheResponse touch();
-
-    @Override
-    FullBinaryMemcacheResponse touch(Object hint);
-
-    @Override
-    FullBinaryMemcacheResponse duplicate();
 }

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
@@ -85,7 +85,7 @@ public class BinaryMemcacheEncoderTest {
         ByteBuf extras = Unpooled.copiedBuffer(extrasContent, CharsetUtil.UTF_8);
         int extrasLength = extras.readableBytes();
 
-        BinaryMemcacheRequest request = new DefaultBinaryMemcacheRequest(extras);
+        BinaryMemcacheRequest request = new DefaultBinaryMemcacheRequest(null, extras);
         request.setExtrasLength((byte) extrasLength);
 
         boolean result = channel.writeOutbound(request);
@@ -100,8 +100,9 @@ public class BinaryMemcacheEncoderTest {
 
     @Test
     public void shouldEncodeKey() {
-        String key = "netty";
-        int keyLength = key.length();
+        String keyContent = "netty";
+        ByteBuf key = Unpooled.copiedBuffer(keyContent, CharsetUtil.UTF_8);
+        int keyLength = key.readableBytes();
 
         BinaryMemcacheRequest request = new DefaultBinaryMemcacheRequest(key);
         request.setKeyLength((byte) keyLength);
@@ -112,7 +113,7 @@ public class BinaryMemcacheEncoderTest {
         ByteBuf written = channel.readOutbound();
         assertThat(written.readableBytes(), is(DEFAULT_HEADER_SIZE + keyLength));
         written.readBytes(DEFAULT_HEADER_SIZE);
-        assertThat(written.readBytes(keyLength).toString(CharsetUtil.UTF_8), equalTo(key));
+        assertThat(written.readBytes(keyLength).toString(CharsetUtil.UTF_8), equalTo(keyContent));
         written.release();
     }
 

--- a/example/src/main/java/io/netty/example/memcache/binary/MemcacheClientHandler.java
+++ b/example/src/main/java/io/netty/example/memcache/binary/MemcacheClientHandler.java
@@ -36,12 +36,13 @@ public class MemcacheClientHandler extends ChannelDuplexHandler {
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
         String command = (String) msg;
         if (command.startsWith("get ")) {
-            String key = command.substring("get ".length());
+            String keyContent = command.substring("get ".length());
+            ByteBuf key = Unpooled.wrappedBuffer(keyContent.getBytes(CharsetUtil.UTF_8));
 
             BinaryMemcacheRequest req = new DefaultBinaryMemcacheRequest(key);
             req.setOpcode(BinaryMemcacheOpcodes.GET);
-            req.setKeyLength((short) key.length());
-            req.setTotalBodyLength(key.length());
+            req.setKeyLength((short) key.readableBytes());
+            req.setTotalBodyLength(key.readableBytes());
 
             ctx.write(req, promise);
         } else if (command.startsWith("set ")) {
@@ -49,18 +50,19 @@ public class MemcacheClientHandler extends ChannelDuplexHandler {
             if (parts.length < 3) {
                 throw new IllegalArgumentException("Malformed Command: " + command);
             }
-            String key = parts[1];
+            String keyContent = parts[1];
             String value = parts[2];
 
+            ByteBuf key = Unpooled.wrappedBuffer(keyContent.getBytes(CharsetUtil.UTF_8));
             ByteBuf content = Unpooled.wrappedBuffer(value.getBytes(CharsetUtil.UTF_8));
             ByteBuf extras = ctx.alloc().buffer(8);
             extras.writeZero(8);
 
             BinaryMemcacheRequest req = new DefaultFullBinaryMemcacheRequest(key, extras, content);
             req.setOpcode(BinaryMemcacheOpcodes.SET);
-            req.setKeyLength((short) key.length());
+            req.setKeyLength((short) key.readableBytes());
             req.setExtrasLength((byte) 8);
-            req.setTotalBodyLength(key.length() + 8 + value.length());
+            req.setTotalBodyLength(key.readableBytes() + 8 + value.length());
 
             ctx.write(req, promise);
         } else {


### PR DESCRIPTION
Motivation:

The key can be ByteBuf to avoid converting between ByteBuf and String. See #3689.

Modifications:

- Replace the type of key with ByteBuf
- Clean up the interfaces to avoid duplicated annoying methods.
- Fix the bug that BinaryMemcacheObjectAggregator doesn't call `retain`.
- Fix the leak of BinaryMemcacheRequestDecoder.currentMessage

Result:

- The type of key becomes ByteBuf
- A lot of codes are cleaned.
- Memory leak issue is fixed.