### PR TITLE
Auto-flush for all channels.

### DIFF
--- a/common/src/main/java/io/netty/util/LongBiConsumer.java
+++ b/common/src/main/java/io/netty/util/LongBiConsumer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util;
+
+/**
+ * Consumer of two {@code long} values.
+ */
+public interface LongBiConsumer {
+
+    /**
+     * Accepts the passed {@code long} values.
+     *
+     * @param aLong1 to accept.
+     * @param aLong2 to accept.
+     */
+    void accept(long aLong1, long aLong2);
+}

--- a/microbench/src/main/java/io/netty/microbench/channel/AbstractChannelBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/AbstractChannelBenchmark.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.channel;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.microbench.util.AbstractSharedExecutorMicrobenchmark;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.Future;
+import io.netty.util.internal.ThreadLocalRandom;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.net.SocketAddress;
+
+import static java.util.concurrent.TimeUnit.*;
+
+abstract class AbstractChannelBenchmark extends AbstractSharedExecutorMicrobenchmark {
+
+    public static final ChannelInitializer<Channel> EMPTY_INITIALIZER = new ChannelInitializer<Channel>() {
+        @Override
+        protected void initChannel(Channel ch) throws Exception {
+            ch.pipeline().addLast(BufferReleaseHandler.INSTANCE);
+        }
+    };
+    protected ChannelPipeline pipeline;
+    protected ByteBuf payload;
+    protected Channel serverChannel;
+    protected Channel clientChannel;
+    protected NioEventLoopGroup serverEventloop;
+    protected NioEventLoopGroup clientEventLoop;
+
+    protected void setup0() {
+        setup0(EMPTY_INITIALIZER, EMPTY_INITIALIZER);
+    }
+
+    protected void setup0(ChannelInitializer<Channel> serverInitializer,
+                          ChannelInitializer<Channel> clientInitializer) {
+        serverEventloop = new NioEventLoopGroup(1, new DefaultThreadFactory("server", true));
+        clientEventLoop = new NioEventLoopGroup(1, new DefaultThreadFactory("client", true));
+        ServerBootstrap sb = new ServerBootstrap();
+        sb.group(serverEventloop)
+          .channel(NioServerSocketChannel.class)
+          .childHandler(serverInitializer);
+
+        payload = createData(1024);
+
+        Bootstrap cb = new Bootstrap();
+        cb.group(clientEventLoop)
+          .channel(NioSocketChannel.class)
+          .handler(clientInitializer);
+
+        ChannelFuture bind = sb.bind(0);
+        SocketAddress serverAddr;
+        try {
+            bind.sync();
+            serverChannel = bind.channel();
+            serverAddr = serverChannel.localAddress();
+            ChannelFuture clientChannelFuture = cb.connect(serverAddr);
+            clientChannelFuture.sync();
+            clientChannel = clientChannelFuture.channel();
+            pipeline = clientChannel.pipeline();
+        } catch (InterruptedException ie) {
+            throw new IllegalStateException(ie);
+        }
+
+        AbstractSharedExecutorMicrobenchmark.executor(clientEventLoop.next());
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() throws Exception {
+        if (clientChannel != null) {
+            clientChannel.close();
+        }
+        if (serverChannel != null) {
+            serverChannel.close();
+        }
+        Future<?> serverGroup = null;
+        Future<?> clientGroup = null;
+
+        if (serverEventloop != null) {
+            serverGroup = serverEventloop.shutdownGracefully(0, 0, MILLISECONDS);
+        }
+        if (clientEventLoop != null) {
+            clientGroup = clientEventLoop.shutdownGracefully(0, 0, MILLISECONDS);
+        }
+        if (serverGroup != null) {
+            serverGroup.sync();
+        }
+        if (clientGroup != null) {
+            clientGroup.sync();
+        }
+        payload.release();
+    }
+
+    protected static ByteBuf createData(int length) {
+        byte[] result = new byte[length];
+        ThreadLocalRandom.current().nextBytes(result);
+        return Unpooled.directBuffer().writeBytes(result);
+    }
+
+    protected void awaitCompletion(ChannelFuture lastWriteFuture) throws Exception {
+        if (lastWriteFuture != null) {
+            lastWriteFuture.await();
+        }
+    }
+
+    @Sharable
+    static final class BufferReleaseHandler extends SimpleChannelInboundHandler<Object> {
+
+        public static final BufferReleaseHandler INSTANCE = new BufferReleaseHandler();
+
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
+            // No Op, just to release the buffer.
+        }
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/channel/AutoFlushBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/AutoFlushBenchmark.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.channel;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.util.concurrent.ScheduledFuture;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import static java.util.concurrent.TimeUnit.*;
+
+@State(Scope.Benchmark)
+public class AutoFlushBenchmark extends AbstractChannelBenchmark {
+
+    @Param({ "true", "false" })
+    public boolean autoFlush;
+
+    @Param({ "1", "10", "100" })
+    public int writeCount;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        setup0(EMPTY_INITIALIZER, new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ch.config().setOption(ChannelOption.AUTO_FLUSH, autoFlush);
+                ch.pipeline().addLast(BufferReleaseHandler.INSTANCE);
+            }
+        });
+    }
+
+    @Benchmark
+    public void compareWithFlushOnEach() throws Exception {
+        ChannelFuture lastWriteFuture = null;
+        if (!autoFlush) {
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.writeAndFlush(payload.retainedDuplicate());
+            }
+        } else {
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+            }
+        }
+
+        awaitCompletion(lastWriteFuture);
+    }
+
+    @Benchmark
+    public void compareWithFlushAtEnd() throws Exception {
+        ChannelFuture lastWriteFuture = null;
+        if (!autoFlush) {
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+            }
+            pipeline.flush();
+        } else {
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+            }
+        }
+
+        awaitCompletion(lastWriteFuture);
+    }
+
+    @Benchmark
+    public void compareWithFlushEvery5() throws Exception {
+        ChannelFuture lastWriteFuture = null;
+        if (!autoFlush) {
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+                if (i % 5 == 0) {
+                    pipeline.flush();
+                }
+            }
+            pipeline.flush();
+        } else {
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+            }
+        }
+
+        awaitCompletion(lastWriteFuture);
+    }
+
+    @Benchmark
+    public void compareWithFlushEverySecond() throws Exception {
+        ChannelFuture lastWriteFuture = null;
+        ScheduledFuture<?> scheduledFuture = null;
+        if (!autoFlush) {
+            scheduledFuture = pipeline.channel().eventLoop().scheduleWithFixedDelay(new Runnable() {
+                @Override
+                public void run() {
+                    pipeline.flush();
+                }
+            }, 1, 1, SECONDS);
+
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+            }
+            pipeline.flush();
+        } else {
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+            }
+        }
+
+        awaitCompletion(lastWriteFuture);
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(true);
+        }
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/channel/ChannelWriteBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/ChannelWriteBenchmark.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.channel;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class ChannelWriteBenchmark extends AbstractChannelBenchmark {
+
+    @Param({ "1", "5", "10" })
+    public int handlerCount;
+
+    @Param({ "1", "10" })
+    public int writeCount;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        setup0(EMPTY_INITIALIZER, new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                for (int i = 0; i < handlerCount; i++) {
+                    ch.pipeline().addLast(new ChannelDuplexHandler());
+                }
+                ch.pipeline().addFirst(BufferReleaseHandler.INSTANCE);
+            }
+        });
+    }
+
+    @Benchmark
+    public void measureWriteWithFlushAtEnd() throws Exception {
+        ChannelFuture lastWriteFuture = null;
+        for (int i = 0; i < writeCount; i++) {
+            lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+        }
+        pipeline.flush();
+        awaitCompletion(lastWriteFuture);
+    }
+
+    @Benchmark
+    public void measureWriteWithFlushOnEach() throws Exception {
+        ChannelFuture lastWriteFuture = null;
+        for (int i = 0; i < writeCount; i++) {
+            lastWriteFuture = pipeline.writeAndFlush(payload.retainedDuplicate());
+        }
+        awaitCompletion(lastWriteFuture);
+    }
+}

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -418,6 +418,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         private boolean inFlush0;
         /** true if the channel has never been registered, false otherwise */
         private boolean neverRegistered = true;
