### PR TITLE
[#4841] Fix segfault if UnpooledUnsafeHeapByteBuf.getShort(..) is use…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
@@ -152,7 +152,8 @@ final class UnsafeByteBufUtil {
             short v = PlatformDependent.getShort(array, index);
             return BIG_ENDIAN_NATIVE_ORDER ? v : Short.reverseBytes(v);
         }
-        return (short) (PlatformDependent.getByte(index) << 8 | PlatformDependent.getByte(index + 1) & 0xff);
+        return (short) (PlatformDependent.getByte(array, index) << 8 |
+                PlatformDependent.getByte(array, index + 1) & 0xff);
     }
 
     static int getUnsignedMedium(byte[] array, int index) {


### PR DESCRIPTION
…d and UNALGINED access is not possible.

Motivation:

We missed to take the byte[] into account when try to access the bytes and so produce a segfault.

Modifications:

Correctly pass the byte[] in.

Result:

No more segfault.