### PR TITLE
EventExecutorGroup unwrap

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -15,12 +15,10 @@
  */
 package io.netty.util.concurrent;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.Callable;
 import java.util.concurrent.RunnableFuture;
@@ -35,7 +33,6 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
     static final long DEFAULT_SHUTDOWN_TIMEOUT = 15;
 
     private final EventExecutorGroup parent;
-    private final Collection<AbstractEventExecutor> selfCollection = Collections.singleton(this);
 
     protected AbstractEventExecutor() {
         this(null);
@@ -63,11 +60,6 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
     @Override
     public Iterator<EventExecutor> iterator() {
         return new EventExecutorIterator();
-    }
-
-    @Override
-    public <E extends EventExecutor> Set<E> children() {
-        return (Set<E>) selfCollection;
     }
 
     @Override
@@ -156,6 +148,11 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
     @Override
     public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public EventExecutor unRollWrapping() {
+        return this;
     }
 
     private final class EventExecutorIterator implements Iterator<EventExecutor> {

--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutorGroup.java
@@ -114,4 +114,9 @@ public abstract class AbstractEventExecutorGroup implements EventExecutorGroup {
     public void execute(Runnable command) {
         next().execute(command);
     }
+
+    @Override
+    public EventExecutorGroup unRollWrapping() {
+        return this;
+    }
 }

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutor.java
@@ -15,8 +15,6 @@
  */
 package io.netty.util.concurrent;
 
-import java.util.Set;
-
 /**
  * The {@link EventExecutor} is a special {@link EventExecutorGroup} which comes
  * with some handy methods to see if a {@link Thread} is executed in a event loop.
@@ -31,12 +29,6 @@ public interface EventExecutor extends EventExecutorGroup {
      */
     @Override
     EventExecutor next();
-
-    /**
-     * Returns an unmodifiable singleton set which contains itself.
-     */
-    @Override
-    <E extends EventExecutor> Set<E> children();
 
     /**
      * Return the {@link EventExecutorGroup} which is the parent of this {@link EventExecutor},
@@ -77,4 +69,7 @@ public interface EventExecutor extends EventExecutorGroup {
      * every call of blocking methods will just return without blocking.
      */
     <V> Future<V> newFailedFuture(Throwable cause);
+
+    @Override
+    EventExecutor unRollWrapping();
 }

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java
@@ -17,7 +17,6 @@ package io.netty.util.concurrent;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -85,16 +84,11 @@ public interface EventExecutorGroup extends ScheduledExecutorService, Iterable<E
     EventExecutor next();
 
     /**
-     * @deprecated Use {@link #children()} instead.
+     * Returns a read-only {@link Iterator} over all {@link EventExecutor}, which are handled by this
+     * {@link EventExecutorGroup} at the time of invoke this method.
      */
     @Override
-    @Deprecated
     Iterator<EventExecutor> iterator();
-
-    /**
-     * Returns the unmodifiable set of {@link EventExecutor}s managed by this {@link EventExecutorGroup}.
-     */
-    <E extends EventExecutor> Set<E> children();
 
     @Override
     Future<?> submit(Runnable task);
@@ -116,4 +110,12 @@ public interface EventExecutorGroup extends ScheduledExecutorService, Iterable<E
 
     @Override
     ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit);
+
+    /**
+     * {@link EventExecutorGroup} can be wrapped to extend and enhance behavior. This method will unroll the wrapping
+     * and return the underlying {@link EventExecutorGroup}.
+     *
+     * @return {@code this} if the object is not wrapped or underlying {@link EventExecutorGroup} instance if wrapped.
+     */
+    EventExecutorGroup unRollWrapping();
 }

