### PR TITLE
[#5013] Fix typo in DefaultStompFrame.toString() method.

### DIFF
--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
@@ -94,7 +94,7 @@ public class DefaultStompFrame extends DefaultStompHeadersSubframe implements St
 
     @Override
     public String toString() {
-        return "DefaultFullStompFrame{" +
+        return "DefaultStompFrame{" +
             "command=" + command +
             ", headers=" + headers +
             ", content=" + content.toString(CharsetUtil.UTF_8) +


### PR DESCRIPTION
Motivation:

DefaultStompFrame.toString() implementations returned a String that contained DefaultFullStompFrame.

Modifications:

Replace DefaultFullStompFrame with DefaultStompFrame.

Result:

Less confusing and more correct return value of toString()