### PR TITLE
Fix for a newly introduced bug in #5377

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -547,7 +547,7 @@ public abstract class OpenSslContext extends SslContext {
 
             ByteBuf buffer = allocator.directBuffer(content.readableBytes());
             try {
-                buffer.writeBytes(content);
+                buffer.writeBytes(content, content.readerIndex(), content.readableBytes());
                 return newBIO(buffer.retainedSlice());
             } finally {
                 try {


### PR DESCRIPTION
Motivation

Modifications

Pass a `ByteBuf#slice()` into `(Direct)ByteBuf#writeBytes(...)` so that the cached instance's readerIndex doesn't change.

Result

It's possible to share/cache/re-use `PemPrivateKey` and `PemX509Certificate` instances as long as their refCnt reamins >= 1.