+        private AutoFlushTask autoFlushTask;
 
         private void assertEventLoop() {
             assert !registered || eventLoop.inEventLoop();
@@ -799,6 +800,17 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             }
 
             outboundBuffer.addMessage(msg, size, promise);
+
+            if (pipeline.isAutoFlush()) {
+                if (eventLoop instanceof SingleThreadEventLoop) {
+                    if (autoFlushTask == null) {
+                        autoFlushTask = new AutoFlushTask(AbstractChannel.this);
+                    }
+                    autoFlushTask.onWrite();
+                } else {
+                    flush(outboundBuffer);
+                }
+            }
         }
 
         @Override
@@ -810,6 +822,10 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 return;
             }
 
+            flush(outboundBuffer);
+        }
+
+        private void flush(ChannelOutboundBuffer outboundBuffer) {
             outboundBuffer.addFlush();
             flush0();
         }
@@ -1051,6 +1067,55 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
         boolean setClosed() {
             return super.trySuccess();
+        }
+    }
+
+    private static final class AutoFlushTask implements Runnable {
+
+        private final AbstractChannel channel;
+        private final SingleThreadEventLoop eventLoop;
+        private boolean writePending;
+        private boolean running;
+
+        AutoFlushTask(AbstractChannel channel) {
+            this.channel = channel;
+            assert channel.eventLoop() instanceof SingleThreadEventLoop;
+            eventLoop = (SingleThreadEventLoop) channel.eventLoop();
+        }
+
+        @Override
+        public void run() {
+            running = true;
+            try {
+                if (writePending) {
+                    writePending = false;
+                    channel.flush();
+                    if (writePending) {
+                        // There may be cases where a handler writes more data from within the flush() method and then
+                        // does not flush. In such a case, if we call flush() on the pipeline again, then it may end up
+                        // in an infinite loop. In order to prevent such an issue, we directly flush the unsafe.
+                        channel.unsafe.flush();
+                        writePending = false;
+                    }
+                }
+            } finally {
+                channel.pipeline.postAutoFlush();
+                if (writePending && channel.isActive() && channel.pipeline.isAutoFlush()) {
+                    eventLoop.executeAfterEventLoopIteration(this);
+                }
+                running = false;
+            }
+        }
+
+        void onWrite() {
+            if (!writePending) {
+                writePending = true;
+                if (!running) {
+                    // Re-entrant (write done from flush) should not enqueue the task again as it will be done at the
+                    // end of loop.
+                    eventLoop.executeAfterEventLoopIteration(this);
+                }
+            }
         }
     }
 }

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -815,6 +815,14 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap
                 task = WriteTask.newInstance(next, m, promise);
             }
             safeExecute(executor, task, promise, m);
