### PR TITLE
Only try to bind if late registration not failed.

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -304,8 +304,9 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
                         // Registration was successful, so set the correct executor to use.
                         // See https://github.com/netty/netty/issues/2586
                         promise.executor = channel.eventLoop();
+
+                        doBind0(regFuture, channel, localAddress, promise);
                     }
-                    doBind0(regFuture, channel, localAddress, promise);
                 }
             });
             return promise;


### PR DESCRIPTION
Motivation:

We should not try to call bind if registration failed.

Modifications:

Only call doBind0(...) when the registration not failed.

Result:

Not try to to bind if the registration failed.