### PR TITLE
OpenSslEngine remove unecessary rejectRemoteInitiatedRenegation call

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -686,8 +686,6 @@ public final class OpenSslEngine extends SSLEngine {
             } while (srcsOffset < srcsEndOffset);
         }
 
-        rejectRemoteInitiatedRenegation();
-
         // Number of produced bytes
         int bytesProduced = 0;
 


### PR DESCRIPTION
Motivation:
OpenSslEngine calls rejectRemoteInitiatedRenegation in a scenario where the number of handshakes has not been observed to change. The number of handshakes has only been observed to change after readPlaintextData is called.

Modifications:
- Remove the call to rejectRemoteInitiatedRenegation before calls to readPlaintextData

Result:
Less code.