### PR TITLE
DefaultHttp2FrameReader stops reading if stream error

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -343,7 +343,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                 if (stream == null) {
                     if (connection.streamMayHaveExisted(streamId)) {
                         if (logger.isInfoEnabled()) {
-                            logger.info("%s ignoring PRIORITY frame for stream id %d. Stream doesn't exist but may " +
+                            logger.info("%s ignoring PRIORITY frame for stream %d. Stream doesn't exist but may " +
                                         " have existed", ctx.channel(), streamId);
                         }
                         return;
@@ -354,7 +354,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                     stream = connection.remote().createIdleStream(streamId);
                 } else if (streamCreatedAfterGoAwaySent(streamId)) {
                     if (logger.isInfoEnabled()) {
-                        logger.info("%s ignoring PRIORITY frame for stream id %d. Stream created after GOAWAY sent. " +
+                        logger.info("%s ignoring PRIORITY frame for stream %d. Stream created after GOAWAY sent. " +
                                     "Last known stream by peer " + connection.remote().lastStreamKnownByPeer(),
                                     ctx.channel(), streamId);
                     }
@@ -482,7 +482,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
             }
 
             if (parentStream == null) {
-                throw connectionError(PROTOCOL_ERROR, "Stream does not exist %d", streamId);
+                throw connectionError(PROTOCOL_ERROR, "Stream %d does not exist", streamId);
             }
 
             switch (parentStream.state()) {
@@ -556,7 +556,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
             if (stream == null) {
                 if (streamCreatedAfterGoAwaySent(streamId)) {
                     if (logger.isInfoEnabled()) {
-                        logger.info("%s ignoring %s frame for stream id %d. Stream sent after GOAWAY sent",
+                        logger.info("%s ignoring %s frame for stream %d. Stream sent after GOAWAY sent",
                                 ctx.channel(), frameName, streamId);
                     }
                     return true;
@@ -564,10 +564,11 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                 // Its possible that this frame would result in stream ID out of order creation (PROTOCOL ERROR) and its
                 // also possible that this frame is received on a CLOSED stream (STREAM_CLOSED after a RST_STREAM is
                 // sent). We don't have enough information to know for sure, so we choose the lesser of the two errors.
-                throw streamError(streamId, STREAM_CLOSED, "Received HEADERS frame for an unknown stream %d", streamId);
+                throw streamError(streamId, STREAM_CLOSED, "Received %s frame for an unknown stream %d",
+                                  frameName, streamId);
             } else if (stream.isResetSent() || streamCreatedAfterGoAwaySent(streamId)) {
                 if (logger.isInfoEnabled()) {
-                    logger.info("%s ignoring %s frame for stream id %d. %s", ctx.channel(), frameName,
+                    logger.info("%s ignoring %s frame for stream %d. %s", ctx.channel(), frameName,
                             stream.isResetSent() ? "RST_STREAM sent." :
                                 ("Stream created after GOAWAY sent. Last known stream by peer " +
                                  connection.remote().lastStreamKnownByPeer()));
@@ -597,7 +598,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
 
         private void verifyStreamMayHaveExisted(int streamId) throws Http2Exception {
             if (!connection.streamMayHaveExisted(streamId)) {
-                throw connectionError(PROTOCOL_ERROR, "Stream does not exist %d", streamId);
+                throw connectionError(PROTOCOL_ERROR, "Stream %d does not exist", streamId);
             }
         }
     }


### PR DESCRIPTION
Motivation:
DefaultHttp2FrameReader will stop reading data if any exception is thrown. However some exceptions are recoverable and we will lose data if we don't continue reading. For example some stream errors are recoverable.

Modifications:
- DefaultHttp2FrameReader should attempt to continue reading if a stream error is encountered.

Result:
Fixes https://github.com/netty/netty/issues/5186