### PR TITLE
Make retained derived buffers recyclable

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -837,6 +837,13 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf readRetainedSlice(int length) {
+        ByteBuf slice = retainedSlice(readerIndex, length);
+        readerIndex += length;
+        return slice;
+    }
+
+    @Override
     public ByteBuf readBytes(byte[] dst, int dstIndex, int length) {
         checkReadableBytes(length);
         getBytes(readerIndex, dst, dstIndex, length);
@@ -1160,13 +1167,28 @@ public abstract class AbstractByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf retainedDuplicate() {
+        return duplicate().retain();
+    }
+
+    @Override
     public ByteBuf slice() {
         return slice(readerIndex, readableBytes());
     }
 
     @Override
+    public ByteBuf retainedSlice() {
+        return slice().retain();
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         return new SlicedAbstractByteBuf(this, index, length);
+    }
+
+    @Override
+    public ByteBuf retainedSlice(int index, int length) {
+        return slice(index, length).retain();
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer;
+
+import io.netty.util.Recycler.Handle;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Abstract base class for derived {@link ByteBuf} implementations.
+ */
+abstract class AbstractPooledDerivedByteBuf<T> extends AbstractReferenceCountedByteBuf {
+
+    private final Handle<AbstractPooledDerivedByteBuf<T>> recyclerHandle;
+    private AbstractByteBuf buffer;
+
+    @SuppressWarnings("unchecked")
+    AbstractPooledDerivedByteBuf(Handle<? extends AbstractPooledDerivedByteBuf<T>> recyclerHandle) {
+        super(0);
+        this.recyclerHandle = (Handle<AbstractPooledDerivedByteBuf<T>>) recyclerHandle;
+    }
+
+    @Override
+    public final AbstractByteBuf unwrap() {
+        return buffer;
+    }
+
+    final <U extends AbstractPooledDerivedByteBuf<T>> U init(
+            AbstractByteBuf buffer, int readerIndex, int writerIndex, int maxCapacity) {
+
+        buffer.retain();
+        this.buffer = buffer;
+
+        boolean success = false;
+        try {
+            maxCapacity(maxCapacity);
+            setIndex(readerIndex, writerIndex);
+            setRefCnt(1);
+
+            @SuppressWarnings("unchecked")
+            final U castThis = (U) this;
+            success = true;
+            return castThis;
+        } finally {
+            if (!success) {
+                this.buffer = null;
+                buffer.release();
+            }
+        }
+    }
+
+    @Override
+    protected final void deallocate() {
+        recyclerHandle.recycle(this);
+        unwrap().release();
+    }
+
+    @Override
+    public final ByteBufAllocator alloc() {
+        return unwrap().alloc();
+    }
+
+    @Override
+    @Deprecated
+    public final ByteOrder order() {
+        return unwrap().order();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return unwrap().isReadOnly();
+    }
+
+    @Override
+    public final boolean isDirect() {
+        return unwrap().isDirect();
+    }
+
+    @Override
+    public boolean hasArray() {
+        return unwrap().hasArray();
+    }
+
+    @Override
+    public byte[] array() {
+        return unwrap().array();
+    }
+
+    @Override
+    public boolean hasMemoryAddress() {
+        return unwrap().hasMemoryAddress();
+    }
+
+    @Override
+    public final int nioBufferCount() {
+        return unwrap().nioBufferCount();
+    }
+
+    @Override
+    public final ByteBuffer internalNioBuffer(int index, int length) {
+        return nioBuffer(index, length);
+    }
+
+    @Override
+    public final ByteBuf retainedDuplicate() {
+        return PooledDuplicatedByteBuf.newInstance(this, readerIndex(), writerIndex());
+    }
+
+    @Override
+    public final ByteBuf retainedSlice() {
+        final int index = readerIndex();
+        return retainedSlice(index, writerIndex() - index);
+    }
+
+    @Override
+    public final ByteBuf retainedSlice(int index, int length) {
+        return PooledSlicedByteBuf.newInstance(this, index, length, index);
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
@@ -77,9 +77,21 @@ final class AdvancedLeakAwareByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public ByteBuf retainedSlice() {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.retainedSlice(), leak);
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         recordLeakNonRefCountingOperation(leak);
         return new AdvancedLeakAwareByteBuf(super.slice(index, length), leak);
+    }
+
+    @Override
+    public ByteBuf retainedSlice(int index, int length) {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.retainedSlice(index, length), leak);
     }
 
     @Override
@@ -89,9 +101,21 @@ final class AdvancedLeakAwareByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public ByteBuf retainedDuplicate() {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.retainedDuplicate(), leak);
+    }
+
+    @Override
     public ByteBuf readSlice(int length) {
         recordLeakNonRefCountingOperation(leak);
         return new AdvancedLeakAwareByteBuf(super.readSlice(length), leak);
+    }
+
+    @Override
+    public ByteBuf readRetainedSlice(int length) {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.readRetainedSlice(length), leak);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
@@ -59,9 +59,21 @@ final class AdvancedLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     }
 
     @Override
+    public ByteBuf retainedSlice() {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.retainedSlice(), leak);
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         recordLeakNonRefCountingOperation(leak);
         return new AdvancedLeakAwareByteBuf(super.slice(index, length), leak);
+    }
+
+    @Override
+    public ByteBuf retainedSlice(int index, int length) {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.retainedSlice(index, length), leak);
     }
 
     @Override
@@ -71,9 +83,21 @@ final class AdvancedLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     }
 
     @Override
