### PR TITLE
HTTP/2 ByteBufUtil.writeUtf8 cleanup

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -150,18 +150,7 @@ public final class Http2CodecUtil {
             return Unpooled.EMPTY_BUFFER;
         }
 
-        // Create the debug message. `* 3` because UTF-8 max character consumes 3 bytes.
-        ByteBuf debugData = ctx.alloc().buffer(cause.getMessage().length() * 3);
-        boolean shouldRelease = true;
-        try {
-            ByteBufUtil.writeUtf8(debugData, cause.getMessage());
-            shouldRelease = false;
-        } finally {
-            if (shouldRelease) {
-                debugData.release();
-            }
-        }
-        return debugData;
+        return ByteBufUtil.writeUtf8(ctx.alloc(), cause.getMessage());
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -16,7 +16,6 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -695,15 +694,8 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
      */
     private ChannelFuture goAway(ChannelHandlerContext ctx, Http2Exception cause) {
         long errorCode = cause != null ? cause.error().code() : NO_ERROR.code();
-        ByteBuf debugData = Unpooled.EMPTY_BUFFER;
-        try {
-            debugData = Http2CodecUtil.toByteBuf(ctx, cause);
-        } catch (Throwable t) {
-            // We must continue on to prevent our internal state from becoming corrupted but we log this exception.
-            logger.warn("caught exception while translating " + cause + " to ByteBuf", t);
-        }
         int lastKnownStream = connection().remote().lastStreamCreated();
-        return goAway(ctx, lastKnownStream, errorCode, debugData, ctx.newPromise());
+        return goAway(ctx, lastKnownStream, errorCode, Http2CodecUtil.toByteBuf(ctx, cause), ctx.newPromise());
     }
 
     private void processRstStreamWriteResult(ChannelHandlerContext ctx, Http2Stream stream, ChannelFuture future) {


### PR DESCRIPTION
Motiviation:
691bc1690e9542d6093b91ffe1fbdf7d075bcd42 made writeUtf8 consistent with String.getBytes() so that it never throws.
94f27be59b637c74763cc3b9fd27cf628b59f7bd provided a writeUtf8 method which takes a ByteBufAllocator to do an appropriately sized buffer allocation.

Result:
- Assume writeUtf8 will not throw in HTTP/2 codec
- Use the new writeUtf8 method

Result:
Cleaner code in codec-http2.