### PR TITLE
issues/4909 - Adding paxexam version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1010,6 +1010,11 @@
           <version>2.6</version>
         </plugin>
         <plugin>
+          <groupId>org.ops4j.pax.exam</groupId>
+          <artifactId>maven-paxexam-plugin</artifactId>
+          <version>1.2.4</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-jar-plugin</artifactId>
           <version>2.5</version>
           <executions>


### PR DESCRIPTION
Motivation:

Build warning message is shown when building netty project. Due to missing paxexam version below[1] warning message is shown when building netty project. 

Modifications:

Added paxexam plugin version into root pom

Result:

paxexam related warning will not be displayed when building the project.  

[1]. https://github.com/netty/netty/issues/4909