### PR TITLE
[#4834] Fix race in AddressResolverGroup

### DIFF
--- a/resolver/src/main/java/io/netty/resolver/AddressResolverGroup.java
+++ b/resolver/src/main/java/io/netty/resolver/AddressResolverGroup.java
@@ -73,7 +73,9 @@ public abstract class AddressResolverGroup<T extends SocketAddress> implements C
                 executor.terminationFuture().addListener(new FutureListener<Object>() {
                     @Override
                     public void operationComplete(Future<Object> future) throws Exception {
-                        resolvers.remove(executor);
+                        synchronized (resolvers) {
+                            resolvers.remove(executor);
+                        }
                         newResolver.close();
                     }
                 });


### PR DESCRIPTION
Motivation:

We miss to use synchronized when remove the executor from the map.

Modifications:

Add synchronized(...) keyword

Result:

No more race.