### PR TITLE
Replace usage of ByteBuf.readBytes(...) with ByteBufUtil.readBytes(..…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -786,8 +786,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
             return Unpooled.EMPTY_BUFFER;
         }
 
-        // Use an unpooled heap buffer because there's no way to mandate a user to free the returned buffer.
-        ByteBuf buf = Unpooled.buffer(length, maxCapacity);
+        ByteBuf buf = alloc().buffer(length, maxCapacity);
         buf.writeBytes(this, readerIndex, length);
         readerIndex += length;
         return buf;

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -1496,6 +1496,7 @@ public abstract class AbstractByteBufTest {
             // Make sure if it is a copied buffer.
             actualValue.setByte(0, (byte) (actualValue.getByte(0) + 1));
             assertFalse(buffer.getByte(i) == actualValue.getByte(0));
+            actualValue.release();
         }
     }
 
@@ -2978,6 +2979,21 @@ public abstract class AbstractByteBufTest {
             }
             file.delete();
         }
+    }
+
+    @Test
+    public void testReadBytes() {
+        ByteBuf buffer = newBuffer(8);
+        byte[] bytes = new byte[8];
+        buffer.writeBytes(bytes);
+
+        ByteBuf buffer2 = buffer.readBytes(4);
+        assertSame(buffer.alloc(), buffer2.alloc());
+        assertEquals(4, buffer.readerIndex());
+        assertTrue(buffer.release());
+        assertEquals(0, buffer.refCnt());
+        assertTrue(buffer2.release());
+        assertEquals(0, buffer2.refCnt());
     }
 
     private void testRefCnt0(final boolean parameter) throws Exception {

--- a/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
@@ -117,7 +117,13 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
     @Test
     @Override
     public void testLittleEndianWithExpand() {
-       // ignore for SlicedByteBuf
+        // ignore for SlicedByteBuf
+    }
+
+    @Test
+    @Override
+    public void testReadBytes() {
+        // ignore for SlicedByteBuf
     }
 
     @Test


### PR DESCRIPTION
….) to allow using the allocator to create the new buffer. Related to [#5093]

Motivation:

ByteBuf.readBytes(...) uses Unpooled.buffer(...) internally which will use a heap ByteBuf and also not able to make use of the allocator which may be pooled. We should better make use of ByteBufUtil.readBytes(...) to ensure we make use of the allocator.

Modifications:

Replace ByteBuf.readBytes(...) usage with ByteBufUtil.readBytes(...) for the reasons explained above.

Result:

Take allocator into account when copy bytes.