### PR TITLE
Implement the ByteBuf methods that should have been overridden

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractDerivedByteBuf.java
@@ -21,7 +21,10 @@ import java.nio.ByteBuffer;
 /**
  * Abstract base class for {@link ByteBuf} implementations that wrap another
  * {@link ByteBuf}.
+ *
+ * @deprecated Do not use.
  */
+@Deprecated
 public abstract class AbstractDerivedByteBuf extends AbstractByteBuf {
 
     protected AbstractDerivedByteBuf(int maxCapacity) {

--- a/buffer/src/main/java/io/netty/buffer/DuplicatedAbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DuplicatedAbstractByteBuf.java
@@ -20,61 +20,102 @@ package io.netty.buffer;
  * is of type {@link AbstractByteBuf}.
  */
 final class DuplicatedAbstractByteBuf extends DuplicatedByteBuf {
-    public DuplicatedAbstractByteBuf(AbstractByteBuf buffer) {
+    DuplicatedAbstractByteBuf(AbstractByteBuf buffer) {
         super(buffer);
     }
 
     @Override
+    public AbstractByteBuf unwrap() {
+        return (AbstractByteBuf) super.unwrap();
+    }
+
+    @Override
     protected byte _getByte(int index) {
-        return unwrap0()._getByte(index);
+        return unwrap()._getByte(index);
     }
 
     @Override
     protected short _getShort(int index) {
-        return unwrap0()._getShort(index);
+        return unwrap()._getShort(index);
+    }
+
+    @Override
+    protected short _getShortLE(int index) {
+        return unwrap()._getShortLE(index);
     }
 
     @Override
     protected int _getUnsignedMedium(int index) {
-        return unwrap0()._getUnsignedMedium(index);
+        return unwrap()._getUnsignedMedium(index);
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return unwrap()._getUnsignedMediumLE(index);
     }
 
     @Override
     protected int _getInt(int index) {
-        return unwrap0()._getInt(index);
+        return unwrap()._getInt(index);
+    }
+
+    @Override
+    protected int _getIntLE(int index) {
+        return unwrap()._getIntLE(index);
     }
 
     @Override
     protected long _getLong(int index) {
-        return unwrap0()._getLong(index);
+        return unwrap()._getLong(index);
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return unwrap()._getLongLE(index);
     }
 
     @Override
     protected void _setByte(int index, int value) {
-        unwrap0()._setByte(index, value);
+        unwrap()._setByte(index, value);
     }
 
     @Override
     protected void _setShort(int index, int value) {
-        unwrap0()._setShort(index, value);
+        unwrap()._setShort(index, value);
+    }
+
+    @Override
+    protected void _setShortLE(int index, int value) {
+        unwrap()._setShortLE(index, value);
     }
 
     @Override
     protected void _setMedium(int index, int value) {
-        unwrap0()._setMedium(index, value);
+        unwrap()._setMedium(index, value);
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        unwrap()._setMediumLE(index, value);
     }
 
     @Override
     protected void _setInt(int index, int value) {
-        unwrap0()._setInt(index, value);
+        unwrap()._setInt(index, value);
+    }
+
+    @Override
+    protected void _setIntLE(int index, int value) {
+        unwrap()._setIntLE(index, value);
     }
 
     @Override
     protected void _setLong(int index, long value) {
-        unwrap0()._setLong(index, value);
+        unwrap()._setLong(index, value);
     }
 
-    private AbstractByteBuf unwrap0() {
-        return (AbstractByteBuf) unwrap();
+    @Override
+    protected void _setLongLE(int index, long value) {
+        unwrap()._setLongLE(index, value);
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/DuplicatedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/DuplicatedByteBuf.java
@@ -26,12 +26,14 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 
-
 /**
  * A derived buffer which simply forwards all data access requests to its
  * parent.  It is recommended to use {@link ByteBuf#duplicate()} instead
  * of calling the constructor explicitly.
+ *
+ * @deprecated Do not use.
  */
+@Deprecated
 public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
 
     private final ByteBuf buffer;
@@ -57,306 +59,346 @@ public class DuplicatedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public ByteBufAllocator alloc() {
-        return buffer.alloc();
+        return unwrap().alloc();
     }
 
     @Override
+    @Deprecated
     public ByteOrder order() {
-        return buffer.order();
+        return unwrap().order();
     }
 
     @Override
     public boolean isDirect() {
-        return buffer.isDirect();
+        return unwrap().isDirect();
     }
 
     @Override
     public int capacity() {
-        return buffer.capacity();
+        return unwrap().capacity();
     }
 
     @Override
     public ByteBuf capacity(int newCapacity) {
-        buffer.capacity(newCapacity);
+        unwrap().capacity(newCapacity);
         return this;
     }
 
     @Override
     public boolean hasArray() {
-        return buffer.hasArray();
+        return unwrap().hasArray();
     }
 
     @Override
     public byte[] array() {
-        return buffer.array();
+        return unwrap().array();
     }
 
     @Override
     public int arrayOffset() {
-        return buffer.arrayOffset();
+        return unwrap().arrayOffset();
     }
 
     @Override
     public boolean hasMemoryAddress() {
-        return buffer.hasMemoryAddress();
+        return unwrap().hasMemoryAddress();
     }
 
     @Override
     public long memoryAddress() {
-        return buffer.memoryAddress();
+        return unwrap().memoryAddress();
     }
 
     @Override
     public byte getByte(int index) {
-        return buffer.getByte(index);
+        return unwrap().getByte(index);
     }
 
     @Override
     protected byte _getByte(int index) {
-        return buffer.getByte(index);
+        return unwrap().getByte(index);
     }
 
     @Override
     public short getShort(int index) {
-        return buffer.getShort(index);
+        return unwrap().getShort(index);
     }
 
     @Override
     protected short _getShort(int index) {
-        return buffer.getShort(index);
+        return unwrap().getShort(index);
+    }
+
+    @Override
+    public short getShortLE(int index) {
+        return unwrap().getShortLE(index);
     }
 
     @Override
     protected short _getShortLE(int index) {
-        return buffer.getShortLE(index);
+        return unwrap().getShortLE(index);
     }
 
     @Override
     public int getUnsignedMedium(int index) {
-        return buffer.getUnsignedMedium(index);
+        return unwrap().getUnsignedMedium(index);
     }
 
     @Override
     protected int _getUnsignedMedium(int index) {
-        return buffer.getUnsignedMedium(index);
+        return unwrap().getUnsignedMedium(index);
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
+        return unwrap().getUnsignedMediumLE(index);
     }
 
     @Override
     protected int _getUnsignedMediumLE(int index) {
-        return buffer.getUnsignedMediumLE(index);
+        return unwrap().getUnsignedMediumLE(index);
     }
 
     @Override
     public int getInt(int index) {
-        return buffer.getInt(index);
+        return unwrap().getInt(index);
     }
 
     @Override
     protected int _getInt(int index) {
-        return buffer.getInt(index);
+        return unwrap().getInt(index);
+    }
+
+    @Override
+    public int getIntLE(int index) {
+        return unwrap().getIntLE(index);
     }
 
     @Override
     protected int _getIntLE(int index) {
-        return buffer.getIntLE(index);
+        return unwrap().getIntLE(index);
     }
 
     @Override
     public long getLong(int index) {
-        return buffer.getLong(index);
+        return unwrap().getLong(index);
     }
 
     @Override
     protected long _getLong(int index) {
-        return buffer.getLong(index);
+        return unwrap().getLong(index);
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        return unwrap().getLongLE(index);
     }
 
     @Override
     protected long _getLongLE(int index) {
-        return buffer.getLongLE(index);
+        return unwrap().getLongLE(index);
     }
 
     @Override
     public ByteBuf copy(int index, int length) {
-        return buffer.copy(index, length);
+        return unwrap().copy(index, length);
     }
 
     @Override
     public ByteBuf slice(int index, int length) {
-        return buffer.slice(index, length);
+        return unwrap().slice(index, length);
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
-        buffer.getBytes(index, dst, dstIndex, length);
+        unwrap().getBytes(index, dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
-        buffer.getBytes(index, dst, dstIndex, length);
+        unwrap().getBytes(index, dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuffer dst) {
-        buffer.getBytes(index, dst);
+        unwrap().getBytes(index, dst);
         return this;
     }
 
     @Override
     public ByteBuf setByte(int index, int value) {
-        buffer.setByte(index, value);
+        unwrap().setByte(index, value);
         return this;
     }
 
     @Override
     protected void _setByte(int index, int value) {
-        buffer.setByte(index, value);
+        unwrap().setByte(index, value);
     }
 
     @Override
     public ByteBuf setShort(int index, int value) {
-        buffer.setShort(index, value);
+        unwrap().setShort(index, value);
         return this;
     }
 
     @Override
     protected void _setShort(int index, int value) {
-        buffer.setShort(index, value);
+        unwrap().setShort(index, value);
+    }
+
+    @Override
+    public ByteBuf setShortLE(int index, int value) {
+        unwrap().setShortLE(index, value);
+        return this;
     }
 
     @Override
     protected void _setShortLE(int index, int value) {
-        buffer.setShortLE(index, value);
+        unwrap().setShortLE(index, value);
     }
 
     @Override
     public ByteBuf setMedium(int index, int value) {
-        buffer.setMedium(index, value);
+        unwrap().setMedium(index, value);
         return this;
     }
 
     @Override
     protected void _setMedium(int index, int value) {
-        buffer.setMedium(index, value);
+        unwrap().setMedium(index, value);
+    }
+
+    @Override
+    public ByteBuf setMediumLE(int index, int value) {
+        unwrap().setMediumLE(index, value);
+        return this;
     }
 
     @Override
     protected void _setMediumLE(int index, int value) {
-        buffer.setMediumLE(index, value);
+        unwrap().setMediumLE(index, value);
     }
 
     @Override
     public ByteBuf setInt(int index, int value) {
-        buffer.setInt(index, value);
+        unwrap().setInt(index, value);
         return this;
     }
 
     @Override
     protected void _setInt(int index, int value) {
-        buffer.setInt(index, value);
+        unwrap().setInt(index, value);
+    }
+
+    @Override
+    public ByteBuf setIntLE(int index, int value) {
+        unwrap().setIntLE(index, value);
+        return this;
     }
 
     @Override
     protected void _setIntLE(int index, int value) {
-        buffer.setIntLE(index, value);
+        unwrap().setIntLE(index, value);
     }
 
     @Override
     public ByteBuf setLong(int index, long value) {
-        buffer.setLong(index, value);
+        unwrap().setLong(index, value);
         return this;
     }
 
     @Override
     protected void _setLong(int index, long value) {
-        buffer.setLong(index, value);
+        unwrap().setLong(index, value);
+    }
+
+    @Override
+    public ByteBuf setLongLE(int index, long value) {
+        unwrap().setLongLE(index, value);
+        return this;
     }
 
     @Override
     protected void _setLongLE(int index, long value) {
-        buffer.setLongLE(index, value);
+        unwrap().setLongLE(index, value);
     }
 
     @Override
     public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
-        buffer.setBytes(index, src, srcIndex, length);
+        unwrap().setBytes(index, src, srcIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
-        buffer.setBytes(index, src, srcIndex, length);
+        unwrap().setBytes(index, src, srcIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf setBytes(int index, ByteBuffer src) {
-        buffer.setBytes(index, src);
+        unwrap().setBytes(index, src);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, OutputStream out, int length)
             throws IOException {
-        buffer.getBytes(index, out, length);
+        unwrap().getBytes(index, out, length);
         return this;
     }
 
     @Override
     public int getBytes(int index, GatheringByteChannel out, int length)
             throws IOException {
-        return buffer.getBytes(index, out, length);
+        return unwrap().getBytes(index, out, length);
     }
 
     @Override
     public int getBytes(int index, FileChannel out, long position, int length)
             throws IOException {
-        return buffer.getBytes(index, out, position, length);
+        return unwrap().getBytes(index, out, position, length);
     }
 
     @Override
     public int setBytes(int index, InputStream in, int length)
             throws IOException {
-        return buffer.setBytes(index, in, length);
+        return unwrap().setBytes(index, in, length);
     }
 
     @Override
     public int setBytes(int index, ScatteringByteChannel in, int length)
             throws IOException {
-        return buffer.setBytes(index, in, length);
+        return unwrap().setBytes(index, in, length);
     }
 
     @Override
     public int setBytes(int index, FileChannel in, long position, int length)
             throws IOException {
-        return buffer.setBytes(index, in, position, length);
+        return unwrap().setBytes(index, in, position, length);
     }
 
     @Override
     public int nioBufferCount() {
-        return buffer.nioBufferCount();
+        return unwrap().nioBufferCount();
     }
 
     @Override
     public ByteBuffer[] nioBuffers(int index, int length) {
-        return buffer.nioBuffers(index, length);
-    }
-
-    @Override
-    public ByteBuffer internalNioBuffer(int index, int length) {
-        return nioBuffer(index, length);
+        return unwrap().nioBuffers(index, length);
     }
 
     @Override
     public int forEachByte(int index, int length, ByteProcessor processor) {
-        return buffer.forEachByte(index, length, processor);
+        return unwrap().forEachByte(index, length, processor);
     }
 
     @Override
     public int forEachByteDesc(int index, int length, ByteProcessor processor) {
-        return buffer.forEachByteDesc(index, length, processor);
+        return unwrap().forEachByteDesc(index, length, processor);
     }
 }
 

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeHeapByteBuf.java
@@ -1,7 +1,9 @@
 /*
  * Copyright 2015 The Netty Project
  *
- * The Netty Project licenses this file tothe License at:
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -47,8 +49,18 @@ final class PooledUnsafeHeapByteBuf extends PooledHeapByteBuf {
     }
 
     @Override
+    protected short _getShortLE(int index) {
+        return UnsafeByteBufUtil.getShortLE(memory, idx(index));
+    }
+
+    @Override
     protected int _getUnsignedMedium(int index) {
         return UnsafeByteBufUtil.getUnsignedMedium(memory, idx(index));
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return UnsafeByteBufUtil.getUnsignedMediumLE(memory, idx(index));
     }
 
     @Override
@@ -57,8 +69,18 @@ final class PooledUnsafeHeapByteBuf extends PooledHeapByteBuf {
     }
 
     @Override
+    protected int _getIntLE(int index) {
+        return UnsafeByteBufUtil.getIntLE(memory, idx(index));
+    }
+
+    @Override
     protected long _getLong(int index) {
         return UnsafeByteBufUtil.getLong(memory, idx(index));
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return UnsafeByteBufUtil.getLongLE(memory, idx(index));
     }
 
     @Override
@@ -72,8 +94,18 @@ final class PooledUnsafeHeapByteBuf extends PooledHeapByteBuf {
     }
 
     @Override
+    protected void _setShortLE(int index, int value) {
+        UnsafeByteBufUtil.setShortLE(memory, idx(index), value);
+    }
+
+    @Override
     protected void _setMedium(int index, int value) {
         UnsafeByteBufUtil.setMedium(memory, idx(index), value);
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        UnsafeByteBufUtil.setMediumLE(memory, idx(index), value);
     }
 
     @Override
@@ -82,11 +114,22 @@ final class PooledUnsafeHeapByteBuf extends PooledHeapByteBuf {
     }
 
     @Override
+    protected void _setIntLE(int index, int value) {
+        UnsafeByteBufUtil.setIntLE(memory, idx(index), value);
+    }
+
+    @Override
     protected void _setLong(int index, long value) {
         UnsafeByteBufUtil.setLong(memory, idx(index), value);
     }
 
     @Override
+    protected void _setLongLE(int index, long value) {
+        UnsafeByteBufUtil.setLongLE(memory, idx(index), value);
+    }
+
+    @Override
+    @Deprecated
     protected SwappedByteBuf newSwappedByteBuf() {
         if (PlatformDependent.isUnaligned()) {
             // Only use if unaligned access is supported otherwise there is no gain.

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
@@ -31,7 +31,10 @@ import java.nio.channels.ScatteringByteChannel;
  * A derived buffer which forbids any write requests to its parent.  It is
  * recommended to use {@link Unpooled#unmodifiableBuffer(ByteBuf)}
  * instead of calling the constructor explicitly.
+ *
+ * @deprecated Do not use.
  */
+@Deprecated
 public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
 
     private final ByteBuf buffer;
@@ -64,17 +67,18 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public ByteBufAllocator alloc() {
-        return buffer.alloc();
+        return unwrap().alloc();
     }
 
     @Override
+    @Deprecated
     public ByteOrder order() {
-        return buffer.order();
+        return unwrap().order();
     }
 
     @Override
     public boolean isDirect() {
-        return buffer.isDirect();
+        return unwrap().isDirect();
     }
 
     @Override
@@ -143,6 +147,11 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    public ByteBuf setShortLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setShortLE(int index, int value) {
         throw new ReadOnlyBufferException();
     }
@@ -154,6 +163,11 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     protected void _setMedium(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setMediumLE(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -173,6 +187,11 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    public ByteBuf setIntLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setIntLE(int index, int value) {
         throw new ReadOnlyBufferException();
     }
@@ -184,6 +203,11 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     protected void _setLong(int index, long value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setLongLE(int index, long value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -210,37 +234,37 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     @Override
     public int getBytes(int index, GatheringByteChannel out, int length)
             throws IOException {
-        return buffer.getBytes(index, out, length);
+        return unwrap().getBytes(index, out, length);
     }
 
     @Override
     public int getBytes(int index, FileChannel out, long position, int length)
             throws IOException {
-        return buffer.getBytes(index, out, position, length);
+        return unwrap().getBytes(index, out, position, length);
     }
 
     @Override
     public ByteBuf getBytes(int index, OutputStream out, int length)
             throws IOException {
-        buffer.getBytes(index, out, length);
+        unwrap().getBytes(index, out, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
-        buffer.getBytes(index, dst, dstIndex, length);
+        unwrap().getBytes(index, dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
-        buffer.getBytes(index, dst, dstIndex, length);
+        unwrap().getBytes(index, dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuffer dst) {
-        buffer.getBytes(index, dst);
+        unwrap().getBytes(index, dst);
         return this;
     }
 
@@ -251,117 +275,132 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public ByteBuf copy(int index, int length) {
-        return buffer.copy(index, length);
+        return unwrap().copy(index, length);
     }
 
     @Override
     public ByteBuf slice(int index, int length) {
-        return Unpooled.unmodifiableBuffer(buffer.slice(index, length));
+        return Unpooled.unmodifiableBuffer(unwrap().slice(index, length));
     }
 
     @Override
     public byte getByte(int index) {
-        return _getByte(index);
+        return unwrap().getByte(index);
     }
 
     @Override
     protected byte _getByte(int index) {
-        return buffer.getByte(index);
+        return unwrap().getByte(index);
     }
 
     @Override
     public short getShort(int index) {
-        return _getShort(index);
+        return unwrap().getShort(index);
     }
 
     @Override
     protected short _getShort(int index) {
-        return buffer.getShort(index);
+        return unwrap().getShort(index);
+    }
+
+    @Override
+    public short getShortLE(int index) {
+        return unwrap().getShortLE(index);
     }
 
     @Override
     protected short _getShortLE(int index) {
-        return buffer.getShortLE(index);
+        return unwrap().getShortLE(index);
     }
 
     @Override
     public int getUnsignedMedium(int index) {
-        return _getUnsignedMedium(index);
+        return unwrap().getUnsignedMedium(index);
     }
 
     @Override
     protected int _getUnsignedMedium(int index) {
-        return buffer.getUnsignedMedium(index);
+        return unwrap().getUnsignedMedium(index);
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
+        return unwrap().getUnsignedMediumLE(index);
     }
 
     @Override
     protected int _getUnsignedMediumLE(int index) {
-        return buffer.getUnsignedMediumLE(index);
+        return unwrap().getUnsignedMediumLE(index);
     }
 
     @Override
     public int getInt(int index) {
-        return _getInt(index);
+        return unwrap().getInt(index);
     }
 
     @Override
     protected int _getInt(int index) {
-        return buffer.getInt(index);
+        return unwrap().getInt(index);
+    }
+
+    @Override
+    public int getIntLE(int index) {
+        return unwrap().getIntLE(index);
     }
 
     @Override
     protected int _getIntLE(int index) {
-        return buffer.getIntLE(index);
+        return unwrap().getIntLE(index);
     }
 
     @Override
     public long getLong(int index) {
-        return _getLong(index);
+        return unwrap().getLong(index);
     }
 
     @Override
     protected long _getLong(int index) {
-        return buffer.getLong(index);
+        return unwrap().getLong(index);
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        return unwrap().getLongLE(index);
     }
 
     @Override
     protected long _getLongLE(int index) {
-        return buffer.getLongLE(index);
+        return unwrap().getLongLE(index);
     }
 
     @Override
     public int nioBufferCount() {
-        return buffer.nioBufferCount();
+        return unwrap().nioBufferCount();
     }
 
     @Override
     public ByteBuffer nioBuffer(int index, int length) {
-        return buffer.nioBuffer(index, length).asReadOnlyBuffer();
+        return unwrap().nioBuffer(index, length).asReadOnlyBuffer();
     }
 
     @Override
     public ByteBuffer[] nioBuffers(int index, int length) {
-        return buffer.nioBuffers(index, length);
-    }
-
-    @Override
-    public ByteBuffer internalNioBuffer(int index, int length) {
-        return nioBuffer(index, length);
+        return unwrap().nioBuffers(index, length);
     }
 
     @Override
     public int forEachByte(int index, int length, ByteProcessor processor) {
-        return buffer.forEachByte(index, length, processor);
+        return unwrap().forEachByte(index, length, processor);
     }
 
     @Override
     public int forEachByteDesc(int index, int length, ByteProcessor processor) {
-        return buffer.forEachByteDesc(index, length, processor);
+        return unwrap().forEachByteDesc(index, length, processor);
     }
 
     @Override
     public int capacity() {
-        return buffer.capacity();
+        return unwrap().capacity();
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -74,6 +74,12 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public short getShortLE(int index) {
+        ensureAccessible();
+        return _getShortLE(index);
+    }
+
+    @Override
     protected short _getShortLE(int index) {
         return ByteBufUtil.swapShort(buffer.getShort(index));
     }
@@ -89,6 +95,12 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
         return (getByte(index) & 0xff)     << 16 |
                (getByte(index + 1) & 0xff) << 8  |
                getByte(index + 2) & 0xff;
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
+        ensureAccessible();
+        return _getUnsignedMediumLE(index);
     }
 
     @Override
@@ -110,6 +122,12 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public int getIntLE(int index) {
+        ensureAccessible();
+        return _getIntLE(index);
+    }
+
+    @Override
     protected int _getIntLE(int index) {
         return ByteBufUtil.swapInt(buffer.getInt(index));
     }
@@ -123,6 +141,12 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected long _getLong(int index) {
         return buffer.getLong(index);
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        ensureAccessible();
+        return _getLongLE(index);
     }
 
     @Override
@@ -177,7 +201,17 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf setByte(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setByte(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setShort(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -187,7 +221,17 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf setShortLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setShortLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setMedium(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -197,7 +241,17 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf setMediumLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setMediumLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setInt(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
@@ -207,12 +261,27 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf setIntLE(int index, int value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setIntLE(int index, int value) {
         throw new ReadOnlyBufferException();
     }
 
     @Override
+    public ByteBuf setLong(int index, long value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     protected void _setLong(int index, long value) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public ByteBuf setLongLE(int index, long value) {
         throw new ReadOnlyBufferException();
     }
 

--- a/buffer/src/main/java/io/netty/buffer/SlicedAbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SlicedAbstractByteBuf.java
@@ -26,56 +26,97 @@ final class SlicedAbstractByteBuf extends SlicedByteBuf {
     }
 
     @Override
+    public AbstractByteBuf unwrap() {
+        return (AbstractByteBuf) super.unwrap();
+    }
+
+    @Override
     protected byte _getByte(int index) {
-        return unwrap0()._getByte(idx(index));
+        return unwrap()._getByte(idx(index));
     }
 
     @Override
     protected short _getShort(int index) {
-        return unwrap0()._getShort(idx(index));
+        return unwrap()._getShort(idx(index));
+    }
+
+    @Override
+    protected short _getShortLE(int index) {
+        return unwrap()._getShortLE(idx(index));
     }
 
     @Override
     protected int _getUnsignedMedium(int index) {
-        return unwrap0()._getUnsignedMedium(idx(index));
+        return unwrap()._getUnsignedMedium(idx(index));
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return unwrap()._getUnsignedMediumLE(idx(index));
     }
 
     @Override
     protected int _getInt(int index) {
-        return unwrap0()._getInt(idx(index));
+        return unwrap()._getInt(idx(index));
+    }
+
+    @Override
+    protected int _getIntLE(int index) {
+        return unwrap()._getIntLE(idx(index));
     }
 
     @Override
     protected long _getLong(int index) {
-        return unwrap0()._getLong(idx(index));
+        return unwrap()._getLong(idx(index));
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return unwrap()._getLongLE(idx(index));
     }
 
     @Override
     protected void _setByte(int index, int value) {
-        unwrap0()._setByte(idx(index), value);
+        unwrap()._setByte(idx(index), value);
     }
 
     @Override
     protected void _setShort(int index, int value) {
-        unwrap0()._setShort(idx(index), value);
+        unwrap()._setShort(idx(index), value);
+    }
+
+    @Override
+    protected void _setShortLE(int index, int value) {
+        unwrap()._setShortLE(idx(index), value);
     }
 
     @Override
     protected void _setMedium(int index, int value) {
-        unwrap0()._setMedium(idx(index), value);
+        unwrap()._setMedium(idx(index), value);
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        unwrap()._setMediumLE(idx(index), value);
     }
 
     @Override
     protected void _setInt(int index, int value) {
-        unwrap0()._setInt(idx(index), value);
+        unwrap()._setInt(idx(index), value);
+    }
+
+    @Override
+    protected void _setIntLE(int index, int value) {
+        unwrap()._setIntLE(idx(index), value);
     }
 
     @Override
     protected void _setLong(int index, long value) {
-        unwrap0()._setLong(idx(index), value);
+        unwrap()._setLong(idx(index), value);
     }
 
-    private AbstractByteBuf unwrap0() {
-        return (AbstractByteBuf) unwrap();
+    @Override
+    protected void _setLongLE(int index, long value) {
+        unwrap()._setLongLE(idx(index), value);
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
@@ -26,13 +26,15 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 
-
 /**
  * A derived buffer which exposes its parent's sub-region only.  It is
  * recommended to use {@link ByteBuf#slice()} and
  * {@link ByteBuf#slice(int, int)} instead of calling the constructor
  * explicitly.
+ *
+ * @deprecated Do not use.
  */
+@Deprecated
 public class SlicedByteBuf extends AbstractDerivedByteBuf {
 
     private final ByteBuf buffer;
@@ -67,17 +69,18 @@ public class SlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public ByteBufAllocator alloc() {
-        return buffer.alloc();
+        return unwrap().alloc();
     }
 
     @Override
+    @Deprecated
     public ByteOrder order() {
-        return buffer.order();
+        return unwrap().order();
     }
 
     @Override
     public boolean isDirect() {
-        return buffer.isDirect();
+        return unwrap().isDirect();
     }
 
     @Override
@@ -92,77 +95,131 @@ public class SlicedByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public boolean hasArray() {
-        return buffer.hasArray();
+        return unwrap().hasArray();
     }
 
     @Override
     public byte[] array() {
-        return buffer.array();
+        return unwrap().array();
     }
 
     @Override
     public int arrayOffset() {
-        return idx(buffer.arrayOffset());
+        return idx(unwrap().arrayOffset());
     }
 
     @Override
     public boolean hasMemoryAddress() {
-        return buffer.hasMemoryAddress();
+        return unwrap().hasMemoryAddress();
     }
 
     @Override
     public long memoryAddress() {
-        return buffer.memoryAddress() + adjustment;
+        return unwrap().memoryAddress() + adjustment;
+    }
+
+    @Override
+    public byte getByte(int index) {
+        checkIndex0(index, 1);
+        return unwrap().getByte(idx(index));
     }
 
     @Override
     protected byte _getByte(int index) {
-        return buffer.getByte(idx(index));
+        return unwrap().getByte(idx(index));
+    }
+
+    @Override
+    public short getShort(int index) {
+        checkIndex0(index, 2);
+        return unwrap().getShort(idx(index));
     }
 
     @Override
     protected short _getShort(int index) {
-        return buffer.getShort(idx(index));
+        return unwrap().getShort(idx(index));
+    }
+
+    @Override
+    public short getShortLE(int index) {
+        checkIndex0(index, 2);
+        return unwrap().getShortLE(idx(index));
     }
 
     @Override
     protected short _getShortLE(int index) {
-        return buffer.getShortLE(idx(index));
+        return unwrap().getShortLE(idx(index));
+    }
+
+    @Override
+    public int getUnsignedMedium(int index) {
+        checkIndex0(index, 3);
+        return unwrap().getUnsignedMedium(idx(index));
     }
 
     @Override
     protected int _getUnsignedMedium(int index) {
-        return buffer.getUnsignedMedium(idx(index));
+        return unwrap().getUnsignedMedium(idx(index));
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
+        checkIndex0(index, 3);
+        return unwrap().getUnsignedMediumLE(idx(index));
     }
 
     @Override
     protected int _getUnsignedMediumLE(int index) {
-        return buffer.getUnsignedMediumLE(idx(index));
+        return unwrap().getUnsignedMediumLE(idx(index));
+    }
+
+    @Override
+    public int getInt(int index) {
+        checkIndex0(index, 4);
+        return unwrap().getInt(idx(index));
     }
 
     @Override
     protected int _getInt(int index) {
-        return buffer.getInt(idx(index));
+        return unwrap().getInt(idx(index));
+    }
+
+    @Override
+    public int getIntLE(int index) {
+        checkIndex0(index, 4);
+        return unwrap().getIntLE(idx(index));
     }
 
     @Override
     protected int _getIntLE(int index) {
-        return buffer.getIntLE(idx(index));
+        return unwrap().getIntLE(idx(index));
+    }
+
+    @Override
+    public long getLong(int index) {
+        checkIndex0(index, 8);
+        return unwrap().getLong(idx(index));
     }
 
     @Override
     protected long _getLong(int index) {
-        return buffer.getLong(idx(index));
+        return unwrap().getLong(idx(index));
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        checkIndex0(index, 8);
+        return unwrap().getLongLE(idx(index));
     }
 
     @Override
     protected long _getLongLE(int index) {
-        return buffer.getLongLE(idx(index));
+        return unwrap().getLongLE(idx(index));
     }
 
     @Override
     public ByteBuf duplicate() {
-        ByteBuf duplicate = buffer.slice(adjustment, length);
+        final ByteBuf duplicate = unwrap().slice(adjustment, length);
         duplicate.setIndex(readerIndex(), writerIndex());
         return duplicate;
     }
@@ -170,165 +227,223 @@ public class SlicedByteBuf extends AbstractDerivedByteBuf {
     @Override
     public ByteBuf copy(int index, int length) {
         checkIndex0(index, length);
-        return buffer.copy(idx(index), length);
+        return unwrap().copy(idx(index), length);
     }
 
     @Override
     public ByteBuf slice(int index, int length) {
         checkIndex0(index, length);
-        return buffer.slice(idx(index), length);
+        return unwrap().slice(idx(index), length);
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
         checkIndex0(index, length);
-        buffer.getBytes(idx(index), dst, dstIndex, length);
+        unwrap().getBytes(idx(index), dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
         checkIndex0(index, length);
-        buffer.getBytes(idx(index), dst, dstIndex, length);
+        unwrap().getBytes(idx(index), dst, dstIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuffer dst) {
         checkIndex0(index, dst.remaining());
-        buffer.getBytes(idx(index), dst);
+        unwrap().getBytes(idx(index), dst);
+        return this;
+    }
+
+    @Override
+    public ByteBuf setByte(int index, int value) {
+        checkIndex0(index, 1);
+        unwrap().setByte(idx(index), value);
         return this;
     }
 
     @Override
     protected void _setByte(int index, int value) {
-        buffer.setByte(idx(index), value);
+        unwrap().setByte(idx(index), value);
+    }
+
+    @Override
+    public ByteBuf setShort(int index, int value) {
+        checkIndex0(index, 2);
+        unwrap().setShort(idx(index), value);
+        return this;
     }
 
     @Override
     protected void _setShort(int index, int value) {
-        buffer.setShort(idx(index), value);
+        unwrap().setShort(idx(index), value);
+    }
+
+    @Override
+    public ByteBuf setShortLE(int index, int value) {
+        checkIndex0(index, 2);
+        unwrap().setShortLE(idx(index), value);
+        return this;
     }
 
     @Override
     protected void _setShortLE(int index, int value) {
-        buffer.setShortLE(idx(index), value);
+        unwrap().setShortLE(idx(index), value);
+    }
+
+    @Override
+    public ByteBuf setMedium(int index, int value) {
+        checkIndex0(index, 3);
+        unwrap().setMedium(idx(index), value);
+        return this;
     }
 
     @Override
     protected void _setMedium(int index, int value) {
-        buffer.setMedium(idx(index), value);
+        unwrap().setMedium(idx(index), value);
+    }
+
+    @Override
+    public ByteBuf setMediumLE(int index, int value) {
+        checkIndex0(index, 3);
+        unwrap().setMediumLE(idx(index), value);
+        return this;
     }
 
     @Override
     protected void _setMediumLE(int index, int value) {
-        buffer.setMediumLE(idx(index), value);
+        unwrap().setMediumLE(idx(index), value);
+    }
+
+    @Override
+    public ByteBuf setInt(int index, int value) {
+        checkIndex0(index, 4);
+        unwrap().setInt(idx(index), value);
+        return this;
     }
 
     @Override
     protected void _setInt(int index, int value) {
-        buffer.setInt(idx(index), value);
+        unwrap().setInt(idx(index), value);
+    }
+
+    @Override
+    public ByteBuf setIntLE(int index, int value) {
+        checkIndex0(index, 4);
+        unwrap().setIntLE(idx(index), value);
+        return this;
     }
 
     @Override
     protected void _setIntLE(int index, int value) {
-        buffer.setIntLE(idx(index), value);
+        unwrap().setIntLE(idx(index), value);
+    }
+
+    @Override
+    public ByteBuf setLong(int index, long value) {
+        checkIndex0(index, 8);
+        unwrap().setLong(idx(index), value);
+        return this;
     }
 
     @Override
     protected void _setLong(int index, long value) {
-        buffer.setLong(idx(index), value);
+        unwrap().setLong(idx(index), value);
+    }
+
+    @Override
+    public ByteBuf setLongLE(int index, long value) {
+        checkIndex0(index, 8);
+        unwrap().setLongLE(idx(index), value);
+        return this;
     }
 
     @Override
     protected void _setLongLE(int index, long value) {
-        buffer.setLongLE(idx(index), value);
+        unwrap().setLongLE(idx(index), value);
     }
 
     @Override
     public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
         checkIndex0(index, length);
-        buffer.setBytes(idx(index), src, srcIndex, length);
+        unwrap().setBytes(idx(index), src, srcIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
         checkIndex0(index, length);
-        buffer.setBytes(idx(index), src, srcIndex, length);
+        unwrap().setBytes(idx(index), src, srcIndex, length);
         return this;
     }
 
     @Override
     public ByteBuf setBytes(int index, ByteBuffer src) {
         checkIndex0(index, src.remaining());
-        buffer.setBytes(idx(index), src);
+        unwrap().setBytes(idx(index), src);
         return this;
     }
 
     @Override
     public ByteBuf getBytes(int index, OutputStream out, int length) throws IOException {
         checkIndex0(index, length);
-        buffer.getBytes(idx(index), out, length);
+        unwrap().getBytes(idx(index), out, length);
         return this;
     }
 
     @Override
     public int getBytes(int index, GatheringByteChannel out, int length) throws IOException {
         checkIndex0(index, length);
-        return buffer.getBytes(idx(index), out, length);
+        return unwrap().getBytes(idx(index), out, length);
     }
 
     @Override
     public int getBytes(int index, FileChannel out, long position, int length) throws IOException {
         checkIndex0(index, length);
-        return buffer.getBytes(idx(index), out, position, length);
+        return unwrap().getBytes(idx(index), out, position, length);
     }
 
     @Override
     public int setBytes(int index, InputStream in, int length) throws IOException {
         checkIndex0(index, length);
-        return buffer.setBytes(idx(index), in, length);
+        return unwrap().setBytes(idx(index), in, length);
     }
 
     @Override
     public int setBytes(int index, ScatteringByteChannel in, int length) throws IOException {
         checkIndex0(index, length);
-        return buffer.setBytes(idx(index), in, length);
+        return unwrap().setBytes(idx(index), in, length);
     }
 
     @Override
     public int setBytes(int index, FileChannel in, long position, int length) throws IOException {
         checkIndex0(index, length);
-        return buffer.setBytes(idx(index), in, position, length);
+        return unwrap().setBytes(idx(index), in, position, length);
     }
 
     @Override
     public int nioBufferCount() {
-        return buffer.nioBufferCount();
+        return unwrap().nioBufferCount();
     }
 
     @Override
     public ByteBuffer nioBuffer(int index, int length) {
         checkIndex0(index, length);
-        return buffer.nioBuffer(idx(index), length);
+        return unwrap().nioBuffer(idx(index), length);
     }
 
     @Override
     public ByteBuffer[] nioBuffers(int index, int length) {
         checkIndex0(index, length);
-        return buffer.nioBuffers(idx(index), length);
-    }
-
-    @Override
-    public ByteBuffer internalNioBuffer(int index, int length) {
-        return nioBuffer(index, length);
+        return unwrap().nioBuffers(idx(index), length);
     }
 
     @Override
     public int forEachByte(int index, int length, ByteProcessor processor) {
         checkIndex0(index, length);
-        int ret = buffer.forEachByte(idx(index), length, processor);
+        int ret = unwrap().forEachByte(idx(index), length, processor);
         if (ret >= adjustment) {
             return ret - adjustment;
         } else {
@@ -339,7 +454,7 @@ public class SlicedByteBuf extends AbstractDerivedByteBuf {
     @Override
     public int forEachByteDesc(int index, int length, ByteProcessor processor) {
         checkIndex0(index, length);
-        int ret = buffer.forEachByteDesc(idx(index), length, processor);
+        int ret = unwrap().forEachByteDesc(idx(index), length, processor);
         if (ret >= adjustment) {
             return ret - adjustment;
         } else {

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -335,6 +335,12 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public short getShortLE(int index) {
+        ensureAccessible();
+        return _getShortLE(index);
+    }
+
+    @Override
     protected short _getShortLE(int index) {
         return HeapByteBufUtil.getShortLE(array, index);
     }
@@ -348,6 +354,12 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected int _getUnsignedMedium(int index) {
         return HeapByteBufUtil.getUnsignedMedium(array, index);
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
+        ensureAccessible();
+        return _getUnsignedMediumLE(index);
     }
 
     @Override
@@ -367,6 +379,12 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public int getIntLE(int index) {
+        ensureAccessible();
+        return _getIntLE(index);
+    }
+
+    @Override
     protected int _getIntLE(int index) {
         return HeapByteBufUtil.getIntLE(array, index);
     }
@@ -380,6 +398,12 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected long _getLong(int index) {
         return HeapByteBufUtil.getLong(array, index);
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        ensureAccessible();
+        return _getLongLE(index);
     }
 
     @Override
@@ -412,6 +436,13 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf setShortLE(int index, int value) {
+        ensureAccessible();
+        _setShortLE(index, value);
+        return this;
+    }
+
+    @Override
     protected void _setShortLE(int index, int value) {
         HeapByteBufUtil.setShortLE(array, index, value);
     }
@@ -426,6 +457,13 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void _setMedium(int index, int value) {
         HeapByteBufUtil.setMedium(array, index, value);
+    }
+
+    @Override
+    public ByteBuf setMediumLE(int index, int   value) {
+        ensureAccessible();
+        _setMediumLE(index, value);
+        return this;
     }
 
     @Override
@@ -446,6 +484,13 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public ByteBuf setIntLE(int index, int   value) {
+        ensureAccessible();
+        _setIntLE(index, value);
+        return this;
+    }
+
+    @Override
     protected void _setIntLE(int index, int value) {
         HeapByteBufUtil.setIntLE(array, index, value);
     }
@@ -460,6 +505,13 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void _setLong(int index, long value) {
         HeapByteBufUtil.setLong(array, index, value);
+    }
+
+    @Override
+    public ByteBuf setLongLE(int index, long  value) {
+        ensureAccessible();
+        _setLongLE(index, value);
+        return this;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
@@ -15,7 +15,6 @@
  */
 package io.netty.buffer;
 
-
 import io.netty.util.internal.PlatformDependent;
 
 final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
@@ -53,6 +52,17 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     }
 
     @Override
+    public short getShortLE(int index) {
+        checkIndex(index, 2);
+        return _getShortLE(index);
+    }
+
+    @Override
+    protected short _getShortLE(int index) {
+        return UnsafeByteBufUtil.getShortLE(array, index);
+    }
+
+    @Override
     public int getUnsignedMedium(int index) {
         checkIndex(index, 3);
         return _getUnsignedMedium(index);
@@ -61,6 +71,17 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     @Override
     protected int _getUnsignedMedium(int index) {
         return UnsafeByteBufUtil.getUnsignedMedium(array, index);
+    }
+
+    @Override
+    public int getUnsignedMediumLE(int index) {
+        checkIndex(index, 3);
+        return _getUnsignedMediumLE(index);
+    }
+
+    @Override
+    protected int _getUnsignedMediumLE(int index) {
+        return UnsafeByteBufUtil.getUnsignedMediumLE(array, index);
     }
 
     @Override
@@ -75,6 +96,17 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     }
 
     @Override
+    public int getIntLE(int index) {
+        checkIndex(index, 4);
+        return _getIntLE(index);
+    }
+
+    @Override
+    protected int _getIntLE(int index) {
+        return UnsafeByteBufUtil.getIntLE(array, index);
+    }
+
+    @Override
     public long getLong(int index) {
         checkIndex(index, 8);
         return _getLong(index);
@@ -83,6 +115,17 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     @Override
     protected long _getLong(int index) {
         return UnsafeByteBufUtil.getLong(array, index);
+    }
+
+    @Override
+    public long getLongLE(int index) {
+        checkIndex(index, 8);
+        return _getLongLE(index);
+    }
+
+    @Override
+    protected long _getLongLE(int index) {
+        return UnsafeByteBufUtil.getLongLE(array, index);
     }
 
     @Override
@@ -110,6 +153,18 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     }
 
     @Override
+    public ByteBuf setShortLE(int index, int value) {
+        checkIndex(index, 2);
+        _setShortLE(index, value);
+        return this;
+    }
+
+    @Override
+    protected void _setShortLE(int index, int value) {
+        UnsafeByteBufUtil.setShortLE(array, index, value);
+    }
+
+    @Override
     public ByteBuf setMedium(int index, int   value) {
         checkIndex(index, 3);
         _setMedium(index, value);
@@ -119,6 +174,18 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     @Override
     protected void _setMedium(int index, int value) {
         UnsafeByteBufUtil.setMedium(array, index, value);
+    }
+
+    @Override
+    public ByteBuf setMediumLE(int index, int   value) {
+        checkIndex(index, 3);
+        _setMediumLE(index, value);
+        return this;
+    }
+
+    @Override
+    protected void _setMediumLE(int index, int value) {
+        UnsafeByteBufUtil.setMediumLE(array, index, value);
     }
 
     @Override
@@ -134,6 +201,18 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     }
 
     @Override
+    public ByteBuf setIntLE(int index, int   value) {
+        checkIndex(index, 4);
+        _setIntLE(index, value);
+        return this;
+    }
+
+    @Override
+    protected void _setIntLE(int index, int value) {
+        UnsafeByteBufUtil.setIntLE(array, index, value);
+    }
+
+    @Override
     public ByteBuf setLong(int index, long  value) {
         checkIndex(index, 8);
         _setLong(index, value);
@@ -146,6 +225,19 @@ final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     }
 
     @Override
+    public ByteBuf setLongLE(int index, long  value) {
+        checkIndex(index, 8);
+        _setLongLE(index, value);
+        return this;
+    }
+
+    @Override
+    protected void _setLongLE(int index, long value) {
+        UnsafeByteBufUtil.setLongLE(array, index, value);
+    }
+
+    @Override
+    @Deprecated
     protected SwappedByteBuf newSwappedByteBuf() {
         if (PlatformDependent.isUnaligned()) {
             // Only use if unaligned access is supported otherwise there is no gain.


### PR DESCRIPTION
Motivation:

Some ByteBuf implementations do not override all necessary methods,
which can lead to potentially sub-optimal behavior.

Also, SlicedByteBuf does not perform the range check correctly due to
missing overrides.

Modifications:

- Add missing overrides
- Use unwrap() instead of direct member access in derived buffers for
  consistency
- Merge unwrap0() into unwrap() using covariant return type
- Deprecate AbstractDerivedByteBuf and its subtypes, because they were
  not meant to be public

Result:

Correctness