### PR TITLE
EpollDatagramChannel sendmmsg sends all datagram packets to the last packet in the list.

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -232,24 +232,24 @@ static jint netty_epoll_native_epollCtlDel0(JNIEnv* env, jclass clazz, jint efd,
 
 static jint netty_epoll_native_sendmmsg0(JNIEnv* env, jclass clazz, jint fd, jobjectArray packets, jint offset, jint len) {
     struct mmsghdr msg[len];
+    struct sockaddr_storage addr[len];
     int i;
 
     memset(msg, 0, sizeof(msg));
 
     for (i = 0; i < len; i++) {
-        struct sockaddr_storage addr;
 
         jobject packet = (*env)->GetObjectArrayElement(env, packets, i + offset);
         jbyteArray address = (jbyteArray) (*env)->GetObjectField(env, packet, packetAddrFieldId);
         jint scopeId = (*env)->GetIntField(env, packet, packetScopeIdFieldId);
         jint port = (*env)->GetIntField(env, packet, packetPortFieldId);
 
-        if (netty_unix_socket_initSockaddr(env, address, scopeId, port, &addr) == -1) {
+        if (netty_unix_socket_initSockaddr(env, address, scopeId, port, &addr[i]) == -1) {
             return -1;
         }
 
-        msg[i].msg_hdr.msg_name = &addr;
-        msg[i].msg_hdr.msg_namelen = sizeof(addr);
+        msg[i].msg_hdr.msg_name = &addr[i];
+        msg[i].msg_hdr.msg_namelen = sizeof(addr[i]);
 
         msg[i].msg_hdr.msg_iov = (struct iovec*) (intptr_t) (*env)->GetLongField(env, packet, packetMemoryAddressFieldId);
         msg[i].msg_hdr.msg_iovlen = (*env)->GetIntField(env, packet, packetCountFieldId);;


### PR DESCRIPTION
When the EpollDatagramChannel uses the sendmmsg call to send multiple datagram packets, the pointers used for all addresses in the msg_hdr.msg_name fields are aliased to a single memory address. This causes _all_ of the datagram packets passed to sendmmsg to be sent to the ip address of the _last_ datagram packet in the list. This pull request allocates an array of addresses on the stack so that each msg_hdr may have a distinct address.