### PR TITLE
Remove double spacing

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -962,7 +962,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 3} is greater than {@code this.capacity}
      */
-    public abstract ByteBuf setMedium(int index, int   value);
+    public abstract ByteBuf setMedium(int index, int value);
 
     /**
      * Sets the specified 24-bit medium integer at the specified absolute
@@ -976,7 +976,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 3} is greater than {@code this.capacity}
      */
-    public abstract ByteBuf setMediumLE(int index, int   value);
+    public abstract ByteBuf setMediumLE(int index, int value);
 
     /**
      * Sets the specified 32-bit integer at the specified absolute
@@ -988,7 +988,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 4} is greater than {@code this.capacity}
      */
-    public abstract ByteBuf setInt(int index, int   value);
+    public abstract ByteBuf setInt(int index, int value);
 
     /**
      * Sets the specified 32-bit integer at the specified absolute
@@ -1013,7 +1013,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 8} is greater than {@code this.capacity}
      */
-    public abstract ByteBuf setLong(int index, long  value);
+    public abstract ByteBuf setLong(int index, long value);
 
     /**
      * Sets the specified 64-bit long integer at the specified absolute
@@ -1025,7 +1025,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         if the specified {@code index} is less than {@code 0} or
      *         {@code index + 8} is greater than {@code this.capacity}
      */
-    public abstract ByteBuf setLongLE(int index, long  value);
+    public abstract ByteBuf setLongLE(int index, long value);
 
     /**
      * Sets the specified 2-byte UTF-16 character at the specified absolute
@@ -1641,7 +1641,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 3}
      */
-    public abstract ByteBuf writeMedium(int   value);
+    public abstract ByteBuf writeMedium(int value);
 
     /**
      * Sets the specified 24-bit medium integer at the current
@@ -1652,7 +1652,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 3}
      */
-    public abstract ByteBuf writeMediumLE(int   value);
+    public abstract ByteBuf writeMediumLE(int value);
 
     /**
      * Sets the specified 32-bit integer at the current {@code writerIndex}
@@ -1661,7 +1661,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 4}
      */
-    public abstract ByteBuf writeInt(int   value);
+    public abstract ByteBuf writeInt(int value);
 
     /**
      * Sets the specified 32-bit integer at the current {@code writerIndex}
@@ -1671,7 +1671,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 4}
      */
-    public abstract ByteBuf writeIntLE(int   value);
+    public abstract ByteBuf writeIntLE(int value);
 
     /**
      * Sets the specified 64-bit long integer at the current
@@ -1681,7 +1681,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 8}
      */
-    public abstract ByteBuf writeLong(long  value);
+    public abstract ByteBuf writeLong(long value);
 
     /**
      * Sets the specified 64-bit long integer at the current
@@ -1692,7 +1692,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * @throws IndexOutOfBoundsException
      *         if {@code this.writableBytes} is less than {@code 8}
      */
-    public abstract ByteBuf writeLongLE(long  value);
+    public abstract ByteBuf writeLongLE(long value);
 
     /**
      * Sets the specified 2-byte UTF-16 character at the current


### PR DESCRIPTION
Motivation:

We had some double spacing in the methods which should be removed to keep things consistent.

Modifications:

Remove redundant spaces.

Result:

Cleaner / consistent coding style.