### PR TITLE
Remove EventExecutor.children

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -19,8 +19,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.Callable;
 import java.util.concurrent.RunnableFuture;
@@ -35,7 +33,7 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
     static final long DEFAULT_SHUTDOWN_TIMEOUT = 15;
 
     private final EventExecutorGroup parent;
-    private final Collection<AbstractEventExecutor> selfCollection = Collections.singleton(this);
+    private final Collection<EventExecutor> selfCollection = Collections.<EventExecutor>singleton(this);
 
     protected AbstractEventExecutor() {
         this(null);
@@ -62,12 +60,7 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
 
     @Override
     public Iterator<EventExecutor> iterator() {
-        return new EventExecutorIterator();
-    }
-
-    @Override
-    public <E extends EventExecutor> Set<E> children() {
-        return (Set<E>) selfCollection;
+        return selfCollection.iterator();
     }
 
     @Override
@@ -156,28 +149,5 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
     @Override
     public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
         throw new UnsupportedOperationException();
-    }
-
-    private final class EventExecutorIterator implements Iterator<EventExecutor> {
-        private boolean nextCalled;
-
-        @Override
-        public boolean hasNext() {
-            return !nextCalled;
-        }
-
-        @Override
-        public EventExecutor next() {
-            if (!hasNext()) {
-                throw new NoSuchElementException();
-            }
-            nextCalled = true;
-            return AbstractEventExecutor.this;
-        }
-
-        @Override
-        public void remove() {
-            throw new UnsupportedOperationException("read-only");
-        }
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutor.java
@@ -33,12 +33,6 @@ public interface EventExecutor extends EventExecutorGroup {
     EventExecutor next();
 
     /**
-     * Returns an unmodifiable singleton set which contains itself.
-     */
-    @Override
-    <E extends EventExecutor> Set<E> children();
-
-    /**
      * Return the {@link EventExecutorGroup} which is the parent of this {@link EventExecutor},
      */
     EventExecutorGroup parent();

--- a/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/EventExecutorGroup.java
@@ -84,17 +84,8 @@ public interface EventExecutorGroup extends ScheduledExecutorService, Iterable<E
      */
     EventExecutor next();
 
-    /**
-     * @deprecated Use {@link #children()} instead.
-     */
     @Override
-    @Deprecated
     Iterator<EventExecutor> iterator();
-
-    /**
-     * Returns the unmodifiable set of {@link EventExecutor}s managed by this {@link EventExecutorGroup}.
-     */
-    <E extends EventExecutor> Set<E> children();
 
     @Override
     Future<?> submit(Runnable task);

--- a/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/MultithreadEventExecutorGroup.java
@@ -130,7 +130,7 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
 
     @Override
     public Iterator<EventExecutor> iterator() {
-        return children().iterator();
+        return readonlyChildren.iterator();
     }
 
     /**
@@ -139,12 +139,6 @@ public abstract class MultithreadEventExecutorGroup extends AbstractEventExecuto
      */
     public final int executorCount() {
         return children.length;
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public final <E extends EventExecutor> Set<E> children() {
-        return (Set<E>) readonlyChildren;
     }
 
     /**

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -106,7 +106,7 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
      * {@code 50}, which means the event loop will try to spend the same amount of time for I/O as for non-I/O tasks.
      */
     public void setIoRatio(int ioRatio) {
-        for (EventExecutor e: children()) {
+        for (EventExecutor e: this) {
             ((EpollEventLoop) e).setIoRatio(ioRatio);
         }
     }

--- a/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoopGroup.java
@@ -49,7 +49,6 @@ public class ThreadPerChannelEventLoopGroup extends AbstractEventExecutorGroup i
     final Executor executor;
     final Set<EventLoop> activeChildren =
             Collections.newSetFromMap(PlatformDependent.<EventLoop, Boolean>newConcurrentHashMap());
-    private final Set<EventLoop> readOnlyActiveChildren = Collections.unmodifiableSet(activeChildren);
     final Queue<EventLoop> idleChildren = new ConcurrentLinkedQueue<EventLoop>();
     private final ChannelException tooManyChannels;
 
@@ -145,12 +144,6 @@ public class ThreadPerChannelEventLoopGroup extends AbstractEventExecutorGroup i
     @Override
     public Iterator<EventExecutor> iterator() {
         return new ReadOnlyIterator<EventExecutor>(activeChildren.iterator());
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <E extends EventExecutor> Set<E> children() {
-        return (Set<E>) readOnlyActiveChildren;
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
@@ -89,7 +89,7 @@ public class NioEventLoopGroup extends MultithreadEventLoopGroup {
      * {@code 50}, which means the event loop will try to spend the same amount of time for I/O as for non-I/O tasks.
      */
     public void setIoRatio(int ioRatio) {
-        for (EventExecutor e: children()) {
+        for (EventExecutor e: this) {
             ((NioEventLoop) e).setIoRatio(ioRatio);
         }
     }
@@ -99,7 +99,7 @@ public class NioEventLoopGroup extends MultithreadEventLoopGroup {
      * around the  infamous epoll 100% CPU bug.
      */
     public void rebuildSelectors() {
-        for (EventExecutor e: children()) {
+        for (EventExecutor e: this) {
             ((NioEventLoop) e).rebuildSelector();
         }
     }


### PR DESCRIPTION
Motivation:
EventExecutor.children uses generics in such a way that an entire colleciton must be cast to a specific type of object. This interface is not very flexible and is impossible to implement if the EventExecutor type must be wrapped. The current usage of this method also does not have any clear need within Netty. The Iterator interface allows for EventExecutor to be wrapped and forces the caller to make assumptions about types instead of building the assumptions into the interface.

Motivation:
- Remove EventExecutor.children and undeprecate the iterator() interface

Result:
EventExecutor interface has one less method and is easier to wrap.