### PR TITLE
HTTP/2 Don't Flow Control Iniital Headers

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -296,7 +296,6 @@ public class DefaultHttp2Connection implements Http2Connection {
         private IntObjectMap<DefaultStream> children = IntCollections.emptyMap();
         private int prioritizableForTree = 1;
         private boolean resetSent;
-        private boolean headerSent;
 
         DefaultStream(int id, State state) {
             this.id = id;
@@ -321,17 +320,6 @@ public class DefaultHttp2Connection implements Http2Connection {
         @Override
         public Http2Stream resetSent() {
             resetSent = true;
-            return this;
-        }
-
-        @Override
-        public boolean isHeaderSent() {
-            return headerSent;
-        }
-
-        @Override
-        public Http2Stream headerSent() {
-            headerSent = true;
             return this;
         }
 
@@ -790,16 +778,6 @@ public class DefaultHttp2Connection implements Http2Connection {
 
         @Override
         public Http2Stream resetSent() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isHeaderSent() {
-            return false;
-        }
-
-        @Override
-        public Http2Stream headerSent() {
             throw new UnsupportedOperationException();
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -231,6 +231,11 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
         }
     }
 
+    @Override
+    public boolean hasFlowControlled(Http2Stream stream) {
+        return state(stream).hasFrame();
+    }
+
     private AbstractState state(Http2Stream stream) {
         return (AbstractState) checkNotNull(stream, "stream").getProperty(stateKey);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -617,7 +617,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         }
 
         final ChannelFuture future;
-        if (stream.state() == IDLE || (connection().local().created(stream) && !stream.isHeaderSent())) {
+        if (stream.state() == IDLE || connection().local().created(stream)) {
             // The other endpoint doesn't know about the stream yet, so we can't actually send
             // the RST_STREAM frame. The HTTP/2 spec also disallows sending RST_STREAM for IDLE streams.
             future = promise.setSuccess();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
@@ -42,6 +42,13 @@ public interface Http2RemoteFlowController extends Http2FlowController {
     void addFlowControlled(Http2Stream stream, FlowControlled payload);
 
     /**
+     * Determine if {@code stream} has any {@link FlowControlled} frames currently queued.
+     * @param stream the stream to check if it has flow controlled frames.
+     * @return {@code true} if {@code stream} has any {@link FlowControlled} frames currently queued.
+     */
+    boolean hasFlowControlled(Http2Stream stream);
+
+    /**
      * Write all data pending in the flow controller up to the flow-control limits.
      *
      * @throws Http2Exception throws if a protocol-related error occurred.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -111,18 +111,6 @@ public interface Http2Stream {
     Http2Stream resetSent();
 
     /**
-     * Indicates whether or not at least one {@code HEADERS} frame has been sent from the local endpoint
-     * for this stream.
-     */
-    boolean isHeaderSent();
-
-    /**
-     * Sets the flag indicating that a {@code HEADERS} frame has been sent from the local endpoint
-     * for this stream. This does not affect the stream state.
-     */
-    Http2Stream headerSent();
-
-    /**
      * Associates the application-defined data with this stream.
      * @return The value that was previously associated with {@code key}, or {@code null} if there was none.
      */

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -265,8 +265,9 @@ public class DefaultHttp2ConnectionEncoderTest {
     public void dataFramesDontMergeWithHeaders() throws Exception {
         createStream(STREAM_ID, false);
         final ByteBuf data = dummyData().retain();
-        encoder.writeData(ctx, STREAM_ID, data, 0, true, newPromise());
-        encoder.writeHeaders(ctx, STREAM_ID, EmptyHttp2Headers.INSTANCE, 0, false, newPromise());
+        encoder.writeData(ctx, STREAM_ID, data, 0, false, newPromise());
+        when(remoteFlow.hasFlowControlled(any(Http2Stream.class))).thenReturn(true);
+        encoder.writeHeaders(ctx, STREAM_ID, EmptyHttp2Headers.INSTANCE, 0, true, newPromise());
         List<FlowControlled> capturedWrites = payloadCaptor.getAllValues();
         assertFalse(capturedWrites.get(0).merge(ctx, capturedWrites.get(1)));
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -315,7 +315,6 @@ public class Http2ConnectionHandlerTest {
         when(frameWriter.writeRstStream(eq(ctx), eq(STREAM_ID),
                 anyLong(), any(ChannelPromise.class))).thenReturn(future);
         when(stream.state()).thenReturn(CLOSED);
-        when(stream.isHeaderSent()).thenReturn(true);
         // The stream is "closed" but is still known about by the connection (connection().stream(..)
         // will return the stream). We should still write a RST_STREAM frame in this scenario.
         handler.resetStream(ctx, STREAM_ID, STREAM_CLOSED.code(), promise);

--- a/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
@@ -72,6 +72,11 @@ public final class NoopHttp2RemoteFlowController implements Http2RemoteFlowContr
     }
 
     @Override
+    public boolean hasFlowControlled(Http2Stream stream) {
+        return false;
+    }
+
+    @Override
     public void channelHandlerContext(ChannelHandlerContext ctx) throws Http2Exception {
         this.ctx = ctx;
     }


### PR DESCRIPTION
Motivation:
Currently the initial headers for every stream is queued in the flow controller. Since the initial header frame may create streams the peer must receive these frames in the order in which they were created, or else this will be a protocol error and the connection will be closed. Tolerating the initial headers being queued would increase the complexity of the WeightedFairQueueByteDistributor and there is benefit of doing so is not clear.

Modifications:
- The initial headers will no longer be queued in the flow controllers

Result:
Fixes https://github.com/netty/netty/issues/4758