### PR TITLE
Epoll.isAvailable() must return false if sun.misc.Unsafe is not present.

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
@@ -16,6 +16,7 @@
 package io.netty.channel.epoll;
 
 import io.netty.channel.unix.FileDescriptor;
+import io.netty.util.internal.PlatformDependent;
 
 /**
  * Tells if <a href="http://netty.io/wiki/native-transports.html">{@code netty-transport-native-epoll}</a> is supported.
@@ -53,7 +54,8 @@ public final class Epoll {
         if (cause != null) {
             UNAVAILABILITY_CAUSE = cause;
         } else {
-            UNAVAILABILITY_CAUSE = null;
+            UNAVAILABILITY_CAUSE = PlatformDependent.hasUnsafe() ? null :
+                    new IllegalStateException("sun.misc.Unsafe not available");
         }
     }
 


### PR DESCRIPTION
Motivation:

Currently our epoll native transport requires sun.misc.Unsafe and so we need to take this into account for Epoll.isAvailable().

Modifications:

Take into account if sun.misc.Unsafe is present.

Result:

Only return true for Epoll.isAvailable() if sun.misc.Unsafe is present.