### PR TITLE
Fix NPE in Http2ConnectionHandler.onHttpServerUpgrade

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -641,7 +641,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
                 }
             });
 
-            if (delta > 0) {
+            if (delta > 0 && isChannelWritable()) {
                 // The window size increased, send any pending frames for all streams.
                 writePendingBytes();
             }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowControllerTest.java
@@ -45,7 +45,9 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.Http2FrameWriter.Configuration;
 import io.netty.util.concurrent.EventExecutor;
+
 import junit.framework.AssertionFailedError;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -901,6 +903,9 @@ public abstract class DefaultHttp2RemoteFlowControllerTest {
     public void initialWindowSizeWithNoContextShouldNotThrow() throws Exception {
         // Re-initialize the controller so we can ensure the context hasn't been set yet.
         initConnectionAndController();
+
+        // This should not throw.
+        controller.initialWindowSize(1024 * 100);
 
         FakeFlowControlled dataA = new FakeFlowControlled(1);
         final Http2Stream stream = stream(STREAM_A);


### PR DESCRIPTION
Motivation:

Performing a server upgrade with a new initial flow control window will cause an NPE in the DefaultHttp2RemoteFlowController. This is due to the fact that the monitor does not check whether or not the channel is writable.

Modifications:

Added a check for channel writability before calling `writePendingBytes`. Also fixed a unit test that was supposed to be testing this :).

Result:

Fixes #5301