### PR TITLE
[#4828] OpenSslContext throws UnsupportedOperationException when Unsa…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -16,9 +16,11 @@
 
 package io.netty.handler.ssl;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.util.internal.NativeLibraryLoader;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.apache.tomcat.jni.Buffer;
 import org.apache.tomcat.jni.Library;
 import org.apache.tomcat.jni.Pool;
 import org.apache.tomcat.jni.SSL;
@@ -188,6 +190,11 @@ public final class OpenSsl {
 
     static boolean isError(long errorCode) {
         return errorCode != SSL.SSL_ERROR_NONE;
+    }
+
+    static long memoryAddress(ByteBuf buf) {
+        assert buf.isDirect();
+        return buf.hasMemoryAddress() ? buf.memoryAddress() : Buffer.address(buf.nioBuffer());
     }
 
     private OpenSsl() { }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -544,7 +544,7 @@ public abstract class OpenSslContext extends SslContext {
     private static long newBIO(ByteBuf buffer) throws Exception {
         long bio = SSL.newMemBIO();
         int readable = buffer.readableBytes();
-        if (SSL.writeToBIO(bio, buffer.memoryAddress(), readable) != readable) {
+        if (SSL.writeToBIO(bio, OpenSsl.memoryAddress(buffer), readable) != readable) {
             SSL.freeBIO(bio);
             throw new IllegalStateException("Could not write data to memory BIO");
         }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -52,6 +52,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
+import static io.netty.handler.ssl.OpenSsl.memoryAddress;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static javax.net.ssl.SSLEngineResult.HandshakeStatus.*;
 import static javax.net.ssl.SSLEngineResult.Status.*;
@@ -1233,14 +1234,6 @@ public final class OpenSslEngine extends SSLEngine {
         // if SSL_do_handshake returns > 0 or sslError == SSL.SSL_ERROR_NAME it means the handshake was finished.
         session.handshakeFinished();
         return FINISHED;
-    }
-
-    private static long memoryAddress(ByteBuf buf) {
-        if (buf.hasMemoryAddress()) {
-            return buf.memoryAddress();
-        } else {
-            return Buffer.address(buf.nioBuffer());
-        }
     }
 
     private SSLEngineResult.Status getEngineStatus() {


### PR DESCRIPTION
…fe not available

Motivation:

OpenSslContext constructor fails with a UnsupportedOperationException if Unsafe is not present on the system.

Modifications:

Make OpenSslContext work also when Unsafe is not present by fallback to using JNI to get the memory address.

Result:

Using OpenSslContext also works on systems without Unsafe.