### PR TITLE
[#3127] Allow to write with VoidPromise to Channels in ChannelGroup

### DIFF
--- a/transport/src/main/java/io/netty/channel/group/ChannelGroup.java
+++ b/transport/src/main/java/io/netty/channel/group/ChannelGroup.java
@@ -133,6 +133,22 @@ public interface ChannelGroup extends Set<Channel>, Comparable<ChannelGroup> {
     ChannelGroupFuture write(Object message, ChannelMatcher matcher);
 
     /**
+     * Writes the specified {@code message} to all {@link Channel}s in this
+     * group that match the given {@link ChannelMatcher}. If the specified {@code message} is an instance of
+     * {@link ByteBuf}, it is automatically
+     * {@linkplain ByteBuf#duplicate() duplicated} to avoid a race
+     * condition. The same is true for {@link ByteBufHolder}. Please note that this operation is asynchronous as
+     * {@link Channel#write(Object)} is.
+     *
+     * If {@code voidPromise} is {@code true} {@link Channel#voidPromise()} is used for the writes and so the same
+     * restrictions to the returned {@link ChannelGroupFuture} apply as to a void promise.
+     *
+     * @return the {@link ChannelGroupFuture} instance that notifies when
+     *         the operation is done for all channels
+     */
+    ChannelGroupFuture write(Object message, ChannelMatcher matcher, boolean voidPromise);
+
+    /**
      * Flush all {@link Channel}s in this
      * group. If the specified {@code messages} are an instance of
      * {@link ByteBuf}, it is automatically
@@ -174,6 +190,12 @@ public interface ChannelGroup extends Set<Channel>, Comparable<ChannelGroup> {
      * {@link Channel}s that match the {@link ChannelMatcher}.
      */
     ChannelGroupFuture writeAndFlush(Object message, ChannelMatcher matcher);
+
+    /**
+     * Shortcut for calling {@link #write(Object, ChannelMatcher, boolean)} and {@link #flush()} and only act on
+     * {@link Channel}s that match the {@link ChannelMatcher}.
+     */
+    ChannelGroupFuture writeAndFlush(Object message, ChannelMatcher matcher, boolean voidPromise);
 
     /**
      * @deprecated Use {@link #writeAndFlush(Object, ChannelMatcher)} instead.

--- a/transport/src/main/java/io/netty/channel/group/VoidChannelGroupFuture.java
+++ b/transport/src/main/java/io/netty/channel/group/VoidChannelGroupFuture.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.group;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+
+final class VoidChannelGroupFuture implements ChannelGroupFuture {
+
+    private static final Iterator<ChannelFuture> EMPTY = Collections.<ChannelFuture>emptyList().iterator();
+    private final ChannelGroup group;
+
+    VoidChannelGroupFuture(ChannelGroup group) {
+        this.group = group;
+    }
+
+    @Override
+    public ChannelGroup group() {
+        return group;
+    }
+
+    @Override
+    public ChannelFuture find(Channel channel) {
+        return null;
+    }
+
+    @Override
+    public boolean isSuccess() {
+        return false;
+    }
+
+    @Override
+    public ChannelGroupException cause() {
+        return null;
+    }
+
+    @Override
+    public boolean isPartialSuccess() {
+        return false;
+    }
+
+    @Override
+    public boolean isPartialFailure() {
+        return false;
+    }
+
+    @Override
+    public ChannelGroupFuture addListener(GenericFutureListener<? extends Future<? super Void>> listener) {
+        throw reject();
+    }
+
+    @Override
+    public ChannelGroupFuture addListeners(GenericFutureListener<? extends Future<? super Void>>... listeners) {
+        throw reject();
+    }
+
+    @Override
+    public ChannelGroupFuture removeListener(GenericFutureListener<? extends Future<? super Void>> listener) {
+        throw reject();
+    }
+
+    @Override
+    public ChannelGroupFuture removeListeners(GenericFutureListener<? extends Future<? super Void>>... listeners) {
+        throw reject();
+    }
+
+    @Override
+    public ChannelGroupFuture await() {
+        throw reject();
+    }
+
+    @Override
+    public ChannelGroupFuture awaitUninterruptibly() {
+        throw reject();
+    }
+
+    @Override
+    public ChannelGroupFuture syncUninterruptibly() {
+        throw reject();
+    }
+
+    @Override
+    public ChannelGroupFuture sync() {
+        throw reject();
+    }
+
+    @Override
+    public Iterator<ChannelFuture> iterator() {
+        return EMPTY;
+    }
+
+    @Override
+    public boolean isCancellable() {
+        return false;
+    }
+
+    @Override
+    public boolean await(long timeout, TimeUnit unit) {
+        throw reject();
+    }
+
+    @Override
+    public boolean await(long timeoutMillis) {
+        throw reject();
+    }
+
+    @Override
+    public boolean awaitUninterruptibly(long timeout, TimeUnit unit) {
+        throw reject();
+    }
+
+    @Override
+    public boolean awaitUninterruptibly(long timeoutMillis) {
+        throw reject();
+    }
+
+    @Override
+    public Void getNow() {
+        return null;
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return false;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return false;
+    }
+
+    @Override
+    public boolean isDone() {
+        return false;
+    }
+
+    @Override
+    public Void get() {
+        throw reject();
+    }
+
+    @Override
+    public Void get(long timeout, TimeUnit unit)  {
+        throw reject();
+    }
+
+    private static RuntimeException reject() {
+        return new IllegalStateException("void future");
+    }
+}


### PR DESCRIPTION
Motivation:

Users sometimes want to use Channel.voidPromise() when write to a Channel to reduce GC-pressure. This should be also possible when write via a ChannelGroup.

Modifications:

Add new write(...) and writeAndFlush(...) overloads which allow to signale that a VoidPromise should be used to write to the Channel

Result:

Users can write with VoidPromise when using ChannelGroup