### PR TITLE
Ensure ChannelHandlerContext.attr(...) and ChannelHandlerContext.hasA…

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -16,15 +16,15 @@
 package io.netty.channel;
 
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.util.Attribute;
-import io.netty.util.AttributeKey;
+import io.netty.util.DefaultAttributeMap;
 import io.netty.util.ResourceLeakHint;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.internal.StringUtil;
 
 import java.net.SocketAddress;
 
-abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, ResourceLeakHint {
+abstract class AbstractChannelHandlerContext extends DefaultAttributeMap
+        implements ChannelHandlerContext, ResourceLeakHint {
 
     volatile AbstractChannelHandlerContext next;
     volatile AbstractChannelHandlerContext prev;
@@ -85,16 +85,6 @@ abstract class AbstractChannelHandlerContext implements ChannelHandlerContext, R
     @Override
     public String name() {
         return name;
-    }
-
-    @Override
-    public <T> Attribute<T> attr(AttributeKey<T> key) {
-        return channel().attr(key);
-    }
-
-    @Override
-    public <T> boolean hasAttr(AttributeKey<T> key) {
-        return channel().hasAttr(key);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandlerContext.java
@@ -17,6 +17,7 @@ package io.netty.channel;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.AttributeMap;
 import io.netty.util.concurrent.EventExecutor;
@@ -493,5 +494,19 @@ public interface ChannelHandlerContext extends AttributeMap {
      * <strong>Be aware this is an expert feature and should be used with care!</strong>
      */
     ChannelPromise voidPromise();
+
+    /**
+     * @deprecated Use {@link Channel#attr(AttributeKey)}
+     */
+    @Deprecated
+    @Override
+    <T> Attribute<T> attr(AttributeKey<T> key);
+
+    /**
+     * @deprecated Use {@link Channel#hasAttr(AttributeKey)}
+     */
+    @Deprecated
+    @Override
+    <T> boolean hasAttr(AttributeKey<T> key);
 
 }


### PR DESCRIPTION
…ttr(...) has no semantic change

Motivation:

The ChannelHandlerContext.attr(...) and ChannelHandlerContext.hasAttr(...) delegated to Channel for the attributes which is a semantic change compared to 4.0 releases. We should not change the semantic to not break users applications when upgrading to 4.1.0

Modifications:

- Revert semantic change
- Mark ChannelHandlerContext.attr(...) and hasAttr(...) as @deprecated so we can remove these later

Result:

Semantic of attribute operations on ChannelHandlerContext is the same in 4.1 as in 4.0 again.