### PR TITLE
04e33fd2d8d81ee114718744893ba9c8a47fd883 incomplete fix

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -529,7 +529,7 @@ public final class NioEventLoop extends SingleThreadEventLoop {
             // and thus the SelectionKey could be cancelled as part of the deregistration process, but the channel is
             // still healthy and should not be closed.
             // See https://github.com/netty/netty/issues/5125
-            if (eventLoop != this || eventLoop == null) {
+            if (eventLoop != this || !ch.isRegistered() || ch.selectionKey() != k) {
                 return;
             }
             // close the channel if the key is not valid anymore


### PR DESCRIPTION
Motivation:
04e33fd2d8d81ee114718744893ba9c8a47fd883 was incomplete. The EventLoop may not change even if the channel is deregistered.

Modifications:
- Check if the channel is registered, and if not return before closing

Result:
Fixes https://github.com/netty/netty/issues/5125