### PR TITLE
[#4331] Helper method to get mime-type from Content-Type header of HttpMessage

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -88,4 +88,16 @@ public class HttpUtilTest {
         message.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTFFF");
         assertEquals(CharsetUtil.UTF_8, HttpUtil.getCharset(message, StandardCharsets.UTF_8));
     }
+
+    @Test
+    public void testGetMimeType() {
+        HttpMessage message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        assertNull(HttpUtil.getMimeType(message));
+        message.headers().set(HttpHeaderNames.CONTENT_TYPE, "");
+        assertNull(HttpUtil.getMimeType(message));
+        message.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html");
+        assertEquals("text/html", HttpUtil.getMimeType(message));
+        message.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=utf-8");
+        assertEquals("text/html", HttpUtil.getMimeType(message));
+    }
 }

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -714,6 +714,34 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
     }
 
     /**
+     * Searches in this string for the index of the specified char {@code ch}.
+     * The search for the char starts at the specified offset {@code start} and moves towards the end of this string.
+     *
+     * @param ch the char to find.
+     * @param start the starting offset.
+     * @return the index of the first occurrence of the specified char {@code ch} in this string,
+     * -1 if found no occurrence.
+     */
+    public int indexOf(char ch, int start) {
+        if (start < 0) {
+            start = 0;
+        }
+
+        final int thisLen = length();
+
+        if (ch > MAX_CHAR_VALUE) {
+            return -1;
+        }
+
+        try {
+            return forEachByte(start, thisLen - start, new IndexOfProcessor((byte) ch));
+        } catch (Exception e) {
+            PlatformDependent.throwException(e);
+            return -1;
+        }
+    }
+
+    /**
      * Searches in this string for the last index of the specified string. The search for the string starts at the end
      * and moves towards the beginning of this string.
      *
@@ -1735,6 +1763,38 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
         }
         for (int i = startPos; i < endLimit; i++) {
             if (regionMatchesAscii(str, true, i, searchStr, 0, searchStrLen)) {
+                return i;
+            }
+        }
+        return INDEX_NOT_FOUND;
+    }
+
+    /**
+     * <p>Finds the first index in the {@code CharSequence} that matches the
+     * specified character.</p>
+     *
+     * @param cs  the {@code CharSequence} to be processed, not null
+     * @param searchChar the char to be searched for
+     * @param start  the start index, negative starts at the string start
+     * @return the index where the search char was found,
+     * -1 if char {@code searchChar} is not found or {@code cs == null}
+     */
+    //-----------------------------------------------------------------------
+    public static int indexOf(final CharSequence cs, final char searchChar, int start) {
+        if (cs instanceof String) {
+            return ((String) cs).indexOf(searchChar, start);
+        } else if (cs instanceof AsciiString) {
+            return ((AsciiString) cs).indexOf(searchChar, start);
+        }
+        if (cs == null) {
+            return INDEX_NOT_FOUND;
+        }
+        final int sz = cs.length();
+        if (start < 0) {
+            start = 0;
+        }
+        for (int i = start; i < sz; i++) {
+            if (cs.charAt(i) == searchChar) {
                 return i;
             }
         }

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -290,4 +290,28 @@ public class AsciiStringCharacterTest {
         assertEquals("abc", new AsciiString("abc  ").trim().toString());
         assertEquals("abc", new AsciiString("  abc  ").trim().toString());
     }
+
+    @Test
+    public void testIndexOfChar() {
+        assertEquals(-1, AsciiString.indexOf(null, 'a', 0));
+        assertEquals(-1, AsciiString.of("").indexOf('a', 0));
+        assertEquals(-1, AsciiString.of("abc").indexOf('d', 0));
+        assertEquals(-1, AsciiString.of("aabaabaa").indexOf('A', 0));
+        assertEquals(0, AsciiString.of("aabaabaa").indexOf('a', 0));
+        assertEquals(1, AsciiString.of("aabaabaa").indexOf('a', 1));
+        assertEquals(3, AsciiString.of("aabaabaa").indexOf('a', 2));
+        assertEquals(3, AsciiString.of("aabdabaa").indexOf('d', 1));
+    }
+
+    @Test
+    public void testStaticIndexOfChar() {
+        assertEquals(-1, AsciiString.indexOf(null, 'a', 0));
+        assertEquals(-1, AsciiString.indexOf("", 'a', 0));
+        assertEquals(-1, AsciiString.indexOf("abc", 'd', 0));
+        assertEquals(-1, AsciiString.indexOf("aabaabaa", 'A', 0));
+        assertEquals(0, AsciiString.indexOf("aabaabaa", 'a', 0));
+        assertEquals(1, AsciiString.indexOf("aabaabaa", 'a', 1));
+        assertEquals(3, AsciiString.indexOf("aabaabaa", 'a', 2));
+        assertEquals(3, AsciiString.indexOf("aabdabaa", 'd', 1));
+    }
 }


### PR DESCRIPTION
Motivation:

Issue #4331:
HttpHeaders already has specific methods for such popular and simple headers like "Host", but if I need to convert POST raw body to string I need to parse complex ContentType header in my code.

Modifications:

Add getMimeType to parse mime-type part of content-type header as an arbitrary CharSequence.

This branch and PR is rebasing of [old PR](https://github.com/netty/netty/pull/4494) which was based on deprecated master.