### PR TITLE
HTTP/2 SimpleChannelPromiseAggregator don't fail fast

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -218,16 +218,16 @@ public final class Http2CodecUtil {
      * Provides the ability to associate the outcome of multiple {@link ChannelPromise}
      * objects into a single {@link ChannelPromise} object.
      */
-    static class SimpleChannelPromiseAggregator extends DefaultChannelPromise {
+    static final class SimpleChannelPromiseAggregator extends DefaultChannelPromise {
         private final ChannelPromise promise;
         private int expectedCount;
-        private int successfulCount;
-        private int failureCount;
+        private int doneCount;
+        private Throwable lastFailure;
         private boolean doneAllocating;
 
         SimpleChannelPromiseAggregator(ChannelPromise promise, Channel c, EventExecutor e) {
             super(c, e);
-            assert promise != null;
+            assert promise != null && !promise.isDone();
             this.promise = promise;
         }
 
@@ -237,9 +237,7 @@ public final class Http2CodecUtil {
          * {@code null} if {@link #doneAllocatingPromises()} was previously called.
          */
         public ChannelPromise newPromise() {
-            if (doneAllocating) {
-                throw new IllegalStateException("Done allocating. No more promises can be allocated.");
-            }
+            assert !doneAllocating : "Done allocating. No more promises can be allocated.";
             ++expectedCount;
             return this;
         }
@@ -252,9 +250,8 @@ public final class Http2CodecUtil {
         public ChannelPromise doneAllocatingPromises() {
             if (!doneAllocating) {
                 doneAllocating = true;
-                if (successfulCount == expectedCount) {
-                    promise.setSuccess();
-                    return super.setSuccess(null);
+                if (doneCount == expectedCount || expectedCount == 0) {
+                    return setPromise();
                 }
             }
             return this;
@@ -263,10 +260,10 @@ public final class Http2CodecUtil {
         @Override
         public boolean tryFailure(Throwable cause) {
             if (allowFailure()) {
-                ++failureCount;
-                if (failureCount == 1) {
-                    promise.tryFailure(cause);
-                    return super.tryFailure(cause);
+                ++doneCount;
+                lastFailure = cause;
+                if (allPromisesDone()) {
+                    return tryPromise();
                 }
                 // TODO: We break the interface a bit here.
                 // Multiple failure events can be processed without issue because this is an aggregation.
@@ -284,30 +281,21 @@ public final class Http2CodecUtil {
         @Override
         public ChannelPromise setFailure(Throwable cause) {
             if (allowFailure()) {
-                ++failureCount;
-                if (failureCount == 1) {
-                    promise.setFailure(cause);
-                    return super.setFailure(cause);
+                ++doneCount;
+                lastFailure = cause;
+                if (allPromisesDone()) {
+                    return setPromise();
                 }
             }
             return this;
         }
 
-        private boolean allowFailure() {
-            return awaitingPromises() || expectedCount == 0;
-        }
-
-        private boolean awaitingPromises() {
-            return successfulCount + failureCount < expectedCount;
-        }
-
         @Override
         public ChannelPromise setSuccess(Void result) {
             if (awaitingPromises()) {
-                ++successfulCount;
-                if (successfulCount == expectedCount && doneAllocating) {
-                    promise.setSuccess(result);
-                    return super.setSuccess(result);
+                ++doneCount;
+                if (allPromisesDone()) {
+                    setPromise();
                 }
             }
             return this;
@@ -316,16 +304,47 @@ public final class Http2CodecUtil {
         @Override
         public boolean trySuccess(Void result) {
             if (awaitingPromises()) {
-                ++successfulCount;
-                if (successfulCount == expectedCount && doneAllocating) {
-                    promise.trySuccess(result);
-                    return super.trySuccess(result);
+                ++doneCount;
+                if (allPromisesDone()) {
+                    return tryPromise();
                 }
                 // TODO: We break the interface a bit here.
                 // Multiple success events can be processed without issue because this is an aggregation.
                 return true;
             }
             return false;
+        }
+
+        private boolean allowFailure() {
+            return awaitingPromises() || expectedCount == 0;
+        }
+
+        private boolean awaitingPromises() {
+            return doneCount < expectedCount;
+        }
+
+        private boolean allPromisesDone() {
+            return doneCount == expectedCount && doneAllocating;
+        }
+
+        private ChannelPromise setPromise() {
+            if (lastFailure == null) {
+                promise.setSuccess();
+                return super.setSuccess(null);
+            } else {
+                promise.setFailure(lastFailure);
+                return super.setFailure(lastFailure);
+            }
+        }
+
+        private boolean tryPromise() {
+            if (lastFailure == null) {
+                promise.trySuccess();
+                return super.trySuccess(null);
+            } else {
+                promise.tryFailure(lastFailure);
+                return super.tryFailure(lastFailure);
+            }
         }
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandler.java
@@ -105,14 +105,13 @@ public class HttpToHttp2ConnectionHandler extends Http2ConnectionHandler {
                     encoder.writeHeaders(ctx, currentStreamId, trailers, 0, true, promiseAggregator.newPromise());
                 }
             }
-
-            promiseAggregator.doneAllocatingPromises();
         } catch (Throwable t) {
             promiseAggregator.setFailure(t);
         } finally {
             if (release) {
                 ReferenceCountUtil.release(msg);
             }
+            promiseAggregator.doneAllocatingPromises();
         }
     }
 }


### PR DESCRIPTION
Motivation:
Http2Codec.SimpleChannelPromiseAggregator currently fails fast if as soon as a tryFailure or setFailure method is called. This can lead to write operations which pass the result of SimpleChannelPromiseAggregator.newPromise to multiple channel.write calls throwing exceptions due to the promise being already done. This behavior is not expected by most of the Netty codecs (SslHandler) and can also create unexpected leaks in the http2 codec (DefaultHttp2FrameWriter).

Modifications:
- Http2Codec.SimpleChannelPromiseAggregator shouldn't complete the promise until doneAllocatingPromises is called
- Usages of Http2Codec.SimpleChannelPromiseAggregator should be adjusted to handle the change in behavior
- What were leaks in DefaultHttp2FrameWriter should be fixed to catch any other cases where ctx.write may throw

Result:
SimpleChannelPromiseAggregator won't generate promises which are done when newPromise is called.