### PR TITLE
Add CharSequence operations to ByteBuf

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -16,6 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.ByteProcessor;
+import io.netty.util.CharsetUtil;
 import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.internal.PlatformDependent;
@@ -484,6 +485,19 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     @Override
+    public CharSequence getCharSequence(int index, int length, Charset charset) {
+        // TODO: We could optimize this for UTF8 and US_ASCII
+        return toString(index, length, charset);
+    }
+
+    @Override
+    public CharSequence readCharSequence(int length, Charset charset) {
+        CharSequence sequence = getCharSequence(readerIndex, length, charset);
+        readerIndex += length;
+        return sequence;
+    }
+
+    @Override
     public ByteBuf setByte(int index, int value) {
         checkIndex(index);
         _setByte(index, value);
@@ -647,6 +661,23 @@ public abstract class AbstractByteBuf extends ByteBuf {
             }
         }
         return this;
+    }
+
+    @Override
+    public int setCharSequence(int index, CharSequence sequence, Charset charset) {
+        if (charset.equals(CharsetUtil.UTF_8)) {
+            ensureWritable(ByteBufUtil.utf8MaxBytes(sequence));
+            return ByteBufUtil.writeUtf8(this, index, sequence, sequence.length());
+        }
+        if (charset.equals(CharsetUtil.US_ASCII)) {
+            int len = sequence.length();
+            ensureWritable(len);
+            return ByteBufUtil.writeAscii(this, index, sequence, len);
+        }
+        byte[] bytes = sequence.toString().getBytes(charset);
+        ensureWritable(bytes.length);
+        setBytes(index, bytes);
+        return bytes.length;
     }
 
     @Override
@@ -1109,6 +1140,13 @@ public abstract class AbstractByteBuf extends ByteBuf {
         }
         writerIndex = wIndex;
         return this;
