### PR TITLE
Make derived buffers recyclable / Add missing overrides to ByteBuf impls

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -70,6 +70,11 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
     public int maxCapacity() {
         return maxCapacity;
     }

--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -800,6 +800,13 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf readSliceRetained(int length) {
+        ByteBuf slice = sliceRetained(readerIndex, length);
+        readerIndex += length;
+        return slice;
+    }
+
+    @Override
     public ByteBuf readBytes(byte[] dst, int dstIndex, int length) {
         checkReadableBytes(length);
         getBytes(readerIndex, dst, dstIndex, length);
@@ -1112,17 +1119,32 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf duplicate() {
-        return new DuplicatedAbstractByteBuf(this);
+        return ByteBufUtil.duplicate(this);
+    }
+
+    @Override
+    public ByteBuf duplicateRetained() {
+        return duplicate().retain();
     }
 
     @Override
     public ByteBuf slice() {
-        return slice(readerIndex, readableBytes());
+        return ByteBufUtil.slice(this);
+    }
+
+    @Override
+    public ByteBuf sliceRetained() {
+        return slice().retain();
     }
 
     @Override
     public ByteBuf slice(int index, int length) {
-        return new SlicedAbstractByteBuf(this, index, length);
+        return ByteBufUtil.slice(this, index, length);
+    }
+
+    @Override
+    public ByteBuf sliceRetained(int index, int length) {
+        return slice(index, length).retain();
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBufAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/AbstractDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractDerivedByteBuf.java
@@ -71,6 +71,11 @@ public abstract class AbstractDerivedByteBuf extends AbstractByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return unwrap().isReadOnly();
+    }
+
+    @Override
     public ByteBuffer internalNioBuffer(int index, int length) {
         return nioBuffer(index, length);
     }

--- a/buffer/src/main/java/io/netty/buffer/AbstractDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractDerivedByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -21,7 +21,10 @@ import java.nio.ByteBuffer;
 /**
  * Abstract base class for {@link ByteBuf} implementations that wrap another
  * {@link ByteBuf}.
+ *
+ * @deprecated Do not use.
  */
+@Deprecated
 public abstract class AbstractDerivedByteBuf extends AbstractByteBuf {
 
     protected AbstractDerivedByteBuf(int maxCapacity) {

--- a/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer;
+
+import io.netty.util.Recycler.Handle;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Abstract base class for derived {@link ByteBuf} implementations.
+ */
+abstract class AbstractPooledDerivedByteBuf<T> extends AbstractByteBuf {
+
+    private final Handle<AbstractPooledDerivedByteBuf<T>> recyclerHandle;
+    private AbstractByteBuf buffer;
+
+    @SuppressWarnings("unchecked")
+    AbstractPooledDerivedByteBuf(Handle<? extends AbstractPooledDerivedByteBuf<T>> recyclerHandle) {
+        super(0);
+        this.recyclerHandle = (Handle<AbstractPooledDerivedByteBuf<T>>) recyclerHandle;
+    }
+
+    @Override
+    public final AbstractByteBuf unwrap() {
+        return buffer;
+    }
+
+    final <U extends AbstractPooledDerivedByteBuf<T>> U init(
+            AbstractByteBuf buffer, int readerIndex, int writerIndex, int maxCapacity) {
+
+        this.buffer = buffer;
+        maxCapacity(maxCapacity);
+
+        setIndex(readerIndex, writerIndex);
+
+        @SuppressWarnings("unchecked")
+        final U castThis = (U) this;
+
+        return castThis;
+    }
+
+    @Override
+    public final int refCnt() {
+        final AbstractByteBuf unwrapped = unwrap();
+        return unwrapped != null ? unwrapped.refCnt() : 0;
+    }
+
+    @Override
+    public final ByteBuf retain() {
+        unwrap().retain();
+        return this;
+    }
+
+    @Override
+    public final ByteBuf retain(int increment) {
+        unwrap().retain(increment);
+        return this;
+    }
+
+    @Override
+    public final ByteBuf touch() {
+        return this;
+    }
+
+    @Override
+    public final ByteBuf touch(Object hint) {
+        return this;
+    }
+
+    @Override
+    public final boolean release() {
+        final boolean deallocated = unwrap().release();
+        if (deallocated) {
+            recycle();
+        }
+        return deallocated;
+    }
+
+    @Override
+    public final boolean release(int decrement) {
+        final boolean deallocated = unwrap().release(decrement);
+        if (deallocated) {
+            recycle();
+        }
+        return deallocated;
+    }
+
+    private void recycle() {
+        recyclerHandle.recycle(this);
+    }
+
+    @Override
+    public final ByteBufAllocator alloc() {
+        return unwrap().alloc();
+    }
+
+    @Override
+    @Deprecated
+    public final ByteOrder order() {
+        return unwrap().order();
+    }
+
+    @Override
+    public final boolean isDirect() {
+        return unwrap().isDirect();
+    }
+
+    @Override
+    public boolean hasArray() {
+        return unwrap().hasArray();
+    }
+
+    @Override
+    public byte[] array() {
+        return unwrap().array();
+    }
+
+    @Override
+    public boolean hasMemoryAddress() {
+        return unwrap().hasMemoryAddress();
+    }
+
+    @Override
+    public final int nioBufferCount() {
+        return unwrap().nioBufferCount();
+    }
+
+    @Override
+    public final ByteBuffer internalNioBuffer(int index, int length) {
+        return nioBuffer(index, length);
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
@@ -116,6 +116,11 @@ abstract class AbstractPooledDerivedByteBuf<T> extends AbstractByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return unwrap().isReadOnly();
+    }
+
+    @Override
     public final boolean isDirect() {
         return unwrap().isDirect();
     }

--- a/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractReferenceCountedByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/AbstractUnsafeSwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractUnsafeSwappedByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -24,6 +24,7 @@ import static io.netty.util.internal.PlatformDependent.BIG_ENDIAN_NATIVE_ORDER;
 /**
  * Special {@link SwappedByteBuf} for {@link ByteBuf}s that is using unsafe.
  */
+@Deprecated
 abstract class AbstractUnsafeSwappedByteBuf extends SwappedByteBuf {
     private final boolean nativeByteOrder;
     private final AbstractByteBuf wrapped;

--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -77,9 +77,21 @@ final class AdvancedLeakAwareByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public ByteBuf sliceRetained() {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.sliceRetained(), leak);
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         recordLeakNonRefCountingOperation(leak);
         return new AdvancedLeakAwareByteBuf(super.slice(index, length), leak);
+    }
+
+    @Override
+    public ByteBuf sliceRetained(int index, int length) {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.sliceRetained(index, length), leak);
     }
 
     @Override
@@ -89,9 +101,21 @@ final class AdvancedLeakAwareByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public ByteBuf duplicateRetained() {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.duplicateRetained(), leak);
+    }
+
+    @Override
     public ByteBuf readSlice(int length) {
         recordLeakNonRefCountingOperation(leak);
         return new AdvancedLeakAwareByteBuf(super.readSlice(length), leak);
+    }
+
+    @Override
+    public ByteBuf readSliceRetained(int length) {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.readSliceRetained(length), leak);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package io.netty.buffer;
 
 
@@ -59,9 +60,21 @@ final class AdvancedLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     }
 
     @Override
+    public ByteBuf sliceRetained() {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.sliceRetained(), leak);
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         recordLeakNonRefCountingOperation(leak);
         return new AdvancedLeakAwareByteBuf(super.slice(index, length), leak);
+    }
+
+    @Override
+    public ByteBuf sliceRetained(int index, int length) {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.sliceRetained(index, length), leak);
     }
 
     @Override
@@ -71,9 +84,21 @@ final class AdvancedLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     }
 
     @Override
+    public ByteBuf duplicateRetained() {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.duplicateRetained(), leak);
+    }
+
+    @Override
     public ByteBuf readSlice(int length) {
         recordLeakNonRefCountingOperation(leak);
         return new AdvancedLeakAwareByteBuf(super.readSlice(length), leak);
+    }
+
+    @Override
+    public ByteBuf readSliceRetained(int length) {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.readSliceRetained(length), leak);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -310,6 +310,11 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract boolean isDirect();
 
     /**
+     * Returns {@code true} if and only if this buffer is read-only.
+     */
+    public abstract boolean isReadOnly();
+
+    /**
      * Returns the {@code readerIndex} of this buffer.
      */
     public abstract int readerIndex();

--- a/buffer/src/main/java/io/netty/buffer/ByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/ByteBufHolder.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/ByteBufProcessor.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/DefaultByteBufHolder.java
+++ b/buffer/src/main/java/io/netty/buffer/DefaultByteBufHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/DuplicatedAbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DuplicatedAbstractByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,63 +18,107 @@ package io.netty.buffer;
 /**
  * {@link DuplicatedByteBuf} implementation that can do optimizations because it knows the duplicated buffer
  * is of type {@link AbstractByteBuf}.
+ *
+ * @deprecated Do not use.
  */
