### PR TITLE
[#5059] Deprecate method with typo and introduce a new one without typo

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
@@ -77,6 +77,11 @@ public class HttpResponseEncoderTest {
         }
 
         @Override
+        public long transferred() {
+            return 0;
+        }
+
+        @Override
         public long count() {
             return INTEGER_OVERLFLOW;
         }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -364,7 +364,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
     private boolean writeFileRegion(
             ChannelOutboundBuffer in, DefaultFileRegion region, int writeSpinCount) throws Exception {
         final long regionCount = region.count();
-        if (region.transfered() >= regionCount) {
+        if (region.transferred() >= regionCount) {
             in.remove();
             return true;
         }
@@ -374,7 +374,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
         long flushedAmount = 0;
 
         for (int i = writeSpinCount - 1; i >= 0; i--) {
-            final long offset = region.transfered();
+            final long offset = region.transferred();
             final long localFlushedAmount =
                     Native.sendfile(fd().intValue(), region, baseOffset, offset, regionCount - offset);
             if (localFlushedAmount == 0) {

--- a/transport/src/main/java/io/netty/channel/DefaultFileRegion.java
+++ b/transport/src/main/java/io/netty/channel/DefaultFileRegion.java
@@ -114,8 +114,14 @@ public class DefaultFileRegion extends AbstractReferenceCounted implements FileR
         return count;
     }
 
+    @Deprecated
     @Override
     public long transfered() {
+        return transfered;
+    }
+
+    @Override
+    public long transferred() {
         return transfered;
     }
 

--- a/transport/src/main/java/io/netty/channel/FileRegion.java
+++ b/transport/src/main/java/io/netty/channel/FileRegion.java
@@ -60,9 +60,17 @@ public interface FileRegion extends ReferenceCounted {
     long position();
 
     /**
-     * Return the bytes which was transfered already
+     * Returns the bytes which was transfered already.
+     *
+     * @deprecated Use {@link #transferred()} instead.
      */
+    @Deprecated
     long transfered();
+
+    /**
+     * Returns the bytes which was transfered already.
+     */
+    long transferred();
 
     /**
      * Returns the number of bytes to transfer.

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -201,7 +201,7 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
                 }
             } else if (msg instanceof FileRegion) {
                 FileRegion region = (FileRegion) msg;
-                boolean done = region.transfered() >= region.count();
+                boolean done = region.transferred() >= region.count();
 
                 if (!done) {
                     long flushedAmount = 0;
@@ -217,7 +217,7 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
                         }
 
                         flushedAmount += localFlushedAmount;
-                        if (region.transfered() >= region.count()) {
+                        if (region.transferred() >= region.count()) {
                             done = true;
                             break;
                         }

--- a/transport/src/main/java/io/netty/channel/oio/AbstractOioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/AbstractOioByteChannel.java
@@ -208,9 +208,9 @@ public abstract class AbstractOioByteChannel extends AbstractOioChannel {
                 in.remove();
             } else if (msg instanceof FileRegion) {
                 FileRegion region = (FileRegion) msg;
-                long transfered = region.transfered();
+                long transferred = region.transferred();
                 doWriteFileRegion(region);
-                in.progress(region.transfered() - transfered);
+                in.progress(region.transferred() - transferred);
                 in.remove();
             } else {
                 in.remove(new UnsupportedOperationException(

--- a/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/OioByteStreamChannel.java
@@ -144,9 +144,9 @@ public abstract class OioByteStreamChannel extends AbstractOioByteChannel {
     }
 
     private static void checkEOF(FileRegion region) throws IOException {
-        if (region.transfered() < region.count()) {
+        if (region.transferred() < region.count()) {
             throw new EOFException("Expected to be able to write " + region.count() + " bytes, " +
-                                   "but only wrote " + region.transfered());
+                                   "but only wrote " + region.transferred());
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -253,7 +253,7 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
 
     @Override
     protected long doWriteFileRegion(FileRegion region) throws Exception {
-        final long position = region.transfered();
+        final long position = region.transferred();
         return region.transferTo(javaChannel(), position);
     }
 


### PR DESCRIPTION
Motivation:

There is a spelling error in FileRegion.transfered() as it should be transferred().

Modifications:

Deprecate old method and add a new one.

Result:

Fix typo and can remove the old method later.