### PR TITLE
Fix EpollServerSocketConfig.isFreebind()

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -507,7 +507,7 @@ static jint netty_epoll_native_getTcpUserTimeout(JNIEnv* env, jclass clazz, jint
 
 static jint netty_epoll_Native_isIpFreeBind(JNIEnv* env, jclass clazz, jint fd) {
      int optval;
-     if (netty_unix_socket_getOption(env, fd, IPPROTO_TCP, IP_FREEBIND, &optval, sizeof(optval)) == -1) {
+     if (netty_unix_socket_getOption(env, fd, IPPROTO_IP, IP_FREEBIND, &optval, sizeof(optval)) == -1) {
          return -1;
      }
      return optval;

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollServerSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollServerSocketChannelConfigTest.java
@@ -67,4 +67,12 @@ public class EpollServerSocketChannelConfigTest {
         ch.config().setReusePort(true);
         assertTrue(ch.config().isReusePort());
     }
+
+    @Test
+    public void testFreeBind() {
+        ch.config().setFreeBind(false);
+        assertFalse(ch.config().isFreeBind());
+        ch.config().setFreeBind(true);
+        assertTrue(ch.config().isFreeBind());
+    }
 }


### PR DESCRIPTION
Motivation:

EpollServerSocketConfig.isFreebind() throws an exception when called.

Modifications:

Use the correct getsockopt arguments.

Result:

No more exception when call EpollServerSocketConfig.isFreebind()