### PR TITLE
Allow to specify tcnative artifactId and verion to allow run tests ea…

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -61,7 +61,7 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-tcnative</artifactId>
+      <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
     </dependency>
     <dependency>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-tcnative</artifactId>
+      <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
       <optional>true</optional>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,8 @@
     <!-- Configure the os-maven-plugin extension to expand the classifier on                  -->
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
+    <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
+    <tcnative.version>1.1.33.Fork11</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <epoll.classifier>${os.detected.name}-${os.detected.arch}</epoll.classifier>
   </properties>
@@ -283,8 +285,8 @@
       <!-- Our own Tomcat Native fork - completely optional, used for acclerating SSL with OpenSSL. -->
       <dependency>
         <groupId>${project.groupId}</groupId>
-        <artifactId>netty-tcnative</artifactId>
-        <version>1.1.33.Fork11</version>
+        <artifactId>${tcnative.artifactId}</artifactId>
+        <version>${tcnative.version}</version>
         <classifier>${tcnative.classifier}</classifier>
         <scope>compile</scope>
         <optional>true</optional>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-tcnative</artifactId>
+      <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
       <optional>true</optional>
     </dependency>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>netty-tcnative</artifactId>
+      <artifactId>${tcnative.artifactId}</artifactId>
       <classifier>${tcnative.classifier}</classifier>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
…sily with different tcnative flavors

Motivation:

As we now can easily build static linked versions of tcnative it makes sense to run our netty build against all of them.
This helps to ensure our code works with libressl, openssl and boringssl.

Modifications:

Allow to specify -Dtcnative.artifactId= and -Dtcnative.version=

Result:

Easy to run netty build against different tcnative flavors.