### PR TITLE
Fix DefaultHeaders.toString() for keys with multiple values.

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -899,8 +899,8 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
             for (int i = 0; i < values.size(); ++i) {
                 builder.append(separator);
                 builder.append(name).append(": ").append(values.get(i));
+                separator = ", ";
             }
-            separator = ", ";
         }
         return builder.append(']').toString();
     }

--- a/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
@@ -450,4 +450,26 @@ public class DefaultHeadersTest {
         headers.set(headers);
         assertEquals(1, headers.size());
     }
+
+    @Test
+    public void testToString() {
+        TestDefaultHeaders headers = newInstance();
+        headers.add(of("name1"), of("value1"));
+        headers.add(of("name1"), of("value2"));
+        headers.add(of("name2"), of("value3"));
+        assertEquals("TestDefaultHeaders[name1: value1, name1: value2, name2: value3]", headers.toString());
+
+        headers = newInstance();
+        headers.add(of("name1"), of("value1"));
+        headers.add(of("name2"), of("value2"));
+        headers.add(of("name3"), of("value3"));
+        assertEquals("TestDefaultHeaders[name1: value1, name2: value2, name3: value3]", headers.toString());
+
+        headers = newInstance();
+        headers.add(of("name1"), of("value1"));
+        assertEquals("TestDefaultHeaders[name1: value1]", headers.toString());
+
+        headers = newInstance();
+        assertEquals("TestDefaultHeaders[]", headers.toString());
+    }
 }


### PR DESCRIPTION
Motivation:

For example,

```java
DefaultHttp2Headers headers = new DefaultHttp2Headers();
headers.add("key1", "value1");
headers.add("key1", "value2");
headers.add("key1", "value3");
headers.add("key2", "value4");
```

produces:

```
DefaultHttp2Headers[key1: value1key1: value2key1: value3, key2: value4]
```
while correctly it should be

```
DefaultHttp2Headers[key1: value1, key1: value2, key1: value3, key2: value4]
```

Modifications:

Change the toString() method to produce the beforementioned output.

Result:

toString() format is correct also for keys with multiple values.