### PR TITLE
[#4906] Ensure addLast(...) works as expected in EmbeddedChannel

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -21,6 +21,7 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.OneTimeTask;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -54,12 +55,14 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
     private final Channel parent;
     private final ChannelId id;
-    private final Unsafe unsafe;
     private final DefaultChannelPipeline pipeline;
     private final ChannelFuture succeededFuture = new SucceededChannelFuture(this, null);
     private final VoidChannelPromise voidPromise = new VoidChannelPromise(this, true);
     private final VoidChannelPromise unsafeVoidPromise = new VoidChannelPromise(this, false);
     private final CloseFuture closeFuture = new CloseFuture(this);
+
+    // Package private as we access it from DefaultChannelPipeline.
+    final AbstractUnsafe unsafe;
 
     private volatile SocketAddress localAddress;
     private volatile SocketAddress remoteAddress;
@@ -965,6 +968,37 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
          */
         protected Executor prepareToClose() {
             return null;
+        }
+
+        /**
+         * Called once a {@link Throwable} hit the end of the {@link ChannelPipeline} without been handled by the user
+         * in {@link ChannelHandler#exceptionCaught(ChannelHandlerContext, Throwable)}.
+         */
+        @UnstableApi
+        protected void unhandledInboundException(Throwable cause) throws Exception {
+            try {
+                logger.warn(
+                        "An exceptionCaught() event was fired, and it reached at the tail of the pipeline. " +
+                                "It usually means the last handler in the pipeline did not handle the exception.",
+                        cause);
+            } finally {
+                ReferenceCountUtil.release(cause);
+            }
+        }
+
+        /**
+         * Called once a message hit the end of the {@link ChannelPipeline} without been handled by the user
+         * in {@link ChannelInboundHandler#channelRead(ChannelHandlerContext, Object)}.
+         */
+        @UnstableApi
+        protected void unhandledInboundMessage(Object msg) throws Exception {
+            try {
+                logger.debug(
+                        "Discarded inbound message {} that reached at the tail of the pipeline. " +
+                                "Please check your pipeline configuration.", msg);
+            } finally {
+                ReferenceCountUtil.release(msg);
+            }
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -1299,9 +1299,10 @@ final class DefaultChannelPipeline implements ChannelPipeline {
     static final class TailContext extends AbstractChannelHandlerContext implements ChannelInboundHandler {
 
         private static final String TAIL_NAME = generateName0(TailContext.class);
-
+        private final AbstractChannel.AbstractUnsafe unsafe;
         TailContext(DefaultChannelPipeline pipeline) {
             super(pipeline, null, TAIL_NAME, true, false);
+            unsafe = pipeline.channel.unsafe;
         }
 
         @Override
@@ -1339,25 +1340,12 @@ final class DefaultChannelPipeline implements ChannelPipeline {
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-            try {
-                logger.warn(
-                        "An exceptionCaught() event was fired, and it reached at the tail of the pipeline. " +
-                                "It usually means the last handler in the pipeline did not handle the exception.",
-                                cause);
-            } finally {
-                ReferenceCountUtil.release(cause);
-            }
+            unsafe.unhandledInboundException(cause);
         }
 
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-            try {
-                logger.debug(
-                        "Discarded inbound message {} that reached at the tail of the pipeline. " +
-                                "Please check your pipeline configuration.", msg);
-            } finally {
-                ReferenceCountUtil.release(msg);
-            }
+            unsafe.unhandledInboundMessage(msg);
         }
 
         @Override

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -21,9 +21,7 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelId;
-import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
@@ -154,7 +152,6 @@ public class EmbeddedChannel extends AbstractChannel {
 
         ChannelFuture future = loop.register(this);
         assert future.isDone();
-        p.addLast(new LastInboundHandler());
     }
 
     @Override
@@ -541,21 +538,19 @@ public class EmbeddedChannel extends AbstractChannel {
         }
     }
 
-    private class DefaultUnsafe extends AbstractUnsafe {
+    private final class DefaultUnsafe extends AbstractUnsafe {
         @Override
         public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
             safeSetSuccess(promise);
         }
-    }
 
-    private final class LastInboundHandler extends ChannelInboundHandlerAdapter {
         @Override
-        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        protected void unhandledInboundMessage(Object msg) throws Exception {
             inboundMessages().add(msg);
         }
 
         @Override
-        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        protected void unhandledInboundException(Throwable cause) throws Exception {
             recordException(cause);
         }
     }

--- a/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
@@ -197,9 +197,14 @@ public class PendingWriteQueueTest {
         assertNull(channel.readOutbound());
     }
 
+    private static EmbeddedChannel newChannel() {
+        // Add a handler so we can access a ChannelHandlerContext via the ChannelPipeline.
+        return new EmbeddedChannel(new ChannelHandlerAdapter() { });
+    }
+
     @Test
     public void testRemoveAndFailAllReentrantFailAll() {
-        EmbeddedChannel channel = new EmbeddedChannel();
+        EmbeddedChannel channel = newChannel();
         final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
 
         ChannelPromise promise = channel.newPromise();
@@ -224,7 +229,7 @@ public class PendingWriteQueueTest {
     @Test
     public void testRemoveAndFailAllReentrantWrite() {
         final List<Integer> failOrder = Collections.synchronizedList(new ArrayList<Integer>());
-        EmbeddedChannel channel = new EmbeddedChannel();
+        EmbeddedChannel channel = newChannel();
         final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
 
         ChannelPromise promise = channel.newPromise();
@@ -267,7 +272,7 @@ public class PendingWriteQueueTest {
 
     @Test
     public void testRemoveAndWriteAllReentrance() {
-        EmbeddedChannel channel = new EmbeddedChannel();
+        EmbeddedChannel channel = newChannel();
         final PendingWriteQueue queue = new PendingWriteQueue(channel.pipeline().firstContext());
 
         ChannelPromise promise = channel.newPromise();


### PR DESCRIPTION
Motivation:

If the user will use addLast(...) on the ChannelPipeline of EmbeddedChannel after its constructor was run it will break the EmbeddedChannel as it will not be able to collect inbound messages and exceptions.

Modifications:

Ensure addLast(...) work as expected by move the logic of handling messages and exceptions that hit the end of the pipeline to AbstractUnsafe and override the default behavior in EmbeddedChannel.DefaultUnsafe.

Result:

addLast(...) works as expected when using EmbeddedChannel.