### PR TITLE
Fix IndexOutOfBoundsException when FixedCompositeByteBuf is construct…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/FixedCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/FixedCompositeByteBuf.java
@@ -49,7 +49,7 @@ final class FixedCompositeByteBuf extends AbstractReferenceCountedByteBuf {
             order = ByteOrder.BIG_ENDIAN;
             nioBufferCount = 1;
             capacity = 0;
-            direct = buffers[0].isDirect();
+            direct = false;
         } else {
             ByteBuf b = buffers[0];
             this.buffers = new Object[buffers.length];

--- a/buffer/src/test/java/io/netty/buffer/FixedCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/FixedCompositeByteBufTest.java
@@ -314,4 +314,10 @@ public class FixedCompositeByteBufTest {
         assertEquals(1, byteBuffers[2].limit());
         composite.release();
     }
+
+    @Test
+    public void testEmptyArray() {
+        ByteBuf buf = newBuffer(new ByteBuf[0]);
+        buf.release();
+    }
 }


### PR DESCRIPTION
…ed with an empty array.

Motivation:

When FixedCompositeByteBuf was constructed with new ByteBuf[0] and IndexOutOfboundsException was thrown.

Modifications:

Fix constructor

Result:

No more exception