+    public ByteBuf retainedDuplicate() {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.retainedDuplicate(), leak);
+    }
+
+    @Override
     public ByteBuf readSlice(int length) {
         recordLeakNonRefCountingOperation(leak);
         return new AdvancedLeakAwareByteBuf(super.readSlice(length), leak);
+    }
+
+    @Override
+    public ByteBuf readRetainedSlice(int length) {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.readRetainedSlice(length), leak);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/ByteBufHolder.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufHolder.java
@@ -28,14 +28,26 @@ public interface ByteBufHolder extends ReferenceCounted {
     ByteBuf content();
 
     /**
-     * Create a deep copy of this {@link ByteBufHolder}.
+     * Creates a deep copy of this {@link ByteBufHolder}.
      */
     ByteBufHolder copy();
 
     /**
-     * Duplicate the {@link ByteBufHolder}. Be aware that this will not automatically call {@link #retain()}.
+     * Duplicates this {@link ByteBufHolder}. Be aware that this will not automatically call {@link #retain()}.
      */
     ByteBufHolder duplicate();
+
+    /**
+     * Duplicates this {@link ByteBufHolder}. This method returns a retained duplicate unlike {@link #duplicate()}.
+     *
+     * @see ByteBuf#retainedDuplicate()
+     */
+    ByteBufHolder retainedDuplicate();
+
+    /**
+     * Returns a new {@link ByteBufHolder} which contains the specified {@code content}.
+     */
+    ByteBufHolder replace(ByteBuf content);
 
     @Override
     ByteBufHolder retain();

--- a/buffer/src/main/java/io/netty/buffer/DefaultByteBufHolder.java
+++ b/buffer/src/main/java/io/netty/buffer/DefaultByteBufHolder.java
@@ -41,14 +41,46 @@ public class DefaultByteBufHolder implements ByteBufHolder {
         return data;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method calls {@code replace(content().copy())} by default.
+     */
     @Override
     public ByteBufHolder copy() {
-        return new DefaultByteBufHolder(data.copy());
+        return replace(data.copy());
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method calls {@code replace(content().duplicate())} by default.
+     */
     @Override
     public ByteBufHolder duplicate() {
-        return new DefaultByteBufHolder(data.duplicate());
+        return replace(data.duplicate());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This method calls {@code replace(content().retainedDuplicate())} by default.
+     */
+    @Override
+    public ByteBufHolder retainedDuplicate() {
+        return replace(data.retainedDuplicate());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Override this method to return a new instance of this object whose content is set to the specified
+     * {@code content}. The default implementation of {@link #copy()}, {@link #duplicate()} and
+     * {@link #retainedDuplicate()} invokes this method to create a copy.
+     */
+    @Override
+    public ByteBufHolder replace(ByteBuf content) {
+        return new DefaultByteBufHolder(content);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -631,6 +631,11 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf readRetainedSlice(int length) {
+        return checkLength(length);
+    }
+
+    @Override
     public ByteBuf readBytes(ByteBuf dst) {
         return checkLength(dst.writableBytes());
     }
@@ -873,12 +878,27 @@ public final class EmptyByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf retainedSlice() {
+        return this;
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         return checkIndex(index, length);
     }
 
     @Override
+    public ByteBuf retainedSlice(int index, int length) {
+        return checkIndex(index, length);
+    }
+
+    @Override
     public ByteBuf duplicate() {
+        return this;
+    }
+
+    @Override
+    public ByteBuf retainedDuplicate() {
         return this;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -136,6 +136,22 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
         return null;
     }
 
+    @Override
+    public final ByteBuf retainedDuplicate() {
+        return PooledDuplicatedByteBuf.newInstance(this, readerIndex(), writerIndex());
+    }
+
+    @Override
+    public final ByteBuf retainedSlice() {
+        final int index = readerIndex();
+        return retainedSlice(index, writerIndex() - index);
+    }
+
+    @Override
+    public final ByteBuf retainedSlice(int index, int length) {
+        return PooledSlicedByteBuf.newInstance(this, index, length, index);
+    }
+
     protected final ByteBuffer internalNioBuffer() {
         ByteBuffer tmpNioBuf = this.tmpNioBuf;
         if (tmpNioBuf == null) {

--- a/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareByteBuf.java
@@ -73,8 +73,18 @@ final class SimpleLeakAwareByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public ByteBuf retainedSlice() {
+        return new SimpleLeakAwareByteBuf(super.retainedSlice(), leak);
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         return new SimpleLeakAwareByteBuf(super.slice(index, length), leak);
+    }
+
+    @Override
+    public ByteBuf retainedSlice(int index, int length) {
+        return new SimpleLeakAwareByteBuf(super.retainedSlice(index, length), leak);
     }
 
     @Override
@@ -83,7 +93,17 @@ final class SimpleLeakAwareByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public ByteBuf retainedDuplicate() {
+        return new SimpleLeakAwareByteBuf(super.retainedDuplicate(), leak);
+    }
+
+    @Override
     public ByteBuf readSlice(int length) {
         return new SimpleLeakAwareByteBuf(super.readSlice(length), leak);
+    }
+
+    @Override
+    public ByteBuf readRetainedSlice(int length) {
+        return new SimpleLeakAwareByteBuf(super.readRetainedSlice(length), leak);
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareCompositeByteBuf.java
@@ -63,8 +63,18 @@ final class SimpleLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     }
 
     @Override
+    public ByteBuf retainedSlice() {
+        return new SimpleLeakAwareByteBuf(super.retainedSlice(), leak);
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         return new SimpleLeakAwareByteBuf(super.slice(index, length), leak);
+    }
+
+    @Override
+    public ByteBuf retainedSlice(int index, int length) {
+        return new SimpleLeakAwareByteBuf(super.retainedSlice(index, length), leak);
     }
 
     @Override
@@ -73,7 +83,17 @@ final class SimpleLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     }
 
     @Override
+    public ByteBuf retainedDuplicate() {
+        return new SimpleLeakAwareByteBuf(super.retainedDuplicate(), leak);
+    }
+
+    @Override
     public ByteBuf readSlice(int length) {
         return new SimpleLeakAwareByteBuf(super.readSlice(length), leak);
+    }
+
+    @Override
+    public ByteBuf readRetainedSlice(int length) {
+        return new SimpleLeakAwareByteBuf(super.readRetainedSlice(length), leak);
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -632,6 +632,11 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf readRetainedSlice(int length) {
+        return buf.readRetainedSlice(length).order(order);
+    }
+
+    @Override
     public ByteBuf readBytes(ByteBuf dst) {
         buf.readBytes(dst);
         return this;
@@ -890,13 +895,28 @@ public class SwappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf retainedSlice() {
+        return buf.slice().order(order);
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
+        return buf.slice(index, length).order(order);
+    }
+
+    @Override
+    public ByteBuf retainedSlice(int index, int length) {
         return buf.slice(index, length).order(order);
     }
 
     @Override
     public ByteBuf duplicate() {
         return buf.duplicate().order(order);
+    }
+
+    @Override
+    public ByteBuf retainedDuplicate() {
+        return buf.retainedDuplicate().order(order);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnreleasableByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnreleasableByteBuf.java
@@ -56,8 +56,18 @@ final class UnreleasableByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public ByteBuf readRetainedSlice(int length) {
+        return new UnreleasableByteBuf(buf.readRetainedSlice(length));
+    }
+
+    @Override
     public ByteBuf slice() {
         return new UnreleasableByteBuf(buf.slice());
+    }
+
+    @Override
+    public ByteBuf retainedSlice() {
+        return new UnreleasableByteBuf(buf.retainedSlice());
     }
 
     @Override
@@ -66,8 +76,18 @@ final class UnreleasableByteBuf extends WrappedByteBuf {
     }
 
     @Override
+    public ByteBuf retainedSlice(int index, int length) {
+        return new UnreleasableByteBuf(buf.retainedSlice(index, length));
+    }
+
+    @Override
     public ByteBuf duplicate() {
         return new UnreleasableByteBuf(buf.duplicate());
+    }
+
+    @Override
+    public ByteBuf retainedDuplicate() {
+        return new UnreleasableByteBuf(buf.retainedDuplicate());
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedByteBuf.java
@@ -622,6 +622,11 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf readRetainedSlice(int length) {
+        return buf.readRetainedSlice(length);
+    }
+
+    @Override
     public ByteBuf readBytes(ByteBuf dst) {
         buf.readBytes(dst);
         return this;
@@ -880,13 +885,28 @@ class WrappedByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf retainedSlice() {
+        return buf.retainedSlice();
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         return buf.slice(index, length);
     }
 
     @Override
+    public ByteBuf retainedSlice(int index, int length) {
+        return buf.retainedSlice(index, length);
+    }
+
+    @Override
     public ByteBuf duplicate() {
         return buf.duplicate();
+    }
+
+    @Override
+    public ByteBuf retainedDuplicate() {
+        return buf.retainedDuplicate();
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
@@ -333,8 +333,18 @@ class WrappedCompositeByteBuf extends CompositeByteBuf {
     }
 
     @Override
+    public ByteBuf retainedSlice() {
+        return wrapped.retainedSlice();
+    }
+
+    @Override
     public ByteBuf slice(int index, int length) {
         return wrapped.slice(index, length);
+    }
+
+    @Override
+    public ByteBuf retainedSlice(int index, int length) {
+        return wrapped.retainedSlice(index, length);
     }
 
     @Override
@@ -418,8 +428,18 @@ class WrappedCompositeByteBuf extends CompositeByteBuf {
     }
 
     @Override
+    public ByteBuf retainedDuplicate() {
+        return wrapped.retainedDuplicate();
+    }
+
+    @Override
     public ByteBuf readSlice(int length) {
         return wrapped.readSlice(length);
+    }
+
+    @Override
+    public ByteBuf readRetainedSlice(int length) {
+        return wrapped.readRetainedSlice(length);
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/DuplicatedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/DuplicatedByteBufTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests duplicated channel buffers
  */
-public class DuplicateByteBufTest extends AbstractByteBufTest {
+public class DuplicatedByteBufTest extends AbstractByteBufTest {
 
     @Override
     protected ByteBuf newBuffer(int length) {

--- a/buffer/src/test/java/io/netty/buffer/RetainedDuplicatedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/RetainedDuplicatedByteBufTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer;
+
+import static org.junit.Assert.assertEquals;
+
+public class RetainedDuplicatedByteBufTest extends DuplicatedByteBufTest {
+    @Override
+    protected ByteBuf newBuffer(int length) {
+        ByteBuf wrapped = Unpooled.buffer(length);
+        ByteBuf buffer = wrapped.retainedDuplicate();
+        wrapped.release();
+
+        assertEquals(wrapped.writerIndex(), buffer.writerIndex());
+        assertEquals(wrapped.readerIndex(), buffer.readerIndex());
+        return buffer;
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/RetainedSlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/RetainedSlicedByteBufTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer;
+
+import io.netty.util.internal.ThreadLocalRandom;
+
+import static org.junit.Assert.assertEquals;
+
+public class RetainedSlicedByteBufTest extends SlicedByteBufTest {
+    @Override
+    protected ByteBuf newBuffer(int length) {
+        ByteBuf wrapped = Unpooled.wrappedBuffer(new byte[length * 2]);
+        ByteBuf buffer = wrapped.retainedSlice(ThreadLocalRandom.current().nextInt(length - 1) + 1, length);
+        wrapped.release();
+
+        assertEquals(0, buffer.readerIndex());
+        assertEquals(length, buffer.writerIndex());
+        return buffer;
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.buffer;
 
+import io.netty.util.internal.ThreadLocalRandom;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -27,12 +28,11 @@ import static org.junit.Assert.*;
  */
 public class SlicedByteBufTest extends AbstractByteBufTest {
 
-    private final Random random = new Random();
-
     @Override
     protected ByteBuf newBuffer(int length) {
         ByteBuf buffer = Unpooled.wrappedBuffer(
-                new byte[length * 2], random.nextInt(length - 1) + 1, length);
+                new byte[length * 2], ThreadLocalRandom.current().nextInt(length - 1) + 1, length);
+        assertEquals(0, buffer.readerIndex());
         assertEquals(length, buffer.writerIndex());
         return buffer;
     }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRawRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRawRecord.java
@@ -69,12 +69,22 @@ public class DefaultDnsRawRecord extends AbstractDnsRecord implements DnsRawReco
 
     @Override
     public DnsRawRecord copy() {
-        return new DefaultDnsRawRecord(name(), type(), dnsClass(), timeToLive(), content().copy());
+        return replace(content().copy());
     }
 
     @Override
     public DnsRawRecord duplicate() {
-        return new DefaultDnsRawRecord(name(), type(), dnsClass(), timeToLive(), content().duplicate());
+        return replace(content().duplicate());
+    }
+
+    @Override
+    public DnsRawRecord retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public DnsRawRecord replace(ByteBuf content) {
+        return new DefaultDnsRawRecord(name(), type(), dnsClass(), timeToLive(), content);
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
@@ -95,7 +95,7 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
             return new DefaultDnsPtrRecord(name, dnsClass, timeToLive, decodeName(in));
         }
         return new DefaultDnsRawRecord(
-                name, type, dnsClass, timeToLive, in.duplicate().setIndex(offset, offset + length).retain());
+                name, type, dnsClass, timeToLive, in.retainedDuplicate().setIndex(offset, offset + length));
     }
 
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsRawRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsRawRecord.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.dns;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.util.internal.UnstableApi;
 
@@ -28,6 +29,12 @@ public interface DnsRawRecord extends DnsRecord, ByteBufHolder {
 
     @Override
     DnsRawRecord duplicate();
+
+    @Override
+    DnsRawRecord retainedDuplicate();
+
+    @Override
+    DnsRawRecord replace(ByteBuf content);
 
     @Override
     DnsRawRecord retain();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/ComposedLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/ComposedLastHttpContent.java
@@ -27,6 +27,7 @@ final class ComposedLastHttpContent implements LastHttpContent {
     ComposedLastHttpContent(HttpHeaders trailingHeaders) {
         this.trailingHeaders = trailingHeaders;
     }
+
     @Override
     public HttpHeaders trailingHeaders() {
         return trailingHeaders;
@@ -37,6 +38,23 @@ final class ComposedLastHttpContent implements LastHttpContent {
         LastHttpContent content = new DefaultLastHttpContent(Unpooled.EMPTY_BUFFER);
         content.trailingHeaders().set(trailingHeaders());
         return content;
+    }
+
+    @Override
+    public LastHttpContent duplicate() {
+        return copy();
+    }
+
+    @Override
+    public LastHttpContent retainedDuplicate() {
+        return copy();
+    }
+
+    @Override
+    public LastHttpContent replace(ByteBuf content) {
+        final LastHttpContent dup = new DefaultLastHttpContent(content);
+        dup.trailingHeaders().setAll(trailingHeaders());
+        return dup;
     }
 
     @Override
@@ -57,11 +75,6 @@ final class ComposedLastHttpContent implements LastHttpContent {
     @Override
     public LastHttpContent touch(Object hint) {
         return this;
-    }
-
-    @Override
-    public LastHttpContent duplicate() {
-        return copy();
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
@@ -125,44 +125,24 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
         return this;
     }
 
-    /**
-     * Copy this object
-     *
-     * @param copyContent
-     * <ul>
-     * <li>{@code true} if this object's {@link #content()} should be used to copy.</li>
-     * <li>{@code false} if {@code newContent} should be used instead.</li>
-     * </ul>
-     * @param newContent
-     * <ul>
-     * <li>if {@code copyContent} is false then this will be used in the copy's content.</li>
-     * <li>if {@code null} then a default buffer of 0 size will be selected</li>
-     * </ul>
-     * @return A copy of this object
-     */
-    private FullHttpRequest copy(boolean copyContent, ByteBuf newContent) {
-        return new DefaultFullHttpRequest(
-                protocolVersion(), method(), uri(),
-                copyContent ? content().copy() :
-                        newContent == null ? Unpooled.buffer(0) : newContent,
-                headers(),
-                trailingHeaders());
-    }
-
-    @Override
-    public FullHttpRequest copy(ByteBuf newContent) {
-        return copy(false, newContent);
-    }
-
     @Override
     public FullHttpRequest copy() {
-        return copy(true, null);
+        return replace(content().copy());
     }
 
     @Override
     public FullHttpRequest duplicate() {
-        return new DefaultFullHttpRequest(
-                protocolVersion(), method(), uri(), content().duplicate(), headers(), trailingHeaders());
+        return replace(content().duplicate());
+    }
+
+    @Override
+    public FullHttpRequest retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public FullHttpRequest replace(ByteBuf content) {
+        return new DefaultFullHttpRequest(protocolVersion(), method(), uri(), content, headers(), trailingHeaders());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
@@ -132,44 +132,24 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
         return this;
     }
 
-    /**
-     * Copy this object
-     *
-     * @param copyContent
-     * <ul>
-     * <li>{@code true} if this object's {@link #content()} should be used to copy.</li>
-     * <li>{@code false} if {@code newContent} should be used instead.</li>
-     * </ul>
-     * @param newContent
-     * <ul>
-     * <li>if {@code copyContent} is false then this will be used in the copy's content.</li>
-     * <li>if {@code null} then a default buffer of 0 size will be selected</li>
-     * </ul>
-     * @return A copy of this object
-     */
-    private FullHttpResponse copy(boolean copyContent, ByteBuf newContent) {
-        return new DefaultFullHttpResponse(
-                protocolVersion(), status(),
-                copyContent ? content().copy() :
-                        newContent == null ? Unpooled.buffer(0) : newContent,
-                headers(),
-                trailingHeaders());
-    }
-
-    @Override
-    public FullHttpResponse copy(ByteBuf newContent) {
-        return copy(false, newContent);
-    }
-
     @Override
     public FullHttpResponse copy() {
-        return copy(true, null);
+        return replace(content().copy());
     }
 
     @Override
     public FullHttpResponse duplicate() {
-        return new DefaultFullHttpResponse(protocolVersion(), status(),
-                content().duplicate(), headers(), trailingHeaders());
+        return replace(content().duplicate());
+    }
+
+    @Override
+    public FullHttpResponse retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public FullHttpResponse replace(ByteBuf content) {
+        return new DefaultFullHttpResponse(protocolVersion(), status(), content, headers(), trailingHeaders());
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpContent.java
@@ -42,12 +42,22 @@ public class DefaultHttpContent extends DefaultHttpObject implements HttpContent
 
     @Override
     public HttpContent copy() {
-        return new DefaultHttpContent(content.copy());
+        return replace(content.copy());
     }
 
     @Override
     public HttpContent duplicate() {
-        return new DefaultHttpContent(content.duplicate());
+        return replace(content.duplicate());
+    }
+
+    @Override
+    public HttpContent retainedDuplicate() {
+        return replace(content.retainedDuplicate());
+    }
+
+    @Override
+    public HttpContent replace(ByteBuf content) {
+        return new DefaultHttpContent(content);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultLastHttpContent.java
@@ -45,16 +45,24 @@ public class DefaultLastHttpContent extends DefaultHttpContent implements LastHt
 
     @Override
     public LastHttpContent copy() {
-        DefaultLastHttpContent copy = new DefaultLastHttpContent(content().copy(), validateHeaders);
-        copy.trailingHeaders().set(trailingHeaders());
-        return copy;
+        return replace(content().copy());
     }
 
     @Override
     public LastHttpContent duplicate() {
-        DefaultLastHttpContent copy = new DefaultLastHttpContent(content().duplicate(), validateHeaders);
-        copy.trailingHeaders().set(trailingHeaders());
-        return copy;
+        return replace(content().duplicate());
+    }
+
+    @Override
+    public LastHttpContent retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public LastHttpContent replace(ByteBuf content) {
+        final DefaultLastHttpContent dup = new DefaultLastHttpContent(content, validateHeaders);
+        dup.trailingHeaders().set(trailingHeaders());
+        return dup;
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpMessage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpMessage.java
@@ -22,18 +22,17 @@ import io.netty.buffer.ByteBuf;
  * message. So it represent a <i>complete</i> http message.
  */
 public interface FullHttpMessage extends HttpMessage, LastHttpContent {
-    /**
-     * Create a copy of this {@link FullHttpMessage} with alternative content.
-     *
-     * @param newContent The buffer to use instead of this {@link FullHttpMessage}'s content in the copy operation.
-     * <p>
-     * NOTE: retain will NOT be called on this buffer. {@code null} results in an empty default choice buffer.
-     * @return The result of the copy operation
-     */
-    FullHttpMessage copy(ByteBuf newContent);
-
     @Override
     FullHttpMessage copy();
+
+    @Override
+    FullHttpMessage duplicate();
+
+    @Override
+    FullHttpMessage retainedDuplicate();
+
+    @Override
+    FullHttpMessage replace(ByteBuf content);
 
     @Override
     FullHttpMessage retain(int increment);
@@ -46,7 +45,4 @@ public interface FullHttpMessage extends HttpMessage, LastHttpContent {
 
     @Override
     FullHttpMessage touch(Object hint);
-
-    @Override
-    FullHttpMessage duplicate();
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpRequest.java
@@ -23,10 +23,16 @@ import io.netty.buffer.ByteBuf;
  */
 public interface FullHttpRequest extends HttpRequest, FullHttpMessage {
     @Override
-    FullHttpRequest copy(ByteBuf newContent);
+    FullHttpRequest copy();
 
     @Override
-    FullHttpRequest copy();
+    FullHttpRequest duplicate();
+
+    @Override
+    FullHttpRequest retainedDuplicate();
+
+    @Override
+    FullHttpRequest replace(ByteBuf content);
 
     @Override
     FullHttpRequest retain(int increment);
@@ -39,9 +45,6 @@ public interface FullHttpRequest extends HttpRequest, FullHttpMessage {
 
     @Override
     FullHttpRequest touch(Object hint);
-
-    @Override
-    FullHttpRequest duplicate();
 
     @Override
     FullHttpRequest setProtocolVersion(HttpVersion version);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/FullHttpResponse.java
@@ -23,10 +23,16 @@ import io.netty.buffer.ByteBuf;
  */
 public interface FullHttpResponse extends HttpResponse, FullHttpMessage {
     @Override
-    FullHttpResponse copy(ByteBuf newContent);
+    FullHttpResponse copy();
 
     @Override
-    FullHttpResponse copy();
+    FullHttpResponse duplicate();
+
+    @Override
+    FullHttpResponse retainedDuplicate();
+
+    @Override
+    FullHttpResponse replace(ByteBuf content);
 
     @Override
     FullHttpResponse retain(int increment);
@@ -39,9 +45,6 @@ public interface FullHttpResponse extends HttpResponse, FullHttpMessage {
 
     @Override
     FullHttpResponse touch(Object hint);
-
-    @Override
-    FullHttpResponse duplicate();
 
     @Override
     FullHttpResponse setProtocolVersion(HttpVersion version);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContent.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.http;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.ChannelPipeline;
 
@@ -32,6 +33,12 @@ public interface HttpContent extends HttpObject, ByteBufHolder {
 
     @Override
     HttpContent duplicate();
+
+    @Override
+    HttpContent retainedDuplicate();
+
+    @Override
+    HttpContent replace(ByteBuf content);
 
     @Override
     HttpContent retain();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -279,7 +279,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             // Keep reading data as a chunk until the end of connection is reached.
             int toRead = Math.min(buffer.readableBytes(), maxChunkSize);
             if (toRead > 0) {
-                ByteBuf content = buffer.readSlice(toRead).retain();
+                ByteBuf content = buffer.readRetainedSlice(toRead);
                 out.add(new DefaultHttpContent(content));
             }
             return;
@@ -301,7 +301,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             if (toRead > chunkSize) {
                 toRead = (int) chunkSize;
             }
-            ByteBuf content = buffer.readSlice(toRead).retain();
+            ByteBuf content = buffer.readRetainedSlice(toRead);
             chunkSize -= toRead;
 
             if (chunkSize == 0) {
@@ -341,7 +341,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             if (toRead == 0) {
                 return;
             }
-            HttpContent chunk = new DefaultHttpContent(buffer.readSlice(toRead).retain());
+            HttpContent chunk = new DefaultHttpContent(buffer.readRetainedSlice(toRead));
             chunkSize -= toRead;
 
             out.add(chunk);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/LastHttpContent.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/LastHttpContent.java
@@ -45,6 +45,16 @@ public interface LastHttpContent extends HttpContent {
         }
 
         @Override
+        public LastHttpContent replace(ByteBuf content) {
+            return new DefaultLastHttpContent(content);
+        }
+
+        @Override
+        public LastHttpContent retainedDuplicate() {
+            return this;
+        }
+
+        @Override
         public HttpHeaders trailingHeaders() {
             return EmptyHttpHeaders.INSTANCE;
         }
@@ -112,6 +122,15 @@ public interface LastHttpContent extends HttpContent {
     LastHttpContent copy();
 
     @Override
+    LastHttpContent duplicate();
+
+    @Override
+    LastHttpContent retainedDuplicate();
+
+    @Override
+    LastHttpContent replace(ByteBuf content);
+
+    @Override
     LastHttpContent retain(int increment);
 
     @Override
@@ -122,7 +141,4 @@ public interface LastHttpContent extends HttpContent {
 
     @Override
     LastHttpContent touch(Object hint);
-
-    @Override
-    LastHttpContent duplicate();
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpData.java
@@ -28,7 +28,10 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 
-import static io.netty.buffer.Unpooled.*;
+import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
+import static io.netty.buffer.Unpooled.buffer;
+import static io.netty.buffer.Unpooled.compositeBuffer;
+import static io.netty.buffer.Unpooled.wrappedBuffer;
 
 /**
  * Abstract Memory HttpData implementation
@@ -209,7 +212,7 @@ public abstract class AbstractMemoryHttpData extends AbstractHttpData {
         if (sizeLeft < length) {
             sliceLength = sizeLeft;
         }
-        ByteBuf chunk = byteBuf.slice(chunkPosition, sliceLength).retain();
+        ByteBuf chunk = byteBuf.retainedSlice(chunkPosition, sliceLength);
         chunkPosition += sliceLength;
         return chunk;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/Attribute.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/Attribute.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http.multipart;
 
+import io.netty.buffer.ByteBuf;
+
 import java.io.IOException;
 
 /**
@@ -36,6 +38,12 @@ public interface Attribute extends HttpData {
 
     @Override
     Attribute duplicate();
+
+    @Override
+    Attribute retainedDuplicate();
+
+    @Override
+    Attribute replace(ByteBuf content);
 
     @Override
     Attribute retain();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/FileUpload.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/FileUpload.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http.multipart;
 
+import io.netty.buffer.ByteBuf;
+
 /**
  * FileUpload interface that could be in memory, on temporary file or any other implementations.
  *
@@ -61,6 +63,12 @@ public interface FileUpload extends HttpData {
 
     @Override
     FileUpload duplicate();
+
+    @Override
+    FileUpload retainedDuplicate();
+
+    @Override
+    FileUpload replace(ByteBuf content);
 
     @Override
     FileUpload retain();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpData.java
@@ -220,6 +220,12 @@ public interface HttpData extends InterfaceHttpData, ByteBufHolder {
     HttpData duplicate();
 
     @Override
+    HttpData retainedDuplicate();
+
+    @Override
+    HttpData replace(ByteBuf content);
+
+    @Override
     HttpData retain();
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -26,11 +26,11 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpConstants;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.stream.ChunkedInput;
@@ -48,7 +48,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import static io.netty.buffer.Unpooled.*;
+import static io.netty.buffer.Unpooled.wrappedBuffer;
 
 /**
  * This encoder will help to encode Request for a FORM as POST.
@@ -836,7 +836,6 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
         int length = currentBuffer.readableBytes();
         if (length > HttpPostBodyUtil.chunkSize) {
             ByteBuf slice = currentBuffer.slice(currentBuffer.readerIndex(), HttpPostBodyUtil.chunkSize);
-            currentBuffer.retain();
             currentBuffer.skipBytes(HttpPostBodyUtil.chunkSize);
             return slice;
         } else {
@@ -1239,45 +1238,24 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
             return this;
         }
 
-        /**
-         * Copy this object
-         *
-         * @param copyContent
-         * <ul>
-         * <li>{@code true} if this object's {@link #content()} should be used to copy.</li>
-         * <li>{@code false} if {@code newContent} should be used instead.</li>
-         * </ul>
-         * @param newContent
-         * <ul>
-         * <li>if {@code copyContent} is false then this will be used in the copy's content.</li>
-         * <li>if {@code null} then a default buffer of 0 size will be selected</li>
-         * </ul>
-         * @return A copy of this object
-         */
-        private FullHttpRequest copy(boolean copyContent, ByteBuf newContent) {
-            DefaultFullHttpRequest copy = new DefaultFullHttpRequest(
-                    protocolVersion(), method(), uri(),
-                    copyContent ? content().copy() :
-                            newContent == null ? buffer(0) : newContent);
-            copy.headers().set(headers());
-            copy.trailingHeaders().set(trailingHeaders());
-            return copy;
-        }
-
-        @Override
-        public FullHttpRequest copy(ByteBuf newContent) {
-            return copy(false, newContent);
-        }
-
         @Override
         public FullHttpRequest copy() {
-            return copy(true, null);
+            return replace(content().copy());
         }
 
         @Override
         public FullHttpRequest duplicate() {
-            DefaultFullHttpRequest duplicate = new DefaultFullHttpRequest(
-                    getProtocolVersion(), getMethod(), getUri(), content().duplicate());
+            return replace(content().duplicate());
+        }
+
+        @Override
+        public FullHttpRequest retainedDuplicate() {
+            return replace(content().retainedDuplicate());
+        }
+
+        @Override
+        public FullHttpRequest replace(ByteBuf content) {
+            DefaultFullHttpRequest duplicate = new DefaultFullHttpRequest(protocolVersion(), method(), uri(), content);
             duplicate.headers().set(headers());
             duplicate.trailingHeaders().set(trailingHeaders());
             return duplicate;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryAttribute.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MemoryAttribute.java
@@ -122,27 +122,43 @@ public class MemoryAttribute extends AbstractMemoryHttpData implements Attribute
 
     @Override
     public Attribute copy() {
-        MemoryAttribute attr = new MemoryAttribute(getName());
-        attr.setCharset(getCharset());
-        ByteBuf content = content();
-        if (content != null) {
-            try {
-                attr.setContent(content.copy());
-            } catch (IOException e) {
-                throw new ChannelException(e);
-            }
-        }
-        return attr;
+        final ByteBuf content = content();
+        return replace(content != null ? content.copy() : null);
     }
 
     @Override
     public Attribute duplicate() {
-        MemoryAttribute attr = new MemoryAttribute(getName());
-        attr.setCharset(getCharset());
+        final ByteBuf content = content();
+        return replace(content != null ? content.duplicate() : null);
+    }
+
+    @Override
+    public Attribute retainedDuplicate() {
         ByteBuf content = content();
         if (content != null) {
+            content = content.retainedDuplicate();
+            boolean success = false;
             try {
-                attr.setContent(content.duplicate());
+                Attribute duplicate = replace(content);
+                success = true;
+                return duplicate;
+            } finally {
+                if (!success) {
+                    content.release();
+                }
+            }
+        } else {
+            return replace(null);
+        }
+    }
+
+    @Override
+    public Attribute replace(ByteBuf content) {
+        MemoryAttribute attr = new MemoryAttribute(getName());
+        attr.setCharset(getCharset());
+        if (content != null) {
+            try {
+                attr.setContent(content);
             } catch (IOException e) {
                 throw new ChannelException(e);
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MixedAttribute.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MixedAttribute.java
@@ -272,6 +272,16 @@ public class MixedAttribute implements Attribute {
     }
 
     @Override
+    public Attribute retainedDuplicate() {
+        return attribute.retainedDuplicate();
+    }
+
+    @Override
+    public Attribute replace(ByteBuf content) {
+        return attribute.replace(content);
+    }
+
+    @Override
     public ByteBuf content() {
         return attribute.content();
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MixedFileUpload.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/MixedFileUpload.java
@@ -294,6 +294,16 @@ public class MixedFileUpload implements FileUpload {
     }
 
     @Override
+    public FileUpload retainedDuplicate() {
+        return fileUpload.retainedDuplicate();
+    }
+
+    @Override
+    public FileUpload replace(ByteBuf content) {
+        return fileUpload.replace(content);
+    }
+
+    @Override
     public ByteBuf content() {
         return fileUpload.content();
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/BinaryWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/BinaryWebSocketFrame.java
@@ -56,12 +56,22 @@ public class BinaryWebSocketFrame extends WebSocketFrame {
 
     @Override
     public BinaryWebSocketFrame copy() {
-        return new BinaryWebSocketFrame(isFinalFragment(), rsv(), content().copy());
+        return (BinaryWebSocketFrame) super.copy();
     }
 
     @Override
     public BinaryWebSocketFrame duplicate() {
-        return new BinaryWebSocketFrame(isFinalFragment(), rsv(), content().duplicate());
+        return (BinaryWebSocketFrame) super.duplicate();
+    }
+
+    @Override
+    public BinaryWebSocketFrame retainedDuplicate() {
+        return (BinaryWebSocketFrame) super.retainedDuplicate();
+    }
+
+    @Override
+    public BinaryWebSocketFrame replace(ByteBuf content) {
+        return new BinaryWebSocketFrame(isFinalFragment(), rsv(), content);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/CloseWebSocketFrame.java
@@ -140,12 +140,22 @@ public class CloseWebSocketFrame extends WebSocketFrame {
 
     @Override
     public CloseWebSocketFrame copy() {
-        return new CloseWebSocketFrame(isFinalFragment(), rsv(), content().copy());
+        return (CloseWebSocketFrame) super.copy();
     }
 
     @Override
     public CloseWebSocketFrame duplicate() {
-        return new CloseWebSocketFrame(isFinalFragment(), rsv(), content().duplicate());
+        return (CloseWebSocketFrame) super.duplicate();
+    }
+
+    @Override
+    public CloseWebSocketFrame retainedDuplicate() {
+        return (CloseWebSocketFrame) super.retainedDuplicate();
+    }
+
+    @Override
+    public CloseWebSocketFrame replace(ByteBuf content) {
+        return new CloseWebSocketFrame(isFinalFragment(), rsv(), content);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/ContinuationWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/ContinuationWebSocketFrame.java
@@ -93,12 +93,22 @@ public class ContinuationWebSocketFrame extends WebSocketFrame {
 
     @Override
     public ContinuationWebSocketFrame copy() {
-        return new ContinuationWebSocketFrame(isFinalFragment(), rsv(), content().copy());
+        return (ContinuationWebSocketFrame) super.copy();
     }
 
     @Override
     public ContinuationWebSocketFrame duplicate() {
-        return new ContinuationWebSocketFrame(isFinalFragment(), rsv(), content().duplicate());
+        return (ContinuationWebSocketFrame) super.duplicate();
+    }
+
+    @Override
+    public ContinuationWebSocketFrame retainedDuplicate() {
+        return (ContinuationWebSocketFrame) super.retainedDuplicate();
+    }
+
+    @Override
+    public ContinuationWebSocketFrame replace(ByteBuf content) {
+        return new ContinuationWebSocketFrame(isFinalFragment(), rsv(), content);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PingWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PingWebSocketFrame.java
@@ -56,12 +56,22 @@ public class PingWebSocketFrame extends WebSocketFrame {
 
     @Override
     public PingWebSocketFrame copy() {
-        return new PingWebSocketFrame(isFinalFragment(), rsv(), content().copy());
+        return (PingWebSocketFrame) super.copy();
     }
 
     @Override
     public PingWebSocketFrame duplicate() {
-        return new PingWebSocketFrame(isFinalFragment(), rsv(), content().duplicate());
+        return (PingWebSocketFrame) super.duplicate();
+    }
+
+    @Override
+    public PingWebSocketFrame retainedDuplicate() {
+        return (PingWebSocketFrame) super.retainedDuplicate();
+    }
+
+    @Override
+    public PingWebSocketFrame replace(ByteBuf content) {
+        return new PingWebSocketFrame(isFinalFragment(), rsv(), content);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PongWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/PongWebSocketFrame.java
@@ -56,12 +56,22 @@ public class PongWebSocketFrame extends WebSocketFrame {
 
     @Override
     public PongWebSocketFrame copy() {
-        return new PongWebSocketFrame(isFinalFragment(), rsv(), content().copy());
+        return (PongWebSocketFrame) super.copy();
     }
 
     @Override
     public PongWebSocketFrame duplicate() {
-        return new PongWebSocketFrame(isFinalFragment(), rsv(), content().duplicate());
+        return (PongWebSocketFrame) super.duplicate();
+    }
+
+    @Override
+    public PongWebSocketFrame retainedDuplicate() {
+        return (PongWebSocketFrame) super.retainedDuplicate();
+    }
+
+    @Override
+    public PongWebSocketFrame replace(ByteBuf content) {
+        return new PongWebSocketFrame(isFinalFragment(), rsv(), content);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/TextWebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/TextWebSocketFrame.java
@@ -96,12 +96,22 @@ public class TextWebSocketFrame extends WebSocketFrame {
 
     @Override
     public TextWebSocketFrame copy() {
-        return new TextWebSocketFrame(isFinalFragment(), rsv(), content().copy());
+        return (TextWebSocketFrame) super.copy();
     }
 
     @Override
     public TextWebSocketFrame duplicate() {
-        return new TextWebSocketFrame(isFinalFragment(), rsv(), content().duplicate());
+        return (TextWebSocketFrame) super.duplicate();
+    }
+
+    @Override
+    public TextWebSocketFrame retainedDuplicate() {
+        return (TextWebSocketFrame) super.retainedDuplicate();
+    }
+
+    @Override
+    public TextWebSocketFrame replace(ByteBuf content) {
+        return new TextWebSocketFrame(isFinalFragment(), rsv(), content);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketFrame.java
@@ -61,10 +61,22 @@ public abstract class WebSocketFrame extends DefaultByteBufHolder {
     }
 
     @Override
-    public abstract WebSocketFrame copy();
+    public WebSocketFrame copy() {
+        return (WebSocketFrame) super.copy();
+    }
 
     @Override
-    public abstract WebSocketFrame duplicate();
+    public WebSocketFrame duplicate() {
+        return (WebSocketFrame) super.duplicate();
+    }
+
+    @Override
+    public WebSocketFrame retainedDuplicate() {
+        return (WebSocketFrame) super.retainedDuplicate();
+    }
+
+    @Override
+    public abstract WebSocketFrame replace(ByteBuf content);
 
     @Override
     public String toString() {

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyDataFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/DefaultSpdyDataFrame.java
@@ -80,14 +80,22 @@ public class DefaultSpdyDataFrame extends DefaultSpdyStreamFrame implements Spdy
 
     @Override
     public SpdyDataFrame copy() {
-        SpdyDataFrame frame = new DefaultSpdyDataFrame(streamId(), content().copy());
-        frame.setLast(isLast());
-        return frame;
+        return replace(content().copy());
     }
 
     @Override
     public SpdyDataFrame duplicate() {
-        SpdyDataFrame frame = new DefaultSpdyDataFrame(streamId(), content().duplicate());
+        return replace(content().duplicate());
+    }
+
+    @Override
+    public SpdyDataFrame retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public SpdyDataFrame replace(ByteBuf content) {
+        SpdyDataFrame frame = new DefaultSpdyDataFrame(streamId(), content);
         frame.setLast(isLast());
         return frame;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyDataFrame.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyDataFrame.java
@@ -46,6 +46,12 @@ public interface SpdyDataFrame extends ByteBufHolder, SpdyStreamFrame {
     SpdyDataFrame duplicate();
 
     @Override
+    SpdyDataFrame retainedDuplicate();
+
+    @Override
+    SpdyDataFrame replace(ByteBuf content);
+
+    @Override
     SpdyDataFrame retain();
 
     @Override

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/AbstractMemoryHttpDataTest.java
@@ -74,22 +74,32 @@ public class AbstractMemoryHttpDataTest {
 
         @Override
         public InterfaceHttpData.HttpDataType getHttpDataType() {
-            throw new UnsupportedOperationException("Should never be called.");
+            throw reject();
         }
 
         @Override
         public HttpData copy() {
-            throw new UnsupportedOperationException("Should never be called.");
+            throw reject();
         }
 
         @Override
         public HttpData duplicate() {
-            throw new UnsupportedOperationException("Should never be called.");
+            throw reject();
+        }
+
+        @Override
+        public HttpData retainedDuplicate() {
+            throw reject();
+        }
+
+        @Override
+        public HttpData replace(ByteBuf content) {
+            return null;
         }
 
         @Override
         public int compareTo(InterfaceHttpData o) {
-            throw new UnsupportedOperationException("Should never be called.");
+            throw reject();
         }
 
         @Override
@@ -100,6 +110,10 @@ public class AbstractMemoryHttpDataTest {
         @Override
         public boolean equals(Object obj) {
             return super.equals(obj);
+        }
+
+        private static UnsupportedOperationException reject() {
+            throw new UnsupportedOperationException("Should never be called.");
         }
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -460,7 +460,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         public void onPingRead(ChannelHandlerContext ctx, ByteBuf data) throws Http2Exception {
             // Send an ack back to the remote client.
             // Need to retain the buffer here since it will be released after the write completes.
-            encoder.writePing(ctx, true, data.slice().retain(), ctx.newPromise());
+            encoder.writePing(ctx, true, data.retainedSlice(), ctx.newPromise());
 
             listener.onPingRead(ctx, data);
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
@@ -15,12 +15,12 @@
  */
 package io.netty.handler.codec.http2;
 
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.internal.UnstableApi;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * The default {@link Http2DataFrame} implementation.
@@ -101,12 +101,22 @@ public final class DefaultHttp2DataFrame extends AbstractHttp2StreamFrame implem
 
     @Override
     public DefaultHttp2DataFrame copy() {
-        return new DefaultHttp2DataFrame(content().copy(), endStream, padding);
+        return replace(content().copy());
     }
 
     @Override
     public DefaultHttp2DataFrame duplicate() {
-        return new DefaultHttp2DataFrame(content().duplicate(), endStream, padding);
+        return replace(content().duplicate());
+    }
+
+    @Override
+    public DefaultHttp2DataFrame retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public DefaultHttp2DataFrame replace(ByteBuf content) {
+        return new DefaultHttp2DataFrame(content, endStream, padding);
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -15,6 +15,14 @@
 
 package io.netty.handler.codec.http2;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http2.Http2CodecUtil.SimpleChannelPromiseAggregator;
+import io.netty.handler.codec.http2.Http2FrameWriter.Configuration;
+import io.netty.util.internal.UnstableApi;
+
 import static io.netty.buffer.Unpooled.directBuffer;
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
 import static io.netty.handler.codec.http2.Http2CodecUtil.CONTINUATION_FRAME_HEADER_LENGTH;
@@ -54,14 +62,6 @@ import static io.netty.handler.codec.http2.Http2FrameTypes.WINDOW_UPDATE;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPromise;
-import io.netty.handler.codec.http2.Http2CodecUtil.SimpleChannelPromiseAggregator;
-import io.netty.handler.codec.http2.Http2FrameWriter.Configuration;
-import io.netty.util.internal.UnstableApi;
 
 /**
  * A {@link Http2FrameWriter} that supports all frame types defined by the HTTP/2 specification.
@@ -304,8 +304,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             // INT_FIELD_LENGTH is for the length of the promisedStreamId
             int nonFragmentLength = INT_FIELD_LENGTH + padding + flags.getPaddingPresenceFieldLength();
             int maxFragmentLength = maxFrameSize - nonFragmentLength;
-            ByteBuf fragment =
-                    headerBlock.readSlice(min(headerBlock.readableBytes(), maxFragmentLength));
+            ByteBuf fragment = headerBlock.readRetainedSlice(min(headerBlock.readableBytes(), maxFragmentLength));
 
             flags.endOfHeaders(!headerBlock.isReadable());
 
@@ -319,7 +318,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             ctx.write(buf, promiseAggregator.newPromise());
 
             // Write the first fragment.
-            ctx.write(fragment.retain(), promiseAggregator.newPromise());
+            ctx.write(fragment, promiseAggregator.newPromise());
 
             if (padding > 0) { // Write out the padding, if any.
                 ctx.write(ZERO_BUFFER.slice(0, padding), promiseAggregator.newPromise());
@@ -429,8 +428,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             // Read the first fragment (possibly everything).
             int nonFragmentBytes = padding + flags.getNumPriorityBytes() + flags.getPaddingPresenceFieldLength();
             int maxFragmentLength = maxFrameSize - nonFragmentBytes;
-            ByteBuf fragment =
-                    headerBlock.readSlice(min(headerBlock.readableBytes(), maxFragmentLength));
+            ByteBuf fragment = headerBlock.readRetainedSlice(min(headerBlock.readableBytes(), maxFragmentLength));
 
             // Set the end of headers flag for the first frame.
             flags.endOfHeaders(!headerBlock.isReadable());
@@ -450,7 +448,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
             ctx.write(buf, promiseAggregator.newPromise());
 
             // Write the first fragment.
-            ctx.write(fragment.retain(), promiseAggregator.newPromise());
+            ctx.write(fragment, promiseAggregator.newPromise());
 
             if (padding > 0) { // Write out the padding, if any.
                 ctx.write(ZERO_BUFFER.slice(0, padding), promiseAggregator.newPromise());
@@ -493,7 +491,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
 
             do {
                 fragmentReadableBytes = min(headerBlock.readableBytes(), maxFragmentLength);
-                ByteBuf fragment = headerBlock.readSlice(fragmentReadableBytes).retain();
+                ByteBuf fragment = headerBlock.readRetainedSlice(fragmentReadableBytes);
 
                 payloadLength = fragmentReadableBytes + nonFragmentLength;
                 if (headerBlock.isReadable()) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
@@ -78,7 +78,7 @@ public final class DefaultHttp2GoAwayFrame extends DefaultByteBufHolder implemen
     }
 
     @Override
-    public DefaultHttp2GoAwayFrame setExtraStreamIds(int extraStreamIds) {
+    public Http2GoAwayFrame setExtraStreamIds(int extraStreamIds) {
         if (extraStreamIds < 0) {
             throw new IllegalArgumentException("extraStreamIds must be non-negative");
         }
@@ -87,41 +87,45 @@ public final class DefaultHttp2GoAwayFrame extends DefaultByteBufHolder implemen
     }
 
     @Override
-    public DefaultHttp2GoAwayFrame copy() {
-        return new DefaultHttp2GoAwayFrame(errorCode, content().copy()).setExtraStreamIds(extraStreamIds);
+    public Http2GoAwayFrame copy() {
+        return (Http2GoAwayFrame) super.copy();
     }
 
     @Override
-    public DefaultHttp2GoAwayFrame duplicate() {
-        return new DefaultHttp2GoAwayFrame(errorCode, content().duplicate()).setExtraStreamIds(extraStreamIds);
+    public Http2GoAwayFrame duplicate() {
+        return (Http2GoAwayFrame) super.duplicate();
     }
 
     @Override
-    public DefaultHttp2GoAwayFrame retain() {
+    public Http2GoAwayFrame retainedDuplicate() {
+        return (Http2GoAwayFrame) super.retainedDuplicate();
+    }
+
+    @Override
+    public Http2GoAwayFrame replace(ByteBuf content) {
+        return new DefaultHttp2GoAwayFrame(errorCode, content).setExtraStreamIds(extraStreamIds);
+    }
+
+    @Override
+    public Http2GoAwayFrame retain() {
         super.retain();
         return this;
     }
 
     @Override
-    public DefaultHttp2GoAwayFrame retain(int increment) {
+    public Http2GoAwayFrame retain(int increment) {
         super.retain(increment);
         return this;
     }
 
     @Override
-    public String toString() {
-        return "DefaultHttp2GoAwayFrame(errorCode=" + errorCode + ", content=" + content()
-            + ", extraStreamIds=" + extraStreamIds + ")";
-    }
-
-    @Override
-    public DefaultHttp2GoAwayFrame touch() {
+    public Http2GoAwayFrame touch() {
         super.touch();
         return this;
     }
 
     @Override
-    public DefaultHttp2GoAwayFrame touch(Object hint) {
+    public Http2GoAwayFrame touch(Object hint) {
         super.touch(hint);
         return this;
     }
@@ -143,5 +147,11 @@ public final class DefaultHttp2GoAwayFrame extends DefaultByteBufHolder implemen
         hash = hash * 31 + content().hashCode();
         hash = hash * 31 + extraStreamIds;
         return hash;
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultHttp2GoAwayFrame(errorCode=" + errorCode + ", content=" + content()
+               + ", extraStreamIds=" + extraStreamIds + ")";
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -119,7 +119,7 @@ public final class Http2CodecUtil {
      */
     public static ByteBuf connectionPrefaceBuf() {
         // Return a duplicate so that modifications to the reader index will not affect the original buffer.
-        return CONNECTION_PREFACE.duplicate().retain();
+        return CONNECTION_PREFACE.retainedDuplicate();
     }
 
     /**
@@ -127,7 +127,7 @@ public final class Http2CodecUtil {
      */
     public static ByteBuf emptyPingBuf() {
         // Return a duplicate so that modifications to the reader index will not affect the original buffer.
-        return EMPTY_PING.duplicate().retain();
+        return EMPTY_PING.retainedDuplicate();
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataFrame.java
@@ -50,6 +50,12 @@ public interface Http2DataFrame extends Http2StreamFrame, ByteBufHolder {
     Http2DataFrame duplicate();
 
     @Override
+    Http2DataFrame retainedDuplicate();
+
+    @Override
+    Http2DataFrame replace(ByteBuf content);
+
+    @Override
     Http2DataFrame retain();
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2GoAwayFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2GoAwayFrame.java
@@ -59,6 +59,12 @@ public interface Http2GoAwayFrame extends Http2Frame, ByteBufHolder {
     Http2GoAwayFrame duplicate();
 
     @Override
+    Http2GoAwayFrame retainedDuplicate();
+
+    @Override
+    Http2GoAwayFrame replace(ByteBuf content);
+
+    @Override
     Http2GoAwayFrame retain();
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -313,7 +313,7 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
                             StreamInfo streamInfo = (StreamInfo) stream.getProperty(streamInfoKey);
                             // TODO: Can we force a user interaction pattern that doesn't require us to duplicate()?
                             // https://github.com/netty/netty/issues/4943
-                            streamInfo.childChannel.pipeline().fireUserEventTriggered(goAway.duplicate().retain());
+                            streamInfo.childChannel.pipeline().fireUserEventTriggered(goAway.retainedDuplicate());
                         }
                         return true;
                     }
@@ -321,12 +321,12 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
             } catch (Throwable t) {
                 ctx.invoker().invokeExceptionCaught(ctx, t);
             }
-            ctx.fireUserEventTriggered(goAway.duplicate().retain());
+            ctx.fireUserEventTriggered(goAway.retainedDuplicate());
         }
     }
 
     class InternalHttp2ConnectionHandler extends Http2ConnectionHandler {
-        public InternalHttp2ConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
+        InternalHttp2ConnectionHandler(Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder,
                 Http2Settings initialSettings) {
             super(decoder, encoder, initialSettings);
         }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -16,6 +16,7 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.FullHttpMessage;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -53,7 +54,7 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
         @Override
         public FullHttpMessage copyIfNeeded(FullHttpMessage msg) {
             if (msg instanceof FullHttpRequest) {
-                FullHttpRequest copy = ((FullHttpRequest) msg).copy(null);
+                FullHttpRequest copy = ((FullHttpRequest) msg).replace(Unpooled.buffer(0));
                 copy.headers().remove(HttpHeaderNames.EXPECT);
                 return copy;
             }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -394,7 +394,7 @@ public class Http2ConnectionRoundtripTest {
                 public void run() throws Http2Exception {
                     http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0,
                             false, newPromise());
-                    http2Client.encoder().writeData(ctx(), 3, data.duplicate().retain(), 0, false, newPromise());
+                    http2Client.encoder().writeData(ctx(), 3, data.retainedDuplicate(), 0, false, newPromise());
 
                     // Write trailers.
                     http2Client.encoder().writeHeaders(ctx(), 3, headers, 0, (short) 16, false, 0,
@@ -479,10 +479,10 @@ public class Http2ConnectionRoundtripTest {
                         // Send a bunch of data on each stream.
                         http2Client.encoder().writeHeaders(ctx(), streamId, headers, 0, (short) 16,
                                 false, 0, false, newPromise());
-                        http2Client.encoder().writePing(ctx(), false, pingData.slice().retain(),
+                        http2Client.encoder().writePing(ctx(), false, pingData.retainedSlice(),
                                 newPromise());
-                        http2Client.encoder().writeData(ctx(), streamId, data.slice().retain(), 0,
-                                false, newPromise());
+                        http2Client.encoder().writeData(ctx(), streamId, data.retainedSlice(), 0,
+                                                        false, newPromise());
                         // Write trailers.
                         http2Client.encoder().writeHeaders(ctx(), streamId, headers, 0, (short) 16,
                                 false, 0, true, newPromise());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -267,7 +267,7 @@ public class InboundHttp2ToHttpAdapterTest {
                 @Override
                 public void run() {
                     clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
-                    clientHandler.encoder().writeData(ctxClient(), 3, content.duplicate().retain(), 0, true,
+                    clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, true,
                                                       newPromiseClient());
                     clientChannel.flush();
                 }
@@ -300,10 +300,11 @@ public class InboundHttp2ToHttpAdapterTest {
                 @Override
                 public void run() {
                     clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
-                    clientHandler.encoder().writeData(ctxClient(), 3, content.slice(0, midPoint).retain(), 0, false,
-                            newPromiseClient());
-                    clientHandler.encoder().writeData(ctxClient(), 3,
-                            content.slice(midPoint, text.length() - midPoint).retain(), 0, true, newPromiseClient());
+                    clientHandler.encoder().writeData(
+                            ctxClient(), 3, content.retainedSlice(0, midPoint), 0, false, newPromiseClient());
+                    clientHandler.encoder().writeData(
+                            ctxClient(), 3, content.retainedSlice(midPoint, text.length() - midPoint),
+                            0, true, newPromiseClient());
                     clientChannel.flush();
                 }
             });
@@ -417,7 +418,7 @@ public class InboundHttp2ToHttpAdapterTest {
                 @Override
                 public void run() {
                     clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
-                    clientHandler.encoder().writeData(ctxClient(), 3, content.duplicate().retain(), 0, false,
+                    clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, false,
                                                       newPromiseClient());
                     clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers2, 0, true, newPromiseClient());
                     clientChannel.flush();
@@ -464,9 +465,9 @@ public class InboundHttp2ToHttpAdapterTest {
                     clientHandler.encoder().writeHeaders(ctxClient(), 5, http2Headers2, 0, false, newPromiseClient());
                     clientChannel.flush(); // Headers are queued in the flow controller and so flush them.
                     clientHandler.encoder().writePriority(ctxClient(), 5, 3, (short) 123, true, newPromiseClient());
-                    clientHandler.encoder().writeData(ctxClient(), 3, content.duplicate().retain(), 0, true,
+                    clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, true,
                                                       newPromiseClient());
-                    clientHandler.encoder().writeData(ctxClient(), 5, content2.duplicate().retain(), 0, true,
+                    clientHandler.encoder().writeData(ctxClient(), 5, content2.retainedDuplicate(), 0, true,
                                                       newPromiseClient());
                     clientChannel.flush();
                 }
@@ -518,9 +519,9 @@ public class InboundHttp2ToHttpAdapterTest {
                 public void run() {
                     clientHandler.encoder().writeHeaders(ctxClient(), 3, http2Headers, 0, false, newPromiseClient());
                     clientHandler.encoder().writeHeaders(ctxClient(), 5, http2Headers2, 0, false, newPromiseClient());
-                    clientHandler.encoder().writeData(ctxClient(), 3, content.duplicate().retain(), 0, true,
+                    clientHandler.encoder().writeData(ctxClient(), 3, content.retainedDuplicate(), 0, true,
                                                       newPromiseClient());
-                    clientHandler.encoder().writeData(ctxClient(), 5, content2.duplicate().retain(), 0, true,
+                    clientHandler.encoder().writeData(ctxClient(), 5, content2.retainedDuplicate(), 0, true,
                                                       newPromiseClient());
                     clientChannel.flush(); // headers and data are queued in the flow controller, so flush them.
                     clientHandler.encoder().writePriority(ctxClient(), 5, 3, (short) 222, false, newPromiseClient());
@@ -592,9 +593,9 @@ public class InboundHttp2ToHttpAdapterTest {
                 public void run() {
                     serverHandler.encoder().writeHeaders(ctxServer(), 3, http2Headers, 0, false, newPromiseServer());
                     serverHandler.encoder().writePushPromise(ctxServer(), 3, 2, http2Headers2, 0, newPromiseServer());
-                    serverHandler.encoder().writeData(ctxServer(), 3, content.duplicate().retain(), 0, true,
+                    serverHandler.encoder().writeData(ctxServer(), 3, content.retainedDuplicate(), 0, true,
                                                       newPromiseServer());
-                    serverHandler.encoder().writeData(ctxServer(), 5, content2.duplicate().retain(), 0, true,
+                    serverHandler.encoder().writeData(ctxServer(), 5, content2.retainedDuplicate(), 0, true,
                                                       newPromiseServer());
                     serverConnectedChannel.flush();
                 }
@@ -627,7 +628,7 @@ public class InboundHttp2ToHttpAdapterTest {
         final FullHttpMessage response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE);
         final String text = "a big payload";
         final ByteBuf payload = Unpooled.copiedBuffer(text.getBytes());
-        final FullHttpMessage request2 = request.copy(payload);
+        final FullHttpMessage request2 = request.replace(payload);
         final FullHttpMessage response2 = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
 
         try {
@@ -660,7 +661,7 @@ public class InboundHttp2ToHttpAdapterTest {
             runInChannel(clientChannel, new Http2Runnable() {
                 @Override
                 public void run() {
-                    clientHandler.encoder().writeData(ctxClient(), 3, payload.duplicate().retain(), 0, true,
+                    clientHandler.encoder().writeData(ctxClient(), 3, payload.retainedDuplicate(), 0, true,
                                                       newPromiseClient());
                     clientChannel.flush();
                 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultLastMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultLastMemcacheContent.java
@@ -60,11 +60,21 @@ public class DefaultLastMemcacheContent extends DefaultMemcacheContent implement
 
     @Override
     public LastMemcacheContent copy() {
-        return new DefaultLastMemcacheContent(content().copy());
+        return replace(content().copy());
     }
 
     @Override
     public LastMemcacheContent duplicate() {
-        return new DefaultLastMemcacheContent(content().duplicate());
+        return replace(content().duplicate());
+    }
+
+    @Override
+    public LastMemcacheContent retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public LastMemcacheContent replace(ByteBuf content) {
+        return new DefaultLastMemcacheContent(content);
     }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/DefaultMemcacheContent.java
@@ -44,12 +44,22 @@ public class DefaultMemcacheContent extends AbstractMemcacheObject implements Me
 
     @Override
     public MemcacheContent copy() {
-        return new DefaultMemcacheContent(content.copy());
+        return replace(content.copy());
     }
 
     @Override
     public MemcacheContent duplicate() {
-        return new DefaultMemcacheContent(content.duplicate());
+        return replace(content.duplicate());
+    }
+
+    @Override
+    public MemcacheContent retainedDuplicate() {
+        return replace(content.retainedDuplicate());
+    }
+
+    @Override
+    public MemcacheContent replace(ByteBuf content) {
+        return new DefaultMemcacheContent(content);
     }
 
     @Override

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/FullMemcacheMessage.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/FullMemcacheMessage.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.memcache;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.util.internal.UnstableApi;
 
 /**
@@ -28,6 +29,15 @@ public interface FullMemcacheMessage extends MemcacheMessage, LastMemcacheConten
     FullMemcacheMessage copy();
 
     @Override
+    FullMemcacheMessage duplicate();
+
+    @Override
+    FullMemcacheMessage retainedDuplicate();
+
+    @Override
+    FullMemcacheMessage replace(ByteBuf content);
+
+    @Override
     FullMemcacheMessage retain(int increment);
 
     @Override
@@ -38,7 +48,4 @@ public interface FullMemcacheMessage extends MemcacheMessage, LastMemcacheConten
 
     @Override
     FullMemcacheMessage touch(Object hint);
-
-    @Override
-    FullMemcacheMessage duplicate();
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/LastMemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/LastMemcacheContent.java
@@ -38,6 +38,21 @@ public interface LastMemcacheContent extends MemcacheContent {
         }
 
         @Override
+        public LastMemcacheContent duplicate() {
+            return this;
+        }
+
+        @Override
+        public LastMemcacheContent retainedDuplicate() {
+            return this;
+        }
+
+        @Override
+        public LastMemcacheContent replace(ByteBuf content) {
+            return new DefaultLastMemcacheContent(content);
+        }
+
+        @Override
         public LastMemcacheContent retain(int increment) {
             return this;
         }
@@ -54,11 +69,6 @@ public interface LastMemcacheContent extends MemcacheContent {
 
         @Override
         public LastMemcacheContent touch(Object hint) {
-            return this;
-        }
-
-        @Override
-        public LastMemcacheContent duplicate() {
             return this;
         }
 
@@ -97,6 +107,15 @@ public interface LastMemcacheContent extends MemcacheContent {
     LastMemcacheContent copy();
 
     @Override
+    LastMemcacheContent duplicate();
+
+    @Override
+    LastMemcacheContent retainedDuplicate();
+
+    @Override
+    LastMemcacheContent replace(ByteBuf content);
+
+    @Override
     LastMemcacheContent retain(int increment);
 
     @Override
@@ -107,7 +126,4 @@ public interface LastMemcacheContent extends MemcacheContent {
 
     @Override
     LastMemcacheContent touch(Object hint);
-
-    @Override
-    LastMemcacheContent duplicate();
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheContent.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/MemcacheContent.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.memcache;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.ChannelPipeline;
 import io.netty.util.internal.UnstableApi;
@@ -35,6 +36,12 @@ public interface MemcacheContent extends MemcacheObject, ByteBufHolder {
 
     @Override
     MemcacheContent duplicate();
+
+    @Override
+    MemcacheContent retainedDuplicate();
+
+    @Override
+    MemcacheContent replace(ByteBuf content);
 
     @Override
     MemcacheContent retain();

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/AbstractBinaryMemcacheDecoder.java
@@ -89,7 +89,7 @@ public abstract class AbstractBinaryMemcacheDecoder<M extends BinaryMemcacheMess
                         return;
                     }
 
-                    currentMessage.setExtras(in.readSlice(extrasLength).retain());
+                    currentMessage.setExtras(in.readRetainedSlice(extrasLength));
                 }
 
                 state = State.READ_KEY;
@@ -105,7 +105,7 @@ public abstract class AbstractBinaryMemcacheDecoder<M extends BinaryMemcacheMess
                         return;
                     }
 
-                    currentMessage.setKey(in.readSlice(keyLength).retain());
+                    currentMessage.setKey(in.readRetainedSlice(keyLength));
                 }
                 out.add(currentMessage.retain());
                 state = State.READ_CONTENT;
@@ -133,7 +133,7 @@ public abstract class AbstractBinaryMemcacheDecoder<M extends BinaryMemcacheMess
                         toRead = remainingLength;
                     }
 
-                    ByteBuf chunkBuffer = in.readSlice(toRead).retain();
+                    ByteBuf chunkBuffer = in.readRetainedSlice(toRead);
 
                     MemcacheContent chunk;
                     if ((alreadyReadChunkSize += toRead) >= valueLength) {

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheRequest.java
@@ -117,4 +117,22 @@ public class DefaultFullBinaryMemcacheRequest extends DefaultBinaryMemcacheReque
         }
         return new DefaultFullBinaryMemcacheRequest(key, extras, content().duplicate());
     }
+
+    @Override
+    public FullBinaryMemcacheRequest retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public FullBinaryMemcacheRequest replace(ByteBuf content) {
+        ByteBuf key = key();
+        if (key != null) {
+            key = key.retainedDuplicate();
+        }
+        ByteBuf extras = extras();
+        if (extras != null) {
+            extras = extras.retainedDuplicate();
+        }
+        return new DefaultFullBinaryMemcacheRequest(key, extras, content);
+    }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/DefaultFullBinaryMemcacheResponse.java
@@ -117,4 +117,22 @@ public class DefaultFullBinaryMemcacheResponse extends DefaultBinaryMemcacheResp
         }
         return new DefaultFullBinaryMemcacheResponse(key, extras, content().duplicate());
     }
+
+    @Override
+    public FullBinaryMemcacheResponse retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public FullBinaryMemcacheResponse replace(ByteBuf content) {
+        ByteBuf key = key();
+        if (key != null) {
+            key = key.retainedDuplicate();
+        }
+        ByteBuf extras = extras();
+        if (extras != null) {
+            extras = extras.retainedDuplicate();
+        }
+        return new DefaultFullBinaryMemcacheResponse(key, extras, content);
+    }
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheRequest.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheRequest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.memcache.binary;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.memcache.FullMemcacheMessage;
 import io.netty.util.internal.UnstableApi;
 
@@ -28,6 +29,15 @@ public interface FullBinaryMemcacheRequest extends BinaryMemcacheRequest, FullMe
     FullBinaryMemcacheRequest copy();
 
     @Override
+    FullBinaryMemcacheRequest duplicate();
+
+    @Override
+    FullBinaryMemcacheRequest retainedDuplicate();
+
+    @Override
+    FullBinaryMemcacheRequest replace(ByteBuf content);
+
+    @Override
     FullBinaryMemcacheRequest retain(int increment);
 
     @Override
@@ -38,7 +48,4 @@ public interface FullBinaryMemcacheRequest extends BinaryMemcacheRequest, FullMe
 
     @Override
     FullBinaryMemcacheRequest touch(Object hint);
-
-    @Override
-    FullBinaryMemcacheRequest duplicate();
 }

--- a/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheResponse.java
+++ b/codec-memcache/src/main/java/io/netty/handler/codec/memcache/binary/FullBinaryMemcacheResponse.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.memcache.binary;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.memcache.FullMemcacheMessage;
 import io.netty.util.internal.UnstableApi;
 
@@ -28,6 +29,15 @@ public interface FullBinaryMemcacheResponse extends BinaryMemcacheResponse, Full
     FullBinaryMemcacheResponse copy();
 
     @Override
+    FullBinaryMemcacheResponse duplicate();
+
+    @Override
+    FullBinaryMemcacheResponse retainedDuplicate();
+
+    @Override
+    FullBinaryMemcacheResponse replace(ByteBuf content);
+
+    @Override
     FullBinaryMemcacheResponse retain(int increment);
 
     @Override
@@ -38,7 +48,4 @@ public interface FullBinaryMemcacheResponse extends BinaryMemcacheResponse, Full
 
     @Override
     FullBinaryMemcacheResponse touch(Object hint);
-
-    @Override
-    FullBinaryMemcacheResponse duplicate();
 }

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -26,7 +26,11 @@ import io.netty.util.CharsetUtil;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.netty.handler.codec.mqtt.MqttCodecUtil.*;
+import static io.netty.handler.codec.mqtt.MqttCodecUtil.isValidClientId;
+import static io.netty.handler.codec.mqtt.MqttCodecUtil.isValidMessageId;
+import static io.netty.handler.codec.mqtt.MqttCodecUtil.isValidPublishTopicName;
+import static io.netty.handler.codec.mqtt.MqttCodecUtil.resetUnusedFields;
+import static io.netty.handler.codec.mqtt.MqttCodecUtil.validateFixedHeader;
 
 /**
  * Decodes Mqtt messages from bytes, following
@@ -409,7 +413,7 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
     }
 
     private static Result<ByteBuf> decodePublishPayload(ByteBuf buffer, int bytesRemainingInVariablePart) {
-        ByteBuf b = buffer.readSlice(bytesRemainingInVariablePart).retain();
+        ByteBuf b = buffer.readRetainedSlice(bytesRemainingInVariablePart);
         return new Result<ByteBuf>(b, bytesRemainingInVariablePart);
     }
 

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPublishMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPublishMessage.java
@@ -53,12 +53,22 @@ public class MqttPublishMessage extends MqttMessage implements ByteBufHolder {
 
     @Override
     public MqttPublishMessage copy() {
-        return new MqttPublishMessage(fixedHeader(), variableHeader(), content().copy());
+        return replace(content().copy());
     }
 
     @Override
     public MqttPublishMessage duplicate() {
-        return new MqttPublishMessage(fixedHeader(), variableHeader(), content().duplicate());
+        return replace(content().duplicate());
+    }
+
+    @Override
+    public MqttPublishMessage retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public MqttPublishMessage replace(ByteBuf content) {
+        return new MqttPublishMessage(fixedHeader(), variableHeader(), content);
     }
 
     @Override

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/BulkStringRedisContent.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/BulkStringRedisContent.java
@@ -15,6 +15,7 @@
 
 package io.netty.handler.codec.redis;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.ChannelPipeline;
 import io.netty.util.internal.UnstableApi;
@@ -28,4 +29,28 @@ import io.netty.util.internal.UnstableApi;
  */
 @UnstableApi
 public interface BulkStringRedisContent extends RedisMessage, ByteBufHolder {
+
+    @Override
+    BulkStringRedisContent copy();
+
+    @Override
+    BulkStringRedisContent duplicate();
+
+    @Override
+    BulkStringRedisContent retainedDuplicate();
+
+    @Override
+    BulkStringRedisContent replace(ByteBuf content);
+
+    @Override
+    BulkStringRedisContent retain();
+
+    @Override
+    BulkStringRedisContent retain(int increment);
+
+    @Override
+    BulkStringRedisContent touch();
+
+    @Override
+    BulkStringRedisContent touch(Object hint);
 }

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/DefaultBulkStringRedisContent.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/DefaultBulkStringRedisContent.java
@@ -36,6 +36,50 @@ public class DefaultBulkStringRedisContent extends DefaultByteBufHolder implemen
     }
 
     @Override
+    public BulkStringRedisContent copy() {
+        return (BulkStringRedisContent) super.copy();
+    }
+
+    @Override
+    public BulkStringRedisContent duplicate() {
+        return (BulkStringRedisContent) super.duplicate();
+    }
+
+    @Override
+    public BulkStringRedisContent retainedDuplicate() {
+        return (BulkStringRedisContent) super.retainedDuplicate();
+    }
+
+    @Override
+    public BulkStringRedisContent replace(ByteBuf content) {
+        return new DefaultBulkStringRedisContent(content);
+    }
+
+    @Override
+    public BulkStringRedisContent retain() {
+        super.retain();
+        return this;
+    }
+
+    @Override
+    public BulkStringRedisContent retain(int increment) {
+        super.retain(increment);
+        return this;
+    }
+
+    @Override
+    public BulkStringRedisContent touch() {
+        super.touch();
+        return this;
+    }
+
+    @Override
+    public BulkStringRedisContent touch(Object hint) {
+        super.touch(hint);
+        return this;
+    }
+
+    @Override
     public String toString() {
         return new StringBuilder(StringUtil.simpleClassName(this))
                 .append('[')

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/DefaultLastBulkStringRedisContent.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/DefaultLastBulkStringRedisContent.java
@@ -32,4 +32,48 @@ public final class DefaultLastBulkStringRedisContent extends DefaultBulkStringRe
     public DefaultLastBulkStringRedisContent(ByteBuf content) {
         super(content);
     }
+
+    @Override
+    public LastBulkStringRedisContent copy() {
+        return (LastBulkStringRedisContent) super.copy();
+    }
+
+    @Override
+    public LastBulkStringRedisContent duplicate() {
+        return (LastBulkStringRedisContent) super.duplicate();
+    }
+
+    @Override
+    public LastBulkStringRedisContent retainedDuplicate() {
+        return (LastBulkStringRedisContent) super.retainedDuplicate();
+    }
+
+    @Override
+    public LastBulkStringRedisContent replace(ByteBuf content) {
+        return new DefaultLastBulkStringRedisContent(content);
+    }
+
+    @Override
+    public LastBulkStringRedisContent retain() {
+        super.retain();
+        return this;
+    }
+
+    @Override
+    public LastBulkStringRedisContent retain(int increment) {
+        super.retain(increment);
+        return this;
+    }
+
+    @Override
+    public LastBulkStringRedisContent touch() {
+        super.touch();
+        return this;
+    }
+
+    @Override
+    public LastBulkStringRedisContent touch(Object hint) {
+        super.touch(hint);
+        return this;
+    }
 }

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/FullBulkStringRedisMessage.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/FullBulkStringRedisMessage.java
@@ -85,6 +85,11 @@ public class FullBulkStringRedisMessage extends DefaultByteBufHolder implements 
         }
 
         @Override
+        public FullBulkStringRedisMessage retainedDuplicate() {
+            return this;
+        }
+
+        @Override
         public int refCnt() {
             return 1;
         }
@@ -131,11 +136,16 @@ public class FullBulkStringRedisMessage extends DefaultByteBufHolder implements 
 
         @Override
         public FullBulkStringRedisMessage copy() {
-            return EMPTY_INSTANCE;
+            return this;
         }
 
         @Override
         public FullBulkStringRedisMessage duplicate() {
+            return this;
+        }
+
+        @Override
+        public FullBulkStringRedisMessage retainedDuplicate() {
             return this;
         }
 
@@ -174,4 +184,48 @@ public class FullBulkStringRedisMessage extends DefaultByteBufHolder implements 
             return false;
         }
     };
+
+    @Override
+    public FullBulkStringRedisMessage copy() {
+        return (FullBulkStringRedisMessage) super.copy();
+    }
+
+    @Override
+    public FullBulkStringRedisMessage duplicate() {
+        return (FullBulkStringRedisMessage) super.duplicate();
+    }
+
+    @Override
+    public FullBulkStringRedisMessage retainedDuplicate() {
+        return (FullBulkStringRedisMessage) super.retainedDuplicate();
+    }
+
+    @Override
+    public FullBulkStringRedisMessage replace(ByteBuf content) {
+        return new FullBulkStringRedisMessage(content);
+    }
+
+    @Override
+    public FullBulkStringRedisMessage retain() {
+        super.retain();
+        return this;
+    }
+
+    @Override
+    public FullBulkStringRedisMessage retain(int increment) {
+        super.retain(increment);
+        return this;
+    }
+
+    @Override
+    public FullBulkStringRedisMessage touch() {
+        super.touch();
+        return this;
+    }
+
+    @Override
+    public FullBulkStringRedisMessage touch(Object hint) {
+        super.touch(hint);
+        return this;
+    }
 }

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/LastBulkStringRedisContent.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/LastBulkStringRedisContent.java
@@ -16,7 +16,6 @@
 package io.netty.handler.codec.redis;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufHolder;
 import io.netty.buffer.Unpooled;
 import io.netty.util.internal.UnstableApi;
 
@@ -37,17 +36,32 @@ public interface LastBulkStringRedisContent extends BulkStringRedisContent {
         }
 
         @Override
-        public ByteBufHolder copy() {
+        public LastBulkStringRedisContent copy() {
             return this;
         }
 
         @Override
-        public ByteBufHolder retain(int increment) {
+        public LastBulkStringRedisContent duplicate() {
             return this;
         }
 
         @Override
-        public ByteBufHolder retain() {
+        public LastBulkStringRedisContent retainedDuplicate() {
+            return this;
+        }
+
+        @Override
+        public LastBulkStringRedisContent replace(ByteBuf content) {
+            return new DefaultLastBulkStringRedisContent(content);
+        }
+
+        @Override
+        public LastBulkStringRedisContent retain(int increment) {
+            return this;
+        }
+
+        @Override
+        public LastBulkStringRedisContent retain() {
             return this;
         }
 
@@ -57,12 +71,12 @@ public interface LastBulkStringRedisContent extends BulkStringRedisContent {
         }
 
         @Override
-        public ByteBufHolder touch() {
+        public LastBulkStringRedisContent touch() {
             return this;
         }
 
         @Override
-        public ByteBufHolder touch(Object hint) {
+        public LastBulkStringRedisContent touch(Object hint) {
             return this;
         }
 
@@ -75,10 +89,29 @@ public interface LastBulkStringRedisContent extends BulkStringRedisContent {
         public boolean release(int decrement) {
             return false;
         }
-
-        @Override
-        public ByteBufHolder duplicate() {
-            return this;
-        }
     };
+
+    @Override
+    LastBulkStringRedisContent copy();
+
+    @Override
+    LastBulkStringRedisContent duplicate();
+
+    @Override
+    LastBulkStringRedisContent retainedDuplicate();
+
+    @Override
+    LastBulkStringRedisContent replace(ByteBuf content);
+
+    @Override
+    LastBulkStringRedisContent retain();
+
+    @Override
+    LastBulkStringRedisContent retain(int increment);
+
+    @Override
+    LastBulkStringRedisContent touch();
+
+    @Override
+    LastBulkStringRedisContent touch(Object hint);
 }

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultLastSmtpContent.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultLastSmtpContent.java
@@ -33,34 +33,44 @@ public final class DefaultLastSmtpContent extends DefaultSmtpContent implements 
 
     @Override
     public LastSmtpContent copy() {
-        return new DefaultLastSmtpContent(content().copy());
+        return (LastSmtpContent) super.copy();
     }
 
     @Override
     public LastSmtpContent duplicate() {
-        return new DefaultLastSmtpContent(content().duplicate());
+        return (LastSmtpContent) super.duplicate();
     }
 
     @Override
-    public LastSmtpContent retain() {
+    public LastSmtpContent retainedDuplicate() {
+        return (LastSmtpContent) super.retainedDuplicate();
+    }
+
+    @Override
+    public LastSmtpContent replace(ByteBuf content) {
+        return new DefaultLastSmtpContent(content);
+    }
+
+    @Override
+    public DefaultLastSmtpContent retain() {
         super.retain();
         return this;
     }
 
     @Override
-    public LastSmtpContent retain(int increment) {
+    public DefaultLastSmtpContent retain(int increment) {
         super.retain(increment);
         return this;
     }
 
     @Override
-    public LastSmtpContent touch() {
+    public DefaultLastSmtpContent touch() {
         super.touch();
         return this;
     }
 
     @Override
-    public LastSmtpContent touch(Object hint) {
+    public DefaultLastSmtpContent touch(Object hint) {
         super.touch(hint);
         return this;
     }

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultSmtpContent.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/DefaultSmtpContent.java
@@ -34,12 +34,22 @@ public class DefaultSmtpContent extends DefaultByteBufHolder implements SmtpCont
 
     @Override
     public SmtpContent copy() {
-        return new DefaultSmtpContent(content().copy());
+        return (SmtpContent) super.copy();
     }
 
     @Override
     public SmtpContent duplicate() {
-        return new DefaultSmtpContent(content().duplicate());
+        return (SmtpContent) super.duplicate();
+    }
+
+    @Override
+    public SmtpContent retainedDuplicate() {
+        return (SmtpContent) super.retainedDuplicate();
+    }
+
+    @Override
+    public SmtpContent replace(ByteBuf content) {
+        return new DefaultSmtpContent(content);
     }
 
     @Override

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/LastSmtpContent.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/LastSmtpContent.java
@@ -43,6 +43,16 @@ public interface LastSmtpContent extends SmtpContent {
         }
 
         @Override
+        public LastSmtpContent retainedDuplicate() {
+            return this;
+        }
+
+        @Override
+        public LastSmtpContent replace(ByteBuf content) {
+            return new DefaultLastSmtpContent(content);
+        }
+
+        @Override
         public LastSmtpContent retain() {
             return this;
         }
@@ -88,6 +98,12 @@ public interface LastSmtpContent extends SmtpContent {
 
     @Override
     LastSmtpContent duplicate();
+
+    @Override
+    LastSmtpContent retainedDuplicate();
+
+    @Override
+    LastSmtpContent replace(ByteBuf content);
 
     @Override
     LastSmtpContent retain();

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/SmtpContent.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/SmtpContent.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.smtp;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.util.internal.UnstableApi;
 
@@ -31,6 +32,12 @@ public interface SmtpContent extends ByteBufHolder {
 
     @Override
     SmtpContent duplicate();
+
+    @Override
+    SmtpContent retainedDuplicate();
+
+    @Override
+    SmtpContent replace(ByteBuf content);
 
     @Override
     SmtpContent retain();

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/SmtpRequestEncoder.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/SmtpRequestEncoder.java
@@ -76,7 +76,7 @@ public final class SmtpRequestEncoder extends MessageToMessageEncoder<Object> {
             final ByteBuf content = ((SmtpContent) msg).content();
             out.add(content.retain());
             if (msg instanceof LastSmtpContent) {
-                out.add(DOT_CRLF_BUFFER.duplicate().retain());
+                out.add(DOT_CRLF_BUFFER.retainedDuplicate());
                 contentExpected = false;
             }
         }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ClientDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ClientDecoder.java
@@ -64,7 +64,7 @@ public class Socks4ClientDecoder extends ReplayingDecoder<State> {
             case SUCCESS: {
                 int readableBytes = actualReadableBytes();
                 if (readableBytes > 0) {
-                    out.add(in.readSlice(readableBytes).retain());
+                    out.add(in.readRetainedSlice(readableBytes));
                 }
                 break;
             }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ServerDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v4/Socks4ServerDecoder.java
@@ -85,7 +85,7 @@ public class Socks4ServerDecoder extends ReplayingDecoder<State> {
             case SUCCESS: {
                 int readableBytes = actualReadableBytes();
                 if (readableBytes > 0) {
-                    out.add(in.readSlice(readableBytes).retain());
+                    out.add(in.readRetainedSlice(readableBytes));
                 }
                 break;
             }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandRequestDecoder.java
@@ -78,7 +78,7 @@ public class Socks5CommandRequestDecoder extends ReplayingDecoder<State> {
             case SUCCESS: {
                 int readableBytes = actualReadableBytes();
                 if (readableBytes > 0) {
-                    out.add(in.readSlice(readableBytes).retain());
+                    out.add(in.readRetainedSlice(readableBytes));
                 }
                 break;
             }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5CommandResponseDecoder.java
@@ -77,7 +77,7 @@ public class Socks5CommandResponseDecoder extends ReplayingDecoder<State> {
             case SUCCESS: {
                 int readableBytes = actualReadableBytes();
                 if (readableBytes > 0) {
-                    out.add(in.readSlice(readableBytes).retain());
+                    out.add(in.readRetainedSlice(readableBytes));
                 }
                 break;
             }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5InitialRequestDecoder.java
@@ -71,7 +71,7 @@ public class Socks5InitialRequestDecoder extends ReplayingDecoder<State> {
             case SUCCESS: {
                 int readableBytes = actualReadableBytes();
                 if (readableBytes > 0) {
-                    out.add(in.readSlice(readableBytes).retain());
+                    out.add(in.readRetainedSlice(readableBytes));
                 }
                 break;
             }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5InitialResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5InitialResponseDecoder.java
@@ -62,7 +62,7 @@ public class Socks5InitialResponseDecoder extends ReplayingDecoder<State> {
             case SUCCESS: {
                 int readableBytes = actualReadableBytes();
                 if (readableBytes > 0) {
-                    out.add(in.readSlice(readableBytes).retain());
+                    out.add(in.readRetainedSlice(readableBytes));
                 }
                 break;
             }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoder.java
@@ -69,7 +69,7 @@ public class Socks5PasswordAuthRequestDecoder extends ReplayingDecoder<State> {
             case SUCCESS: {
                 int readableBytes = actualReadableBytes();
                 if (readableBytes > 0) {
-                    out.add(in.readSlice(readableBytes).retain());
+                    out.add(in.readRetainedSlice(readableBytes));
                 }
                 break;
             }

--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthResponseDecoder.java
@@ -59,7 +59,7 @@ public class Socks5PasswordAuthResponseDecoder extends ReplayingDecoder<State> {
             case SUCCESS: {
                 int readableBytes = actualReadableBytes();
                 if (readableBytes > 0) {
-                    out.add(in.readSlice(readableBytes).retain());
+                    out.add(in.readRetainedSlice(readableBytes));
                 }
                 break;
             }

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultLastStompContentSubframe.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultLastStompContentSubframe.java
@@ -27,6 +27,26 @@ public class DefaultLastStompContentSubframe extends DefaultStompContentSubframe
     }
 
     @Override
+    public LastStompContentSubframe copy() {
+        return (LastStompContentSubframe) super.copy();
+    }
+
+    @Override
+    public LastStompContentSubframe duplicate() {
+        return (LastStompContentSubframe) super.duplicate();
+    }
+
+    @Override
+    public LastStompContentSubframe retainedDuplicate() {
+        return (LastStompContentSubframe) super.retainedDuplicate();
+    }
+
+    @Override
+    public LastStompContentSubframe replace(ByteBuf content) {
+        return new DefaultLastStompContentSubframe(content);
+    }
+
+    @Override
     public DefaultLastStompContentSubframe retain() {
         super.retain();
         return this;
@@ -48,16 +68,6 @@ public class DefaultLastStompContentSubframe extends DefaultStompContentSubframe
     public LastStompContentSubframe touch(Object hint) {
         super.touch(hint);
         return this;
-    }
-
-    @Override
-    public LastStompContentSubframe copy() {
-        return new DefaultLastStompContentSubframe(content().copy());
-    }
-
-    @Override
-    public LastStompContentSubframe duplicate() {
-        return new DefaultLastStompContentSubframe(content().duplicate());
     }
 
     @Override

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompContentSubframe.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompContentSubframe.java
@@ -17,74 +17,61 @@ package io.netty.handler.codec.stomp;
 
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.DefaultByteBufHolder;
 import io.netty.handler.codec.DecoderResult;
 
 /**
  * The default {@link StompContentSubframe} implementation.
  */
-public class DefaultStompContentSubframe implements StompContentSubframe {
+public class DefaultStompContentSubframe extends DefaultByteBufHolder implements StompContentSubframe {
     private DecoderResult decoderResult = DecoderResult.SUCCESS;
-    private final ByteBuf content;
 
     public DefaultStompContentSubframe(ByteBuf content) {
-        if (content == null) {
-            throw new NullPointerException("content");
-        }
-        this.content = content;
-    }
-
-    @Override
-    public ByteBuf content() {
-        return content;
+        super(content);
     }
 
     @Override
     public StompContentSubframe copy() {
-        return new DefaultStompContentSubframe(content().copy());
+        return (StompContentSubframe) super.copy();
     }
 
     @Override
     public StompContentSubframe duplicate() {
-        return new DefaultStompContentSubframe(content().duplicate());
+        return (StompContentSubframe) super.duplicate();
     }
 
     @Override
-    public int refCnt() {
-        return content().refCnt();
+    public StompContentSubframe retainedDuplicate() {
+        return (StompContentSubframe) super.retainedDuplicate();
+    }
+
+    @Override
+    public StompContentSubframe replace(ByteBuf content) {
+        return new DefaultStompContentSubframe(content);
     }
 
     @Override
     public StompContentSubframe retain() {
-        content().retain();
+        super.retain();
         return this;
     }
 
     @Override
     public StompContentSubframe retain(int increment) {
-        content().retain(increment);
+        super.retain(increment);
         return this;
     }
 
     @Override
     public StompContentSubframe touch() {
-        content.touch();
+        super.touch();
         return this;
     }
 
     @Override
     public StompContentSubframe touch(Object hint) {
-        content.touch(hint);
+        super.touch(hint);
         return this;
-    }
-
-    @Override
-    public boolean release() {
-        return content().release();
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        return content().release(decrement);
     }
 
     @Override

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
@@ -45,12 +45,22 @@ public class DefaultStompFrame extends DefaultStompHeadersSubframe implements St
 
     @Override
     public StompFrame copy() {
-        return new DefaultStompFrame(command, content.copy());
+        return replace(content.copy());
     }
 
     @Override
     public StompFrame duplicate() {
-        return new DefaultStompFrame(command, content.duplicate());
+        return replace(content.duplicate());
+    }
+
+    @Override
+    public StompFrame retainedDuplicate() {
+        return replace(content.retainedDuplicate());
+    }
+
+    @Override
+    public StompFrame replace(ByteBuf content) {
+        return new DefaultStompFrame(command, content);
     }
 
     @Override

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/LastStompContentSubframe.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/LastStompContentSubframe.java
@@ -45,6 +45,16 @@ public interface LastStompContentSubframe extends StompContentSubframe {
         }
 
         @Override
+        public LastStompContentSubframe retainedDuplicate() {
+            return this;
+        }
+
+        @Override
+        public LastStompContentSubframe replace(ByteBuf content) {
+            return new DefaultLastStompContentSubframe(content);
+        }
+
+        @Override
         public LastStompContentSubframe retain() {
             return this;
         }
@@ -95,6 +105,12 @@ public interface LastStompContentSubframe extends StompContentSubframe {
 
     @Override
     LastStompContentSubframe duplicate();
+
+    @Override
+    LastStompContentSubframe retainedDuplicate();
+
+    @Override
+    LastStompContentSubframe replace(ByteBuf content);
 
     @Override
     LastStompContentSubframe retain();

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompContentSubframe.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompContentSubframe.java
@@ -15,6 +15,7 @@
  */
 package io.netty.handler.codec.stomp;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.ChannelPipeline;
 
@@ -31,6 +32,12 @@ public interface StompContentSubframe extends ByteBufHolder, StompSubframe {
 
     @Override
     StompContentSubframe duplicate();
+
+    @Override
+    StompContentSubframe retainedDuplicate();
+
+    @Override
+    StompContentSubframe replace(ByteBuf content);
 
     @Override
     StompContentSubframe retain();

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompFrame.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompFrame.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.stomp;
 
+import io.netty.buffer.ByteBuf;
+
 /**
  * Combines {@link StompHeadersSubframe} and {@link LastStompContentSubframe} into one
  * frame. So it represent a <i>complete</i> STOMP frame.
@@ -25,6 +27,12 @@ public interface StompFrame extends StompHeadersSubframe, LastStompContentSubfra
 
     @Override
     StompFrame duplicate();
+
+    @Override
+    StompFrame retainedDuplicate();
+
+    @Override
+    StompFrame replace(ByteBuf content);
 
     @Override
     StompFrame retain();

--- a/codec/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoder.java
@@ -268,13 +268,13 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoder {
             }
 
             if (stripDelimiter) {
-                frame = buffer.readSlice(minFrameLength);
+                frame = buffer.readRetainedSlice(minFrameLength);
                 buffer.skipBytes(minDelimLength);
             } else {
-                frame = buffer.readSlice(minFrameLength + minDelimLength);
+                frame = buffer.readRetainedSlice(minFrameLength + minDelimLength);
             }
 
-            return frame.retain();
+            return frame;
         } else {
             if (!discardingTooLongFrame) {
                 if (buffer.readableBytes() > maxFrameLength) {

--- a/codec/src/main/java/io/netty/handler/codec/FixedLengthFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/FixedLengthFrameDecoder.java
@@ -74,7 +74,7 @@ public class FixedLengthFrameDecoder extends ByteToMessageDecoder {
         if (in.readableBytes() < frameLength) {
             return null;
         } else {
-            return in.readSlice(frameLength).retain();
+            return in.readRetainedSlice(frameLength);
         }
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -491,7 +491,7 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
      * is overridden to avoid memory copy.
      */
     protected ByteBuf extractFrame(ChannelHandlerContext ctx, ByteBuf buffer, int index, int length) {
-        return buffer.slice(index, length).retain();
+        return buffer.retainedSlice(index, length);
     }
 
     private void fail(long frameLength) {

--- a/codec/src/main/java/io/netty/handler/codec/LineBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LineBasedFrameDecoder.java
@@ -101,13 +101,13 @@ public class LineBasedFrameDecoder extends ByteToMessageDecoder {
                 }
 
                 if (stripDelimiter) {
-                    frame = buffer.readSlice(length);
+                    frame = buffer.readRetainedSlice(length);
                     buffer.skipBytes(delimLength);
                 } else {
-                    frame = buffer.readSlice(length + delimLength);
+                    frame = buffer.readRetainedSlice(length + delimLength);
                 }
 
-                return frame.retain();
+                return frame;
             } else {
                 final int length = buffer.readableBytes();
                 if (length > maxLength) {

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoderByteBuf.java
@@ -74,8 +74,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf capacity(int newCapacity) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
@@ -131,8 +130,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf clear() {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
@@ -142,14 +140,12 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public int compareTo(ByteBuf buffer) {
-        reject();
-        return 0;
+        throw reject();
     }
 
     @Override
     public ByteBuf copy() {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
@@ -160,26 +156,27 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf discardReadBytes() {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf ensureWritable(int writableBytes) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public int ensureWritable(int minWritableBytes, boolean force) {
-        reject();
-        return 0;
+        throw reject();
     }
 
     @Override
     public ByteBuf duplicate() {
-        reject();
-        return this;
+        throw reject();
+    }
+
+    @Override
+    public ByteBuf retainedDuplicate() {
+        throw reject();
     }
 
     @Override
@@ -216,8 +213,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf getBytes(int index, ByteBuffer dst) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
@@ -229,32 +225,27 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf getBytes(int index, ByteBuf dst, int length) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf getBytes(int index, ByteBuf dst) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public int getBytes(int index, GatheringByteChannel out, int length) {
-        reject();
-        return 0;
+        throw reject();
     }
 
     @Override
     public int getBytes(int index, FileChannel out, long position, int length) {
-        reject();
-        return 0;
+        throw reject();
     }
 
     @Override
     public ByteBuf getBytes(int index, OutputStream out, int length) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
@@ -367,8 +358,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public int hashCode() {
-        reject();
-        return 0;
+        throw reject();
     }
 
     @Override
@@ -451,8 +441,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
         if (terminated) {
             return buffer.forEachByteDesc(processor);
         } else {
-            reject();
-            return 0;
+            throw reject();
         }
     }
 
@@ -473,8 +462,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf markWriterIndex() {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
@@ -551,8 +539,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf readBytes(ByteBuffer dst) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
@@ -564,8 +551,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf readBytes(ByteBuf dst, int length) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
@@ -577,14 +563,12 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public int readBytes(GatheringByteChannel out, int length) {
-        reject();
-        return 0;
+        throw reject();
     }
 
     @Override
     public int readBytes(FileChannel out, long position, int length) {
-        reject();
-        return 0;
+        throw reject();
     }
 
     @Override
@@ -600,9 +584,14 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
     }
 
     @Override
+    public ByteBuf readRetainedSlice(int length) {
+        checkReadableBytes(length);
+        return buffer.readRetainedSlice(length);
+    }
+
+    @Override
     public ByteBuf readBytes(OutputStream out, int length) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
@@ -732,152 +721,127 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf resetWriterIndex() {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setBoolean(int index, boolean value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setByte(int index, int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setBytes(int index, byte[] src) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setBytes(int index, ByteBuffer src) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setBytes(int index, ByteBuf src, int length) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setBytes(int index, ByteBuf src) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public int setBytes(int index, InputStream in, int length) {
-        reject();
-        return 0;
+        throw reject();
     }
 
     @Override
     public ByteBuf setZero(int index, int length) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public int setBytes(int index, ScatteringByteChannel in, int length) {
-        reject();
-        return 0;
+        throw reject();
     }
 
     @Override
     public int setBytes(int index, FileChannel in, long position, int length) {
-        reject();
-        return 0;
+        throw reject();
     }
 
     @Override
     public ByteBuf setIndex(int readerIndex, int writerIndex) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setInt(int index, int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setIntLE(int index, int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setLong(int index, long value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setLongLE(int index, long value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setMedium(int index, int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setMediumLE(int index, int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setShort(int index, int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setShortLE(int index, int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setChar(int index, int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setFloat(int index, float value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf setDouble(int index, double value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
@@ -889,12 +853,22 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf slice() {
-        reject();
-        return this;
+        throw reject();
+    }
+
+    @Override
+    public ByteBuf retainedSlice() {
+        throw reject();
     }
 
     @Override
     public ByteBuf slice(int index, int length) {
+        checkIndex(index, length);
+        return buffer.slice(index, length);
+    }
+
+    @Override
+    public ByteBuf retainedSlice(int index, int length) {
         checkIndex(index, length);
         return buffer.slice(index, length);
     }
@@ -906,8 +880,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuffer nioBuffer() {
-        reject();
-        return null;
+        throw reject();
     }
 
     @Override
@@ -918,8 +891,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuffer[] nioBuffers() {
-        reject();
-        return null;
+        throw reject();
     }
 
     @Override
@@ -942,8 +914,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public String toString(Charset charsetName) {
-        reject();
-        return null;
+        throw reject();
     }
 
     @Override
@@ -979,110 +950,92 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf writeBoolean(boolean value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeByte(int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeBytes(byte[] src, int srcIndex, int length) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeBytes(byte[] src) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeBytes(ByteBuffer src) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeBytes(ByteBuf src, int srcIndex, int length) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeBytes(ByteBuf src, int length) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeBytes(ByteBuf src) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public int writeBytes(InputStream in, int length) {
-        reject();
-        return 0;
+        throw reject();
     }
 
     @Override
     public int writeBytes(ScatteringByteChannel in, int length) {
-        reject();
-        return 0;
+        throw reject();
     }
 
     @Override
     public int writeBytes(FileChannel in, long position, int length) {
-        reject();
-        return 0;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeInt(int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeIntLE(int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeLong(long value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeLongLE(long value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeMedium(int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeMediumLE(int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeZero(int length) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
@@ -1092,50 +1045,42 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf writerIndex(int writerIndex) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeShort(int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeShortLE(int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeChar(int value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeFloat(float value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf writeDouble(double value) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public int setCharSequence(int index, CharSequence sequence, Charset charset) {
-        reject();
-        return -1;
+        throw reject();
     }
 
     @Override
     public int writeCharSequence(CharSequence sequence, Charset charset) {
-        reject();
-        return -1;
+        throw reject();
     }
 
     private void checkIndex(int index, int length) {
@@ -1152,8 +1097,7 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf discardSomeReadBytes() {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
@@ -1163,14 +1107,12 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf retain() {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
     public ByteBuf retain(int increment) {
-        reject();
-        return this;
+        throw reject();
     }
 
     @Override
@@ -1187,23 +1129,20 @@ final class ReplayingDecoderByteBuf extends ByteBuf {
 
     @Override
     public boolean release() {
-        reject();
-        return false;
+        throw reject();
     }
 
     @Override
     public boolean release(int decrement) {
-        reject();
-        return false;
+        throw reject();
     }
 
     @Override
     public ByteBuf unwrap() {
-        reject();
-        return this;
+        throw reject();
     }
 
-    private static void reject() {
-        throw new UnsupportedOperationException("not a replayable operation");
+    private static UnsupportedOperationException reject() {
+        return new UnsupportedOperationException("not a replayable operation");
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/compression/LzfDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/LzfDecoder.java
@@ -24,11 +24,11 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
-import static com.ning.compress.lzf.LZFChunk.BYTE_Z;
-import static com.ning.compress.lzf.LZFChunk.BYTE_V;
-import static com.ning.compress.lzf.LZFChunk.HEADER_LEN_NOT_COMPRESSED;
-import static com.ning.compress.lzf.LZFChunk.BLOCK_TYPE_NON_COMPRESSED;
 import static com.ning.compress.lzf.LZFChunk.BLOCK_TYPE_COMPRESSED;
+import static com.ning.compress.lzf.LZFChunk.BLOCK_TYPE_NON_COMPRESSED;
+import static com.ning.compress.lzf.LZFChunk.BYTE_V;
+import static com.ning.compress.lzf.LZFChunk.BYTE_Z;
+import static com.ning.compress.lzf.LZFChunk.HEADER_LEN_NOT_COMPRESSED;
 
 /**
  * Uncompresses a {@link ByteBuf} encoded with the LZF format.
@@ -189,7 +189,7 @@ public class LzfDecoder extends ByteToMessageDecoder {
                         recycler.releaseInputBuffer(inputArray);
                     }
                 } else if (chunkLength > 0) {
-                    out.add(in.readSlice(chunkLength).retain());
+                    out.add(in.readRetainedSlice(chunkLength));
                 }
 
                 currentState = State.INIT_BLOCK;

--- a/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java
@@ -22,7 +22,7 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 import java.util.Arrays;
 import java.util.List;
 
-import static io.netty.handler.codec.compression.Snappy.*;
+import static io.netty.handler.codec.compression.Snappy.validateChecksum;
 
 /**
  * Uncompresses a {@link ByteBuf} encoded with the Snappy framing format.
@@ -153,7 +153,7 @@ public class SnappyFrameDecoder extends ByteToMessageDecoder {
                     } else {
                         in.skipBytes(4);
                     }
-                    out.add(in.readSlice(chunkLength - 4).retain());
+                    out.add(in.readRetainedSlice(chunkLength - 4));
                     break;
                 case COMPRESSED_DATA:
                     if (!started) {

--- a/codec/src/main/java/io/netty/handler/codec/json/JsonObjectDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/json/JsonObjectDecoder.java
@@ -177,7 +177,7 @@ public class JsonObjectDecoder extends ByteToMessageDecoder {
      */
     @SuppressWarnings("UnusedParameters")
     protected ByteBuf extractObject(ChannelHandlerContext ctx, ByteBuf buffer, int index, int length) {
-        return buffer.slice(index, length).retain();
+        return buffer.retainedSlice(index, length);
     }
 
     private void decodeByte(byte c, ByteBuf in, int idx) {

--- a/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
@@ -15,13 +15,14 @@
  */
 package io.netty.handler.codec.protobuf;
 
-import java.io.IOException;
-import java.util.List;
-
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.nano.CodedInputByteBufferNano;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.CorruptedFrameException;
+
+import java.util.List;
 
 /**
  * A decoder that splits the received {@link ByteBuf}s dynamically by the
@@ -36,7 +37,7 @@ import io.netty.handler.codec.CorruptedFrameException;
  * +--------+---------------+      +---------------+
  * </pre>
  *
- * @see {@link CodedInputStream } or {@link CodedInputByteBufferNano}
+ * @see {@link CodedInputStream} or {@link CodedInputByteBufferNano}
  */
 public class ProtobufVarint32FrameDecoder extends ByteToMessageDecoder {
 
@@ -58,10 +59,8 @@ public class ProtobufVarint32FrameDecoder extends ByteToMessageDecoder {
 
         if (in.readableBytes() < length) {
             in.resetReaderIndex();
-            return;
         } else {
-            out.add(in.readSlice(length).retain());
-            return;
+            out.add(in.readRetainedSlice(length));
         }
     }
 
@@ -69,9 +68,8 @@ public class ProtobufVarint32FrameDecoder extends ByteToMessageDecoder {
      * Reads variable length 32bit int from buffer
      *
      * @return decoded int if buffers readerIndex has been forwarded else nonsense value
-     * @throws IOException
      */
-    private static int readRawVarint32(ByteBuf buffer) throws IOException {
+    private static int readRawVarint32(ByteBuf buffer) {
         if (!buffer.isReadable()) {
             return 0;
         }

--- a/codec/src/test/java/io/netty/handler/codec/LengthFieldBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/LengthFieldBasedFrameDecoderTest.java
@@ -21,7 +21,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static io.netty.util.ReferenceCountUtil.*;
+import static io.netty.util.ReferenceCountUtil.releaseLater;
 
 public class LengthFieldBasedFrameDecoderTest {
 
@@ -64,12 +64,12 @@ public class LengthFieldBasedFrameDecoderTest {
         buf.writeByte('a');
         EmbeddedChannel channel = new EmbeddedChannel(new LengthFieldBasedFrameDecoder(16, 0, 4));
         try {
-            channel.writeInbound(buf.readSlice(14).retain());
+            channel.writeInbound(buf.readRetainedSlice(14));
             Assert.fail();
         } catch (TooLongFrameException e) {
             // expected
         }
-        Assert.assertTrue(channel.writeInbound(buf.readSlice(buf.readableBytes()).retain()));
+        Assert.assertTrue(channel.writeInbound(buf.readRetainedSlice(buf.readableBytes())));
 
         Assert.assertTrue(channel.finish());
 

--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractDecoderTest.java
@@ -28,7 +28,8 @@ import org.junit.experimental.theories.Theory;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Theories.class)
 public abstract class AbstractDecoderTest extends AbstractCompressionTest {
@@ -106,8 +107,8 @@ public abstract class AbstractDecoderTest extends AbstractCompressionTest {
         final int compressedLength = data.readableBytes();
         int written = 0, length = rand.nextInt(100);
         while (written + length < compressedLength) {
-            ByteBuf compressedBuf = data.slice(written, length);
-            channel.writeInbound(compressedBuf.retain());
+            ByteBuf compressedBuf = data.retainedSlice(written, length);
+            channel.writeInbound(compressedBuf);
             written += length;
             length = rand.nextInt(100);
         }

--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
@@ -26,7 +26,8 @@ import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Theories.class)
 public abstract class AbstractEncoderTest extends AbstractCompressionTest {
@@ -88,13 +89,13 @@ public abstract class AbstractEncoderTest extends AbstractCompressionTest {
         final int dataLength = data.readableBytes();
         int written = 0, length = rand.nextInt(100);
         while (written + length < dataLength) {
-            ByteBuf in = data.slice(written, length);
-            assertTrue(channel.writeOutbound(in.retain()));
+            ByteBuf in = data.retainedSlice(written, length);
+            assertTrue(channel.writeOutbound(in));
             written += length;
             length = rand.nextInt(100);
         }
-        ByteBuf in = data.slice(written, dataLength - written);
-        assertTrue(channel.writeOutbound(in.retain()));
+        ByteBuf in = data.retainedSlice(written, dataLength - written);
+        assertTrue(channel.writeOutbound(in));
         assertTrue(channel.finish());
 
         ByteBuf decompressed = readDecompressed(dataLength);

--- a/codec/src/test/java/io/netty/handler/codec/compression/LzmaFrameEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/LzmaFrameEncoderTest.java
@@ -29,7 +29,8 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class LzmaFrameEncoderTest extends AbstractEncoderTest {
 
@@ -50,16 +51,16 @@ public class LzmaFrameEncoderTest extends AbstractEncoderTest {
         final int dataLength = data.readableBytes();
         int written = 0, length = rand.nextInt(50);
         while (written + length < dataLength) {
-            ByteBuf in = data.slice(written, length);
-            assertTrue(channel.writeOutbound(in.retain()));
+            ByteBuf in = data.retainedSlice(written, length);
+            assertTrue(channel.writeOutbound(in));
             written += length;
             originalLengths.add(length);
             length = rand.nextInt(50);
         }
         length = dataLength - written;
-        ByteBuf in = data.slice(written, dataLength - written);
+        ByteBuf in = data.retainedSlice(written, dataLength - written);
         originalLengths.add(length);
-        assertTrue(channel.writeOutbound(in.retain()));
+        assertTrue(channel.writeOutbound(in));
         assertTrue(channel.finish());
 
         CompositeByteBuf decompressed = Unpooled.compositeBuffer();

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractCompatibleMarshallingDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractCompatibleMarshallingDecoderTest.java
@@ -28,7 +28,10 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractCompatibleMarshallingDecoderTest {
     @SuppressWarnings("RedundantStringConstructorCall")
@@ -81,9 +84,9 @@ public abstract class AbstractCompatibleMarshallingDecoderTest {
         byte[] testBytes = bout.toByteArray();
 
         ByteBuf buffer = input(testBytes);
-        ByteBuf slice = buffer.readSlice(2);
+        ByteBuf slice = buffer.readRetainedSlice(2);
 
-        ch.writeInbound(slice.retain());
+        ch.writeInbound(slice);
         ch.writeInbound(buffer);
         assertTrue(ch.finish());
 

--- a/example/src/main/java/io/netty/example/discard/DiscardClientHandler.java
+++ b/example/src/main/java/io/netty/example/discard/DiscardClientHandler.java
@@ -62,7 +62,7 @@ public class DiscardClientHandler extends SimpleChannelInboundHandler<Object> {
     private void generateTraffic() {
         // Flush the outbound buffer to the socket.
         // Once flushed, generate the same amount of traffic again.
-        ctx.writeAndFlush(content.duplicate().retain()).addListener(trafficGenerator);
+        ctx.writeAndFlush(content.retainedDuplicate()).addListener(trafficGenerator);
     }
 
     private final ChannelFutureListener trafficGenerator = new ChannelFutureListener() {

--- a/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
@@ -131,7 +131,7 @@ public class ChunkedWriteHandlerTest {
                     return null;
                 }
                 done = true;
-                return buffer.duplicate().retain();
+                return buffer.retainedDuplicate();
             }
 
             @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -52,7 +52,8 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
 public class SocketSslGreetingTest extends AbstractSocketTest {
@@ -200,7 +201,7 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
         public void channelActive(ChannelHandlerContext ctx)
                 throws Exception {
             channel = ctx.channel();
-            channel.writeAndFlush(greeting.duplicate().retain());
+            channel.writeAndFlush(greeting.retainedDuplicate());
         }
 
         @Override

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpMessage.java
@@ -150,19 +150,25 @@ public final class SctpMessage extends DefaultByteBufHolder {
 
     @Override
     public SctpMessage copy() {
-        if (msgInfo == null) {
-            return new SctpMessage(protocolIdentifier, streamIdentifier, unordered, content().copy());
-        } else {
-            return new SctpMessage(msgInfo, content().copy());
-        }
+        return (SctpMessage) super.copy();
     }
 
     @Override
     public SctpMessage duplicate() {
+        return (SctpMessage) super.duplicate();
+    }
+
+    @Override
+    public SctpMessage retainedDuplicate() {
+        return (SctpMessage) super.retainedDuplicate();
+    }
+
+    @Override
+    public SctpMessage replace(ByteBuf content) {
         if (msgInfo == null) {
-            return new SctpMessage(protocolIdentifier, streamIdentifier, unordered, content().duplicate());
+            return new SctpMessage(protocolIdentifier, streamIdentifier, unordered, content);
         } else {
-            return new SctpMessage(msgInfo, content().duplicate());
+            return new SctpMessage(msgInfo, content);
         }
     }
 

--- a/transport-udt/src/main/java/io/netty/channel/udt/UdtMessage.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/UdtMessage.java
@@ -33,12 +33,22 @@ public final class UdtMessage extends DefaultByteBufHolder {
 
     @Override
     public UdtMessage copy() {
-        return new UdtMessage(content().copy());
+        return (UdtMessage) super.copy();
     }
 
     @Override
     public UdtMessage duplicate() {
-        return new UdtMessage(content().duplicate());
+        return (UdtMessage) super.duplicate();
+    }
+
+    @Override
+    public UdtMessage retainedDuplicate() {
+        return (UdtMessage) super.retainedDuplicate();
+    }
+
+    @Override
+    public UdtMessage replace(ByteBuf content) {
+        return new UdtMessage(content);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/CoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty/channel/CoalescingBufferQueue.java
@@ -129,7 +129,7 @@ public final class CoalescingBufferQueue {
                 bufAndListenerPairs.addFirst(entryBuffer);
                 if (bytes > 0) {
                     // Take a slice of what we can consume and retain it.
-                    toReturn = compose(toReturn, entryBuffer.readSlice(bytes).retain());
+                    toReturn = compose(toReturn, entryBuffer.readRetainedSlice(bytes));
                     bytes = 0;
                 }
                 break;

--- a/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
+++ b/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
@@ -244,9 +244,9 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
     // See https://github.com/netty/netty/issues/1461
     private static Object safeDuplicate(Object message) {
         if (message instanceof ByteBuf) {
-            return ((ByteBuf) message).duplicate().retain();
+            return ((ByteBuf) message).retainedDuplicate();
         } else if (message instanceof ByteBufHolder) {
-            return ((ByteBufHolder) message).duplicate().retain();
+            return ((ByteBufHolder) message).retainedDuplicate();
         } else {
             return ReferenceCountUtil.retain(message);
         }

--- a/transport/src/main/java/io/netty/channel/socket/DatagramPacket.java
+++ b/transport/src/main/java/io/netty/channel/socket/DatagramPacket.java
@@ -44,12 +44,22 @@ public final class DatagramPacket
 
     @Override
     public DatagramPacket copy() {
-        return new DatagramPacket(content().copy(), recipient(), sender());
+        return replace(content().copy());
     }
 
     @Override
     public DatagramPacket duplicate() {
-        return new DatagramPacket(content().duplicate(), recipient(), sender());
+        return replace(content().duplicate());
+    }
+
+    @Override
+    public DatagramPacket retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public DatagramPacket replace(ByteBuf content) {
+        return new DatagramPacket(content, recipient(), sender());
     }
 
     @Override

--- a/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
@@ -150,7 +150,7 @@ public class PendingWriteQueueTest {
 
         ByteBuf[] buffers = new ByteBuf[count];
         for (int i = 0; i < buffers.length; i++) {
-            buffers[i] = buffer.duplicate().retain();
+            buffers[i] = buffer.retainedDuplicate();
         }
         assertTrue(channel.writeOutbound(buffers));
         assertTrue(channel.finish());
@@ -182,7 +182,7 @@ public class PendingWriteQueueTest {
         final EmbeddedChannel channel = new EmbeddedChannel(handler);
         ByteBuf[] buffers = new ByteBuf[count];
         for (int i = 0; i < buffers.length; i++) {
-            buffers[i] = buffer.duplicate().retain();
+            buffers[i] = buffer.retainedDuplicate();
         }
         try {
             assertFalse(channel.writeOutbound(buffers));

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -375,7 +375,7 @@ public class LocalChannelTest {
                                 ccCpy.pipeline().lastContext().close();
                             }
                         });
-                        ccCpy.writeAndFlush(data.duplicate().retain(), promise);
+                        ccCpy.writeAndFlush(data.retainedDuplicate(), promise);
                     }
                 });
 
@@ -436,10 +436,10 @@ public class LocalChannelTest {
                         promise.addListener(new ChannelFutureListener() {
                             @Override
                             public void operationComplete(ChannelFuture future) throws Exception {
-                                ccCpy.writeAndFlush(data2.duplicate().retain(), ccCpy.newPromise());
+                                ccCpy.writeAndFlush(data2.retainedDuplicate(), ccCpy.newPromise());
                             }
                         });
-                        ccCpy.writeAndFlush(data.duplicate().retain(), promise);
+                        ccCpy.writeAndFlush(data.retainedDuplicate(), promise);
                     }
                 });
 
@@ -519,10 +519,10 @@ public class LocalChannelTest {
                         @Override
                         public void operationComplete(ChannelFuture future) throws Exception {
                             Channel serverChannelCpy = serverChannelRef.get();
-                            serverChannelCpy.writeAndFlush(data2.duplicate().retain(), serverChannelCpy.newPromise());
+                            serverChannelCpy.writeAndFlush(data2.retainedDuplicate(), serverChannelCpy.newPromise());
                         }
                     });
-                    ccCpy.writeAndFlush(data.duplicate().retain(), promise);
+                    ccCpy.writeAndFlush(data.retainedDuplicate(), promise);
                 }
             });
 
@@ -601,11 +601,11 @@ public class LocalChannelTest {
                             @Override
                             public void operationComplete(ChannelFuture future) throws Exception {
                                 Channel serverChannelCpy = serverChannelRef.get();
-                                serverChannelCpy.writeAndFlush(data2.duplicate().retain(),
-                                        serverChannelCpy.newPromise());
+                                serverChannelCpy.writeAndFlush(
+                                        data2.retainedDuplicate(), serverChannelCpy.newPromise());
                             }
                         });
-                        ccCpy.writeAndFlush(data.duplicate().retain(), promise);
+                        ccCpy.writeAndFlush(data.retainedDuplicate(), promise);
                     }
                 });
 
@@ -683,7 +683,7 @@ public class LocalChannelTest {
                                 serverChannelRef.get().close();
                             }
                         });
-                        ccCpy.writeAndFlush(data.duplicate().retain(), promise);
+                        ccCpy.writeAndFlush(data.retainedDuplicate(), promise);
                     }
                 });
 
@@ -757,7 +757,7 @@ public class LocalChannelTest {
                 cc.pipeline().lastContext().executor().execute(new OneTimeTask() {
                     @Override
                     public void run() {
-                        ccCpy.writeAndFlush(data.duplicate().retain(), ccCpy.newPromise())
+                        ccCpy.writeAndFlush(data.retainedDuplicate(), ccCpy.newPromise())
                         .addListener(new ChannelFutureListener() {
                             @Override
                             public void operationComplete(ChannelFuture future) throws Exception {
@@ -777,7 +777,7 @@ public class LocalChannelTest {
                                                 fail();
                                             }
                                         }
-                                        serverChannelCpy.writeAndFlush(data2.duplicate().retain(),
+                                        serverChannelCpy.writeAndFlush(data2.retainedDuplicate(),
                                                                        serverChannelCpy.newPromise())
                                             .addListener(new ChannelFutureListener() {
                                             @Override
@@ -864,7 +864,7 @@ public class LocalChannelTest {
     }
 
     private static final class LatchChannelFutureListener extends CountDownLatch implements ChannelFutureListener {
-        public LatchChannelFutureListener(int count) {
+        private LatchChannelFutureListener(int count) {
             super(count);
         }
 


### PR DESCRIPTION
Related: #4333 #4421 #5128

Motivation:

slice(), duplicate() and readSlice() currently create a non-recyclable
derived buffer instance. Under heavy load, an application that creates a
lot of derived buffers can put the garbage collector under pressure.

Modifications:

- Add the following methods which creates a non-recyclable derived buffer
  - retainedSlice()
  - retainedDuplicate()
  - readRetainedSlice()
- Add the new recyclable derived buffer implementations, which has its
  own reference count value
- Add ByteBufUtil.retainedSlice() and retainedDuplicate() so that a user
  can implement the new ByteBuf methods easily
- Add ByteBufHolder.retainedDuplicate()
- Add ByteBufHolder.replace(ByteBuf) so that..
  - a user can replace the content of the holder in a consistent way
  - copy/duplicate/retainedDuplicate() can delegate the holder
    construction to replace(ByteBuf)
- Use retainedDuplicate() and retainedSlice() wherever possible

Result:

Derived buffers are now recycled when created via retainedSlice() and
retainedDuplicate()