### PR TITLE
PoolChunkList.allocate(...) should return false without the need to w…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -95,12 +95,12 @@ abstract class PoolArena<T> implements PoolArenaMetric {
             smallSubpagePools[i] = newSubpagePoolHead(pageSize);
         }
 
-        q100 = new PoolChunkList<T>(null, 100, Integer.MAX_VALUE);
-        q075 = new PoolChunkList<T>(q100, 75, 100);
-        q050 = new PoolChunkList<T>(q075, 50, 100);
-        q025 = new PoolChunkList<T>(q050, 25, 75);
-        q000 = new PoolChunkList<T>(q025, 1, 50);
-        qInit = new PoolChunkList<T>(q000, Integer.MIN_VALUE, 25);
+        q100 = new PoolChunkList<T>(null, 100, Integer.MAX_VALUE, chunkSize);
+        q075 = new PoolChunkList<T>(q100, 75, 100, chunkSize);
+        q050 = new PoolChunkList<T>(q075, 50, 100, chunkSize);
+        q025 = new PoolChunkList<T>(q050, 25, 75, chunkSize);
+        q000 = new PoolChunkList<T>(q025, 1, 50, chunkSize);
+        qInit = new PoolChunkList<T>(q000, Integer.MIN_VALUE, 25, chunkSize);
 
         q100.prevList(q075);
         q075.prevList(q050);


### PR DESCRIPTION
…alk all the contained PoolChunks when the requested capacity is too big.

Motivation:

PoolChunkList.allocate(...) should return false without the need to walk all the contained PoolChunks when the requested capacity is larger then the capacity that can be allocated out of the PoolChunks in respect to the minUsage() and maxUsage() of the PoolChunkList.

Modifications:

Precompute the maximal capacity that can be allocated out of the PoolChunks that are contained in the PoolChunkList and use this to fast return from the allocate(...) method if an allocation capacity larger then that is requested.

Result:

Faster detection of allocations that can not be handled by the PoolChunkList and so faster allocations in general via the PoolArena.