### PR TITLE
Epoll ET AutoRead support

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -824,7 +824,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel {
                     allocHandle.incMessagesRead(1);
                     pipeline.fireChannelRead(byteBuf);
                     byteBuf = null;
-                } while (allocHandle.continueReading());
+                } while (config.isAutoRead() && allocHandle.continueReading());
 
                 allocHandle.readComplete();
                 pipeline.fireChannelReadComplete();

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
@@ -165,4 +165,17 @@ public class EpollChannelConfig extends DefaultChannelConfig {
     protected final void autoReadCleared() {
         channel.clearEpollIn();
     }
+
+    @Override
+    protected void autoReadEnabled() {
+        if (EpollMode.EDGE_TRIGGERED == getEpollMode()) {
+            // Calling super.autoReadEnabled() (aka channel.read()) is not enough for ET mode.
+            // There may be remaining data on the socket still to be read, but ET will not notify
+            // us of that, so force a manual read
+            ((AbstractEpollChannel.AbstractEpollUnsafe) channel.unsafe()).epollInReady();
+        }
+
+        // Inform the OS we are ready for more data
+        super.autoReadEnabled();
+    }
 }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -574,7 +574,7 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
 
                         readBuf.add(new DatagramPacket(data, (InetSocketAddress) localAddress(), remoteAddress));
                         data = null;
-                    } while (allocHandle.continueReading());
+                    } while (config.isAutoRead() && allocHandle.continueReading());
                 } catch (Throwable t) {
                     if (data != null) {
                         data.release();

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -312,7 +312,7 @@ public class DefaultChannelConfig implements ChannelConfig {
     public ChannelConfig setAutoRead(boolean autoRead) {
         boolean oldAutoRead = AUTOREAD_UPDATER.getAndSet(this, autoRead ? 1 : 0) == 1;
         if (autoRead && !oldAutoRead) {
-            channel.read();
+            autoReadEnabled();
         } else if (!autoRead && oldAutoRead) {
             autoReadCleared();
         }
@@ -324,6 +324,14 @@ public class DefaultChannelConfig implements ChannelConfig {
      * {@code true} before.
      */
     protected void autoReadCleared() { }
+
+    /**
+     * Is called once {@link #setAutoRead(boolean)} is called with {@code true} and {@link #isAutoRead()} was
+     * {@code false} before.
+     */
+    protected void autoReadEnabled() {
+        channel.read();
+    }
 
     @Override
     public boolean isAutoClose() {


### PR DESCRIPTION
Motivation:
Currently when using Epoll in Edge Triggered mode, autoread is not supported.

Modifications:
When autoRead is enabled and ```EpollMode``` is set to ```EpollMode.EDGE_TRIGGERED```, call ```epollInReady()``` directly to force a read from the socket

Result:
AutoRead functionality can now be supported in Edge Triggered mode.