### PR TITLE
[#4836] Enforce 64bit JDK when build netty.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -558,6 +558,13 @@
                 <requireMavenVersion>
                   <version>[3.1.1,)</version>
                 </requireMavenVersion>
+                <requireProperty>
+                  <regexMessage>
+                    x86_64 JDK must be used.
+                  </regexMessage>
+                  <property>os.detected.arch</property>
+                  <regex>^x86_64$</regex>
+                </requireProperty>
               </rules>
             </configuration>
           </execution>


### PR DESCRIPTION
Motivation:

As we only provide tcnative jars for 64bit we should enforce 64bit when try to build netty, to make it easier for the user to understand why the build fails.

Modifications:

Add enforce rule.

Result:

Ensure 64bit is used when build netty.