--- a/common/src/main/java/io/netty/util/internal/ArrayIterator.java
+++ b/common/src/main/java/io/netty/util/internal/ArrayIterator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * An {@link Iterator} which traverses an array.
+ */
+public final class ArrayIterator<T> implements Iterator<T> {
+    private final T[] array;
+    private int i;
+
+    public ArrayIterator(T[] array) {
+        this.array = ObjectUtil.checkNotNull(array, "array");
+    }
+
+    @Override
+    public boolean hasNext() {
+        return i < array.length;
+    }
+
+    @Override
+    public T next() {
+        if (i == array.length) {
+            throw new NoSuchElementException();
+        }
+        return array[i++];
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("remove");
+    }
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -121,7 +121,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
 
     @Override
     protected boolean isCompatible(EventLoop loop) {
-        return loop instanceof EpollEventLoop;
+        return loop.unRollWrapping() instanceof EpollEventLoop;
     }
 
     @Override
@@ -131,7 +131,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
 
     @Override
     protected void doDeregister() throws Exception {
-        ((EpollEventLoop) eventLoop()).remove(this);
+        ((EpollEventLoop) eventLoop().unRollWrapping()).remove(this);
     }
 
     @Override
@@ -170,14 +170,13 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
 
     private void modifyEvents() throws IOException {
         if (isOpen() && isRegistered()) {
-            ((EpollEventLoop) eventLoop()).modify(this);
+            ((EpollEventLoop) eventLoop().unRollWrapping()).modify(this);
         }
     }
 
     @Override
     protected void doRegister() throws Exception {
-        EpollEventLoop loop = (EpollEventLoop) eventLoop();
-        loop.add(this);
+        ((EpollEventLoop) eventLoop().unRollWrapping()).add(this);
     }
 
     @Override

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -67,7 +67,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
 
     @Override
     protected boolean isCompatible(EventLoop loop) {
-        return loop instanceof EpollEventLoop;
+        return loop.unRollWrapping() instanceof EpollEventLoop;
     }
 
     @Override

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -464,7 +464,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel {
     private boolean doWriteMultiple(ChannelOutboundBuffer in, int writeSpinCount) throws Exception {
         if (PlatformDependent.hasUnsafe()) {
             // this means we can cast to IovArray and write the IovArray directly.
-            IovArray array = ((EpollEventLoop) eventLoop()).cleanArray();
+            IovArray array = ((EpollEventLoop) eventLoop().unRollWrapping()).cleanArray();
             in.forEachFlushedMessage(array);
 
             int cnt = array.count();

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -382,7 +382,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             writtenBytes = fd().sendToAddress(memoryAddress, data.readerIndex(), data.writerIndex(),
                     remoteAddress.getAddress(), remoteAddress.getPort());
         } else if (data instanceof CompositeByteBuf) {
-            IovArray array = ((EpollEventLoop) eventLoop()).cleanArray();
+            IovArray array = ((EpollEventLoop) eventLoop().unRollWrapping()).cleanArray();
             array.add(data);
             int cnt = array.count();
             assert cnt != 0;

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ThreadFactory;
  * {@link EventLoopGroup} which uses epoll under the covers. Because of this
  * it only works on linux.
  */
-public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
+public class EpollEventLoopGroup extends MultithreadEventLoopGroup {
 
     /**
      * Create a new instance using the default number of threads and the default {@link ThreadFactory}.
@@ -46,7 +46,6 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
     /**
      * Create a new instance using the specified number of threads and the given {@link ThreadFactory}.
      */
-    @SuppressWarnings("deprecation")
     public EpollEventLoopGroup(int nThreads, ThreadFactory threadFactory) {
         this(nThreads, threadFactory, 0);
     }
@@ -67,9 +66,9 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
      * Sets the percentage of the desired amount of time spent for I/O in the child event loops.  The default value is
      * {@code 50}, which means the event loop will try to spend the same amount of time for I/O as for non-I/O tasks.
      */
-    public void setIoRatio(int ioRatio) {
-        for (EventExecutor e: children()) {
-            ((EpollEventLoop) e).setIoRatio(ioRatio);
+    public final void setIoRatio(int ioRatio) {
+        for (EventExecutor e: this) {
+            ((EpollEventLoop) e.unRollWrapping()).setIoRatio(ioRatio);
         }
     }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -80,7 +80,7 @@ public final class EpollServerSocketChannel extends AbstractEpollServerChannel i
 
     @Override
     protected boolean isCompatible(EventLoop loop) {
-        return loop instanceof EpollEventLoop;
+        return loop.unRollWrapping() instanceof EpollEventLoop;
     }
 
     @Override

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannel.java
@@ -246,7 +246,7 @@ public final class EpollSocketChannel extends AbstractEpollStreamChannel impleme
                     // because we try to read or write until the actual close happens which may be later due
                     // SO_LINGER handling.
                     // See https://github.com/netty/netty/issues/4449
-                    ((EpollEventLoop) eventLoop()).remove(EpollSocketChannel.this);
+                    ((EpollEventLoop) eventLoop().unRollWrapping()).remove(EpollSocketChannel.this);
                     return GlobalEventExecutor.INSTANCE;
                 }
             } catch (Throwable ignore) {

--- a/transport/src/main/java/io/netty/channel/AbstractEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/AbstractEventLoop.java
@@ -38,4 +38,9 @@ public abstract class AbstractEventLoop extends AbstractEventExecutor implements
     public EventLoop next() {
         return (EventLoop) super.next();
     }
+
+    @Override
+    public EventLoop unRollWrapping() {
+        return this;
+    }
 }

--- a/transport/src/main/java/io/netty/channel/AbstractEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/AbstractEventLoopGroup.java
@@ -24,4 +24,9 @@ import io.netty.util.concurrent.AbstractEventExecutorGroup;
 public abstract class AbstractEventLoopGroup extends AbstractEventExecutorGroup implements EventLoopGroup {
     @Override
     public abstract EventLoop next();
+
+    @Override
+    public EventLoopGroup unRollWrapping() {
+        return this;
+    }
 }

--- a/transport/src/main/java/io/netty/channel/EventLoop.java
+++ b/transport/src/main/java/io/netty/channel/EventLoop.java
@@ -33,4 +33,7 @@ public interface EventLoop extends EventExecutor, EventLoopGroup {
      * invoke event handler methods.
      */
     ChannelHandlerInvoker asInvoker();
+
+    @Override
+    EventLoop unRollWrapping();
 }

--- a/transport/src/main/java/io/netty/channel/EventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/EventLoopGroup.java
@@ -40,4 +40,7 @@ public interface EventLoopGroup extends EventExecutorGroup {
      * will get notified once the registration was complete and also will get returned.
      */
     ChannelFuture register(Channel channel, ChannelPromise promise);
+
+    @Override
+    EventLoopGroup unRollWrapping();
 }

--- a/transport/src/main/java/io/netty/channel/MultithreadEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/MultithreadEventLoopGroup.java
@@ -79,4 +79,9 @@ public abstract class MultithreadEventLoopGroup extends MultithreadEventExecutor
     public ChannelFuture register(Channel channel, ChannelPromise promise) {
         return next().register(channel, promise);
     }
+
+    @Override
+    public EventLoopGroup unRollWrapping() {
+        return this;
+    }
 }

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -70,6 +70,11 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
     }
 
     @Override
+    public EventLoop unRollWrapping() {
+        return this;
+    }
+
+    @Override
     protected boolean wakesUpForTask(Runnable task) {
         return !(task instanceof NonWakeupRunnable);
     }

--- a/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoopGroup.java
@@ -49,7 +49,6 @@ public class ThreadPerChannelEventLoopGroup extends AbstractEventExecutorGroup i
     final Executor executor;
     final Set<EventLoop> activeChildren =
             Collections.newSetFromMap(PlatformDependent.<EventLoop, Boolean>newConcurrentHashMap());
-    private final Set<EventLoop> readOnlyActiveChildren = Collections.unmodifiableSet(activeChildren);
     final Queue<EventLoop> idleChildren = new ConcurrentLinkedQueue<EventLoop>();
     private final ChannelException tooManyChannels;
 
@@ -145,12 +144,6 @@ public class ThreadPerChannelEventLoopGroup extends AbstractEventExecutorGroup i
     @Override
     public Iterator<EventExecutor> iterator() {
         return new ReadOnlyIterator<EventExecutor>(activeChildren.iterator());
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <E extends EventExecutor> Set<E> children() {
-        return (Set<E>) readOnlyActiveChildren;
     }
 
     @Override
@@ -298,6 +291,11 @@ public class ThreadPerChannelEventLoopGroup extends AbstractEventExecutorGroup i
             promise.setFailure(t);
             return promise;
         }
+    }
+
+    @Override
+    public EventLoopGroup unRollWrapping() {
+        return this;
     }
 
     private EventLoop nextChild() throws Exception {

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -403,7 +403,7 @@ public class EmbeddedChannel extends AbstractChannel {
 
     @Override
     protected boolean isCompatible(EventLoop loop) {
-        return loop instanceof EmbeddedEventLoop;
+        return loop.unRollWrapping() instanceof EmbeddedEventLoop;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
@@ -156,6 +156,11 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
     }
 
     @Override
+    public EmbeddedEventLoop unRollWrapping() {
+        return this;
+    }
+
+    @Override
     public void invokeChannelRegistered(ChannelHandlerContext ctx) {
         invokeChannelRegisteredNow(ctx);
     }

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
@@ -77,8 +77,8 @@ public class NioEventLoopGroup extends MultithreadEventLoopGroup {
      * {@code 50}, which means the event loop will try to spend the same amount of time for I/O as for non-I/O tasks.
      */
     public void setIoRatio(int ioRatio) {
-        for (EventExecutor e: children()) {
-            ((NioEventLoop) e).setIoRatio(ioRatio);
+        for (EventExecutor e: this) {
+            ((NioEventLoop) e.unRollWrapping()).setIoRatio(ioRatio);
         }
     }
 
@@ -87,8 +87,8 @@ public class NioEventLoopGroup extends MultithreadEventLoopGroup {
      * around the  infamous epoll 100% CPU bug.
      */
     public void rebuildSelectors() {
-        for (EventExecutor e: children()) {
-            ((NioEventLoop) e).rebuildSelector();
+        for (EventExecutor e: this) {
+            ((NioEventLoop) e.unRollWrapping()).rebuildSelector();
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/oio/AbstractOioChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/AbstractOioChannel.java
@@ -76,7 +76,7 @@ public abstract class AbstractOioChannel extends AbstractChannel {
 
     @Override
     protected boolean isCompatible(EventLoop loop) {
-        return loop instanceof ThreadPerChannelEventLoop;
+        return loop.unRollWrapping() instanceof ThreadPerChannelEventLoop;
     }
 
     /**


### PR DESCRIPTION
Motivation:
The current channel implementations are tied to their specific type of EventLoop. This limits the ability to wrap the EventLoop / EventLoopGroup to extend the functionality of these executors. Supporting a method like ByteBuf.unwrap will allow the functionality to be extended.

Modifications:
- Add an unwrap method to EventExecutorGroup, EventExecutor, EventLoopGroup, and EventLoop
- Remove EventExecutorGroup.children() as introduced by 7dc63cc. children() allows the call sites to make assumptions about the type of `EventExecutor` that is maintained by the EventExecutorGroup, which may be invalid if they are actually wrapped. Netty is currently not taking advantage of the implicit cast and is still using EventExcecutorGroup as an iterator anyways.
- Make sure the Channels and places which care about a specific type of EventLoop get unwrapped / checked correctly

Result:
EventLoops can be wrapped to extend functionality.