### PR TITLE
Fix incorrect name encoding/decoding in DNS records

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoder.java
@@ -20,6 +20,8 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.handler.codec.UnsupportedMessageTypeException;
 import io.netty.util.internal.StringUtil;
 
+import static io.netty.handler.codec.dns.DefaultDnsRecordDecoder.ROOT;
+
 /**
  * The default {@link DnsRecordEncoder} implementation.
  *
@@ -77,19 +79,24 @@ public class DefaultDnsRecordEncoder implements DnsRecordEncoder {
     }
 
     protected void encodeName(String name, ByteBuf buf) throws Exception {
-        String[] parts = StringUtil.split(name, '.');
-        for (String part: parts) {
-            final int partLen = part.length();
-            // We always need to write the length even if its 0.
-            // See:
-            // - https://github.com/netty/netty/issues/5014
-            // - https://www.ietf.org/rfc/rfc1035.txt , Section 3.1
-            buf.writeByte(partLen);
-            if (partLen == 0) {
-                continue;
-            }
-            ByteBufUtil.writeAscii(buf, part);
+        if (ROOT.equals(name)) {
+            // Root domain
+            buf.writeByte(0);
+            return;
         }
+
+        final String[] labels = StringUtil.split(name, '.');
+        for (String label : labels) {
+            final int labelLen = label.length();
+            if (labelLen == 0) {
+                // zero-length label means the end of the name.
+                break;
+            }
+
+            buf.writeByte(labelLen);
+            ByteBufUtil.writeAscii(buf, label);
+        }
+
         buf.writeByte(0); // marks end of name field
     }
 }

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoderTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoderTest.java
@@ -24,19 +24,46 @@ import org.junit.Test;
 public class DefaultDnsRecordDecoderTest {
 
     @Test
-    public void testDecodeEmptyName() {
-        testDecodeEmptyName0(Unpooled.buffer().writeByte('0'));
+    public void testDecodeName() {
+        testDecodeName("netty.io.", Unpooled.wrappedBuffer(new byte[] {
+                5, 'n', 'e', 't', 't', 'y', 2, 'i', 'o', 0
+        }));
     }
 
     @Test
-    public void testDecodeEmptyNameNonRFC() {
-        testDecodeEmptyName0(Unpooled.EMPTY_BUFFER);
+    public void testDecodeNameWithoutTerminator() {
+        testDecodeName("netty.io.", Unpooled.wrappedBuffer(new byte[] {
+                5, 'n', 'e', 't', 't', 'y', 2, 'i', 'o'
+        }));
     }
 
-    private static void testDecodeEmptyName0(ByteBuf buffer) {
+    @Test
+    public void testDecodeNameWithExtraTerminator() {
+        // Should not be decoded as 'netty.io..'
+        testDecodeName("netty.io.", Unpooled.wrappedBuffer(new byte[] {
+                5, 'n', 'e', 't', 't', 'y', 2, 'i', 'o', 0, 0
+        }));
+    }
+
+    @Test
+    public void testDecodeEmptyName() {
+        testDecodeName(".", Unpooled.buffer().writeByte(0));
+    }
+
+    @Test
+    public void testDecodeEmptyNameFromEmptyBuffer() {
+        testDecodeName(".", Unpooled.EMPTY_BUFFER);
+    }
+
+    @Test
+    public void testDecodeEmptyNameFromExtraZeroes() {
+        testDecodeName(".", Unpooled.wrappedBuffer(new byte[] { 0, 0 }));
+    }
+
+    private static void testDecodeName(String expected, ByteBuf buffer) {
         try {
             DefaultDnsRecordDecoder decoder = new DefaultDnsRecordDecoder();
-            Assert.assertEquals(StringUtil.EMPTY_STRING, decoder.decodeName(buffer));
+            Assert.assertEquals(expected, decoder.decodeName(buffer));
         } finally {
             buffer.release();
         }

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoderTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoderTest.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.internal.StringUtil;
 import org.junit.Test;
@@ -24,18 +25,42 @@ import static org.junit.Assert.assertEquals;
 
 public class DefaultDnsRecordEncoderTest {
 
+    @Test
+    public void testEncodeName() throws Exception {
+        testEncodeName(new byte[] { 5, 'n', 'e', 't', 't', 'y', 2, 'i', 'o', 0 }, "netty.io.");
+    }
+
+    @Test
+    public void testEncodeNameWithoutTerminator() throws Exception {
+        testEncodeName(new byte[] { 5, 'n', 'e', 't', 't', 'y', 2, 'i', 'o', 0 }, "netty.io");
+    }
+
+    @Test
+    public void testEncodeNameWithExtraTerminator() throws Exception {
+        testEncodeName(new byte[] { 5, 'n', 'e', 't', 't', 'y', 2, 'i', 'o', 0 }, "netty.io..");
+    }
+
     // Test for https://github.com/netty/netty/issues/5014
     @Test
     public void testEncodeEmptyName() throws Exception {
+        testEncodeName(new byte[] { 0 }, StringUtil.EMPTY_STRING);
+    }
+
+    @Test
+    public void testEncodeRootName() throws Exception {
+        testEncodeName(new byte[] { 0 }, ".");
+    }
+
+    private static void testEncodeName(byte[] expected, String name) throws Exception {
         DefaultDnsRecordEncoder encoder = new DefaultDnsRecordEncoder();
         ByteBuf out = Unpooled.buffer();
+        ByteBuf expectedBuf = Unpooled.wrappedBuffer(expected);
         try {
-            encoder.encodeName(StringUtil.EMPTY_STRING, out);
-            assertEquals(2, out.readableBytes());
-            assertEquals(0, out.readByte());
-            assertEquals(0, out.readByte());
+            encoder.encodeName(name, out);
+            assertEquals(expectedBuf, out);
         } finally {
             out.release();
+            expectedBuf.release();
         }
     }
 }


### PR DESCRIPTION
Motivation:

- The decoded name should always end with a dot (.), but we currently
  strip it, which is incorrect.
  - (O) 0 -> "."
  - (X) 0 -> ""
  - (O) 5 netty 2 io 0 -> "netty.io."
  - (X) 5 netty 2 io 0 -> "netty.io"
- The encoded name should end with a null-label, which is a label whose
  length is 0, but we currently append an extra NUL, causing FORMERR(1)
  on a strict DNS server:
  - (O) . -> 0
  - (X) . -> 0 0
  - (O) netty.io. -> 5 netty 2 io 0
  - (X) netty.io. -> 5 netty 2 io 0 0

Modifications:

- Make sure to append '.' when decoding a name.
- Improve index checks so that the decoder can raise
  CorruptFrameException instead of IIOBE
- Do not encode extra NUL
- Add more tests

Result:

Robustness and correctness