### PR TITLE
OioServerChannel Default Max Messages Per Read Too High

### DIFF
--- a/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/oio/OioSctpServerChannel.java
@@ -54,7 +54,7 @@ public class OioSctpServerChannel extends AbstractOioMessageChannel
     private static final InternalLogger logger =
             InternalLoggerFactory.getInstance(OioSctpServerChannel.class);
 
-    private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
+    private static final ChannelMetadata METADATA = new ChannelMetadata(false, 1);
 
     private static SctpServerChannel newServerSocket() {
         try {

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannel.java
@@ -44,7 +44,7 @@ public class OioServerSocketChannel extends AbstractOioMessageChannel
     private static final InternalLogger logger =
         InternalLoggerFactory.getInstance(OioServerSocketChannel.class);
 
-    private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
+    private static final ChannelMetadata METADATA = new ChannelMetadata(false, 1);
 
     private static ServerSocket newServerSocket() {
         try {


### PR DESCRIPTION
Motivation:
A few implementations of OioServerChannel have a default max messages per read set to 16. We should set the default to 1 to prevent blocking on a read before setting a socket that has just been accepted.

Modifications:
- OioSctpServerChannel and OioServerSocketChannel metadata changed to use the default (1) max messages per read

Result:
Oio based servers will complete accepting a socket before potentially blocking waiting to accept other sockets.