### PR TITLE
codec-http2: Stop leaking in header downgrader test

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ServerDowngraderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ServerDowngraderTest.java
@@ -34,6 +34,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
 
 import org.junit.Test;
 
@@ -246,6 +247,7 @@ public class Http2ServerDowngraderTest {
         assertTrue(ch.writeInbound(new DefaultHttp2HeadersFrame(headers, true)));
 
         FullHttpRequest request = ch.readInbound();
+        ReferenceCountUtil.releaseLater(request);
         assertThat(request.uri(), is("/"));
         assertThat(request.method(), is(HttpMethod.GET));
         assertThat(request.protocolVersion(), is(HttpVersion.HTTP_1_1));


### PR DESCRIPTION
Motivation:

We're leaking requests in our Http2ServerDowngrader tests when we allocate a buffer using the local allocator.

Modification:

Release the request later when the request is constructed with the local allocator.

Result:

Less leaky tests.

## Open Question

Why don't the other kinds of tests leak?  Did I fix this problem in the right place?  Should I be retaining the bytebufs as soon as I create them, and then make sure I release those too?