### PR TITLE
Make all InternalLoggerFactory implementations be singletons

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/CommonsLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/CommonsLoggerFactory.java
@@ -28,7 +28,14 @@ import java.util.Map;
  */
 public class CommonsLoggerFactory extends InternalLoggerFactory {
 
-    Map<String, InternalLogger> loggerMap = new HashMap<String, InternalLogger>();
+    public static final InternalLoggerFactory INSTANCE = new CommonsLoggerFactory();
+
+    /**
+     * @deprecated Use {@link #INSTANCE} instead.
+     */
+    @Deprecated
+    public CommonsLoggerFactory() {
+    }
 
     @Override
     public InternalLogger newInstance(String name) {

--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -25,7 +25,7 @@ import io.netty.util.internal.ThreadLocalRandom;
  * {@link JdkLoggerFactory} is used.  You can change it to your preferred
  * logging framework before other Netty classes are loaded:
  * <pre>
- * {@link InternalLoggerFactory}.setDefaultFactory(new {@link Log4JLoggerFactory}());
+ * {@link InternalLoggerFactory}.setDefaultFactory({@link Log4JLoggerFactory}.INSTANCE);
  * </pre>
  * Please note that the new default factory is effective only for the classes
  * which were loaded after the default factory is changed.  Therefore,
@@ -55,10 +55,10 @@ public abstract class InternalLoggerFactory {
             f.newInstance(name).debug("Using SLF4J as the default logging framework");
         } catch (Throwable t1) {
             try {
-                f = new Log4JLoggerFactory();
+                f = Log4JLoggerFactory.INSTANCE;
                 f.newInstance(name).debug("Using Log4J as the default logging framework");
             } catch (Throwable t2) {
-                f = new JdkLoggerFactory();
+                f = JdkLoggerFactory.INSTANCE;
                 f.newInstance(name).debug("Using java.util.logging as the default logging framework");
             }
         }

--- a/common/src/main/java/io/netty/util/internal/logging/JdkLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/JdkLoggerFactory.java
@@ -25,6 +25,15 @@ import java.util.logging.Logger;
  */
 public class JdkLoggerFactory extends InternalLoggerFactory {
 
+    public static final InternalLoggerFactory INSTANCE = new JdkLoggerFactory();
+
+    /**
+     * @deprecated Use {@link #INSTANCE} instead.
+     */
+    @Deprecated
+    public JdkLoggerFactory() {
+    }
+
     @Override
     public InternalLogger newInstance(String name) {
         return new JdkLogger(Logger.getLogger(name));

--- a/common/src/main/java/io/netty/util/internal/logging/Log4J2LoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Log4J2LoggerFactory.java
@@ -19,6 +19,15 @@ import org.apache.logging.log4j.LogManager;
 
 public final class Log4J2LoggerFactory extends InternalLoggerFactory {
 
+    public static final InternalLoggerFactory INSTANCE = new Log4J2LoggerFactory();
+
+    /**
+     * @deprecated Use {@link #INSTANCE} instead.
+     */
+    @Deprecated
+    public Log4J2LoggerFactory() {
+    }
+
     @Override
     public InternalLogger newInstance(String name) {
         return new Log4J2Logger(LogManager.getLogger(name));

--- a/common/src/main/java/io/netty/util/internal/logging/Log4JLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Log4JLoggerFactory.java
@@ -24,6 +24,15 @@ import org.apache.log4j.Logger;
  */
 public class Log4JLoggerFactory extends InternalLoggerFactory {
 
+    public static final InternalLoggerFactory INSTANCE = new Log4JLoggerFactory();
+
+    /**
+     * @deprecated Use {@link #INSTANCE} instead.
+     */
+    @Deprecated
+    public Log4JLoggerFactory() {
+    }
+
     @Override
     public InternalLogger newInstance(String name) {
         return new Log4JLogger(Logger.getLogger(name));

--- a/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
@@ -29,6 +29,12 @@ import java.io.UnsupportedEncodingException;
  */
 public class Slf4JLoggerFactory extends InternalLoggerFactory {
 
+    public static final InternalLoggerFactory INSTANCE = new Slf4JLoggerFactory();
+
+    /**
+     * @deprecated Use {@link #INSTANCE} instead.
+     */
+    @Deprecated
     public Slf4JLoggerFactory() {
     }
 

--- a/common/src/test/java/io/netty/util/internal/logging/CommonsLoggerFactoryTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/CommonsLoggerFactoryTest.java
@@ -23,7 +23,7 @@ public class CommonsLoggerFactoryTest {
 
     @Test
     public void testCreation() {
-        InternalLogger logger = new CommonsLoggerFactory().newInstance("foo");
+        InternalLogger logger = CommonsLoggerFactory.INSTANCE.newInstance("foo");
         assertTrue(logger instanceof CommonsLogger);
         assertEquals("foo", logger.name());
     }

--- a/common/src/test/java/io/netty/util/internal/logging/JdkLoggerFactoryTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/JdkLoggerFactoryTest.java
@@ -23,7 +23,7 @@ public class JdkLoggerFactoryTest {
 
     @Test
     public void testCreation() {
-        InternalLogger logger = new JdkLoggerFactory().newInstance("foo");
+        InternalLogger logger = JdkLoggerFactory.INSTANCE.newInstance("foo");
         assertTrue(logger instanceof JdkLogger);
         assertEquals("foo", logger.name());
     }

--- a/common/src/test/java/io/netty/util/internal/logging/Log4J2LoggerFactoryTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/Log4J2LoggerFactoryTest.java
@@ -24,7 +24,7 @@ public class Log4J2LoggerFactoryTest {
 
     @Test
     public void testCreation() {
-        InternalLogger logger = new Log4J2LoggerFactory().newInstance("foo");
+        InternalLogger logger = Log4J2LoggerFactory.INSTANCE.newInstance("foo");
         assertTrue(logger instanceof Log4J2Logger);
         assertEquals("foo", logger.name());
     }

--- a/common/src/test/java/io/netty/util/internal/logging/Log4JLoggerFactoryTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/Log4JLoggerFactoryTest.java
@@ -23,7 +23,7 @@ public class Log4JLoggerFactoryTest {
 
     @Test
     public void testCreation() {
-        InternalLogger logger = new Log4JLoggerFactory().newInstance("foo");
+        InternalLogger logger = Log4JLoggerFactory.INSTANCE.newInstance("foo");
         assertTrue(logger instanceof Log4JLogger);
         assertEquals("foo", logger.name());
     }

--- a/common/src/test/java/io/netty/util/internal/logging/Slf4JLoggerFactoryTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/Slf4JLoggerFactoryTest.java
@@ -23,7 +23,7 @@ public class Slf4JLoggerFactoryTest {
 
     @Test
     public void testCreation() {
-        InternalLogger logger = new Slf4JLoggerFactory().newInstance("foo");
+        InternalLogger logger = Slf4JLoggerFactory.INSTANCE.newInstance("foo");
         assertTrue(logger instanceof Slf4JLogger);
         assertEquals("foo", logger.name());
     }


### PR DESCRIPTION
Motivation:

It's better to make all InternalLoggerFactory implementations be singletons according to the discussions in #5047

Modifications:

Make all InternalLoggerFactory implementations be singletons and hide the construtors.

Result:

All InternalLoggerFactory implementations be singletons.