### PR TITLE
fix the issue netty#2944 in 4.0

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -349,7 +349,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 srcAddr = remoteAddr;
                 dstAddr = localAddr;
             }
-            strVal = String.format("[id: 0x%08x, %s %s %s]", (int) hashCode, srcAddr, active? "=>" : ":>", dstAddr);
+            strVal = String.format("[id: 0x%08x, %s %s %s]", (int) hashCode, srcAddr, active? "<=>" : "<:>", dstAddr);
         } else if (localAddr != null) {
             strVal = String.format("[id: 0x%08x, %s]", (int) hashCode, localAddr);
         } else {


### PR DESCRIPTION
Motivation:

 fix the issue netty#2944

Modifications:

use <=> instead of =>, use <:> instead of :> due to the connection is bidirectional. What's more, toString() method don't know the direction or there is no need to know the direction when only log channel information.

Result:

after the fix, log won't confuse the user