### PR TITLE
Add a EventLoopGroup.register(ChannelPromise)

### DIFF
--- a/transport/src/main/java/io/netty/channel/EventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/EventLoopGroup.java
@@ -36,8 +36,17 @@ public interface EventLoopGroup extends EventExecutorGroup {
     ChannelFuture register(Channel channel);
 
     /**
+     * Register a {@link Channel} with this {@link EventLoop} using a {@link ChannelFuture}. The passed
+     * {@link ChannelFuture} will get notified once the registration was complete and also will get returned.
+     */
+    ChannelFuture register(ChannelPromise promise);
+
+    /**
      * Register a {@link Channel} with this {@link EventLoop}. The passed {@link ChannelFuture}
      * will get notified once the registration was complete and also will get returned.
+     *
+     * @deprecated Use {@link #register(ChannelPromise)} instead.
      */
+    @Deprecated
     ChannelFuture register(Channel channel, ChannelPromise promise);
 }

--- a/transport/src/main/java/io/netty/channel/MultithreadEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/MultithreadEventLoopGroup.java
@@ -76,6 +76,12 @@ public abstract class MultithreadEventLoopGroup extends MultithreadEventExecutor
     }
 
     @Override
+    public ChannelFuture register(ChannelPromise promise) {
+        return next().register(promise);
+    }
+
+    @Deprecated
+    @Override
     public ChannelFuture register(Channel channel, ChannelPromise promise) {
         return next().register(channel, promise);
     }

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -16,6 +16,7 @@
 package io.netty.channel;
 
 import io.netty.util.concurrent.SingleThreadEventExecutor;
+import io.netty.util.internal.ObjectUtil;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
@@ -53,9 +54,17 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
 
     @Override
     public ChannelFuture register(Channel channel) {
-        return register(channel, new DefaultChannelPromise(channel, this));
+        return register(new DefaultChannelPromise(channel, this));
     }
 
