### PR TITLE
HTTP/2 codec may not always call Http2Connection.onStreamRemoved

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -16,6 +16,8 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
 
 /**
  * Manager for the state of an HTTP/2 connection with the remote end-point.
@@ -291,6 +293,16 @@ public interface Http2Connection {
      */
     interface PropertyKey {
     }
+
+    /**
+     * Close this connection. No more new streams can be created after this point and
+     * all streams that exists (active or otherwise) will be closed and removed.
+     * <p>Note if iterating active streams via {@link #forEachActiveStream(Http2StreamVisitor)} and an exception is
+     * thrown it is necessary to call this method again to ensure the close completes.
+     * @param promise Will be completed when all streams have been removed, and listeners have been notified.
+     * @return A future that will be completed when all streams have been removed, and listeners have been notified.
+     */
+    Future<Void> close(Promise<Void> promise);
 
     /**
      * Creates a new key that is unique within this {@link Http2Connection}.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -175,18 +175,9 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
             encoder().close();
             decoder().close();
 
-            final Http2Connection connection = connection();
-            // Check if there are streams to avoid the overhead of creating the ChannelFuture.
-            if (connection.numActiveStreams() > 0) {
-                final ChannelFuture future = ctx.newSucceededFuture();
-                connection.forEachActiveStream(new Http2StreamVisitor() {
-                    @Override
-                    public boolean visit(Http2Stream stream) throws Http2Exception {
-                        closeStream(stream, future);
-                        return true;
-                    }
-                });
-            }
+            // We need to remove all streams (not just the active ones).
+            // See https://github.com/netty/netty/issues/4838.
+            connection().close(ctx.voidPromise());
         }
 
         /**

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -26,6 +26,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.Promise;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -269,11 +270,12 @@ public class Http2ConnectionHandlerTest {
         verify(decoder, atLeastOnce()).decodeFrame(eq(ctx), any(ByteBuf.class), Matchers.<List<Object>>any());
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void channelInactiveShouldCloseStreams() throws Exception {
         handler = newHandler();
         handler.channelInactive(ctx);
-        verify(stream).close();
+        verify(connection).close(any(Promise.class));
     }
 
     @Test


### PR DESCRIPTION
Motivation:
Http2Connection.onStreamRemoved is not always called if Http2Connection.onStreamAdded is called. This is problematic as users may rely on the onStreamRemoved method to be called to release ByteBuf objects and do other cleanup.

Modifications:
- Http2Connection.close will remove all streams existing streams and prevent new ones from being created
- Http2ConnectionHandler will call the new close method in channelInactive

Result:
Http2Connection.onStreamRemoved is always called when Http2Connection.onStreamRemoved is called to preserve the Http2Connection guarantees.
Fixes https://github.com/netty/netty/issues/4838