### PR TITLE
Speed up the slow path of FastThreadLocal

### DIFF
--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -41,18 +41,10 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
 
     public static InternalThreadLocalMap getIfSet() {
         Thread thread = Thread.currentThread();
-        InternalThreadLocalMap threadLocalMap;
         if (thread instanceof FastThreadLocalThread) {
-            threadLocalMap = ((FastThreadLocalThread) thread).threadLocalMap();
-        } else {
-            ThreadLocal<InternalThreadLocalMap> slowThreadLocalMap = UnpaddedInternalThreadLocalMap.slowThreadLocalMap;
-            if (slowThreadLocalMap == null) {
-                threadLocalMap = null;
-            } else {
-                threadLocalMap = slowThreadLocalMap.get();
-            }
+            return ((FastThreadLocalThread) thread).threadLocalMap();
         }
-        return threadLocalMap;
+        return slowThreadLocalMap.get();
     }
 
     public static InternalThreadLocalMap get() {
@@ -74,11 +66,6 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
 
     private static InternalThreadLocalMap slowGet() {
         ThreadLocal<InternalThreadLocalMap> slowThreadLocalMap = UnpaddedInternalThreadLocalMap.slowThreadLocalMap;
-        if (slowThreadLocalMap == null) {
-            UnpaddedInternalThreadLocalMap.slowThreadLocalMap =
-                    slowThreadLocalMap = new ThreadLocal<InternalThreadLocalMap>();
-        }
-
         InternalThreadLocalMap ret = slowThreadLocalMap.get();
         if (ret == null) {
             ret = new InternalThreadLocalMap();
@@ -92,15 +79,12 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
         if (thread instanceof FastThreadLocalThread) {
             ((FastThreadLocalThread) thread).setThreadLocalMap(null);
         } else {
-            ThreadLocal<InternalThreadLocalMap> slowThreadLocalMap = UnpaddedInternalThreadLocalMap.slowThreadLocalMap;
-            if (slowThreadLocalMap != null) {
-                slowThreadLocalMap.remove();
-            }
+            slowThreadLocalMap.remove();
         }
     }
 
     public static void destroy() {
-        slowThreadLocalMap = null;
+        slowThreadLocalMap.remove();
     }
 
     public static int nextVariableIndex() {

--- a/common/src/main/java/io/netty/util/internal/UnpaddedInternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/UnpaddedInternalThreadLocalMap.java
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 class UnpaddedInternalThreadLocalMap {
 
-    static ThreadLocal<InternalThreadLocalMap> slowThreadLocalMap;
+    static final ThreadLocal<InternalThreadLocalMap> slowThreadLocalMap = new ThreadLocal<InternalThreadLocalMap>();
     static final AtomicInteger nextIndex = new AtomicInteger();
 
     /** Used by {@link FastThreadLocal} */

--- a/microbench/src/main/java/io/netty/microbench/concurrent/FastThreadLocalFastPathBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/concurrent/FastThreadLocalFastPathBenchmark.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.concurrent;
+
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.concurrent.FastThreadLocal;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Threads;
+
+import java.util.Random;
+
+/**
+ * This class benchmarks the fast path of FastThreadLocal and the JDK ThreadLocal.
+ */
+@Threads(4)
+@Measurement(iterations = 10, batchSize = 100)
+public class FastThreadLocalFastPathBenchmark extends AbstractMicrobenchmark {
+
+    private static final Random rand = new Random();
+
+    @SuppressWarnings("unchecked")
+    private static final ThreadLocal<Integer>[] jdkThreadLocals = new ThreadLocal[128];
+    @SuppressWarnings("unchecked")
+    private static final FastThreadLocal<Integer>[] fastThreadLocals = new FastThreadLocal[jdkThreadLocals.length];
+
+    static {
+        for (int i = 0; i < jdkThreadLocals.length; i ++) {
+            final int num = rand.nextInt();
+            jdkThreadLocals[i] = new ThreadLocal<Integer>() {
+                @Override
+                protected Integer initialValue() {
+                    return num;
+                }
+            };
+            fastThreadLocals[i] = new FastThreadLocal<Integer>() {
+                @Override
+                protected Integer initialValue() {
+                    return num;
+                }
+            };
+        }
+    }
+
+    @Benchmark
+    public int jdkThreadLocalGet() {
+        int result = 0;
+        for (ThreadLocal<Integer> i: jdkThreadLocals) {
+            result += i.get();
+        }
+        return result;
+    }
+
+    @Benchmark
+    public int fastThreadLocal() {
+        int result = 0;
+        for (FastThreadLocal<Integer> i: fastThreadLocals) {
+            result += i.get();
+        }
+        return result;
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/concurrent/FastThreadLocalSlowPathBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/concurrent/FastThreadLocalSlowPathBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -24,11 +24,11 @@ import org.openjdk.jmh.annotations.Threads;
 import java.util.Random;
 
 /**
- * This class benchmarks different allocators with different allocation sizes.
+ * This class benchmarks the slow path of FastThreadLocal and the JDK ThreadLocal.
  */
 @Threads(4)
 @Measurement(iterations = 10, batchSize = 100)
-public class FastThreadLocalBenchmark extends AbstractMicrobenchmark {
+public class FastThreadLocalSlowPathBenchmark extends AbstractMicrobenchmark {
 
     private static final Random rand = new Random();
 
@@ -39,22 +39,24 @@ public class FastThreadLocalBenchmark extends AbstractMicrobenchmark {
 
     static {
         for (int i = 0; i < jdkThreadLocals.length; i ++) {
+            final int num = rand.nextInt();
             jdkThreadLocals[i] = new ThreadLocal<Integer>() {
                 @Override
                 protected Integer initialValue() {
-                    return rand.nextInt();
+                    return num;
                 }
             };
-        }
-
-        for (int i = 0; i < fastThreadLocals.length; i ++) {
             fastThreadLocals[i] = new FastThreadLocal<Integer>() {
                 @Override
                 protected Integer initialValue() {
-                    return rand.nextInt();
+                    return num;
                 }
             };
         }
+    }
+
+    public FastThreadLocalSlowPathBenchmark() {
+        super(false, true);
     }
 
     @Benchmark


### PR DESCRIPTION
Motivation:

The current slow path of FastThreadLocal is much slower than JDK ThreadLocal. See #4418

Modifications:

- Add FastThreadLocalSlowPathBenchmark for the flow path of FastThreadLocal
- Add final to speed up the slow path of FastThreadLocal

Result:

The slow path of FastThreadLocal is improved.