### PR TITLE
Ensure all methods are correctly overrides in *LeakAware*ByteBuf imple…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
@@ -101,6 +101,18 @@ final class AdvancedLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     }
 
     @Override
+    public ByteBuf asReadOnly() {
+        recordLeakNonRefCountingOperation(leak);
+        return new AdvancedLeakAwareByteBuf(super.asReadOnly(), leak);
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        recordLeakNonRefCountingOperation(leak);
+        return super.isReadOnly();
+    }
+
+    @Override
     public CompositeByteBuf discardReadBytes() {
         recordLeakNonRefCountingOperation(leak);
         return super.discardReadBytes();

--- a/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareByteBuf.java
@@ -106,4 +106,9 @@ final class SimpleLeakAwareByteBuf extends WrappedByteBuf {
     public ByteBuf readRetainedSlice(int length) {
         return new SimpleLeakAwareByteBuf(super.readRetainedSlice(length), leak);
     }
+
+    @Override
+    public ByteBuf asReadOnly() {
+        return new SimpleLeakAwareByteBuf(super.asReadOnly(), leak);
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareCompositeByteBuf.java
@@ -96,4 +96,9 @@ final class SimpleLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     public ByteBuf readRetainedSlice(int length) {
         return new SimpleLeakAwareByteBuf(super.readRetainedSlice(length), leak);
     }
+
+    @Override
+    public ByteBuf asReadOnly() {
+        return new SimpleLeakAwareByteBuf(super.asReadOnly(), leak);
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/WrappedCompositeByteBuf.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 import java.nio.charset.Charset;
@@ -1027,6 +1028,61 @@ class WrappedCompositeByteBuf extends CompositeByteBuf {
     public CompositeByteBuf readBytes(OutputStream out, int length) throws IOException {
         wrapped.readBytes(out, length);
         return this;
+    }
+
+    @Override
+    public int getBytes(int index, FileChannel out, long position, int length) throws IOException {
+        return wrapped.getBytes(index, out, position, length);
+    }
+
+    @Override
+    public int setBytes(int index, FileChannel in, long position, int length) throws IOException {
+        return wrapped.setBytes(index, in, position, length);
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return wrapped.isReadOnly();
+    }
+
+    @Override
+    public ByteBuf asReadOnly() {
+        return wrapped.asReadOnly();
+    }
+
+    @Override
+    protected SwappedByteBuf newSwappedByteBuf() {
+        return wrapped.newSwappedByteBuf();
+    }
+
+    @Override
+    public CharSequence getCharSequence(int index, int length, Charset charset) {
+        return wrapped.getCharSequence(index, length, charset);
+    }
+
+    @Override
+    public CharSequence readCharSequence(int length, Charset charset) {
+        return wrapped.readCharSequence(length, charset);
+    }
+
+    @Override
+    public int setCharSequence(int index, CharSequence sequence, Charset charset) {
+        return wrapped.setCharSequence(index, sequence, charset);
+    }
+
+    @Override
+    public int readBytes(FileChannel out, long position, int length) throws IOException {
+        return wrapped.readBytes(out, position, length);
+    }
+
+    @Override
+    public int writeBytes(FileChannel in, long position, int length) throws IOException {
+        return wrapped.writeBytes(in, position, length);
+    }
+
+    @Override
+    public int writeCharSequence(CharSequence sequence, Charset charset) {
+        return wrapped.writeCharSequence(sequence, charset);
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/AdvancedLeakAwareByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdvancedLeakAwareByteBufTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+public class AdvancedLeakAwareByteBufTest extends SimpleLeakAwareByteBufTest {
+
+    @Override
+    protected Class<? extends ByteBuf> leakClass() {
+        return AdvancedLeakAwareByteBuf.class;
+    }
+
+    @Override
+    protected ByteBuf wrap(ByteBuf buffer) {
+        return new AdvancedLeakAwareByteBuf(buffer, NoopResourceLeak.INSTANCE);
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBufTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+public class AdvancedLeakAwareCompositeByteBufTest extends SimpleLeakAwareCompositeByteBufTest {
+
+    @Override
+    protected WrappedCompositeByteBuf wrap(CompositeByteBuf buffer) {
+        return new AdvancedLeakAwareCompositeByteBuf(buffer, NoopResourceLeak.INSTANCE);
+    }
+
+    @Override
+    protected Class<? extends ByteBuf> leakClass() {
+        return AdvancedLeakAwareByteBuf.class;
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/NoopResourceLeak.java
+++ b/buffer/src/test/java/io/netty/buffer/NoopResourceLeak.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.ResourceLeak;
+
+final class NoopResourceLeak implements ResourceLeak {
+
+    static final NoopResourceLeak INSTANCE = new NoopResourceLeak();
+
+    private NoopResourceLeak() { }
+
+    @Override
+    public void record() { }
+
+    @Override
+    public void record(Object hint) { }
+
+    @Override
+    public boolean close() {
+        return false;
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareByteBufTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SimpleLeakAwareByteBufTest extends BigEndianHeapByteBufTest {
+    private final Class<? extends ByteBuf> clazz = leakClass();
+
+    @Override
+    protected final ByteBuf newBuffer(int capacity) {
+        return wrap(super.newBuffer(capacity));
+    }
+
+    protected ByteBuf wrap(ByteBuf buffer) {
+        return new SimpleLeakAwareByteBuf(buffer, NoopResourceLeak.INSTANCE);
+    }
+
+    protected Class<? extends ByteBuf> leakClass() {
+        return SimpleLeakAwareByteBuf.class;
+    }
+
+    @Test
+    public void testWrapSlice() {
+        assertWrapped(newBuffer(8).slice());
+    }
+
+    @Test
+    public void testWrapSlice2() {
+        assertWrapped(newBuffer(8).slice(0, 1));
+    }
+
+    @Test
+    public void testWrapReadSlice() {
+        assertWrapped(newBuffer(8).readSlice(1));
+    }
+
+    @Test
+    public void testWrapRetainedSlice() {
+        assertWrapped(newBuffer(8).retainedSlice());
+    }
+
+    @Test
+    public void testWrapRetainedSlice2() {
+        assertWrapped(newBuffer(8).retainedSlice(0, 1));
+    }
+
+    @Test
+    public void testWrapReadRetainedSlice() {
+        assertWrapped(newBuffer(8).readRetainedSlice(1));
+    }
+
+    @Test
+    public void testWrapDuplicate() {
+        assertWrapped(newBuffer(8).duplicate());
+    }
+
+    @Test
+    public void testWrapRetainedDuplicate() {
+        assertWrapped(newBuffer(8).retainedDuplicate());
+    }
+
+    @Test
+    public void testWrapReadOnly() {
+        assertWrapped(newBuffer(8).asReadOnly());
+    }
+
+    protected final void assertWrapped(ByteBuf buf) {
+        try {
+            Assert.assertSame(clazz, buf.getClass());
+        } finally {
+            buf.release();
+        }
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareCompositeByteBufTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SimpleLeakAwareCompositeByteBufTest extends WrappedCompositeByteBufTest {
+
+    private final Class<? extends ByteBuf> clazz = leakClass();
+
+    @Override
+    protected WrappedCompositeByteBuf wrap(CompositeByteBuf buffer) {
+        return new SimpleLeakAwareCompositeByteBuf(buffer, NoopResourceLeak.INSTANCE);
+    }
+
+    protected Class<? extends ByteBuf> leakClass() {
+        return SimpleLeakAwareByteBuf.class;
+    }
+
+   @Test
+    public void testWrapSlice() {
+        assertWrapped(newBuffer(8).slice());
+    }
+
+    @Test
+    public void testWrapSlice2() {
+        assertWrapped(newBuffer(8).slice(0, 1));
+    }
+
+    @Test
+    public void testWrapReadSlice() {
+        assertWrapped(newBuffer(8).readSlice(1));
+    }
+
+    @Test
+    public void testWrapRetainedSlice() {
+        assertWrapped(newBuffer(8).retainedSlice());
+    }
+
+    @Test
+    public void testWrapRetainedSlice2() {
+        assertWrapped(newBuffer(8).retainedSlice(0, 1));
+    }
+
+    @Test
+    public void testWrapReadRetainedSlice() {
+        assertWrapped(newBuffer(8).readRetainedSlice(1));
+    }
+
+    @Test
+    public void testWrapDuplicate() {
+        assertWrapped(newBuffer(8).duplicate());
+    }
+
+    @Test
+    public void testWrapRetainedDuplicate() {
+        assertWrapped(newBuffer(8).retainedDuplicate());
+    }
+
+    @Test
+    public void testWrapReadOnly() {
+        assertWrapped(newBuffer(8).asReadOnly());
+    }
+
+    protected final void assertWrapped(ByteBuf buf) {
+        try {
+            Assert.assertSame(clazz, buf.getClass());
+        } finally {
+            buf.release();
+        }
+    }
+}

--- a/buffer/src/test/java/io/netty/buffer/WrappedCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/WrappedCompositeByteBufTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+public class WrappedCompositeByteBufTest extends BigEndianCompositeByteBufTest {
+
+    @Override
+    protected final ByteBuf newBuffer(int length) {
+        return wrap((CompositeByteBuf) super.newBuffer(length));
+    }
+
+    protected WrappedCompositeByteBuf wrap(CompositeByteBuf buffer) {
+        return new WrappedCompositeByteBuf(buffer);
+    }
+}


### PR DESCRIPTION
…mentations

Motivation:

We missed to override a few methods and so some actions on the ByteBuf failed.

Modifications:

- Override all methods
- Add unit tests to ensure all is fixed.

Result:

All *LeakAware*ByteBuf have correct implementations