### PR TITLE
[SPDY|HTTP/2] Use ByteBufAllocator to allocate ByteBuf for FullHttpMe…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -15,6 +15,7 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -143,12 +144,15 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
      * <li>{@code true} to validate HTTP headers in the http-codec</li>
      * <li>{@code false} not to validate HTTP headers in the http-codec</li>
      * </ul>
+     * @param alloc The {@link ByteBufAllocator} to use to generate the content of the message
      * @throws Http2Exception
      */
-    protected FullHttpMessage newMessage(Http2Stream stream, Http2Headers headers, boolean validateHttpHeaders)
+    protected FullHttpMessage newMessage(Http2Stream stream, Http2Headers headers, boolean validateHttpHeaders,
+                                         ByteBufAllocator alloc)
             throws Http2Exception {
-        return connection.isServer() ? HttpConversionUtil.toHttpRequest(stream.id(), headers,
-                validateHttpHeaders) : HttpConversionUtil.toHttpResponse(stream.id(), headers, validateHttpHeaders);
+        return connection.isServer() ? HttpConversionUtil.toHttpRequest(stream.id(), headers, alloc,
+                validateHttpHeaders) : HttpConversionUtil.toHttpResponse(stream.id(), headers, alloc,
+                                                                         validateHttpHeaders);
     }
 
     /**
@@ -180,7 +184,7 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
         FullHttpMessage msg = getMessage(stream);
         boolean release = true;
         if (msg == null) {
-            msg = newMessage(stream, headers, validateHttpHeaders);
+            msg = newMessage(stream, headers, validateHttpHeaders, ctx.alloc());
         } else if (allowAppend) {
             release = false;
             HttpConversionUtil.addHttp2ToHttpHeaders(stream.id(), headers, msg, appendToTrailer);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpPriorityAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpPriorityAdapter.java
@@ -204,7 +204,7 @@ public final class InboundHttp2ToHttpPriorityAdapter extends InboundHttp2ToHttpA
             Http2Headers http2Headers = new DefaultHttp2Headers(validateHttpHeaders, httpHeaders.size());
             initializePseudoHeaders(http2Headers);
             addHttpHeadersToHttp2Headers(httpHeaders, http2Headers);
-            msg = newMessage(stream, http2Headers, validateHttpHeaders);
+            msg = newMessage(stream, http2Headers, validateHttpHeaders, ctx.alloc());
             fireChannelRead(ctx, msg, false, stream);
         }
     }


### PR DESCRIPTION
…ssage

Motivation:
When converting SPDY or HTTP/2 frames to HTTP/1.x, netty always used an unpooled heap ByteBuf.

Modifications:
When constructing the FullHttpMessage pass in the ByteBuf to use via the ByteBufAllocator assigned via the context.

Result:
The ByteBuf assigned to the FullHttpMessage can now be configured as a pooled/unpooled, direct/heap based ByteBuf via the ByteBufAllocator used.