+    @Override
+    public ChannelFuture register(final ChannelPromise promise) {
+        ObjectUtil.checkNotNull(promise, "promise");
+        promise.channel().unsafe().register(this, promise);
+        return promise;
+    }
+
+    @Deprecated
     @Override
     public ChannelFuture register(final Channel channel, final ChannelPromise promise) {
         if (channel == null) {

--- a/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
@@ -31,6 +31,21 @@ public class ThreadPerChannelEventLoop extends SingleThreadEventLoop {
     }
 
     @Override
+    public ChannelFuture register(ChannelPromise promise) {
+        return super.register(promise).addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) throws Exception {
+                if (future.isSuccess()) {
+                    ch = future.channel();
+                } else {
+                    deregister();
+                }
+            }
+        });
+    }
+
+    @Deprecated
+    @Override
     public ChannelFuture register(Channel channel, ChannelPromise promise) {
         return super.register(channel, promise).addListener(new ChannelFutureListener() {
             @Override

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedEventLoop.java
@@ -26,6 +26,7 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.AbstractScheduledEventExecutor;
 import io.netty.util.concurrent.Future;
+import io.netty.util.internal.ObjectUtil;
 
 import java.net.SocketAddress;
 import java.util.ArrayDeque;
@@ -126,9 +127,17 @@ final class EmbeddedEventLoop extends AbstractScheduledEventExecutor implements 
 
     @Override
     public ChannelFuture register(Channel channel) {
-        return register(channel, new DefaultChannelPromise(channel, this));
+        return register(new DefaultChannelPromise(channel, this));
     }
 
+    @Override
+    public ChannelFuture register(ChannelPromise promise) {
+        ObjectUtil.checkNotNull(promise, "promise");
+        promise.channel().unsafe().register(this, promise);
+        return promise;
+    }
+
+    @Deprecated
     @Override
     public ChannelFuture register(Channel channel, ChannelPromise promise) {
         channel.unsafe().register(this, promise);

--- a/transport/src/main/java/io/netty/channel/oio/OioEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/oio/OioEventLoopGroup.java
@@ -46,7 +46,7 @@ public class OioEventLoopGroup extends ThreadPerChannelEventLoopGroup {
      * @param maxChannels       the maximum number of channels to handle with this instance. Once you try to register
      *                          a new {@link Channel} and the maximum is exceed it will throw an
      *                          {@link ChannelException} on the {@link #register(Channel)} and
-     *                          {@link #register(Channel, ChannelPromise)} method.
+     *                          {@link #register(ChannelPromise)} method.
      *                          Use {@code 0} to use no limit
      */
     public OioEventLoopGroup(int maxChannels) {
@@ -59,7 +59,7 @@ public class OioEventLoopGroup extends ThreadPerChannelEventLoopGroup {
      * @param maxChannels       the maximum number of channels to handle with this instance. Once you try to register
      *                          a new {@link Channel} and the maximum is exceed it will throw an
      *                          {@link ChannelException} on the {@link #register(Channel)} and
-     *                          {@link #register(Channel, ChannelPromise)} method.
+     *                          {@link #register(ChannelPromise)} method.
      *                          Use {@code 0} to use no limit
      * @param executor     the {@link Executor} used to create new {@link Thread} instances that handle the
      *                          registered {@link Channel}s
@@ -74,7 +74,7 @@ public class OioEventLoopGroup extends ThreadPerChannelEventLoopGroup {
      * @param maxChannels       the maximum number of channels to handle with this instance. Once you try to register
      *                          a new {@link Channel} and the maximum is exceed it will throw an
      *                          {@link ChannelException} on the {@link #register(Channel)} and
-     *                          {@link #register(Channel, ChannelPromise)} method.
+     *                          {@link #register(ChannelPromise)} method.
      *                          Use {@code 0} to use no limit
      * @param threadFactory     the {@link ThreadFactory} used to create new {@link Thread} instances that handle the
      *                          registered {@link Channel}s

--- a/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
+++ b/transport/src/test/java/io/netty/bootstrap/BootstrapTest.java
@@ -276,6 +276,11 @@ public class BootstrapTest {
         }
 
         @Override
+        public ChannelFuture register(ChannelPromise promise) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public ChannelFuture register(Channel channel, final ChannelPromise promise) {
             throw new UnsupportedOperationException();
         }

--- a/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/SingleThreadEventLoopTest.java
@@ -381,7 +381,7 @@ public class SingleThreadEventLoopTest {
         }
 
         try {
-            ChannelFuture f = loopA.register(ch, promise);
+            ChannelFuture f = loopA.register(promise);
             f.awaitUninterruptibly();
             assertFalse(f.isSuccess());
             assertThat(f.cause(), is(instanceOf(RejectedExecutionException.class)));

--- a/transport/src/test/java/io/netty/channel/ThreadPerChannelEventLoopGroupTest.java
+++ b/transport/src/test/java/io/netty/channel/ThreadPerChannelEventLoopGroupTest.java
@@ -82,7 +82,7 @@ public class ThreadPerChannelEventLoopGroupTest {
         ChannelGroup channelGroup = new DefaultChannelGroup(testExecutor);
         while (taskCount-- > 0) {
             Channel channel = new EmbeddedChannel(NOOP_HANDLER);
-            loopGroup.register(channel, new DefaultChannelPromise(channel, testExecutor));
+            loopGroup.register(new DefaultChannelPromise(channel, testExecutor));
             channelGroup.add(channel);
         }
         channelGroup.close().sync();


### PR DESCRIPTION
Motivation:

EventLoopGroup.register doesn't need the Channel paramter when ChannelPromise is provided as we can get the Channel from ChannelPromise. Resolves #2422.

Modifications:

- Add EventLoopGroup.register(ChannelPromise)
- Deprecate EventLoopGroup.register(Channel, ChannelPromise)

Result:

EventLoopGroup.register is more convenient as people only need to set one parameter.