### PR TITLE
[#4705] Ensure ChannelHandler.handlerAdded(...) is always called as f…

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -38,7 +38,21 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
     private final boolean outbound;
     private final DefaultChannelPipeline pipeline;
     private final String name;
-    private boolean removed;
+    private boolean handlerRemoved;
+
+    /**
+     * This is set to {@code true} once the {@link ChannelHandler#handlerAdded(ChannelHandlerContext) method is called.
+     * We need to keep track of this to ensure we will never call another {@link ChannelHandler} method before handlerAdded(...)
+     * is called to guard against ordering issues. {@link ChannelHandler#handlerAdded(ChannelHandlerContext)} MUST be the first
+     * method that is called for handler when it becomes a part of the {@link ChannelPipeline} in all cases. Not doing
+     * so may lead to unexpected side-effects as {@link ChannelHandler} implementations may need to do initialization
+     * steps before a {@link ChannelHandler} can be used.
+     *
+     * See <a href="https://github.com/netty/netty/issues/4705">#4705</a>
+     *
+     * No need to mark volatile as this will be made visible as next/prev is volatile.
+     */
+    private boolean handlerAdded;
 
     // Will be set to null if no child executor should be used, otherwise it will be set to the
     // child executor.
@@ -100,7 +114,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
     public ChannelHandlerContext fireChannelRegistered() {
         final AbstractChannelHandlerContext next = findContextInbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeChannelRegistered();
         } else {
             executor.execute(new OneTimeTask() {
@@ -125,7 +139,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
     public ChannelHandlerContext fireChannelUnregistered() {
         final AbstractChannelHandlerContext next = findContextInbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeChannelUnregistered();
         } else {
             executor.execute(new OneTimeTask() {
@@ -150,7 +164,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
     public ChannelHandlerContext fireChannelActive() {
         final AbstractChannelHandlerContext next = findContextInbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeChannelActive();
         } else {
             executor.execute(new OneTimeTask() {
@@ -175,7 +189,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
     public ChannelHandlerContext fireChannelInactive() {
         final AbstractChannelHandlerContext next = findContextInbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeChannelInactive();
         } else {
             executor.execute(new OneTimeTask() {
@@ -205,7 +219,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
         final AbstractChannelHandlerContext next = this.next;
 
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeExceptionCaught(cause);
         } else {
             try {
@@ -222,7 +236,6 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
                 }
             }
         }
-
         return this;
     }
 
@@ -246,7 +259,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
 
         final AbstractChannelHandlerContext next = findContextInbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeUserEventTriggered(event);
         } else {
             executor.execute(new OneTimeTask() {
@@ -275,7 +288,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
 
         final AbstractChannelHandlerContext next = findContextInbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeChannelRead(msg);
         } else {
             executor.execute(new OneTimeTask() {
@@ -300,7 +313,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
     public ChannelHandlerContext fireChannelReadComplete() {
         final AbstractChannelHandlerContext next = findContextInbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeChannelReadComplete();
         } else {
             Runnable task = next.invokeChannelReadCompleteTask;
@@ -329,7 +342,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
     public ChannelHandlerContext fireChannelWritabilityChanged() {
         final AbstractChannelHandlerContext next = findContextInbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeChannelWritabilityChanged();
         } else {
             Runnable task = next.invokeChannelWritableStateChangedTask;
@@ -396,7 +409,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
 
         final AbstractChannelHandlerContext next = findContextOutbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeBind(localAddress, promise);
         } else {
             safeExecute(executor, new OneTimeTask() {
@@ -406,7 +419,6 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
                 }
             }, promise, null);
         }
-
         return promise;
     }
 
@@ -437,7 +449,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
 
         final AbstractChannelHandlerContext next = findContextOutbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeConnect(remoteAddress, localAddress, promise);
         } else {
             safeExecute(executor, new OneTimeTask() {
@@ -447,7 +459,6 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
                 }
             }, promise, null);
         }
-
         return promise;
     }
 
@@ -468,7 +479,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
 
         final AbstractChannelHandlerContext next = findContextOutbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             // Translate disconnect to close if the channel has no notion of disconnect-reconnect.
             // So far, UDP/IP is the only transport that has such behavior.
             if (!channel().metadata().hasDisconnect()) {
@@ -488,7 +499,6 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
                 }
             }, promise, null);
         }
-
         return promise;
     }
 
@@ -509,7 +519,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
 
         final AbstractChannelHandlerContext next = findContextOutbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeClose(promise);
         } else {
             safeExecute(executor, new OneTimeTask() {
@@ -540,7 +550,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
 
         final AbstractChannelHandlerContext next = findContextOutbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeDeregister(promise);
         } else {
             safeExecute(executor, new OneTimeTask() {
@@ -566,7 +576,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
     public ChannelHandlerContext read() {
         final AbstractChannelHandlerContext next = findContextOutbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeRead();
         } else {
             Runnable task = next.invokeReadTask;
@@ -625,7 +635,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
     public ChannelHandlerContext flush() {
         final AbstractChannelHandlerContext next = findContextOutbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeFlush();
         } else {
             Runnable task = next.invokeFlushTask;
@@ -671,7 +681,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
     private void write(Object msg, boolean flush, ChannelPromise promise) {
         AbstractChannelHandlerContext next = findContextOutbound();
         EventExecutor executor = next.executor();
-        if (executor.inEventLoop()) {
+        if (next.isHandlerAddedCalled() && executor.inEventLoop()) {
             next.invokeWrite(msg, promise);
             if (flush) {
                 next.invokeFlush();
@@ -816,12 +826,20 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap impleme
     }
 
     void setRemoved() {
-        removed = true;
+        handlerRemoved = true;
     }
 
     @Override
     public boolean isRemoved() {
-        return removed;
+        return handlerRemoved;
+    }
+
+    final void setHandlerAddedCalled() {
+        handlerAdded = true;
+    }
+
+    final boolean isHandlerAddedCalled() {
+        return handlerAdded;
     }
 
     private static void safeExecute(EventExecutor executor, Runnable runnable, ChannelPromise promise, Object msg) {


### PR DESCRIPTION
…irst method of the handler

Motivation:

If a user adds a ChannelHandler from outside the EventLoop it is possible to get into the situation that handlerAdded(...) is scheduled on the EventLoop and so called after another methods of the ChannelHandler as the EventLoop may already be executing on this point in time.

Modification:

- Ensure we always check if the handlerAdded(...) method was called already and if not add the currently needed call to the EventLoop so it will be picked up after handlerAdded(...) was called. This works as if the handler is added to the ChannelPipeline from outside the EventLoop the actual handlerAdded(...) operation is scheduled on the EventLoop.
- Some cleanup in the DefaultChannelPipeline

Result:

Correctly order of method executions of ChannelHandler.