### PR TITLE
HTTP/2 HPACK Header Name Validation and Trailing Padding

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -53,6 +53,9 @@ public class DefaultHttpHeaders extends HttpHeaders {
     static final NameValidator<CharSequence> HttpNameValidator = new NameValidator<CharSequence>() {
         @Override
         public void validateName(CharSequence name) {
+            if (name == null || name.length() == 0) {
+                throw new IllegalArgumentException("empty headers are not allowed [" + name + "]");
+            }
             if (name instanceof AsciiString) {
                 try {
                     ((AsciiString) name).forEachByte(HEADER_NAME_VALIDATOR);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
@@ -36,6 +36,16 @@ import static org.junit.Assert.assertTrue;
 public class DefaultHttpHeadersTest {
     private static final CharSequence HEADER_NAME = "testHeader";
 
+    @Test(expected = IllegalArgumentException.class)
+    public void nullHeaderNameNotAllowed() {
+        new DefaultHttpHeaders().add(null, "foo");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void emtpyHeaderNameNotAllowed() {
+        new DefaultHttpHeaders().add("", "foo");
+    }
+
     @Test
     public void keysShouldBeCaseInsensitive() {
         DefaultHttpHeaders headers = new DefaultHttpHeaders();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -37,6 +37,10 @@ public class DefaultHttp2Headers
     private static final NameValidator<CharSequence> HTTP2_NAME_VALIDATOR = new NameValidator<CharSequence>() {
         @Override
         public void validateName(CharSequence name) {
+            if (name == null || name.length() == 0) {
+                PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
+                        "empty headers are not allowed [%s]", name));
+            }
             if (name instanceof AsciiString) {
                 final int index;
                 try {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/HeaderField.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/HeaderField.java
@@ -31,8 +31,8 @@
  */
 package io.netty.handler.codec.http2.internal.hpack;
 
-import static io.netty.handler.codec.http2.internal.hpack.HpackUtil.ISO_8859_1;
-import static io.netty.handler.codec.http2.internal.hpack.HpackUtil.requireNonNull;
+import static io.netty.util.CharsetUtil.ISO_8859_1;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 class HeaderField implements Comparable<HeaderField> {
 
@@ -54,8 +54,8 @@ class HeaderField implements Comparable<HeaderField> {
     }
 
     HeaderField(byte[] name, byte[] value) {
-        this.name = requireNonNull(name);
-        this.value = requireNonNull(value);
+        this.name = checkNotNull(name, "name");
+        this.value = checkNotNull(value, "value");
     }
 
     int size() {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/HpackUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/HpackUtil.java
@@ -34,9 +34,6 @@ package io.netty.handler.codec.http2.internal.hpack;
 import java.nio.charset.Charset;
 
 final class HpackUtil {
-
-    static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
-
     /**
      * A string compare that doesn't leak timing information.
      */
@@ -49,16 +46,6 @@ final class HpackUtil {
             c |= s1[i] ^ s2[i];
         }
         return c == 0;
-    }
-
-    /**
-     * Checks that the specified object reference is not {@code null}.
-     */
-    static <T> T requireNonNull(T obj) {
-        if (obj == null) {
-            throw new NullPointerException();
-        }
-        return obj;
     }
 
     // Section 6.2. Literal Header Field Representation

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/StaticTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/StaticTable.java
@@ -36,6 +36,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.netty.util.CharsetUtil.ISO_8859_1;
+
 final class StaticTable {
 
     private static final String EMPTY = "";
@@ -125,7 +127,7 @@ final class StaticTable {
      * -1 if the header field name is not in the static table.
      */
     static int getIndex(byte[] name) {
-        String nameString = new String(name, 0, name.length, HpackUtil.ISO_8859_1);
+        String nameString = new String(name, 0, name.length, ISO_8859_1);
         Integer index = STATIC_INDEX_BY_NAME.get(nameString);
         if (index == null) {
             return -1;
@@ -166,7 +168,7 @@ final class StaticTable {
         // save the smallest index for a given name in the map.
         for (int index = length; index > 0; index--) {
             HeaderField entry = getEntry(index);
-            String name = new String(entry.name, 0, entry.name.length, HpackUtil.ISO_8859_1);
+            String name = new String(entry.name, 0, entry.name.length, ISO_8859_1);
             ret.put(name, index);
         }
         return ret;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -30,6 +30,16 @@ import static org.junit.Assert.fail;
 
 public class DefaultHttp2HeadersTest {
 
+    @Test(expected = Http2Exception.class)
+    public void nullHeaderNameNotAllowed() {
+        new DefaultHttp2Headers().add(null, "foo");
+    }
+
+    @Test(expected = Http2Exception.class)
+    public void emtpyHeaderNameNotAllowed() {
+        new DefaultHttp2Headers().add("", "foo");
+    }
+
     @Test
     public void testPseudoHeadersMustComeFirstWhenIterating() {
         Http2Headers headers = newHeaders();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/internal/hpack/HuffmanTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/internal/hpack/HuffmanTest.java
@@ -72,7 +72,7 @@ public class HuffmanTest {
         Huffman.DECODER.decode(buf);
     }
 
-    @Test//(expected = IOException.class) TODO(jpinner) fix me
+    @Test(expected = IOException.class)
     public void testDecodeExtraPadding() throws IOException {
         byte[] buf = new byte[2];
         buf[0] = 0x0F; // '1', 'EOS'


### PR DESCRIPTION
Motivation:
The HPACK code currently disallows empty header names. This is not explicitly forbidden by the HPACK RFC https://tools.ietf.org/html/rfc7541. However the HTTP/1.x RFC https://tools.ietf.org/html/rfc7230#section-3.2 and thus HTTP/2 both disallow empty header names, and so this precondition check should be moved from the HPACK code to the protocol level.
HPACK also requires that string literals which are huffman encoded must be treated as an encoding error if the string has more than 7 trailing padding bits https://tools.ietf.org/html/rfc7541#section-5.2, but this is currently not enforced.

Result:
- HPACK to allow empty header names
- HTTP/1.x and HTTP/2 header validation should not allow empty header names
- Enforce max of 7 trailing padding bits

Result:
Code is more compliant with the above mentioned RFCs
Fixes netty#5228