### PR TITLE
Allow to retrieve the number of active bytes per PoolArena.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArenaMetric.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArenaMetric.java
@@ -132,4 +132,9 @@ public interface PoolArenaMetric {
      * Return the number of currently active huge allocations.
      */
     long numActiveHugeAllocations();
+
+    /**
+     * Return the number of active bytes that are currently allocated by the arena.
+     */
+    long numActiveBytes();
 }


### PR DESCRIPTION
Motivation:

To better understand how much memory is used by Netty for ByteBufs it is useful to understand how many bytes are currently active (allocated) per PoolArena.

Modifications:

- Add PoolArenaMetric.numActiveBytes()
- Simplify code by using Math.max(...)

Result:

The user is able to get better insight into the PooledByteBufAllocator.