+            if (!flush) {
+                /**
+                 * Whenever there is a write, if auto-flush is enabled, the eventloop is required to be woken up,
+                 * otherwise the write may never be flushed or have latency.
+                 * This method just wakes up the eventloop once till the next auto-flush task is run.
+                 */
+                pipeline.wakeUpForAutoFlushIfRequired();
+            }
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -18,6 +18,7 @@ package io.netty.channel;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.AbstractConstant;
 import io.netty.util.ConstantPool;
+import io.netty.util.internal.UnstableApi;
 
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -97,6 +98,15 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
 
     public static final ChannelOption<Boolean> ALLOW_HALF_CLOSURE = valueOf("ALLOW_HALF_CLOSURE");
     public static final ChannelOption<Boolean> AUTO_READ = valueOf("AUTO_READ");
+
+    /**
+     * Provides a way to eliminate explicit flushing of writes on this channel. If turned-on, any pending writes on the
+     * channel will be flushed on the next iteration of the eventloop if possible or directly (depending on the
+     * implementation).
+     * Explicit flushes will still be honored.
+     */
+    @UnstableApi
+    public static final ChannelOption<Boolean> AUTO_FLUSH = valueOf("AUTO_FLUSH");
 
     /**
      * @deprecated From version 5.0, {@link Channel} will not be closed on write failure.

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -35,6 +35,7 @@ import static io.netty.channel.ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK;
 import static io.netty.channel.ChannelOption.WRITE_BUFFER_LOW_WATER_MARK;
 import static io.netty.channel.ChannelOption.WRITE_BUFFER_WATER_MARK;
 import static io.netty.channel.ChannelOption.WRITE_SPIN_COUNT;
+import static io.netty.channel.ChannelOption.AUTO_FLUSH;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -75,6 +76,7 @@ public class DefaultChannelConfig implements ChannelConfig {
     private volatile int writeSpinCount = 16;
     @SuppressWarnings("FieldMayBeFinal")
     private volatile int autoRead = 1;
+    private volatile boolean autoFlush;
     private volatile boolean autoClose = true;
     private volatile WriteBufferWaterMark writeBufferWaterMark = WriteBufferWaterMark.DEFAULT;
 
@@ -93,7 +95,7 @@ public class DefaultChannelConfig implements ChannelConfig {
         return getOptions(
                 null,
                 CONNECT_TIMEOUT_MILLIS, MAX_MESSAGES_PER_READ, WRITE_SPIN_COUNT,
-                ALLOCATOR, AUTO_READ, AUTO_CLOSE, RCVBUF_ALLOCATOR, WRITE_BUFFER_HIGH_WATER_MARK,
+                ALLOCATOR, AUTO_FLUSH, AUTO_READ, AUTO_CLOSE, RCVBUF_ALLOCATOR, WRITE_BUFFER_HIGH_WATER_MARK,
                 WRITE_BUFFER_LOW_WATER_MARK, WRITE_BUFFER_WATER_MARK, MESSAGE_SIZE_ESTIMATOR);
     }
 
@@ -147,6 +149,9 @@ public class DefaultChannelConfig implements ChannelConfig {
         if (option == RCVBUF_ALLOCATOR) {
             return (T) getRecvByteBufAllocator();
         }
+        if (option == AUTO_FLUSH) {
+            return (T) Boolean.valueOf(isAutoFlush());
+        }
         if (option == AUTO_READ) {
             return (T) Boolean.valueOf(isAutoRead());
         }
@@ -183,6 +188,8 @@ public class DefaultChannelConfig implements ChannelConfig {
             setAllocator((ByteBufAllocator) value);
         } else if (option == RCVBUF_ALLOCATOR) {
             setRecvByteBufAllocator((RecvByteBufAllocator) value);
+        } else if (option == AUTO_FLUSH) {
+            setAutoFlush((Boolean) value);
         } else if (option == AUTO_READ) {
             setAutoRead((Boolean) value);
         } else if (option == AUTO_CLOSE) {
@@ -299,6 +306,27 @@ public class DefaultChannelConfig implements ChannelConfig {
     @Override
     public ChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
         rcvBufAllocator = checkNotNull(allocator, "allocator");
+        return this;
+    }
+
+    /**
+     * Tells whether {@link ChannelOption#AUTO_FLUSH} is enabled for this channel.
+     *
+     * @return {@code true} if {@link ChannelOption#AUTO_FLUSH} is enabled for this channel.
+     */
+    private boolean isAutoFlush() {
+        return autoFlush;
+    }
+
+    /**
+     * Sets the {@link ChannelOption#AUTO_FLUSH} option for the associated channel.
+     *
+     * @param autoFlush Auto flush value to set for the option.
+     *
+     * @return {@code this}
+     */
+    private ChannelConfig setAutoFlush(boolean autoFlush) {
+        this.autoFlush = autoFlush;
         return this;
     }
 

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -22,6 +22,7 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -36,6 +37,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.WeakHashMap;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 /**
  * The default {@link ChannelPipeline} implementation.  It is usually created
@@ -82,6 +84,27 @@ public class DefaultChannelPipeline implements ChannelPipeline {
      * change.
      */
     private boolean registered;
