### PR TITLE
Correctly pass ChannelPromise on to the next ChannelOutboundHandler w…

### DIFF
--- a/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
@@ -504,7 +504,7 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
 
         @Override
         public ChannelFuture deregister(ChannelPromise promise) {
-            return ctx.deregister();
+            return ctx.deregister(promise);
         }
 
         @Override

--- a/transport/src/test/java/io/netty/channel/CombinedChannelDuplexHandlerTest.java
+++ b/transport/src/test/java/io/netty/channel/CombinedChannelDuplexHandlerTest.java
@@ -321,4 +321,70 @@ public class CombinedChannelDuplexHandlerTest {
         channel.pipeline().close();
         channel.pipeline().deregister();
     }
+
+    @Test(timeout = 3000)
+    public void testPromisesPassed() {
+        ChannelOutboundHandler outboundHandler = new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void bind(ChannelHandlerContext ctx, SocketAddress localAddress,
+                             ChannelPromise promise) throws Exception {
+                promise.setSuccess();
+            }
+
+            @Override
+            public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress,
+                                SocketAddress localAddress, ChannelPromise promise) throws Exception {
+                promise.setSuccess();
+            }
+
+            @Override
+            public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+                promise.setSuccess();
+            }
+
+            @Override
+            public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+                promise.setSuccess();
+            }
+
+            @Override
+            public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+                promise.setSuccess();
+            }
+
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+                promise.setSuccess();
+            }
+        };
+        EmbeddedChannel ch = new EmbeddedChannel(outboundHandler,
+                new CombinedChannelDuplexHandler<ChannelInboundHandler, ChannelOutboundHandler>(
+                        new ChannelInboundHandlerAdapter(), new ChannelOutboundHandlerAdapter()));
+        ChannelPipeline pipeline = ch.pipeline();
+
+        ChannelPromise promise = ch.newPromise();
+        pipeline.connect(null, null, promise);
+        promise.syncUninterruptibly();
+
+        promise = ch.newPromise();
+        pipeline.bind(null, promise);
+        promise.syncUninterruptibly();
+
+        promise = ch.newPromise();
+        pipeline.close(promise);
+        promise.syncUninterruptibly();
+
+        promise = ch.newPromise();
+        pipeline.disconnect(promise);
+        promise.syncUninterruptibly();
+
+        promise = ch.newPromise();
+        pipeline.write("test", promise);
+        promise.syncUninterruptibly();
+
+        promise = ch.newPromise();
+        pipeline.deregister(promise);
+        promise.syncUninterruptibly();
+        ch.finish();
+    }
 }


### PR DESCRIPTION
…hen use CombinedChannelDuplexHandler.

Motivation:

Due a regression introduced by e969b6917c848c83f02617386f0f73d8f0e130a2 we missed to pass the original ChannelPromise to the next ChannelOutboundHandler and so
may never notify the origin ChannelPromise. This is related to #4805.

Modifications:

- Correctly pass the ChannelPromise
- Add unit test.

Result:

Correctly pass the ChannelPromise on deregister(...)