### PR TITLE
Add PooledByteBufAllocator.dumpStatus() which allows to obtain a huma…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -18,6 +18,7 @@ package io.netty.buffer;
 
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -454,31 +455,33 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator {
         return threadCache.get();
     }
 
-    // Too noisy at the moment.
-    //
-    //public String toString() {
-    //    StringBuilder buf = new StringBuilder();
-    //    int heapArenasLen = heapArenas == null ? 0 : heapArenas.length;
-    //    buf.append(heapArenasLen);
-    //    buf.append(" heap arena(s):");
-    //    buf.append(StringUtil.NEWLINE);
-    //    if (heapArenasLen > 0) {
-    //        for (PoolArena<byte[]> a: heapArenas) {
-    //            buf.append(a);
-    //        }
-    //    }
-    //
-    //    int directArenasLen = directArenas == null ? 0 : directArenas.length;
-    //
-    //    buf.append(directArenasLen);
-    //    buf.append(" direct arena(s):");
-    //    buf.append(StringUtil.NEWLINE);
-    //    if (directArenasLen > 0) {
-    //        for (PoolArena<ByteBuffer> a: directArenas) {
-    //            buf.append(a);
-    //        }
-    //    }
-    //
-    //    return buf.toString();
-    //}
+    /**
+     * Returns the status of the allocator (which contains all metrics) as string. Be aware this may be expensive
+     * and so should not called too frequently.
+     */
+    public String dumpStats() {
+        int heapArenasLen = heapArenas == null ? 0 : heapArenas.length;
+        StringBuilder buf = new StringBuilder(512)
+                .append(heapArenasLen)
+                .append(" heap arena(s):")
+                .append(StringUtil.NEWLINE);
+        if (heapArenasLen > 0) {
+            for (PoolArena<byte[]> a: heapArenas) {
+                buf.append(a);
+            }
+        }
+
+        int directArenasLen = directArenas == null ? 0 : directArenas.length;
+
+        buf.append(directArenasLen)
+           .append(" direct arena(s):")
+           .append(StringUtil.NEWLINE);
+        if (directArenasLen > 0) {
+            for (PoolArena<ByteBuffer> a: directArenas) {
+                buf.append(a);
+            }
+        }
+
+        return buf.toString();
+    }
 }


### PR DESCRIPTION
…n-readable status of the allocator.

Motiviation:

Sometimes it is useful to dump the status of the PooledByteBufAllocator and log it. Doing this is currently a bit cumbersome as the user needs to basically iterate through all the metrics and compose the String. we would better provide an easy way to do this.

Modification:

Add dumpStatus() method.

Result:

Easier to get a view into the status of the allocator.