+
+    private static final AtomicIntegerFieldUpdater<DefaultChannelPipeline> ENQUEUE_WAKEUP_TASK_UPDATER;
+    private static final Runnable WAKEUP_TASK = new Runnable() {
+        @Override
+        public void run() {
+            // No Op
+        }
+    };
+
+    static {
+        AtomicIntegerFieldUpdater<DefaultChannelPipeline> enqueueWakeupTaskUpdater =
+                PlatformDependent.newAtomicIntegerFieldUpdater(DefaultChannelPipeline.class, "enqueueWakeupTask");
+        if (enqueueWakeupTaskUpdater == null) {
+            enqueueWakeupTaskUpdater = AtomicIntegerFieldUpdater.newUpdater(DefaultChannelPipeline.class,
+                                                                            "enqueueWakeupTask");
+        }
+        ENQUEUE_WAKEUP_TASK_UPDATER = enqueueWakeupTaskUpdater;
+    }
+
+    @SuppressWarnings("unused")
+    private volatile int enqueueWakeupTask;
 
     protected DefaultChannelPipeline(Channel channel) {
         this.channel = ObjectUtil.checkNotNull(channel, "channel");
@@ -1116,6 +1139,38 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             }
             pending.next = task;
         }
+    }
+
+    /**
+     * Wakes up the selector, if the following conditions are met:
+     * <ul>
+     *   <li>{@link #isAutoFlush()} is {@code true}</li>
+     *   <li>This is the first write, since the last time {@link #postAutoFlush()} was called, which is called, after
+     *   an auto-flush task has run.</li>
+     * </ul>
+     */
+    final void wakeUpForAutoFlushIfRequired() {
+        if (isAutoFlush() && ENQUEUE_WAKEUP_TASK_UPDATER.compareAndSet(this, 0, 1)) {
+            channel().eventLoop().execute(WAKEUP_TASK);
+        }
+    }
+
+    /**
+     * Whether {@link ChannelOption#AUTO_FLUSH} is enabled for this channel.
+     *
+     * @return {@code true} if auto-flush is enabled for the channel.
+     */
+    final boolean isAutoFlush() {
+        Boolean autoFlush = channel.config().getOption(ChannelOption.AUTO_FLUSH);
+        return autoFlush != null && autoFlush;
+    }
+
+    /**
+     * Callback when an auto-flush task has run. This will make sure that the next invocation of
+     * {@link #wakeUpForAutoFlushIfRequired()} will wakeup the selector, if auto-flush is still enabled.
+     */
+    final void postAutoFlush() {
+        ENQUEUE_WAKEUP_TASK_UPDATER.set(this, 0);
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -15,12 +15,14 @@
  */
 package io.netty.channel;
 
+import io.netty.util.LongBiConsumer;
 import io.netty.util.concurrent.RejectedExecutionHandler;
 import io.netty.util.concurrent.RejectedExecutionHandlers;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.SystemPropertyUtil;
 
+import java.util.Queue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 
@@ -32,6 +34,16 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
 
     protected static final int DEFAULT_MAX_PENDING_TASKS = Math.max(16,
             SystemPropertyUtil.getInt("io.netty.eventLoop.maxPendingTasks", Integer.MAX_VALUE));
+
+    private final Queue<Runnable> tailTasks;
+    private final LongBiConsumer runTimeoutUpdater = new LongBiConsumer() {
+        @Override
+        public void accept(long tailTasksStartTime, long tailTasksEndTime) {
+            runTimeout -= tailTasksEndTime - tailTasksStartTime;
+        }
+    };
+    private boolean lastRunTimedOut;
+    private long runTimeout;
 
     protected SingleThreadEventLoop(EventLoopGroup parent, ThreadFactory threadFactory, boolean addTaskWakesUp) {
         this(parent, threadFactory, addTaskWakesUp, DEFAULT_MAX_PENDING_TASKS, RejectedExecutionHandlers.reject());
@@ -45,12 +57,14 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
                                     boolean addTaskWakesUp, int maxPendingTasks,
                                     RejectedExecutionHandler rejectedExecutionHandler) {
         super(parent, threadFactory, addTaskWakesUp, maxPendingTasks, rejectedExecutionHandler);
+        tailTasks = newTaskQueue(maxPendingTasks);
     }
 
     protected SingleThreadEventLoop(EventLoopGroup parent, Executor executor,
                                     boolean addTaskWakesUp, int maxPendingTasks,
                                     RejectedExecutionHandler rejectedExecutionHandler) {
         super(parent, executor, addTaskWakesUp, maxPendingTasks, rejectedExecutionHandler);
+        tailTasks = newTaskQueue(maxPendingTasks);
     }
 
     @Override
@@ -89,9 +103,84 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
         return promise;
     }
 
