### PR TITLE
Correctly skip OpenSsl* tests if OpenSsl.isAvailable() is false.

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslClientContextTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslClientContextTest.java
@@ -16,11 +16,20 @@
 package io.netty.handler.ssl;
 
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.junit.BeforeClass;
 
 import javax.net.ssl.SSLException;
 import java.io.File;
 
+import static org.junit.Assume.assumeTrue;
+
 public class OpenSslClientContextTest extends SslContextTest  {
+
+    @BeforeClass
+    public static void checkOpenSsl() {
+        assumeTrue(OpenSsl.isAvailable());
+    }
+
     @Override
     protected SslContext newServerContext(File crtFile, File keyFile, String pass) throws SSLException {
         return new OpenSslClientContext(crtFile, InsecureTrustManagerFactory.INSTANCE, crtFile, keyFile, pass,

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -19,6 +19,7 @@ import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.internal.ThreadLocalRandom;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
@@ -37,9 +38,13 @@ public class OpenSslEngineTest extends SSLEngineTest {
     private static final String PREFERRED_APPLICATION_LEVEL_PROTOCOL = "my-protocol-http2";
     private static final String FALLBACK_APPLICATION_LEVEL_PROTOCOL = "my-protocol-http1_1";
 
+    @BeforeClass
+    public static void checkOpenSsl() {
+        assumeTrue(OpenSsl.isAvailable());
+    }
+
     @Test
     public void testNpn() throws Exception {
-        assumeTrue(OpenSsl.isAvailable());
         ApplicationProtocolConfig apn = acceptingNegotiator(Protocol.NPN,
                 PREFERRED_APPLICATION_LEVEL_PROTOCOL);
         setupHandlers(apn);
@@ -48,7 +53,6 @@ public class OpenSslEngineTest extends SSLEngineTest {
 
     @Test
     public void testAlpn() throws Exception {
-        assumeTrue(OpenSsl.isAvailable());
         assumeTrue(OpenSsl.isAlpnSupported());
         ApplicationProtocolConfig apn = acceptingNegotiator(Protocol.ALPN,
                 PREFERRED_APPLICATION_LEVEL_PROTOCOL);
@@ -58,7 +62,6 @@ public class OpenSslEngineTest extends SSLEngineTest {
 
     @Test
     public void testAlpnCompatibleProtocolsDifferentClientOrder() throws Exception {
-        assumeTrue(OpenSsl.isAvailable());
         assumeTrue(OpenSsl.isAlpnSupported());
         ApplicationProtocolConfig clientApn = acceptingNegotiator(Protocol.ALPN,
                 FALLBACK_APPLICATION_LEVEL_PROTOCOL, PREFERRED_APPLICATION_LEVEL_PROTOCOL);
@@ -71,50 +74,11 @@ public class OpenSslEngineTest extends SSLEngineTest {
 
     @Test
     public void testEnablingAnAlreadyDisabledSslProtocol() throws Exception {
-        assumeTrue(OpenSsl.isAvailable());
         testEnablingAnAlreadyDisabledSslProtocol(new String[]{PROTOCOL_SSL_V2_HELLO},
             new String[]{PROTOCOL_SSL_V2_HELLO, PROTOCOL_TLS_V1_2});
     }
-
-    @Override
-    public void testMutualAuthSameCerts() throws Exception {
-        assumeTrue(OpenSsl.isAvailable());
-        super.testMutualAuthSameCerts();
-    }
-
-    @Override
-    public void testMutualAuthDiffCerts() throws Exception {
-        assumeTrue(OpenSsl.isAvailable());
-        super.testMutualAuthDiffCerts();
-    }
-
-    @Override
-    public void testMutualAuthDiffCertsServerFailure() throws Exception {
-        assumeTrue(OpenSsl.isAvailable());
-        super.testMutualAuthDiffCertsServerFailure();
-    }
-
-    @Override
-    public void testMutualAuthDiffCertsClientFailure() throws Exception {
-        assumeTrue(OpenSsl.isAvailable());
-        super.testMutualAuthDiffCertsClientFailure();
-    }
-
-    @Override
-    public void testGetCreationTime() throws Exception {
-        assumeTrue(OpenSsl.isAvailable());
-        super.testGetCreationTime();
-    }
-
-    @Override
-    public void testSessionInvalidate() throws Exception {
-        assumeTrue(OpenSsl.isAvailable());
-        super.testSessionInvalidate();
-    }
-
     @Test
     public void testWrapHeapBuffersNoWritePendingError() throws Exception {
-        assumeTrue(OpenSsl.isAvailable());
         final SslContext clientContext = SslContextBuilder.forClient()
                 .trustManager(InsecureTrustManagerFactory.INSTANCE)
                 .sslProvider(sslProvider())

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslRenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslRenegotiateTest.java
@@ -15,16 +15,18 @@
  */
 package io.netty.handler.ssl;
 
-import org.junit.Assume;
+import org.junit.BeforeClass;
+
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 public class OpenSslRenegotiateTest extends RenegotiateTest {
 
-    @Override
-    public void testRenegotiateServer() throws Throwable {
+    @BeforeClass
+    public static void checkOpenSsl() {
+        assumeTrue(OpenSsl.isAvailable());
         // BoringSSL does not support renegotiation intentionally.
-        Assume.assumeFalse("BoringSSL".equals(OpenSsl.versionString()));
-        Assume.assumeTrue(OpenSsl.isAvailable());
-        super.testRenegotiateServer();
+        assumeFalse("BoringSSL".equals(OpenSsl.versionString()));
     }
 
     @Override

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslServerContextTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslServerContextTest.java
@@ -17,11 +17,19 @@
 package io.netty.handler.ssl;
 
 import org.junit.Assume;
+import org.junit.BeforeClass;
 
 import javax.net.ssl.SSLException;
 import java.io.File;
 
+import static org.junit.Assume.assumeTrue;
+
 public class OpenSslServerContextTest extends SslContextTest {
+
+    @BeforeClass
+    public static void checkOpenSsl() {
+        assumeTrue(OpenSsl.isAvailable());
+    }
 
     @Override
     protected SslContext newServerContext(File crtFile, File keyFile, String pass) throws SSLException {


### PR DESCRIPTION
Motivation:

We missed to skip some tests for OpenSsl when OpenSsl.isAvailable() is false.

Modifications:

- Correctly skip tests when OpenSsl.isAvailable() is false.
- Simplify some code by using @BeforeClass.

Result:

Be able to compile netty even when OpenSsl is not present on the system.