### PR TITLE
[#5216] Correctly increment deallocationsHuge when call PoolArena.free

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -254,7 +254,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
             int size = chunk.chunkSize();
             destroyChunk(chunk);
             activeBytesHuge.add(-size);
-            deallocationsHuge.decrement();
+            deallocationsHuge.increment();
         } else {
             SizeClass sizeClass = sizeClass(normCapacity);
             if (cache != null && cache.add(this, chunk, handle, normCapacity, sizeClass)) {


### PR DESCRIPTION
Motivation:

We called deallocationsHuge.decrement() but it needs to be increment()

Modifications:

Replace decrement() with increment()

Result:

Correct metrics.