### PR TITLE
HTTP/2 DefaultHttp2Connection NPE

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -127,7 +127,7 @@ public interface Http2Stream {
     <V> V removeProperty(Http2Connection.PropertyKey key);
 
     /**
-     * Updates an priority for this stream. Calling this method may affect the straucture of the
+     * Updates an priority for this stream. Calling this method may affect the structure of the
      * priority tree.
      *
      * @param parentStreamId the parent stream that given stream should depend on. May be {@code 0},

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -222,6 +222,22 @@ public class DefaultHttp2ConnectionTest {
     }
 
     @Test
+    public void closeWhileIteratingDoesNotNPE() throws Http2Exception {
+        final Http2Stream streamA = client.local().createStream(3, false);
+        final Http2Stream streamB = client.local().createStream(5, false);
+        final Http2Stream streamC = client.local().createStream(7, false);
+        streamB.setPriority(streamA.id(), Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT, false);
+        client.forEachActiveStream(new Http2StreamVisitor() {
+            @Override
+            public boolean visit(Http2Stream stream) throws Http2Exception {
+                streamA.close();
+                streamB.setPriority(streamC.id(), Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT, false);
+                return true;
+            }
+        });
+    }
+
+    @Test
     public void goAwayReceivedShouldCloseStreamsGreaterThanLastStream() throws Exception {
         Http2Stream stream1 = client.local().createStream(3, false);
         Http2Stream stream2 = client.local().createStream(5, false);


### PR DESCRIPTION
Motivation:
If while iterating the active streams a close operation occurs this will be queued and process after the iteration has completed to avoid a concurrent modification exception. However it is possible that during the iteration the stream which was closed could have been removed from the priority tree and its parent would be set to null. Then after the iteration completes the close operation will attempt to dereference the parent and results in a NPE.

Modifications:
- pending close operations should verify the stream's parent is not null before processing the event

Result:
No More NPE.