### PR TITLE
Fix the possible reference leak in Recycler

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -340,6 +340,7 @@ public abstract class Recycler<T> {
             }
             size --;
             DefaultHandle ret = elements[size];
+            elements[size] = null;
             if (ret.lastRecycledId != ret.recycleId) {
                 throw new IllegalStateException("recycled multiple times");
             }


### PR DESCRIPTION
Motivation:

Under very unlikely (however possible) circumstances, Recycler may leak
references. This happens _only_ when the object was already recycled
at least once (which means it's got written to the stack) and then
taken out again, and never returned.

The "never returned" part may be the fault of the user (forgotten
`finally` clause) or the situation when Recycler drops the possibly
youngest item itself: https://github.com/netty/netty/blob/4.0/common/src/main/java/io/netty/util/Recycler.java#L404

Modifications:

Nullify the item taken from the stack.

Result:

Reference is cleaned up. If the object is lost, it will be a subject for
GC. The rest of Stack / Recycler functionality remains unaffected.