### PR TITLE
Ensure handlerAdded(...) and handlerRemoved(...) is always called fro…

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -55,7 +55,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     private final Channel parent;
     private final ChannelId id;
     private final Unsafe unsafe;
-    private final ChannelPipeline pipeline;
+    private final DefaultChannelPipeline pipeline;
     private final ChannelFuture succeededFuture = new SucceededChannelFuture(this, null);
     private final VoidChannelPromise voidPromise = new VoidChannelPromise(this, true);
     private final VoidChannelPromise unsafeVoidPromise = new VoidChannelPromise(this, false);
@@ -499,6 +499,11 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 doRegister();
                 neverRegistered = false;
                 registered = true;
+
+                // We are now registered to the EventLoop. It's time to call the callbacks for the ChannelHandlers,
+                // that were added before the registration was done.
+                pipeline.callHandlerAdded();
+
                 safeSetSuccess(promise);
                 pipeline.fireChannelRegistered();
                 // Only fire a channelActive if the channel has never been registered. This prevents firing

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -621,6 +621,16 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
         return invoker == null ? channel().unsafe().invoker() : invoker;
     }
 
+    EventExecutor executorSafe() {
+        if (invoker == null) {
+            // We check for channel().isRegistered and handlerAdded because even if isRegistered() is false we
+            // can safely access the invoker() if handlerAdded is true. This is because in this case the Channel
+            // was previously registered and so we can still access the old EventLoop to dispatch things.
+            return channel().isRegistered() || handlerAdded ? channel().unsafe().invoker().executor() : null;
+        }
+        return invoker.executor();
+    }
+
     final void setHandlerAddedCalled() {
         handlerAdded = true;
     }


### PR DESCRIPTION
…m the right thread.

Motiviation:

We should ensure that handlerAdded(...) and handlerRemoved(...) is always called from the EventExecutor that also invokes the other methods of the ChannelHandler.

Motifications:

- Ensure that the right thread is used to call the methods
- Add tests

Result:

Respect the thread-model for handlerAdded(...) and handlerRemoved(...)