### PR TITLE
KObjectHashMap probeNext improvement

### DIFF
--- a/common/src/main/templates/io/netty/util/collection/KObjectHashMap.template
+++ b/common/src/main/templates/io/netty/util/collection/KObjectHashMap.template
@@ -145,10 +145,6 @@ public class @K@ObjectHashMap<V> implements @K@ObjectMap<V> {
         }
     }
 
-    private int probeNext(int index) {
-        return index == values.length - 1 ? 0 : index + 1;
-    }
-
     @Override
     public void putAll(Map<? extends @O@, ? extends V> sourceMap) {
         if (sourceMap instanceof @K@ObjectHashMap) {
@@ -367,6 +363,7 @@ public class @K@ObjectHashMap<V> implements @K@ObjectMap<V> {
      * Returns the hashed index for the given key.
      */
     private int hashIndex(@k@ key) {
+        // The array lengths are always a power of two, so we can use a bitmask to stay inside the array bounds.
         return hashCode(key) & mask;
     }
 
@@ -375,6 +372,14 @@ public class @K@ObjectHashMap<V> implements @K@ObjectMap<V> {
      */
     private static int hashCode(@k@ key) {
        return @HASH_CODE@;
+    }
+
+    /**
+     * Get the next sequential index after {@code index} and wraps if necessary.
+     */
+    private int probeNext(int index) {
+        // The array lengths are always a power of two, so we can use a bitmask to stay inside the array bounds.
+        return (index + 1) & mask;
     }
 
     /**

--- a/microbench/src/main/java/io/netty/microbenchmark/common/MathOperationsBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbenchmark/common/MathOperationsBenchmark.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.microbenchmark.common;
+
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
+
+public class MathOperationsBenchmark extends AbstractMicrobenchmark {
+    private int index;
+    private final int length = 1 << 20;
+    private final int mask = length - 1;
+
+    @Benchmark
+    public int nextIndexNoConditionals() {
+        return (index + 1) & mask;
+    }
+
+    @Benchmark
+    public int nextIndexConditionals() {
+        return index == length - 1 ? 0 : index + 1;
+    }
+}


### PR DESCRIPTION
Motivation:
KObjectHashMap.probeNext(..) usually involves 2 conditional statements and 2 aritmatic operations. This can be improved to have 0 conditional statements.

Modifications:
- Use bit masking to avoid conditional statements

Result:
Improved performance for KObjecthashMap.probeNext(..)