### PR TITLE
[#5223] Remove indirection in DefaultChannelPipeline.executorSafe(...)

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -1286,7 +1286,7 @@ final class DefaultChannelPipeline implements ChannelPipeline {
             // We check for channel().isRegistered and handlerAdded because even if isRegistered() is false we
             // can safely access the invoker() if handlerAdded is true. This is because in this case the Channel
             // was previously registered and so we can still access the old EventLoop to dispatch things.
-            return channel.isRegistered() || registered ? channel.unsafe().invoker().executor() : null;
+            return channel.isRegistered() || registered ? channel.eventLoop() : null;
         }
         return invoker.executor();
     }


### PR DESCRIPTION
Motivation:

We use channel.unsafe().invoker().executor() in DefaultChannelPipeline.executorSafe(...) which is an unnecessary indirection to channel.eventLoop().

Modifications:

Remove indirection by using channel.eventLoop().

Result:

Cleaner code.