### PR TITLE
Remove ByteBuf.readBytes(int) calls when possible

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -437,9 +437,10 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
             numberOfBytesConsumed += size;
             return new Result<String>(null, numberOfBytesConsumed);
         }
-        ByteBuf buf = buffer.readBytes(size);
+        String s = buffer.toString(buffer.readerIndex(), size, CharsetUtil.UTF_8);
+        buffer.skipBytes(size);
         numberOfBytesConsumed += size;
-        return new Result<String>(buf.toString(CharsetUtil.UTF_8), numberOfBytesConsumed);
+        return new Result<String>(s, numberOfBytesConsumed);
     }
 
     private static Result<Integer> decodeMsbLsb(ByteBuf buffer) {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksAuthRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksAuthRequestDecoder.java
@@ -19,7 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.handler.codec.socks.SocksAuthRequestDecoder.State;
-import io.netty.util.CharsetUtil;
 
 import java.util.List;
 
@@ -51,12 +50,12 @@ public class SocksAuthRequestDecoder extends ReplayingDecoder<State> {
             }
             case READ_USERNAME: {
                 fieldLength = byteBuf.readByte();
-                username = byteBuf.readBytes(fieldLength).toString(CharsetUtil.US_ASCII);
+                username = SocksCommonUtils.readUsAscii(byteBuf, fieldLength);
                 checkpoint(State.READ_PASSWORD);
             }
             case READ_PASSWORD: {
                 fieldLength = byteBuf.readByte();
-                password = byteBuf.readBytes(fieldLength).toString(CharsetUtil.US_ASCII);
+                password = SocksCommonUtils.readUsAscii(byteBuf, fieldLength);
                 msg = new SocksAuthRequest(username, password);
             }
         }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequestDecoder.java
@@ -19,7 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.handler.codec.socks.SocksCmdRequestDecoder.State;
-import io.netty.util.CharsetUtil;
 
 import java.util.List;
 
@@ -69,13 +68,15 @@ public class SocksCmdRequestDecoder extends ReplayingDecoder<State> {
                     }
                     case DOMAIN: {
                         fieldLength = byteBuf.readByte();
-                        host = byteBuf.readBytes(fieldLength).toString(CharsetUtil.US_ASCII);
+                        host = SocksCommonUtils.readUsAscii(byteBuf, fieldLength);
                         port = byteBuf.readUnsignedShort();
                         msg = new SocksCmdRequest(cmdType, addressType, host, port);
                         break;
                     }
                     case IPv6: {
-                        host = SocksCommonUtils.ipv6toStr(byteBuf.readBytes(16).array());
+                        byte[] bytes = new byte[16];
+                        byteBuf.readBytes(bytes);
+                        host = SocksCommonUtils.ipv6toStr(bytes);
                         port = byteBuf.readUnsignedShort();
                         msg = new SocksCmdRequest(cmdType, addressType, host, port);
                         break;

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponseDecoder.java
@@ -19,7 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.handler.codec.socks.SocksCmdResponseDecoder.State;
-import io.netty.util.CharsetUtil;
 
 import java.util.List;
 
@@ -68,13 +67,15 @@ public class SocksCmdResponseDecoder extends ReplayingDecoder<State> {
                     }
                     case DOMAIN: {
                         fieldLength = byteBuf.readByte();
-                        host = byteBuf.readBytes(fieldLength).toString(CharsetUtil.US_ASCII);
+                        host = SocksCommonUtils.readUsAscii(byteBuf, fieldLength);
                         port = byteBuf.readUnsignedShort();
                         msg = new SocksCmdResponse(cmdStatus, addressType, host, port);
                         break;
                     }
                     case IPv6: {
-                        host = SocksCommonUtils.ipv6toStr(byteBuf.readBytes(16).array());
+                        byte[] bytes = new byte[16];
+                        byteBuf.readBytes(bytes);
+                        host = SocksCommonUtils.ipv6toStr(bytes);
                         port = byteBuf.readUnsignedShort();
                         msg = new SocksCmdResponse(cmdStatus, addressType, host, port);
                         break;

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCommonUtils.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCommonUtils.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.socks;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.util.CharsetUtil;
 import io.netty.util.internal.StringUtil;
 
 final class SocksCommonUtils {
@@ -102,5 +104,11 @@ final class SocksCommonUtils {
 
     private static void appendHextet(StringBuilder sb, byte[] src, int i) {
         StringUtil.toHexString(sb, src, i << 1, 2);
+    }
+
+    static String readUsAscii(ByteBuf buffer, int length) {
+        String s = buffer.toString(buffer.readerIndex(), length, CharsetUtil.US_ASCII);
+        buffer.skipBytes(length);
+        return s;
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
@@ -60,7 +60,7 @@ public class ProtobufVarint32FrameDecoder extends ByteToMessageDecoder {
             in.resetReaderIndex();
             return;
         } else {
-            out.add(in.readBytes(length));
+            out.add(in.readSlice(length).retain());
             return;
         }
     }


### PR DESCRIPTION
Motivation:

We use ByteBuf.readBytes(int) in various places where we could either remove it completely or use readSlice(int).retain().

Modifications:

- Remove ByteBuf.readBytes(int) when possible or replace by readSlice(int).retain().

Result:

Faster code.