### PR TITLE
Change hosts file resolver to be case-insensitive

### DIFF
--- a/resolver/src/main/java/io/netty/resolver/HostsFileParser.java
+++ b/resolver/src/main/java/io/netty/resolver/HostsFileParser.java
@@ -29,6 +29,7 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -151,10 +152,11 @@ public final class HostsFileParser {
                 // loop over hostname and aliases
                 for (int i = 1; i < lineParts.size(); i ++) {
                     String hostname = lineParts.get(i);
-                    if (!entries.containsKey(hostname)) {
+                    String hostnameLower = hostname.toLowerCase(Locale.ENGLISH);
+                    if (!entries.containsKey(hostnameLower)) {
                         // trying to map a host to multiple IPs is wrong
                         // only the first entry is honored
-                        entries.put(hostname, InetAddress.getByAddress(hostname, ipBytes));
+                        entries.put(hostnameLower, InetAddress.getByAddress(hostname, ipBytes));
                     }
                 }
             }

--- a/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
+++ b/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,21 +13,22 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+/**
+ * show issue https://github.com/netty/netty/issues/5182
+ * HostsFileParser tries to resolve hostnames as case-sensitive
+ */
 package io.netty.resolver;
 
-import java.net.InetAddress;
-import java.util.Locale;
-import java.util.Map;
+import org.junit.Test;
 
-/**
- * Default {@link HostsFileEntriesResolver} that resolves hosts file entries only once.
- */
-public final class DefaultHostsFileEntriesResolver implements HostsFileEntriesResolver {
+import static org.junit.Assert.assertNotNull;
 
-    private final Map<String, InetAddress> entries = HostsFileParser.parseSilently();
+public class DefaultHostsFileEntriesResolverTest {
 
-    @Override
-    public InetAddress address(String inetHost) {
-        return entries.get(inetHost.toLowerCase(Locale.ENGLISH));
+    @Test
+    public void testLocalhost() {
+        DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver();
+        assertNotNull("localhost doesn't resolve", resolver.address("localhost"));
+        assertNotNull("LOCALHOST doesn't resolve", resolver.address("LOCALHOST"));
     }
 }

--- a/resolver/src/test/java/io/netty/resolver/HostsFileParserTest.java
+++ b/resolver/src/test/java/io/netty/resolver/HostsFileParserTest.java
@@ -38,16 +38,20 @@ public class HostsFileParserTest {
                 .append("192.168.0.2  host3  #comment").append("\n") // comment after hostname
                 .append("192.168.0.3  host4  host5 host6").append("\n") // multiple aliases
                 .append("192.168.0.4  host4").append("\n") // host mapped to a second address, must be ignored
+                .append("192.168.0.5  HOST7").append("\n") // uppercase host, should match lowercase host
+                .append("192.168.0.6  host7").append("\n") // should be ignored since we have the uppercase host already
                 .toString();
 
         Map<String, InetAddress> entries = HostsFileParser.parse(new BufferedReader(new StringReader(hostsString)));
 
-        assertEquals("Expected 6 entries", 6, entries.size());
+        assertEquals("Expected 7 entries", 7, entries.size());
         assertEquals("127.0.0.1", entries.get("host1").getHostAddress());
         assertEquals("192.168.0.1", entries.get("host2").getHostAddress());
         assertEquals("192.168.0.2", entries.get("host3").getHostAddress());
         assertEquals("192.168.0.3", entries.get("host4").getHostAddress());
         assertEquals("192.168.0.3", entries.get("host5").getHostAddress());
         assertEquals("192.168.0.3", entries.get("host6").getHostAddress());
+        assertNotNull("uppercase host doesn't resolve", entries.get("host7"));
+        assertEquals("192.168.0.5", entries.get("host7").getHostAddress());
     }
 }


### PR DESCRIPTION
fix issue #5182: HostsFileParser tries to resolve hostnames as case-sensitive
