### PR TITLE
[#5334] Add InstrumentedEventExecutor / InstrumentedEventLoop which e…

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/InstrumentedEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/InstrumentedEventExecutor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import io.netty.util.internal.UnstableApi;
+
+/**
+ * An {@link EventExecutor} that allows to obtain metrics.
+ */
+@UnstableApi
+public interface InstrumentedEventExecutor extends EventExecutor {
+
+    /**
+     * Return the number of tasks that are pending for processing.
+     *
+     * <strong>Be aware that this operation may be expensive as it depends on the internal implementation of the
+     * InstrumentedEventExecutor. So use it was care!</strong>
+     */
+    int pendingTasks();
+}

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -39,7 +39,8 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
  * Abstract base class for {@link EventExecutor}'s that execute all its submitted tasks in a single thread.
  *
  */
-public abstract class SingleThreadEventExecutor extends AbstractScheduledEventExecutor {
+public abstract class SingleThreadEventExecutor extends AbstractScheduledEventExecutor
+        implements InstrumentedEventExecutor {
 
     private static final InternalLogger logger =
             InternalLoggerFactory.getInstance(SingleThreadEventExecutor.class);
@@ -264,12 +265,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
         return !taskQueue.isEmpty();
     }
 
-    /**
-     * Return the number of tasks that are pending for processing.
-     *
-     * <strong>Be aware that this operation may be expensive as it depends on the internal implementation of the
-     * SingleThreadEventExecutor. So use it was care!</strong>
-     */
+    @Override
     public int pendingTasks() {
         return taskQueue.size();
     }

--- a/transport/src/main/java/io/netty/channel/InstrumentedEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/InstrumentedEventLoop.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import io.netty.util.concurrent.InstrumentedEventExecutor;
+import io.netty.util.internal.UnstableApi;
+
+/**
+ * An {@link EventLoop} that allows to obtain metrics.
+ */
+@UnstableApi
+public interface InstrumentedEventLoop extends EventLoop, InstrumentedEventExecutor {
+
+    /**
+     * Returns the number of registered {@link Channel}s.
+     */
+    int registeredChannels();
+
+    /**
+     * Returns the number of milliseconds the last processing of all IO took.
+     */
+    long lastIoProcessingTime();
+
+    /**
+     * Returns the number of milliseconds the last processing of all tasks took.
+     */
+    long lastTaskProcessingTime();
+
+    /**
+     * Returns the number {@link Channel}s that where processed in the last run.
+     */
+    int lastProcessedChannels();
+
+    /**
+     * Returns the number of milliseconds the {@link EventLoop} blocked before run to pick up IO and tasks.
+     */
+    long lastBlockingAmount();
+}

--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -60,15 +60,8 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
     @Deprecated
     @Override
     public ChannelFuture register(final Channel channel, final ChannelPromise promise) {
-        if (channel == null) {
-            throw new NullPointerException("channel");
-        }
-        if (promise == null) {
-            throw new NullPointerException("promise");
-        }
-
-        channel.unsafe().register(this, promise);
-        return promise;
+        ObjectUtil.checkNotNull(channel, "channel");
+        return register(promise);
     }
 
     @Override


### PR DESCRIPTION
…xpose some metrics.

Motivation:

It would be useful for users to be able to obtain metrics from EventExecutor and EventLoop. This could also be useful in the context of EventExecutorChooser, to choose EventExecutor that is under utilized.

Modifications:
- Add InstrumentedEventExecutor and let SingleThreadEventLoop implement it.
- Add InstrumentedEventLoop and let NioEventLoop / EpollEventLoop implement it.

Result:

Be able to obtain metrics for EventExecutor / EventLoop implementations.
