### PR TITLE
Change the DnsMessage.id() to be a short.

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsMessage.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsMessage.java
@@ -54,26 +54,26 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
     /**
      * Creates a new instance with the specified {@code id} and {@link DnsOpCode#QUERY} opCode.
      */
-    protected AbstractDnsMessage(int id) {
+    protected AbstractDnsMessage(short id) {
         this(id, DnsOpCode.QUERY);
     }
 
     /**
      * Creates a new instance with the specified {@code id} and {@code opCode}.
      */
-    protected AbstractDnsMessage(int id, DnsOpCode opCode) {
+    protected AbstractDnsMessage(short id, DnsOpCode opCode) {
         setId(id);
         setOpCode(opCode);
     }
 
     @Override
-    public int id() {
-        return id & 0xFFFF;
+    public short id() {
+        return id;
     }
 
     @Override
-    public DnsMessage setId(int id) {
-        this.id = (short) id;
+    public DnsMessage setId(short id) {
+        this.id = id;
         return this;
     }
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQuery.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQuery.java
@@ -37,7 +37,7 @@ public class DatagramDnsQuery extends DefaultDnsQuery
      * @param id the {@code ID} of the DNS query
      */
     public DatagramDnsQuery(
-            InetSocketAddress sender, InetSocketAddress recipient, int id) {
+            InetSocketAddress sender, InetSocketAddress recipient, short id) {
         this(sender, recipient, id, DnsOpCode.QUERY);
     }
 
@@ -50,7 +50,7 @@ public class DatagramDnsQuery extends DefaultDnsQuery
      * @param opCode the {@code opCode} of the DNS query
      */
     public DatagramDnsQuery(
-            InetSocketAddress sender, InetSocketAddress recipient, int id, DnsOpCode opCode) {
+            InetSocketAddress sender, InetSocketAddress recipient, short id, DnsOpCode opCode) {
         super(id, opCode);
 
         if (recipient == null && sender == null) {
@@ -77,7 +77,7 @@ public class DatagramDnsQuery extends DefaultDnsQuery
     }
 
     @Override
-    public DatagramDnsQuery setId(int id) {
+    public DatagramDnsQuery setId(short id) {
         return (DatagramDnsQuery) super.setId(id);
     }
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryDecoder.java
@@ -76,7 +76,7 @@ public class DatagramDnsQueryDecoder extends MessageToMessageDecoder<DatagramPac
     }
 
     private static DnsQuery newQuery(DatagramPacket packet, ByteBuf buf) {
-        final int id = buf.readUnsignedShort();
+        final short id = buf.readShort();
 
         final int flags = buf.readUnsignedShort();
         if (flags >> 15 == 1) {

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponse.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponse.java
@@ -37,7 +37,7 @@ public class DatagramDnsResponse extends DefaultDnsResponse
      * @param recipient the address of the recipient
      * @param id the {@code ID} of the DNS response
      */
-    public DatagramDnsResponse(InetSocketAddress sender, InetSocketAddress recipient, int id) {
+    public DatagramDnsResponse(InetSocketAddress sender, InetSocketAddress recipient, short id) {
         this(sender, recipient, id, DnsOpCode.QUERY, DnsResponseCode.NOERROR);
     }
 
@@ -49,7 +49,7 @@ public class DatagramDnsResponse extends DefaultDnsResponse
      * @param id the {@code ID} of the DNS response
      * @param opCode the {@code opCode} of the DNS response
      */
-    public DatagramDnsResponse(InetSocketAddress sender, InetSocketAddress recipient, int id, DnsOpCode opCode) {
+    public DatagramDnsResponse(InetSocketAddress sender, InetSocketAddress recipient, short id, DnsOpCode opCode) {
         this(sender, recipient, id, opCode, DnsResponseCode.NOERROR);
     }
 
@@ -64,7 +64,7 @@ public class DatagramDnsResponse extends DefaultDnsResponse
      */
     public DatagramDnsResponse(
             InetSocketAddress sender, InetSocketAddress recipient,
-            int id, DnsOpCode opCode, DnsResponseCode responseCode) {
+            short id, DnsOpCode opCode, DnsResponseCode responseCode) {
         super(id, opCode, responseCode);
 
         if (recipient == null && sender == null) {
@@ -111,7 +111,7 @@ public class DatagramDnsResponse extends DefaultDnsResponse
     }
 
     @Override
-    public DatagramDnsResponse setId(int id) {
+    public DatagramDnsResponse setId(short id) {
         return (DatagramDnsResponse) super.setId(id);
     }
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponseDecoder.java
@@ -22,7 +22,6 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.CorruptedFrameException;
 import io.netty.handler.codec.MessageToMessageDecoder;
 
-import java.net.InetSocketAddress;
 import java.util.List;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -76,7 +75,7 @@ public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<Datagram
     }
 
     private static DnsResponse newResponse(DatagramPacket packet, ByteBuf buf) {
-        final int id = buf.readUnsignedShort();
+        final short id = buf.readShort();
 
         final int flags = buf.readUnsignedShort();
         if (flags >> 15 == 0) {

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsQuery.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsQuery.java
@@ -25,7 +25,7 @@ public class DefaultDnsQuery extends AbstractDnsMessage implements DnsQuery {
      *
      * @param id the {@code ID} of the DNS query
      */
-    public DefaultDnsQuery(int id) {
+    public DefaultDnsQuery(short id) {
         super(id);
     }
 
@@ -35,12 +35,12 @@ public class DefaultDnsQuery extends AbstractDnsMessage implements DnsQuery {
      * @param id the {@code ID} of the DNS query
      * @param opCode the {@code opCode} of the DNS query
      */
-    public DefaultDnsQuery(int id, DnsOpCode opCode) {
+    public DefaultDnsQuery(short id, DnsOpCode opCode) {
         super(id, opCode);
     }
 
     @Override
-    public DnsQuery setId(int id) {
+    public DnsQuery setId(short id) {
         return (DnsQuery) super.setId(id);
     }
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsResponse.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsResponse.java
@@ -33,7 +33,7 @@ public class DefaultDnsResponse extends AbstractDnsMessage implements DnsRespons
      *
      * @param id the {@code ID} of the DNS response
      */
-    public DefaultDnsResponse(int id) {
+    public DefaultDnsResponse(short id) {
         this(id, DnsOpCode.QUERY, DnsResponseCode.NOERROR);
     }
 
@@ -43,7 +43,7 @@ public class DefaultDnsResponse extends AbstractDnsMessage implements DnsRespons
      * @param id the {@code ID} of the DNS response
      * @param opCode the {@code opCode} of the DNS response
      */
-    public DefaultDnsResponse(int id, DnsOpCode opCode) {
+    public DefaultDnsResponse(short id, DnsOpCode opCode) {
         this(id, opCode, DnsResponseCode.NOERROR);
     }
 
@@ -54,7 +54,7 @@ public class DefaultDnsResponse extends AbstractDnsMessage implements DnsRespons
      * @param opCode the {@code opCode} of the DNS response
      * @param code the {@code RCODE} of the DNS response
      */
-    public DefaultDnsResponse(int id, DnsOpCode opCode, DnsResponseCode code) {
+    public DefaultDnsResponse(short id, DnsOpCode opCode, DnsResponseCode code) {
         super(id, opCode);
         setCode(code);
     }
@@ -104,7 +104,7 @@ public class DefaultDnsResponse extends AbstractDnsMessage implements DnsRespons
     }
 
     @Override
-    public DnsResponse setId(int id) {
+    public DnsResponse setId(short id) {
         return (DnsResponse) super.setId(id);
     }
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessage.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessage.java
@@ -25,12 +25,12 @@ public interface DnsMessage extends ReferenceCounted {
     /**
      * Returns the {@code ID} of this DNS message.
      */
-    int id();
+    short id();
 
     /**
      * Sets the {@code ID} of this DNS message.
      */
-    DnsMessage setId(int id);
+    DnsMessage setId(short id);
 
     /**
      * Returns the {@code opCode} of this DNS message.

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuery.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuery.java
@@ -20,7 +20,7 @@ package io.netty.handler.codec.dns;
  */
 public interface DnsQuery extends DnsMessage {
     @Override
-    DnsQuery setId(int id);
+    DnsQuery setId(short id);
 
     @Override
     DnsQuery setOpCode(DnsOpCode opCode);

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponse.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponse.java
@@ -73,7 +73,7 @@ public interface DnsResponse extends DnsMessage {
     DnsResponse setCode(DnsResponseCode code);
 
     @Override
-    DnsResponse setId(int id);
+    DnsResponse setId(short id);
 
     @Override
     DnsResponse setOpCode(DnsOpCode opCode);

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsQueryTest.java
@@ -35,19 +35,19 @@ public class DnsQueryTest {
         InetSocketAddress addr = new InetSocketAddress("8.8.8.8", 53);
         EmbeddedChannel embedder = new EmbeddedChannel(new DatagramDnsQueryEncoder());
         List<DnsQuery> queries = new ArrayList<DnsQuery>(5);
-        queries.add(new DatagramDnsQuery(null, addr, 1).setRecord(
+        queries.add(new DatagramDnsQuery(null, addr, (short) 1).setRecord(
                 DnsSection.QUESTION,
                 new DefaultDnsQuestion("1.0.0.127.in-addr.arpa", DnsRecordType.PTR)));
-        queries.add(new DatagramDnsQuery(null, addr, 1).setRecord(
+        queries.add(new DatagramDnsQuery(null, addr, (short) 1).setRecord(
                 DnsSection.QUESTION,
                 new DefaultDnsQuestion("www.example.com", DnsRecordType.A)));
-        queries.add(new DatagramDnsQuery(null, addr, 1).setRecord(
+        queries.add(new DatagramDnsQuery(null, addr, (short) 1).setRecord(
                 DnsSection.QUESTION,
                 new DefaultDnsQuestion("example.com", DnsRecordType.AAAA)));
-        queries.add(new DatagramDnsQuery(null, addr, 1).setRecord(
+        queries.add(new DatagramDnsQuery(null, addr, (short) 1).setRecord(
                 DnsSection.QUESTION,
                 new DefaultDnsQuestion("example.com", DnsRecordType.MX)));
-        queries.add(new DatagramDnsQuery(null, addr, 1).setRecord(
+        queries.add(new DatagramDnsQuery(null, addr, (short) 1).setRecord(
                 DnsSection.QUESTION,
                 new DefaultDnsQuestion("example.com", DnsRecordType.CNAME)));
 

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsResponseTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DnsResponseTest.java
@@ -82,7 +82,7 @@ public class DnsResponseTest {
             assertThat(response, is(sameInstance((Object) envelope)));
 
             ByteBuf raw = Unpooled.wrappedBuffer(p);
-            assertThat(response.id(), is(raw.getUnsignedShort(0)));
+            assertThat(response.id(), is(raw.getShort(0)));
             assertThat(response.count(DnsSection.QUESTION), is(raw.getUnsignedShort(4)));
             assertThat(response.count(DnsSection.ANSWER), is(raw.getUnsignedShort(6)));
             assertThat(response.count(DnsSection.AUTHORITY), is(raw.getUnsignedShort(8)));

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -592,7 +592,7 @@ public class DnsNameResolver extends InetNameResolver {
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
             try {
                 final DatagramDnsResponse res = (DatagramDnsResponse) msg;
-                final int queryId = res.id();
+                final short queryId = res.id();
 
                 if (logger.isDebugEnabled()) {
                     logger.debug("{} RECEIVED: [{}: {}], {}", ch, queryId, res.sender(), res);

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -45,7 +45,7 @@ final class DnsQueryContext {
 
     private final DnsNameResolver parent;
     private final Promise<AddressedEnvelope<DnsResponse, InetSocketAddress>> promise;
-    private final int id;
+    private final short id;
     private final DnsQuestion question;
     private final Iterable<DnsRecord> additional;
     private final DnsRecord optResource;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContextManager.java
@@ -38,10 +38,10 @@ final class DnsQueryContextManager {
     final Map<InetSocketAddress, IntObjectMap<DnsQueryContext>> map =
             new HashMap<InetSocketAddress, IntObjectMap<DnsQueryContext>>();
 
-    int add(DnsQueryContext qCtx) {
+    short add(DnsQueryContext qCtx) {
         final IntObjectMap<DnsQueryContext> contexts = getOrCreateContextMap(qCtx.nameServerAddr());
 
-        int id = ThreadLocalRandom.current().nextInt(1, 65536);
+        short id = (short) ThreadLocalRandom.current().nextInt(Short.MIN_VALUE, Short.MAX_VALUE);
         final int maxTries = 65535 << 1;
         int tries = 0;
 
@@ -52,7 +52,7 @@ final class DnsQueryContextManager {
                     return id;
                 }
 
-                id = id + 1 & 0xFFFF;
+                id++;
 
                 if (++tries >= maxTries) {
                     throw new IllegalStateException("query ID space exhausted: " + qCtx.question());
@@ -61,7 +61,7 @@ final class DnsQueryContextManager {
         }
     }
 
-    DnsQueryContext get(InetSocketAddress nameServerAddr, int id) {
+    DnsQueryContext get(InetSocketAddress nameServerAddr, short id) {
         final IntObjectMap<DnsQueryContext> contexts = getContextMap(nameServerAddr);
         final DnsQueryContext qCtx;
         if (contexts != null) {
@@ -75,7 +75,7 @@ final class DnsQueryContextManager {
         return qCtx;
     }
 
-    DnsQueryContext remove(InetSocketAddress nameServerAddr, int id) {
+    DnsQueryContext remove(InetSocketAddress nameServerAddr, short id) {
         final IntObjectMap<DnsQueryContext> contexts = getContextMap(nameServerAddr);
         if (contexts == null) {
             return null;


### PR DESCRIPTION
Motivation:

The id of a DnsMessage should be a 16 bit identifier accourding to RFC 1035 Section 4.1.1.

See also https://www.ietf.org/rfc/rfc1035.txt

Modifications:

Change id from unsigned short to short to be compliant with the spec.

Result:

Correctly handle dns message id.