### PR TITLE
[#5029] Fix type of EpollChannelOption.TCP_QUICKACK

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelOption.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelOption.java
@@ -35,7 +35,7 @@ public final class EpollChannelOption<T> extends ChannelOption<T> {
     public static final ChannelOption<Boolean> IP_FREEBIND = ChannelOption.valueOf("IP_FREEBIND");
     public static final ChannelOption<Integer> TCP_FASTOPEN = valueOf(T, "TCP_FASTOPEN");
     public static final ChannelOption<Integer> TCP_DEFER_ACCEPT = ChannelOption.valueOf(T, "TCP_DEFER_ACCEPT");
-    public static final ChannelOption<Integer> TCP_QUICKACK = ChannelOption.valueOf(T, "TCP_QUICKACK");
+    public static final ChannelOption<Boolean> TCP_QUICKACK = ChannelOption.valueOf(T, "TCP_QUICKACK");
 
     public static final ChannelOption<DomainSocketReadMode> DOMAIN_SOCKET_READ_MODE =
             ChannelOption.valueOf(T, "DOMAIN_SOCKET_READ_MODE");


### PR DESCRIPTION
Motivation:

TCP_QUICKACK uses Integer but needs to be Boolean

Modifications:

Fix type

Result:

Be able to use EpollChannelOption.TCP_QUICKACK