### PR TITLE
Clean up the interfaces to avoid duplicated annoying methods.

### DIFF
--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObject.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObject.java
@@ -16,11 +16,12 @@
 package io.netty.handler.codec.memcache;
 
 import io.netty.handler.codec.DecoderResult;
+import io.netty.util.AbstractReferenceCounted;
 
 /**
  * The default {@link MemcacheObject} implementation.
  */
-public abstract class AbstractMemcacheObject implements MemcacheObject {
+public abstract class AbstractMemcacheObject extends AbstractReferenceCounted implements MemcacheObject {
 
     private DecoderResult decoderResult = DecoderResult.SUCCESS;
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultLastMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultLastMemcacheContent.java
@@ -33,30 +33,6 @@ public class DefaultLastMemcacheContent extends DefaultMemcacheContent implement
     }
 
     @Override
-    public LastMemcacheContent retain() {
-        super.retain();
-        return this;
-    }
-
-    @Override
-    public LastMemcacheContent retain(int increment) {
-        super.retain(increment);
-        return this;
-    }
-
-    @Override
-    public LastMemcacheContent touch() {
-        super.touch();
-        return this;
-    }
-
-    @Override
-    public LastMemcacheContent touch(Object hint) {
-        super.touch(hint);
-        return this;
-    }
-
-    @Override
     public LastMemcacheContent copy() {
         return new DefaultLastMemcacheContent(content().copy());
     }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
@@ -51,42 +51,32 @@ public class DefaultMemcacheContent extends AbstractMemcacheObject implements Me
     }
 
     @Override
