### PR TITLE
Add support for directly decoding/encoding DNS PTR Records

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsPtrRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsPtrRecord.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+import io.netty.util.internal.StringUtil;
+
+public class DefaultDnsPtrRecord extends AbstractDnsRecord implements DnsPtrRecord {
+
+    private final String hostname;
+
+    /**
+     * Creates a new PTR record.
+     *
+     * @param name the domain name
+     * @param type the type of the record
+     * @param dnsClass the class of the record, usually one of the following:
+     *                 <ul>
+     *                     <li>{@link #CLASS_IN}</li>
+     *                     <li>{@link #CLASS_CSNET}</li>
+     *                     <li>{@link #CLASS_CHAOS}</li>
+     *                     <li>{@link #CLASS_HESIOD}</li>
+     *                     <li>{@link #CLASS_NONE}</li>
+     *                     <li>{@link #CLASS_ANY}</li>
+     *                 </ul>
+     * @param timeToLive the TTL value of the record
+     * @param hostname the hostname this PTR record resolves to.
+     */
+    public DefaultDnsPtrRecord(
+            String name, int dnsClass, long timeToLive, String hostname) {
+        super(name, DnsRecordType.PTR, dnsClass, timeToLive);
+        this.hostname = checkNotNull(hostname, "hostname");
+    }
+
+    @Override
+    public String hostname() {
+        return hostname;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder(64).append(StringUtil.simpleClassName(this)).append('(');
+        final DnsRecordType type = type();
+        buf.append(name().isEmpty()? "<root>" : name())
+           .append(' ')
+           .append(timeToLive())
+           .append(' ');
+
+        DnsMessageUtil.appendRecordClass(buf, dnsClass())
+                      .append(' ')
+                      .append(type.name());
+
+        buf.append(' ')
+           .append(hostname);
+
+        return buf.toString();
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
@@ -87,6 +87,10 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
             String name, DnsRecordType type, int dnsClass, long timeToLive,
             ByteBuf in, int offset, int length) throws Exception {
 
+        if (type == DnsRecordType.PTR) {
+            in.setIndex(offset, offset + length);
+            return new DefaultDnsPtrRecord(name, dnsClass, timeToLive, decodeName(in));
+        }
         return new DefaultDnsRawRecord(
                 name, type, dnsClass, timeToLive, in.duplicate().setIndex(offset, offset + length).retain());
     }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoder.java
@@ -43,11 +43,23 @@ public class DefaultDnsRecordEncoder implements DnsRecordEncoder {
     public void encodeRecord(DnsRecord record, ByteBuf out) throws Exception {
         if (record instanceof DnsQuestion) {
             encodeQuestion((DnsQuestion) record, out);
+        } else if (record instanceof DnsPtrRecord) {
+            encodePtrRecord((DnsPtrRecord) record, out);
         } else if (record instanceof DnsRawRecord) {
             encodeRawRecord((DnsRawRecord) record, out);
         } else {
             throw new UnsupportedMessageTypeException(StringUtil.simpleClassName(record));
         }
+    }
+
+    private void encodePtrRecord(DnsPtrRecord record, ByteBuf out) throws Exception {
+        encodeName(record.name(), out);
+
+        out.writeShort(record.type().intValue());
+        out.writeShort(record.dnsClass());
+        out.writeInt((int) record.timeToLive());
+
+        encodeName(record.hostname(), out);
     }
 
     private void encodeRawRecord(DnsRawRecord record, ByteBuf out) throws Exception {

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsPtrRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsPtrRecord.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+public interface DnsPtrRecord extends DnsRecord {
+
+    /**
+     * Returns the hostname this PTR record resolves to.
+     */
+    String hostname();
+
+}


### PR DESCRIPTION
Motivation:

The current implementation will provide a DnsRawRecord, which, while
containing the host name it resolves to, would require the user to
decode the name using the decode method currently private to
DefaultDnsRecordDecoder, which in fact means copying it.

Modifications:

Introduce DnsPtrRecord, which is a specialization of DnsRecord which
provides a decoded host name.

Result:

PTR Records are much easier to work with, as the name is decoded already.