### PR TITLE
[#5033] Fix typo in exception message introduced by acbca192bd93b2691…

### DIFF
--- a/transport-native-epoll/src/main/c/netty_unix_socket.c
+++ b/transport-native-epoll/src/main/c/netty_unix_socket.c
@@ -300,7 +300,7 @@ int netty_unix_socket_getOption(JNIEnv* env, jint fd, int level, int optname, vo
         if (err == EBADF) {
             netty_unix_errors_throwClosedChannelException(env);
         } else {
-            netty_unix_errors_throwChannelExceptionErrorNo(env, "setsockopt() failed: ", err);
+            netty_unix_errors_throwChannelExceptionErrorNo(env, "getsockopt() failed: ", err);
         }
     }
     return rc;


### PR DESCRIPTION
…c86c5cec06e4fc1f15d6a05

Motivation:

I introduced a typo as part of acbca192bd93b2691c86c5cec06e4fc1f15d6a05.

Modifications:

Fix typo

Result:

Correct message in exception.