### PR TITLE
Added Channels utility class.

### DIFF
--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollChannelsTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollChannelsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.epoll;
+
+import io.netty.channel.Channels;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.oio.OioEventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.channel.socket.oio.OioDatagramChannel;
+import io.netty.channel.socket.oio.OioServerSocketChannel;
+import io.netty.channel.socket.oio.OioSocketChannel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class EpollChannelsTest {
+    @Test
+    public void oioTest() {
+        Class<? extends EventLoopGroup> groupClass = OioEventLoopGroup.class;
+
+        Class<DatagramChannel> datagram = Channels.datagramChannelType(groupClass);
+        Class<SocketChannel> socket = Channels.socketChannelType(groupClass);
+        Class<ServerSocketChannel> serverSocket = Channels.serverSocketChannelType(groupClass);
+
+        assertTrue("datagram channel mismatch.", OioDatagramChannel.class.equals(datagram));
+        assertTrue("socket channel mismatch.", OioSocketChannel.class.equals(socket));
+        assertTrue("server socket channel mismatch.", OioServerSocketChannel.class.equals(serverSocket));
+    }
+
+    @Test
+    public void nioTest() {
+        Class<? extends EventLoopGroup> groupClass = NioEventLoopGroup.class;
+
+        Class<DatagramChannel> datagram = Channels.datagramChannelType(groupClass);
+        Class<SocketChannel> socket = Channels.socketChannelType(groupClass);
+        Class<ServerSocketChannel> serverSocket = Channels.serverSocketChannelType(groupClass);
+
+        assertTrue("datagram channel mismatch.", NioDatagramChannel.class.equals(datagram));
+        assertTrue("socket channel mismatch.", NioSocketChannel.class.equals(socket));
+        assertTrue("server socket channel mismatch.", NioServerSocketChannel.class.equals(serverSocket));
+    }
+
+    @Test
+    public void epollTest() {
+        Class<? extends EventLoopGroup> groupClass = EpollEventLoopGroup.class;
+
+        Class<DatagramChannel> datagram = Channels.datagramChannelType(groupClass);
+        Class<SocketChannel> socket = Channels.socketChannelType(groupClass);
+        Class<ServerSocketChannel> serverSocket = Channels.serverSocketChannelType(groupClass);
+
+        assertTrue("datagram channel mismatch.", EpollDatagramChannel.class.equals(datagram));
+        assertTrue("socket channel mismatch.", EpollSocketChannel.class.equals(socket));
+        assertTrue("server socket channel mismatch.", EpollServerSocketChannel.class.equals(serverSocket));
+    }
+}

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopGroupsTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopGroupsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.epoll;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.EventLoopGroups;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.concurrent.ThreadFactory;
+
+import static org.junit.Assert.assertTrue;
+
+public class EpollEventLoopGroupsTest {
+
+    private EventLoopGroup elg;
+
+    @After
+    public void after() {
+        if (elg != null) {
+            elg.shutdownNow();
+            elg = null;
+        }
+    }
+
+    @Test
+    public void testNativeNoArgs() {
+        elg = EventLoopGroups.fastestNonBlocking();
+        assertTrue("Received unexpected event loop group: " + elg, elg instanceof EpollEventLoopGroup);
+    }
+
+    @Test
+    public void testNativeWithNumThreads() {
+        elg = EventLoopGroups.fastestNonBlocking(2);
+        assertTrue("Received unexpected event loop group: " + elg, elg instanceof EpollEventLoopGroup);
+    }
+
+    @Test
+    public void testNativeWithNumThreadsAndThreadFactory() {
+        ThreadFactory threadFactory = new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r);
+                t.setDaemon(true);
+                return t;
+            }
+        };
+
+        elg = EventLoopGroups.fastestNonBlocking(2, threadFactory);
+        assertTrue("Received unexpected event loop group: " + elg, elg instanceof EpollEventLoopGroup);
+    }
+}

