### PR TITLE
Identify the source of IdleStateEvents

### DIFF
--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateEvent.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateEvent.java
@@ -21,19 +21,14 @@ import io.netty.channel.Channel;
  * A user event triggered by {@link IdleStateHandler} when a {@link Channel} is idle.
  */
 public final class IdleStateEvent {
-    public static final IdleStateEvent FIRST_READER_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.READER_IDLE, true);
-    public static final IdleStateEvent READER_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.READER_IDLE, false);
-    public static final IdleStateEvent FIRST_WRITER_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.WRITER_IDLE, true);
-    public static final IdleStateEvent WRITER_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.WRITER_IDLE, false);
-    public static final IdleStateEvent FIRST_ALL_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.ALL_IDLE, true);
-    public static final IdleStateEvent ALL_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.ALL_IDLE, false);
-
     private final IdleState state;
     private final boolean first;
+    private final IdleStateHandler source;
 
-    private IdleStateEvent(IdleState state, boolean first) {
+    IdleStateEvent(IdleState state, boolean first, IdleStateHandler source) {
         this.state = state;
         this.first = first;
+        this.source = source;
     }
 
     /**
@@ -48,5 +43,14 @@ public final class IdleStateEvent {
      */
     public boolean isFirst() {
         return first;
+    }
+
+    /**
+     * Returns the {@link IdleStateHandler} that triggered this event.
+     *
+     * @return the {@code IdleStateHandler} that triggered this event
+     */
+    public IdleStateHandler source() {
+        return source;
     }
 }

--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -110,12 +110,12 @@ public class IdleStateHandler extends ChannelDuplexHandler {
     private final long writerIdleTimeNanos;
     private final long allIdleTimeNanos;
 
-    private final IdleStateEvent FIRST_READER_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.READER_IDLE, true, this);
-    private final IdleStateEvent READER_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.READER_IDLE, false, this);
-    private final IdleStateEvent FIRST_WRITER_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.WRITER_IDLE, true, this);
-    private final IdleStateEvent WRITER_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.WRITER_IDLE, false, this);
-    private final IdleStateEvent FIRST_ALL_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.ALL_IDLE, true, this);
-    private final IdleStateEvent ALL_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.ALL_IDLE, false, this);
+    private final IdleStateEvent firstReaderIdleStateEvent = new IdleStateEvent(IdleState.READER_IDLE, true, this);
+    private final IdleStateEvent readerIdleStateEvent = new IdleStateEvent(IdleState.READER_IDLE, false, this);
+    private final IdleStateEvent firstWriterIdleStateEvent = new IdleStateEvent(IdleState.WRITER_IDLE, true, this);
+    private final IdleStateEvent writerIdleStateEvent = new IdleStateEvent(IdleState.WRITER_IDLE, false, this);
+    private final IdleStateEvent firstAllIdleStateEvent = new IdleStateEvent(IdleState.ALL_IDLE, true, this);
+    private final IdleStateEvent allIdleStateEvent = new IdleStateEvent(IdleState.ALL_IDLE, false, this);
 
     volatile ScheduledFuture<?> readerIdleTimeout;
     volatile long lastReadTime;
