### PR TITLE
Handle the backslash with double quote in JsonObjectDecoder

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/json/JsonObjectDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/json/JsonObjectDecoder.java
@@ -190,9 +190,22 @@ public class JsonObjectDecoder extends ByteToMessageDecoder {
             // also contain braces/brackets and that could lead to incorrect results.
             if (!insideString) {
                 insideString = true;
-            // If the double quote wasn't escaped then this is the end of a string.
-            } else if (in.getByte(idx - 1) != '\\') {
-                insideString = false;
+            } else {
+                int backslashCount = 0;
+                idx--;
+                while (idx >= 0) {
+                    if (in.getByte(idx) == '\\') {
+                        backslashCount++;
+                        idx--;
+                    } else {
+                        break;
+                    }
+                }
+                // The double quote isn't escaped only if there are even "\"s.
+                if (backslashCount % 2 == 0) {
+                    // Since the double quote isn't escaped then this is the end of a string.
+                    insideString = false;
+                }
             }
         }
     }

--- a/codec/src/test/java/io/netty/handler/codec/json/JsonObjectDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/json/JsonObjectDecoderTest.java
@@ -88,6 +88,51 @@ public class JsonObjectDecoderTest {
     }
 
     @Test
+    public void testBackslashInString1() {
+        EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
+        // {"foo" : "bar\""}
+        String json = "{\"foo\" : \"bar\\\"\"}";
+        System.out.println(json);
+        ch.writeInbound(Unpooled.copiedBuffer(json, CharsetUtil.UTF_8));
+
+        ByteBuf res = ch.readInbound();
+        assertEquals(json, res.toString(CharsetUtil.UTF_8));
+        res.release();
+
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testBackslashInString2() {
+        EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
+        // {"foo" : "bar\\"}
+        String json = "{\"foo\" : \"bar\\\\\"}";
+        System.out.println(json);
+        ch.writeInbound(Unpooled.copiedBuffer(json, CharsetUtil.UTF_8));
+
+        ByteBuf res = ch.readInbound();
+        assertEquals(json, res.toString(CharsetUtil.UTF_8));
+        res.release();
+
+        assertFalse(ch.finish());
+    }
+
+    @Test
+    public void testBackslashInString3() {
+        EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
+        // {"foo" : "bar\\\""}
+        String json = "{\"foo\" : \"bar\\\\\\\"\"}";
+        System.out.println(json);
+        ch.writeInbound(Unpooled.copiedBuffer(json, CharsetUtil.UTF_8));
+
+        ByteBuf res = ch.readInbound();
+        assertEquals(json, res.toString(CharsetUtil.UTF_8));
+        res.release();
+
+        assertFalse(ch.finish());
+    }
+
+    @Test
     public void testMultipleJsonObjectsInOneWrite() {
         EmbeddedChannel ch = new EmbeddedChannel(new JsonObjectDecoder());
 


### PR DESCRIPTION
Motivation:

The double quote may be escaped in a JSON string, but JsonObjectDecoder doesn't handle it. Resolves #5157.

Modifications:

Don't end a JSON string when processing an escaped double quote.

Result:

JsonObjectDecoder can handle backslash and double quote in a JSON string correctly.