### PR TITLE
HTTP/2 DefaultHttp2ConnectionEncoder data frame size incorrect if error

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/UniformStreamByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/UniformStreamByteDistributor.java
@@ -146,7 +146,8 @@ public final class UniformStreamByteDistributor implements StreamByteDistributor
         }
 
         void updateStreamableBytes(int newStreamableBytes, boolean hasFrame, int windowSize) {
-            assert hasFrame || newStreamableBytes == 0;
+            assert hasFrame || newStreamableBytes == 0 :
+                "hasFrame: " + hasFrame + " newStreamableBytes: " + newStreamableBytes;
 
             int delta = newStreamableBytes - streamableBytes;
             if (delta != 0) {

--- a/transport/src/main/java/io/netty/channel/CoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty/channel/CoalescingBufferQueue.java
@@ -37,11 +37,16 @@ import java.util.ArrayDeque;
 public final class CoalescingBufferQueue {
 
     private final Channel channel;
-    private final ArrayDeque<Object> bufAndListenerPairs = new ArrayDeque<Object>();
+    private final ArrayDeque<Object> bufAndListenerPairs;
     private int readableBytes;
 
     public CoalescingBufferQueue(Channel channel) {
+        this(channel, 4);
+    }
+
+    public CoalescingBufferQueue(Channel channel, int initSize) {
         this.channel = ObjectUtil.checkNotNull(channel, "channel");
+        bufAndListenerPairs = new ArrayDeque<Object>(initSize);
     }
 
     /**


### PR DESCRIPTION
Motivation:
If an error occurs during a write operation then DefaultHttp2ConnectionEncoder.FlowControlledData will clear the CoalescingBufferQueue which will reset the queue's readable bytes to 0. To recover from an error the DefaultHttp2RemoteFlowController will attempt to return bytes to the flow control window, but since the frame has reset its own size this will lead to invalid flow control accounting.

Modifications:
- DefaultHttp2ConnectionEncoder.FlowControlledData should not reset its size if an error occurs

Result:
No more flow controller errors due to DefaultHttp2ConnectionEncoder.FlowControlledData setting its size to 0 if an error occurs.