+    /**
+     * Adds a task to be run once at the end of next (or current) {@code eventloop} iteration.
+     *
+     * @param task to be added.
+     */
+    final void executeAfterEventLoopIteration(Runnable task) {
+        ObjectUtil.checkNotNull(task, "task");
+        if (isShutdown()) {
+            reject();
+        }
+
+        if (!tailTasks.offer(task)) {
+            reject(task);
+        }
+
+        if (wakesUpForTask(task)) {
+            wakeup(inEventLoop());
+        }
+    }
+
+    /**
+     * Removes a task that was added previously via {@link #executeAfterEventLoopIteration(Runnable)}.
+     *
+     * @param task to be removed.
+     *
+     * @return {@code true} if the task was removed as a result of this call.
+     */
+    final boolean removeAfterEventLoopIterationTask(Runnable task) {
+        return tailTasks.remove(ObjectUtil.checkNotNull(task, "task"));
+    }
+
     @Override
     protected boolean wakesUpForTask(Runnable task) {
         return !(task instanceof NonWakeupRunnable);
+    }
+
+    @Override
+    protected boolean runAllTasks(long timeoutNanos) {
+        assert inEventLoop();
+        runTimeout = timeoutNanos;
+        if (lastRunTimedOut) {
+            //If the last run timed out, then run tail tasks first, otherwise, tail tasks may be starved.
+            lastRunTimedOut = false;
+            if (runAllTasksFrom(tailTasks, timeoutNanos, runTimeoutUpdater) == DeadlineRunResult.TIMED_OUT
+                || runTimeout <= 0) {
+                /**
+                 * Although, it didn't run any actual tasks, returning false, will indicate that there are no tasks
+                 * available, which we are not sure of.
+                 * Note: If every run of tail tasks and normal tasks time out, then this code will alternate, between
+                 * running tail tasks first and at end, which is fair. This is the reason, lastRunTimedOut is not set
+                 * to true here.
+                 */
+                return true;
+            }
+        }
+
+        return super.runAllTasks(runTimeout);
+    }
+
+    @Override
+    protected void afterRunningAllTasks(boolean timedOut) {
+        lastRunTimedOut = timedOut;
+        if (timedOut) {
+            // Do not run tail tasks on time out. Next run of tasks will run the tail tasks first.
+            return;
+        }
+
+        runAllTasksFrom(tailTasks);
+    }
+
+    @Override
+    protected boolean hasTasks() {
+        return super.hasTasks() || !tailTasks.isEmpty();
+    }
+
+    @Override
+    public int pendingTasks() {
+        return super.pendingTasks() + tailTasks.size();
     }
 
     /**

--- a/transport/src/test/java/io/netty/channel/AutoFlushTest.java
+++ b/transport/src/test/java/io/netty/channel/AutoFlushTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.concurrent.PromiseCombiner;
+import io.netty.util.internal.ThreadLocalRandom;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.SocketAddress;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class AutoFlushTest {
+
+    public static TestEnvironment environment;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        environment = new TestEnvironment((SingleThreadEventLoop) new NioEventLoopGroup().next(),
+                                          (SingleThreadEventLoop) new NioEventLoopGroup().next(),
+                                          NioServerSocketChannel.class, NioSocketChannel.class);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        environment.shutdown();
+    }
+
+    @Test(timeout = 20000)
+    public void testSingleWrite() throws Exception {
+        environment.connect();
+        environment.pipeline.write(newDataBuffer()).sync();
+    }
+
+    @Test(timeout = 20000)
+    public void testWithWriteOnContext() throws Exception {
+        environment.connect();
+        environment.pipeline.firstContext().write(newDataBuffer()).sync();
+    }
+
+    @Test(timeout = 20000)
+    public void testWriteFromFlush() throws Exception {
+        environment.connect();
+        environment.clientChannel.pipeline().addLast(new ChannelDuplexHandler() {
+            private boolean written;
+            @Override
+            public void flush(ChannelHandlerContext ctx) throws Exception {
+                if (!written) {
+                    written = true;
+                    environment.pipeline.write(newDataBuffer());
+                }
+                super.flush(ctx);
+            }
+        });
+        environment.pipeline.write(newDataBuffer()).sync();
+    }
+
+    @Test(timeout = 20000)
+    public void testMultipleWrites() throws Exception {
+        environment.connect();
+        final ChannelPromise aggreggatedPromise = environment.clientChannel.newPromise();
+        ByteBuf data = newDataBuffer();
+        PromiseCombiner promiseCombiner = new PromiseCombiner();
+        for (int i = 0; i < 10; i++) {
+            ChannelPromise promise = environment.clientChannel.newPromise();
+            promiseCombiner.add(promise);
+            environment.clientChannel.write(data.retainedDuplicate(), promise);
+        }
+        promiseCombiner.finish(aggreggatedPromise);
+        aggreggatedPromise.sync();
+    }
+
+    @Test(timeout = 20000)
+    public void testFromWithinEventloop() throws Exception {
+        environment.connect();
+        final AtomicReference<ChannelFuture> writeResult = new AtomicReference<ChannelFuture>();
+        environment.clientChannel.eventLoop().submit(new Runnable() {
+            @Override
+            public void run() {
+                writeResult.set(environment.pipeline.write(newDataBuffer()));
+            }
+        }).sync();
+
+        writeResult.get().sync();
+    }
+
+    private static ByteBuf newDataBuffer() {
+        byte[] dataArr = new byte[32];
+        ThreadLocalRandom.current().nextBytes(dataArr);
+        return Unpooled.wrappedBuffer(dataArr);
+    }
+
+    public static final class TestEnvironment {
+
+        private final SingleThreadEventLoop serverEventloop;
+        private final SingleThreadEventLoop clientEventloop;
+        private final ServerBootstrap serverBootstrap;
+        private final Bootstrap bootstrap;
+        private ChannelPipeline pipeline;
+        private Channel clientChannel;
+        private Channel serverChannel;
+
+        private TestEnvironment(SingleThreadEventLoop serverEventloop, SingleThreadEventLoop clientEventloop,
+                                Class<? extends ServerChannel> serverChannelClass,
+                                Class<? extends Channel> clientChannelClass) {
+            this.serverEventloop = serverEventloop;
+            this.clientEventloop = clientEventloop;
+            serverBootstrap = new ServerBootstrap();
+            serverBootstrap.group(serverEventloop)
+                           .channel(serverChannelClass)
+                           .childHandler(new ChannelInitializer<Channel>() {
+                  @Override
+                  protected void initChannel(Channel ch) throws Exception {
+                      ch.pipeline().addLast(BufferReleaseHandler.INSTANCE);
+                  }
+              });
+            bootstrap = new Bootstrap();
+            bootstrap.option(ChannelOption.AUTO_FLUSH, true)
+                     .group(clientEventloop)
+                     .channel(clientChannelClass)
+                     .handler(new ChannelInitializer<Channel>() {
+                         @Override
+                         protected void initChannel(Channel ch) throws Exception {
+                             ch.pipeline().addLast(BufferReleaseHandler.INSTANCE);
+                         }
+                     });
+        }
+
+        public void connect() {
+            ChannelFuture bind = serverBootstrap.bind(0);
+            SocketAddress serverAddr;
+            try {
+                bind.sync();
+                serverChannel = bind.channel();
+                serverAddr = serverChannel.localAddress();
+                ChannelFuture clientChannelFuture = bootstrap.connect(serverAddr);
+                clientChannelFuture.sync();
+                clientChannel = clientChannelFuture.channel();
+            } catch (InterruptedException ie) {
+                throw new RuntimeException(ie);
+            }
+            pipeline = clientChannel.pipeline();
+            if (!clientChannel.config().getOption(ChannelOption.AUTO_FLUSH)) {
+                throw new IllegalStateException("Auto-flush not set.");
+            }
+        }
+
+        private void shutdown() throws InterruptedException {
+            clientChannel.close().sync();
+            serverChannel.close().sync();
+            serverEventloop.shutdownGracefully();
+            clientEventloop.shutdownGracefully();
+        }
+    }
+
+    @Sharable
+    private static final class BufferReleaseHandler extends SimpleChannelInboundHandler<Object> {
+
+        public static final BufferReleaseHandler INSTANCE = new BufferReleaseHandler();
+
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
+            // No Op, just to release the buffer.
+        }
+    }
+}


### PR DESCRIPTION
###   Motivation

  Netty is extremely flexible in providing a way to batch writes on the physical socket by providing a means to `write` and `flush` writes separately. This works for the usecases when the application pattern is one that provides predictable finite streams of data. In cases, when an infinite stream of data is to be written on a channel which does not have any predictable length and duration of writes, a user has the following choices:

 - Flush every write. 
 - Flush batches based on time and count (eg: Flush every 10 message or 1 second)   

Neither of the above is ideal as the nature of stream is completely unpredictable. Flushing every write is costly as `flush` is a system call. Flushing batches is arbitrary and has to be deviced for each stream in an arbitrary way.  

### Modifications  

This change is a Proof Of Concept, is __not__ complete and has the following missing pieces:

  1. _UnitTests_: I haven't yet added any tests.
2. `DefaultChannelPipeline` caches the value of `ChannelConfig.isAutoRead()` at channel activation and does not update it later.
3. _Documentation_: I haven’t yet added any javadocs or comments to explain the changes.   

__I would like to invest more time on this change, if there is some consensus on whether this makes sense.  __

 Here are the details of the change:   

##### `ChannelOption.AUTO_FLUSH`   

 A channel option for enable/disable auto flush (this feature) is added.  When, this option is enabled, explicit flushes of writes on that channel are not required. Users can just call `write` and these writes will be flushed on every iteration of the associated `eventLoop` for that channel.
Any explicit flushes on the channel work as before i.e. it flushes all writes that happened before the flush and were not flushed. 

##### Changes to `EventLoop`

Two methods:

```java
void onEventLoopIteration(Runnable task);  
boolean removeOnEventLoopIterationTask(Runnable task);
```

are added to `EventLoop` interface for adding/removing a task to be executed at the end of each iteration of this `eventloop`.

##### Changes to `SingleThreadEventExecutor`

Added a method to `SingleThreadEventExecutor`

```java
protected void afterRunningAllTasks(boolean timedOut) { }

```

This is invoked after all tasks are run for this executor OR if the passed timeout value for `runAllTasks(long timeoutNanos)` is expired. In case of `timeout` the argument to this method is `true`.

##### Changes to `SingleThreadEventLoop`

Added a queue of `tailTasks` to this class to hold all tasks to be executed at the end of every iteration.
In the case if `afterRunningAllTasks` is invoked as a result of a timeout, no tail tasks are executed. Instead, the tail tasks are executed at the start of the next iteration.

##### Changes to `DefaultChannelPipeline`

Additional calls to `wakeup` the selector for the first `unflushed` write. This is done so that there isn’t a latency between the first `unflushed` write and invocation of the tails tasks.

##### Changes to `AbstractChannel`

Manages the lifecycle of `AutoFlushTask` per channel as the task to be invoked per iteration of the eventloop.
 
### Result

  This results in a much better model for infinite streams written to a channel.

I wrote a micro-benchmark(`io.netty.microbench.channel.AutoFlushBenchmark`) to demonstrate the throughput variations between all possible current alternatives.
Here are the results for the same:

```
Benchmark                                             (flush)  (writeCount)   Mode  Cnt      Score       Error  Units
AutoFlushBenchmark.measureWritesWithFlushAtEnd           true             1  thrpt   10  50679.715 ±  1557.854  ops/s
AutoFlushBenchmark.measureWritesWithFlushAtEnd           true            10  thrpt   10  38835.955 ±   887.623  ops/s
AutoFlushBenchmark.measureWritesWithFlushAtEnd           true           100  thrpt   10  11916.433 ±    96.373  ops/s
AutoFlushBenchmark.measureWritesWithFlushAtEnd          false             1  thrpt   10  50452.022 ±  1366.724  ops/s
AutoFlushBenchmark.measureWritesWithFlushAtEnd          false            10  thrpt   10  37895.350 ±   492.081  ops/s
AutoFlushBenchmark.measureWritesWithFlushAtEnd          false           100  thrpt   10  11586.364 ±   132.067  ops/s
AutoFlushBenchmark.measureWritesWithFlushEvery5          true             1  thrpt   10  50592.297 ±  1102.360  ops/s
AutoFlushBenchmark.measureWritesWithFlushEvery5          true            10  thrpt   10  27176.931 ±   335.812  ops/s
AutoFlushBenchmark.measureWritesWithFlushEvery5          true           100  thrpt   10   5447.520 ±    82.222  ops/s
AutoFlushBenchmark.measureWritesWithFlushEvery5         false             1  thrpt   10  49741.284 ±   752.898  ops/s
AutoFlushBenchmark.measureWritesWithFlushEvery5         false            10  thrpt   10  37140.030 ±  1556.103  ops/s
AutoFlushBenchmark.measureWritesWithFlushEvery5         false           100  thrpt   10  11503.099 ±    94.868  ops/s
AutoFlushBenchmark.measureWritesWithFlushEverySecond     true             1  thrpt   10  36295.567 ± 13013.318  ops/s
AutoFlushBenchmark.measureWritesWithFlushEverySecond     true            10  thrpt   10  26575.064 ±  3091.255  ops/s
AutoFlushBenchmark.measureWritesWithFlushEverySecond     true           100  thrpt   10   8088.351 ±  1390.408  ops/s
AutoFlushBenchmark.measureWritesWithFlushEverySecond    false             1  thrpt   10  49721.904 ±   718.826  ops/s
AutoFlushBenchmark.measureWritesWithFlushEverySecond    false            10  thrpt   10  38451.303 ±   712.448  ops/s
AutoFlushBenchmark.measureWritesWithFlushEverySecond    false           100  thrpt   10  11387.047 ±   139.104  ops/s
AutoFlushBenchmark.measureWritesWithFlushOnEach          true             1  thrpt   10  51501.154 ±  3866.709  ops/s
AutoFlushBenchmark.measureWritesWithFlushOnEach          true            10  thrpt   10  15308.538 ±   351.524  ops/s
AutoFlushBenchmark.measureWritesWithFlushOnEach          true           100  thrpt   10   1746.113 ±    31.679  ops/s
AutoFlushBenchmark.measureWritesWithFlushOnEach         false             1  thrpt   10  49927.340 ±  1482.713  ops/s
AutoFlushBenchmark.measureWritesWithFlushOnEach         false            10  thrpt   10  37389.582 ±  1859.288  ops/s
AutoFlushBenchmark.measureWritesWithFlushOnEach         false           100  thrpt   10  11604.148 ±   342.597  ops/s
```

This was done on MBP with 16GB of memory and 8 processors.