### PR TITLE
epoll_wait timeout reset when called multiple times

### DIFF
--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -26,6 +26,10 @@
   <name>Netty/Transport/Native/Epoll</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <jni.compiler.args.ldflags>LDFLAGS=-Wl,--no-as-needed -lrt</jni.compiler.args.ldflags>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.netty</groupId>
@@ -74,7 +78,8 @@
               <forceConfigure>true</forceConfigure>
               <forceAutogen>true</forceAutogen>
               <configureArgs>
-                <arg>${jni.compiler.args}</arg>
+                <arg>${jni.compiler.args.ldflags}</arg>
+                <arg>${jni.compiler.args.cflags}</arg>
               </configureArgs>
             </configuration>
             <goals>
@@ -187,7 +192,7 @@
               <goal>regex-property</goal>
             </goals>
             <configuration>
-              <name>jni.compiler.args</name>
+              <name>jni.compiler.args.cflags</name>
               <value>${linux.sendmmsg.support}${glibc.sendmmsg.support}</value>
               <!-- If glibc and linux kernel are both not sufficient...then define the CFLAGS -->
               <regex>.*IO_NETTY_SENDMSSG_NOT_FOUND.*</regex>
@@ -203,8 +208,8 @@
               <goal>regex-property</goal>
             </goals>
             <configuration>
-              <name>jni.compiler.args</name>
-              <value>${jni.compiler.args}</value>
+              <name>jni.compiler.args.cflags</name>
+              <value>${jni.compiler.args.cflags}</value>
               <!-- If glibc and linux kernel are both not sufficient...then define the CFLAGS -->
               <regex>^((?!CFLAGS=).)*$</regex>
               <replacement>CFLAGS=-O3 -Werror</replacement>


### PR DESCRIPTION
Motivation:
epoll_wait accepts a timeout argument which will specify the maximum amount of time the epoll_wait will wait for an event to occur. If the epoll_wait method returns for any reason that is not fatal (e.g. EINTR) the original timeout value is re-used. This does not honor the timeout interface contract and can lead to unbounded time in epoll_wait.

Modifications:
- The time taken by epoll_wait should be decremented before calling epoll_wait again, and if the remaining time is exhausted we should return 0 according to the epoll_wait interface docs http://man7.org/linux/man-pages/man2/epoll_wait.2.html

Result:
epoll_wait will wait for at most timeout ms according to the epoll_wait interface contract.