### PR TITLE
Ensure we null out cumulation buffer before fire through the pipeline…

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
@@ -21,7 +21,6 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.util.Signal;
-import io.netty.util.internal.RecyclableArrayList;
 import io.netty.util.internal.StringUtil;
 
 import java.util.List;


### PR DESCRIPTION
… in handlerRemoved(...)

Motivation:

We should ensure we null out the cumulation buffer before we fire it through the pipleine in handlerRemoved(...) as in theory it could be possible that another method is triggered as result of the fireChannelRead(...) or fireChannelReadComplete() that will try to access the cumulation.

Modifications:

Null out cumulation buffer early in handlerRemoved(...)

Result:

No possible to access the cumulation buffer that was already handed over.