### PR TITLE
Add ByteBuf.isReadOnly()

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -70,6 +70,11 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
     public int maxCapacity() {
         return maxCapacity;
     }

--- a/buffer/src/main/java/io/netty/buffer/AbstractDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractDerivedByteBuf.java
@@ -71,6 +71,11 @@ public abstract class AbstractDerivedByteBuf extends AbstractByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return unwrap().isReadOnly();
+    }
+
+    @Override
     public ByteBuffer internalNioBuffer(int index, int length) {
         return nioBuffer(index, length);
     }

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -296,6 +296,11 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract boolean isDirect();
 
     /**
+     * Returns {@code true} if and only if this buffer is read-only.
+     */
+    public abstract boolean isReadOnly();
+
+    /**
      * Returns the {@code readerIndex} of this buffer.
      */
     public abstract int readerIndex();

--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -96,6 +96,11 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
     public boolean isDirect() {
         return true;
     }

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
@@ -51,6 +51,11 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
     public boolean isWritable() {
         return false;
     }

--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -316,6 +316,11 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return buffer.isReadOnly();
+    }
+
+    @Override
     public boolean isDirect() {
         return buffer.isDirect();
     }

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -93,6 +93,11 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return buf.isReadOnly();
+    }
+
+    @Override
     public boolean isDirect() {
         return buf.isDirect();
     }

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -94,6 +94,11 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return buf.isReadOnly();
+    }
+
+    @Override
     public final boolean isDirect() {
         return buf.isDirect();
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -39,7 +39,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.EmptyByteBuf;
-import io.netty.buffer.ReadOnlyByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -127,7 +126,7 @@ public class Http2FrameRoundtripTest {
             // Now verify that all of the reference counts are zero.
             for (ByteBuf buf : needReleasing) {
                 int expectedFinalRefCount = 0;
-                if (buf instanceof ReadOnlyByteBuf || buf instanceof EmptyByteBuf) {
+                if (buf.isReadOnly() || buf instanceof EmptyByteBuf) {
                     // Special case for when we're writing slices of the padding buffer.
                     expectedFinalRefCount = 1;
                 }

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
@@ -89,6 +89,11 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    public boolean isReadOnly() {
+        return false;
+    }
+
+    @Override
     public boolean isDirect() {
         return buffer.isDirect();
     }


### PR DESCRIPTION
Motivation:

It is sometimes useful to determins if a buffer is read-only.

Modifications:

Add ByteBuf.isReadOnly()

Result:

One more feature