### PR TITLE
[#4794] Support window size flag by default if ZlibCodecFactory suppo…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshaker.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.http.websocketx.extensions.compression;
 
 import static io.netty.handler.codec.http.websocketx.extensions.compression.
         PerMessageDeflateServerExtensionHandshaker.*;
+
+import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtension;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtensionHandshaker;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionData;
@@ -43,7 +45,7 @@ public final class PerMessageDeflateClientExtensionHandshaker implements WebSock
      * Constructor with default configuration.
      */
     public PerMessageDeflateClientExtensionHandshaker() {
-        this(6, false, MAX_WINDOW_SIZE, false, false);
+        this(6, ZlibCodecFactory.isSupportingWindowSizeAndMemLevel(), MAX_WINDOW_SIZE, false, false);
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshaker.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.http.websocketx.extensions.compression;
 
+import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionData;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionDecoder;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionEncoder;
@@ -50,7 +51,7 @@ public final class PerMessageDeflateServerExtensionHandshaker implements WebSock
      * Constructor with default configuration.
      */
     public PerMessageDeflateServerExtensionHandshaker() {
-        this(6, false, MAX_WINDOW_SIZE, false, false);
+        this(6, ZlibCodecFactory.isSupportingWindowSizeAndMemLevel(), MAX_WINDOW_SIZE, false, false);
     }
 
     /**

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
@@ -18,6 +18,8 @@ package io.netty.handler.codec.http.websocketx.extensions.compression;
 import static io.netty.handler.codec.http.websocketx.extensions.compression.
         PerMessageDeflateServerExtensionHandshaker.*;
 import static org.junit.Assert.*;
+
+import io.netty.handler.codec.compression.ZlibCodecFactory;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketClientExtension;
 import io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionData;
 
@@ -37,7 +39,7 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
         WebSocketExtensionData data = handshaker.newRequestData();
 
         assertEquals(PERMESSAGE_DEFLATE_EXTENSION, data.name());
-        assertTrue(data.parameters().isEmpty());
+        assertEquals(ZlibCodecFactory.isSupportingWindowSizeAndMemLevel() ? 1 : 0, data.parameters().size());
     }
 
     @Test

--- a/codec/src/main/java/io/netty/handler/codec/compression/ZlibCodecFactory.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/ZlibCodecFactory.java
@@ -31,6 +31,7 @@ public final class ZlibCodecFactory {
 
     private static final boolean noJdkZlibDecoder;
     private static final boolean noJdkZlibEncoder;
+    private static final boolean supportsWindowSizeAndMemLevel;
 
     static {
         noJdkZlibDecoder = SystemPropertyUtil.getBoolean("io.netty.noJdkZlibDecoder",
@@ -39,6 +40,15 @@ public final class ZlibCodecFactory {
 
         noJdkZlibEncoder = SystemPropertyUtil.getBoolean("io.netty.noJdkZlibEncoder", false);
         logger.debug("-Dio.netty.noJdkZlibEncoder: {}", noJdkZlibEncoder);
+
+        supportsWindowSizeAndMemLevel = noJdkZlibDecoder || PlatformDependent.javaVersion() >= 7;
+    }
+
+    /**
+     * Returns {@code true} if specify a custom window size and mem level is supported.
+     */
+    public static boolean isSupportingWindowSizeAndMemLevel() {
+        return supportsWindowSizeAndMemLevel;
     }
 
     public static ZlibEncoder newZlibEncoder(int compressionLevel) {


### PR DESCRIPTION
…rts it.

Motivation:

If the ZlibCodecFactory can support using a custom window size we should support it by default in the websocket extensions as well.

Modifications:

Detect if a custom window size can be handled by the ZlibCodecFactory and if so enable it by default for PerMessageDeflate*ExtensionHandshaker.

Result:

Support window size flag by default in most installations.