### PR TITLE
Decouple AbstractChannel and AbstractChannelHandlerContext

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -50,8 +50,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         NOT_YET_CONNECTED_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
     }
 
-    private MessageSizeEstimator.Handle estimatorHandle;
-
     private final Channel parent;
     private final ChannelId id;
     private final Unsafe unsafe;
@@ -399,13 +397,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     @Override
     public final ChannelPromise voidPromise() {
         return pipeline.voidPromise();
-    }
-
-    final MessageSizeEstimator.Handle estimatorHandle() {
-        if (estimatorHandle == null) {
-            estimatorHandle = config().getMessageSizeEstimator().newHandle();
-        }
-        return estimatorHandle;
     }
 
     /**
@@ -793,7 +784,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             int size;
             try {
                 msg = filterOutboundMessage(msg);
-                size = estimatorHandle().size(msg);
+                size = pipeline.estimatorHandle().size(msg);
                 if (size < 0) {
                     size = 0;
                 }

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -1011,7 +1011,7 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap
 
                 // Check for null as it may be set to null if the channel is closed already
                 if (buffer != null) {
-                    task.size = ((AbstractChannel) ctx.channel()).estimatorHandle().size(msg) + WRITE_TASK_OVERHEAD;
+                    task.size = ctx.pipeline.estimatorHandle().size(msg) + WRITE_TASK_OVERHEAD;
                     buffer.incrementPendingOutboundBytes(task.size);
                 } else {
                     task.size = 0;

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -53,16 +53,16 @@ final class DefaultChannelPipeline implements ChannelPipeline {
         }
     };
 
-    final AbstractChannel channel;
-
     final AbstractChannelHandlerContext head;
     final AbstractChannelHandlerContext tail;
 
+    private final Channel channel;
     private final ChannelFuture succeededFuture;
     private final VoidChannelPromise voidPromise;
     private final boolean touch = ResourceLeakDetector.isEnabled();
 
     private Map<EventExecutorGroup, EventExecutor> childExecutors;
+    private MessageSizeEstimator.Handle estimatorHandle;
 
     /**
      * This is the head of a linked list that is processed by {@link #callHandlerAddedForAllHandlers()} and so process
@@ -93,6 +93,13 @@ final class DefaultChannelPipeline implements ChannelPipeline {
 
         head.next = tail;
         tail.prev = head;
+    }
+
+    MessageSizeEstimator.Handle estimatorHandle() {
+        if (estimatorHandle == null) {
+            estimatorHandle = channel.config().getMessageSizeEstimator().newHandle();
+        }
+        return estimatorHandle;
     }
 
     Object touch(Object msg, AbstractChannelHandlerContext next) {


### PR DESCRIPTION
Motivation:

We do a "blind" cast to AbstractChannel in AbstractChannelHandlerContext which we should better no do. It would be better to decouble AbstractChannelHandlerContext from AbstractChannel.

Modifications:

Decouble AbstractChannelHandlerContext from AbstractChannel by move logic to DefaultChannelPipeline

Result:

Less coubling and less casting.