### PR TITLE
EmbeddedChannel Pipeline LastInboundHandler not always last

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -96,9 +96,23 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         pipeline = new DefaultChannelPipeline(this);
     }
 
+    protected AbstractChannel(Channel parent, ChannelId id, ChannelInboundHandler pipelineTail) {
+        this.parent = parent;
+        this.id = id;
+        unsafe = newUnsafe();
+        pipeline = new DefaultChannelPipeline(this, pipelineTail);
+    }
+
     @Override
     public final ChannelId id() {
         return id;
+    }
+
+    /**
+     * If the {@code pipelineTail} was specified in the constructor, this will return that object.
+     */
+    protected ChannelInboundHandler pipelineTail() {
+        return pipeline.tailDelegate();
     }
 
     /**

--- a/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
@@ -197,6 +197,8 @@ public class PendingWriteQueueTest {
     @Test
     public void testRemoveAndFailAllReentrance() {
         EmbeddedChannel channel = new EmbeddedChannel();
+        // Just add any handler to satisfy PendingWriteQueue's interface contract requiring a ChannelHandlerContext.
+        channel.pipeline().addLast(new ChannelInboundHandlerAdapter());
         final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
 
         ChannelPromise promise = channel.newPromise();
@@ -219,6 +221,8 @@ public class PendingWriteQueueTest {
     @Test
     public void testRemoveAndWriteAllReentrance() {
         EmbeddedChannel channel = new EmbeddedChannel();
+        // Just add any handler to satisfy PendingWriteQueue's interface contract requiring a ChannelHandlerContext.
+        channel.pipeline().addLast(new ChannelInboundHandlerAdapter());
         final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
 
         ChannelPromise promise = channel.newPromise();


### PR DESCRIPTION
Motivation:
EmbeddedChannel was designed with the assumption that it can insert a handler in the pipeline at construction time and that handler will always be the last handler in the pipeline. This assumption does not hold true if the user modifies the pipeline with a addLast or similar type method. If the user does this the behavior of the pipeline for EmbeddedChannel will not mimic a real channel's behavior which will make testing scenarios less representative of real scenarios.

Modifications:
- Modify DefaultChannelPipeline so the tail handler can be configurable.
- Modify AbstractChannel to allow the tail of the DefaultChannelPipeline to be configured
- EmbeddedChannel no longer does an addLast but instead sets the tail element in the pipeline

Result:
EmbeddedChannel behaves more like a real channel implementation.
Fixes https://github.com/netty/netty/issues/4906