### PR TITLE
Fix typo in log message

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -689,7 +689,7 @@ public final class ChannelOutboundBuffer {
                 logger.warn("Failed to mark a promise as failure because it has succeeded already: {}", promise, cause);
             } else {
                 logger.warn(
-                        "Failed to mark a promise as failure because it hass failed already: {}, unnotified cause {}",
+                        "Failed to mark a promise as failure because it has failed already: {}, unnotified cause {}",
                         promise, ThrowableUtils.stackTraceToString(err), cause);
             }
         }


### PR DESCRIPTION
Motivation:

We had a typo in the log message.

Modifications:

Remove extra "s" in log message.

Result:

Correct spelling in log message.