### PR TITLE
Correctly implement DefaultByteBufHolder.equals(...) and hashCode()

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/DefaultByteBufHolder.java
+++ b/buffer/src/main/java/io/netty/buffer/DefaultByteBufHolder.java
@@ -134,4 +134,20 @@ public class DefaultByteBufHolder implements ByteBufHolder {
     public String toString() {
         return StringUtil.simpleClassName(this) + '(' + contentToString() + ')';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o instanceof ByteBufHolder) {
+            return data.equals(((ByteBufHolder) o).content());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return data.hashCode();
+    }
 }

--- a/buffer/src/test/java/io/netty/buffer/DefaultByteBufHolderTest.java
+++ b/buffer/src/test/java/io/netty/buffer/DefaultByteBufHolderTest.java
@@ -29,4 +29,17 @@ public class DefaultByteBufHolderTest {
         assertTrue(holder.release());
         assertNotNull(holder.toString());
     }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        ByteBufHolder holder = new DefaultByteBufHolder(Unpooled.EMPTY_BUFFER);
+        ByteBufHolder copy = holder.copy();
+        try {
+            assertEquals(holder, copy);
+            assertEquals(holder.hashCode(), copy.hashCode());
+        } finally {
+            holder.release();
+            copy.release();
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

DefaultByteBufHolder.equals(...) and hashCode() should be implemented so it works correctly with instances that share the same content.

Modifications:

Add implementations and a unit-test.

Result:

Have correctly working equals(...) and hashCode() method