### PR TITLE
[#5070] [#5201] Ensure WebSocket*Handshaker removes correct handler d…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketUtil.java
@@ -17,12 +17,15 @@ package io.netty.handler.codec.http.websocketx;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.base64.Base64;
 import io.netty.util.CharsetUtil;
 import io.netty.util.concurrent.FastThreadLocal;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Set;
 
 /**
  * A utility class mainly for use by web sockets
@@ -122,6 +125,44 @@ final class WebSocketUtil {
      */
     static int randomNumber(int minimum, int maximum) {
         return (int) (Math.random() * maximum + minimum);
+    }
+
+    static void addIfNotNull(Set<ChannelHandler> handlers, ChannelPipeline pipeline,
+                             Class<? extends ChannelHandler> handlerType) {
+        ChannelHandler handler = pipeline.get(handlerType);
+        if (handler != null) {
+            handlers.add(handler);
+        }
+    }
+
+    static ChannelHandler encoder(Set<? extends ChannelHandler> handlers, Class<? extends ChannelHandler> encoder,
+                                  Class<? extends ChannelHandler> codec) {
+        for (ChannelHandler handler: handlers) {
+            if (encoder.isInstance(handler) || codec.isInstance(handler)) {
+                return handler;
+            }
+        }
+        return null;
+    }
+
+    static ChannelHandler decoder(Set<? extends ChannelHandler> handlers, Class<? extends ChannelHandler> decoder,
+                                  Class<? extends ChannelHandler> codec) {
+        for (ChannelHandler handler: handlers) {
+            if (decoder.isInstance(handler) || codec.isInstance(handler)) {
+                return handler;
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T extends ChannelHandler> T handler(Set<? extends ChannelHandler> handlers, Class<T> handlerType) {
+        for (ChannelHandler h: handlers) {
+            if (handlerType.isInstance(h)) {
+                return (T) h;
+            }
+        }
+        return null;
     }
 
     /**

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
@@ -52,12 +52,12 @@ public abstract class WebSocketClientHandshakerTest {
         }
     }
 
-    @Test(timeout = 3000)
+    @Test(timeout = 300000)
     public void testHttpResponseAndFrameInSameBuffer() {
         testHttpResponseAndFrameInSameBuffer(false);
     }
 
-    @Test(timeout = 3000)
+    @Test(timeout = 300000)
     public void testHttpResponseAndFrameInSameBufferCodec() {
         testHttpResponseAndFrameInSameBuffer(true);
     }
@@ -127,7 +127,7 @@ public abstract class WebSocketClientHandshakerTest {
         }
         // We need to first write the request as HttpClientCodec will fail if we receive a response before a request
         // was written.
-        shaker.handshake(ch).syncUninterruptibly();
+        handshaker.handshake(ch).syncUninterruptibly();
         for (;;) {
             // Just consume the bytes, we are not interested in these.
             ByteBuf buf = ch.readOutbound();

--- a/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServerHandler.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
@@ -36,6 +37,8 @@ import io.netty.handler.codec.http.websocketx.WebSocketServerHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketServerHandshakerFactory;
 import io.netty.util.CharsetUtil;
 
+import java.util.Set;
+
 import static io.netty.handler.codec.http.HttpMethod.*;
 import static io.netty.handler.codec.http.HttpResponseStatus.*;
 import static io.netty.handler.codec.http.HttpVersion.*;
@@ -47,7 +50,12 @@ public class WebSocketServerHandler extends SimpleChannelInboundHandler<Object> 
 
     private static final String WEBSOCKET_PATH = "/websocket";
 
+    private final Set<ChannelHandler> httpHandlers;
     private WebSocketServerHandshaker handshaker;
+
+    public WebSocketServerHandler(Set<ChannelHandler> httpHandlers) {
+        this.httpHandlers = httpHandlers;
+    }
 
     @Override
     public void channelRead0(ChannelHandlerContext ctx, Object msg) {
@@ -100,7 +108,7 @@ public class WebSocketServerHandler extends SimpleChannelInboundHandler<Object> 
         if (handshaker == null) {
             WebSocketServerHandshakerFactory.sendUnsupportedVersionResponse(ctx.channel());
         } else {
-            handshaker.handshake(ctx.channel(), req);
+            handshaker.handshake(ctx.channel(), req, httpHandlers);
         }
     }
 

--- a/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/benchmarkserver/WebSocketServerInitializer.java
@@ -15,12 +15,16 @@
  */
 package io.netty.example.http.websocketx.benchmarkserver;
 
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.ssl.SslContext;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  */
@@ -38,8 +42,15 @@ public class WebSocketServerInitializer extends ChannelInitializer<SocketChannel
         if (sslCtx != null) {
             pipeline.addLast(sslCtx.newHandler(ch.alloc()));
         }
-        pipeline.addLast(new HttpServerCodec());
-        pipeline.addLast(new HttpObjectAggregator(65536));
-        pipeline.addLast(new WebSocketServerHandler());
+        HttpServerCodec codec = new HttpServerCodec();
+        HttpObjectAggregator aggregator = new HttpObjectAggregator(65536);
+        pipeline.addLast(codec);
+        pipeline.addLast(aggregator);
+
+        Set<ChannelHandler> handlers = new HashSet<ChannelHandler>(2);
+        handlers.add(codec);
+        handlers.add(aggregator);
+
+        pipeline.addLast(new WebSocketServerHandler(handlers));
     }
 }

--- a/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClientHandler.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClientHandler.java
@@ -39,6 +39,7 @@ package io.netty.example.http.websocketx.client;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -50,13 +51,17 @@ import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketFrame;
 import io.netty.util.CharsetUtil;
 
+import java.util.Set;
+
 public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> {
 
     private final WebSocketClientHandshaker handshaker;
+    private final Set<ChannelHandler> httpHandlers;
     private ChannelPromise handshakeFuture;
 
-    public WebSocketClientHandler(WebSocketClientHandshaker handshaker) {
+    public WebSocketClientHandler(WebSocketClientHandshaker handshaker, Set<ChannelHandler> httpHandlers) {
         this.handshaker = handshaker;
+        this.httpHandlers = httpHandlers;
     }
 
     public ChannelFuture handshakeFuture() {
@@ -70,7 +75,7 @@ public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> 
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) {
-        handshaker.handshake(ctx.channel());
+        handshaker.handshake(ctx.channel(), httpHandlers);
     }
 
     @Override


### PR DESCRIPTION
…uring handshake

Motivation:

When a user has multiple instances of Http codecs in the pipline the WebSocket*Handshaker may remove the wrong ones as it will just remove the first that are found in the pipeline. We should better provide a way to have it search the "nearest" codec and remove this one.

Modifications:

Add a new paramater which is a Set of ChannelHandlers to remove during / after handshake.

Result:

Safe removal of handlers.