--- a/transport/src/main/java/io/netty/channel/Channels.java
+++ b/transport/src/main/java/io/netty/channel/Channels.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel;
+
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.SocketChannel;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.netty.channel.EventLoopGroups.fqcn;
+import static io.netty.channel.EventLoopGroups.ucFirst;
+
+/**
+ * {@link Channel} helper utilities.
+ */
+public final class Channels {
+    private static final Map<Class<? extends EventLoopGroup>, Class<? extends Channel>> datagram = createDatagramMap();
+    private static final Map<Class<? extends EventLoopGroup>, Class<? extends Channel>> client = createClientMap();
+    private static final Map<Class<? extends EventLoopGroup>, Class<? extends Channel>> server = createServerMap();
+
+    private Channels() {
+    }
+
+    /**
+     * Returns {@link SocketChannel} class that is compatible with specified event loop group.
+     *
+     * @param group event loop group.
+     * @return channel class if found, otherwise <code>null</code>.
+     * @see io.netty.channel.socket.SocketChannel
+     */
+    public static Class<SocketChannel> socketChannelType(EventLoopGroup group) {
+        return (group == null) ? null : socketChannelType(group.getClass());
+    }
+
+    /**
+     * Returns {@link io.netty.channel.socket.SocketChannel} class that is compatible with specified event loop group
+     * class.
+     *
+     * @param groupClass event loop group class.
+     * @return channel class if found, otherwise <code>null</code>.
+     * @see io.netty.channel.socket.SocketChannel
+     */
+    public static Class<SocketChannel> socketChannelType(Class<? extends EventLoopGroup> groupClass) {
+        return (Class<SocketChannel>) getFromMap(client, groupClass);
+    }
+
+    /**
+     * Returns {@link io.netty.channel.socket.ServerSocketChannel} class that is compatible with specified event loop
+     * group.
+     *
+     * @param group event loop group.
+     * @return channel class if found, otherwise <code>null</code>.
+     * @see io.netty.channel.socket.ServerSocketChannel
+     */
+    public static Class<ServerSocketChannel> serverSocketChannelType(EventLoopGroup group) {
+        return (group == null) ? null : serverSocketChannelType(group.getClass());
+    }
+
+    /**
+     * Returns {@link io.netty.channel.socket.ServerSocketChannel} class that is compatible with specified event loop
+     * group class.
+     *
+     * @param groupClass event loop group class.
+     * @return channel class if found, otherwise <code>null</code>.
+     * @see io.netty.channel.socket.SocketChannel
+     */
+    public static Class<ServerSocketChannel> serverSocketChannelType(Class<? extends EventLoopGroup> groupClass) {
+        return (Class<ServerSocketChannel>) getFromMap(server, groupClass);
+    }
+
+    /**
+     * Returns {@link io.netty.channel.socket.DatagramChannel} class that is compatible with specified event loop group.
+     *
+     * @param group event loop group.
+     * @return channel class if found, otherwise <code>null</code>.
+     * @see io.netty.channel.socket.DatagramChannel
+     */
+    public static Class<DatagramChannel> datagramChannelType(EventLoopGroup group) {
+        return (group == null) ? null : datagramChannelType(group.getClass());
+    }
+
+    /**
+     * Returns {@link io.netty.channel.socket.DatagramChannel} class that is compatible with specified event loop group
+     * class.
+     *
+     * @param groupClass event loop group class.
+     * @return channel class if found, otherwise <code>null</code>.
+     * @see io.netty.channel.socket.DatagramChannel
+     */
+    public static Class<DatagramChannel> datagramChannelType(Class<? extends EventLoopGroup> groupClass) {
+        return (Class<DatagramChannel>) getFromMap(datagram, groupClass);
+    }
+
+    private static Class<? extends Channel> getFromMap(
+            Map<Class<? extends EventLoopGroup>, Class<? extends Channel>> map,
+            Class<? extends EventLoopGroup> groupClass) {
+
+        if (map == null || groupClass == null) {
+            return null;
+        }
+
+        Class<? extends Channel> clazz = map.get(groupClass);
+        if (clazz == null) {
+            for (Map.Entry<Class<? extends EventLoopGroup>, Class<? extends Channel>> e : map.entrySet()) {
+                if (e.getKey().isAssignableFrom(groupClass)) {
+                    clazz = e.getValue();
+                    break;
+                }
+            }
+        }
+
+        return clazz;
+    }
+
+    private static Map<Class<? extends EventLoopGroup>, Class<? extends Channel>> createMap() {
+        return new HashMap<Class<? extends EventLoopGroup>, Class<? extends Channel>>(4);
+    }
+
+    private static Map<Class<? extends EventLoopGroup>, Class<? extends Channel>> createDatagramMap() {
+        Map<Class<? extends EventLoopGroup>, Class<? extends Channel>> res = createMap();
+
+        for (String impl : EventLoopGroups.standardImplementations()) {
+            Class<? extends EventLoopGroup> elgClass = loadStandardEventLoopGroupClass(impl);
+            Class<? extends Channel> channelClass = loadStandardChannelClass(impl, "DatagramChannel");
+            if (elgClass == null || channelClass == null) {
+                continue;
+            }
+            res.put(elgClass, channelClass);
+        }
+
+        addNativeImplementations(res, "DatagramChannel");
+
+        return Collections.unmodifiableMap(res);
+    }
+
+    private static Map<Class<? extends EventLoopGroup>, Class<? extends Channel>> createClientMap() {
+        Map<Class<? extends EventLoopGroup>, Class<? extends Channel>> res = createMap();
+
+        for (String impl : EventLoopGroups.standardImplementations()) {
+            Class<? extends EventLoopGroup> elgClass = loadStandardEventLoopGroupClass(impl);
+            Class<? extends Channel> channelClass = loadStandardChannelClass(impl, "SocketChannel");
+            if (elgClass == null || channelClass == null) {
+                continue;
+            }
+            res.put(elgClass, channelClass);
+        }
+
+        addNativeImplementations(res, "SocketChannel");
+        return Collections.unmodifiableMap(res);
+    }
+
+    private static Map<Class<? extends EventLoopGroup>, Class<? extends Channel>> createServerMap() {
+        Map<Class<? extends EventLoopGroup>, Class<? extends Channel>> res = createMap();
+
+        for (String impl : EventLoopGroups.standardImplementations()) {
+            Class<? extends EventLoopGroup> elgClass = loadStandardEventLoopGroupClass(impl);
+            Class<? extends Channel> channelClass = loadStandardChannelClass(impl, "ServerSocketChannel");
+            if (elgClass == null || channelClass == null) {
+                continue;
+            }
+            res.put(elgClass, channelClass);
+        }
+
+        addNativeImplementations(res, "ServerSocketChannel");
+        return Collections.unmodifiableMap(res);
+    }
+
+    private static void addNativeImplementations(Map<Class<? extends EventLoopGroup>, Class<? extends Channel>> map,
+                                                 String classSuffix) {
+        for (String implementation : EventLoopGroups.nativeImplementations()) {
+            String pkg = EventLoopGroups.CHANNEL_PACKAGE + "." + implementation;
+
+            // load event loop group class name
+            String eventLoopGroupClassName = pkg + "." + ucFirst(implementation) + "EventLoopGroup";
+            Class<? extends EventLoopGroup> elgClass = EventLoopGroups.loadEventLoopGroupClass(eventLoopGroupClassName);
+            if (elgClass == null) {
+                continue;
+            }
+
+            // load channel class name.
+            String channelClassName = pkg + "." + ucFirst(implementation) + classSuffix;
+            Class<? extends Channel> channelClass = loadChannelClass(channelClassName);
+            if (channelClass == null) {
+                continue;
+            }
+
+            map.put(elgClass, channelClass);
+        }
+    }
+
+    private static Class<? extends Channel> loadStandardChannelClass(String impl, String className) {
+        return loadChannelClass(fqcn("socket." + impl + "." + ucFirst(impl) + className));
+    }
+
+    private static Class<? extends EventLoopGroup> loadStandardEventLoopGroupClass(String impl) {
+        return EventLoopGroups.loadEventLoopGroupClass(fqcn(impl + "." + ucFirst(impl) + "EventLoopGroup"));
+    }
+
+    private static Class<? extends Channel> loadChannelClass(String fqcn) {
+        return EventLoopGroups.loadClass(fqcn, Channel.class);
+    }
+}

