### PR TITLE
SocketRstTest fails due to exception message check

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketRstTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketRstTest.java
@@ -35,7 +35,8 @@ import static org.junit.Assert.assertTrue;
 public class SocketRstTest extends AbstractSocketTest {
     protected void assertRstOnCloseException(IOException cause, Channel clientChannel) {
         if (Locale.getDefault() == Locale.US || Locale.getDefault() == Locale.UK) {
-            assertTrue("actual message: " + cause.getMessage(), cause.getMessage().contains("reset"));
+            assertTrue("actual message: " + cause.getMessage(),
+                       cause.getMessage().contains("reset") || cause.getMessage().contains("closed"));
         }
     }
 


### PR DESCRIPTION
Motivation:
For lack of a better way the SocketRstTest inspects the content of the exception message to check if a RST occurred. However on windows the exception message is different than on other Unix based platforms and the assertion statement fails.

Modifications:
- Hack another string check in the unit test

Result:
SocketRstTest passes on windows
Fixes https://github.com/netty/netty/issues/5335