### PR TITLE
Use AbstractReferenceCounted to clean up the codes for codec-memcache

### DIFF
--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObject.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/AbstractMemcacheObject.java
@@ -16,11 +16,12 @@
 package io.netty.handler.codec.memcache;
 
 import io.netty.handler.codec.DecoderResult;
+import io.netty.util.AbstractReferenceCounted;
 
 /**
  * The default {@link MemcacheObject} implementation.
  */
-public abstract class AbstractMemcacheObject implements MemcacheObject {
+public abstract class AbstractMemcacheObject extends AbstractReferenceCounted implements MemcacheObject {
 
     private DecoderResult decoderResult = DecoderResult.SUCCESS;
 

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
@@ -51,25 +51,20 @@ public class DefaultMemcacheContent extends AbstractMemcacheObject implements Me
     }
 
     @Override
-    public int refCnt() {
-        return content.refCnt();
-    }
-
-    @Override
     public MemcacheContent retain() {
-        content.retain();
+        super.retain();
         return this;
     }
 
     @Override
     public MemcacheContent retain(int increment) {
-        content.retain(increment);
+        super.retain(increment);
         return this;
     }
 
     @Override
     public MemcacheContent touch() {
-        content.touch();
+        super.touch();
         return this;
     }
 
@@ -80,13 +75,8 @@ public class DefaultMemcacheContent extends AbstractMemcacheObject implements Me
     }
 
     @Override
-    public boolean release() {
-        return content.release();
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        return content.release(decrement);
+    protected void deallocate() {
+        content.release();
     }
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheMessage.java
@@ -166,48 +166,28 @@ public abstract class AbstractBinaryMemcacheMessage
     }
 
     @Override
-    public int refCnt() {
-        if (extras != null) {
-            return extras.refCnt();
-        }
-        return 1;
-    }
-
-    @Override
     public BinaryMemcacheMessage retain() {
-        if (extras != null) {
-            extras.retain();
-        }
+        super.retain();
         return this;
     }
 
     @Override
     public BinaryMemcacheMessage retain(int increment) {
-        if (extras != null) {
-            extras.retain(increment);
-        }
+        super.retain(increment);
         return this;
     }
 
     @Override
-    public boolean release() {
+    protected void deallocate() {
         if (extras != null) {
-            return extras.release();
+            extras.release();
         }
-        return false;
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        if (extras != null) {
-            return extras.release(decrement);
-        }
-        return false;
     }
 
     @Override
     public BinaryMemcacheMessage touch() {
-        return touch(null);
+        super.touch();
+        return this;
     }
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
@@ -59,28 +59,20 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
     }
 
     @Override
-    public int refCnt() {
-        return content.refCnt();
-    }
-
-    @Override
     public FullBinaryMemcacheRequest retain() {
         super.retain();
-        content.retain();
         return this;
     }
 
     @Override
     public FullBinaryMemcacheRequest retain(int increment) {
         super.retain(increment);
-        content.retain(increment);
         return this;
     }
 
     @Override
     public FullBinaryMemcacheRequest touch() {
         super.touch();
-        content.touch();
         return this;
     }
 
@@ -92,15 +84,9 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
     }
 
     @Override
-    public boolean release() {
-        super.release();
-        return content.release();
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        super.release(decrement);
-        return content.release(decrement);
+    protected void deallocate() {
+        super.deallocate();
+        content.release();
     }
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
@@ -59,28 +59,20 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
     }
 
     @Override
-    public int refCnt() {
-        return content.refCnt();
-    }
-
-    @Override
     public FullBinaryMemcacheResponse retain() {
         super.retain();
-        content.retain();
         return this;
     }
 
     @Override
     public FullBinaryMemcacheResponse retain(int increment) {
         super.retain(increment);
-        content.retain(increment);
         return this;
     }
 
     @Override
     public FullBinaryMemcacheResponse touch() {
         super.touch();
-        content.touch();
         return this;
     }
 
@@ -92,15 +84,9 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
     }
 
     @Override
-    public boolean release() {
-        super.release();
-        return content.release();
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        super.release(decrement);
-        return content.release(decrement);
+    protected void deallocate() {
+        super.deallocate();
+        content.release();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Some duplicated methods in message types of codec-memcache can be cleaned using AbstractReferenceCounted.

Modifications:

Use AbstractReferenceCounted to avoid duplicated methods.

Result:

Duplicated methods are cleaned.