### PR TITLE
[#4993] Correctly handle trailing dot in DNS requests and responses f…

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsRecord.java
@@ -67,10 +67,17 @@ public abstract class AbstractDnsRecord implements DnsRecord {
         // See:
         //   - https://github.com/netty/netty/issues/4937
         //   - https://github.com/netty/netty/issues/4935
-        this.name = IDN.toASCII(checkNotNull(name, "name"));
+        this.name = appendTrailingDot(IDN.toASCII(checkNotNull(name, "name")));
         this.type = checkNotNull(type, "type");
         this.dnsClass = (short) dnsClass;
         this.timeToLive = timeToLive;
+    }
+
+    private static String appendTrailingDot(String name) {
+        if (name.length() > 0 && name.charAt(name.length() - 1) != '.') {
+            return name + '.';
+        }
+        return name;
     }
 
     @Override

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/AbstractDnsRecordTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/AbstractDnsRecordTest.java
@@ -24,14 +24,28 @@ public class AbstractDnsRecordTest {
     public void testValidDomainName() {
         String name = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         AbstractDnsRecord record = new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
-        Assert.assertEquals(name, record.name());
+        Assert.assertEquals(name + '.', record.name());
     }
 
     @Test
     public void testValidDomainNameUmlaut() {
         String name = "ä";
         AbstractDnsRecord record = new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
-        Assert.assertEquals("xn--4ca", record.name());
+        Assert.assertEquals("xn--4ca.", record.name());
+    }
+
+    @Test
+    public void testValidDomainNameTrailingDot() {
+        String name = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.";
+        AbstractDnsRecord record = new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
+        Assert.assertEquals(name, record.name());
+    }
+
+    @Test
+    public void testValidDomainNameUmlautTrailingDot() {
+        String name = "ä.";
+        AbstractDnsRecord record = new AbstractDnsRecord(name, DnsRecordType.A, 0) { };
+        Assert.assertEquals("xn--4ca.", record.name());
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
…or the hostname.

Motivation:

We need to handle the trailing dot in the correct manner when creating DNS questions and responses.

Modifications:

- Add a trailing dot if not given to the hostname when construct a AbstractDnsRecord (this is the same as dig does).

Result:

Correctly handle trailing dots.