### PR TITLE
EpollEventLoopGroup support Executor

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -15,8 +15,8 @@
  */
 package io.netty.channel.epoll;
 
-import io.netty.channel.EventLoop;
 import io.netty.channel.DefaultSelectStrategyFactory;
+import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.channel.SelectStrategyFactory;
@@ -50,7 +50,7 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
      */
     @SuppressWarnings("deprecation")
     public EpollEventLoopGroup(int nThreads, SelectStrategyFactory selectStrategyFactory) {
-        this(nThreads, null, selectStrategyFactory);
+        this(nThreads, (ThreadFactory) null, selectStrategyFactory);
     }
 
     /**
@@ -59,6 +59,10 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
     @SuppressWarnings("deprecation")
     public EpollEventLoopGroup(int nThreads, ThreadFactory threadFactory) {
         this(nThreads, threadFactory, 0);
+    }
+
+    public EpollEventLoopGroup(int nThreads, Executor executor) {
+        this(nThreads, executor, DefaultSelectStrategyFactory.INSTANCE);
     }
 
     /**
@@ -91,6 +95,10 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
     public EpollEventLoopGroup(int nThreads, ThreadFactory threadFactory, int maxEventsAtOnce,
                                SelectStrategyFactory selectStrategyFactory) {
         super(nThreads, threadFactory, maxEventsAtOnce, selectStrategyFactory);
+    }
+
+    public EpollEventLoopGroup(int nThreads, Executor executor, SelectStrategyFactory selectStrategyFactory) {
+        super(nThreads, executor, 0, selectStrategyFactory);
     }
 
     /**


### PR DESCRIPTION
Motivation:
NioEventLoopGroup supports constructors which take an executor but EpollEventLoopGroup does not. EPOLL should be consistent with NIO where ever possible.

Modifications:
- Add constructors to EpollEventLoopGroup which accept an Executor as a parameter

Result:
EpollEventLoopGroup is more consistent with NioEventLoopGroup
Fixes https://github.com/netty/netty/issues/5161