### PR TITLE
HTTP/2 HPACK Header Name Validation and Trailing Padding

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -53,6 +53,9 @@ public class DefaultHttpHeaders extends HttpHeaders {
     static final NameValidator<CharSequence> HttpNameValidator = new NameValidator<CharSequence>() {
         @Override
         public void validateName(CharSequence name) {
+            if (name == null || name.length() == 0) {
+                throw new IllegalArgumentException("empty headers are not allowed [" + name + "]");
+            }
             if (name instanceof AsciiString) {
                 try {
                     ((AsciiString) name).forEachByte(HEADER_NAME_VALIDATOR);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpHeadersTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http;
 
 import io.netty.handler.codec.http.HttpHeadersTestUtils.HeaderValue;
 import io.netty.util.AsciiString;
+import io.netty.util.internal.StringUtil;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -35,6 +36,16 @@ import static org.junit.Assert.assertTrue;
 
 public class DefaultHttpHeadersTest {
     private static final CharSequence HEADER_NAME = "testHeader";
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullHeaderNameNotAllowed() {
+        new DefaultHttpHeaders().add(null, "foo");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void emtpyHeaderNameNotAllowed() {
+        new DefaultHttpHeaders().add(StringUtil.EMPTY_STRING, "foo");
+    }
 
     @Test
     public void keysShouldBeCaseInsensitive() {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -37,6 +37,10 @@ public class DefaultHttp2Headers
     private static final NameValidator<CharSequence> HTTP2_NAME_VALIDATOR = new NameValidator<CharSequence>() {
         @Override
         public void validateName(CharSequence name) {
+            if (name == null || name.length() == 0) {
+                PlatformDependent.throwException(connectionError(PROTOCOL_ERROR,
+                        "empty headers are not allowed [%s]", name));
+            }
             if (name instanceof AsciiString) {
                 final int index;
                 try {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/HeaderField.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/HeaderField.java
@@ -31,8 +31,8 @@
  */
 package io.netty.handler.codec.http2.internal.hpack;
 
-import static io.netty.handler.codec.http2.internal.hpack.HpackUtil.ISO_8859_1;
-import static io.netty.handler.codec.http2.internal.hpack.HpackUtil.requireNonNull;
+import static io.netty.util.CharsetUtil.ISO_8859_1;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 class HeaderField implements Comparable<HeaderField> {
 
@@ -54,8 +54,8 @@ class HeaderField implements Comparable<HeaderField> {
     }
 
     HeaderField(byte[] name, byte[] value) {
-        this.name = requireNonNull(name);
-        this.value = requireNonNull(value);
+        this.name = checkNotNull(name, "name");
+        this.value = checkNotNull(value, "value");
     }
 
     int size() {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/HpackUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/HpackUtil.java
@@ -34,9 +34,6 @@ package io.netty.handler.codec.http2.internal.hpack;
 import java.nio.charset.Charset;
 
 final class HpackUtil {
-
-    static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
-
     /**
      * A string compare that doesn't leak timing information.
      */
@@ -49,16 +46,6 @@ final class HpackUtil {
             c |= s1[i] ^ s2[i];
         }
         return c == 0;
-    }
-
-    /**
-     * Checks that the specified object reference is not {@code null}.
-     */
-    static <T> T requireNonNull(T obj) {
-        if (obj == null) {
-            throw new NullPointerException();
-        }
-        return obj;
     }
 
     // Section 6.2. Literal Header Field Representation

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/HuffmanDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/HuffmanDecoder.java
@@ -31,13 +31,20 @@
  */
 package io.netty.handler.codec.http2.internal.hpack;
 
+import io.netty.util.internal.EmptyArrays;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 final class HuffmanDecoder {
 
-    private static final IOException EOS_DECODED = new IOException("EOS Decoded");
-    private static final IOException INVALID_PADDING = new IOException("Invalid Padding");
+    private static final IOException EOS_DECODED = new IOException("HPACK - EOS Decoded");
+    private static final IOException INVALID_PADDING = new IOException("HPACK - Invalid Padding");
+
+    static {
+        EOS_DECODED.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
+        INVALID_PADDING.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
+    }
 
     private final Node root;
 
@@ -65,44 +72,77 @@ final class HuffmanDecoder {
     public byte[] decode(byte[] buf) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
+        /*
+         * The idea here is to consume whole bytes at a time rather than individual bits. node
+         * represents the Huffman tree, with all bit patterns denormalized as 256 children. Each
+         * child represents the last 8 bits of the huffman code. The parents of each child each
+         * represent the successive 8 bit chunks that lead up to the last most part. 8 bit bytes
+         * from buf are used to traverse these tree until a terminal node is found.
+         *
+         * current is a bit buffer. The low order bits represent how much of the huffman code has
+         * not been used to traverse the tree. Thus, the high order bits are just garbage.
+         * currentBits represents how many of the low order bits of current are actually valid.
+         * currentBits will vary between 0 and 15.
+         *
+         * symbolBits is the number of bits of the the symbol being decoded, *including* all those
+         * of the parent nodes. symbolBits tells how far down the tree we are. For example, when
+         * decoding the invalid sequence {0xff, 0xff}, currentBits will be 0, but symbolBits will be
+         * 16. This is used to know if buf ended early (before consuming a whole symbol) or if
+         * there is too much padding.
+         */
         Node node = root;
         int current = 0;
-        int bits = 0;
+        int currentBits = 0;
+        int symbolBits = 0;
         for (int i = 0; i < buf.length; i++) {
             int b = buf[i] & 0xFF;
             current = (current << 8) | b;
-            bits += 8;
-            while (bits >= 8) {
-                int c = (current >>> (bits - 8)) & 0xFF;
+            currentBits += 8;
+            symbolBits += 8;
+            // While there are unconsumed bits in current, keep consuming symbols.
+            while (currentBits >= 8) {
+                int c = (current >>> (currentBits - 8)) & 0xFF;
                 node = node.children[c];
-                bits -= node.bits;
+                currentBits -= node.bits;
                 if (node.isTerminal()) {
                     if (node.symbol == HpackUtil.HUFFMAN_EOS) {
                         throw EOS_DECODED;
                     }
                     baos.write(node.symbol);
                     node = root;
+                    // Upon consuming a whole symbol, reset the symbol bits to the number of bits
+                    // left over in the byte.
+                    symbolBits = currentBits;
                 }
             }
         }
 
-        while (bits > 0) {
-            int c = (current << (8 - bits)) & 0xFF;
+        /*
+         * We have consumed all the bytes in buf, but haven't consumed all the symbols. We may be on
+         * a partial symbol, so consume until there is nothing left. This will loop at most 2 times.
+         */
+        while (currentBits > 0) {
+            int c = (current << (8 - currentBits)) & 0xFF;
             node = node.children[c];
-            if (node.isTerminal() && node.bits <= bits) {
-                bits -= node.bits;
+            if (node.isTerminal() && node.bits <= currentBits) {
+                if (node.symbol == HpackUtil.HUFFMAN_EOS) {
+                    throw EOS_DECODED;
+                }
+                currentBits -= node.bits;
                 baos.write(node.symbol);
                 node = root;
+                symbolBits = currentBits;
             } else {
                 break;
             }
         }
 
         // Section 5.2. String Literal Representation
+        // A padding strictly longer than 7 bits MUST be treated as a decoding error.
         // Padding not corresponding to the most significant bits of the code
         // for the EOS symbol (0xFF) MUST be treated as a decoding error.
-        int mask = (1 << bits) - 1;
-        if ((current & mask) != mask) {
+        int mask = (1 << symbolBits) - 1;
+        if (symbolBits > 7 || (current & mask) != mask) {
             throw INVALID_PADDING;
         }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/StaticTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/StaticTable.java
@@ -36,6 +36,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.netty.util.CharsetUtil.ISO_8859_1;
+
 final class StaticTable {
 
     private static final String EMPTY = "";
@@ -125,7 +127,7 @@ final class StaticTable {
      * -1 if the header field name is not in the static table.
      */
     static int getIndex(byte[] name) {
-        String nameString = new String(name, 0, name.length, HpackUtil.ISO_8859_1);
+        String nameString = new String(name, 0, name.length, ISO_8859_1);
         Integer index = STATIC_INDEX_BY_NAME.get(nameString);
         if (index == null) {
             return -1;
@@ -166,7 +168,7 @@ final class StaticTable {
         // save the smallest index for a given name in the map.
         for (int index = length; index > 0; index--) {
             HeaderField entry = getEntry(index);
-            String name = new String(entry.name, 0, entry.name.length, HpackUtil.ISO_8859_1);
+            String name = new String(entry.name, 0, entry.name.length, ISO_8859_1);
             ret.put(name, index);
         }
         return ret;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -17,6 +17,7 @@
 package io.netty.handler.codec.http2;
 
 import io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName;
+import io.netty.util.internal.StringUtil;
 import org.junit.Test;
 
 import java.util.Map.Entry;
@@ -29,6 +30,16 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class DefaultHttp2HeadersTest {
+
+    @Test(expected = Http2Exception.class)
+    public void nullHeaderNameNotAllowed() {
+        new DefaultHttp2Headers().add(null, "foo");
+    }
+
+    @Test(expected = Http2Exception.class)
+    public void emtpyHeaderNameNotAllowed() {
+        new DefaultHttp2Headers().add(StringUtil.EMPTY_STRING, "foo");
+    }
 
     @Test
     public void testPseudoHeadersMustComeFirstWhenIterating() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/internal/hpack/HuffmanTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/internal/hpack/HuffmanTest.java
@@ -72,12 +72,54 @@ public class HuffmanTest {
         Huffman.DECODER.decode(buf);
     }
 
-    @Test//(expected = IOException.class) TODO(jpinner) fix me
+    @Test(expected = IOException.class)
     public void testDecodeExtraPadding() throws IOException {
-        byte[] buf = new byte[2];
-        buf[0] = 0x0F; // '1', 'EOS'
-        buf[1] = (byte) 0xFF; // 'EOS'
+        byte[] buf = makeBuf(0x0f, 0xFF); // '1', 'EOS'
         Huffman.DECODER.decode(buf);
+    }
+
+    @Test(expected = IOException.class)
+    public void testDecodeExtraPadding1byte() throws IOException {
+        byte[] buf = makeBuf(0xFF);
+        Huffman.DECODER.decode(buf);
+    }
+
+    @Test(expected = IOException.class)
+    public void testDecodeExtraPadding2byte() throws IOException {
+        byte[] buf = makeBuf(0x1F, 0xFF); // 'a'
+        Huffman.DECODER.decode(buf);
+    }
+
+    @Test(expected = IOException.class)
+    public void testDecodeExtraPadding3byte() throws IOException {
+        byte[] buf = makeBuf(0x1F, 0xFF, 0xFF); // 'a'
+        Huffman.DECODER.decode(buf);
+    }
+
+    @Test(expected = IOException.class)
+    public void testDecodeExtraPadding4byte() throws IOException {
+        byte[] buf = makeBuf(0x1F, 0xFF, 0xFF, 0xFF); // 'a'
+        Huffman.DECODER.decode(buf);
+    }
+
+    @Test(expected = IOException.class)
+    public void testDecodeExtraPadding29bit() throws IOException {
+        byte[] buf = makeBuf(0xFF, 0x9F, 0xFF, 0xFF, 0xFF);  // '|'
+        Huffman.DECODER.decode(buf);
+    }
+
+    @Test(expected = IOException.class)
+    public void testDecodePartialSymbol() throws IOException {
+        byte[] buf = makeBuf(0x52, 0xBC, 0x30, 0xFF, 0xFF, 0xFF, 0xFF); // " pFA\x00", 31 bits of padding, a.k.a. EOS
+        Huffman.DECODER.decode(buf);
+    }
+
+    private byte[] makeBuf(int ... bytes) {
+        byte[] buf = new byte[bytes.length];
+        for (int i = 0; i < buf.length; i++) {
+            buf[i] = (byte) bytes[i];
+        }
+        return buf;
     }
 
     private void roundTrip(String s) throws IOException {


### PR DESCRIPTION
Motivation:
The HPACK code currently disallows empty header names. This is not explicitly forbidden by the HPACK RFC https://tools.ietf.org/html/rfc7541. However the HTTP/1.x RFC https://tools.ietf.org/html/rfc7230#section-3.2 and thus HTTP/2 both disallow empty header names, and so this precondition check should be moved from the HPACK code to the protocol level.
HPACK also requires that string literals which are huffman encoded must be treated as an encoding error if the string has more than 7 trailing padding bits https://tools.ietf.org/html/rfc7541#section-5.2, but this is currently not enforced.

Result:
- HPACK to allow empty header names
- HTTP/1.x and HTTP/2 header validation should not allow empty header names
- Enforce max of 7 trailing padding bits

Result:
Code is more compliant with the above mentioned RFCs
Fixes https://github.com/netty/netty/issues/5228