### PR TITLE
Cleanup of codec-mqtt

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttCodecUtil.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttCodecUtil.java
@@ -42,7 +42,8 @@ final class MqttCodecUtil {
         if (mqttVersion == MqttVersion.MQTT_3_1) {
             return clientId != null && clientId.length() >= MIN_CLIENT_ID_LENGTH &&
                 clientId.length() <= MAX_CLIENT_ID_LENGTH;
-        } else if (mqttVersion == MqttVersion.MQTT_3_1_1) {
+        }
+        if (mqttVersion == MqttVersion.MQTT_3_1_1) {
             // In 3.1.3.1 Client Identifier of MQTT 3.1.1 specification, The Server MAY allow ClientId’s
             // that contain more than 23 encoded bytes. And, The Server MAY allow zero-length ClientId.
             return clientId != null;

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnAckVariableHeader.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnAckVariableHeader.java
@@ -21,7 +21,7 @@ import io.netty.util.internal.StringUtil;
 /**
  * Variable header of {@link MqttConnectMessage}
  */
-public class MqttConnAckVariableHeader {
+public final class MqttConnAckVariableHeader {
 
     private final MqttConnectReturnCode connectReturnCode;
 

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnectPayload.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnectPayload.java
@@ -21,7 +21,7 @@ import io.netty.util.internal.StringUtil;
 /**
  * Payload of {@link MqttConnectMessage}
  */
-public class MqttConnectPayload {
+public final class MqttConnectPayload {
 
     private final String clientIdentifier;
     private final String willTopic;

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnectReturnCode.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnectReturnCode.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Return Code of {@link io.netty.handler.codec.mqtt.MqttConnAckMessage}
+ * Return Code of {@link MqttConnAckMessage}
  */
 public enum MqttConnectReturnCode {
     CONNECTION_ACCEPTED((byte) 0x00),

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnectVariableHeader.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnectVariableHeader.java
@@ -21,7 +21,7 @@ import io.netty.util.internal.StringUtil;
 /**
  * Variable Header for the {@link MqttConnectMessage}
  */
-public class MqttConnectVariableHeader {
+public final class MqttConnectVariableHeader {
 
     private final String name;
     private final int version;

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -33,7 +33,7 @@ import static io.netty.handler.codec.mqtt.MqttCodecUtil.*;
  * <a href="http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html">
  *     the MQTT protocl specification v3.1</a>
  */
-public class MqttDecoder extends ReplayingDecoder<DecoderState> {
+public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
 
     private static final int DEFAULT_MAX_BYTES_IN_MESSAGE = 8092;
 

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
@@ -21,20 +21,21 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageEncoder;
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.EmptyArrays;
 
 import java.util.List;
 
 import static io.netty.handler.codec.mqtt.MqttCodecUtil.*;
 
 /**
- * Encodes Mqtt messages into bytes following the protocl specification v3.1
+ * Encodes Mqtt messages into bytes following the protocol specification v3.1
  * as described here <a href="http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html">MQTTV3.1</a>
  */
-public class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
+public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
 
-    public static final MqttEncoder DEFAUL_ENCODER = new MqttEncoder();
+    public static final MqttEncoder INSTANCE = new MqttEncoder();
 
-    private static final byte[] EMPTY = new byte[0];
+    private MqttEncoder() { }
 
     @Override
     protected void encode(ChannelHandlerContext ctx, MqttMessage msg, List<Object> out) throws Exception {
@@ -109,22 +110,22 @@ public class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
 
         // Will topic and message
         String willTopic = payload.willTopic();
-        byte[] willTopicBytes = willTopic != null ? encodeStringUtf8(willTopic) : EMPTY;
+        byte[] willTopicBytes = willTopic != null ? encodeStringUtf8(willTopic) : EmptyArrays.EMPTY_BYTES;
         String willMessage = payload.willMessage();
-        byte[] willMessageBytes = willMessage != null ? encodeStringUtf8(willMessage) : EMPTY;
+        byte[] willMessageBytes = willMessage != null ? encodeStringUtf8(willMessage) : EmptyArrays.EMPTY_BYTES;
         if (variableHeader.isWillFlag()) {
             payloadBufferSize += 2 + willTopicBytes.length;
             payloadBufferSize += 2 + willMessageBytes.length;
         }
 
         String userName = payload.userName();
-        byte[] userNameBytes = userName != null ? encodeStringUtf8(userName) : EMPTY;
+        byte[] userNameBytes = userName != null ? encodeStringUtf8(userName) : EmptyArrays.EMPTY_BYTES;
         if (variableHeader.hasUserName()) {
             payloadBufferSize += 2 + userNameBytes.length;
         }
 
         String password = payload.password();
-        byte[] passwordBytes = password != null ? encodeStringUtf8(password) : EMPTY;
+        byte[] passwordBytes = password != null ? encodeStringUtf8(password) : EmptyArrays.EMPTY_BYTES;
         if (variableHeader.hasPassword()) {
             payloadBufferSize += 2 + passwordBytes.length;
         }

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttFixedHeader.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttFixedHeader.java
@@ -16,13 +16,14 @@
 
 package io.netty.handler.codec.mqtt;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 /**
  * See <a href="http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#fixed-header">
  *     MQTTV3.1/fixed-header</a>
  */
-public class MqttFixedHeader {
+public final class MqttFixedHeader {
 
     private final MqttMessageType messageType;
     private final boolean isDup;
@@ -36,9 +37,9 @@ public class MqttFixedHeader {
             MqttQoS qosLevel,
             boolean isRetain,
             int remainingLength) {
-        this.messageType = messageType;
+        this.messageType = ObjectUtil.checkNotNull(messageType, "messageType");
         this.isDup = isDup;
-        this.qosLevel = qosLevel;
+        this.qosLevel = ObjectUtil.checkNotNull(qosLevel, "qosLevel");
         this.isRetain = isRetain;
         this.remainingLength = remainingLength;
     }

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttIdentifierRejectedException.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttIdentifierRejectedException.java
@@ -20,7 +20,7 @@ import io.netty.handler.codec.DecoderException;
 /**
  * A {@link MqttIdentifierRejectedException} which is thrown when a CONNECT request contains invalid client identifier.
  */
-public class MqttIdentifierRejectedException extends DecoderException {
+public final class MqttIdentifierRejectedException extends DecoderException {
 
     private static final long serialVersionUID = -1323503322689614981L;
 

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPubAckMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPubAckMessage.java
@@ -19,7 +19,7 @@ package io.netty.handler.codec.mqtt;
 /**
  * See <a href="http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#puback">MQTTV3.1/puback</a>
  */
-public class MqttPubAckMessage extends MqttMessage {
+public final class MqttPubAckMessage extends MqttMessage {
 
     public MqttPubAckMessage(MqttFixedHeader mqttFixedHeader, MqttMessageIdVariableHeader variableHeader) {
         super(mqttFixedHeader, variableHeader);

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPublishVariableHeader.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPublishVariableHeader.java
@@ -21,7 +21,7 @@ import io.netty.util.internal.StringUtil;
 /**
  * Variable Header of the {@link MqttPublishMessage}
  */
-public class MqttPublishVariableHeader {
+public final class MqttPublishVariableHeader {
 
     private final String topicName;
     private final int messageId;

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubAckMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubAckMessage.java
@@ -19,7 +19,7 @@ package io.netty.handler.codec.mqtt;
 /**
  * See <a href="http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#suback">MQTTV3.1/suback</a>
  */
-public class MqttSubAckMessage extends MqttMessage {
+public final class MqttSubAckMessage extends MqttMessage {
 
     public MqttSubAckMessage(
             MqttFixedHeader mqttFixedHeader,

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscribeMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscribeMessage.java
@@ -20,7 +20,7 @@ package io.netty.handler.codec.mqtt;
  * See <a href="http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#subscribe">
  *     MQTTV3.1/subscribe</a>
  */
-public class MqttSubscribeMessage extends MqttMessage {
+public final class MqttSubscribeMessage extends MqttMessage {
 
     public MqttSubscribeMessage(
             MqttFixedHeader mqttFixedHeader,

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscribePayload.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscribePayload.java
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * Payload of the {@link MqttSubscribeMessage}
  */
-public class MqttSubscribePayload {
+public final class MqttSubscribePayload {
 
     private final List<MqttTopicSubscription> topicSubscriptions;
 

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttTopicSubscription.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttTopicSubscription.java
@@ -22,7 +22,7 @@ import io.netty.util.internal.StringUtil;
  * Contains a topic name and Qos Level.
  * This is part of the {@link MqttSubscribePayload}
  */
-public class MqttTopicSubscription {
+public final class MqttTopicSubscription {
 
     private final String topicFilter;
     private final MqttQoS qualityOfService;

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnacceptableProtocolVersionException.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnacceptableProtocolVersionException.java
@@ -21,7 +21,7 @@ import io.netty.handler.codec.DecoderException;
  * A {@link MqttUnacceptableProtocolVersionException} which is thrown when
  * a CONNECT request contains unacceptable protocol version.
  */
-public class MqttUnacceptableProtocolVersionException extends DecoderException {
+public final class MqttUnacceptableProtocolVersionException extends DecoderException {
 
     private static final long serialVersionUID = 4914652213232455749L;
 

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnsubAckMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnsubAckMessage.java
@@ -19,7 +19,7 @@ package io.netty.handler.codec.mqtt;
 /**
  * See <a href="http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#unsuback">MQTTV3.1/unsuback</a>
  */
-public class MqttUnsubAckMessage extends MqttMessage {
+public final class MqttUnsubAckMessage extends MqttMessage {
 
     public MqttUnsubAckMessage(MqttFixedHeader mqttFixedHeader, MqttMessageIdVariableHeader variableHeader) {
         super(mqttFixedHeader, variableHeader, null);

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnsubscribeMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnsubscribeMessage.java
@@ -20,7 +20,7 @@ package io.netty.handler.codec.mqtt;
  * See <a href="http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#unsubscribe">
  *     MQTTV3.1/unsubscribe</a>
  */
-public class MqttUnsubscribeMessage extends MqttMessage {
+public final class MqttUnsubscribeMessage extends MqttMessage {
 
     public MqttUnsubscribeMessage(
             MqttFixedHeader mqttFixedHeader,

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnsubscribePayload.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnsubscribePayload.java
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * Pyaload of the {@link MqttUnsubscribeMessage}
  */
-public class MqttUnsubscribePayload {
+public final class MqttUnsubscribePayload {
 
     private final List<String> topics;
 

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttVersion.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttVersion.java
@@ -17,6 +17,7 @@
 package io.netty.handler.codec.mqtt;
 
 import io.netty.util.CharsetUtil;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * Mqtt version specific constant values used by multiple classes in mqtt-codec.
@@ -25,12 +26,12 @@ public enum MqttVersion {
     MQTT_3_1("MQIsdp", (byte) 3),
     MQTT_3_1_1("MQTT", (byte) 4);
 
-    private String name;
-    private byte level;
+    private final String name;
+    private final byte level;
 
-    private MqttVersion(String protocolName, byte protocolLevel) {
-        this.name = protocolName;
-        this.level = protocolLevel;
+    MqttVersion(String protocolName, byte protocolLevel) {
+        name = ObjectUtil.checkNotNull(protocolName, "protocolName");
+        level = protocolLevel;
     }
 
     public String protocolName() {
@@ -58,5 +59,4 @@ public enum MqttVersion {
         }
         throw new MqttUnacceptableProtocolVersionException(protocolName + "is unknown protocol name");
     }
-
 }


### PR DESCRIPTION
Motivation:

codec-mqtt had some typos and was not restrict enough in terms of making things final and private constructors.

Modifications:

- Fix typos
- Make most pojos final
- Remove redundant else blocks.

Result:

Cleaner and more restrict code.