### PR TITLE
fixed "sensative" typo to read "sensitive"

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/CharSequenceMap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/CharSequenceMap.java
@@ -27,11 +27,11 @@ final class CharSequenceMap<V> extends DefaultHeaders<CharSequence, V, CharSeque
         this(true);
     }
 
-    public CharSequenceMap(boolean caseSensative) {
-        this(caseSensative, UnsupportedValueConverter.<V>instance());
+    public CharSequenceMap(boolean caseSensitive) {
+        this(caseSensitive, UnsupportedValueConverter.<V>instance());
     }
 
-    public CharSequenceMap(boolean caseSensative, ValueConverter<V> valueConverter) {
-        super(caseSensative ? CASE_SENSITIVE_HASHER : CASE_INSENSITIVE_HASHER, valueConverter);
+    public CharSequenceMap(boolean caseSensitive, ValueConverter<V> valueConverter) {
+        super(caseSensitive ? CASE_SENSITIVE_HASHER : CASE_INSENSITIVE_HASHER, valueConverter);
     }
 }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompHeadersTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompHeadersTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertNull;
 
 public class StompHeadersTest {
     @Test
-    public void testHeadersCaseSensative() {
+    public void testHeadersCaseSensitive() {
         DefaultStompHeaders headers = new DefaultStompHeaders();
         AsciiString foo = new AsciiString("foo");
         AsciiString value = new AsciiString("value");

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -152,8 +152,8 @@ public class AsciiStringCharacterTest {
         assertContains(a, b, false, true);
     }
 
-    private static void assertContains(String a, String b, boolean caseSensativeEquals, boolean caseInsenstaiveEquals) {
-        assertEquals(caseSensativeEquals, contains(a, b));
+    private static void assertContains(String a, String b, boolean caseSensitiveEquals, boolean caseInsenstaiveEquals) {
+        assertEquals(caseSensitiveEquals, contains(a, b));
         assertEquals(caseInsenstaiveEquals, containsIgnoreCase(a, b));
     }
 
@@ -199,14 +199,14 @@ public class AsciiStringCharacterTest {
         assertEquals(errorString, lowerCaseExpected, lowerCaseAscii.hashCode());
 
         // Test case insensitive hash codes are equal
-        final int expectedCaseInsensative = lowerCaseAscii.hashCode();
-        assertEquals(errorString, expectedCaseInsensative, AsciiString.hashCode(upperCaseBuilder));
-        assertEquals(errorString, expectedCaseInsensative, AsciiString.hashCode(upperCaseString));
-        assertEquals(errorString, expectedCaseInsensative, AsciiString.hashCode(lowerCaseString));
-        assertEquals(errorString, expectedCaseInsensative, AsciiString.hashCode(lowerCaseAscii));
-        assertEquals(errorString, expectedCaseInsensative, AsciiString.hashCode(upperCaseAscii));
-        assertEquals(errorString, expectedCaseInsensative, lowerCaseAscii.hashCode());
-        assertEquals(errorString, expectedCaseInsensative, upperCaseAscii.hashCode());
+        final int expectedCaseInsensitive = lowerCaseAscii.hashCode();
+        assertEquals(errorString, expectedCaseInsensitive, AsciiString.hashCode(upperCaseBuilder));
+        assertEquals(errorString, expectedCaseInsensitive, AsciiString.hashCode(upperCaseString));
+        assertEquals(errorString, expectedCaseInsensitive, AsciiString.hashCode(lowerCaseString));
+        assertEquals(errorString, expectedCaseInsensitive, AsciiString.hashCode(lowerCaseAscii));
+        assertEquals(errorString, expectedCaseInsensitive, AsciiString.hashCode(upperCaseAscii));
+        assertEquals(errorString, expectedCaseInsensitive, lowerCaseAscii.hashCode());
+        assertEquals(errorString, expectedCaseInsensitive, upperCaseAscii.hashCode());
 
         // Test that opposite cases are equal
         assertEquals(errorString, lowerCaseAscii.hashCode(), AsciiString.hashCode(upperCaseString));


### PR DESCRIPTION
I was reading [CharSequenceMap][0] and noticed a typo, so I fixed it.

[0]: https://github.com/netty/netty/blob/4.1/codec-http2/src/main/java/io/netty/handler/codec/http2/CharSequenceMap.java