### PR TITLE
Deprecate ReadTimeoutHandler

### DIFF
--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -90,9 +90,6 @@ import java.util.concurrent.TimeUnit;
  * bootstrap.childHandler(new MyChannelInitializer());
  * ...
  * </pre>
- *
- * @see ReadTimeoutHandler
- * @see WriteTimeoutHandler
  */
 public class IdleStateHandler extends ChannelDuplexHandler {
     private static final long MIN_TIMEOUT_NANOS = TimeUnit.MILLISECONDS.toNanos(1);

--- a/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutException.java
+++ b/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutException.java
@@ -18,7 +18,9 @@ package io.netty.handler.timeout;
 /**
  * A {@link TimeoutException} raised by {@link ReadTimeoutHandler} when no data
  * was read within a certain period of time.
+ * @deprecated No more used, since {@link ReadTimeoutHandler} has been deprecated.
  */
+@Deprecated
 public final class ReadTimeoutException extends TimeoutException {
 
     private static final long serialVersionUID = 169287984113283421L;

--- a/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/ReadTimeoutHandler.java
@@ -60,7 +60,9 @@ import java.util.concurrent.TimeUnit;
  * </pre>
  * @see WriteTimeoutHandler
  * @see IdleStateHandler
+ * @deprecated Use {@link IdleStateHandler} instead.
  */
+@Deprecated
 public class ReadTimeoutHandler extends ChannelInboundHandlerAdapter {
     private static final long MIN_TIMEOUT_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
 


### PR DESCRIPTION
Motivation:

Deprecate `ReadTimeoutHandler` because:
1. The inconsistent behaviors between `ReadTimeoutHandler` and `WriteTimeoutHandler` make people confused.
2. `IdleStateHandler` can be used for `ReadTimeoutHandler` use case.

Modifications:

1. Deprecated `ReadTimeoutHandler`.
2. Deprecated `ReadTimeoutException`, since it was only used by `ReadTimeoutHandler`.

Result:

Deprecate `ReadTimeoutHandler` to eliminate the inconsistent behaviors, which may cause confusion.