### PR TITLE
HTTP/2 Reduce Log Level

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -735,8 +735,8 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
                     ctx.close();
                 }
             } else {
-                if (logger.isWarnEnabled()) {
-                    logger.warn("{} Sending GOAWAY failed: lastStreamId '{}', errorCode '{}', " +
+                if (logger.isDebugEnabled()) {
+                    logger.debug("{} Sending GOAWAY failed: lastStreamId '{}', errorCode '{}', " +
                                  "debugData '{}'. Forcing shutdown of the connection.",
                                  ctx.channel(), lastStreamId, errorCode, debugData.toString(UTF_8), future.cause());
                 }


### PR DESCRIPTION
Motivation:
https://github.com/netty/netty/commit/83c4aa6ad880445856551de1f7d4aeb40ee06df4 changed the log level to warn, but should have changed to debug.

Modifications:
- Change the log level to debug in Http2ConnectionHandler if the GO_AWAY fails to send. The write failure could be the result of the channel already being closed.

Result:
Fixes https://github.com/netty/netty/issues/4930.