### PR TITLE
Reset a `Bootstrap` instance's resolver by passing `null`

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -70,13 +70,15 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
 
     /**
      * Sets the {@link NameResolver} which will resolve the address of the unresolved named address.
+     *
+     * @param resolver the {@link NameResolver} for this {@code Bootstrap}; may be {@code null}, in which case a default
+     *                 resolver will be used
+     *
+     * @see io.netty.resolver.DefaultAddressResolverGroup
      */
     @SuppressWarnings("unchecked")
     public Bootstrap resolver(AddressResolverGroup<?> resolver) {
-        if (resolver == null) {
-            throw new NullPointerException("resolver");
-        }
-        this.resolver = (AddressResolverGroup<SocketAddress>) resolver;
+        this.resolver = (AddressResolverGroup<SocketAddress>) (resolver == null ? DEFAULT_RESOLVER : resolver);
         return this;
     }
 


### PR DESCRIPTION
Motivation:

`Bootstrap` has a notion of a default resolver group, but it's hidden from the public. To allow callers to reset a `Bootstrap` instance's resolver group, we could either make `DEFAULT_RESOLVER` public, or we could allow callers to pass `null` as an argument to `Bootstrap#resolver(AddressResolverGroup<?>)`. This pull request does the latter.

Modifications:

- Allow `Bootstrap#resolver(AddressResolverGroup<?>)` to accept `null` as an argument

Result:

Callers may pass `null` to `Bootstrap#resolver(AddressResolverGroup<?>)` to cause the `Bootstrap` instance to use its default resolver group.