### PR TITLE
InboundHttp2ToHttpAdapter leak and logic improvements

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Error.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Error.java
@@ -35,6 +35,16 @@ public enum Http2Error {
     HTTP_1_1_REQUIRED(0xD);
 
     private final long code;
+    private static final Http2Error[] INT_TO_ENUM_MAP;
+    static {
+        Http2Error[] errors = Http2Error.values();
+        Http2Error[] map = new Http2Error[errors.length];
+        for (int i = 0; i < errors.length; ++i) {
+            Http2Error error = errors[i];
+            map[(int) error.code()] = error;
+        }
+        INT_TO_ENUM_MAP = map;
+    }
 
     Http2Error(long code) {
         this.code = code;
@@ -45,5 +55,9 @@ public enum Http2Error {
      */
     public long code() {
         return code;
+    }
+
+    public static Http2Error valueOf(long value) {
+        return value >= INT_TO_ENUM_MAP.length || value < 0 ? null : INT_TO_ENUM_MAP[(int) value];
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -199,7 +199,15 @@ public final class HttpConversionUtil {
         // HTTP/2 does not define a way to carry the version or reason phrase that is included in an
         // HTTP/1.1 status line.
         FullHttpResponse msg = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status, validateHttpHeaders);
-        addHttp2ToHttpHeaders(streamId, http2Headers, msg, false);
+        try {
+            addHttp2ToHttpHeaders(streamId, http2Headers, msg, false);
+        } catch (Http2Exception e) {
+            msg.release();
+            throw e;
+        } catch (Throwable t) {
+            msg.release();
+            throw streamError(streamId, PROTOCOL_ERROR, t, "HTTP/2 to HTTP/1.x headers conversion error");
+        }
         return msg;
     }
 
@@ -224,7 +232,15 @@ public final class HttpConversionUtil {
                 "path header cannot be null in conversion to HTTP/1.x");
         FullHttpRequest msg = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.valueOf(method
                         .toString()), path.toString(), validateHttpHeaders);
-        addHttp2ToHttpHeaders(streamId, http2Headers, msg, false);
+        try {
+            addHttp2ToHttpHeaders(streamId, http2Headers, msg, false);
+        } catch (Http2Exception e) {
+            msg.release();
+            throw e;
+        } catch (Throwable t) {
+            msg.release();
+            throw streamError(streamId, PROTOCOL_ERROR, t, "HTTP/2 to HTTP/1.x headers conversion error");
+        }
         return msg;
     }
 


### PR DESCRIPTION
Motivation:
In HttpConversionUtil's toHttpRequest and toHttpResponse methods can
allocate FullHttpMessage objects, and if an exeception is thrown during
the header conversion then this object will not be released. If a
FullHttpMessage is not fired up the pipeline, and the stream is closed
then we remove from the map, but do not release the object. This leads
to a ByteBuf leak. Some of the logic related to stream lifetime management
and FullHttpMessage also predates the RFC being finalized and is not correct.

Modifications:
- Fix leaks in HttpConversionUtil
- Ensure the objects are released when they are removed from the map.
- Correct logic and unit tests where they are found to be incorrect.

Result:
Fixes https://github.com/netty/netty/issues/4780
Fixes https://github.com/netty/netty/issues/3619