-    public int refCnt() {
-        return content.refCnt();
-    }
-
-    @Override
-    public MemcacheContent retain() {
-        content.retain();
+    public DefaultMemcacheContent retain() {
+        super.retain();
         return this;
     }
 
     @Override
-    public MemcacheContent retain(int increment) {
-        content.retain(increment);
+    public DefaultMemcacheContent retain(int increment) {
+        super.retain(increment);
         return this;
     }
 
     @Override
-    public MemcacheContent touch() {
-        content.touch();
+    public DefaultMemcacheContent touch() {
+        super.touch();
         return this;
     }
 
     @Override
-    public MemcacheContent touch(Object hint) {
+    public DefaultMemcacheContent touch(Object hint) {
         content.touch(hint);
         return this;
     }
 
     @Override
-    public boolean release() {
-        return content.release();
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        return content.release(decrement);
+    protected void deallocate() {
+        content.release();
     }
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/FullMemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/FullMemcacheMessage.java
@@ -20,22 +20,4 @@ package io.netty.handler.codec.memcache;
  * message. So it represent a <i>complete</i> memcache message.
  */
 public interface FullMemcacheMessage extends MemcacheMessage, LastMemcacheContent {
-
-    @Override
-    FullMemcacheMessage copy();
-
-    @Override
-    FullMemcacheMessage retain(int increment);
-
-    @Override
-    FullMemcacheMessage retain();
-
-    @Override
-    FullMemcacheMessage touch();
-
-    @Override
-    FullMemcacheMessage touch(Object hint);
-
-    @Override
-    FullMemcacheMessage duplicate();
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/LastMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/LastMemcacheContent.java
@@ -90,22 +90,4 @@ public interface LastMemcacheContent extends MemcacheContent {
             return false;
         }
     };
-
-    @Override
-    LastMemcacheContent copy();
-
-    @Override
-    LastMemcacheContent retain(int increment);
-
-    @Override
-    LastMemcacheContent retain();
-
-    @Override
-    LastMemcacheContent touch();
-
-    @Override
-    LastMemcacheContent touch(Object hint);
-
-    @Override
-    LastMemcacheContent duplicate();
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheContent.java
@@ -27,22 +27,4 @@ import io.netty.channel.ChannelPipeline;
  * in the {@link ChannelPipeline}.
  */
 public interface MemcacheContent extends MemcacheObject, ByteBufHolder {
-
-    @Override
-    MemcacheContent copy();
-
-    @Override
-    MemcacheContent duplicate();
-
-    @Override
-    MemcacheContent retain();
-
-    @Override
-    MemcacheContent retain(int increment);
-
-    @Override
-    MemcacheContent touch();
-
-    @Override
-    MemcacheContent touch(Object hint);
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheMessage.java
@@ -21,22 +21,4 @@ import io.netty.util.ReferenceCounted;
  * Marker interface for both ascii and binary messages.
  */
 public interface MemcacheMessage extends MemcacheObject, ReferenceCounted {
-
-    /**
-     * Increases the reference count by {@code 1}.
-     */
-    @Override
-    MemcacheMessage retain();
-
-    /**
-     * Increases the reference count by the specified {@code increment}.
-     */
-    @Override
-    MemcacheMessage retain(int increment);
-
-    @Override
-    MemcacheMessage touch();
-
-    @Override
-    MemcacheMessage touch(Object hint);
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheMessage.java
@@ -166,55 +166,17 @@ public abstract class AbstractBinaryMemcacheMessage
     }
 
     @Override
-    public int refCnt() {
-        if (extras != null) {
-            return extras.refCnt();
-        }
-        return 1;
-    }
-
-    @Override
-    public BinaryMemcacheMessage retain() {
-        if (extras != null) {
-            extras.retain();
-        }
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheMessage retain(int increment) {
-        if (extras != null) {
-            extras.retain(increment);
-        }
-        return this;
-    }
-
-    @Override
-    public boolean release() {
-        if (extras != null) {
-            return extras.release();
-        }
-        return false;
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        if (extras != null) {
-            return extras.release(decrement);
-        }
-        return false;
-    }
-
-    @Override
-    public BinaryMemcacheMessage touch() {
-        return touch(null);
-    }
-
-    @Override
     public BinaryMemcacheMessage touch(Object hint) {
         if (extras != null) {
             extras.touch(hint);
         }
         return this;
+    }
+
+    @Override
+    protected void deallocate() {
+        if (extras != null) {
+            extras.release();
+        }
     }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheMessage.java
@@ -182,22 +182,4 @@ public interface BinaryMemcacheMessage extends MemcacheMessage {
      * @param extras the extras buffer of the document.
      */
     BinaryMemcacheMessage setExtras(ByteBuf extras);
-
-    /**
-     * Increases the reference count by {@code 1}.
-     */
-    @Override
-    BinaryMemcacheMessage retain();
-
-    /**
-     * Increases the reference count by the specified {@code increment}.
-     */
-    @Override
-    BinaryMemcacheMessage retain(int increment);
-
-    @Override
-    BinaryMemcacheMessage touch();
-
-    @Override
-    BinaryMemcacheMessage touch(Object hint);
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheRequest.java
@@ -33,16 +33,4 @@ public interface BinaryMemcacheRequest extends BinaryMemcacheMessage {
      * @param reserved the reserved field value.
      */
     BinaryMemcacheRequest setReserved(short reserved);
-
-    @Override
-    BinaryMemcacheRequest retain();
-
-    @Override
-    BinaryMemcacheRequest retain(int increment);
-
-    @Override
-    BinaryMemcacheRequest touch();
-
-    @Override
-    BinaryMemcacheRequest touch(Object hint);
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheResponse.java
@@ -33,16 +33,4 @@ public interface BinaryMemcacheResponse extends BinaryMemcacheMessage {
      * @param status the status to set.
      */
     BinaryMemcacheResponse setStatus(short status);
-
-    @Override
-    BinaryMemcacheResponse retain();
-
-    @Override
-    BinaryMemcacheResponse retain(int increment);
-
-    @Override
-    BinaryMemcacheResponse touch();
-
-    @Override
-    BinaryMemcacheResponse touch(Object hint);
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheRequest.java
@@ -75,28 +75,4 @@ public class DefaultBinaryMemcacheRequest extends AbstractBinaryMemcacheMessage 
         this.reserved = reserved;
         return this;
     }
-
-    @Override
-    public BinaryMemcacheRequest retain() {
-        super.retain();
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheRequest retain(int increment) {
-        super.retain(increment);
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheRequest touch() {
-        super.touch();
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheRequest touch(Object hint) {
-        super.touch(hint);
-        return this;
-    }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultBinaryMemcacheResponse.java
@@ -75,28 +75,4 @@ public class DefaultBinaryMemcacheResponse extends AbstractBinaryMemcacheMessage
         this.status = status;
         return this;
     }
-
-    @Override
-    public BinaryMemcacheResponse retain() {
-        super.retain();
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheResponse retain(int increment) {
-        super.retain(increment);
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheResponse touch() {
-        super.touch();
-        return this;
-    }
-
-    @Override
-    public BinaryMemcacheResponse touch(Object hint) {
-        super.touch(hint);
-        return this;
-    }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
@@ -59,48 +59,34 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
     }
 
     @Override
-    public int refCnt() {
-        return content.refCnt();
-    }
-
-    @Override
-    public FullBinaryMemcacheRequest retain() {
+    public DefaultFullBinaryMemcacheRequest retain() {
         super.retain();
-        content.retain();
         return this;
     }
 
     @Override
-    public FullBinaryMemcacheRequest retain(int increment) {
+    public DefaultFullBinaryMemcacheRequest retain(int increment) {
         super.retain(increment);
-        content.retain(increment);
         return this;
     }
 
     @Override
-    public FullBinaryMemcacheRequest touch() {
+    public DefaultFullBinaryMemcacheRequest touch() {
         super.touch();
+        return this;
+    }
+
+    @Override
+    public DefaultFullBinaryMemcacheRequest touch(Object hint) {
+        super.touch(hint);
         content.touch();
         return this;
     }
 
     @Override
-    public FullBinaryMemcacheRequest touch(Object hint) {
-        super.touch(hint);
-        content.touch(hint);
-        return this;
-    }
-
-    @Override
-    public boolean release() {
-        super.release();
-        return content.release();
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        super.release(decrement);
-        return content.release(decrement);
+    protected void deallocate() {
+        super.deallocate();
+        content.release();
     }
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
@@ -59,48 +59,34 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
     }
 
     @Override
-    public int refCnt() {
-        return content.refCnt();
-    }
-
-    @Override
-    public FullBinaryMemcacheResponse retain() {
+    public DefaultFullBinaryMemcacheResponse retain() {
         super.retain();
-        content.retain();
         return this;
     }
 
     @Override
-    public FullBinaryMemcacheResponse retain(int increment) {
+    public DefaultFullBinaryMemcacheResponse retain(int increment) {
         super.retain(increment);
-        content.retain(increment);
         return this;
     }
 
     @Override
-    public FullBinaryMemcacheResponse touch() {
+    public DefaultFullBinaryMemcacheResponse touch() {
         super.touch();
-        content.touch();
         return this;
     }
 
     @Override
-    public FullBinaryMemcacheResponse touch(Object hint) {
+    public DefaultFullBinaryMemcacheResponse touch(Object hint) {
         super.touch(hint);
         content.touch(hint);
         return this;
     }
 
     @Override
-    public boolean release() {
-        super.release();
-        return content.release();
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        super.release(decrement);
-        return content.release(decrement);
+    protected void deallocate() {
+        super.deallocate();
+        content.release();
     }
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheRequest.java
@@ -21,22 +21,4 @@ import io.netty.handler.codec.memcache.FullMemcacheMessage;
  * A {@link BinaryMemcacheRequest} that also includes the content.
  */
 public interface FullBinaryMemcacheRequest extends BinaryMemcacheRequest, FullMemcacheMessage {
-
-    @Override
-    FullBinaryMemcacheRequest copy();
-
-    @Override
-    FullBinaryMemcacheRequest retain(int increment);
-
-    @Override
-    FullBinaryMemcacheRequest retain();
-
-    @Override
-    FullBinaryMemcacheRequest touch();
-
-    @Override
-    FullBinaryMemcacheRequest touch(Object hint);
-
-    @Override
-    FullBinaryMemcacheRequest duplicate();
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheResponse.java
@@ -21,22 +21,4 @@ import io.netty.handler.codec.memcache.FullMemcacheMessage;
  * A {@link BinaryMemcacheResponse} that also includes the content.
  */
 public interface FullBinaryMemcacheResponse extends BinaryMemcacheResponse, FullMemcacheMessage {
-
-    @Override
-    FullBinaryMemcacheResponse copy();
-
-    @Override
-    FullBinaryMemcacheResponse retain(int increment);
-
-    @Override
-    FullBinaryMemcacheResponse retain();
-
-    @Override
-    FullBinaryMemcacheResponse touch();
-
-    @Override
-    FullBinaryMemcacheResponse touch(Object hint);
-
-    @Override
-    FullBinaryMemcacheResponse duplicate();
 }


### PR DESCRIPTION
Motivation:

There are a lot duplicated annoying methods in message types of codec-memcache

Modifications:

Use AbstractReferenceCounted to avoid duplicated methods.

Result:

Duplicated methods are removed.