### PR TITLE
Use higher maxQueriesPerResolve and make exception message more clear.

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -48,7 +48,7 @@ public final class DnsNameResolverBuilder {
     private long queryTimeoutMillis = 5000;
     private InternetProtocolFamily[] resolvedAddressTypes = DnsNameResolver.DEFAULT_RESOLVE_ADDRESS_TYPES;
     private boolean recursionDesired = true;
-    private int maxQueriesPerResolve = 3;
+    private int maxQueriesPerResolve = 16;
     private boolean traceEnabled;
     private int maxPayloadSize = 4096;
     private boolean optResourceEnabled = true;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -412,25 +412,23 @@ abstract class DnsNameResolverContext<T> {
         final int tries = maxAllowedQueries - allowedQueries;
         final StringBuilder buf = new StringBuilder(64);
 
-        buf.append("failed to resolve ");
-        buf.append(hostname);
-
+        buf.append("failed to resolve '")
+           .append(hostname).append('\'');
         if (tries > 1) {
-            buf.append(" after ");
-            buf.append(tries);
-            if (trace != null) {
-                buf.append(" queries:");
-                buf.append(trace);
+            if (tries < maxAllowedQueries) {
+                buf.append(" after ")
+                   .append(tries)
+                   .append(" queries ");
             } else {
-                buf.append(" queries");
-            }
-        } else {
-            if (trace != null) {
-                buf.append(':');
-                buf.append(trace);
+                buf.append(". Exceeded max queries per resolve ")
+                .append(maxAllowedQueries)
+                .append(' ');
             }
         }
-
+        if (trace != null) {
+            buf.append(':')
+               .append(trace);
+        }
         final UnknownHostException cause = new UnknownHostException(buf.toString());
 
         resolveCache.cache(hostname, cause, parent.ch.eventLoop());


### PR DESCRIPTION
Motivation:

We use a default of 3 for maxQueriesPerResolve when using the DnsNameResolverBuilder, which is too low if you want to resolve a hostname that uses a lot of CNAME records.

Modifications:

- Use higher default (16)
- Make exception message more clear why it failed.

Result:

Be able to resolve more domains by default and be able to better trouble shoot why a resolver failed.