### PR TITLE
Ensure WebSocket*Handshaker removes closest codecs

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandshakeHandler.java
@@ -31,7 +31,7 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
     @Override
     public void channelActive(final ChannelHandlerContext ctx) throws Exception {
         super.channelActive(ctx);
-        handshaker.handshake(ctx.channel()).addListener(new ChannelFutureListener() {
+        handshaker.handshake(ctx).addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(ChannelFuture future) throws Exception {
                 if (!future.isSuccess()) {
@@ -54,7 +54,7 @@ class WebSocketClientProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
         FullHttpResponse response = (FullHttpResponse) msg;
         try {
             if (!handshaker.isHandshakeComplete()) {
-                handshaker.finishHandshake(ctx.channel(), response);
+                handshaker.finishHandshake(ctx, response);
                 ctx.fireUserEventTriggered(
                         WebSocketClientProtocolHandler.ClientHandshakeStateEvent.HANDSHAKE_COMPLETE);
                 ctx.pipeline().remove(this);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -170,17 +171,15 @@ public class WebSocketServerHandshaker00 extends WebSocketServerHandshaker {
         return res;
     }
 
-    /**
-     * Echo back the closing frame
-     *
-     * @param channel
-     *            Channel
-     * @param frame
-     *            Web Socket frame that was received
-     */
     @Override
+    @Deprecated
     public ChannelFuture close(Channel channel, CloseWebSocketFrame frame, ChannelPromise promise) {
         return channel.writeAndFlush(frame, promise);
+    }
+
+    @Override
+    public ChannelFuture close(ChannelHandlerContext ctx, CloseWebSocketFrame frame, ChannelPromise promise) {
+        return ctx.writeAndFlush(frame, promise);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshakerFactory.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http.websocketx;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -155,11 +156,25 @@ public class WebSocketServerHandshakerFactory {
      * Return that we need cannot not support the web socket version
      */
     public static ChannelFuture sendUnsupportedVersionResponse(Channel channel, ChannelPromise promise) {
+        return sendUnsupportedVersionResponse(channel.pipeline().lastContext(), promise);
+    }
+
+    /**
+     * Return that we need cannot not support the web socket version
+     */
+    public static ChannelFuture sendUnsupportedVersionResponse(ChannelHandlerContext ctx) {
+        return sendUnsupportedVersionResponse(ctx, ctx.newPromise());
+    }
+
+    /**
+     * Return that we need cannot not support the web socket version
+     */
+    public static ChannelFuture sendUnsupportedVersionResponse(ChannelHandlerContext ctx, ChannelPromise promise) {
         HttpResponse res = new DefaultFullHttpResponse(
                 HttpVersion.HTTP_1_1,
                 HttpResponseStatus.UPGRADE_REQUIRED);
         res.headers().set(HttpHeaderNames.SEC_WEBSOCKET_VERSION, WebSocketVersion.V13.toHttpHeaderValue());
         HttpUtil.setContentLength(res, 0);
-        return channel.writeAndFlush(res, promise);
+        return ctx.writeAndFlush(res, promise);
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -118,7 +118,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
             WebSocketServerHandshaker handshaker = getHandshaker(ctx.channel());
             if (handshaker != null) {
                 frame.retain();
-                handshaker.close(ctx.channel(), (CloseWebSocketFrame) frame);
+                handshaker.close(ctx, (CloseWebSocketFrame) frame);
             } else {
                 ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
             }
@@ -132,7 +132,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
         if (cause instanceof WebSocketHandshakeException) {
             FullHttpResponse response = new DefaultFullHttpResponse(
                     HTTP_1_1, HttpResponseStatus.BAD_REQUEST, Unpooled.wrappedBuffer(cause.getMessage().getBytes()));
-            ctx.channel().writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+            ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
         } else {
             ctx.close();
         }
@@ -154,7 +154,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
                     ((FullHttpRequest) msg).release();
                     FullHttpResponse response =
                             new DefaultFullHttpResponse(HTTP_1_1, HttpResponseStatus.FORBIDDEN);
-                    ctx.channel().writeAndFlush(response);
+                    ctx.writeAndFlush(response);
                 } else {
                     ctx.fireChannelRead(msg);
                 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -71,9 +71,9 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
                             allowExtensions, maxFramePayloadSize, allowMaskMismatch);
             final WebSocketServerHandshaker handshaker = wsFactory.newHandshaker(req);
             if (handshaker == null) {
-                WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ctx.channel());
+                WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ctx);
             } else {
-                final ChannelFuture handshakeFuture = handshaker.handshake(ctx.channel(), req);
+                final ChannelFuture handshakeFuture = handshaker.handshake(ctx, req);
                 handshakeFuture.addListener(new ChannelFutureListener() {
                     @Override
                     public void operationComplete(ChannelFuture future) throws Exception {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
@@ -118,7 +118,7 @@ public abstract class WebSocketClientHandshakerTest {
                 new SimpleChannelInboundHandler<FullHttpResponse>() {
                     @Override
                     protected void channelRead0(ChannelHandlerContext ctx, FullHttpResponse msg) throws Exception {
-                        handshaker.finishHandshake(ctx.channel(), msg);
+                        handshaker.finishHandshake(ctx, msg);
                         ctx.pipeline().remove(this);
                     }
                 });
@@ -129,7 +129,7 @@ public abstract class WebSocketClientHandshakerTest {
         }
         // We need to first write the request as HttpClientCodec will fail if we receive a response before a request
         // was written.
-        shaker.handshake(ch).syncUninterruptibly();
+        shaker.handshake(ch.pipeline().lastContext()).syncUninterruptibly();
         for (;;) {
             // Just consume the bytes, we are not interested in these.
             ByteBuf buf = ch.readOutbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00Test.java
@@ -64,10 +64,12 @@ public class WebSocketServerHandshaker00Test {
 
         if (subProtocol) {
             new WebSocketServerHandshaker00(
-                    "ws://example.com/chat", "chat", Integer.MAX_VALUE).handshake(ch, req);
+                    "ws://example.com/chat", "chat", Integer.MAX_VALUE).handshake(
+                    ch.pipeline().lastContext(), req);
         } else {
             new WebSocketServerHandshaker00(
-                    "ws://example.com/chat", null, Integer.MAX_VALUE).handshake(ch, req);
+                    "ws://example.com/chat", null, Integer.MAX_VALUE).handshake(
+                    ch.pipeline().lastContext(), req);
         }
 
         EmbeddedChannel ch2 = new EmbeddedChannel(new HttpResponseDecoder());

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08Test.java
@@ -61,10 +61,12 @@ public class WebSocketServerHandshaker08Test {
 
         if (subProtocol) {
             new WebSocketServerHandshaker08(
-                    "ws://example.com/chat", "chat", false, Integer.MAX_VALUE, false).handshake(ch, req);
+                    "ws://example.com/chat", "chat", false, Integer.MAX_VALUE, false)
+                    .handshake(ch.pipeline().lastContext(), req);
         } else {
             new WebSocketServerHandshaker08(
-                    "ws://example.com/chat", null, false, Integer.MAX_VALUE, false).handshake(ch, req);
+                    "ws://example.com/chat", null, false, Integer.MAX_VALUE, false)
+                    .handshake(ch.pipeline().lastContext(), req);
         }
 
         ByteBuf resBuf = ch.readOutbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
@@ -61,10 +61,12 @@ public class WebSocketServerHandshaker13Test {
 
         if (subProtocol) {
             new WebSocketServerHandshaker13(
-                    "ws://example.com/chat", "chat", false, Integer.MAX_VALUE, false).handshake(ch, req);
+                    "ws://example.com/chat", "chat", false, Integer.MAX_VALUE, false)
+                    .handshake(ch.pipeline().lastContext(), req);
         } else {
             new WebSocketServerHandshaker13(
-                    "ws://example.com/chat", null, false, Integer.MAX_VALUE, false).handshake(ch, req);
+                    "ws://example.com/chat", null, false, Integer.MAX_VALUE, false)
+                    .handshake(ch.pipeline().lastContext(), req);
         }
 
         ByteBuf resBuf = ch.readOutbound();

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
@@ -129,10 +129,10 @@ public class WebSocketServerProtocolHandlerTest {
 
     private EmbeddedChannel createChannel(ChannelHandler handler) {
         return new EmbeddedChannel(
-                new WebSocketServerProtocolHandler("/test", null, false),
                 new HttpRequestDecoder(),
                 new HttpResponseEncoder(),
                 new MockOutboundHandler(),
+                new WebSocketServerProtocolHandler("/test", null, false),
                 handler);
     }
 

--- a/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServerHandler.java
@@ -98,9 +98,9 @@ public class WebSocketServerHandler extends SimpleChannelInboundHandler<Object> 
                 getWebSocketLocation(req), null, true, 5 * 1024 * 1024);
         handshaker = wsFactory.newHandshaker(req);
         if (handshaker == null) {
-            WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ctx.channel());
+            WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ctx);
         } else {
-            handshaker.handshake(ctx.channel(), req);
+            handshaker.handshake(ctx, req);
         }
     }
 
@@ -108,7 +108,7 @@ public class WebSocketServerHandler extends SimpleChannelInboundHandler<Object> 
 
         // Check for closing frame
         if (frame instanceof CloseWebSocketFrame) {
-            handshaker.close(ctx.channel(), (CloseWebSocketFrame) frame.retain());
+            handshaker.close(ctx, (CloseWebSocketFrame) frame.retain());
             return;
         }
         if (frame instanceof PingWebSocketFrame) {
@@ -123,7 +123,6 @@ public class WebSocketServerHandler extends SimpleChannelInboundHandler<Object> 
         if (frame instanceof BinaryWebSocketFrame) {
             // Echo the frame
             ctx.write(frame.retain());
-            return;
         }
     }
 

--- a/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClientHandler.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClientHandler.java
@@ -37,7 +37,6 @@
 
 package io.netty.example.http.websocketx.client;
 
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
@@ -80,9 +79,8 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
 
     @Override
     public void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
-        Channel ch = ctx.channel();
         if (!handshaker.isHandshakeComplete()) {
-            handshaker.finishHandshake(ch, (FullHttpResponse) msg);
+            handshaker.finishHandshake(ctx, (FullHttpResponse) msg);
             System.out.println("WebSocket Client connected!");
             handshakeFuture.setSuccess();
             return;
@@ -103,7 +101,7 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
             System.out.println("WebSocket Client received pong");
         } else if (frame instanceof CloseWebSocketFrame) {
             System.out.println("WebSocket Client received closing");
-            ch.close();
+            ctx.close();
         }
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/websockets/autobahn/AutobahnServerHandler.java
+++ b/testsuite/src/main/java/io/netty/testsuite/websockets/autobahn/AutobahnServerHandler.java
@@ -90,7 +90,7 @@ public class AutobahnServerHandler extends ChannelInboundHandlerAdapter {
         if (handshaker == null) {
             WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ctx.channel());
         } else {
-            handshaker.handshake(ctx.channel(), req);
+            handshaker.handshake(ctx, req);
         }
     }
 
@@ -101,7 +101,7 @@ public class AutobahnServerHandler extends ChannelInboundHandlerAdapter {
         }
 
         if (frame instanceof CloseWebSocketFrame) {
-            handshaker.close(ctx.channel(), (CloseWebSocketFrame) frame);
+            handshaker.close(ctx, (CloseWebSocketFrame) frame);
         } else if (frame instanceof PingWebSocketFrame) {
             ctx.write(new PongWebSocketFrame(frame.isFinalFragment(), frame.rsv(), frame.content()));
         } else if (frame instanceof TextWebSocketFrame ||

--- a/transport/src/main/java/io/netty/channel/ChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPipeline.java
@@ -633,6 +633,24 @@ public interface ChannelPipeline extends Iterable<Entry<String, ChannelHandler>>
     <T extends ChannelHandler> T get(Class<T> handlerType);
 
     /**
+     * Returns the first {@link ChannelHandler} of the specified type in this
+     * pipeline that is found before the given {@link ChannelHandlerContext}.
+     *
+     * @return the handler of the specified handler type.
+     *         {@code null} if there's no such handler in this pipeline.
+     */
+    <T extends ChannelHandler> T getBefore(ChannelHandlerContext ctx, Class<T> handlerType);
+
+    /**
+     * Returns the first {@link ChannelHandler} of the specified type in this
+     * pipeline that is found after the given {@link ChannelHandlerContext}.
+     *
+     * @return the handler of the specified handler type.
+     *         {@code null} if there's no such handler in this pipeline.
+     */
+    <T extends ChannelHandler> T getAfter(ChannelHandlerContext ctx, Class<T> handlerType);
+
+    /**
      * Returns the context object of the specified {@link ChannelHandler} in
      * this pipeline.
      *
@@ -658,6 +676,24 @@ public interface ChannelPipeline extends Iterable<Entry<String, ChannelHandler>>
      *         {@code null} if there's no such handler in this pipeline.
      */
     ChannelHandlerContext context(Class<? extends ChannelHandler> handlerType);
+
+    /**
+     * Returns the context object of the {@link ChannelHandler} of the
+     * specified type in this pipeline that is found before the given {@link ChannelHandlerContext}.
+     *
+     * @return the context object of the handler of the specified type.
+     *         {@code null} if there's no such handler in this pipeline.
+     */
+    ChannelHandlerContext contextBefore(ChannelHandlerContext ctx, Class<? extends ChannelHandler> handlerType);
+
+    /**
+     * Returns the context object of the {@link ChannelHandler} of the
+     * specified type in this pipeline that is found after the given {@link ChannelHandlerContext}.
+     *
+     * @return the context object of the handler of the specified type.
+     *         {@code null} if there's no such handler in this pipeline.
+     */
+    ChannelHandlerContext contextAfter(ChannelHandlerContext ctx, Class<? extends ChannelHandler> handlerType);
 
     /**
      * Returns the {@link Channel} that this pipeline is attached to.


### PR DESCRIPTION
Motivation:

When a user has multiple instances of Http codecs in the pipline the WebSocket*Handshaker may remove the wrong ones as it will just remove the first that are found in the pipeline. We should better provide a way to have it search the "nearest" codec and remove this one.

This fixes [#5070]

Modifications:

- Add ChannelPipeline.contextBefore/After and getBefore/getAfter and make use of it in the handshakers
- Deprecate old methods in handshakers and add new ones that uses the ChannelHandlerContext and so be able to detect the "closest" codec.

Result:

Chances are less likely to remove the wrong codec.