### PR TITLE
EPOLL Socket Shutdown Fix

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/unix/FileDescriptor.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/unix/FileDescriptor.java
@@ -220,18 +220,12 @@ public class FileDescriptor {
         return (state & STATE_OUTPUT_SHUTDOWN_MASK) != 0;
     }
 
-    static boolean shouldAttemptShutdown(int state, boolean read, boolean write) {
-        return !isClosed(state) && (read && !isInputShutdown(state) || write && !isOutputShutdown(state));
+    static int inputShutdown(int state) {
+        return state | STATE_INPUT_SHUTDOWN_MASK;
     }
 
-    static int calculateShutdownState(int state, boolean read, boolean write) {
-        if (read) {
-            state |= STATE_INPUT_SHUTDOWN_MASK;
-        }
-        if (write) {
-            state |= STATE_OUTPUT_SHUTDOWN_MASK;
-        }
-        return state;
+    static int outputShutdown(int state) {
+        return state | STATE_OUTPUT_SHUTDOWN_MASK;
     }
 
     private static native int open(String path);


### PR DESCRIPTION
Motivation:
8dbf5d02e53a72c42467b8dc0a5e1482d5f49af4 modified the shutdown code for Socket but did not correctly calculate the change in shutdown state and only applying this change. This is significant because if sockets are being opening and closed quickly and the underlying FD happens to be reused we need to take care that we don't unintentionally change the state of the new FD by acting on an object which represents the old incarnation of that FD.

Modifications:
- Calculate the shutdown change, and only apply what has changed, or exit if no change.

Result:
Socket.shutdown can not inadvertently affect the state of another logical FD.