### PR TITLE
Add maven profile to run tests with -Dio.netty.noUnsafe=true

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,12 @@
       </properties>
     </profile>
     <profile>
+      <id>noUnsafe</id>
+      <properties>
+        <argLine.noUnsafe>-Dio.netty.noUnsafe</argLine.noUnsafe>
+      </properties>
+    </profile>
+    <profile>
       <id>coverage</id>
       <properties>
         <argLine.coverage>${jacoco.argLine}</argLine.coverage>
@@ -211,6 +217,7 @@
     <!-- Default to ALPN. See forcenpn profile to force NPN -->
     <argLine.alpnAgent>-javaagent:${jetty.alpnAgent.path}=${jetty.alpnAgent.option}</argLine.alpnAgent>
     <argLine.leak>-D_</argLine.leak> <!-- Overridden when 'leak' profile is active -->
+    <argLine.noUnsafe>-D_</argLine.noUnsafe> <!-- Overridden when 'noUnsafe' profile is active -->
     <argLine.coverage>-D_</argLine.coverage> <!-- Overridden when 'coverage' profile is active -->
     <!-- Configure the os-maven-plugin extension to expand the classifier on                  -->
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
@@ -740,7 +747,7 @@
             <exclude>**/TestUtil*</exclude>
           </excludes>
           <runOrder>random</runOrder>
-          <argLine>${argLine.common} ${argLine.alpnAgent} ${argLine.leak} ${argLine.coverage}</argLine>
+          <argLine>${argLine.common} ${argLine.alpnAgent} ${argLine.leak} ${argLine.coverage} ${argLine.noUnsafe}</argLine>
         </configuration>
       </plugin>
       <!-- always produce osgi bundles -->


### PR DESCRIPTION
Motivation:

We had reports of failures before when sun.misc.Unsafe was not present. We should run our tests also with it disable to ensure everything works even if sun.misc.Unsafe is not present on the system.

Modifications:

Add a new profile which allows to run tests without Unsafe (using -PnoUnsafe)

Result:

Better testing of netty for systems where sun.misc.Unsafe is not present.