### PR TITLE
Add Log4J2LoggerFactory and Log4J2Logger

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -61,6 +61,16 @@
       <artifactId>log4j</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/common/src/main/java/io/netty/util/internal/logging/Log4J2Logger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Log4J2Logger.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal.logging;
+
+import org.apache.logging.log4j.Logger;
+
+final class Log4J2Logger extends AbstractInternalLogger {
+
+    private static final long serialVersionUID = 5485418394879791397L;
+
+    private final transient Logger logger;
+
+    Log4J2Logger(Logger logger) {
+        super(logger.getName());
+        this.logger = logger;
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return logger.isTraceEnabled();
+    }
+
+    @Override
+    public void trace(String msg) {
+        logger.trace(msg);
+    }
+
+    @Override
+    public void trace(String format, Object arg) {
+        logger.trace(format, arg);
+    }
+
+    @Override
+    public void trace(String format, Object argA, Object argB) {
+        logger.trace(format, argA, argB);
+    }
+
+    @Override
+    public void trace(String format, Object... arguments) {
+        logger.trace(format, arguments);
+    }
+
+    @Override
+    public void trace(String msg, Throwable t) {
+        logger.trace(msg, t);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    @Override
+    public void debug(String msg) {
+        logger.debug(msg);
+    }
+
+    @Override
+    public void debug(String format, Object arg) {
+        logger.debug(format, arg);
+    }
+
+    @Override
+    public void debug(String format, Object argA, Object argB) {
+        logger.debug(format, argA, argB);
+    }
+
+    @Override
+    public void debug(String format, Object... arguments) {
+        logger.debug(format, arguments);
+    }
+
+    @Override
+    public void debug(String msg, Throwable t) {
+        logger.debug(msg, t);
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return logger.isInfoEnabled();
+    }
+
+    @Override
+    public void info(String msg) {
+        logger.info(msg);
+    }
+
+    @Override
+    public void info(String format, Object arg) {
+        logger.info(format, arg);
+    }
+
+    @Override
+    public void info(String format, Object argA, Object argB) {
+        logger.info(format, argA, argB);
+    }
+
+    @Override
+    public void info(String format, Object... arguments) {
+        logger.info(format, arguments);
+    }
+
+    @Override
+    public void info(String msg, Throwable t) {
+        logger.info(msg, t);
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return logger.isWarnEnabled();
+    }
+
+    @Override
+    public void warn(String msg) {
+        logger.warn(msg);
+    }
+
+    @Override
+    public void warn(String format, Object arg) {
+        logger.warn(format, arg);
+    }
+
+    @Override
+    public void warn(String format, Object... arguments) {
+        logger.warn(format, arguments);
+    }
+
+    @Override
+    public void warn(String format, Object argA, Object argB) {
+        logger.warn(format, argA, argB);
+    }
+
+    @Override
+    public void warn(String msg, Throwable t) {
+        logger.warn(msg, t);
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return logger.isErrorEnabled();
+    }
+
+    @Override
+    public void error(String msg) {
+        logger.error(msg);
+    }
+
+    @Override
+    public void error(String format, Object arg) {
+        logger.error(format, arg);
+    }
+
+    @Override
+    public void error(String format, Object argA, Object argB) {
+        logger.error(format, argA, argB);
+    }
+
+    @Override
+    public void error(String format, Object... arguments) {
+        logger.error(format, arguments);
+    }
+
+    @Override
+    public void error(String msg, Throwable t) {
+        logger.error(msg, t);
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/logging/Log4J2LoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Log4J2LoggerFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal.logging;
+
+import org.apache.logging.log4j.LogManager;
+
+public final class Log4J2LoggerFactory extends InternalLoggerFactory {
+
+    @Override
+    public InternalLogger newInstance(String name) {
+        return new Log4J2Logger(LogManager.getLogger(name));
+    }
+}

--- a/common/src/test/java/io/netty/util/internal/logging/Log4J2LoggerFactoryTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/Log4J2LoggerFactoryTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal.logging;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Log4J2LoggerFactoryTest {
+
+    @Test
+    public void testCreation() {
+        InternalLogger logger = new Log4J2LoggerFactory().newInstance("foo");
+        assertTrue(logger instanceof Log4J2Logger);
+        assertEquals("foo", logger.name());
+    }
+}

--- a/common/src/test/java/io/netty/util/internal/logging/Log4J2LoggerTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/Log4J2LoggerTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal.logging;
+
+import org.junit.Test;
+import org.apache.logging.log4j.Logger;
+
+import static org.easymock.EasyMock.createStrictMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.junit.Assert.assertTrue;
+
+public class Log4J2LoggerTest {
+    private static final Exception e = new Exception();
+
+    @Test
+    public void testIsTraceEnabled() {
+        Logger mock = createStrictMock(Logger.class);
+
+        expect(mock.getName()).andReturn("foo");
+        expect(mock.isTraceEnabled()).andReturn(true);
+        replay(mock);
+
+        InternalLogger logger = new Log4J2Logger(mock);
+        assertTrue(logger.isTraceEnabled());
+        verify(mock);
+    }
+
+    @Test
+    public void testIsDebugEnabled() {
+        Logger mock = createStrictMock(Logger.class);
+
+        expect(mock.getName()).andReturn("foo");
+        expect(mock.isDebugEnabled()).andReturn(true);
+        replay(mock);
+
+        InternalLogger logger = new Log4J2Logger(mock);
+        assertTrue(logger.isDebugEnabled());
+        verify(mock);
+    }
+
+    @Test
+    public void testIsInfoEnabled() {
+        Logger mock = createStrictMock(Logger.class);
+
+        expect(mock.getName()).andReturn("foo");
+        expect(mock.isInfoEnabled()).andReturn(true);
+        replay(mock);
+
+        InternalLogger logger = new Log4J2Logger(mock);
+        assertTrue(logger.isInfoEnabled());
+        verify(mock);
+    }
+
+    @Test
+    public void testIsWarnEnabled() {
+        Logger mock = createStrictMock(Logger.class);
+
+        expect(mock.getName()).andReturn("foo");
+        expect(mock.isWarnEnabled()).andReturn(true);
+        replay(mock);
+
+        InternalLogger logger = new Log4J2Logger(mock);
+        assertTrue(logger.isWarnEnabled());
+        verify(mock);
+    }
+
+    @Test
+    public void testIsErrorEnabled() {
+        Logger mock = createStrictMock(Logger.class);
+
+        expect(mock.getName()).andReturn("foo");
+        expect(mock.isErrorEnabled()).andReturn(true);
+        replay(mock);
+
+        InternalLogger logger = new Log4J2Logger(mock);
+        assertTrue(logger.isErrorEnabled());
+        verify(mock);
+    }
+
+    @Test
+    public void testTrace() {
+        Logger mock = createStrictMock(Logger.class);
+
+        expect(mock.getName()).andReturn("foo");
+        mock.trace("a");
+        replay(mock);
+
+        InternalLogger logger = new Log4J2Logger(mock);
+        logger.trace("a");
+        verify(mock);
+    }
+
+    @Test
+    public void testTraceWithException() {
+        Logger mock = createStrictMock(Logger.class);
+
+        expect(mock.getName()).andReturn("foo");
+        mock.trace("a", e);
+        replay(mock);
+
+        InternalLogger logger = new Log4J2Logger(mock);
+        logger.trace("a", e);
+        verify(mock);
+    }
+
+    @Test
+    public void testDebug() {
+        Logger mock = createStrictMock(Logger.class);
+
+        expect(mock.getName()).andReturn("foo");
+        mock.debug("a");
+        replay(mock);
+
+        InternalLogger logger = new Log4J2Logger(mock);
+        logger.debug("a");
+        verify(mock);
+    }
+
+    @Test
+    public void testDebugWithException() {
+        Logger mock = createStrictMock(Logger.class);
+
+        expect(mock.getName()).andReturn("foo");
+        mock.debug("a", e);
+        replay(mock);
+
+        InternalLogger logger = new Log4J2Logger(mock);
+        logger.debug("a", e);
+        verify(mock);
+    }
+
+    @Test
+    public void testInfo() {
+        Logger mock = createStrictMock(Logger.class);
+
+        expect(mock.getName()).andReturn("foo");
+        mock.info("a");
+        replay(mock);
+
+        InternalLogger logger = new Log4J2Logger(mock);
+        logger.info("a");
+        verify(mock);
+    }
+
+    @Test
+    public void testInfoWithException() {
+        Logger mock = createStrictMock(Logger.class);
+
+        expect(mock.getName()).andReturn("foo");
+        mock.info("a", e);
+        replay(mock);
+
+        InternalLogger logger = new Log4J2Logger(mock);
+        logger.info("a", e);
+        verify(mock);
+    }
+
+    @Test
+    public void testWarn() {
+        Logger mock = createStrictMock(Logger.class);
+
+        expect(mock.getName()).andReturn("foo");
+        mock.warn("a");
+        replay(mock);
+
+        InternalLogger logger = new Log4J2Logger(mock);
+        logger.warn("a");
+        verify(mock);
+    }
+
+    @Test
+    public void testWarnWithException() {
+        Logger mock = createStrictMock(Logger.class);
+
+        expect(mock.getName()).andReturn("foo");
+        mock.warn("a", e);
+        replay(mock);
+
+        InternalLogger logger = new Log4J2Logger(mock);
+        logger.warn("a", e);
+        verify(mock);
+    }
+
+    @Test
+    public void testError() {
+        Logger mock = createStrictMock(Logger.class);
+
+        expect(mock.getName()).andReturn("foo");
+        mock.error("a");
+        replay(mock);
+
+        InternalLogger logger = new Log4J2Logger(mock);
+        logger.error("a");
+        verify(mock);
+    }
+
+    @Test
+    public void testErrorWithException() {
+        Logger mock = createStrictMock(Logger.class);
+
+        expect(mock.getName()).andReturn("foo");
+        mock.error("a", e);
+        replay(mock);
+
+        InternalLogger logger = new Log4J2Logger(mock);
+        logger.error("a", e);
+        verify(mock);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -383,6 +383,11 @@
         <version>1.1.3</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>2.3</version>
+      </dependency>
+      <dependency>
         <groupId>log4j</groupId>
         <artifactId>log4j</artifactId>
         <version>1.2.17</version>
@@ -520,6 +525,14 @@
         <groupId>org.apache.directory.server</groupId>
         <artifactId>apacheds-protocol-dns</artifactId>
         <version>1.5.7</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- Test dependency for log4j2 tests -->
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>2.3</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
Motivation:

See #3095

Modifications:

Add Log4J2LoggerFactory and Log4J2Logger which is an InternalLogger implementation based on log4j2.

Result:

The user can use log4j2 directly without a special slf4j binding.