### PR TITLE
Add DomainNameMapping.entries to allow retrieving the domain match lists

### DIFF
--- a/common/src/main/java/io/netty/util/DomainMappingBuilder.java
+++ b/common/src/main/java/io/netty/util/DomainMappingBuilder.java
@@ -16,6 +16,8 @@
 
 package io.netty.util;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -135,6 +137,16 @@ public final class DomainMappingBuilder<V> {
             }
 
             return defaultValue;
+        }
+
+        @Override
+        public Set<Map.Entry<String, V>> entries() {
+            int length = domainNamePatterns.length;
+            Map<String, V> map = new HashMap<String, V>(length);
+            for (int index = 0; index < length; ++index) {
+                map.put(domainNamePatterns[index], values[index]);
+            }
+            return Collections.unmodifiableSet(map.entrySet());
         }
 
         @Override

--- a/common/src/main/java/io/netty/util/DomainNameMapping.java
+++ b/common/src/main/java/io/netty/util/DomainNameMapping.java
@@ -19,9 +19,11 @@ package io.netty.util;
 import io.netty.util.internal.StringUtil;
 
 import java.net.IDN;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.StringUtil.commonSuffixOfLength;
@@ -130,6 +132,13 @@ public class DomainNameMapping<V> implements Mapping<String, V> {
             }
         }
         return defaultValue;
+    }
+
+    /**
+     * Returns a read-only {@link Set} of the domain mapping patterns and their associated value objects.
+     */
+    public Set<Map.Entry<String, V>> entries() {
+        return Collections.unmodifiableSet(map.entrySet());
     }
 
     @Override

--- a/common/src/test/java/io/netty/util/DomainNameMappingTest.java
+++ b/common/src/test/java/io/netty/util/DomainNameMappingTest.java
@@ -16,6 +16,9 @@
 
 package io.netty.util;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -180,5 +183,38 @@ public class DomainNameMappingTest {
         assertEquals(
             "ImmutableDomainNameMapping(default: NotFound, map: {*.netty.io=Netty, downloads.netty.io=Netty-Download})",
             mapping.toString());
+    }
+
+    @Test
+    public void testEntries() {
+        DomainNameMapping<String> mapping = new DomainNameMapping<String>("NotFound")
+            .add("netty.io", "Netty")
+            .add("downloads.netty.io", "Netty-Downloads");
+
+        Map<String, String> entries = new HashMap<String, String>();
+        for (Map.Entry<String, String> entry: mapping.entries()) {
+            entries.put(entry.getKey(), entry.getValue());
+        }
+
+        assertEquals(2, entries.size());
+        assertEquals("Netty", entries.get("netty.io"));
+        assertEquals("Netty-Downloads", entries.get("downloads.netty.io"));
+    }
+
+    @Test
+    public void testEntriesWithImmutableDomainNameMapping() {
+        DomainNameMapping<String> mapping = new DomainMappingBuilder<String>("NotFound")
+            .add("netty.io", "Netty")
+            .add("downloads.netty.io", "Netty-Downloads")
+            .build();
+
+        Map<String, String> entries = new HashMap<String, String>();
+        for (Map.Entry<String, String> entry: mapping.entries()) {
+            entries.put(entry.getKey(), entry.getValue());
+        }
+
+        assertEquals(2, entries.size());
+        assertEquals("Netty", entries.get("netty.io"));
+        assertEquals("Netty-Downloads", entries.get("downloads.netty.io"));
     }
 }


### PR DESCRIPTION
Motivation:

See #4200.

Modifications:

Add DomainNameMapping.entries to allow retrieving the domain match lists.

Result:

People can use DomainNameMapping.entries to retrive the match list in DomainNameMapping.