+@Deprecated
 final class DuplicatedAbstractByteBuf extends DuplicatedByteBuf {
-    public DuplicatedAbstractByteBuf(AbstractByteBuf buffer) {
+    DuplicatedAbstractByteBuf(AbstractByteBuf buffer) {
         super(buffer);
     }
 
     @Override
+    public AbstractByteBuf unwrap() {
+        return (AbstractByteBuf) super.unwrap();
+    }
+
+    @Override
     protected byte _getByte(int index) {
-        return unwrap0()._getByte(index);
+        return unwrap()._getByte(index);
     }
 
     @Override
     protected short _getShort(int index) {
-        return unwrap0()._getShort(index);
+        return unwrap()._getShort(index);
+    }
+
+    @Override
+    protected short _getShortLE(int index) {
+        return unwrap()._getShortLE(index);
     }
 
     @Override
     protected int _getUnsignedMedium(int index) {
-        return unwrap0()._getUnsignedMedium(index);
+        return unwrap()._getUnsignedMedium(index);
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return unwrap()._getUnsignedMediumLE(index);
     }
 
     @Override
     protected int _getInt(int index) {
-        return unwrap0()._getInt(index);
+        return unwrap()._getInt(index);
+    }
+
+    @Override
+    protected int _getIntLE(int index) {
+        return unwrap()._getIntLE(index);
     }
 
     @Override
     protected long _getLong(int index) {
-        return unwrap0()._getLong(index);
+        return unwrap()._getLong(index);
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return unwrap()._getLongLE(index);
     }
 
     @Override
     protected void _setByte(int index, int value) {
-        unwrap0()._setByte(index, value);
+        unwrap()._setByte(index, value);
     }
 
     @Override
     protected void _setShort(int index, int value) {
-        unwrap0()._setShort(index, value);
+        unwrap()._setShort(index, value);
+    }
+
+    @Override
+    protected void _setShortLE(int index, int value) {
+        unwrap()._setShortLE(index, value);
     }
 
     @Override
     protected void _setMedium(int index, int value) {
-        unwrap0()._setMedium(index, value);
+        unwrap()._setMedium(index, value);
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        unwrap()._setMediumLE(index, value);
     }
 
     @Override
     protected void _setInt(int index, int value) {
-        unwrap0()._setInt(index, value);
+        unwrap()._setInt(index, value);
+    }
+
+    @Override
+    protected void _setIntLE(int index, int value) {
+        unwrap()._setIntLE(index, value);
     }
 
     @Override
     protected void _setLong(int index, long value) {
-        unwrap0()._setLong(index, value);
+        unwrap()._setLong(index, value);
     }
 
-    private AbstractByteBuf unwrap0() {
-        return (AbstractByteBuf) unwrap();
+    @Override
+    protected void _setLongLE(int index, long value) {
+        unwrap()._setLongLE(index, value);
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -610,6 +610,11 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf readSliceRetained(int length) {
+        return checkLength(length);
+    }
+
+    @Override
     public ByteBuf readBytes(ByteBuf dst) {
         return checkLength(dst.writableBytes());
     }
@@ -841,12 +846,27 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf sliceRetained() {
+        return this;
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         return checkIndex(index, length);
     }
 
     @Override
+    public ByteBuf sliceRetained(int index, int length) {
+        return checkIndex(index, length);
+    }
+
+    @Override
     public ByteBuf duplicate() {
+        return this;
+    }
+
+    @Override
+    public ByteBuf duplicateRetained() {
         return this;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -96,6 +96,11 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
     public boolean isDirect() {
         return true;
     }

--- a/buffer/src/main/java/io/netty/buffer/FixedCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/FixedCompositeByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/HeapByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/HeapByteBufUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/PoolArenaMetric.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArenaMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/PoolChunkListMetric.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunkListMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/PoolChunkMetric.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunkMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/PoolSubpageMetric.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpageMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolThreadCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDirectByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/PooledDuplicatedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledDuplicatedByteBuf.java
@@ -13,402 +13,367 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package io.netty.buffer;
 
 import io.netty.util.ByteProcessor;
+import io.netty.util.Recycler;
+import io.netty.util.Recycler.Handle;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 
+final class PooledDuplicatedByteBuf extends AbstractPooledDerivedByteBuf<PooledDuplicatedByteBuf> {
 
-/**
- * A derived buffer which simply forwards all data access requests to its
- * parent.  It is recommended to use {@link ByteBuf#duplicate()} instead
- * of calling the constructor explicitly.
- *
- * @deprecated Do not use.
- */
-@Deprecated
-public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
+    private static final Recycler<PooledDuplicatedByteBuf> RECYCLER = new Recycler<PooledDuplicatedByteBuf>() {
+        @Override
+        protected PooledDuplicatedByteBuf newObject(Handle<PooledDuplicatedByteBuf> handle) {
+            return new PooledDuplicatedByteBuf(handle);
+        }
+    };
 
-    private final ByteBuf buffer;
+    static PooledDuplicatedByteBuf newInstance(AbstractByteBuf buffer, int readerIndex, int writerIndex) {
+        final AbstractByteBuf unwrapped;
+        if (buffer instanceof DuplicatedAbstractByteBuf ||
+            buffer instanceof PooledDuplicatedByteBuf) {
 
-    public DuplicatedByteBuf(ByteBuf buffer) {
-        this(buffer, buffer.readerIndex(), buffer.writerIndex());
-    }
-
-    DuplicatedByteBuf(ByteBuf buffer, int readerIndex, int writerIndex) {
-        super(buffer.maxCapacity());
-
-        if (buffer instanceof DuplicatedByteBuf) {
-            this.buffer = buffer.unwrap();
+            unwrapped = (AbstractByteBuf) buffer.unwrap();
         } else {
-            this.buffer = buffer;
+            unwrapped = buffer;
         }
 
-        setIndex(readerIndex, writerIndex);
-        markReaderIndex();
-        markWriterIndex();
+        final PooledDuplicatedByteBuf duplicate = RECYCLER.get();
+        duplicate.init(unwrapped, readerIndex, writerIndex, buffer.maxCapacity());
+        duplicate.markReaderIndex();
+        duplicate.markWriterIndex();
+
+        return duplicate;
     }
 
-    @Override
-    public ByteBuf unwrap() {
-        return buffer;
-    }
-
-    @Override
-    public ByteBufAllocator alloc() {
-        return buffer.alloc();
-    }
-
-    @Override
-    @Deprecated
-    public ByteOrder order() {
-        return buffer.order();
-    }
-
-    @Override
-    public boolean isDirect() {
-        return buffer.isDirect();
+    private PooledDuplicatedByteBuf(Handle<PooledDuplicatedByteBuf> handle) {
+        super(handle);
     }
 
     @Override
     public int capacity() {
-        return buffer.capacity();
+        return unwrap().capacity();
     }
 
     @Override
     public ByteBuf capacity(int newCapacity) {
-        buffer.capacity(newCapacity);
+        unwrap().capacity(newCapacity);
         return this;
     }
 
     @Override
-    public boolean hasArray() {
-        return buffer.hasArray();
-    }
-
-    @Override
-    public byte[] array() {
-        return buffer.array();
-    }
-
-    @Override
     public int arrayOffset() {
-        return buffer.arrayOffset();
-    }
-
-    @Override
-    public boolean hasMemoryAddress() {
-        return buffer.hasMemoryAddress();
+        return unwrap().arrayOffset();
     }
 
     @Override
     public long memoryAddress() {
-        return buffer.memoryAddress();
+        return unwrap().memoryAddress();
     }
 
     @Override
-    public byte getByte(int index) {
-        return buffer.getByte(index);
+    public ByteBuffer nioBuffer(int index, int length) {
+        return unwrap().nioBuffer(index, length);
     }
 
     @Override
-    protected byte _getByte(int index) {
-        return buffer.getByte(index);
-    }
-
-    @Override
-    public short getShort(int index) {
-        return buffer.getShort(index);
-    }
-
-    @Override
-    protected short _getShort(int index) {
-        return buffer.getShort(index);
-    }
-
-    @Override
-    public short getShortLE(int index) {
-        return buffer.getShortLE(index);
-    }
-
-    @Override
-    protected short _getShortLE(int index) {
-        return buffer.getShortLE(index);
-    }
-
-    @Override
-    public int getUnsignedMedium(int index) {
-        return buffer.getUnsignedMedium(index);
-    }
-
-    @Override
-    protected int _getUnsignedMedium(int index) {
-        return buffer.getUnsignedMedium(index);
-    }
-
-    @Override
-    public int getUnsignedMediumLE(int index) {
-        return buffer.getUnsignedMediumLE(index);
-    }
-
-    @Override
-    protected int _getUnsignedMediumLE(int index) {
-        return buffer.getUnsignedMediumLE(index);
-    }
-
-    @Override
-    public int getInt(int index) {
-        return buffer.getInt(index);
-    }
-
-    @Override
-    protected int _getInt(int index) {
-        return buffer.getInt(index);
-    }
-
-    @Override
-    public int getIntLE(int index) {
-        return buffer.getIntLE(index);
-    }
-
-    @Override
-    protected int _getIntLE(int index) {
-        return buffer.getIntLE(index);
-    }
-
-    @Override
-    public long getLong(int index) {
-        return buffer.getLong(index);
-    }
-
-    @Override
-    protected long _getLong(int index) {
-        return buffer.getLong(index);
-    }
-
-    @Override
-    public long getLongLE(int index) {
-        return buffer.getLongLE(index);
-    }
-
-    @Override
-    protected long _getLongLE(int index) {
-        return buffer.getLongLE(index);
+    public ByteBuffer[] nioBuffers(int index, int length) {
+        return unwrap().nioBuffers(index, length);
     }
 
     @Override
     public ByteBuf copy(int index, int length) {
-        return buffer.copy(index, length);
+        return unwrap().copy(index, length);
     }
 
     @Override
     public ByteBuf slice(int index, int length) {
-        return buffer.slice(index, length);
+        return unwrap().slice(index, length);
     }
 
     @Override
     public ByteBuf sliceRetained(int index, int length) {
-        return buffer.sliceRetained(index, length);
+        return unwrap().sliceRetained(index, length);
+    }
+
+    @Override
+    public byte getByte(int index) {
+        return unwrap().getByte(index);
+    }
+
+    @Override
+    protected byte _getByte(int index) {
+        return unwrap()._getByte(index);
+    }
+
+    @Override
+    public short getShort(int index) {
+        return unwrap().getShort(index);
+    }
+
+    @Override
+    protected short _getShort(int index) {
+        return unwrap()._getShort(index);
+    }
+
+    @Override
+    public short getShortLE(int index) {
+        return unwrap().getShortLE(index);
+    }
+
+    @Override
+    protected short _getShortLE(int index) {
+        return unwrap()._getShortLE(index);
+    }
+
+    @Override
+    public int getUnsignedMedium(int index) {
+        return unwrap().getUnsignedMedium(index);
+    }
+
+    @Override
+    protected int _getUnsignedMedium(int index) {
+        return unwrap()._getUnsignedMedium(index);
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
+        return unwrap().getUnsignedMediumLE(index);
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return unwrap()._getUnsignedMediumLE(index);
+    }
+
+    @Override
+    public int getInt(int index) {
+        return unwrap().getInt(index);
+    }
+
+    @Override
+    protected int _getInt(int index) {
+        return unwrap()._getInt(index);
+    }
+
+    @Override
+    public int getIntLE(int index) {
+        return unwrap().getIntLE(index);
+    }
+
+    @Override
+    protected int _getIntLE(int index) {
+        return unwrap()._getIntLE(index);
+    }
+
+    @Override
+    public long getLong(int index) {
+        return unwrap().getLong(index);
+    }
+
+    @Override
+    protected long _getLong(int index) {
+        return unwrap()._getLong(index);
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        return unwrap().getLongLE(index);
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return unwrap()._getLongLE(index);
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
-        buffer.getBytes(index, dst, dstIndex, length);
+        unwrap().getBytes(index, dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
-        buffer.getBytes(index, dst, dstIndex, length);
+        unwrap().getBytes(index, dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuffer dst) {
-        buffer.getBytes(index, dst);
+        unwrap().getBytes(index, dst);
         return this;
     }
 
     @Override
     public ByteBuf setByte(int index, int value) {
-        buffer.setByte(index, value);
+        unwrap().setByte(index, value);
         return this;
     }
 
     @Override
     protected void _setByte(int index, int value) {
-        buffer.setByte(index, value);
+        unwrap()._setByte(index, value);
     }
 
     @Override
     public ByteBuf setShort(int index, int value) {
-        buffer.setShort(index, value);
+        unwrap().setShort(index, value);
         return this;
     }
 
     @Override
     protected void _setShort(int index, int value) {
-        buffer.setShort(index, value);
+        unwrap()._setShort(index, value);
     }
 
     @Override
     public ByteBuf setShortLE(int index, int value) {
-        buffer.setShortLE(index, value);
+        unwrap().setShortLE(index, value);
         return this;
     }
 
     @Override
     protected void _setShortLE(int index, int value) {
-        buffer.setShortLE(index, value);
+        unwrap()._setShortLE(index, value);
     }
 
     @Override
     public ByteBuf setMedium(int index, int value) {
-        buffer.setMedium(index, value);
+        unwrap().setMedium(index, value);
         return this;
     }
 
     @Override
     protected void _setMedium(int index, int value) {
-        buffer.setMedium(index, value);
+        unwrap()._setMedium(index, value);
     }
 
     @Override
     public ByteBuf setMediumLE(int index, int value) {
-        buffer.setMediumLE(index, value);
+        unwrap().setMediumLE(index, value);
         return this;
     }
 
     @Override
     protected void _setMediumLE(int index, int value) {
-        buffer.setMediumLE(index, value);
+        unwrap()._setMediumLE(index, value);
     }
 
     @Override
     public ByteBuf setInt(int index, int value) {
-        buffer.setInt(index, value);
+        unwrap().setInt(index, value);
         return this;
     }
 
     @Override
     protected void _setInt(int index, int value) {
-        buffer.setInt(index, value);
+        unwrap()._setInt(index, value);
     }
 
     @Override
     public ByteBuf setIntLE(int index, int value) {
-        buffer.setIntLE(index, value);
+        unwrap().setIntLE(index, value);
         return this;
     }
 
     @Override
     protected void _setIntLE(int index, int value) {
-        buffer.setIntLE(index, value);
+        unwrap()._setIntLE(index, value);
     }
 
     @Override
     public ByteBuf setLong(int index, long value) {
-        buffer.setLong(index, value);
+        unwrap().setLong(index, value);
         return this;
     }
 
     @Override
     protected void _setLong(int index, long value) {
-        buffer.setLong(index, value);
+        unwrap()._setLong(index, value);
     }
 
     @Override
     public ByteBuf setLongLE(int index, long value) {
-        buffer.setLongLE(index, value);
+        unwrap().setLongLE(index, value);
         return this;
     }
 
     @Override
     protected void _setLongLE(int index, long value) {
-        buffer.setLongLE(index, value);
+        unwrap().setLongLE(index, value);
     }
 
     @Override
     public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
-        buffer.setBytes(index, src, srcIndex, length);
+        unwrap().setBytes(index, src, srcIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
-        buffer.setBytes(index, src, srcIndex, length);
+        unwrap().setBytes(index, src, srcIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf setBytes(int index, ByteBuffer src) {
-        buffer.setBytes(index, src);
+        unwrap().setBytes(index, src);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, OutputStream out, int length)
             throws IOException {
-        buffer.getBytes(index, out, length);
+        unwrap().getBytes(index, out, length);
         return this;
     }
 
     @Override
     public int getBytes(int index, GatheringByteChannel out, int length)
             throws IOException {
-        return buffer.getBytes(index, out, length);
+        return unwrap().getBytes(index, out, length);
     }
 
     @Override
     public int getBytes(int index, FileChannel out, long position, int length)
             throws IOException {
-        return buffer.getBytes(index, out, position, length);
+        return unwrap().getBytes(index, out, position, length);
     }
 
     @Override
     public int setBytes(int index, InputStream in, int length)
             throws IOException {
-        return buffer.setBytes(index, in, length);
+        return unwrap().setBytes(index, in, length);
     }
 
     @Override
     public int setBytes(int index, ScatteringByteChannel in, int length)
             throws IOException {
-        return buffer.setBytes(index, in, length);
+        return unwrap().setBytes(index, in, length);
     }
 
     @Override
     public int setBytes(int index, FileChannel in, long position, int length)
             throws IOException {
-        return buffer.setBytes(index, in, position, length);
-    }
-
-    @Override
-    public int nioBufferCount() {
-        return buffer.nioBufferCount();
-    }
-
-    @Override
-    public ByteBuffer[] nioBuffers(int index, int length) {
-        return buffer.nioBuffers(index, length);
+        return unwrap().setBytes(index, in, position, length);
     }
 
     @Override
     public int forEachByte(int index, int length, ByteProcessor processor) {
-        return buffer.forEachByte(index, length, processor);
+        return unwrap().forEachByte(index, length, processor);
     }
 
     @Override
     public int forEachByteDesc(int index, int length, ByteProcessor processor) {
-        return buffer.forEachByteDesc(index, length, processor);
+        return unwrap().forEachByteDesc(index, length, processor);
     }
 }
-

--- a/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledHeapByteBuf.java
@@ -1,7 +1,9 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
- * The Netty Project licenses this file tothe License at:
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/buffer/src/main/java/io/netty/buffer/PooledReadOnlyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledReadOnlyByteBuf.java
@@ -60,6 +60,11 @@ final class PooledReadOnlyByteBuf extends AbstractPooledDerivedByteBuf<PooledRea
     }
 
     @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
     public boolean isWritable() {
         return false;
     }

--- a/buffer/src/main/java/io/netty/buffer/PooledReadOnlyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledReadOnlyByteBuf.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer;
+
+import io.netty.util.ByteProcessor;
+import io.netty.util.Recycler;
+import io.netty.util.Recycler.Handle;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ReadOnlyBufferException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.ScatteringByteChannel;
+
+final class PooledReadOnlyByteBuf extends AbstractPooledDerivedByteBuf<PooledReadOnlyByteBuf> {
+
+    private static final Recycler<PooledReadOnlyByteBuf> RECYCLER = new Recycler<PooledReadOnlyByteBuf>() {
+        @Override
+        protected PooledReadOnlyByteBuf newObject(Handle<PooledReadOnlyByteBuf> handle) {
+            return new PooledReadOnlyByteBuf(handle);
+        }
+    };
+
+    static PooledReadOnlyByteBuf newInstance(AbstractByteBuf buffer) {
+        final AbstractByteBuf unwrapped;
+        if (buffer instanceof PooledReadOnlyByteBuf ||
+            buffer instanceof PooledDuplicatedByteBuf || buffer instanceof DuplicatedAbstractByteBuf) {
+            unwrapped = (AbstractByteBuf) buffer.unwrap();
+        } else {
+            unwrapped = buffer;
+        }
+
+        final PooledReadOnlyByteBuf readOnly = RECYCLER.get();
+        readOnly.init(unwrapped, buffer.readerIndex(), buffer.writerIndex(), buffer.maxCapacity());
+        readOnly.markReaderIndex();
+        readOnly.markWriterIndex();
+
+        return readOnly;
+    }
+
+    private PooledReadOnlyByteBuf(Handle<PooledReadOnlyByteBuf> handle) {
+        super(handle);
+    }
+
+    @Override
+    public boolean isWritable() {
+        return false;
+    }
+
+    @Override
+    public boolean isWritable(int numBytes) {
+        return false;
+    }
+
+    @Override
+    public int capacity() {
+        return unwrap().capacity();
+    }
+
+    @Override
+    public ByteBuf capacity(int newCapacity) {
+        unwrap().capacity(newCapacity);
+        return this;
+    }
+
+    @Override
+    public boolean hasArray() {
+        return false;
+    }
+
+    @Override
+    public byte[] array() {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public int arrayOffset() {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public boolean hasMemoryAddress() {
+        return false;
+    }
+
+    @Override
+    public long memoryAddress() {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuffer nioBuffer(int index, int length) {
+        return unwrap().nioBuffer(index, length).asReadOnlyBuffer();
+    }
+
+    @Override
+    public ByteBuffer[] nioBuffers(int index, int length) {
+        final ByteBuffer[] nioBuffers = unwrap().nioBuffers(index, length);
+        for (int i = 0; i < nioBuffers.length; i++) {
+            nioBuffers[i] = nioBuffers[i].asReadOnlyBuffer();
+        }
+        return nioBuffers;
+    }
+
+    @Override
+    public ByteBuf discardReadBytes() {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf copy(int index, int length) {
+        return unwrap().copy(index, length);
+    }
+
+    @Override
+    public byte getByte(int index) {
+        return unwrap().getByte(index);
+    }
+
+    @Override
+    protected byte _getByte(int index) {
+        return unwrap()._getByte(index);
+    }
+
+    @Override
+    public short getShort(int index) {
+        return unwrap().getShort(index);
+    }
+
+    @Override
+    protected short _getShort(int index) {
+        return unwrap()._getShort(index);
+    }
+
+    @Override
+    public short getShortLE(int index) {
+        return unwrap().getShortLE(index);
+    }
+
+    @Override
+    protected short _getShortLE(int index) {
+        return unwrap()._getShortLE(index);
+    }
+
+    @Override
+    public int getUnsignedMedium(int index) {
+        return unwrap().getUnsignedMedium(index);
+    }
+
+    @Override
+    protected int _getUnsignedMedium(int index) {
+        return unwrap()._getUnsignedMedium(index);
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
+        return unwrap().getUnsignedMediumLE(index);
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return unwrap()._getUnsignedMediumLE(index);
+    }
+
+    @Override
+    public int getInt(int index) {
+        return unwrap().getInt(index);
+    }
+
+    @Override
+    protected int _getInt(int index) {
+        return unwrap()._getInt(index);
+    }
+
+    @Override
+    public int getIntLE(int index) {
+        return unwrap().getIntLE(index);
+    }
+
+    @Override
+    protected int _getIntLE(int index) {
+        return unwrap()._getIntLE(index);
+    }
+
+    @Override
+    public long getLong(int index) {
+        return unwrap().getLong(index);
+    }
+
+    @Override
+    protected long _getLong(int index) {
+        return unwrap()._getLong(index);
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        return unwrap().getLongLE(index);
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return unwrap()._getLongLE(index);
+    }
+
+    @Override
+    public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
+        unwrap().getBytes(index, dst, dstIndex, length);
+        return this;
+    }
+
+    @Override
+    public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
+        unwrap().getBytes(index, dst, dstIndex, length);
+        return this;
+    }
+
+    @Override
+    public ByteBuf getBytes(int index, ByteBuffer dst) {
+        unwrap().getBytes(index, dst);
+        return this;
+    }
+
+    @Override
+    public ByteBuf setByte(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    protected void _setByte(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setShort(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    protected void _setShort(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setShortLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    protected void _setShortLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setMedium(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    protected void _setMedium(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setMediumLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setInt(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    protected void _setInt(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setIntLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    protected void _setIntLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setLong(int index, long value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    protected void _setLong(int index, long value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setLongLE(int index, long value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setBytes(int index, ByteBuffer src) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf getBytes(int index, OutputStream out, int length) throws IOException {
+        unwrap().getBytes(index, out, length);
+        return this;
+    }
+
+    @Override
+    public int getBytes(int index, GatheringByteChannel out, int length) throws IOException {
+        return unwrap().getBytes(index, out, length);
+    }
+
+    @Override
+    public int getBytes(int index, FileChannel out, long position, int length) throws IOException {
+        return unwrap().getBytes(index, out, position, length);
+    }
+
+    @Override
+    public int setBytes(int index, InputStream in, int length) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public int setBytes(int index, ScatteringByteChannel in, int length) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public int setBytes(int index, FileChannel in, long position, int length) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public int forEachByte(int index, int length, ByteProcessor processor) {
+        return unwrap().forEachByte(index, length, processor);
+    }
+
+    @Override
+    public int forEachByteDesc(int index, int length, ByteProcessor processor) {
+        return unwrap().forEachByteDesc(index, length, processor);
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/PooledSlicedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledSlicedByteBuf.java
@@ -13,441 +13,414 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package io.netty.buffer;
 
 import io.netty.util.ByteProcessor;
+import io.netty.util.Recycler;
+import io.netty.util.Recycler.Handle;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 
+final class PooledSlicedByteBuf extends AbstractPooledDerivedByteBuf<PooledSlicedByteBuf> {
 
-/**
- * A derived buffer which exposes its parent's sub-region only.  It is
- * recommended to use {@link ByteBuf#slice()} and
- * {@link ByteBuf#slice(int, int)} instead of calling the constructor
- * explicitly.
- *
- * @deprecated Do not use.
- */
-@Deprecated
-public class SlicedByteBuf extends AbstractDerivedByteBuf {
+    private static final Recycler<PooledSlicedByteBuf> RECYCLER = new Recycler<PooledSlicedByteBuf>() {
+        @Override
+        protected PooledSlicedByteBuf newObject(Handle<PooledSlicedByteBuf> handle) {
+            return new PooledSlicedByteBuf(handle);
+        }
+    };
 
-    private final ByteBuf buffer;
-    private final int adjustment;
-    private final int length;
-
-    public SlicedByteBuf(ByteBuf buffer, int index, int length) {
-        super(length);
+    static PooledSlicedByteBuf newInstance(AbstractByteBuf buffer, int index, int length) {
         if (index < 0 || index > buffer.capacity() - length) {
             throw new IndexOutOfBoundsException(buffer + ".slice(" + index + ", " + length + ')');
         }
 
-        if (buffer instanceof SlicedByteBuf) {
-            this.buffer = ((SlicedByteBuf) buffer).buffer;
-            adjustment = ((SlicedByteBuf) buffer).adjustment + index;
-        } else if (buffer instanceof DuplicatedByteBuf) {
-            this.buffer = buffer.unwrap();
+        final AbstractByteBuf unwrapped;
+        final int adjustment;
+        if (buffer instanceof PooledSlicedByteBuf) {
+            unwrapped = ((PooledSlicedByteBuf) buffer).unwrap();
+            adjustment = ((PooledSlicedByteBuf) buffer).adjustment + index;
+        } else if (buffer instanceof PooledDuplicatedByteBuf) {
+            unwrapped = ((PooledDuplicatedByteBuf) buffer).unwrap();
+            adjustment = index;
+        } else if (buffer instanceof SlicedAbstractByteBuf) {
+            unwrapped = ((SlicedAbstractByteBuf) buffer).unwrap();
+            adjustment = ((SlicedAbstractByteBuf) buffer).adjustment() + index;
+        } else if (buffer instanceof DuplicatedAbstractByteBuf) {
+            unwrapped = ((DuplicatedAbstractByteBuf) buffer).unwrap();
             adjustment = index;
         } else {
-            this.buffer = buffer;
+            unwrapped = buffer;
             adjustment = index;
         }
-        this.length = length;
 
-        writerIndex(length);
+        final PooledSlicedByteBuf slice = RECYCLER.get();
+        slice.init(unwrapped, 0, length, length);
+        slice.discardMarks();
+        slice.adjustment = adjustment;
+
+        return slice;
     }
 
-    int adjustment() {
-        return adjustment;
-    }
+    private int adjustment;
 
-    @Override
-    public ByteBuf unwrap() {
-        return buffer;
-    }
-
-    @Override
-    public ByteBufAllocator alloc() {
-        return buffer.alloc();
-    }
-
-    @Override
-    @Deprecated
-    public ByteOrder order() {
-        return buffer.order();
-    }
-
-    @Override
-    public boolean isDirect() {
-        return buffer.isDirect();
+    private PooledSlicedByteBuf(Handle<PooledSlicedByteBuf> handle) {
+        super(handle);
     }
 
     @Override
     public int capacity() {
-        return length;
+        return maxCapacity();
     }
 
     @Override
     public ByteBuf capacity(int newCapacity) {
-        throw new UnsupportedOperationException("sliced buffer");
-    }
-
-    @Override
-    public boolean hasArray() {
-        return buffer.hasArray();
-    }
-
-    @Override
-    public byte[] array() {
-        return buffer.array();
+        return reject();
     }
 
     @Override
     public int arrayOffset() {
-        return idx(buffer.arrayOffset());
-    }
-
-    @Override
-    public boolean hasMemoryAddress() {
-        return buffer.hasMemoryAddress();
+        return idx(unwrap().arrayOffset());
     }
 
     @Override
     public long memoryAddress() {
-        return buffer.memoryAddress() + adjustment;
+        return unwrap().memoryAddress() + adjustment;
     }
 
     @Override
-    public byte getByte(int index) {
-        checkIndex0(index, 1);
-        return buffer.getByte(idx(index));
+    public ByteBuffer nioBuffer(int index, int length) {
+        checkIndex0(index, length);
+        return unwrap().nioBuffer(idx(index), length);
     }
 
     @Override
-    protected byte _getByte(int index) {
-        return buffer.getByte(idx(index));
-    }
-
-    @Override
-    public short getShort(int index) {
-        checkIndex0(index, 2);
-        return buffer.getShort(idx(index));
-    }
-
-    @Override
-    protected short _getShort(int index) {
-        return buffer.getShort(idx(index));
-    }
-
-    @Override
-    public short getShortLE(int index) {
-        checkIndex0(index, 2);
-        return buffer.getShortLE(idx(index));
-    }
-
-    @Override
-    protected short _getShortLE(int index) {
-        return buffer.getShortLE(idx(index));
-    }
-
-    @Override
-    public int getUnsignedMedium(int index) {
-        checkIndex0(index, 3);
-        return buffer.getUnsignedMedium(idx(index));
-    }
-
-    @Override
-    protected int _getUnsignedMedium(int index) {
-        return buffer.getUnsignedMedium(idx(index));
-    }
-
-    @Override
-    public int getUnsignedMediumLE(int index) {
-        checkIndex0(index, 3);
-        return buffer.getUnsignedMediumLE(idx(index));
-    }
-
-    @Override
-    protected int _getUnsignedMediumLE(int index) {
-        return buffer.getUnsignedMediumLE(idx(index));
-    }
-
-    @Override
-    public int getInt(int index) {
-        checkIndex0(index, 4);
-        return buffer.getInt(idx(index));
-    }
-
-    @Override
-    protected int _getInt(int index) {
-        return buffer.getInt(idx(index));
-    }
-
-    @Override
-    public int getIntLE(int index) {
-        checkIndex0(index, 4);
-        return buffer.getIntLE(idx(index));
-    }
-
-    @Override
-    protected int _getIntLE(int index) {
-        return buffer.getIntLE(idx(index));
-    }
-
-    @Override
-    public long getLong(int index) {
-        checkIndex0(index, 8);
-        return buffer.getLong(idx(index));
-    }
-
-    @Override
-    protected long _getLong(int index) {
-        return buffer.getLong(idx(index));
-    }
-
-    @Override
-    public long getLongLE(int index) {
-        checkIndex0(index, 8);
-        return buffer.getLongLE(idx(index));
-    }
-
-    @Override
-    protected long _getLongLE(int index) {
-        return buffer.getLongLE(idx(index));
+    public ByteBuffer[] nioBuffers(int index, int length) {
+        checkIndex0(index, length);
+        return unwrap().nioBuffers(idx(index), length);
     }
 
     @Override
     public ByteBuf copy(int index, int length) {
         checkIndex0(index, length);
-        return buffer.copy(idx(index), length);
+        return unwrap().copy(idx(index), length);
     }
 
     @Override
     public ByteBuf slice(int index, int length) {
         checkIndex0(index, length);
-        return buffer.slice(idx(index), length);
+        return unwrap().slice(idx(index), length);
     }
 
     @Override
     public ByteBuf sliceRetained(int index, int length) {
         checkIndex0(index, length);
-        return buffer.sliceRetained(idx(index), length);
+        return unwrap().sliceRetained(idx(index), length);
+    }
+
+    @Override
+    public byte getByte(int index) {
+        checkIndex0(index, 1);
+        return unwrap().getByte(idx(index));
+    }
+
+    @Override
+    protected byte _getByte(int index) {
+        return unwrap()._getByte(idx(index));
+    }
+
+    @Override
+    public short getShort(int index) {
+        checkIndex0(index, 2);
+        return unwrap().getShort(idx(index));
+    }
+
+    @Override
+    protected short _getShort(int index) {
+        return unwrap()._getShort(idx(index));
+    }
+
+    @Override
+    public short getShortLE(int index) {
+        checkIndex0(index, 2);
+        return unwrap().getShortLE(idx(index));
+    }
+
+    @Override
+    protected short _getShortLE(int index) {
+        return unwrap()._getShortLE(idx(index));
+    }
+
+    @Override
+    public int getUnsignedMedium(int index) {
+        checkIndex0(index, 3);
+        return unwrap().getUnsignedMedium(idx(index));
+    }
+
+    @Override
+    protected int _getUnsignedMedium(int index) {
+        return unwrap()._getUnsignedMedium(idx(index));
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
+        checkIndex0(index, 3);
+        return unwrap().getUnsignedMediumLE(idx(index));
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return unwrap()._getUnsignedMediumLE(idx(index));
+    }
+
+    @Override
+    public int getInt(int index) {
+        checkIndex0(index, 4);
+        return unwrap().getInt(idx(index));
+    }
+
+    @Override
+    protected int _getInt(int index) {
+        return unwrap()._getInt(idx(index));
+    }
+
+    @Override
+    public int getIntLE(int index) {
+        checkIndex0(index, 4);
+        return unwrap().getIntLE(idx(index));
+    }
+
+    @Override
+    protected int _getIntLE(int index) {
+        return unwrap()._getIntLE(idx(index));
+    }
+
+    @Override
+    public long getLong(int index) {
+        checkIndex0(index, 8);
+        return unwrap().getLong(idx(index));
+    }
+
+    @Override
+    protected long _getLong(int index) {
+        return unwrap()._getLong(idx(index));
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        checkIndex0(index, 8);
+        return unwrap().getLongLE(idx(index));
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return unwrap()._getLongLE(idx(index));
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
         checkIndex0(index, length);
-        buffer.getBytes(idx(index), dst, dstIndex, length);
+        unwrap().getBytes(idx(index), dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
         checkIndex0(index, length);
-        buffer.getBytes(idx(index), dst, dstIndex, length);
+        unwrap().getBytes(idx(index), dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuffer dst) {
         checkIndex0(index, dst.remaining());
-        buffer.getBytes(idx(index), dst);
+        unwrap().getBytes(idx(index), dst);
         return this;
     }
 
     @Override
     public ByteBuf setByte(int index, int value) {
         checkIndex0(index, 1);
-        buffer.setByte(idx(index), value);
+        unwrap().setByte(idx(index), value);
         return this;
     }
 
     @Override
     protected void _setByte(int index, int value) {
-        buffer.setByte(idx(index), value);
+        unwrap()._setByte(idx(index), value);
     }
 
     @Override
     public ByteBuf setShort(int index, int value) {
         checkIndex0(index, 2);
-        buffer.setShort(idx(index), value);
+        unwrap().setShort(idx(index), value);
         return this;
     }
 
     @Override
     protected void _setShort(int index, int value) {
-        buffer.setShort(idx(index), value);
+        unwrap()._setShort(idx(index), value);
     }
 
     @Override
     public ByteBuf setShortLE(int index, int value) {
         checkIndex0(index, 2);
-        buffer.setShortLE(idx(index), value);
+        unwrap().setShortLE(idx(index), value);
         return this;
     }
 
     @Override
     protected void _setShortLE(int index, int value) {
-        buffer.setShortLE(idx(index), value);
+        unwrap()._setShortLE(idx(index), value);
     }
 
     @Override
     public ByteBuf setMedium(int index, int value) {
         checkIndex0(index, 3);
-        buffer.setMedium(idx(index), value);
+        unwrap().setMedium(idx(index), value);
         return this;
     }
 
     @Override
     protected void _setMedium(int index, int value) {
-        buffer.setMedium(idx(index), value);
+        unwrap()._setMedium(idx(index), value);
     }
 
     @Override
     public ByteBuf setMediumLE(int index, int value) {
         checkIndex0(index, 3);
-        buffer.setMediumLE(idx(index), value);
+        unwrap().setMediumLE(idx(index), value);
         return this;
     }
 
     @Override
     protected void _setMediumLE(int index, int value) {
-        buffer.setMediumLE(idx(index), value);
+        unwrap()._setMediumLE(idx(index), value);
     }
 
     @Override
     public ByteBuf setInt(int index, int value) {
         checkIndex0(index, 4);
-        buffer.setInt(idx(index), value);
+        unwrap().setInt(idx(index), value);
         return this;
     }
 
     @Override
     protected void _setInt(int index, int value) {
-        buffer.setInt(idx(index), value);
+        unwrap()._setInt(idx(index), value);
     }
 
     @Override
     public ByteBuf setIntLE(int index, int value) {
         checkIndex0(index, 4);
-        buffer.setIntLE(idx(index), value);
+        unwrap().setIntLE(idx(index), value);
         return this;
     }
 
     @Override
     protected void _setIntLE(int index, int value) {
-        buffer.setIntLE(idx(index), value);
+        unwrap()._setIntLE(idx(index), value);
     }
 
     @Override
     public ByteBuf setLong(int index, long value) {
         checkIndex0(index, 8);
-        buffer.setLong(idx(index), value);
+        unwrap().setLong(idx(index), value);
         return this;
     }
 
     @Override
     protected void _setLong(int index, long value) {
-        buffer.setLong(idx(index), value);
+        unwrap()._setLong(idx(index), value);
     }
 
     @Override
     public ByteBuf setLongLE(int index, long value) {
         checkIndex0(index, 8);
-        buffer.setLongLE(idx(index), value);
+        unwrap().setLongLE(idx(index), value);
         return this;
     }
 
     @Override
     protected void _setLongLE(int index, long value) {
-        buffer.setLongLE(idx(index), value);
+        unwrap().setLongLE(idx(index), value);
     }
 
     @Override
     public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
         checkIndex0(index, length);
-        buffer.setBytes(idx(index), src, srcIndex, length);
+        unwrap().setBytes(idx(index), src, srcIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
         checkIndex0(index, length);
-        buffer.setBytes(idx(index), src, srcIndex, length);
+        unwrap().setBytes(idx(index), src, srcIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf setBytes(int index, ByteBuffer src) {
         checkIndex0(index, src.remaining());
-        buffer.setBytes(idx(index), src);
+        unwrap().setBytes(idx(index), src);
         return this;
     }
 
     @Override
-    public ByteBuf getBytes(int index, OutputStream out, int length) throws IOException {
+    public ByteBuf getBytes(int index, OutputStream out, int length)
+            throws IOException {
         checkIndex0(index, length);
-        buffer.getBytes(idx(index), out, length);
+        unwrap().getBytes(idx(index), out, length);
         return this;
     }
 
     @Override
-    public int getBytes(int index, GatheringByteChannel out, int length) throws IOException {
+    public int getBytes(int index, GatheringByteChannel out, int length)
+            throws IOException {
         checkIndex0(index, length);
-        return buffer.getBytes(idx(index), out, length);
+        return unwrap().getBytes(idx(index), out, length);
     }
 
     @Override
-    public int getBytes(int index, FileChannel out, long position, int length) throws IOException {
+    public int getBytes(int index, FileChannel out, long position, int length)
+            throws IOException {
         checkIndex0(index, length);
-        return buffer.getBytes(idx(index), out, position, length);
+        return unwrap().getBytes(idx(index), out, position, length);
     }
 
     @Override
-    public int setBytes(int index, InputStream in, int length) throws IOException {
+    public int setBytes(int index, InputStream in, int length)
+            throws IOException {
         checkIndex0(index, length);
-        return buffer.setBytes(idx(index), in, length);
+        return unwrap().setBytes(idx(index), in, length);
     }
 
     @Override
-    public int setBytes(int index, ScatteringByteChannel in, int length) throws IOException {
+    public int setBytes(int index, ScatteringByteChannel in, int length)
+            throws IOException {
         checkIndex0(index, length);
-        return buffer.setBytes(idx(index), in, length);
+        return unwrap().setBytes(idx(index), in, length);
     }
 
     @Override
-    public int setBytes(int index, FileChannel in, long position, int length) throws IOException {
+    public int setBytes(int index, FileChannel in, long position, int length)
+            throws IOException {
         checkIndex0(index, length);
-        return buffer.setBytes(idx(index), in, position, length);
-    }
-
-    @Override
-    public int nioBufferCount() {
-        return buffer.nioBufferCount();
-    }
-
-    @Override
-    public ByteBuffer nioBuffer(int index, int length) {
-        checkIndex0(index, length);
-        return buffer.nioBuffer(idx(index), length);
-    }
-
-    @Override
-    public ByteBuffer[] nioBuffers(int index, int length) {
-        checkIndex0(index, length);
-        return buffer.nioBuffers(idx(index), length);
+        return unwrap().setBytes(idx(index), in, position, length);
     }
 
     @Override
     public int forEachByte(int index, int length, ByteProcessor processor) {
         checkIndex0(index, length);
-        int ret = buffer.forEachByte(idx(index), length, processor);
+        int ret = unwrap().forEachByte(idx(index), length, processor);
         if (ret >= adjustment) {
             return ret - adjustment;
         } else {
@@ -458,7 +431,7 @@ public class SlicedByteBuf extends AbstractDerivedByteBuf {
     @Override
     public int forEachByteDesc(int index, int length, ByteProcessor processor) {
         checkIndex0(index, length);
-        int ret = buffer.forEachByteDesc(idx(index), length, processor);
+        int ret = unwrap().forEachByteDesc(idx(index), length, processor);
         if (ret >= adjustment) {
             return ret - adjustment;
         } else {
@@ -466,10 +439,11 @@ public class SlicedByteBuf extends AbstractDerivedByteBuf {
         }
     }
 
-    /**
-     * Returns the index with the needed adjustment.
-     */
-    final int idx(int index) {
+    private int idx(int index) {
         return index + adjustment;
+    }
+
+    private static ByteBuf reject() {
+        throw new UnsupportedOperationException("sliced buffer");
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -364,6 +364,7 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
     }
 
     @Override
+    @Deprecated
     protected SwappedByteBuf newSwappedByteBuf() {
         if (PlatformDependent.isUnaligned()) {
             // Only use if unaligned access is supported otherwise there is no gain.

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeHeapByteBuf.java
@@ -1,7 +1,9 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
- * The Netty Project licenses this file tothe License at:
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -47,8 +49,18 @@ final class PooledUnsafeHeapByteBuf extends PooledHeapByteBuf {
     }
 
     @Override
+    protected short _getShortLE(int index) {
+        return UnsafeByteBufUtil.getShortLE(memory, idx(index));
+    }
+
+    @Override
     protected int _getUnsignedMedium(int index) {
         return UnsafeByteBufUtil.getUnsignedMedium(memory, idx(index));
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return UnsafeByteBufUtil.getUnsignedMediumLE(memory, idx(index));
     }
 
     @Override
@@ -57,8 +69,18 @@ final class PooledUnsafeHeapByteBuf extends PooledHeapByteBuf {
     }
 
     @Override
+    protected int _getIntLE(int index) {
+        return UnsafeByteBufUtil.getIntLE(memory, idx(index));
+    }
+
+    @Override
     protected long _getLong(int index) {
         return UnsafeByteBufUtil.getLong(memory, idx(index));
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return UnsafeByteBufUtil.getLongLE(memory, idx(index));
     }
 
     @Override
@@ -72,8 +94,18 @@ final class PooledUnsafeHeapByteBuf extends PooledHeapByteBuf {
     }
 
     @Override
+    protected void _setShortLE(int index, int value) {
+        UnsafeByteBufUtil.setShortLE(memory, idx(index), value);
+    }
+
+    @Override
     protected void _setMedium(int index, int value) {
         UnsafeByteBufUtil.setMedium(memory, idx(index), value);
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        UnsafeByteBufUtil.setMediumLE(memory, idx(index), value);
     }
 
     @Override
@@ -82,11 +114,22 @@ final class PooledUnsafeHeapByteBuf extends PooledHeapByteBuf {
     }
 
     @Override
+    protected void _setIntLE(int index, int value) {
+        UnsafeByteBufUtil.setIntLE(memory, idx(index), value);
+    }
+
+    @Override
     protected void _setLong(int index, long value) {
         UnsafeByteBufUtil.setLong(memory, idx(index), value);
     }
 
     @Override
+    protected void _setLongLE(int index, long value) {
+        UnsafeByteBufUtil.setLongLE(memory, idx(index), value);
+    }
+
+    @Override
+    @Deprecated
     protected SwappedByteBuf newSwappedByteBuf() {
         if (PlatformDependent.isUnaligned()) {
             // Only use if unaligned access is supported otherwise there is no gain.

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
@@ -52,6 +52,11 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
     public boolean isWritable() {
         return false;
     }

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -31,7 +31,10 @@ import java.nio.channels.ScatteringByteChannel;
  * A derived buffer which forbids any write requests to its parent.  It is
  * recommended to use {@link Unpooled#unmodifiableBuffer(ByteBuf)}
  * instead of calling the constructor explicitly.
+ *
+ * @deprecated Do not use.
  */
+@Deprecated
 public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
 
     private final ByteBuf buffer;
@@ -39,7 +42,8 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     public ReadOnlyByteBuf(ByteBuf buffer) {
         super(buffer.maxCapacity());
 
-        if (buffer instanceof ReadOnlyByteBuf || buffer instanceof DuplicatedByteBuf) {
+        if (buffer instanceof ReadOnlyByteBuf || buffer instanceof PooledReadOnlyByteBuf ||
+            buffer instanceof DuplicatedByteBuf || buffer instanceof PooledDuplicatedByteBuf) {
             this.buffer = buffer.unwrap();
         } else {
             this.buffer = buffer;
@@ -68,6 +72,7 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    @Deprecated
     public ByteOrder order() {
         return buffer.order();
     }
@@ -143,6 +148,11 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    public ByteBuf setShortLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setShortLE(int index, int value) {
         throw new ReadOnlyBufferException();
     }
@@ -154,6 +164,11 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     protected void _setMedium(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setMediumLE(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -173,6 +188,11 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    public ByteBuf setIntLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setIntLE(int index, int value) {
         throw new ReadOnlyBufferException();
     }
@@ -184,6 +204,11 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     protected void _setLong(int index, long value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setLongLE(int index, long value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -245,23 +270,13 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
-    public ByteBuf duplicate() {
-        return new ReadOnlyByteBuf(this);
-    }
-
-    @Override
     public ByteBuf copy(int index, int length) {
         return buffer.copy(index, length);
     }
 
     @Override
-    public ByteBuf slice(int index, int length) {
-        return Unpooled.unmodifiableBuffer(buffer.slice(index, length));
-    }
-
-    @Override
     public byte getByte(int index) {
-        return _getByte(index);
+        return buffer.getByte(index);
     }
 
     @Override
@@ -271,12 +286,17 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public short getShort(int index) {
-        return _getShort(index);
+        return buffer.getShort(index);
     }
 
     @Override
     protected short _getShort(int index) {
         return buffer.getShort(index);
+    }
+
+    @Override
+    public short getShortLE(int index) {
+        return buffer.getShortLE(index);
     }
 
     @Override
@@ -286,12 +306,17 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public int getUnsignedMedium(int index) {
-        return _getUnsignedMedium(index);
+        return buffer.getUnsignedMedium(index);
     }
 
     @Override
     protected int _getUnsignedMedium(int index) {
         return buffer.getUnsignedMedium(index);
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
+        return buffer.getUnsignedMediumLE(index);
     }
 
     @Override
@@ -301,12 +326,17 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public int getInt(int index) {
-        return _getInt(index);
+        return buffer.getInt(index);
     }
 
     @Override
     protected int _getInt(int index) {
         return buffer.getInt(index);
+    }
+
+    @Override
+    public int getIntLE(int index) {
+        return buffer.getIntLE(index);
     }
 
     @Override
@@ -316,12 +346,17 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public long getLong(int index) {
-        return _getLong(index);
+        return buffer.getLong(index);
     }
 
     @Override
     protected long _getLong(int index) {
         return buffer.getLong(index);
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        return buffer.getLongLE(index);
     }
 
     @Override
@@ -342,11 +377,6 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     @Override
     public ByteBuffer[] nioBuffers(int index, int length) {
         return buffer.nioBuffers(index, length);
-    }
-
-    @Override
-    public ByteBuffer internalNioBuffer(int index, int length) {
-        return nioBuffer(index, length);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -316,6 +316,11 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return buffer.isReadOnly();
+    }
+
+    @Override
     public boolean isDirect() {
         return buffer.isDirect();
     }

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -74,6 +74,12 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public short getShortLE(int index) {
+        ensureAccessible();
+        return _getShortLE(index);
+    }
+
+    @Override
     protected short _getShortLE(int index) {
         return ByteBufUtil.swapShort(buffer.getShort(index));
     }
@@ -89,6 +95,12 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
         return (getByte(index) & 0xff)     << 16 |
                (getByte(index + 1) & 0xff) << 8  |
                getByte(index + 2) & 0xff;
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
+        ensureAccessible();
+        return _getUnsignedMediumLE(index);
     }
 
     @Override
@@ -110,6 +122,12 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public int getIntLE(int index) {
+        ensureAccessible();
+        return _getIntLE(index);
+    }
+
+    @Override
     protected int _getIntLE(int index) {
         return ByteBufUtil.swapInt(buffer.getInt(index));
     }
@@ -123,6 +141,12 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected long _getLong(int index) {
         return buffer.getLong(index);
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        ensureAccessible();
+        return _getLongLE(index);
     }
 
     @Override
@@ -177,7 +201,17 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf setByte(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setByte(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setShort(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -187,7 +221,17 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf setShortLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setShortLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setMedium(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -197,7 +241,17 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf setMediumLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setMediumLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setInt(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -207,12 +261,27 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf setIntLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setIntLE(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
+    public ByteBuf setLong(int index, long value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setLong(int index, long value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setLongLE(int index, long value) {
         throw new ReadOnlyBufferException();
     }
 

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -73,8 +73,18 @@ final class SimpleLeakAwareByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public ByteBuf sliceRetained() {
+        return new SimpleLeakAwareByteBuf(super.sliceRetained(), leak);
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         return new SimpleLeakAwareByteBuf(super.slice(index, length), leak);
+    }
+
+    @Override
+    public ByteBuf sliceRetained(int index, int length) {
+        return new SimpleLeakAwareByteBuf(super.sliceRetained(index, length), leak);
     }
 
     @Override
@@ -83,7 +93,17 @@ final class SimpleLeakAwareByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public ByteBuf duplicateRetained() {
+        return new SimpleLeakAwareByteBuf(super.duplicateRetained(), leak);
+    }
+
+    @Override
     public ByteBuf readSlice(int length) {
         return new SimpleLeakAwareByteBuf(super.readSlice(length), leak);
+    }
+
+    @Override
+    public ByteBuf readSliceRetained(int length) {
+        return new SimpleLeakAwareByteBuf(super.readSliceRetained(length), leak);
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareCompositeByteBuf.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package io.netty.buffer;
 
 
@@ -63,8 +64,18 @@ final class SimpleLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     }
 
     @Override
+    public ByteBuf sliceRetained() {
+        return new SimpleLeakAwareByteBuf(super.sliceRetained(), leak);
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         return new SimpleLeakAwareByteBuf(super.slice(index, length), leak);
+    }
+
+    @Override
+    public ByteBuf sliceRetained(int index, int length) {
+        return new SimpleLeakAwareByteBuf(super.sliceRetained(index, length), leak);
     }
 
     @Override
@@ -73,7 +84,17 @@ final class SimpleLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     }
 
     @Override
+    public ByteBuf duplicateRetained() {
+        return new SimpleLeakAwareByteBuf(super.duplicateRetained(), leak);
+    }
+
+    @Override
     public ByteBuf readSlice(int length) {
         return new SimpleLeakAwareByteBuf(super.readSlice(length), leak);
+    }
+
+    @Override
+    public ByteBuf readSliceRetained(int length) {
+        return new SimpleLeakAwareByteBuf(super.readSliceRetained(length), leak);
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/SlicedAbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SlicedAbstractByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,7 +18,10 @@ package io.netty.buffer;
 /**
  * A special {@link SlicedByteBuf} that can make optimizations because it knows the sliced buffer is of type
  * {@link AbstractByteBuf}.
+ *
+ * @deprecated Do not use.
  */
+@Deprecated
 final class SlicedAbstractByteBuf extends SlicedByteBuf {
 
     SlicedAbstractByteBuf(AbstractByteBuf buffer, int index, int length) {
@@ -26,56 +29,97 @@ final class SlicedAbstractByteBuf extends SlicedByteBuf {
     }
 
     @Override
+    public AbstractByteBuf unwrap() {
+        return (AbstractByteBuf) super.unwrap();
+    }
+
+    @Override
     protected byte _getByte(int index) {
-        return unwrap0()._getByte(idx(index));
+        return unwrap()._getByte(idx(index));
     }
 
     @Override
     protected short _getShort(int index) {
-        return unwrap0()._getShort(idx(index));
+        return unwrap()._getShort(idx(index));
+    }
+
+    @Override
+    protected short _getShortLE(int index) {
+        return unwrap()._getShortLE(idx(index));
     }
 
     @Override
     protected int _getUnsignedMedium(int index) {
-        return unwrap0()._getUnsignedMedium(idx(index));
+        return unwrap()._getUnsignedMedium(idx(index));
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return unwrap()._getUnsignedMediumLE(idx(index));
     }
 
     @Override
     protected int _getInt(int index) {
-        return unwrap0()._getInt(idx(index));
+        return unwrap()._getInt(idx(index));
+    }
+
+    @Override
+    protected int _getIntLE(int index) {
+        return unwrap()._getIntLE(idx(index));
     }
 
     @Override
     protected long _getLong(int index) {
-        return unwrap0()._getLong(idx(index));
+        return unwrap()._getLong(idx(index));
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return unwrap()._getLongLE(idx(index));
     }
 
     @Override
     protected void _setByte(int index, int value) {
-        unwrap0()._setByte(idx(index), value);
+        unwrap()._setByte(idx(index), value);
     }
 
     @Override
     protected void _setShort(int index, int value) {
-        unwrap0()._setShort(idx(index), value);
+        unwrap()._setShort(idx(index), value);
+    }
+
+    @Override
+    protected void _setShortLE(int index, int value) {
+        unwrap()._setShortLE(idx(index), value);
     }
 
     @Override
     protected void _setMedium(int index, int value) {
-        unwrap0()._setMedium(idx(index), value);
+        unwrap()._setMedium(idx(index), value);
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        unwrap()._setMediumLE(idx(index), value);
     }
 
     @Override
     protected void _setInt(int index, int value) {
-        unwrap0()._setInt(idx(index), value);
+        unwrap()._setInt(idx(index), value);
+    }
+
+    @Override
+    protected void _setIntLE(int index, int value) {
+        unwrap()._setIntLE(idx(index), value);
     }
 
     @Override
     protected void _setLong(int index, long value) {
-        unwrap0()._setLong(idx(index), value);
+        unwrap()._setLong(idx(index), value);
     }
 
-    private AbstractByteBuf unwrap0() {
-        return (AbstractByteBuf) unwrap();
+    @Override
+    protected void _setLongLE(int index, long value) {
+        unwrap()._setLongLE(idx(index), value);
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -33,6 +33,7 @@ import java.nio.charset.Charset;
  * @deprecated use the Little Endian accessors, e.g. {@code getShortLE}, {@code getIntLE}
  * instead.
  */
+@Deprecated
 public class SwappedByteBuf extends ByteBuf {
 
     private final ByteBuf buf;
@@ -611,6 +612,11 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf readSliceRetained(int length) {
+        return buf.readSliceRetained(length).order(order);
+    }
+
+    @Override
     public ByteBuf readBytes(ByteBuf dst) {
         buf.readBytes(dst);
         return this;
@@ -859,13 +865,28 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf sliceRetained() {
+        return buf.sliceRetained().order(order);
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         return buf.slice(index, length).order(order);
     }
 
     @Override
+    public ByteBuf sliceRetained(int index, int length) {
+        return buf.sliceRetained(index, length).order(order);
+    }
+
+    @Override
     public ByteBuf duplicate() {
         return buf.duplicate().order(order);
+    }
+
+    @Override
+    public ByteBuf duplicateRetained() {
+        return buf.duplicateRetained().order(order);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -94,6 +94,11 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return buf.isReadOnly();
+    }
+
+    @Override
     public boolean isDirect() {
         return buf.isDirect();
     }

--- a/buffer/src/main/java/io/netty/buffer/Unpooled.java
+++ b/buffer/src/main/java/io/netty/buffer/Unpooled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -676,12 +676,15 @@ public final class Unpooled {
      * {@code buffer}.
      */
     public static ByteBuf unmodifiableBuffer(ByteBuf buffer) {
-        ByteOrder endianness = buffer.order();
-        if (endianness == BIG_ENDIAN) {
-            return new ReadOnlyByteBuf(buffer);
+        final ByteBuf bigEndianBuffer = buffer.order(BIG_ENDIAN);
+        final ByteBuf unmodifiable;
+        if (bigEndianBuffer instanceof AbstractByteBuf) {
+            unmodifiable = PooledReadOnlyByteBuf.newInstance((AbstractByteBuf) bigEndianBuffer);
+        } else {
+            unmodifiable = new ReadOnlyByteBuf(bigEndianBuffer);
         }
 
-        return new ReadOnlyByteBuf(buffer.order(BIG_ENDIAN)).order(LITTLE_ENDIAN);
+        return buffer.order() == BIG_ENDIAN ? unmodifiable : unmodifiable.order(LITTLE_ENDIAN);
     }
 
     /**

--- a/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledDirectByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -335,6 +335,12 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public short getShortLE(int index) {
+        ensureAccessible();
+        return _getShortLE(index);
+    }
+
+    @Override
     protected short _getShortLE(int index) {
         return HeapByteBufUtil.getShortLE(array, index);
     }
@@ -348,6 +354,12 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected int _getUnsignedMedium(int index) {
         return HeapByteBufUtil.getUnsignedMedium(array, index);
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
+        ensureAccessible();
+        return _getUnsignedMediumLE(index);
     }
 
     @Override
@@ -367,6 +379,12 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public int getIntLE(int index) {
+        ensureAccessible();
+        return _getIntLE(index);
+    }
+
+    @Override
     protected int _getIntLE(int index) {
         return HeapByteBufUtil.getIntLE(array, index);
     }
@@ -380,6 +398,12 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected long _getLong(int index) {
         return HeapByteBufUtil.getLong(array, index);
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        ensureAccessible();
+        return _getLongLE(index);
     }
 
     @Override
@@ -412,6 +436,13 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf setShortLE(int index, int value) {
+        ensureAccessible();
+        _setShortLE(index, value);
+        return this;
+    }
+
+    @Override
     protected void _setShortLE(int index, int value) {
         HeapByteBufUtil.setShortLE(array, index, value);
     }
@@ -426,6 +457,13 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void _setMedium(int index, int value) {
         HeapByteBufUtil.setMedium(array, index, value);
+    }
+
+    @Override
+    public ByteBuf setMediumLE(int index, int   value) {
+        ensureAccessible();
+        _setMediumLE(index, value);
+        return this;
     }
 
     @Override
@@ -446,6 +484,13 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf setIntLE(int index, int   value) {
+        ensureAccessible();
+        _setIntLE(index, value);
+        return this;
+    }
+
+    @Override
     protected void _setIntLE(int index, int value) {
         HeapByteBufUtil.setIntLE(array, index, value);
     }
@@ -460,6 +505,13 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void _setLong(int index, long value) {
         HeapByteBufUtil.setLong(array, index, value);
+    }
+
+    @Override
+    public ByteBuf setLongLE(int index, long  value) {
+        ensureAccessible();
+        _setLongLE(index, value);
+        return this;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -496,6 +496,7 @@ public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf
     }
 
     @Override
+    @Deprecated
     protected SwappedByteBuf newSwappedByteBuf() {
         if (PlatformDependent.isUnaligned()) {
             // Only use if unaligned access is supported otherwise there is no gain.

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -53,6 +53,17 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     }
 
     @Override
+    public short getShortLE(int index) {
+        checkIndex(index, 2);
+        return _getShortLE(index);
+    }
+
+    @Override
+    protected short _getShortLE(int index) {
+        return UnsafeByteBufUtil.getShortLE(array, index);
+    }
+
+    @Override
     public int getUnsignedMedium(int index) {
         checkIndex(index, 3);
         return _getUnsignedMedium(index);
@@ -61,6 +72,17 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     @Override
     protected int _getUnsignedMedium(int index) {
         return UnsafeByteBufUtil.getUnsignedMedium(array, index);
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
+        checkIndex(index, 3);
+        return _getUnsignedMediumLE(index);
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return UnsafeByteBufUtil.getUnsignedMediumLE(array, index);
     }
 
     @Override
@@ -75,6 +97,17 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     }
 
     @Override
+    public int getIntLE(int index) {
+        checkIndex(index, 4);
+        return _getIntLE(index);
+    }
+
+    @Override
+    protected int _getIntLE(int index) {
+        return UnsafeByteBufUtil.getIntLE(array, index);
+    }
+
+    @Override
     public long getLong(int index) {
         checkIndex(index, 8);
         return _getLong(index);
@@ -83,6 +116,17 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     @Override
     protected long _getLong(int index) {
         return UnsafeByteBufUtil.getLong(array, index);
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        checkIndex(index, 8);
+        return _getLongLE(index);
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return UnsafeByteBufUtil.getLongLE(array, index);
     }
 
     @Override
@@ -110,6 +154,18 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     }
 
     @Override
+    public ByteBuf setShortLE(int index, int value) {
+        checkIndex(index, 2);
+        _setShortLE(index, value);
+        return this;
+    }
+
+    @Override
+    protected void _setShortLE(int index, int value) {
+        UnsafeByteBufUtil.setShortLE(array, index, value);
+    }
+
+    @Override
     public ByteBuf setMedium(int index, int   value) {
         checkIndex(index, 3);
         _setMedium(index, value);
@@ -119,6 +175,18 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     @Override
     protected void _setMedium(int index, int value) {
         UnsafeByteBufUtil.setMedium(array, index, value);
+    }
+
+    @Override
+    public ByteBuf setMediumLE(int index, int   value) {
+        checkIndex(index, 3);
+        _setMediumLE(index, value);
+        return this;
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        UnsafeByteBufUtil.setMediumLE(array, index, value);
     }
 
     @Override
@@ -134,6 +202,18 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     }
 
     @Override
+    public ByteBuf setIntLE(int index, int   value) {
+        checkIndex(index, 4);
+        _setIntLE(index, value);
+        return this;
+    }
+
+    @Override
+    protected void _setIntLE(int index, int value) {
+        UnsafeByteBufUtil.setIntLE(array, index, value);
+    }
+
+    @Override
     public ByteBuf setLong(int index, long  value) {
         checkIndex(index, 8);
         _setLong(index, value);
@@ -146,6 +226,19 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     }
 
     @Override
+    public ByteBuf setLongLE(int index, long  value) {
+        checkIndex(index, 8);
+        _setLongLE(index, value);
+        return this;
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
+        UnsafeByteBufUtil.setLongLE(array, index, value);
+    }
+
+    @Override
+    @Deprecated
     protected SwappedByteBuf newSwappedByteBuf() {
         if (PlatformDependent.isUnaligned()) {
             // Only use if unaligned access is supported otherwise there is no gain.

--- a/buffer/src/main/java/io/netty/buffer/UnreleasableByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnreleasableByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -51,7 +51,17 @@ final class UnreleasableByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public ByteBuf readSliceRetained(int length) {
+        return new UnreleasableByteBuf(buf.readSlice(length));
+    }
+
+    @Override
     public ByteBuf slice() {
+        return new UnreleasableByteBuf(buf.slice());
+    }
+
+    @Override
+    public ByteBuf sliceRetained() {
         return new UnreleasableByteBuf(buf.slice());
     }
 
@@ -61,7 +71,17 @@ final class UnreleasableByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public ByteBuf sliceRetained(int index, int length) {
+        return new UnreleasableByteBuf(buf.slice(index, length));
+    }
+
+    @Override
     public ByteBuf duplicate() {
+        return new UnreleasableByteBuf(buf.duplicate());
+    }
+
+    @Override
+    public ByteBuf duplicateRetained() {
         return new UnreleasableByteBuf(buf.duplicate());
     }
 

--- a/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/main/java/io/netty/buffer/UnsafeDirectSwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeDirectSwappedByteBuf.java
@@ -1,18 +1,18 @@
 /*
-* Copyright 2014 The Netty Project
-*
-* The Netty Project licenses this file to you under the Apache License,
-* version 2.0 (the "License"); you may not use this file except in compliance
-* with the License. You may obtain a copy of the License at:
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 
 package io.netty.buffer;
 

--- a/buffer/src/main/java/io/netty/buffer/UnsafeHeapSwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeHeapSwappedByteBuf.java
@@ -1,18 +1,18 @@
 /*
-* Copyright 2014 The Netty Project
-*
-* The Netty Project licenses this file to you under the Apache License,
-* version 2.0 (the "License"); you may not use this file except in compliance
-* with the License. You may obtain a copy of the License at:
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 
 package io.netty.buffer;
 

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -602,6 +602,11 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf readSliceRetained(int length) {
+        return buf.readSliceRetained(length);
+    }
+
+    @Override
     public ByteBuf readBytes(ByteBuf dst) {
         buf.readBytes(dst);
         return this;
@@ -850,13 +855,28 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf sliceRetained() {
+        return buf.sliceRetained();
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         return buf.slice(index, length);
     }
 
     @Override
+    public ByteBuf sliceRetained(int index, int length) {
+        return buf.sliceRetained(index, length);
+    }
+
+    @Override
     public ByteBuf duplicate() {
         return buf.duplicate();
+    }
+
+    @Override
+    public ByteBuf duplicateRetained() {
+        return buf.duplicateRetained();
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -94,6 +94,11 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return buf.isReadOnly();
+    }
+
+    @Override
     public final boolean isDirect() {
         return buf.isDirect();
     }

--- a/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package io.netty.buffer;
 
 import io.netty.util.ByteProcessor;
@@ -333,8 +334,18 @@ class WrappedCompositeByteBuf extends CompositeByteBuf {
     }
 
     @Override
+    public ByteBuf sliceRetained() {
+        return wrapped.sliceRetained();
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         return wrapped.slice(index, length);
+    }
+
+    @Override
+    public ByteBuf sliceRetained(int index, int length) {
+        return wrapped.sliceRetained(index, length);
     }
 
     @Override
@@ -418,8 +429,18 @@ class WrappedCompositeByteBuf extends CompositeByteBuf {
     }
 
     @Override
+    public ByteBuf duplicateRetained() {
+        return wrapped.duplicateRetained();
+    }
+
+    @Override
     public ByteBuf readSlice(int length) {
         return wrapped.readSlice(length);
+    }
+
+    @Override
+    public ByteBuf readSliceRetained(int length) {
+        return wrapped.readSliceRetained(length);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/package-info.java
+++ b/buffer/src/main/java/io/netty/buffer/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -2840,10 +2840,56 @@ public abstract class AbstractByteBufTest {
     }
 
     @Test
+    public void testSliceRetained() {
+        ByteBuf buf = newBuffer(8);
+        assertEquals(1, buf.refCnt());
+        assertFalse(buf.sliceRetained().release());
+        assertEquals(1, buf.refCnt());
+        assertTrue(buf.release());
+
+        buf = newBuffer(8);
+        ByteBuf slice = buf.slice().retain();
+        assertEquals(2, buf.refCnt());
+        assertFalse(slice.release(1));
+        assertEquals(1, buf.refCnt());
+        assertTrue(slice.release(1));
+        assertEquals(0, buf.refCnt());
+
+        buf = newBuffer(8);
+        slice = buf.slice().retain(2);
+        assertEquals(3, buf.refCnt());
+        assertTrue(slice.release(3));
+        assertEquals(0, buf.refCnt());
+    }
+
+    @Test
     public void testDuplicateRelease() {
         ByteBuf buf = newBuffer(8);
         assertEquals(1, buf.refCnt());
         assertTrue(buf.duplicate().release());
+        assertEquals(0, buf.refCnt());
+    }
+
+    @Test
+    public void testDuplicateRetained() {
+        ByteBuf buf = newBuffer(8);
+        assertEquals(1, buf.refCnt());
+        assertFalse(buf.duplicateRetained().release());
+        assertEquals(1, buf.refCnt());
+        assertTrue(buf.release());
+
+        buf = newBuffer(8);
+        ByteBuf duplicate = buf.duplicate().retain();
+        assertEquals(2, buf.refCnt());
+        assertFalse(duplicate.release(1));
+        assertEquals(1, buf.refCnt());
+        assertTrue(duplicate.release(1));
+        assertEquals(0, buf.refCnt());
+
+        buf = newBuffer(8);
+        duplicate = buf.duplicate().retain(2);
+        assertEquals(3, buf.refCnt());
+        assertTrue(duplicate.release(3));
         assertEquals(0, buf.refCnt());
     }
 

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -456,7 +456,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
     public void testComponentMustBeSlice() {
         CompositeByteBuf buf = releaseLater(compositeBuffer());
         buf.addComponent(buffer(4).setIndex(1, 3));
-        assertThat(buf.component(0), is(instanceOf(SlicedByteBuf.class)));
+        assertThat(buf.component(0), is(instanceOf(PooledSlicedByteBuf.class)));
         assertThat(buf.component(0).capacity(), is(2));
         assertThat(buf.component(0).maxCapacity(), is(2));
     }

--- a/buffer/src/test/java/io/netty/buffer/ByteBufDerivationTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufDerivationTest.java
@@ -34,7 +34,7 @@ public class ByteBufDerivationTest {
         ByteBuf buf = Unpooled.buffer(8).setIndex(1, 7);
         ByteBuf slice = buf.slice(1, 7);
 
-        assertThat(slice, instanceOf(SlicedByteBuf.class));
+        assertThat(slice, instanceOf(PooledSlicedByteBuf.class));
         assertThat(slice.unwrap(), sameInstance(buf));
         assertThat(slice.readerIndex(), is(0));
         assertThat(slice.writerIndex(), is(7));
@@ -53,7 +53,7 @@ public class ByteBufDerivationTest {
         ByteBuf slice2 = slice.slice(0, 6);
 
         assertThat(slice2, not(sameInstance(slice)));
-        assertThat(slice2, instanceOf(SlicedByteBuf.class));
+        assertThat(slice2, instanceOf(PooledSlicedByteBuf.class));
         assertThat(slice2.unwrap(), sameInstance(buf));
         assertThat(slice2.writerIndex(), is(6));
         assertThat(slice2.capacity(), is(6));
@@ -64,7 +64,7 @@ public class ByteBufDerivationTest {
         ByteBuf buf = Unpooled.buffer(8).setIndex(1, 7);
         ByteBuf dup = buf.duplicate();
 
-        assertThat(dup, instanceOf(DuplicatedByteBuf.class));
+        assertThat(dup, instanceOf(PooledDuplicatedByteBuf.class));
         assertThat(dup.unwrap(), sameInstance(buf));
         assertThat(dup.readerIndex(), is(buf.readerIndex()));
         assertThat(dup.writerIndex(), is(buf.writerIndex()));
@@ -83,7 +83,7 @@ public class ByteBufDerivationTest {
         ByteBuf dup2 = dup.duplicate();
 
         assertThat(dup2, not(sameInstance(dup)));
-        assertThat(dup2, instanceOf(DuplicatedByteBuf.class));
+        assertThat(dup2, instanceOf(PooledDuplicatedByteBuf.class));
         assertThat(dup2.unwrap(), sameInstance(buf));
         assertThat(dup2.readerIndex(), is(dup.readerIndex()));
         assertThat(dup2.writerIndex(), is(dup.writerIndex()));
@@ -96,7 +96,7 @@ public class ByteBufDerivationTest {
         ByteBuf buf = Unpooled.buffer(8).setIndex(1, 7);
         ByteBuf ro = Unpooled.unmodifiableBuffer(buf);
 
-        assertThat(ro, instanceOf(ReadOnlyByteBuf.class));
+        assertThat(ro, instanceOf(PooledReadOnlyByteBuf.class));
         assertThat(ro.unwrap(), sameInstance(buf));
         assertThat(ro.readerIndex(), is(buf.readerIndex()));
         assertThat(ro.writerIndex(), is(buf.writerIndex()));
@@ -114,7 +114,7 @@ public class ByteBufDerivationTest {
         ByteBuf ro2 = Unpooled.unmodifiableBuffer(ro);
 
         assertThat(ro2, not(sameInstance(ro)));
-        assertThat(ro2, instanceOf(ReadOnlyByteBuf.class));
+        assertThat(ro2, instanceOf(PooledReadOnlyByteBuf.class));
         assertThat(ro2.unwrap(), sameInstance(buf));
         assertThat(ro2.readerIndex(), is(ro.readerIndex()));
         assertThat(ro2.writerIndex(), is(ro.writerIndex()));
@@ -128,7 +128,7 @@ public class ByteBufDerivationTest {
         ByteBuf dup = buf.duplicate().setIndex(2, 6);
         ByteBuf ro = Unpooled.unmodifiableBuffer(dup);
 
-        assertThat(ro, instanceOf(ReadOnlyByteBuf.class));
+        assertThat(ro, instanceOf(PooledReadOnlyByteBuf.class));
         assertThat(ro.unwrap(), sameInstance(buf));
         assertThat(ro.readerIndex(), is(dup.readerIndex()));
         assertThat(ro.writerIndex(), is(dup.writerIndex()));
@@ -142,7 +142,7 @@ public class ByteBufDerivationTest {
         ByteBuf ro = Unpooled.unmodifiableBuffer(buf).setIndex(2, 6);
         ByteBuf dup = ro.duplicate();
 
-        assertThat(dup, instanceOf(ReadOnlyByteBuf.class));
+        assertThat(dup, instanceOf(PooledReadOnlyByteBuf.class));
         assertThat(dup.unwrap(), sameInstance(buf));
         assertThat(dup.readerIndex(), is(ro.readerIndex()));
         assertThat(dup.writerIndex(), is(ro.writerIndex()));

--- a/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
@@ -31,8 +31,7 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
 
     @Override
     protected ByteBuf newBuffer(int length) {
-        ByteBuf buffer = Unpooled.wrappedBuffer(
-                new byte[length * 2], random.nextInt(length - 1) + 1, length);
+        ByteBuf buffer = Unpooled.wrappedBuffer(new byte[length * 2], random.nextInt(length - 1) + 1, length);
         assertEquals(length, buffer.writerIndex());
         return buffer;
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -127,7 +127,7 @@ public class Http2FrameRoundtripTest {
             // Now verify that all of the reference counts are zero.
             for (ByteBuf buf : needReleasing) {
                 int expectedFinalRefCount = 0;
-                if (buf instanceof ReadOnlyByteBuf || buf instanceof EmptyByteBuf) {
+                if (buf.isReadOnly()) {
                     // Special case for when we're writing slices of the padding buffer.
                     expectedFinalRefCount = 1;
                 }

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
@@ -41,6 +41,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     private ByteBuf buffer;
     private boolean terminated;
+    @SuppressWarnings("deprecation")
     private SwappedByteBuf swapped;
 
     static final ReplayingDecoderByteBuf EMPTY_BUFFER = new ReplayingDecoderByteBuf(Unpooled.EMPTY_BUFFER);
@@ -167,6 +168,12 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf duplicate() {
+        reject();
+        return this;
+    }
+
+    @Override
+    public ByteBuf duplicateRetained() {
         reject();
         return this;
     }
@@ -461,11 +468,13 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    @Deprecated
     public ByteOrder order() {
         return buffer.order();
     }
 
     @Override
+    @Deprecated
     public ByteBuf order(ByteOrder endianness) {
         if (endianness == null) {
             throw new NullPointerException("endianness");
@@ -580,6 +589,12 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     public ByteBuf readSlice(int length) {
         checkReadableBytes(length);
         return buffer.readSlice(length);
+    }
+
+    @Override
+    public ByteBuf readSliceRetained(int length) {
+        checkReadableBytes(length);
+        return buffer.readSliceRetained(length);
     }
 
     @Override
@@ -871,7 +886,19 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf sliceRetained() {
+        reject();
+        return this;
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
+        checkIndex(index, length);
+        return buffer.slice(index, length);
+    }
+
+    @Override
+    public ByteBuf sliceRetained(int index, int length) {
         checkIndex(index, length);
         return buffer.slice(index, length);
     }

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
@@ -90,6 +90,11 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
     public boolean isDirect() {
         return buffer.isDirect();
     }


### PR DESCRIPTION
Related: #4333 #4421

Motivation:

slice(), duplicate() and readSlice() currently create a non-recyclable
derived buffer instance. Under heavy load, an application that creates a
lot of derived buffers can put the garbage collector under pressure.

Modifications:

- Deprecate the old derived buffer implementations
- Add the new recyclable derived buffer implementations, which has its
  own reference count value
  - When a derived buffer is created, its internal reference count is 0.
  - When retain() is called on a derived buffer, the internal reference
    count becomes a positive value and the original buffer's retain() is
    called.
  - When release() is called on a derived buffer, the internal reference
    count is decreased first, and then the original buffer's release()
    is called when the internal reference count is 0.
- Add ByteBufUtil.duplicate/slice() so that a user can easily implement
  ByteBuf.duplicate/slice()
- Add missing overrides in some ByteBuf impls
- Fix incorrect range checks in SlicedByteBuf
- Miscellaneous:
  - Merge Duplicated/SlicedAbstractByteBuf.unwrap0() into unwrap() using
    covariant return type

Result:

- Derived buffers are now recycled when retained and released, although
  they are not recycled if a user called release() against the original
  buffer.

    buf.slice().retain().release(); // recycled
    buf.slice().retain(); buf.release(); // not recycled

- Correct range checks in SlicedByteBuf