### PR TITLE
Ensure Bootstrap.connect(...) not throw IllegalStateException when re…

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -303,7 +303,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
                     } else {
                         // Registration was successful, so set the correct executor to use.
                         // See https://github.com/netty/netty/issues/2586
-                        promise.executor = channel.eventLoop();
+                        promise.registered();
                     }
                     doBind0(regFuture, channel, localAddress, promise);
                 }
@@ -451,23 +451,27 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
         return buf.toString();
     }
 
-    private static final class PendingRegistrationPromise extends DefaultChannelPromise {
+    static final class PendingRegistrationPromise extends DefaultChannelPromise {
+
         // Is set to the correct EventExecutor once the registration was successful. Otherwise it will
         // stay null and so the GlobalEventExecutor.INSTANCE will be used for notifications.
-        private volatile EventExecutor executor;
+        private volatile boolean registered;
 
-        private PendingRegistrationPromise(Channel channel) {
+        PendingRegistrationPromise(Channel channel) {
             super(channel);
+        }
+
+        void registered() {
+            registered = true;
         }
 
         @Override
         protected EventExecutor executor() {
-            EventExecutor executor = this.executor;
-            if (executor != null) {
+            if (registered) {
                 // If the registration was a success executor is set.
                 //
                 // See https://github.com/netty/netty/issues/2586
-                return executor;
+                return super.executor();
             }
             // The registration failed so we can only use the GlobalEventExecutor as last resort to notify.
             return GlobalEventExecutor.INSTANCE;


### PR DESCRIPTION
…gistration is delayed.

Motivation:

Bootstrap.connect(...) tries to obtain the EventLoop of a Channel before it may be registered. This will cause an IllegalStateException. We need to ensure we handle the cause of late registration and not throw in this case.

Modifications:

Ensure we only try to access the EventLoop after the Channel is registered and handle the case of late registration.

Result:

Bootstrap.connect(...) not fails on late registration.