### PR TITLE
Reproducer for JDK GCM Bug

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -900,17 +900,17 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             in.skipBytes(totalLength);
 
             // If SSLEngine expects a heap buffer for unwrapping, do the conversion.
-            if (in.isDirect() && wantsInboundHeapBuffer) {
-                ByteBuf copy = ctx.alloc().heapBuffer(totalLength);
-                try {
-                    copy.writeBytes(in, startOffset, totalLength);
-                    decoded = unwrap(ctx, copy, 0, totalLength);
-                } finally {
-                    copy.release();
-                }
-            } else {
+//            if (in.isDirect() && wantsInboundHeapBuffer) {
+//                ByteBuf copy = ctx.alloc().heapBuffer(totalLength);
+//                try {
+//                    copy.writeBytes(in, startOffset, totalLength);
+//                    decoded = unwrap(ctx, copy, 0, totalLength);
+//                } finally {
+//                    copy.release();
+//                }
+//            } else {
                 decoded = unwrap(ctx, in, startOffset, totalLength);
-            }
+//            }
 
             if (!firedChannelRead) {
                 // Check first if firedChannelRead is not set yet as it may have been set in a

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -50,6 +50,7 @@ import java.io.File;
 import java.io.IOException;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
@@ -122,11 +123,14 @@ public class SocketSslEchoTest extends AbstractSocketTest {
             "serverUsesDelegatedTaskExecutor = {3}, clientUsesDelegatedTaskExecutor = {4}, " +
             "autoRead = {5}, useChunkedWriteHandler = {6}, useCompositeByteBuf = {7}")
     public static Collection<Object[]> data() throws Exception {
+        Iterable<String> ciphers = Arrays.asList("TLS_RSA_WITH_AES_128_GCM_SHA256");
         List<SslContext> serverContexts = new ArrayList<SslContext>();
-        serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE).sslProvider(SslProvider.JDK).build());
+        serverContexts.add(SslContextBuilder.forServer(CERT_FILE, KEY_FILE).sslProvider(SslProvider.JDK)
+                .ciphers(ciphers).build());
 
         List<SslContext> clientContexts = new ArrayList<SslContext>();
-        clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.JDK).trustManager(CERT_FILE).build());
+        clientContexts.add(SslContextBuilder.forClient().sslProvider(SslProvider.JDK).trustManager(CERT_FILE)
+                .ciphers(ciphers).build());
 
         boolean hasOpenSsl = OpenSsl.isAvailable();
         if (hasOpenSsl) {


### PR DESCRIPTION
Motivation:
There is a bug in jdk 1.8.0_25 (and lower versions) where the JDK core dumps if you attempt to unwrap a direct buffer using a GCM cipher. This branch reproduces that bug.

Modifications:
- Don't copy to heap buffer before unwrap

Result:
Reproduces https://bugs.openjdk.java.net/browse/JDK-8068574