### PR TITLE
Let getSoError() throw IOException as well

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -22,6 +22,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoop;
@@ -57,6 +58,14 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         readFlag = flag;
         flags |= flag;
         this.active = active;
+    }
+
+    static boolean isSoErrorZero(Socket fd) {
+        try {
+            return fd.getSoError() == 0;
+        } catch (IOException e) {
+            throw new ChannelException(e);
+        }
     }
 
     void setFlag(int flag) throws IOException {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -52,7 +52,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
      */
     @Deprecated
     protected AbstractEpollServerChannel(Socket fd) {
-        this(fd, fd.getSoError() == 0);
+        this(fd, isSoErrorZero(fd));
     }
 
     protected AbstractEpollServerChannel(Socket fd, boolean active) {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -106,7 +106,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
      */
     @Deprecated
     protected AbstractEpollStreamChannel(Socket fd) {
-        this(fd, fd.getSoError() == 0);
+        this(fd, isSoErrorZero(fd));
     }
 
     protected AbstractEpollStreamChannel(Channel parent, Socket fd) {

--- a/transport-native-epoll/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/unix/Socket.java
@@ -272,7 +272,7 @@ public final class Socket extends FileDescriptor {
         return isTcpQuickAck(fd) != 0;
     }
 
-    public int getSoError() {
+    public int getSoError() throws IOException {
         return getSoError(fd);
     }
 
@@ -367,22 +367,22 @@ public final class Socket extends FileDescriptor {
     private static native int newSocketDgramFd();
     private static native int newSocketDomainFd();
 
-    private static native int getReceiveBufferSize(int fd);
-    private static native int getSendBufferSize(int fd);
-    private static native int isKeepAlive(int fd);
-    private static native int isTcpNoDelay(int fd);
-    private static native int isTcpCork(int fd);
-    private static native int getSoLinger(int fd);
-    private static native int getSoError(int fd);
-    private static native int getTcpDeferAccept(int fd);
-    private static native int isTcpQuickAck(int fd);
+    private static native int getReceiveBufferSize(int fd) throws IOException;
+    private static native int getSendBufferSize(int fd) throws IOException;
+    private static native int isKeepAlive(int fd) throws IOException;
+    private static native int isTcpNoDelay(int fd) throws IOException;
+    private static native int isTcpCork(int fd) throws IOException;
+    private static native int getSoLinger(int fd) throws IOException;
+    private static native int getSoError(int fd) throws IOException;
+    private static native int getTcpDeferAccept(int fd) throws IOException;
+    private static native int isTcpQuickAck(int fd) throws IOException;
 
-    private static native void setKeepAlive(int fd, int keepAlive);
-    private static native void setReceiveBufferSize(int fd, int receiveBufferSize);
-    private static native void setSendBufferSize(int fd, int sendBufferSize);
-    private static native void setTcpNoDelay(int fd, int tcpNoDelay);
-    private static native void setTcpCork(int fd, int tcpCork);
-    private static native void setSoLinger(int fd, int soLinger);
-    private static native void setTcpDeferAccept(int fd, int deferAccept);
-    private static native void setTcpQuickAck(int fd, int quickAck);
+    private static native void setKeepAlive(int fd, int keepAlive) throws IOException;
+    private static native void setReceiveBufferSize(int fd, int receiveBufferSize) throws IOException;
+    private static native void setSendBufferSize(int fd, int sendBufferSize) throws IOException;
+    private static native void setTcpNoDelay(int fd, int tcpNoDelay) throws IOException;
+    private static native void setTcpCork(int fd, int tcpCork) throws IOException;
+    private static native void setSoLinger(int fd, int soLinger) throws IOException;
+    private static native void setTcpDeferAccept(int fd, int deferAccept) throws IOException;
+    private static native void setTcpQuickAck(int fd, int quickAck) throws IOException;
 }


### PR DESCRIPTION
Motivation:

In commit acbca192bd93b2691c86c5cec06e4fc1f15d6a05 we changed to have our native operations which either gall getsockopt or setsockopt throw IOExceptions (to be more specific we throw a ClosedChannelException in some cases). Unfortunally I missed to also do the same for getSoError() and missed to add throws IOException to the native methods.

Modifications:

- Correctly throw IOException from getSoError()
- Add throws IOException to native methods where it was missed.

Result:

Correct declaration of getSoError() and other native methods.