### PR TITLE
[#5391] DnsNameResolver does not resolve property A+CNAME answer

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
@@ -92,7 +92,7 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
 
         if (type == DnsRecordType.PTR) {
             in.setIndex(offset, offset + length);
-            return new DefaultDnsPtrRecord(name, dnsClass, timeToLive, decodeName(in));
+            return new DefaultDnsPtrRecord(name, dnsClass, timeToLive, decodeName0(in));
         }
         return new DefaultDnsRawRecord(
                 name, type, dnsClass, timeToLive, in.retainedDuplicate().setIndex(offset, offset + length));
@@ -106,7 +106,19 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
      * @param in the byte buffer containing the DNS packet
      * @return the domain name for an entry
      */
-    protected String decodeName(ByteBuf in) {
+    protected String decodeName0(ByteBuf in) {
+        return decodeName(in);
+    }
+
+    /**
+     * Retrieves a domain name given a buffer containing a DNS packet. If the
+     * name contains a pointer, the position of the buffer will be set to
+     * directly after the pointer's index after the name has been read.
+     *
+     * @param in the byte buffer containing the DNS packet
+     * @return the domain name for an entry
+     */
+    public static String decodeName(ByteBuf in) {
         int position = -1;
         int checked = 0;
         final int end = in.writerIndex();


### PR DESCRIPTION
Motivation:

The current DnsNameResolver fails to resolve an A+CNAME answer. For example:

dig moose.rmq.cloudamqp.com

...
;; ANSWER SECTION:
moose.rmq.cloudamqp.com. 1800   IN  CNAME   ec2-54-152-221-139.compute-1.amazonaws.com.
ec2-54-152-221-139.compute-1.amazonaws.com. 583612 IN A 54.152.221.139
...

The resolver constructs a map of cnames but forgets the trailing "." in the values which lead to not resolve the A record.

Modifications:

Reuse the code of DefaltDnsRecordDecoder which correctly handles the trailing dot.

Result:

Correctly resolve.