### PR TITLE
Fix DNS CNAME resolver issue

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
@@ -166,10 +166,6 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
             return ROOT;
         }
 
-        if (name.charAt(name.length() - 1) != '.') {
-            name.append('.');
-        }
-
         return name.toString();
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -482,7 +482,7 @@ abstract class DnsNameResolverContext<T> {
                 return null;
             }
 
-            return name.substring(0, name.length() - 1);
+            return name.toString();
         } finally {
             buf.resetReaderIndex();
         }


### PR DESCRIPTION
Motivation:

`DnsNameResolverContext.decodeDomainName` and `DefaultDnsRecordDecoder.decodeName` should have the same logic: the returned name should end with ".". Otherwise, the comparsion with those names will fail. (#5391)

Modifications:

- Make `DnsNameResolverContext.decodeDomainName` return a name ending with ".".
- Remove useless codes in `DefaultDnsRecordDecoder.decodeName`.

Result:

Fix the DNS CNAME resovler issue.