### PR TITLE
fix one java doc issue: extra }

### DIFF
--- a/transport/src/main/java/io/netty/channel/WriteBufferWaterMark.java
+++ b/transport/src/main/java/io/netty/channel/WriteBufferWaterMark.java
@@ -22,7 +22,7 @@ package io.netty.channel;
  * for write buffer.
  * <p>
  * If the number of bytes queued in the write buffer exceeds the
- * {@linkplain #high}  high water mark}, {@link Channel#isWritable()}
+ * {@linkplain #high high water mark}, {@link Channel#isWritable()}
  * will start to return {@code false}.
  * <p>
  * If the number of bytes queued in the write buffer exceeds the


### PR DESCRIPTION
fix one java doc issue: extra } 

Motivation:

There is one extra } for WriteBufferWaterMark's javadoc:
{@linkplain #high}  high water mark}

The generated javadoc will show the content: "the high high water mark}"

Modifications:

remove the }

Result:
The generated javadoc will show the content: "the high water mark" instead of "the high high water mark}"