### PR TITLE
Throw exception if KeyManagerFactory is used with OpenSslClientContext

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
@@ -175,6 +175,7 @@ public final class OpenSslClientContext extends OpenSslContext {
                 ClientAuth.NONE);
         boolean success = false;
         try {
+            checkKeyManagerFactory(keyManagerFactory);
             if (trustCertChainFile != null && !trustCertChainFile.isFile()) {
                 throw new IllegalArgumentException("trustCertChainFile is not a file: " + trustCertChainFile);
             }
@@ -275,6 +276,7 @@ public final class OpenSslClientContext extends OpenSslContext {
                 ClientAuth.NONE);
         boolean success = false;
         try {
+            checkKeyManagerFactory(keyManagerFactory);
             if (key == null && keyCertChain != null || key != null && keyCertChain == null) {
                 throw new IllegalArgumentException(
                         "Either both keyCertChain and key needs to be null or none of them");

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -29,6 +29,7 @@ import org.apache.tomcat.jni.Pool;
 import org.apache.tomcat.jni.SSL;
 import org.apache.tomcat.jni.SSLContext;
 
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
@@ -565,5 +566,12 @@ public abstract class OpenSslContext extends SslContext {
             throw new IllegalStateException("Could not write data to memory BIO");
         }
         return bio;
+    }
+
+    static void checkKeyManagerFactory(KeyManagerFactory keyManagerFactory) {
+        if (keyManagerFactory != null) {
+            throw new IllegalArgumentException(
+                    "KeyManagerFactory is currently not supported with OpenSslContext");
+        }
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -530,11 +530,4 @@ public final class OpenSslServerContext extends OpenSslContext {
     public OpenSslServerSessionContext sessionContext() {
         return sessionContext;
     }
-
-    private static void checkKeyManagerFactory(KeyManagerFactory keyManagerFactory) {
-        if (keyManagerFactory != null) {
-            throw new IllegalArgumentException(
-                    "KeyManagerFactory is currently not supported with OpenSslServerContext");
-        }
-    }
 }


### PR DESCRIPTION
Motivation:

We currently not supported using KeyManagerFactory with OpenSslClientContext and so should throw an exception if the user tries to do so. This will at least not give suprising and hard to debug problems later.

Modifications:

Throw exception if a user tries to construct a OpenSslClientContext with a KeyManagerFactory

Result:

Fail fast if the user tries to use something that is not supported.