### PR TITLE
Cleanup code and so eliminate warnings.

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCache.java
@@ -28,8 +28,6 @@ public interface DnsCache {
     /**
      * Clears all the resolved addresses cached by this resolver.
      *
-     * @return {@code this}
-     *
      * @see #clear(String)
      */
     void clear();

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -38,7 +38,7 @@ public final class DnsNameResolverBuilder {
     private final EventLoop eventLoop;
     private ChannelFactory<? extends DatagramChannel> channelFactory;
     private InetSocketAddress localAddress = DnsNameResolver.ANY_LOCAL_ADDR;
-    private DnsServerAddresses nameServerAddresses = DefaultDnsServerAddresses.defaultAddresses();
+    private DnsServerAddresses nameServerAddresses = DnsServerAddresses.defaultAddresses();
     private DnsCache resolveCache;
     private Integer minTtl;
     private Integer maxTtl;
@@ -77,7 +77,7 @@ public final class DnsNameResolverBuilder {
      * Sets the {@link ChannelFactory} as a {@link ReflectiveChannelFactory} of this type.
      * Use as an alternative to {@link #channelFactory(ChannelFactory)}.
      *
-     * @param channelType
+     * @param channelType the type
      * @return {@code this}
      */
     public DnsNameResolverBuilder channelType(Class<? extends DatagramChannel> channelType) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddresses.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddresses.java
@@ -23,7 +23,6 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -262,7 +261,7 @@ public abstract class DnsServerAddresses {
 
     /**
      * Starts a new infinite stream of DNS server addresses. This method is invoked by {@link DnsNameResolver} on every
-     * uncached {@link DnsNameResolver#resolve(SocketAddress)} or {@link DnsNameResolver#resolveAll(SocketAddress)}.
+     * uncached {@link DnsNameResolver#resolve(String)}or {@link DnsNameResolver#resolveAll(String)}.
      */
     public abstract DnsServerAddressStream stream();
 }


### PR DESCRIPTION
Motivation:

There were some warning in the resolver-dns code base.

Modifications:

- Fix javadocs
- Use the base class to call static method.

Result:

Cleaner code.