### PR TITLE
Fix a small spell mistake

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -82,7 +82,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
     private static final byte OPCODE_PONG = 0xA;
 
     /**
-     * The size thsreshold for gathering writes. Non-Masked messages bigger than this size will be be sent fragmented as
+     * The size threshold for gathering writes. Non-Masked messages bigger than this size will be be sent fragmented as
      * a header and a content ByteBuf whereas messages smaller than the size will be merged into a single buffer and
      * sent at once.<br>
      * Masked messages will always be sent at once.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameEncoder.java
@@ -82,12 +82,12 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
     private static final byte OPCODE_PONG = 0xA;
 
     /**
-     * The size treshold for gathering writes. Non-Masked messages bigger than this size will be be sent fragmented as
+     * The size thsreshold for gathering writes. Non-Masked messages bigger than this size will be be sent fragmented as
      * a header and a content ByteBuf whereas messages smaller than the size will be merged into a single buffer and
      * sent at once.<br>
      * Masked messages will always be sent at once.
      */
-    private static final int GATHERING_WRITE_TRESHOLD = 1024;
+    private static final int GATHERING_WRITE_THRESHOLD = 1024;
 
     private final boolean maskPayload;
 
@@ -148,7 +148,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
             int maskLength = maskPayload ? 4 : 0;
             if (length <= 125) {
                 int size = 2 + maskLength;
-                if (maskPayload || length <= GATHERING_WRITE_TRESHOLD) {
+                if (maskPayload || length <= GATHERING_WRITE_THRESHOLD) {
                     size += length;
                 }
                 buf = ctx.alloc().buffer(size);
@@ -157,7 +157,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                 buf.writeByte(b);
             } else if (length <= 0xFFFF) {
                 int size = 4 + maskLength;
-                if (maskPayload || length <= GATHERING_WRITE_TRESHOLD) {
+                if (maskPayload || length <= GATHERING_WRITE_THRESHOLD) {
                     size += length;
                 }
                 buf = ctx.alloc().buffer(size);
@@ -167,7 +167,7 @@ public class WebSocket08FrameEncoder extends MessageToMessageEncoder<WebSocketFr
                 buf.writeByte(length & 0xFF);
             } else {
                 int size = 10 + maskLength;
-                if (maskPayload || length <= GATHERING_WRITE_TRESHOLD) {
+                if (maskPayload || length <= GATHERING_WRITE_THRESHOLD) {
                     size += length;
                 }
                 buf = ctx.alloc().buffer(size);


### PR DESCRIPTION
Fix a spell mistake.

Modifications:

Change 'treshold' to 'threshold'

Result:

The spellchecker warnings of the IDE disappeared.