### PR TITLE
Cleanup transport-native-epoll code.

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -411,7 +411,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         }
 
         /**
-         * Create a new {@EpollRecvByteAllocatorHandle} instance.
+         * Create a new {@link EpollRecvByteAllocatorHandle} instance.
          * @param handle The handle to wrap with EPOLL specific logic.
          */
         EpollRecvByteAllocatorHandle newEpollHandle(RecvByteBufAllocator.Handle handle) {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -35,6 +35,7 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
     /**
      * @deprecated Use {@link #AbstractEpollServerChannel(Socket, boolean)}.
      */
+    @Deprecated
     protected AbstractEpollServerChannel(int fd) {
         this(new Socket(fd), false);
     }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -640,7 +640,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
         }
     }
 
-    private void safeClosePipe(FileDescriptor fd) {
+    private static void safeClosePipe(FileDescriptor fd) {
         if (fd != null) {
             try {
                 fd.close();
@@ -930,7 +930,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
             return this;
         }
 
-        abstract boolean spliceIn(RecvByteBufAllocator.Handle handle) throws IOException;
+        abstract boolean spliceIn(RecvByteBufAllocator.Handle handle);
 
         protected final int spliceIn(FileDescriptor pipeOut, RecvByteBufAllocator.Handle handle) throws IOException {
             // calculate the maximum amount of data we are allowed to splice
@@ -967,7 +967,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
         }
 
         @Override
-        public boolean spliceIn(RecvByteBufAllocator.Handle handle) throws IOException {
+        public boolean spliceIn(RecvByteBufAllocator.Handle handle) {
             assert ch.eventLoop().inEventLoop();
             if (len == 0) {
                 promise.setSuccess();
@@ -1061,7 +1061,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
     private final class SpliceFdTask extends SpliceInTask {
         private final FileDescriptor fd;
         private final ChannelPromise promise;
-        private int offset;
+        private final int offset;
 
         SpliceFdTask(FileDescriptor fd, int offset, int len, ChannelPromise promise) {
             super(len, promise);
@@ -1076,7 +1076,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
         }
 
         @Override
-        public boolean spliceIn(RecvByteBufAllocator.Handle handle) throws IOException {
+        public boolean spliceIn(RecvByteBufAllocator.Handle handle) {
             assert eventLoop().inEventLoop();
             if (len == 0) {
                 promise.setSuccess();

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -575,7 +575,6 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
                 } catch (Throwable t) {
                     if (data != null) {
                         data.release();
-                        data = null;
                     }
                     exception = t;
                 }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollRecvByteAllocatorHandle.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollRecvByteAllocatorHandle.java
@@ -50,7 +50,7 @@ class EpollRecvByteAllocatorHandle extends RecvByteBufAllocator.DelegatingHandle
          * EPOLL ET requires that we read until we get an EAGAIN
          * (see Q9 in <a href="http://man7.org/linux/man-pages/man7/epoll.7.html">epoll man</a>). However in order to
          * respect auto read we supporting reading to stop if auto read is off. If auto read is on we force reading to
-         * continue to avoid a {@link java.lang.StackOverflowError} between channelReadComplete and reading from the
+         * continue to avoid a {@link StackOverflowError} between channelReadComplete and reading from the
          * channel. It is expected that the {@link #EpollSocketChannel} implementations will track if we are in
          * edgeTriggered mode and all data was not read, and will force a EPOLLIN ready event.
          *

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerSocketChannel.java
@@ -127,6 +127,6 @@ public final class EpollServerSocketChannel extends AbstractEpollServerChannel i
     }
 
     void setTcpMd5Sig(Map<InetAddress, byte[]> keys) throws IOException {
-        this.tcpMd5SigAddresses = TcpMd5Util.newTcpMd5Sigs(this, tcpMd5SigAddresses, keys);
+        tcpMd5SigAddresses = TcpMd5Util.newTcpMd5Sigs(this, tcpMd5SigAddresses, keys);
     }
 }


### PR DESCRIPTION
Motivation:

The code of transport-native-epoll missed some things in terms of static keywords, @deprecated annotations and other minor things.

Modifications:

- Add missing @deprecated annotation
- Not using FQCN in javadocs
- Add static keyword where possible
- Use final fields when possible
- Remove throws IOException from method where it is not needed.

Result:

Cleaner code.