### PR TITLE
Ensure read components can be discarded when COMPOSITE_CUMULATOR is u…

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -121,7 +121,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                     composite = (CompositeByteBuf) cumulation;
                 } else {
                     int readable = cumulation.readableBytes();
-                    composite = alloc.compositeBuffer();
+                    composite = alloc.compositeBuffer(Integer.MAX_VALUE);
                     composite.addComponent(cumulation).writerIndex(readable);
                 }
                 composite.addComponent(in).writerIndex(composite.writerIndex() + in.readableBytes());


### PR DESCRIPTION
…sed.

Motivation:

ByteToMessageDecoder must ensure that read components of the CompositeByteBuf can be discard by default when discardSomeReadBytes() is called. This may not be the case before as because of the default maxNumComponents that will cause consolidation.

Modifications:

Ensure we not do any consolidation to actually be abel to discard read components

Result:

Less memory usage and allocations.