### PR TITLE
Use ConnectException when connection failed for LocalChannel

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -34,6 +34,7 @@ import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.OneTimeTask;
 import io.netty.util.internal.PlatformDependent;
 
+import java.net.ConnectException;
 import java.net.SocketAddress;
 import java.nio.channels.AlreadyConnectedException;
 import java.nio.channels.ClosedChannelException;
@@ -481,7 +482,7 @@ public class LocalChannel extends AbstractChannel {
 
             Channel boundChannel = LocalChannelRegistry.get(remoteAddress);
             if (!(boundChannel instanceof LocalServerChannel)) {
-                Exception cause = new ChannelException("connection refused");
+                Exception cause = new ConnectException("connection refused: " + remoteAddress);
                 safeSetFailure(promise, cause);
                 close(voidPromise());
                 return;

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -42,6 +42,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.net.ConnectException;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -861,6 +862,15 @@ public class LocalChannelTest {
             closeChannel(cc);
             closeChannel(sc);
         }
+    }
+
+    @Test(expected = ConnectException.class)
+    public void testConnectionRefused() {
+        Bootstrap sb = new Bootstrap();
+        sb.group(group1)
+        .channel(LocalChannel.class)
+        .handler(new TestHandler())
+        .connect(LocalAddress.ANY).syncUninterruptibly();
     }
 
     private static final class LatchChannelFutureListener extends CountDownLatch implements ChannelFutureListener {


### PR DESCRIPTION
Motivation:

To be more consistent we should use ConnectException when we fail the connect attempt because no LocalServerChannel exists with the given address.

Modifications:

Use correct exception.

Result:

More consistent handling of connection refused between different transports.