### PR TITLE
Correctly handle ChannelInputShutdownEvent in ReplayingDecoder

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -323,12 +323,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
     private void channelInputClosed(ChannelHandlerContext ctx, boolean callChannelInactive) throws Exception {
         RecyclableArrayList out = RecyclableArrayList.newInstance();
         try {
-            if (cumulation != null) {
-                callDecode(ctx, cumulation, out);
-                decodeLast(ctx, cumulation, out);
-            } else {
-                decodeLast(ctx, Unpooled.EMPTY_BUFFER, out);
-            }
+            channelInputClosed(ctx, out);
         } catch (DecoderException e) {
             throw e;
         } catch (Exception e) {
@@ -352,6 +347,19 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                 // recycle in all cases
                 out.recycle();
             }
+        }
+    }
+
+    /**
+     * Called when the input of the channel was closed which may be because it changed to inactive or because of
+     * {@link ChannelInputShutdownEvent}.
+     */
+    void channelInputClosed(ChannelHandlerContext ctx, List<Object> out) throws Exception {
+        if (cumulation != null) {
+            callDecode(ctx, cumulation, out);
+            decodeLast(ctx, cumulation, out);
+        } else {
+            decodeLast(ctx, Unpooled.EMPTY_BUFFER, out);
         }
     }
 


### PR DESCRIPTION
Motivation:

b112673554bafc1eccfd43913a3e8605337dd7fb added ChannelInputShutdownEvent support to ByteToMessageDecoder but missed updating the code for ReplayingDecoder. This has the effect:

- If a ChannelInputShutdownEvent is fired ByteToMessageDecoder (the super-class of ReplayingDecoder) will call the channelInputClosed(...) method which will pass the incorrect buffer to the decode method of ReplayingDecoder.

Modifications:

Share more code between ByteToMessageDEcoder and ReplayingDecoder and so also support ChannelInputShutdownEvent correctly in ReplayingDecoder

Result:

ChannelInputShutdownEvent is corrrectly handle in ReplayingDecoder as well.