### PR TITLE
[#5218] Zero out private key copied to ByteBuf before release.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -517,16 +517,22 @@ public abstract class OpenSslContext extends SslContext {
                 try {
                     buffer.writeBytes(encodedBuf);
                 } finally {
-                    encodedBuf.release();
+                    zerooutAndRelease(encodedBuf);
                 }
             } finally {
-                wrappedBuf.release();
+                zerooutAndRelease(wrappedBuf);
             }
             buffer.writeBytes(END_PRIVATE_KEY);
             return newBIO(buffer);
         } finally {
-            buffer.release();
+            // Zero out the buffer and so the private key it held.
+            zerooutAndRelease(buffer);
         }
+    }
+
+    private static void zerooutAndRelease(ByteBuf buffer) {
+        buffer.setZero(0, buffer.capacity());
+        buffer.release();
     }
 
     /**


### PR DESCRIPTION
Motivation:

We should zero-out the private key as soon as possible when we not need it anymore.

Modifications:

zero out the private key before release the buffer.

Result:

Limit the time the private key resist in memory.