### PR TITLE
Add more HttpHeaders values

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
@@ -23,6 +23,10 @@ import io.netty.util.AsciiString;
  */
 public final class HttpHeaderValues {
     /**
+     * {@code "application/json"}
+     */
+    public static final AsciiString APPLICATION_JSON = new AsciiString("application/json");
+    /**
      * {@code "application/x-www-form-urlencoded"}
      */
     public static final AsciiString APPLICATION_X_WWW_FORM_URLENCODED =
@@ -99,6 +103,10 @@ public final class HttpHeaderValues {
      * {@code "gzip"}
      */
     public static final AsciiString GZIP = new AsciiString("gzip");
+    /**
+     * {@code "gzip,deflate"}
+     */
+    public static final AsciiString GZIP_DEFLATE = new AsciiString("gzip,deflate");
     /**
      * {@code "x-gzip"}
      */

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -359,6 +359,10 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     @Deprecated
     public static final class Values {
         /**
+         * {@code "application/json"}
+         */
+        public static final String APPLICATION_JSON = "application/json";
+        /**
          * {@code "application/x-www-form-urlencoded"}
          */
         public static final String APPLICATION_X_WWW_FORM_URLENCODED =
@@ -407,6 +411,10 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
          * {@code "gzip"}
          */
         public static final String GZIP = "gzip";
+        /**
+         * {@code "gzip,deflate"}
+         */
+        public static final String GZIP_DEFLATE = "gzip,deflate";
         /**
          * {@code "identity"}
          */


### PR DESCRIPTION
Motivation:
Some commons values are missing from HttpHeader values constants.

Modifications:
- Add constants for "application/json" Content-Type
- Add constants for "gzip,deflate" Content-Encoding

Result:
More HttpHeader values constants available, both in
`HttpHeaders.Values` and `HttpHeaderValues`.