### PR TITLE
Fix PoolChunkList.minUsage() and maxUsage() for head and tail

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
@@ -122,12 +122,12 @@ final class PoolChunkList<T> implements PoolChunkListMetric {
 
     @Override
     public int minUsage() {
-        return minUsage;
+        return minUsage == Integer.MIN_VALUE ? 1 : minUsage;
     }
 
     @Override
     public int maxUsage() {
-        return maxUsage;
+        return maxUsage == Integer.MAX_VALUE ? 100 : maxUsage;
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -35,6 +35,28 @@ import static org.junit.Assert.assertTrue;
 
 public class PooledByteBufAllocatorTest {
 
+    @Test
+    public void testPoolChunkListMetric() {
+        for (PoolArenaMetric arenaMetric: PooledByteBufAllocator.DEFAULT.heapArenas()) {
+            assertPoolChunkListMetric(arenaMetric);
+        }
+    }
+
+    private static void assertPoolChunkListMetric(PoolArenaMetric arenaMetric) {
+        List<PoolChunkListMetric> lists = arenaMetric.chunkLists();
+        assertEquals(6, lists.size());
+        assertPoolChunkListMetric(lists.get(0), 1, 25);
+        assertPoolChunkListMetric(lists.get(1), 1, 50);
+        assertPoolChunkListMetric(lists.get(2), 25, 75);
+        assertPoolChunkListMetric(lists.get(4), 75, 100);
+        assertPoolChunkListMetric(lists.get(5), 100, 100);
+    }
+
+    private static void assertPoolChunkListMetric(PoolChunkListMetric m, int min, int max) {
+        assertEquals(min, m.minUsage());
+        assertEquals(max, m.maxUsage());
+    }
+
     // The ThreadDeathWatcher sleeps 1s, give it double that time.
     @Test (timeout = 2000)
     public void testThreadCacheDestroyedByThreadDeathWatcher() {


### PR DESCRIPTION
Motivation:

The PoolChunkList.minUsage() and maxUsage() needs to take special action to translate Integer.MIN_VALUE / MAX_VALUE as these are used internal for tail and head of the linked-list structure.

Modifications:

- Correct the minUsage() and maxUsage() methods.
- Add unit test.

Result:

Correct metrics