+    }
+
+    @Override
+    public int writeCharSequence(CharSequence sequence, Charset charset) {
+        int written = setCharSequence(writerIndex, sequence, charset);
+        writerIndex += written;
+        return written;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
@@ -245,6 +245,12 @@ final class AdvancedLeakAwareByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public CharSequence getCharSequence(int index, int length, Charset charset) {
+        recordLeakNonRefCountingOperation(leak);
+        return super.getCharSequence(index, length, charset);
+    }
+
+    @Override
     public ByteBuf setBoolean(int index, boolean value) {
         recordLeakNonRefCountingOperation(leak);
         return super.setBoolean(index, value);
@@ -350,6 +356,12 @@ final class AdvancedLeakAwareByteBuf extends WrappedByteBuf {
     public ByteBuf setZero(int index, int length) {
         recordLeakNonRefCountingOperation(leak);
         return super.setZero(index, length);
+    }
+
+    @Override
+    public int setCharSequence(int index, CharSequence sequence, Charset charset) {
+        recordLeakNonRefCountingOperation(leak);
+        return super.setCharSequence(index, sequence, charset);
     }
 
     @Override
@@ -482,6 +494,12 @@ final class AdvancedLeakAwareByteBuf extends WrappedByteBuf {
     public int readBytes(GatheringByteChannel out, int length) throws IOException {
         recordLeakNonRefCountingOperation(leak);
         return super.readBytes(out, length);
+    }
+
+    @Override
+    public CharSequence readCharSequence(int length, Charset charset) {
+        recordLeakNonRefCountingOperation(leak);
+        return super.readCharSequence(length, charset);
     }
 
     @Override
@@ -842,6 +860,12 @@ final class AdvancedLeakAwareByteBuf extends WrappedByteBuf {
     public ByteBuf writeLongLE(long value) {
         recordLeakNonRefCountingOperation(leak);
         return super.writeLongLE(value);
+    }
+
+    @Override
+    public int writeCharSequence(CharSequence sequence, Charset charset) {
+        recordLeakNonRefCountingOperation(leak);
+        return super.writeCharSequence(sequence, charset);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
@@ -227,6 +227,12 @@ final class AdvancedLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     }
 
     @Override
+    public CharSequence getCharSequence(int index, int length, Charset charset) {
+        recordLeakNonRefCountingOperation(leak);
+        return super.getCharSequence(index, length, charset);
+    }
+
+    @Override
     public CompositeByteBuf setBoolean(int index, boolean value) {
         recordLeakNonRefCountingOperation(leak);
         return super.setBoolean(index, value);
@@ -467,6 +473,12 @@ final class AdvancedLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     }
 
     @Override
+    public CharSequence readCharSequence(int length, Charset charset) {
+        recordLeakNonRefCountingOperation(leak);
+        return super.readCharSequence(length, charset);
+    }
+
+    @Override
     public CompositeByteBuf skipBytes(int length) {
         recordLeakNonRefCountingOperation(leak);
         return super.skipBytes(length);
@@ -578,6 +590,12 @@ final class AdvancedLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     public CompositeByteBuf writeZero(int length) {
         recordLeakNonRefCountingOperation(leak);
         return super.writeZero(length);
+    }
+
+    @Override
+    public int writeCharSequence(CharSequence sequence, Charset charset) {
+        recordLeakNonRefCountingOperation(leak);
+        return super.writeCharSequence(sequence, charset);
     }
 
     @Override
@@ -758,6 +776,12 @@ final class AdvancedLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     public ByteBuf setLongLE(int index, long value) {
         recordLeakNonRefCountingOperation(leak);
         return super.setLongLE(index, value);
+    }
+
+    @Override
+    public int setCharSequence(int index, CharSequence sequence, Charset charset) {
+        recordLeakNonRefCountingOperation(leak);
+        return super.setCharSequence(index, sequence, charset);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -914,6 +914,17 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract int getBytes(int index, FileChannel out, long position, int length) throws IOException;
 
     /**
+     * Gets a {@link CharSequence} with the given length at the given index.
+     *
+     * @param length the length to read
+     * @param charset that should be used
+     * @return the sequence
+     * @throws IndexOutOfBoundsException
+     *         if {@code length} is greater than {@code this.readableBytes}
+     */
+    public abstract CharSequence getCharSequence(int index, int length, Charset charset);
+
+    /**
      * Sets the specified boolean at the specified absolute {@code index} in this
      * buffer.
      * This method does not modify {@code readerIndex} or {@code writerIndex} of
@@ -1248,6 +1259,19 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract ByteBuf setZero(int index, int length);
 
     /**
+     * Writes the specified {@link CharSequence} at the current {@code writerIndex} and increases
+     * the {@code writerIndex} by the written bytes.
+     *
+     * @param index on which the sequence should be written
+     * @param sequence to write
+     * @param charset that should be used.
+     * @return the written number of bytes.
+     * @throws IndexOutOfBoundsException
+     *         if {@code this.writableBytes} is not large enough to write the whole sequence
+     */
+    public abstract int setCharSequence(int index, CharSequence sequence, Charset charset);
+
+    /**
      * Gets a boolean at the current {@code readerIndex} and increases
      * the {@code readerIndex} by {@code 1} in this buffer.
      *
@@ -1580,6 +1604,18 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract int readBytes(GatheringByteChannel out, int length) throws IOException;
 
     /**
+     * Gets a {@link CharSequence} with the given length at the current {@code readerIndex}
+     * and increases the {@code readerIndex} by the given length.
+     *
+     * @param length the length to read
+     * @param charset that should be used
+     * @return the sequence
+     * @throws IndexOutOfBoundsException
+     *         if {@code length} is greater than {@code this.readableBytes}
+     */
+    public abstract CharSequence readCharSequence(int length, Charset charset);
+
+    /**
      * Transfers this buffer's data starting at the current {@code readerIndex}
      * to the specified channel starting at the given file position.
      * This method does not modify the channel's position.
@@ -1884,6 +1920,19 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      *         if {@code length} is greater than {@code this.writableBytes}
      */
     public abstract ByteBuf writeZero(int length);
+
+    /**
+     * Writes the specified {@link CharSequence} at the current {@code writerIndex} and increases
+     * the {@code writerIndex} by the written bytes.
+     * in this buffer.
+     *
+     * @param sequence to write
+     * @param charset that should be used
+     * @return the written number of bytes
+     * @throws IndexOutOfBoundsException
+     *         if {@code this.writableBytes} is not large enough to write the whole sequence
+     */
+    public abstract int writeCharSequence(CharSequence sequence, Charset charset);
 
     /**
      * Locates the first occurrence of the specified {@code value} in this

--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -392,6 +392,12 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public CharSequence getCharSequence(int index, int length, Charset charset) {
+        checkIndex(index, length);
+        return null;
+    }
+
+    @Override
     public ByteBuf setBoolean(int index, boolean value) {
         throw new IndexOutOfBoundsException();
     }
@@ -507,6 +513,11 @@ public final class EmptyByteBuf extends ByteBuf {
     @Override
     public ByteBuf setZero(int index, int length) {
         return checkIndex(index, length);
+    }
+
+    @Override
+    public int setCharSequence(int index, CharSequence sequence, Charset charset) {
+        throw new IndexOutOfBoundsException();
     }
 
     @Override
@@ -667,6 +678,12 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public CharSequence readCharSequence(int length, Charset charset) {
+        checkLength(length);
+        return null;
+    }
+
+    @Override
     public ByteBuf skipBytes(int length) {
         return checkLength(length);
     }
@@ -787,6 +804,11 @@ public final class EmptyByteBuf extends ByteBuf {
     @Override
     public ByteBuf writeZero(int length) {
         return checkLength(length);
+    }
+
+    @Override
+    public int writeCharSequence(CharSequence sequence, Charset charset) {
+        throw new IndexOutOfBoundsException();
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
@@ -16,6 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.ByteProcessor;
+import io.netty.util.CharsetUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,6 +26,7 @@ import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
+import java.nio.charset.Charset;
 
 /**
  * A derived buffer which exposes its parent's sub-region only.  It is
@@ -265,6 +267,12 @@ public class SlicedByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    public CharSequence getCharSequence(int index, int length, Charset charset) {
+        checkIndex0(index, length);
+        return buffer.getCharSequence(idx(index), length, charset);
+    }
+
+    @Override
     protected void _setByte(int index, int value) {
         unwrap().setByte(idx(index), value);
     }
@@ -384,6 +392,23 @@ public class SlicedByteBuf extends AbstractDerivedByteBuf {
         checkIndex0(index, src.remaining());
         unwrap().setBytes(idx(index), src);
         return this;
+    }
+
+    @Override
+    public int setCharSequence(int index, CharSequence sequence, Charset charset) {
+        if (charset.equals(CharsetUtil.UTF_8)) {
+            checkIndex0(index, ByteBufUtil.utf8MaxBytes(sequence));
+            return ByteBufUtil.writeUtf8(this, idx(index), sequence, sequence.length());
+        }
+        if (charset.equals(CharsetUtil.US_ASCII)) {
+            int len = sequence.length();
+            checkIndex0(index, len);
+            return ByteBufUtil.writeAscii(this, idx(index), sequence, len);
+        }
+        byte[] bytes = sequence.toString().getBytes(charset);
+        checkIndex0(index, bytes.length);
+        buffer.setBytes(idx(index), bytes);
+        return bytes.length;
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -377,6 +377,11 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public CharSequence getCharSequence(int index, int length, Charset charset) {
+        return buf.getCharSequence(index, length, charset);
+    }
+
+    @Override
     public ByteBuf setBoolean(int index, boolean value) {
         buf.setBoolean(index, value);
         return this;
@@ -509,6 +514,11 @@ public class SwappedByteBuf extends ByteBuf {
     public ByteBuf setZero(int index, int length) {
         buf.setZero(index, length);
         return this;
+    }
+
+    @Override
+    public int setCharSequence(int index, CharSequence sequence, Charset charset) {
+        return buf.setCharSequence(index, sequence, charset);
     }
 
     @Override
@@ -674,6 +684,11 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public CharSequence readCharSequence(int length, Charset charset) {
+        return buf.readCharSequence(length, charset);
+    }
+
+    @Override
     public ByteBuf skipBytes(int length) {
         buf.skipBytes(length);
         return this;
@@ -812,6 +827,11 @@ public class SwappedByteBuf extends ByteBuf {
     public ByteBuf writeZero(int length) {
         buf.writeZero(length);
         return this;
+    }
+
+    @Override
+    public int writeCharSequence(CharSequence sequence, Charset charset) {
+        return buf.writeCharSequence(sequence, charset);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -367,6 +367,11 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public CharSequence getCharSequence(int index, int length, Charset charset) {
+        return buf.getCharSequence(index, length, charset);
+    }
+
+    @Override
     public ByteBuf setBoolean(int index, boolean value) {
         buf.setBoolean(index, value);
         return this;
@@ -499,6 +504,11 @@ class WrappedByteBuf extends ByteBuf {
     public ByteBuf setZero(int index, int length) {
         buf.setZero(index, length);
         return this;
+    }
+
+    @Override
+    public int setCharSequence(int index, CharSequence sequence, Charset charset) {
+        return buf.setCharSequence(index, sequence, charset);
     }
 
     @Override
@@ -664,6 +674,11 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public CharSequence readCharSequence(int length, Charset charset) {
+        return buf.readCharSequence(length, charset);
+    }
+
+    @Override
     public ByteBuf skipBytes(int length) {
         buf.skipBytes(length);
         return this;
@@ -802,6 +817,11 @@ class WrappedByteBuf extends ByteBuf {
     public ByteBuf writeZero(int length) {
         buf.writeZero(length);
         return this;
+    }
+
+    @Override
+    public int writeCharSequence(CharSequence sequence, Charset charset) {
+        return buf.writeCharSequence(sequence, charset);
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
@@ -360,6 +360,12 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    public CharSequence getCharSequence(int index, int length, Charset charset) {
+        checkIndex(index, length);
+        return buffer.getCharSequence(index, length, charset);
+    }
+
+    @Override
     public int hashCode() {
         reject();
         return 0;
@@ -710,6 +716,12 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     public double readDouble() {
         checkReadableBytes(8);
         return buffer.readDouble();
+    }
+
+    @Override
+    public CharSequence readCharSequence(int length, Charset charset) {
+        checkReadableBytes(length);
+        return buffer.readCharSequence(length, charset);
     }
 
     @Override
@@ -1112,6 +1124,18 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     public ByteBuf writeDouble(double value) {
         reject();
         return this;
+    }
+
+    @Override
+    public int setCharSequence(int index, CharSequence sequence, Charset charset) {
+        reject();
+        return -1;
+    }
+
+    @Override
+    public int writeCharSequence(CharSequence sequence, Charset charset) {
+        reject();
+        return -1;
     }
 
     private void checkIndex(int index, int length) {


### PR DESCRIPTION
Motivation:

Often users either need to read or write CharSequences to a ByteBuf. We should add methods for this to ByteBuf as we can do some optimizations for this depending on the implementation.

Modifications:

Add setCharSequence, writeCharSequence, getCharSequence and readCharSequence

Result:

Easier reading / writing of CharSequence with ByteBuf.