### PR TITLE
Ensure native memory is released when OpenSslServercontext constructo…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -319,24 +319,22 @@ public final class OpenSslServerContext extends OpenSslContext {
             long sessionCacheSize, long sessionTimeout) throws SSLException {
         super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_SERVER, null,
                 ClientAuth.NONE);
-        OpenSsl.ensureAvailability();
-
-        checkKeyManagerFactory(keyManagerFactory);
-        checkNotNull(keyCertChainFile, "keyCertChainFile");
-        if (!keyCertChainFile.isFile()) {
-            throw new IllegalArgumentException("keyCertChainFile is not a file: " + keyCertChainFile);
-        }
-        checkNotNull(keyFile, "keyFile");
-        if (!keyFile.isFile()) {
-            throw new IllegalArgumentException("keyFile is not a file: " + keyFile);
-        }
-        if (keyPassword == null) {
-            keyPassword = "";
-        }
-
         // Create a new SSL_CTX and configure it.
         boolean success = false;
         try {
+            checkKeyManagerFactory(keyManagerFactory);
+            checkNotNull(keyCertChainFile, "keyCertChainFile");
+            if (!keyCertChainFile.isFile()) {
+                throw new IllegalArgumentException("keyCertChainFile is not a file: " + keyCertChainFile);
+            }
+            checkNotNull(keyFile, "keyFile");
+            if (!keyFile.isFile()) {
+                throw new IllegalArgumentException("keyFile is not a file: " + keyFile);
+            }
+            if (keyPassword == null) {
+                keyPassword = "";
+            }
+
             synchronized (OpenSslContext.class) {
                 /* Set certificate verification policy. */
                 SSLContext.setVerify(ctx, SSL.SSL_CVERIFY_NONE, VERIFY_DEPTH);
@@ -419,19 +417,17 @@ public final class OpenSslServerContext extends OpenSslContext {
             long sessionCacheSize, long sessionTimeout, ClientAuth clientAuth) throws SSLException {
         super(ciphers, cipherFilter, apn, sessionCacheSize, sessionTimeout, SSL.SSL_MODE_SERVER, keyCertChain,
                 clientAuth);
-        OpenSsl.ensureAvailability();
-
-        checkKeyManagerFactory(keyManagerFactory);
-        checkNotNull(keyCertChain, "keyCertChainFile");
-        checkNotNull(key, "keyFile");
-
-        if (keyPassword == null) {
-            keyPassword = "";
-        }
-
         // Create a new SSL_CTX and configure it.
         boolean success = false;
         try {
+            checkKeyManagerFactory(keyManagerFactory);
+            checkNotNull(keyCertChain, "keyCertChainFile");
+            checkNotNull(key, "keyFile");
+
+            if (keyPassword == null) {
+                keyPassword = "";
+            }
+
             synchronized (OpenSslContext.class) {
                 /* Set certificate verification policy. */
                 SSLContext.setVerify(ctx, SSL.SSL_CVERIFY_NONE, VERIFY_DEPTH);


### PR DESCRIPTION
…r throws exception

Motivation:

We need to ensure we do all checks inside of the try / catch block so we free native memory that was allocated in the constructor of the super class in a timely manner.
Modifications:

Move all checks inside of the try block.

Result:

Correctly release native memory (and not depend on the finalizer) when a check in the constructors fails