--- a/transport/src/main/java/io/netty/channel/EventLoopGroups.java
+++ b/transport/src/main/java/io/netty/channel/EventLoopGroups.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel;
+
+import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * {@link EventLoopGroup} utilities.
+ */
+public final class EventLoopGroups {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(EventLoopGroups.class);
+
+    protected static final String CHANNEL_PACKAGE = SystemPropertyUtil.get(
+            "io.netty.packagePrefix", EventLoopGroups.class.getPackage().getName());
+
+    private static final List<String> STANDARD_IMPLEMENTATIONS = Collections.unmodifiableList(Arrays.asList(
+            "nio", "oio"));
+
+    private static final List<String> NATIVE_IMPLEMENTATIONS = Collections.unmodifiableList(Arrays.asList(
+            "epoll"
+    ));
+
+    private static final List<Constructor<? extends EventLoopGroup>> EVENT_LOOP_CONSTRUCTORS =
+            createEventLoopGroupConstructors();
+
+    private EventLoopGroups() {
+    }
+
+    /**
+     * Returns list of standard netty event loop group implementations.
+     *
+     * @return list of standard implementations.
+     */
+    protected static List<String> standardImplementations() {
+        return STANDARD_IMPLEMENTATIONS;
+    }
+
+    /**
+     * Returns list of native implementations.
+     *
+     * @return list of native implementations.
+     */
+    protected static List<String> nativeImplementations() {
+        return NATIVE_IMPLEMENTATIONS;
+    }
+
+    /**
+     * Returns fastest non-blocking {@link EventLoopGroup} instance for running platform. Tries to initialize native
+     * implementation for running platform (epoll on Linux for example) first and fallbacks to
+     * {@link io.netty.channel.nio.NioEventLoopGroup} if native implementation for running platform is not available.
+     *
+     * @return event loop group
+     */
+    public static EventLoopGroup fastestNonBlocking() {
+        return fastestNonBlocking(0);
+    }
+
+    /**
+     * Returns fastest non-blocking {@link EventLoopGroup} instance for running platform. Tries to initialize native
+     * implementation for running platform (epoll on Linux for example) first and fallbacks to
+     * {@link io.netty.channel.nio.NioEventLoopGroup} if native implementation for running platform is not available.
+     *
+     * @param nThreads number of threads
+     * @return event loop group
+     */
+    public static EventLoopGroup fastestNonBlocking(int nThreads) {
+        return fastestNonBlocking(nThreads, null);
+    }
+
+    /**
+     * Returns fastest non-blocking {@link EventLoopGroup} instance for running platform. Tries to initialize native
+     * implementation for running platform (epoll on Linux for example) first and fallbacks to
+     * {@link io.netty.channel.nio.NioEventLoopGroup} if native implementation for running platform is not available.
+     *
+     * @param nThreads      number of threads
+     * @param threadFactory thread factory
+     * @return event loop group
+     */
+    public static EventLoopGroup fastestNonBlocking(int nThreads, ThreadFactory threadFactory) {
+        for (Constructor<? extends EventLoopGroup> constructor : EVENT_LOOP_CONSTRUCTORS) {
+            try {
+                return constructor.newInstance(nThreads, threadFactory);
+            } catch (Exception e) {
+                logger.debug("Cannot invoke event loop group constructor: {}", constructor, e);
+            }
+        }
+        throw new IllegalStateException(
+                "Cannot successfully invoke any of discovered createEventLoopGroupConstructors: " +
+                        EVENT_LOOP_CONSTRUCTORS);
+    }
+
+    /**
+     * Tries to load {@link EventLoopGroup} class.
+     *
+     * @param fqcn event loop group fully qualified class name.
+     * @return event loop group class on success, otherwise <code>null</code>.
+     * @see #loadClass(String, Class)
+     */
+    protected static Class<? extends EventLoopGroup> loadEventLoopGroupClass(String fqcn) {
+        return loadClass(fqcn, EventLoopGroup.class);
+    }
+
+    /**
+     * Tries to load class with specified fully qualified class name.
+     *
+     * @param fqcn      fully qualified class name.
+     * @param classType class into which loaded class should be cast.
+     * @param <T>       class type.
+     * @return class on success, otherwise <code>null</code>.
+     */
+    protected static <T> Class<T> loadClass(String fqcn, Class<T> classType) {
+        try {
+            Class<?> clazz = Class.forName(fqcn);
+            return (Class<T>) clazz.asSubclass(classType);
+        } catch (ClassNotFoundException e) {
+            logger.trace("Unable to load class {}: class is not present on classpath.", fqcn);
+            return null;
+        }
+    }
+
+    protected static String ucFirst(String s) {
+        char[] chars = s.toCharArray();
+        chars[0] = Character.toUpperCase(chars[0]);
+        return new String(chars);
+    }
+
+    private static List<Constructor<? extends EventLoopGroup>> createEventLoopGroupConstructors() {
+        List<Constructor<? extends EventLoopGroup>> res = new ArrayList<Constructor<? extends EventLoopGroup>>(4);
+        createEventLoopGroupConstructors(nativeImplementations(), res);
+        createEventLoopGroupConstructors(standardImplementations(), res);
+        return Collections.unmodifiableList(res);
+    }
+
+    private static void createEventLoopGroupConstructors(List<String> implementations,
+                                                         List<Constructor<? extends EventLoopGroup>> dst) {
+        for (String impl : implementations) {
+            try {
+                Class<? extends EventLoopGroup> clazz = loadEventLoopGroupClass(eventLoopGroupClass(impl));
+                Constructor<? extends EventLoopGroup> constructor =
+                        clazz.getConstructor(int.class, ThreadFactory.class);
+                dst.add(constructor);
+            } catch (Exception e) {
+                // no one cares
+            }
+        }
+    }
+
+    protected static String eventLoopGroupClass(String implementation) {
+        String pkg = EventLoopGroups.CHANNEL_PACKAGE + "." + implementation;
+        return pkg + "." + ucFirst(implementation) + "EventLoopGroup";
+    }
+
+    protected static String fqcn(String s) {
+        return EventLoopGroups.CHANNEL_PACKAGE + "." + s;
+    }
+}

