### PR TITLE
Add logging configuration to pom.xml

### DIFF
--- a/common/src/test/resources/logback-test.xml
+++ b/common/src/test/resources/logback-test.xml
@@ -1,0 +1,11 @@
+<configuration debug="false">
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="${logLevel:-info}">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,8 @@
     <tcnative.version>1.1.33.Fork15</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <epoll.classifier>${os.detected.name}-${os.detected.arch}</epoll.classifier>
+    <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>
+    <logging.logLevel>debug</logging.logLevel>
   </properties>
 
   <modules>
@@ -807,6 +809,10 @@
             <exclude>**/TestUtil*</exclude>
           </excludes>
           <runOrder>random</runOrder>
+          <systemPropertyVariables>
+            <logback.configurationFile>${logging.config}</logback.configurationFile>
+            <logLevel>${logging.logLevel}</logLevel>
+          </systemPropertyVariables>
           <argLine>${argLine.common} ${argLine.alpnAgent} ${argLine.leak} ${argLine.coverage} ${argLine.noUnsafe}</argLine>
           <properties>
             <property>


### PR DESCRIPTION
Motivation:
Currently the default log level when running tests is debug. When
running the build on the CI server it might be nice to avoid this debug
level and allow for the level to be configured.

Modifications:
Re-using the logback.xml configuration that exists for the example
module. This allows for the logLevel to be configured.
The default level will still be debug.

Result:
The log level can now be configured from the command line:
$ mvn test -DlogLevel=error