@@ -377,9 +377,9 @@ public class IdleStateHandler extends ChannelDuplexHandler {
                     IdleStateEvent event;
                     if (firstReaderIdleEvent) {
                         firstReaderIdleEvent = false;
-                        event = FIRST_READER_IDLE_STATE_EVENT;
+                        event = firstReaderIdleStateEvent;
                     } else {
-                        event = READER_IDLE_STATE_EVENT;
+                        event = readerIdleStateEvent;
                     }
                     channelIdle(ctx, event);
                 } catch (Throwable t) {
@@ -416,9 +416,9 @@ public class IdleStateHandler extends ChannelDuplexHandler {
                     IdleStateEvent event;
                     if (firstWriterIdleEvent) {
                         firstWriterIdleEvent = false;
-                        event = FIRST_WRITER_IDLE_STATE_EVENT;
+                        event = firstWriterIdleStateEvent;
                     } else {
-                        event = WRITER_IDLE_STATE_EVENT;
+                        event = writerIdleStateEvent;
                     }
                     channelIdle(ctx, event);
                 } catch (Throwable t) {
@@ -458,9 +458,9 @@ public class IdleStateHandler extends ChannelDuplexHandler {
                     IdleStateEvent event;
                     if (firstAllIdleEvent) {
                         firstAllIdleEvent = false;
-                        event = FIRST_ALL_IDLE_STATE_EVENT;
+                        event = firstAllIdleStateEvent;
                     } else {
-                        event = ALL_IDLE_STATE_EVENT;
+                        event = allIdleStateEvent;
                     }
                     channelIdle(ctx, event);
                 } catch (Throwable t) {

--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -110,6 +110,13 @@ public class IdleStateHandler extends ChannelDuplexHandler {
     private final long writerIdleTimeNanos;
     private final long allIdleTimeNanos;
 
+    private final IdleStateEvent FIRST_READER_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.READER_IDLE, true, this);
+    private final IdleStateEvent READER_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.READER_IDLE, false, this);
+    private final IdleStateEvent FIRST_WRITER_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.WRITER_IDLE, true, this);
+    private final IdleStateEvent WRITER_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.WRITER_IDLE, false, this);
+    private final IdleStateEvent FIRST_ALL_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.ALL_IDLE, true, this);
+    private final IdleStateEvent ALL_IDLE_STATE_EVENT = new IdleStateEvent(IdleState.ALL_IDLE, false, this);
+
     volatile ScheduledFuture<?> readerIdleTimeout;
     volatile long lastReadTime;
     private boolean firstReaderIdleEvent = true;
@@ -370,9 +377,9 @@ public class IdleStateHandler extends ChannelDuplexHandler {
                     IdleStateEvent event;
                     if (firstReaderIdleEvent) {
                         firstReaderIdleEvent = false;
-                        event = IdleStateEvent.FIRST_READER_IDLE_STATE_EVENT;
+                        event = FIRST_READER_IDLE_STATE_EVENT;
                     } else {
-                        event = IdleStateEvent.READER_IDLE_STATE_EVENT;
+                        event = READER_IDLE_STATE_EVENT;
                     }
                     channelIdle(ctx, event);
                 } catch (Throwable t) {
@@ -409,9 +416,9 @@ public class IdleStateHandler extends ChannelDuplexHandler {
                     IdleStateEvent event;
                     if (firstWriterIdleEvent) {
                         firstWriterIdleEvent = false;
-                        event = IdleStateEvent.FIRST_WRITER_IDLE_STATE_EVENT;
+                        event = FIRST_WRITER_IDLE_STATE_EVENT;
                     } else {
-                        event = IdleStateEvent.WRITER_IDLE_STATE_EVENT;
+                        event = WRITER_IDLE_STATE_EVENT;
                     }
                     channelIdle(ctx, event);
                 } catch (Throwable t) {
@@ -451,9 +458,9 @@ public class IdleStateHandler extends ChannelDuplexHandler {
                     IdleStateEvent event;
                     if (firstAllIdleEvent) {
                         firstAllIdleEvent = false;
-                        event = IdleStateEvent.FIRST_ALL_IDLE_STATE_EVENT;
+                        event = FIRST_ALL_IDLE_STATE_EVENT;
                     } else {
-                        event = IdleStateEvent.ALL_IDLE_STATE_EVENT;
+                        event = ALL_IDLE_STATE_EVENT;
                     }
                     channelIdle(ctx, event);
                 } catch (Throwable t) {


### PR DESCRIPTION
### Motivation

Suppose you have an application that wants to flush all pending writes after 50ms of inactivity, but also wants to send a ping after a minute of inactivity. One solution would be to have an `IdleStateHandler` with a 50ms period and then have a handler that counted `IdleStateEvents`. Another—and possibly slightly more convenient—approach would be to have two `IdleStateHandlers` with different periods. The trouble there is that it's impossible to distinguish idle state events from the two handlers. This change allows callers to differentiate events from multiple `IdleStateHandlers`.

### Modifications

- Added a `source` property/getter to `IdleStateEvents`.
- Made pre-defined `IdleStateEvents` properties of individual `IdleStateHandler` instances instead of static properties of the class.

### Result

Handlers can now identify which `IdleStateHandler` triggered an `IdleStateEvent`.