### PR TITLE
Ensure the correct wrapped buffer is released in AbstractPooledDerive…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
@@ -66,8 +66,12 @@ abstract class AbstractPooledDerivedByteBuf<T> extends AbstractReferenceCountedB
 
     @Override
     protected final void deallocate() {
+        // We need to first store a reference to the wrapped buffer before recycle this instance. This is needed as
+        // otherwise it is possible that the same AbstractPooledDerivedByteBuf is again obtained and init(...) is
+        // called before we actually have a chance to call release(). This leads to call release() on the wrong buffer.
+        ByteBuf wrapped = unwrap();
         recyclerHandle.recycle(this);
-        unwrap().release();
+        wrapped.release();
     }
 
     @Override


### PR DESCRIPTION
…dByteBuf.deallocate()

Motivation:

We need to first store a reference to the wrapped buffer before recycle the AbstractPooledDerivedByteBuf instance. This is needed as otherwise it is possible that the same AbstractPooledDerivedByteBuf is again obtained and init(...) is called before we actually have a chance to call release(). This leads to call release() on the wrong buffer.

Modifications:

Store a reference to the wrapped buffer before call recycle and call release on the previous stored reference.

Result:

Always release the correct wrapped buffer when deallocate the AbstractPooledDerivedByteBuf.