### PR TITLE
PoolChunkList not correctly move PoolChunks when these are moved.

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -31,9 +31,39 @@ import java.util.concurrent.locks.LockSupport;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class PooledByteBufAllocatorTest {
+
+    @Test
+    public void testFreePoolChunk() {
+        int chunkSize = 16 * 1024 * 1024;
+        PooledByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 0, 8192, 11, 0, 0, 0);
+        ByteBuf buffer = allocator.heapBuffer(chunkSize);
+        List<PoolArenaMetric> arenas = allocator.heapArenas();
+        assertEquals(1, arenas.size());
+        List<PoolChunkListMetric> lists = arenas.get(0).chunkLists();
+        assertEquals(6, lists.size());
+
+        assertFalse(lists.get(0).iterator().hasNext());
+        assertFalse(lists.get(1).iterator().hasNext());
+        assertFalse(lists.get(2).iterator().hasNext());
+        assertFalse(lists.get(3).iterator().hasNext());
+        assertFalse(lists.get(4).iterator().hasNext());
+
+        // Must end up in the 6th PoolChunkList
+        assertTrue(lists.get(5).iterator().hasNext());
+        assertTrue(buffer.release());
+
+        // Should be completely removed and so all PoolChunkLists must be empty
+        assertFalse(lists.get(0).iterator().hasNext());
+        assertFalse(lists.get(1).iterator().hasNext());
+        assertFalse(lists.get(2).iterator().hasNext());
+        assertFalse(lists.get(3).iterator().hasNext());
+        assertFalse(lists.get(4).iterator().hasNext());
+        assertFalse(lists.get(5).iterator().hasNext());
+    }
 
     // The ThreadDeathWatcher sleeps 1s, give it double that time.
     @Test (timeout = 2000)


### PR DESCRIPTION
Motivation:

When a PoolChunk needs to get moved to the previous PoolChunkList because of the minUsage / maxUsage constraints we always just moved it one level which is incorrect and so could lead to have PoolChunks in the wrong PoolChunkList (in respect to their minUsage / maxUsage settings). This then could have the effect that PoolChunks are not released / freed in a timely fashion and so.

Modifications:

- Correctly move PoolChunks between PoolChunkLists, which includes moving it multiple "levels".
- Add unit test

Result:

Correctlty move the PoolChunk to PoolChunkList when it is freed, even if its multiple layers.