### PR TITLE
Use smaller connect timeout to speed up tests.

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketTcpMd5Test.java
@@ -17,6 +17,7 @@ package io.netty.channel.epoll;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.CharsetUtil;
@@ -94,6 +95,7 @@ public class EpollSocketTcpMd5Test {
                 .handler(new ChannelInboundHandlerAdapter())
                 .option(EpollChannelOption.TCP_MD5SIG,
                         Collections.<InetAddress, byte[]>singletonMap(NetUtil.LOCALHOST4, BAD_KEY))
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000)
                 .connect(server.localAddress()).syncUninterruptibly().channel();
         client.close().syncUninterruptibly();
     }


### PR DESCRIPTION
Motivation:

For on tests we expected a ConnectTimeoutException but used the default timeout of 10 seconds. This slows down testing.

Modifications:

Use connect timeout of 1 second in unit test.

Result:

Faster execution of unit test.