### PR TITLE
Fix type inference w/ JDK8

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessageUtil.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessageUtil.java
@@ -173,7 +173,7 @@ final class DnsMessageUtil {
         for (int i = 0; i < count; i ++) {
             buf.append(StringUtil.NEWLINE)
                .append(StringUtil.TAB)
-               .append(message.recordAt(section, i));
+               .append(message.<DnsRecord>recordAt(section, i));
         }
     }
 


### PR DESCRIPTION
Motivation:

Compile crash w/ JDK8:

```
[ERROR]
/Users/slandelle/Documents/dev/workspaces/workspace-ahc2/async-http-clie
nt-project/netty-bp/codec-dns/src/main/java/io/netty/handler/codec/dns/D
nsMessageUtil.java:[176,16] reference to append is ambiguous
  both method append(java.lang.String) in java.lang.StringBuilder and
method append(java.lang.StringBuffer) in java.lang.StringBuilder match
```

Modification:

Force type explicitly

Result:

Class compiles w/ JDK8