### PR TITLE
Add @Deprecated when the javadoc says its deprecated

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBuf.java
@@ -267,6 +267,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * @deprecated use the Little Endian accessors, e.g. {@code getShortLE}, {@code getIntLE}
      * instead of creating a buffer with swapped {@code endianness}.
      */
+    @Deprecated
     public abstract ByteOrder order();
 
     /**
@@ -280,6 +281,7 @@ public abstract class ByteBuf implements ReferenceCounted, Comparable<ByteBuf> {
      * @deprecated use the Little Endian accessors, e.g. {@code getShortLE}, {@code getIntLE}
      * instead of creating a buffer with swapped {@code endianness}.
      */
+    @Deprecated
     public abstract ByteBuf order(ByteOrder endianness);
 
     /**

--- a/buffer/src/main/java/io/netty/buffer/ByteBufProcessor.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufProcessor.java
@@ -21,11 +21,13 @@ import io.netty.util.ByteProcessor;
 /**
  * @deprecated Use {@link ByteProcessor}.
  */
+@Deprecated
 public interface ByteBufProcessor extends ByteProcessor {
 
     /**
      * @deprecated Use {@link ByteProcessor#FIND_NUL}.
      */
+    @Deprecated
     ByteBufProcessor FIND_NUL = new ByteBufProcessor() {
         @Override
         public boolean process(byte value) throws Exception {
@@ -36,6 +38,7 @@ public interface ByteBufProcessor extends ByteProcessor {
     /**
      * @deprecated Use {@link ByteProcessor#FIND_NON_NUL}.
      */
+    @Deprecated
     ByteBufProcessor FIND_NON_NUL = new ByteBufProcessor() {
         @Override
         public boolean process(byte value) throws Exception {
@@ -46,6 +49,7 @@ public interface ByteBufProcessor extends ByteProcessor {
     /**
      * @deprecated Use {@link ByteProcessor#FIND_CR}.
      */
+    @Deprecated
     ByteBufProcessor FIND_CR = new ByteBufProcessor() {
         @Override
         public boolean process(byte value) throws Exception {
@@ -56,6 +60,7 @@ public interface ByteBufProcessor extends ByteProcessor {
     /**
      * @deprecated Use {@link ByteProcessor#FIND_NON_CR}.
      */
+    @Deprecated
     ByteBufProcessor FIND_NON_CR = new ByteBufProcessor() {
         @Override
         public boolean process(byte value) throws Exception {
@@ -66,6 +71,7 @@ public interface ByteBufProcessor extends ByteProcessor {
     /**
      * @deprecated Use {@link ByteProcessor#FIND_LF}.
      */
+    @Deprecated
     ByteBufProcessor FIND_LF = new ByteBufProcessor() {
         @Override
         public boolean process(byte value) throws Exception {
@@ -76,6 +82,7 @@ public interface ByteBufProcessor extends ByteProcessor {
     /**
      * @deprecated Use {@link ByteProcessor#FIND_NON_LF}.
      */
+    @Deprecated
     ByteBufProcessor FIND_NON_LF = new ByteBufProcessor() {
         @Override
         public boolean process(byte value) throws Exception {
@@ -86,6 +93,7 @@ public interface ByteBufProcessor extends ByteProcessor {
     /**
      * @deprecated Use {@link ByteProcessor#FIND_CRLF}.
      */
+    @Deprecated
     ByteBufProcessor FIND_CRLF = new ByteBufProcessor() {
         @Override
         public boolean process(byte value) throws Exception {
@@ -96,6 +104,7 @@ public interface ByteBufProcessor extends ByteProcessor {
     /**
      * @deprecated Use {@link ByteProcessor#FIND_NON_CRLF}.
      */
+    @Deprecated
     ByteBufProcessor FIND_NON_CRLF = new ByteBufProcessor() {
         @Override
         public boolean process(byte value) throws Exception {
@@ -106,6 +115,7 @@ public interface ByteBufProcessor extends ByteProcessor {
     /**
      * @deprecated Use {@link ByteProcessor#FIND_LINEAR_WHITESPACE}.
      */
+    @Deprecated
     ByteBufProcessor FIND_LINEAR_WHITESPACE = new ByteBufProcessor() {
         @Override
         public boolean process(byte value) throws Exception {
@@ -116,6 +126,7 @@ public interface ByteBufProcessor extends ByteProcessor {
     /**
      * @deprecated Use {@link ByteProcessor#FIND_NON_LINEAR_WHITESPACE}.
      */
+    @Deprecated
     ByteBufProcessor FIND_NON_LINEAR_WHITESPACE = new ByteBufProcessor() {
         @Override
         public boolean process(byte value) throws Exception {

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -33,6 +33,7 @@ import java.nio.charset.Charset;
  * @deprecated use the Little Endian accessors, e.g. {@code getShortLE}, {@code getIntLE}
  * instead.
  */
+@Deprecated
 public class SwappedByteBuf extends ByteBuf {
 
     private final ByteBuf buf;

--- a/transport/src/main/java/io/netty/channel/ChannelInboundHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelInboundHandler.java
@@ -70,6 +70,6 @@ public interface ChannelInboundHandler extends ChannelHandler {
      * Gets called if a {@link Throwable} was thrown.
      */
     @Override
-    @SuppressWarnings("deprecated")
+    @SuppressWarnings("deprecation")
     void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception;
 }

--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -79,6 +79,7 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
     /**
      * @deprecated Use {@link MaxMessagesRecvByteBufAllocator}
      */
+    @Deprecated
     public static final ChannelOption<Integer> MAX_MESSAGES_PER_READ = valueOf("MAX_MESSAGES_PER_READ");
     public static final ChannelOption<Integer> WRITE_SPIN_COUNT = valueOf("WRITE_SPIN_COUNT");
     /**


### PR DESCRIPTION
Our internal build chain nags when the javadoc says `@deprecated` but it lacks the annotation.  This adds the tag to silence the warning, and hopefully have IDEs notice it more easily.


cc: @nmittler 