### PR TITLE
Allow InputStreams for key/trust managers in SslContextBuilder

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -42,6 +42,7 @@ import javax.net.ssl.TrustManagerFactory;
 import javax.security.auth.x500.X500Principal;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyException;
@@ -912,7 +913,23 @@ public abstract class SslContext {
         if (keyFile == null) {
             return null;
         }
-        ByteBuf encodedKeyBuf = PemReader.readPrivateKey(keyFile);
+        return getPrivateKeyFromByteBuffer(PemReader.readPrivateKey(keyFile), keyPassword);
+    }
+
+    static PrivateKey toPrivateKey(InputStream keyInputStream, String keyPassword) throws NoSuchAlgorithmException,
+                                                                NoSuchPaddingException, InvalidKeySpecException,
+                                                                InvalidAlgorithmParameterException,
+                                                                KeyException, IOException {
+        if (keyInputStream == null) {
+            return null;
+        }
+        return getPrivateKeyFromByteBuffer(PemReader.readPrivateKey(keyInputStream), keyPassword);
+    }
+
+    private static PrivateKey getPrivateKeyFromByteBuffer(ByteBuf encodedKeyBuf, String keyPassword)
+            throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeySpecException,
+            InvalidAlgorithmParameterException, KeyException, IOException {
+
         byte[] encodedKey = new byte[encodedKeyBuf.readableBytes()];
         encodedKeyBuf.readBytes(encodedKey).release();
 
@@ -955,8 +972,18 @@ public abstract class SslContext {
         if (file == null) {
             return null;
         }
+        return getCertificatesFromBuffers(PemReader.readCertificates(file));
+    }
+
+    static X509Certificate[] toX509Certificates(InputStream in) throws CertificateException {
+        if (in == null) {
+            return null;
+        }
+        return getCertificatesFromBuffers(PemReader.readCertificates(in));
+    }
+
+    private static X509Certificate[] getCertificatesFromBuffers(ByteBuf[] certs) throws CertificateException {
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-        ByteBuf[] certs = PemReader.readCertificates(file);
         X509Certificate[] x509Certs = new X509Certificate[certs.length];
 
         try {


### PR DESCRIPTION
Sometimes it's easier to get keys/certificates as `InputStream`s than it is to get an actual `File`. This is especially true when operating in a container environment and [`getResourceAsInputStream`](http://docs.oracle.com/javase/6/docs/api/java/lang/Class.html#getResourceAsStream(java.lang.String)) is the best way to load resources packaged with an application.

This change allows callers to pass an `InputStream` instead of a `File` to many methods in `SslContextBuilder`.

The approach I took—start at `PemReader` and work outwards—means that there's a little duplicate logic in `SslContextBuilder`. An alternative approach would be to make `InputStream` the main unit of currency in `SslContextBuilder`, and then have all of the `File`-based methods create `FileInputStreams` and pass them to their `InputStream`-based counterparts. That would cut down on repeated logic, but would introduce some resource-management complexity. I'm open to either approach.