### PR TITLE
EPOLL SO_LINGER=0 sends FIN+RST

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketRstTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketRstTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.testsuite.transport.socket;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class SocketRstTest extends AbstractSocketTest {
+    protected void assertRstOnCloseException(IOException cause, Channel clientChannel) {
+        if (Locale.getDefault() == Locale.US || Locale.getDefault() == Locale.UK) {
+            assertTrue("actual message: " + cause.getMessage(), cause.getMessage().contains("reset"));
+        }
+    }
+
+    @Test(timeout = 3000)
+    public void testSoLingerZeroCausesOnlyRstOnClose() throws Throwable {
+        run();
+    }
+
+    public void testSoLingerZeroCausesOnlyRstOnClose(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        final AtomicReference<Channel> serverChannelRef = new AtomicReference<Channel>();
+        final AtomicReference<Throwable> throwableRef = new AtomicReference<Throwable>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch latch2 = new CountDownLatch(1);
+        // SO_LINGER=0 means that we must send ONLY a RST when closing (not a FIN + RST).
+        sb.childOption(ChannelOption.SO_LINGER, 0);
+        sb.childHandler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                serverChannelRef.compareAndSet(null, ch);
+                latch.countDown();
+            }
+        });
+        cb.handler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                        throwableRef.compareAndSet(null, cause);
+                    }
+
+                    @Override
+                    public void channelInactive(ChannelHandlerContext ctx) {
+                        latch2.countDown();
+                    }
+                });
+            }
+        });
+        Channel sc = sb.bind().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
+
+        // Wait for the server to get setup.
+        latch.await();
+
+        // The server has SO_LINGER=0 and so it must send a RST when close is called.
+        serverChannelRef.get().close();
+
+        // Wait for the client to get channelInactive.
+        latch2.await();
+
+        // Verify the client received a RST.
+        Throwable cause = throwableRef.get();
+        assertTrue("actual [type, message]: [" + cause.getClass() + ", " + cause.getMessage() + "]",
+                   cause instanceof IOException);
+        assertRstOnCloseException((IOException) cause, cc);
+    }
+
+    @Test(timeout = 3000)
+    public void testNoRstIfSoLingerOnClose() throws Throwable {
+        run();
+    }
+
+    public void testNoRstIfSoLingerOnClose(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        final AtomicReference<Channel> serverChannelRef = new AtomicReference<Channel>();
+        final AtomicReference<Throwable> throwableRef = new AtomicReference<Throwable>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch latch2 = new CountDownLatch(1);
+        sb.childHandler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                serverChannelRef.compareAndSet(null, ch);
+                latch.countDown();
+            }
+        });
+        cb.handler(new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+                    @Override
+                    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                        throwableRef.compareAndSet(null, cause);
+                    }
+
+                    @Override
+                    public void channelInactive(ChannelHandlerContext ctx) {
+                        latch2.countDown();
+                    }
+                });
+            }
+        });
+        Channel sc = sb.bind().sync().channel();
+        cb.connect(sc.localAddress()).syncUninterruptibly();
+
+        // Wait for the server to get setup.
+        latch.await();
+
+        // The server has SO_LINGER=0 and so it must send a RST when close is called.
+        serverChannelRef.get().close();
+
+        // Wait for the client to get channelInactive.
+        latch2.await();
+
+        // Verify the client did not received a RST.
+        assertNull(throwableRef.get());
+    }
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -97,21 +97,11 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
 
     @Override
     protected void doClose() throws Exception {
-        this.active = false;
-        Socket fd = fileDescriptor;
+        active = false;
         try {
-            // deregister from epoll now and shutdown the socket.
             doDeregister();
-            if (!fd.isShutdown()) {
-                try {
-                    fd().shutdown();
-                } catch (IOException ignored) {
-                    // The FD will be closed, so if shutdown fails there is nothing we can do.
-                }
-            }
         } finally {
-            // Ensure the file descriptor is closed in all cases.
-            fd.close();
+            fileDescriptor.close();
         }
     }
 

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketRstTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketRstTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.unix.Errors;
+import io.netty.channel.unix.Errors.NativeIoException;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketRstTest;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EpollSocketRstTest extends SocketRstTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return EpollSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void assertRstOnCloseException(IOException cause, Channel clientChannel) {
+        if (!AbstractEpollChannel.class.isInstance(clientChannel)) {
+            super.assertRstOnCloseException(cause, clientChannel);
+            return;
+        }
+
+        assertTrue("actual [type, message]: [" + cause.getClass() + ", " + cause.getMessage() + "]",
+                   cause instanceof NativeIoException);
+        assertEquals(Errors.ERRNO_ECONNRESET_NEGATIVE, ((NativeIoException) cause).expectedErr());
+    }
+}


### PR DESCRIPTION
Motivation:
If SO_LINGER is set to 0 the EPOLL transport will send a FIN followed by a RST. This is not consistent with the behavior of the NIO transport. This variation in behavior can cause protocol violations in streaming protocols (e.g. HTTP) where a FIN may be interpreted as a valid end to a data stream, but RST may be treated as the data is corrupted and should be discarded.

https://github.com/netty/netty/issues/4170 Claims the behavior of NIO always issues a shutdown when close occurs. I could not find any evidence of this in Netty's NIO transport nor in the JDK's SocketChannel.close() implementation.

Modifications:
- AbstractEpollChannel should be consistent with the NIO transport and not force a shutdown on every close
- FileDescriptor to keep state in a consistent manner with the JDK and not allow a shutdown after a close
- Unit tests for NIO and EPOLL to ensure consistent behavior

Result:
EPOLL is capable of sending just a RST to terminate a connection.