### PR TITLE
Add final keyword which was missing in 47b598e6ce6c1f0e57d6955d10652d…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -57,15 +57,16 @@ abstract class PoolArena<T> implements PoolArenaMetric {
     private final List<PoolChunkListMetric> chunkListMetrics;
 
     // Metrics for allocations and deallocations
-    private LongCounter allocationsTiny = PlatformDependent.newLongCounter();
-    private LongCounter allocationsSmall = PlatformDependent.newLongCounter();
     private long allocationsNormal;
     // We need to use the LongCounter here as this is not guarded via synchronized block.
+    private final LongCounter allocationsTiny = PlatformDependent.newLongCounter();
+    private final LongCounter allocationsSmall = PlatformDependent.newLongCounter();
     private final LongCounter allocationsHuge = PlatformDependent.newLongCounter();
 
     private long deallocationsTiny;
     private long deallocationsSmall;
     private long deallocationsNormal;
+
     // We need to use the LongCounter here as this is not guarded via synchronized block.
     private final LongCounter deallocationsHuge = PlatformDependent.newLongCounter();
 


### PR DESCRIPTION
…d5e5bc1462

Motivation:

The two fields should have final keyword.

Modifications:

Add final keyword

Result:

Cleaner code.