### PR TITLE
[#5190] Ensure memory is not leaked when readEndOfLine(...) throws an…

### DIFF
--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisDecoder.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/RedisDecoder.java
@@ -205,9 +205,10 @@ public final class RedisDecoder extends ByteToMessageDecoder {
 
         // if this is last frame.
         if (readableBytes >= remainingBulkLength + RedisConstants.EOL_LENGTH) {
-            ByteBuf content = in.readSlice(remainingBulkLength).retain();
+            ByteBuf content = in.readSlice(remainingBulkLength);
             readEndOfLine(in);
-            out.add(new DefaultLastBulkStringRedisContent(content));
+            // Only call retain after readEndOfLine(...) as the method may throw an exception.
+            out.add(new DefaultLastBulkStringRedisContent(content.retain()));
             resetDecoder();
             return true;
         }


### PR DESCRIPTION
… exception.

Motivation:

We need to ensure we not retain the buffer until readEndOfLine(...) completes as otherwise we may leak memory in the case of an exception.

Modifications:

Only call retain after readEndOfLine(...) returns.

Result:

No more leak in case of exception while decoding redis messages.