### PR TITLE
[#3297] Fix race while resolve remote address that can cause NPE

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -172,15 +172,16 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
         }
 
         final Future<SocketAddress> resolveFuture = resolver.resolve(remoteAddress);
-        final Throwable resolveFailureCause = resolveFuture.cause();
-
-        if (resolveFailureCause != null) {
-            // Failed to resolve immediately
-            channel.close();
-            return channel.newFailedFuture(resolveFailureCause);
-        }
 
         if (resolveFuture.isDone()) {
+            final Throwable resolveFailureCause = resolveFuture.cause();
+
+            if (resolveFailureCause != null) {
+                // Failed to resolve immediately
+                channel.close();
+                return channel.newFailedFuture(resolveFailureCause);
+            }
+
             // Succeeded to resolve immediately; cached? (or did a blocking lookup)
             return doConnect(resolveFuture.getNow(), localAddress, regFuture, channel.newPromise());
         }


### PR DESCRIPTION
Motivation:

We may produce a NPE due a race that can happen while check if a resolution was done and failed.

Modifications:

Correctly first check if the resultion is done before try to detect if it failed and so remove the race that can produce a NPE.

Result:

No more race possible while resolve address during connect.