### PR TITLE
Make "CorsConfigBuilder.allowNullOrigin()" public

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsConfigBuilder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsConfigBuilder.java
@@ -103,7 +103,7 @@ public final class CorsConfigBuilder {
      *
      * @return {@link CorsConfigBuilder} to support method chaining.
      */
-    CorsConfigBuilder allowNullOrigin() {
+    public CorsConfigBuilder allowNullOrigin() {
         allowNullOrigin = true;
         return this;
     }


### PR DESCRIPTION
Motivation:

"CorsConfigBuilder.allowNullOrigin()" should be public otherwise people can not set it. See #4835

Modifications:

Make "CorsConfigBuilder.allowNullOrigin()" public.

Result:

The user can call "CorsConfigBuilder.allowNullOrigin()" now.