### PR TITLE
Ensure connect promise is notifed before fireChannelActive() is calle…

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -501,6 +501,9 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                     EpollDatagramChannel.this.local = fd().localAddress();
                     success = true;
 
+                    // First notify the promise before notifying the handler.
+                    channelPromise.trySuccess();
+
                     // Regardless if the connection attempt was cancelled, channelActive() event should be triggered,
                     // because what happened is what happened.
                     if (!wasActive && isActive()) {
@@ -510,12 +513,11 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                     if (!success) {
                         doClose();
                     } else {
-                        channelPromise.setSuccess();
                         connected = true;
                     }
                 }
             } catch (Throwable cause) {
-                channelPromise.setFailure(cause);
+                channelPromise.tryFailure(cause);
             }
         }
 


### PR DESCRIPTION
…d. Related to [#4927]

Motivation:

We should always first notify the promise before trigger an event through the pipeline to be consistent.

Modifications:

Ensure we notify the promise before fire event.

Result:

Consistent behavior