### PR TITLE
Allow NioEventLoop extension

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -48,7 +48,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * {@link Selector} and so does the multi-plexing of these in the event loop.
  *
  */
-public final class NioEventLoop extends SingleThreadEventLoop {
+public class NioEventLoop extends SingleThreadEventLoop {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(NioEventLoop.class);
 
@@ -304,42 +304,8 @@ public final class NioEventLoop extends SingleThreadEventLoop {
         for (;;) {
             boolean oldWakenUp = wakenUp.getAndSet(false);
             try {
-                if (hasTasks()) {
-                    selectNow();
-                } else {
-                    select(oldWakenUp);
-
-                    // 'wakenUp.compareAndSet(false, true)' is always evaluated
-                    // before calling 'selector.wakeup()' to reduce the wake-up
-                    // overhead. (Selector.wakeup() is an expensive operation.)
-                    //
-                    // However, there is a race condition in this approach.
-                    // The race condition is triggered when 'wakenUp' is set to
-                    // true too early.
-                    //
-                    // 'wakenUp' is set to true too early if:
-                    // 1) Selector is waken up between 'wakenUp.set(false)' and
-                    //    'selector.select(...)'. (BAD)
-                    // 2) Selector is waken up between 'selector.select(...)' and
-                    //    'if (wakenUp.get()) { ... }'. (OK)
-                    //
-                    // In the first case, 'wakenUp' is set to true and the
-                    // following 'selector.select(...)' will wake up immediately.
-                    // Until 'wakenUp' is set to false again in the next round,
-                    // 'wakenUp.compareAndSet(false, true)' will fail, and therefore
-                    // any attempt to wake up the Selector will fail, too, causing
-                    // the following 'selector.select(...)' call to block
-                    // unnecessarily.
-                    //
-                    // To fix this problem, we wake up the selector again if wakenUp
-                    // is true immediately after selector.select(...).
-                    // It is inefficient in that it wakes up the selector for both
-                    // the first case (BAD - wake-up required) and the second case
-                    // (OK - no wake-up required).
-
-                    if (wakenUp.get()) {
-                        selector.wakeup();
-                    }
+                if (doConditionalSelect(oldWakenUp)) {
+                    continue;
                 }
 
                 cancelledKeys = 0;
@@ -375,6 +341,53 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                 }
             }
         }
+    }
+
+    /**
+     * Helper method which can be overridden to implement custom select logic.
+     *
+     * Note:
+     *
+     * 'wakenUp.compareAndSet(false, true)' is always evaluated
+     * before calling 'selector.wakeup()' to reduce the wake-up
+     * overhead. (Selector.wakeup() is an expensive operation.)
+     *
+     * However, there is a race condition in this approach.
+     * The race condition is triggered when 'wakenUp' is set to
+     * true too early.
+     *
+     * 'wakenUp' is set to true too early if:
+     * 1) Selector is waken up between 'wakenUp.set(false)' and
+     *    'selector.select(...)'. (BAD)
+     * 2) Selector is waken up between 'selector.select(...)' and
+     *    'if (wakenUp.get()) { ... }'. (OK)
+     *
+     * In the first case, 'wakenUp' is set to true and the
+     * following 'selector.select(...)' will wake up immediately.
+     * Until 'wakenUp' is set to false again in the next round,
+     * 'wakenUp.compareAndSet(false, true)' will fail, and therefore
+     * any attempt to wake up the Selector will fail, too, causing
+     * the following 'selector.select(...)' call to block
+     * unnecessarily.
+     *
+     * To fix this problem, we wake up the selector again if wakenUp
+     * is true immediately after selector.select(...).
+     * It is inefficient in that it wakes up the selector for both
+     * the first case (BAD - wake-up required) and the second case
+     * (OK - no wake-up required).
+     */
+    protected boolean doConditionalSelect(boolean oldWakenUp) throws Exception {
+        if (hasTasks()) {
+            selectNow();
+        } else {
+            select(oldWakenUp);
+
+            if (wakenUp.get()) {
+                selector.wakeup();
+            }
+        }
+
+        return false;
     }
 
     private void processSelectedKeys() {
@@ -592,9 +605,9 @@ public final class NioEventLoop extends SingleThreadEventLoop {
         }
     }
 
-    void selectNow() throws IOException {
+    protected int selectNow() throws IOException {
         try {
-            selector.selectNow();
+            return selector.selectNow();
         } finally {
             // restore wakup state if needed
             if (wakenUp.get()) {

--- a/transport/src/main/java/io/netty/channel/nio/NioSelectNowEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioSelectNowEventLoop.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.nio;
+
+
+import java.nio.channels.spi.SelectorProvider;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.locks.LockSupport;
+
+
+public class NioSelectNowEventLoop extends NioEventLoop {
+
+    private int backoffCounter;
+
+    public NioSelectNowEventLoop(NioEventLoopGroup parent, ThreadFactory threadFactory,
+        SelectorProvider selectorProvider) {
+        super(parent, threadFactory, selectorProvider);
+    }
+
+    @Override
+    protected void wakeup(boolean inEventLoop) {
+        // we never need to wakeup.
+    }
+
+    @Override
+    protected boolean doConditionalSelect(boolean oldWakenUp) throws Exception {
+        if (selectNow() == 0 && !hasTasks()) {
+            backoffCounter = backoff(backoffCounter);
+            return true;
+        } else {
+            backoffCounter = 0;
+            return false;
+        }
+    }
+
+    private static int backoff(final int backoffCounter) {
+        if (backoffCounter > 3000) {
+            LockSupport.parkNanos(100000);
+        } else if (backoffCounter > 2000) {
+            Thread.yield();
+        } else if (backoffCounter > 1000) {
+            LockSupport.parkNanos(1);
+        }
+        return backoffCounter + 1;
+    }
+
+}


### PR DESCRIPTION
Hi folks,

I'd like to push this up sooner than later to get feedback - I don't expect this to be the final solution, but if it is I'll polish it up of course (for example if the select now part is merged in making the backoff parts more flexible).

@nitsanw did a POC some time ago (#2635) which uses `selectNow()` with a custom backoff strategy instead of `select`. The changes has never been pushed forward, I think there was a lack of interest.

As it turns out, this way of working with the event loops is super important to increase performance when you want to write from the outside in. the couchbase java client uses netty heavily, but always needs to write into the event loop. I identified this as one of the bottlenecks and this PR shows a solution.

I don't want to decrease the stability of the `NioEventLoop` so I tried to do as little changes as possible, only allowing to extend it. I'm perfectly fine just having the event loop changes merged in and maintain the custom event loop on my own, but having it as part of netty maybe would also benefit other people (pretty sure @mp911de will love it too, see his pr on #3919).

Cheers,
Michael