### PR TITLE
Add ByteBuf.asReadOnly()

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -74,6 +74,15 @@ public abstract class AbstractByteBuf extends ByteBuf {
         return false;
     }
 
+    @SuppressWarnings("deprecation")
+    @Override
+    public ByteBuf asReadOnly() {
+        if (isReadOnly()) {
+            return this;
+        }
+        return Unpooled.unmodifiableBuffer(this);
+    }
+
     @Override
     public int maxCapacity() {
         return maxCapacity;

--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
@@ -869,6 +869,12 @@ final class AdvancedLeakAwareByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public ByteBuf asReadOnly() {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.asReadOnly(), leak);
+    }
+
+    @Override
     public ByteBuf retain() {
         leak.record();
         return super.retain();

--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -301,6 +301,11 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
     public abstract boolean isReadOnly();
 
     /**
+     * Returns a read-only version of this buffer.
+     */
+    public abstract ByteBuf asReadOnly();
+
+    /**
      * Returns the {@code readerIndex} of this buffer.
      */
     public abstract int readerIndex();

--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -96,6 +96,11 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf asReadOnly() {
+        return Unpooled.unmodifiableBuffer(this);
+    }
+
+    @Override
     public boolean isReadOnly() {
         return false;
     }

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -98,6 +98,11 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf asReadOnly() {
+        return Unpooled.unmodifiableBuffer(this);
+    }
+
+    @Override
     public boolean isDirect() {
         return buf.isDirect();
     }

--- a/buffer/src/main/java/io/netty/buffer/Unpooled.java
+++ b/buffer/src/main/java/io/netty/buffer/Unpooled.java
@@ -674,7 +674,10 @@ public final class Unpooled {
      * on the specified {@code buffer}.  The new buffer has the same
      * {@code readerIndex} and {@code writerIndex} with the specified
      * {@code buffer}.
+     *
+     * @deprecated Use {@link ByteBuf#asReadOnly()}.
      */
+    @Deprecated
     public static ByteBuf unmodifiableBuffer(ByteBuf buffer) {
         ByteOrder endianness = buffer.order();
         if (endianness == BIG_ENDIAN) {

--- a/buffer/src/main/java/io/netty/buffer/UnreleasableByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnreleasableByteBuf.java
@@ -46,6 +46,11 @@ final class UnreleasableByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public ByteBuf asReadOnly() {
+        return new UnreleasableByteBuf(buf.asReadOnly());
+    }
+
+    @Override
     public ByteBuf readSlice(int length) {
         return new UnreleasableByteBuf(buf.readSlice(length));
     }

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -94,6 +94,11 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf asReadOnly() {
+        return buf.asReadOnly();
+    }
+
+    @Override
     public boolean isReadOnly() {
         return buf.isReadOnly();
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.http2;
 
 import static io.netty.buffer.Unpooled.directBuffer;
-import static io.netty.buffer.Unpooled.unmodifiableBuffer;
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
 import static io.netty.handler.codec.http2.Http2CodecUtil.CONTINUATION_FRAME_HEADER_LENGTH;
 import static io.netty.handler.codec.http2.Http2CodecUtil.DATA_FRAME_HEADER_LENGTH;
@@ -74,8 +73,8 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
      * When padding is needed it can be taken as a slice of this buffer. Users should call {@link ByteBuf#retain()}
      * before using their slice.
      */
-    private static final ByteBuf ZERO_BUFFER = unmodifiableBuffer(
-            unreleasableBuffer(directBuffer(MAX_UNSIGNED_BYTE).writeZero(MAX_UNSIGNED_BYTE)));
+    private static final ByteBuf ZERO_BUFFER =
+            unreleasableBuffer(directBuffer(MAX_UNSIGNED_BYTE).writeZero(MAX_UNSIGNED_BYTE)).asReadOnly();
 
     private final Http2HeadersEncoder headersEncoder;
     private int maxFrameSize;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -27,7 +27,6 @@ import io.netty.util.AsciiString;
 import io.netty.util.concurrent.EventExecutor;
 
 import static io.netty.buffer.Unpooled.directBuffer;
-import static io.netty.buffer.Unpooled.unmodifiableBuffer;
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
 import static io.netty.util.CharsetUtil.UTF_8;
 import static java.lang.Math.max;
@@ -54,10 +53,12 @@ public final class Http2CodecUtil {
     public static final short MAX_WEIGHT = 256;
     public static final short MIN_WEIGHT = 1;
 
-    private static final ByteBuf CONNECTION_PREFACE = unmodifiableBuffer(
-            unreleasableBuffer(directBuffer(24).writeBytes("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(UTF_8))));
-    private static final ByteBuf EMPTY_PING = unmodifiableBuffer(
-            unreleasableBuffer(directBuffer(PING_FRAME_PAYLOAD_LENGTH).writeZero(PING_FRAME_PAYLOAD_LENGTH)));
+    private static final ByteBuf CONNECTION_PREFACE =
+            unreleasableBuffer(directBuffer(24).writeBytes("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".getBytes(UTF_8)))
+                    .asReadOnly();
+    private static final ByteBuf EMPTY_PING =
+            unreleasableBuffer(directBuffer(PING_FRAME_PAYLOAD_LENGTH).writeZero(PING_FRAME_PAYLOAD_LENGTH))
+                    .asReadOnly();
 
     private static final int MAX_PADDING_LENGTH_LENGTH = 1;
     public static final int DATA_FRAME_HEADER_LENGTH = FRAME_HEADER_LENGTH + MAX_PADDING_LENGTH_LENGTH;

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
@@ -93,6 +93,12 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
         return false;
     }
 
+    @SuppressWarnings("deprecation")
+    @Override
+    public ByteBuf asReadOnly() {
+        return Unpooled.unmodifiableBuffer(this);
+    }
+
     @Override
     public boolean isDirect() {
         return buffer.isDirect();

--- a/example/src/main/java/io/netty/example/http2/tiles/FallbackRequestHandler.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/FallbackRequestHandler.java
@@ -17,7 +17,6 @@
 package io.netty.example.http2.tiles;
 
 import static io.netty.buffer.Unpooled.copiedBuffer;
-import static io.netty.buffer.Unpooled.unmodifiableBuffer;
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
@@ -40,10 +39,10 @@ import io.netty.handler.codec.http2.Http2CodecUtil;
  */
 public final class FallbackRequestHandler extends SimpleChannelInboundHandler<HttpRequest> {
 
-    private static final ByteBuf response = unmodifiableBuffer(unreleasableBuffer(copiedBuffer("<!DOCTYPE html>"
+    private static final ByteBuf response = unreleasableBuffer(copiedBuffer("<!DOCTYPE html>"
             + "<html><body><h2>To view the example you need a browser that supports HTTP/2 ("
             + Http2CodecUtil.TLS_UPGRADE_PROTOCOL_NAME
-            + ")</h2></body></html>", UTF_8)));
+            + ")</h2></body></html>", UTF_8)).asReadOnly();
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, HttpRequest req) throws Exception {

--- a/example/src/main/java/io/netty/example/http2/tiles/ImageCache.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/ImageCache.java
@@ -16,7 +16,6 @@
 
 package io.netty.example.http2.tiles;
 
-import static io.netty.buffer.Unpooled.unmodifiableBuffer;
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
 import static io.netty.example.http2.Http2ExampleUtil.toByteBuf;
 import io.netty.buffer.ByteBuf;
@@ -51,8 +50,8 @@ public final class ImageCache {
             for (int x = 0; x < 20; x++) {
                 try {
                     String name = name(x, y);
-                    ByteBuf fileBytes = unreleasableBuffer(unmodifiableBuffer(toByteBuf(getClass()
-                            .getResourceAsStream(name))));
+                    ByteBuf fileBytes = unreleasableBuffer(toByteBuf(getClass()
+                            .getResourceAsStream(name)).asReadOnly());
                     imageBank.put(name, fileBytes);
                 } catch (IOException e) {
                     e.printStackTrace();


### PR DESCRIPTION
Motivation:

We lately added ByteBuf.isReadOnly() which allows to detect if a buffer is read-only or not. We should add ByteBuf.asReadOnly() to allow easily access a read-only version of a buffer.

Modifications:

- Add ByteBuf.asReadOnly()
- Deprecate Unpooled.unmodifiableBuffer(Bytebuf)

Result:

More consistent api.