### PR TITLE
EPOLL dladdr unexpected return value

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -947,11 +947,15 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 
     Dl_info dlinfo;
     jint status = 0;
-    if (!dladdr((void*) JNI_OnLoad, &dlinfo)) {
+    // We need to use an address of a function that is uniquely part of this library, so choose a static
+    // function. See https://github.com/netty/netty/issues/4840.
+    if (!dladdr((void*) parsePackagePrefix, &dlinfo)) {
+        fprintf(stderr, "FATAL: transport-native-epoll JNI call to dladdr failed!\n");
         return JNI_ERR;
     }
     char* packagePrefix = parsePackagePrefix(dlinfo.dli_fname, &status);
     if (status == JNI_ERR) {
+        fprintf(stderr, "FATAL: transport-native-epoll JNI encountered unexpected dlinfo.dli_fname: %s\n", dlinfo.dli_fname);
         return JNI_ERR;
     }
 


### PR DESCRIPTION
Motivation:
netty_epoll_native.c uses dladdr in attempt to get the name of the library that the code is running in. However the address passed to this funciton (JNI_OnLoad) may not be unique in the context of the application which loaded it. For example if another JNI library is loaded this address may first resolve to the other JNI library and cause the path name parsing to fail, which will cause the library to fail.

Modifications:
- Pass an addresses which is local to the current library to dladdr

Result:
EPOLL JNI library can be loaded in an environment where multiple JNI libraries are loaded.
Fixes https://github.com/netty/netty/issues/4840