### PR TITLE
Add xml-maven-plugin to check indentation and fix violations

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -361,7 +361,7 @@
                       </patternset>
                     </unzip>
                     <concat destfile="${project.build.outputDirectory}/META-INF/${project.groupId}.versions.properties" append="true">
-                            <path path="${dependencyVersionsDir}/META-INF/${project.groupId}.versions.properties" />
+                      <path path="${dependencyVersionsDir}/META-INF/${project.groupId}.versions.properties" />
                     </concat>
                   </sequential>
                 </for>
@@ -433,14 +433,14 @@
             <goals>
               <goal>jar</goal>
             </goals>
-        <configuration>
-          <archive>
-            <manifest>
-              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-            </manifest>
-            <index>true</index>
-          </archive>
-        </configuration>
+            <configuration>
+              <archive>
+                <manifest>
+                  <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                </manifest>
+                <index>true</index>
+              </archive>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -54,14 +54,14 @@
         </dependency>
       </dependencies>
       <build>
-      	<plugins>
-      	  <plugin>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                  <includes>
-                      <include>**/*.java</include>
-                  </includes>
-               </configuration>
+        <plugins>
+          <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/*.java</include>
+              </includes>
+            </configuration>
           </plugin>
         </plugins>
       </build>
@@ -109,7 +109,7 @@
 
   <build>
     <plugins>
-  	  <plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -469,7 +469,7 @@
         <artifactId>jboss-marshalling-serial</artifactId>
         <version>${jboss.marshalling.version}</version>
         <scope>test</scope>
-       </dependency>
+      </dependency>
       <dependency>
         <groupId>org.jboss.marshalling</groupId>
         <artifactId>jboss-marshalling-river</artifactId>
@@ -632,12 +632,12 @@
         <artifactId>animal-sniffer-maven-plugin</artifactId>
         <version>1.9</version>
         <dependencies>
-            <!-- Upgrade ASM and support Java 8 bytecode -->
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm-all</artifactId>
-                <version>5.0.3</version>
-            </dependency>
+          <!-- Upgrade ASM and support Java 8 bytecode -->
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-all</artifactId>
+            <version>5.0.3</version>
+          </dependency>
         </dependencies>
         <configuration>
           <signature>
@@ -718,6 +718,31 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>xml-maven-plugin</artifactId>
+        <version>1.0.1</version>
+        <executions>
+          <execution>
+            <id>check-style</id>
+            <goals>
+              <goal>check-format</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <formatFileSets>
+            <formatFileSet>
+              <directory>${project.basedir}</directory>
+              <includes>
+                <include>**/pom.xml</include>
+              </includes>
+            </formatFileSet>
+          </formatFileSets>
+          <useDefaultFormatFileSet>false</useDefaultFormatFileSet>
+        </configuration>
+      </plugin>
       <!-- Download the npn-boot.jar in advance to add it to the boot classpath. -->
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -740,8 +765,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <includes>
-             <include>**/*Test*.java</include>
-             <include>**/*Benchmark*.java</include>
+            <include>**/*Test*.java</include>
+            <include>**/*Benchmark*.java</include>
           </includes>
           <excludes>
             <exclude>**/Abstract*</exclude>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -221,12 +221,12 @@
         <groupId>org.ops4j.pax.exam</groupId>
         <artifactId>maven-paxexam-plugin</artifactId>
         <executions>
-           <execution>
-             <id>generate-config</id>
-             <goals>
-               <goal>generate-depends-file</goal>
-             </goals>
-           </execution>
+          <execution>
+            <id>generate-config</id>
+            <goals>
+              <goal>generate-depends-file</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/transport-sctp/pom.xml
+++ b/transport-sctp/pom.xml
@@ -34,11 +34,11 @@
       <artifactId>netty-buffer</artifactId>
       <version>${project.version}</version>
     </dependency>
-      <dependency>
-          <groupId>${project.groupId}</groupId>
-          <artifactId>netty-codec</artifactId>
-          <version>${project.version}</version>
-      </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport</artifactId>


### PR DESCRIPTION
Motivation:

See https://github.com/netty/netty-build/issues/5

Modifications:

Add xml-maven-plugin to check indentation and fix violations

Result:
pom.xml will be checked in the PR build