--- a/transport/src/test/java/io/netty/channel/ChannelsTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel;
+
+
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.oio.OioEventLoopGroup;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.channel.socket.oio.OioDatagramChannel;
+import io.netty.channel.socket.oio.OioServerSocketChannel;
+import io.netty.channel.socket.oio.OioSocketChannel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class ChannelsTest {
+
+    @Test
+    public void oioTest() {
+        Class<? extends EventLoopGroup> groupClass = OioEventLoopGroup.class;
+
+        Class<DatagramChannel> datagram = Channels.datagramChannelType(groupClass);
+        Class<SocketChannel> socket = Channels.socketChannelType(groupClass);
+        Class<ServerSocketChannel> serverSocket = Channels.serverSocketChannelType(groupClass);
+
+        assertTrue("datagram channel mismatch.", OioDatagramChannel.class.equals(datagram));
+        assertTrue("socket channel mismatch.", OioSocketChannel.class.equals(socket));
+        assertTrue("server socket channel mismatch.", OioServerSocketChannel.class.equals(serverSocket));
+    }
+
+    @Test
+    public void nioTest() {
+        Class<? extends EventLoopGroup> groupClass = NioEventLoopGroup.class;
+
+        Class<DatagramChannel> datagram = Channels.datagramChannelType(groupClass);
+        Class<SocketChannel> socket = Channels.socketChannelType(groupClass);
+        Class<ServerSocketChannel> serverSocket = Channels.serverSocketChannelType(groupClass);
+
+        assertTrue("datagram channel mismatch.", NioDatagramChannel.class.equals(datagram));
+        assertTrue("socket channel mismatch.", NioSocketChannel.class.equals(socket));
+        assertTrue("server socket channel mismatch.", NioServerSocketChannel.class.equals(serverSocket));
+    }
+}

