### PR TITLE
[#4937] [#4935] Correctly valid domain name length and convert to ASCII.

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsRecord.java
@@ -17,6 +17,8 @@ package io.netty.handler.codec.dns;
 
 import io.netty.util.internal.StringUtil;
 
+import java.net.IDN;
+
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -61,7 +63,11 @@ public abstract class AbstractDnsRecord implements DnsRecord {
         if (timeToLive < 0) {
             throw new IllegalArgumentException("timeToLive: " + timeToLive + " (expected: >= 0)");
         }
-        this.name = checkNotNull(name, "name");
+        // Convert to ASCII which will also check that the length is not too big.
+        // See:
+        //   - https://github.com/netty/netty/issues/4937
+        //   - https://github.com/netty/netty/issues/4935
+        this.name = IDN.toASCII(checkNotNull(name, "name"));
         this.type = checkNotNull(type, "type");
         this.dnsClass = (short) dnsClass;
         this.timeToLive = timeToLive;

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/AbstractDnsRecordTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/AbstractDnsRecordTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AbstractDnsRecordTest {
+
+    @Test
+    public void testValidDomainName() {
+        String name = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        AbstractDnsRecord record = new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
+        Assert.assertEquals(name, record.name());
+    }
+
+    @Test
+    public void testValidDomainNameUmlaut() {
+        String name = "ä";
+        AbstractDnsRecord record = new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
+        Assert.assertEquals("xn--4ca", record.name());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidDomainNameLength() {
+        String name = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValidDomainNameUmlautLength() {
+        String name = "äaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
+    }
+}


### PR DESCRIPTION
Motivation:

Domain name labels must be converted to ASCII and not be longer then 63 chars.

Modifications:

Correctly convert to ASCII which also will enforce the 63 chars length.

Result:

Correctly guard against invalid input.