### PR TITLE
Replace DomainNameMapping.entries() with asMap()

### DIFF
--- a/common/src/main/java/io/netty/util/DomainNameMapping.java
+++ b/common/src/main/java/io/netty/util/DomainNameMapping.java
@@ -135,10 +135,10 @@ public class DomainNameMapping<V> implements Mapping<String, V> {
     }
 
     /**
-     * Returns a read-only {@link Set} of the domain mapping patterns and their associated value objects.
+     * Returns a read-only {@link Map} of the domain mapping patterns and their associated value objects.
      */
-    public Set<Map.Entry<String, V>> entries() {
-        return Collections.unmodifiableSet(map.entrySet());
+    public Map<String, V> asMap() {
+        return Collections.unmodifiableMap(map);
     }
 
     @Override

--- a/common/src/test/java/io/netty/util/DomainNameMappingTest.java
+++ b/common/src/test/java/io/netty/util/DomainNameMappingTest.java
@@ -16,10 +16,9 @@
 
 package io.netty.util;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.junit.Test;
+
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -186,15 +185,12 @@ public class DomainNameMappingTest {
     }
 
     @Test
-    public void testEntries() {
+    public void testAsMap() {
         DomainNameMapping<String> mapping = new DomainNameMapping<String>("NotFound")
             .add("netty.io", "Netty")
             .add("downloads.netty.io", "Netty-Downloads");
 
-        Map<String, String> entries = new HashMap<String, String>();
-        for (Map.Entry<String, String> entry: mapping.entries()) {
-            entries.put(entry.getKey(), entry.getValue());
-        }
+        Map<String, String> entries = mapping.asMap();
 
         assertEquals(2, entries.size());
         assertEquals("Netty", entries.get("netty.io"));
@@ -202,16 +198,13 @@ public class DomainNameMappingTest {
     }
 
     @Test
-    public void testEntriesWithImmutableDomainNameMapping() {
+    public void testAsMapWithImmutableDomainNameMapping() {
         DomainNameMapping<String> mapping = new DomainMappingBuilder<String>("NotFound")
             .add("netty.io", "Netty")
             .add("downloads.netty.io", "Netty-Downloads")
             .build();
 
-        Map<String, String> entries = new HashMap<String, String>();
-        for (Map.Entry<String, String> entry: mapping.entries()) {
-            entries.put(entry.getKey(), entry.getValue());
-        }
+        Map<String, String> entries = mapping.asMap();
 
         assertEquals(2, entries.size());
         assertEquals("Netty", entries.get("netty.io"));


### PR DESCRIPTION
Motivation:

DomainNameMapping.entries() returns `Set<Map.Entry<String, V>>`, which
doesn't sound very natural.

Modifications:

Replace entries() with asMap() which returns a `Map<String, V>` instead.

Result:

- Better looking API
- User can do a lookup because it's a Map