### PR TITLE
Make JCtools available (provided scope) for tests and optional for OSGI

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -17,7 +17,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>io.netty</groupId>
     <artifactId>netty-parent</artifactId>
@@ -40,6 +40,8 @@
     <dependency>
       <groupId>org.jctools</groupId>
       <artifactId>jctools-core</artifactId>
+      <!-- Need compile scope to be taken into account by shade plugin -->
+      <scope>compile</scope>
       <!-- Mark as optional as otherwise the bundle plugin will add strict import statements and so fail in OSGI containers-->
       <optional>true</optional>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -537,6 +537,13 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <!-- Provided dependency for tests inside IDEs -->
+    <dependency>
+      <groupId>org.jctools</groupId>
+      <artifactId>jctools-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Make JCtools available (provided scope) for tests and optional for compile and OSGI, fixes #5383