### PR TITLE
Clarified IdleStateHandler's documentation

### DIFF
--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelPromise;
 import io.netty.util.concurrent.EventExecutor;
 
 import java.util.concurrent.ScheduledFuture;
@@ -31,6 +32,9 @@ import java.util.concurrent.TimeUnit;
 /**
  * Triggers an {@link IdleStateEvent} when a {@link Channel} has not performed
  * read, write, or both operation for a while.
+ * Notice, that {@link IdleStateEvent} will be triggered for write operations only in the case when
+ * {@link DefaultChannelPromise} is used (i.e. {@link ChannelHandlerContext#write(Object)} or
+ * {@link ChannelHandlerContext#writeAndFlush(Object)}). IllegalArgumentException will be thrown otherwise.
  *
  * <h3>Supported idle states</h3>
  * <table border="1">


### PR DESCRIPTION
Motivation:

IdleStateHandler's documentation doesn't say that IllegalArgumentException will be thrown in case VoidPromise is used while performing write operations.

Modifications:

Updated IdleStateHandler's documentation according to the Motivation section.

Result:

There's no more misunderstanding of how IdleStateHandler actually works.

This PR is related to #5264