### PR TITLE
HTTP/2 stream removed from map before onStreamClosed called

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -96,6 +96,20 @@ public class DefaultHttp2ConnectionTest {
         server = new DefaultHttp2Connection(true);
         client = new DefaultHttp2Connection(false);
         client.addListener(clientListener);
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                assertNotNull(client.stream(invocation.getArgumentAt(0, Http2Stream.class).id()));
+                return null;
+            }
+        }).when(clientListener).onStreamClosed(any(Http2Stream.class));
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                assertNull(client.stream(invocation.getArgumentAt(0, Http2Stream.class).id()));
+                return null;
+            }
+        }).when(clientListener).onStreamRemoved(any(Http2Stream.class));
     }
 
     @Test


### PR DESCRIPTION
Motivation:
The interface contract of Http2Connection.Listener.onStreamClosed says that the stream will be removed from the active stream map, and not necessarily the stream map. If the channel becomes inactive we may remove from the stream map before calling onStreamClosed.

Modifications:
- Don't remove from the stream map during iteration until after onStreamClosed is called

Result:
Expectations of onStreamClosed interface are not violated