### PR TITLE
DefaultPromise LateListener StackOverflowException

### DIFF
--- a/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
@@ -192,8 +192,8 @@ public class DefaultPromiseTest {
      * <ol>
      * <li>A write is done</li>
      * <li>The write operation completes, and the promise state is changed to done</li>
-     * <li>A listener is added to the return from the write. The {@link FutureListener#operationComplete()} updates
-     * state which must be invoked before the response to the previous write is read.</li>
+     * <li>A listener is added to the return from the write. The {@link FutureListener#operationComplete(Future)}
+     * updates state which must be invoked before the response to the previous write is read.</li>
      * <li>The write operation</li>
      * </ol>
      */

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
@@ -42,6 +43,19 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.Assert.*;
 
 public class EmbeddedChannelTest {
+
+    @Test(timeout = 2000)
+    public void promiseDoesNotInfiniteLoop() throws InterruptedException {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.closeFuture().addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) throws Exception {
+                future.channel().close();
+            }
+        });
+
+        channel.close().syncUninterruptibly();
+    }
 
     @Test
     public void testConstructWithChannelInitializer() {


### PR DESCRIPTION
Motivation:
DefaultPromise attempts to execute a task to notify listeners that were added after the promise completed under the assumption that a thread context switch will occur to ensure listeners which were added before the promise completed are notified first. If the executor does not introduce a thread context switch then this code will enter an infinite loop and generate a StackOverflowException.

Modifications:
- Add a best effort detection in DefaultPromise.LateListeners to avoid infinite loop and notify the listeners immediately while sacrificing listener notification order

Result:
No More StackOverflowException while processing LateListeners in DefaultPromise
Fixes https://github.com/netty/netty/issues/5185