### PR TITLE
DefaultHttp2Connection.close Reentrant Modification

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2LocalFlowController.java
@@ -284,7 +284,6 @@ public class DefaultHttp2LocalFlowController implements Http2LocalFlowController
     }
 
     private FlowState state(Http2Stream stream) {
-        checkNotNull(stream, "stream");
         return stream.getProperty(stateKey);
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DelegatingDecompressorFrameListener.java
@@ -322,11 +322,6 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
         }
 
         @Override
-        public int initialWindowSize(Http2Stream stream) {
-            return flowController.initialWindowSize(stream);
-        }
-
-        @Override
         public void incrementWindowSize(Http2Stream stream, int delta) throws Http2Exception {
             flowController.incrementWindowSize(stream, delta);
         }
@@ -366,6 +361,11 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
         @Override
         public int unconsumedBytes(Http2Stream stream) {
             return flowController.unconsumedBytes(stream);
+        }
+
+        @Override
+        public int initialWindowSize(Http2Stream stream) {
+            return flowController.initialWindowSize(stream);
         }
     }
 
@@ -418,7 +418,7 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
 
         /**
          * Increment the number of bytes after the decompression process. Under normal circumstances this
-         * delta should not exceed {@link Http2Decompressor#processedBytes()}.
+         * delta should not exceed {@link Http2Decompressor#processed)}.
          */
         void incrementDecompressedByes(int delta) {
             if (decompressed + delta < 0) {
@@ -428,10 +428,10 @@ public class DelegatingDecompressorFrameListener extends Http2FrameListenerDecor
         }
 
         /**
-         * Decrements {@link Http2Decompressor#processedBytes()} by {@code processedBytes} and determines the ratio
-         * between {@code processedBytes} and {@link Http2Decompressor#decompressedBytes()}.
-         * This ratio is used to decrement {@link Http2Decompressor#decompressedBytes()} and
-         * {@link Http2Decompressor#compressedBytes()}.
+         * Decrements {@link Http2Decompressor#processed} by {@code processedBytes} and determines the ratio
+         * between {@code processedBytes} and {@link Http2Decompressor#decompressed}.
+         * This ratio is used to decrement {@link Http2Decompressor#decompressed} and
+         * {@link Http2Decompressor#compressed}.
          * @param processedBytes The number of post-decompressed bytes that have been processed.
          * @return The number of pre-decompressed bytes that have been consumed.
          */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FlowController.java
@@ -57,13 +57,6 @@ public interface Http2FlowController {
     int windowSize(Http2Stream stream);
 
     /**
-     * Get the initial flow control window size for the given stream. This quantity is measured in number of bytes. Note
-     * the unavailable window portion can be calculated by {@link #initialWindowSize()} - {@link
-     * #windowSize(Http2Stream)}.
-     */
-    int initialWindowSize(Http2Stream stream);
-
-    /**
      * Increments the size of the stream's flow control window by the given delta.
      * <p>
      * In the case of a {@link Http2RemoteFlowController} this is called upon receipt of a

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
@@ -76,4 +76,11 @@ public interface Http2LocalFlowController extends Http2FlowController {
      * @return the number of unconsumed bytes for the stream.
      */
     int unconsumedBytes(Http2Stream stream);
+
+    /**
+     * Get the initial flow control window size for the given stream. This quantity is measured in number of bytes. Note
+     * the unavailable window portion can be calculated by {@link #initialWindowSize()} - {@link
+     * #windowSize(Http2Stream)}.
+     */
+    int initialWindowSize(Http2Stream stream);
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -167,13 +167,6 @@ public interface Http2Stream {
     Http2Stream parent();
 
     /**
-     * Get the number of streams in the priority tree rooted at this node that are OK to exist in the priority
-     * tree on their own right. Some streams may be in the priority tree because their dependents require them to
-     * remain.
-     */
-    int prioritizableForTree();
-
-    /**
      * Indicates whether or not this stream is a descendant in the priority tree from the given stream.
      */
     boolean isDescendantOf(Http2Stream stream);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributorTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributorTest.java
@@ -798,7 +798,7 @@ public class WeightedFairQueueByteDistributorTest {
     }
 
     /**
-     * In this test, we close an internal stream in the priority tree but tree should not change.
+     * In this test, we close an internal stream in the priority tree.
      *
      * <pre>
      *         0
@@ -806,6 +806,13 @@ public class WeightedFairQueueByteDistributorTest {
      *       A   B
      *      / \
      *     C   D
+     * </pre>
+     *
+     * After the close:
+     * <pre>
+     *          0
+     *        / | \
+     *       C  D  B
      * </pre>
      */
     @Test
@@ -819,8 +826,7 @@ public class WeightedFairQueueByteDistributorTest {
 
         assertTrue(write(500));
         verifyNeverWrite(STREAM_A);
-        assertEquals(200, captureWrites(STREAM_B));
-        assertEquals(300, captureWrites(STREAM_C) + captureWrites(STREAM_D));
+        assertEquals(500, captureWrites(STREAM_B) + captureWrites(STREAM_C) + captureWrites(STREAM_D));
 
         assertFalse(write(1300));
         verifyNeverWrite(STREAM_A);

--- a/common/src/main/java/io/netty/util/BooleanSupplier.java
+++ b/common/src/main/java/io/netty/util/BooleanSupplier.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util;
+
+/**
+ * Represents a supplier of {@code boolean}-valued results.
+ */
+public interface BooleanSupplier {
+    /**
+     * Gets a boolean value.
+     * @return a boolean value.
+     * @throws Exception If an exception occurs.
+     */
+    boolean get() throws Exception;
+
+    /**
+     * A supplier which always returns {@code false} and never throws.
+     */
+    BooleanSupplier FALSE_SUPPLIER = new BooleanSupplier() {
+        @Override
+        public boolean get() {
+            return false;
+        }
+    };
+
+    /**
+     * A supplier which always returns {@code true} and never throws.
+     */
+    BooleanSupplier TRUE_SUPPLIER = new BooleanSupplier() {
+        @Override
+        public boolean get() {
+            return true;
+        }
+    };
+}

--- a/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/NoopHttp2RemoteFlowController.java
@@ -47,11 +47,6 @@ public final class NoopHttp2RemoteFlowController implements Http2RemoteFlowContr
     }
 
     @Override
-    public int initialWindowSize(Http2Stream stream) {
-        return MAX_INITIAL_WINDOW_SIZE;
-    }
-
-    @Override
     public void incrementWindowSize(Http2Stream stream, int delta) throws Http2Exception {
     }
 


### PR DESCRIPTION
Motivation:
The DefaultHttp2Conneciton.close method accounts for active streams being iterated and attempts to avoid reentrant modifications of the underlying stream map by using iterators to remove from the stream map. However there are a few issues:

- While iterating over the stream map we don't prevent iterations over the active stream collection
- Removing a single stream may actually remove > 1 streams due to closed non-leaf streams being preserved in the priority tree which may result in NPE

Preserving closed non-leaf streams in the priority tree is no longer necessary with our current allocation algorithms, and so this feature (and related complexity) can be removed.

Modifications:
- DefaultHttp2Connection.close should prevent others from iterating over the active streams and reentrant modification scenarios which may result from this
- DefaultHttp2Connection should not keep closed stream in the priority tree
  - Remove all associated code in DefaultHttp2RemoteFlowController which accounts for this case including the ReducedState object
  - This includes fixing writability changes which depended on ReducedState
- Update unit tests

Result:
Fixes netty#5198