### PR TITLE
Add includeScope to not include test dependencies for maven-dependenc…

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -313,6 +313,7 @@
             <configuration>
               <classifier>sources</classifier>
               <includes>io/netty/**</includes>
+              <includeScope>runtime</includeScope>
               <includeGroupIds>${project.groupId}</includeGroupIds>
               <outputDirectory>${generatedSourceDir}</outputDirectory>
             </configuration>
@@ -328,6 +329,7 @@
             <configuration>
               <excludes>io/netty/example/**,META-INF/native/libnetty-tcnative*</excludes>
               <includes>io/netty/**,META-INF/native/**</includes>
+              <includeScope>runtime</includeScope>
               <includeGroupIds>${project.groupId}</includeGroupIds>
               <outputDirectory>${project.build.outputDirectory}</outputDirectory>
             </configuration>


### PR DESCRIPTION
…y-plugin

Motivation:

maven-dependency-plugin will include dependencies of all scopes by default. We should limit the scope to avoid pulling test dependencies. See #5317.

Modifications:

Add includeScope to avoid pulling test dependencies.

Result:

netty-all doesn't include codes from netty-build