### PR TITLE
Remove invalid return

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -975,5 +975,5 @@ void JNI_OnUnload(JavaVM* vm, void* reserved) {
         // Something is wrong but nothing we can do about this :(
         return;
     }
-    return netty_epoll_native_JNI_OnUnLoad(env);
+    netty_epoll_native_JNI_OnUnLoad(env);
 }


### PR DESCRIPTION
Motivation:

JNI_OnUnload(...) does not return anything (has void in its signature) so we should not try to return something.

Modifications:

Remove return.

Result:

Fix incorrect but harmless code.