### PR TITLE
OpenSslEngine encrypt more data per wrap call

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+import javax.net.ssl.SSLEngineResult.Status;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLParameters;
@@ -525,7 +526,10 @@ public final class OpenSslEngine extends SSLEngine {
 
                     pendingNetResult = readPendingBytesFromBIO(dst, bytesConsumed, bytesProduced, status);
                     if (pendingNetResult != null) {
-                        return pendingNetResult;
+                        if (pendingNetResult.getStatus() != OK) {
+                            return pendingNetResult;
+                        }
+                        bytesProduced = pendingNetResult.bytesProduced();
                     }
                 } else {
                     int sslError = SSL.getError(ssl, result);
@@ -1257,7 +1261,7 @@ public final class OpenSslEngine extends SSLEngine {
         return FINISHED;
     }
 
-    private SSLEngineResult.Status getEngineStatus() {
+    private Status getEngineStatus() {
         return engineClosed? CLOSED : OK;
     }
 


### PR DESCRIPTION
Motivation:
OpenSslEngine.wrap will only encrypt at most 1 buffer per call. We may be able to encrypt multiple buffers per call.

Modifications:
- OpensslEngine.wrap should continue encrypting data until there is an error, no more data, or until the destination buffer would be overflowed.

Result:
More encryption is done per OpenSslEngine.wrap call