### PR TITLE
Not cache SwappedByteBuf in AbstractByteBuf to reduce memory footprint.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -57,10 +57,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
     int writerIndex;
     private int markedReaderIndex;
     private int markedWriterIndex;
-
     private int maxCapacity;
-
-    private SwappedByteBuf swappedBuf;
 
     protected AbstractByteBuf(int maxCapacity) {
         if (maxCapacity < 0) {
@@ -313,12 +310,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
         if (endianness == order()) {
             return this;
         }
-
-        SwappedByteBuf swappedBuf = this.swappedBuf;
-        if (swappedBuf == null) {
-            this.swappedBuf = swappedBuf = newSwappedByteBuf();
-        }
-        return swappedBuf;
+        return newSwappedByteBuf();
     }
 
     /**

--- a/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
@@ -53,7 +53,7 @@ public abstract class AbstractPooledByteBufTest extends AbstractByteBufTest {
 
         ByteBuf buf2 = newBuffer(capacity);
 
-        assertSame(unwrapIfNeeded(buf), unwrapIfNeeded(buf2));
+        assertEquals(unwrapIfNeeded(buf), unwrapIfNeeded(buf2));
 
         buf2.writeShort(1);
 


### PR DESCRIPTION
Motivation:

We should not cache the SwappedByteBuf in AbstractByteBuf to reduce the memory footprint.

Modifications:

Not cache the SwappedByteBuf.

Result:

Less memory footprint.