### PR TITLE
HTTP/2 DefaultHttp2HeadersDecoder weighted average error

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
@@ -33,7 +33,7 @@ import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 
 public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2HeadersDecoder.Configuration {
-    private static final float HEADERS_COUNT_WEIGHT_NEW = 1 / 5;
+    private static final float HEADERS_COUNT_WEIGHT_NEW = 1 / 5f;
     private static final float HEADERS_COUNT_WEIGHT_HISTORICAL = 1 - HEADERS_COUNT_WEIGHT_NEW;
 
     private final int maxHeaderSize;
@@ -109,8 +109,8 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
                         headers.size(), headerTable.maxHeaderListSize());
             }
 
-            headerArraySizeAccumulator =  HEADERS_COUNT_WEIGHT_NEW * headers.size() +
-                                          HEADERS_COUNT_WEIGHT_HISTORICAL * headerArraySizeAccumulator;
+            headerArraySizeAccumulator = HEADERS_COUNT_WEIGHT_NEW * headers.size() +
+                                         HEADERS_COUNT_WEIGHT_HISTORICAL * headerArraySizeAccumulator;
             return headers;
         } catch (IOException e) {
             throw connectionError(COMPRESSION_ERROR, e, e.getMessage());


### PR DESCRIPTION
Motiviation:
cfcee5798d6680d87aec3ae68cdded74a1402f84 introduced code to resize the headers based upon a weighted average. The weight used for new entries was initialized using integer arithmetic when it should have been floating point arithmetic and so new values contribute 0 weight.

Modifications:
- Cast to float when initializing

Result:
Weighted average does not give 0 weight to new headers in DefaultHttp2HeadersDecoder.