### PR TITLE
[#5308] Ensure InetSocketAddressResolver.close() will close the wrapp…

### DIFF
--- a/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
@@ -88,4 +88,9 @@ public class InetSocketAddressResolver extends AbstractAddressResolver<InetSocke
                     }
                 });
     }
+
+    @Override
+    public void close() {
+        nameResolver.close();
+    }
 }

--- a/resolver/src/test/java/io/netty/resolver/InetSocketAddressResolverTest.java
+++ b/resolver/src/test/java/io/netty/resolver/InetSocketAddressResolverTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver;
+
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import org.junit.Test;
+
+import java.net.InetAddress;
+
+import static org.mockito.Mockito.*;
+
+public class InetSocketAddressResolverTest {
+
+    @Test
+    public void testCloseDelegates() {
+        @SuppressWarnings("unchecked")
+        NameResolver<InetAddress> nameResolver = mock(NameResolver.class);
+        InetSocketAddressResolver resolver = new InetSocketAddressResolver(
+                ImmediateEventExecutor.INSTANCE, nameResolver);
+        resolver.close();
+        verify(nameResolver, times(1)).close();
+    }
+}


### PR DESCRIPTION
…ed NameResolver.

Motivation:

InetSocketAddressResolver.close() must call close() on the wrapped NameResolver.

Modifications:

Correctly call close() on wrapped NameResolver and added test.

Result:

close() is correctly propergated to the wrapped resolver.