### PR TITLE
Revert "[#5028] Fix re-entrance issue with channelWritabilityChanged(…

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -89,7 +89,7 @@ public final class ChannelOutboundBuffer {
     @SuppressWarnings("UnusedDeclaration")
     private volatile int unwritable;
 
-    private final Runnable fireChannelWritabilityChangedTask;
+    private volatile Runnable fireChannelWritabilityChangedTask;
 
     static {
         AtomicIntegerFieldUpdater<ChannelOutboundBuffer> unwritableUpdater =
@@ -107,9 +107,8 @@ public final class ChannelOutboundBuffer {
         TOTAL_PENDING_SIZE_UPDATER = pendingSizeUpdater;
     }
 
-    ChannelOutboundBuffer(final AbstractChannel channel) {
+    ChannelOutboundBuffer(AbstractChannel channel) {
         this.channel = channel;
-        fireChannelWritabilityChangedTask = new ChannelWritabilityChangedTask(channel);
     }
 
     /**
@@ -132,7 +131,7 @@ public final class ChannelOutboundBuffer {
 
         // increment pending bytes after adding message to the unflushed arrays.
         // See https://github.com/netty/netty/issues/1619
-        incrementPendingOutboundBytes(size, true);
+        incrementPendingOutboundBytes(size, false);
     }
 
     /**
@@ -155,7 +154,7 @@ public final class ChannelOutboundBuffer {
                 if (!entry.promise.setUncancellable()) {
                     // Was cancelled so make sure we free up memory and notify about the freed bytes
                     int pending = entry.cancel();
-                    decrementPendingOutboundBytes(pending, true);
+                    decrementPendingOutboundBytes(pending, false, true);
                 }
                 entry = entry.next;
             } while (entry != null);
@@ -169,14 +168,18 @@ public final class ChannelOutboundBuffer {
      * Increment the pending bytes which will be written at some point.
      * This method is thread-safe!
      */
-    void incrementPendingOutboundBytes(long size, boolean notifyWritability) {
+    void incrementPendingOutboundBytes(long size) {
+        incrementPendingOutboundBytes(size, true);
+    }
+
+    private void incrementPendingOutboundBytes(long size, boolean invokeLater) {
         if (size == 0) {
             return;
         }
 
         long newWriteBufferSize = TOTAL_PENDING_SIZE_UPDATER.addAndGet(this, size);
         if (newWriteBufferSize >= channel.config().getWriteBufferHighWaterMark()) {
-            setUnwritable(notifyWritability);
+            setUnwritable(invokeLater);
         }
     }
 
@@ -184,15 +187,19 @@ public final class ChannelOutboundBuffer {
      * Decrement the pending bytes which will be written at some point.
      * This method is thread-safe!
      */
-    void decrementPendingOutboundBytes(long size, boolean notifyWritability) {
+    void decrementPendingOutboundBytes(long size) {
+        decrementPendingOutboundBytes(size, true, true);
+    }
+
+    private void decrementPendingOutboundBytes(long size, boolean invokeLater, boolean notifyWritability) {
         if (size == 0) {
             return;
         }
 
         long newWriteBufferSize = TOTAL_PENDING_SIZE_UPDATER.addAndGet(this, -size);
-        if (newWriteBufferSize == 0
-            || newWriteBufferSize <= channel.config().getWriteBufferLowWaterMark()) {
-            setWritable(notifyWritability);
+        if (notifyWritability && (newWriteBufferSize == 0
+            || newWriteBufferSize <= channel.config().getWriteBufferLowWaterMark())) {
+            setWritable(invokeLater);
         }
     }
 
@@ -257,7 +264,7 @@ public final class ChannelOutboundBuffer {
             // only release message, notify and decrement if it was not canceled before.
             ReferenceCountUtil.safeRelease(msg);
             safeSuccess(promise);
-            decrementPendingOutboundBytes(size, true);
+            decrementPendingOutboundBytes(size, false, true);
         }
 
         // recycle the entry
@@ -293,7 +300,7 @@ public final class ChannelOutboundBuffer {
             ReferenceCountUtil.safeRelease(msg);
 
             safeFail(promise, cause);
-            decrementPendingOutboundBytes(size, notifyWritability);
+            decrementPendingOutboundBytes(size, false, notifyWritability);
         }
 
         // recycle the entry
@@ -515,7 +522,7 @@ public final class ChannelOutboundBuffer {
             final int newValue = oldValue & mask;
             if (UNWRITABLE_UPDATER.compareAndSet(this, oldValue, newValue)) {
                 if (oldValue != 0 && newValue == 0) {
-                    fireChannelWritabilityChanged();
+                    fireChannelWritabilityChanged(true);
                 }
                 break;
             }
@@ -529,7 +536,7 @@ public final class ChannelOutboundBuffer {
             final int newValue = oldValue | mask;
             if (UNWRITABLE_UPDATER.compareAndSet(this, oldValue, newValue)) {
                 if (oldValue == 0 && newValue != 0) {
-                    fireChannelWritabilityChanged();
+                    fireChannelWritabilityChanged(true);
                 }
                 break;
             }
@@ -543,36 +550,48 @@ public final class ChannelOutboundBuffer {
         return 1 << index;
     }
 
-    private void setWritable(boolean notify) {
+    private void setWritable(boolean invokeLater) {
         for (;;) {
             final int oldValue = unwritable;
             final int newValue = oldValue & ~1;
             if (UNWRITABLE_UPDATER.compareAndSet(this, oldValue, newValue)) {
-                if (notify && oldValue != 0 && newValue == 0) {
-                    fireChannelWritabilityChanged();
+                if (oldValue != 0 && newValue == 0) {
+                    fireChannelWritabilityChanged(invokeLater);
                 }
                 break;
             }
         }
     }
 
-    private void setUnwritable(boolean notify) {
+    private void setUnwritable(boolean invokeLater) {
         for (;;) {
             final int oldValue = unwritable;
             final int newValue = oldValue | 1;
             if (UNWRITABLE_UPDATER.compareAndSet(this, oldValue, newValue)) {
-                if (notify && oldValue == 0 && newValue != 0) {
-                    fireChannelWritabilityChanged();
+                if (oldValue == 0 && newValue != 0) {
+                    fireChannelWritabilityChanged(invokeLater);
                 }
                 break;
             }
         }
     }
 
-    private void fireChannelWritabilityChanged() {
-        // Always invoke it later to prevent re-entrance bug.
-        // See https://github.com/netty/netty/issues/5028
-        channel.eventLoop().execute(fireChannelWritabilityChangedTask);
+    private void fireChannelWritabilityChanged(boolean invokeLater) {
+        final ChannelPipeline pipeline = channel.pipeline();
+        if (invokeLater) {
+            Runnable task = fireChannelWritabilityChangedTask;
+            if (task == null) {
+                fireChannelWritabilityChangedTask = task = new Runnable() {
+                    @Override
+                    public void run() {
+                        pipeline.fireChannelWritabilityChanged();
+                    }
+                };
+            }
+            channel.eventLoop().execute(task);
+        } else {
+            pipeline.fireChannelWritabilityChanged();
+        }
     }
 
     /**
@@ -841,27 +860,6 @@ public final class ChannelOutboundBuffer {
             Entry next = this.next;
             recycle();
             return next;
-        }
-    }
-
-    private static final class ChannelWritabilityChangedTask implements Runnable {
-        private final Channel channel;
-        private boolean writable = true;
-
-        ChannelWritabilityChangedTask(Channel channel) {
-            this.channel = channel;
-        }
-
-        @Override
-        public void run() {
-            if (channel.isActive()) {
-                boolean newWritable = channel.isWritable();
-
-                if (writable != newWritable) {
-                    writable = newWritable;
-                    channel.pipeline().fireChannelWritabilityChanged();
-                }
-            }
         }
     }
 }

--- a/transport/src/main/java/io/netty/channel/DefaultChannelHandlerInvoker.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelHandlerInvoker.java
@@ -470,9 +470,7 @@ public class DefaultChannelHandlerInvoker implements ChannelHandlerInvoker {
                 // Check for null as it may be set to null if the channel is closed already
                 if (buffer != null) {
                     task.size = ((AbstractChannel) ctx.channel()).estimatorHandle().size(msg) + WRITE_TASK_OVERHEAD;
-                    // We increment the pending bytes but NOT call fireChannelWritabilityChanged() because this
-                    // will be done automaticaly once we add the message to the ChannelOutboundBuffer.
-                    buffer.incrementPendingOutboundBytes(task.size, false);
+                    buffer.incrementPendingOutboundBytes(task.size);
                 } else {
                     task.size = 0;
                 }
@@ -493,9 +491,7 @@ public class DefaultChannelHandlerInvoker implements ChannelHandlerInvoker {
                 ChannelOutboundBuffer buffer = ctx.channel().unsafe().outboundBuffer();
                 // Check for null as it may be set to null if the channel is closed already
                 if (ESTIMATE_TASK_SIZE_ON_SUBMIT && buffer != null) {
-                    // We decrement the pending bytes but NOT call fireChannelWritabilityChanged() because this
-                    // will be done automaticaly once we pick up the messages out of the buffer to actually write these.
-                    buffer.decrementPendingOutboundBytes(size, false);
+                    buffer.decrementPendingOutboundBytes(size);
                 }
                 invokeWriteNow(ctx, msg, promise);
             } finally {

--- a/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
+++ b/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
@@ -94,7 +94,7 @@ public final class PendingWriteQueue {
         // if the channel was already closed when constructing the PendingWriteQueue.
         // See https://github.com/netty/netty/issues/3967
         if (buffer != null) {
-            buffer.incrementPendingOutboundBytes(write.size, true);
+            buffer.incrementPendingOutboundBytes(write.size);
         }
     }
 
@@ -264,7 +264,7 @@ public final class PendingWriteQueue {
         // if the channel was already closed when constructing the PendingWriteQueue.
         // See https://github.com/netty/netty/issues/3967
         if (buffer != null) {
-            buffer.decrementPendingOutboundBytes(writeSize, true);
+            buffer.decrementPendingOutboundBytes(writeSize);
         }
     }
 

--- a/transport/src/test/java/io/netty/channel/BaseChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/BaseChannelTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalServerChannel;
+
+import static org.junit.Assert.*;
+
+class BaseChannelTest {
+
+    private final LoggingHandler loggingHandler;
+
+    BaseChannelTest() {
+        loggingHandler = new LoggingHandler();
+    }
+
+    ServerBootstrap getLocalServerBootstrap() {
+        EventLoopGroup serverGroup = new DefaultEventLoopGroup();
+        ServerBootstrap sb = new ServerBootstrap();
+        sb.group(serverGroup);
+        sb.channel(LocalServerChannel.class);
+        sb.childHandler(new ChannelInitializer<LocalChannel>() {
+            @Override
+            public void initChannel(LocalChannel ch) throws Exception {
+            }
+        });
+
+        return sb;
+    }
+
+    Bootstrap getLocalClientBootstrap() {
+        EventLoopGroup clientGroup = new DefaultEventLoopGroup();
+        Bootstrap cb = new Bootstrap();
+        cb.channel(LocalChannel.class);
+        cb.group(clientGroup);
+
+        cb.handler(loggingHandler);
+
+        return cb;
+    }
+
+    static ByteBuf createTestBuf(int len) {
+        ByteBuf buf = Unpooled.buffer(len, len);
+        buf.setIndex(0, len);
+        return buf;
+    }
+
+    void assertLog(String firstExpected, String... otherExpected) {
+        String actual = loggingHandler.getLog();
+        if (firstExpected.equals(actual)) {
+            return;
+        }
+        for (String e: otherExpected) {
+            if (e.equals(actual)) {
+                return;
+            }
+        }
+
+        // Let the comparison fail with the first expectation.
+        assertEquals(firstExpected, actual);
+    }
+
+    void clearLog() {
+        loggingHandler.clear();
+    }
+
+    void setInterest(LoggingHandler.Event... events) {
+        loggingHandler.setInterest(events);
+    }
+
+}

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -229,17 +229,11 @@ public class ChannelOutboundBufferTest {
 
         // Ensure exceeding the high watermark makes channel unwritable.
         ch.write(buffer().writeZero(128));
-        assertThat(buf.toString(), is(""));
-
-        ch.runPendingTasks();
         assertThat(buf.toString(), is("false "));
 
         // Ensure going down to the low watermark makes channel writable again by flushing the first write.
         assertThat(ch.unsafe().outboundBuffer().remove(), is(true));
         assertThat(ch.unsafe().outboundBuffer().totalPendingWriteBytes(), is(128L));
-        assertThat(buf.toString(), is("false "));
-
-        ch.runPendingTasks();
         assertThat(buf.toString(), is("false true "));
 
         safeClose(ch);
@@ -337,9 +331,6 @@ public class ChannelOutboundBufferTest {
 
         // Trigger channelWritabilityChanged() by writing a lot.
         ch.write(buffer().writeZero(256));
-        assertThat(buf.toString(), is(""));
-
-        ch.runPendingTasks();
         assertThat(buf.toString(), is("false "));
 
         // Ensure that setting a user-defined writability flag to false does not trigger channelWritabilityChanged()


### PR DESCRIPTION
…...) and write(...)"

Motivation:
Revert d0943dcd30b08eb4043aeb88fd983bcebf8c3432. Delaying the notification of writability change may lead to notification being missed. This is a ABA type of concurrency problem.

Modifications:
- Revert d0943dcd30b08eb4043aeb88fd983bcebf8c3432.

Result:
channelWritabilityChange will be called on every change, and will not be suppressed due to ABA scenario.