### PR TITLE
Add timeout to PooledByteBufAllocatorTest

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -125,7 +125,7 @@ public class PooledByteBufAllocatorTest {
         assertTrue(threadCachesCreated.get());
     }
 
-    @Test
+    @Test(timeout = 3000)
     public void testNumThreadCachesWithNoDirectArenas() throws InterruptedException {
         int numHeapArenas = 1;
         final PooledByteBufAllocator allocator =
@@ -144,7 +144,7 @@ public class PooledByteBufAllocatorTest {
         assertEquals(0, allocator.numThreadLocalCaches());
     }
 
-    @Test
+    @Test(timeout = 3000)
     public void testThreadCacheToArenaMappings() throws InterruptedException {
         int numArenas = 2;
         final PooledByteBufAllocator allocator =


### PR DESCRIPTION
Motivation:

Some tests in PooledByteBufAllocatorTest are blocking on a CountDownLatch. We should use a timeout on these tests so these will not block forever on a failure.

Modifications:

Add timeout param to @Test annotation

Result:

Have sane timeouts on tests.