### PR TITLE
Use custom ChannelId instances with AbstractChannel(Channel parent) constructor

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -78,7 +78,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      */
     protected AbstractChannel(Channel parent) {
         this.parent = parent;
-        id = DefaultChannelId.newInstance();
+        id = newId();
         unsafe = newUnsafe();
         pipeline = new DefaultChannelPipeline(this);
     }
@@ -99,6 +99,14 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     @Override
     public final ChannelId id() {
         return id;
+    }
+
+    /**
+     * Returns a new {@link DefaultChannelId} instance. Subclasses may override this method to assign custom
+     * {@link ChannelId}s to {@link Channel}s that use the {@link AbstractChannel#AbstractChannel(Channel)} constructor.
+     */
+    protected ChannelId newId() {
+        return DefaultChannelId.newInstance();
     }
 
     @Override

--- a/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/AbstractChannelTest.java
@@ -22,6 +22,8 @@ import org.easymock.IAnswer;
 import org.junit.Test;
 
 import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
 
 public class AbstractChannelTest {
 
@@ -88,6 +90,13 @@ public class AbstractChannelTest {
 
         checkForHandlerException(throwable);
         verify(handler);
+    }
+
+    @Test
+    public void ensureDefaultChannelId() {
+        TestChannel channel = new TestChannel();
+        final ChannelId channelId = channel.id();
+        assertThat(channelId, instanceOf(DefaultChannelId.class));
     }
 
     private static void registerChannel(EventLoop eventLoop, Channel channel) throws Exception {


### PR DESCRIPTION
Made it easier to use custom ChannelId instances with Channel implementations that
rely on the AbstractChannel(Channel parent) constructor.

Motivation:

The AbstractChannel(Channel parent) constructor was previously hard-coded to always
call DefaultChannelId.newInstance(), and this made it difficult to use a custom
ChannelId implementation with some commonly used Channel implementations.

Modifications:

Introduced newId() method in AbstractChannel, which by default returns
DefaultChannelId.newInstance() but can be overridden by subclasses. Added
ensureDefaultChannelId() test to AbstractChannelTest, to ensure the prior
behavior of calling DefaultChannelId.newInstance() still holds with the
AbstractChannel(Channel parent) constructor.

Result:

AbstractChannel now has the protected newId() method, but there is no functional
difference.