--- a/transport/src/test/java/io/netty/channel/EventLoopGroupsTest.java
+++ b/transport/src/test/java/io/netty/channel/EventLoopGroupsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel;
+
+import io.netty.channel.nio.NioEventLoopGroup;
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.concurrent.ThreadFactory;
+
+import static org.junit.Assert.assertTrue;
+
+public class EventLoopGroupsTest {
+
+    private EventLoopGroup elg;
+
+    @After
+    public void after() {
+        if (elg != null) {
+            elg.shutdownNow();
+            elg = null;
+        }
+    }
+
+    @Test
+    public void testNativeNoArgs() {
+        elg = EventLoopGroups.fastestNonBlocking();
+        assertTrue("Received unexpected event loop group: " + elg, elg instanceof NioEventLoopGroup);
+    }
+
+    @Test
+    public void testNativeWithNumThreads() {
+        elg = EventLoopGroups.fastestNonBlocking(2);
+        assertTrue("Received unexpected event loop group: " + elg, elg instanceof NioEventLoopGroup);
+    }
+
+    @Test
+    public void testNativeWithNumThreadsAndThreadFactory() {
+        ThreadFactory threadFactory = new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r);
+                t.setDaemon(true);
+                return t;
+            }
+        };
+
+        elg = EventLoopGroups.fastestNonBlocking(2, threadFactory);
+        assertTrue("Received unexpected event loop group: " + elg, elg instanceof NioEventLoopGroup);
+    }
+}


### PR DESCRIPTION
```
Added Channels utility class.

Motivation:

Third party libraries using netty often support specifying
netty event loop group for their operation. Because there is
no netty way to map channel classes from event loop group
most of them support/hardcode only nio event loop group
socket channel class family, thus disabling performance gains
provided by epoll on linux operating system.

There was also no API available for creating fastest available
event loop group implementation.

Modifications:

  * added class Channels and tests
  * added class EventLoopGroups and tests

Result:

Libraries can simply query for socket channel classes using
simple API and create fastest available event loop group available.
```
