### PR TITLE
fix the issue netty#2944 in 4.1

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -373,7 +373,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             StringBuilder buf = new StringBuilder(64)
                 .append("[id: 0x")
                 .append(id.asShortText())
-                .append(", ")
+                .append(", L:")
                 .append(localAddr)
                 .append(']');
             strVal = buf.toString();

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -363,9 +363,9 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             StringBuilder buf = new StringBuilder(96)
                 .append("[id: 0x")
                 .append(id.asShortText())
-                .append(", ")
+                .append(", L:")
                 .append(localAddr)
-                .append(active? " - " : " ! ")
+                .append(active? " - " : " ! R:")
                 .append(remoteAddr)
                 .append(']');
             strVal = buf.toString();

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -365,7 +365,8 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 .append(id.asShortText())
                 .append(", L:")
                 .append(localAddr)
-                .append(active? " - " : " ! R:")
+                .append(active? " - " : " ! ")
+                .append("R:")
                 .append(remoteAddr)
                 .append(']');
             strVal = buf.toString();

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -360,23 +360,13 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         SocketAddress remoteAddr = remoteAddress();
         SocketAddress localAddr = localAddress();
         if (remoteAddr != null) {
-            SocketAddress srcAddr;
-            SocketAddress dstAddr;
-            if (parent == null) {
-                srcAddr = localAddr;
-                dstAddr = remoteAddr;
-            } else {
-                srcAddr = remoteAddr;
-                dstAddr = localAddr;
-            }
-
             StringBuilder buf = new StringBuilder(96)
                 .append("[id: 0x")
                 .append(id.asShortText())
                 .append(", ")
-                .append(srcAddr)
-                .append(active? " => " : " :> ")
-                .append(dstAddr)
+                .append(localAddr)
+                .append(active? " - " : " ! ")
+                .append(remoteAddr)
                 .append(']');
             strVal = buf.toString();
         } else if (localAddr != null) {


### PR DESCRIPTION
Motivation:

fix the issue netty#2944

Modifications:

use - instead of =>, use ! instead of :> due to the connection is bidirectional. What's more, toString() method don't know the direction or there is no need to know the direction when only log channel information.

Result:

after the fix, log won't confuse the user