### PR TITLE
Allow to create a JdkSslContext from an existing JDK SSLContext. Rela…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -570,22 +570,6 @@ public abstract class OpenSslContext extends SslContext {
         return bio;
     }
 
-    static PrivateKey toPrivateKeyInternal(File keyFile, String keyPassword) throws SSLException {
-        try {
-            return SslContext.toPrivateKey(keyFile, keyPassword);
-        } catch (Exception e) {
-            throw new SSLException(e);
-        }
-    }
-
-    static X509Certificate[] toX509CertificatesInternal(File file) throws SSLException {
-        try {
-            return SslContext.toX509Certificates(file);
-        } catch (CertificateException e) {
-            throw new SSLException(e);
-        }
-    }
-
     static void checkKeyManagerFactory(KeyManagerFactory keyManagerFactory) {
         if (keyManagerFactory != null) {
             throw new IllegalArgumentException(

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -1018,4 +1018,20 @@ public abstract class SslContext {
 
         return trustManagerFactory;
     }
+
+    static PrivateKey toPrivateKeyInternal(File keyFile, String keyPassword) throws SSLException {
+        try {
+            return toPrivateKey(keyFile, keyPassword);
+        } catch (Exception e) {
+            throw new SSLException(e);
+        }
+    }
+
+    static X509Certificate[] toX509CertificatesInternal(File file) throws SSLException {
+        try {
+            return toX509Certificates(file);
+        } catch (CertificateException e) {
+            throw new SSLException(e);
+        }
+    }
 }


### PR DESCRIPTION
…ted to [#5095] and [#4929]

Motivation:

Sometimes a user only has access to a preconfigured SSLContext but still would like to use our ssl sub-system. For this situations it would be very useful if the user could create a JdkSslContext instance from an existing SSLContext.

Modifications:

- Create new public constructors in JdkSslContext which allow to wrap an existing SSLContext and make the class non-abstract
- Mark JdkSslServerContext and JdkSslClientContext as deprecated as the user should not directly use these.

Result:

It's now possible to create an JdkSslContext from an existing SSLContext.