### PR TITLE
Guard against re-entrance in PendingWriteQueue.

### DIFF
--- a/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
+++ b/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
@@ -73,6 +73,8 @@ public final class PendingWriteQueue {
         if (promise == null) {
             throw new NullPointerException("promise");
         }
+        // It is possible for writes to be triggered from removeAndFailAll(). To preserve ordering,
+        // we should add them to the queue and let removeAndFailAll() fail them later.
         int messageSize = estimatorHandle.size(msg);
         if (messageSize < 0) {
             // Size may be unknow so just use 0
@@ -104,18 +106,20 @@ public final class PendingWriteQueue {
         if (cause == null) {
             throw new NullPointerException("cause");
         }
-        // Guard against re-entrance by directly reset
-        PendingWrite write = head;
-        head = tail = null;
-        size = 0;
+        // It is possible for some of the failed promises to trigger more writes. The new writes
+        // will "revive" the queue, so we need to clean them up until the queue is empty.
+        for (PendingWrite write = head; write != null; write = head) {
+            head = tail = null;
+            size = 0;
 
-        while (write != null) {
-            PendingWrite next = write.next;
-            ReferenceCountUtil.safeRelease(write.msg);
-            ChannelPromise promise = write.promise;
-            recycle(write, false);
-            safeFail(promise, cause);
-            write = next;
+            while (write != null) {
+                PendingWrite next = write.next;
+                ReferenceCountUtil.safeRelease(write.msg);
+                ChannelPromise promise = write.promise;
+                recycle(write, false);
+                safeFail(promise, cause);
+                write = next;
+            }
         }
         assertEmpty();
     }


### PR DESCRIPTION
Motivation:

PendingWriteQueue should guard against re-entrant writes once
removeAndFailAll() is run.

Modifications:

removeAndFailAll() should repeat until the queue is finally empty.

Result:

assertEmpty() will always hold.