### PR TITLE
Correctly handle user home directory with spaces when construct javaa…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
     <netty.build.version>22</netty.build.version>
     <jboss.marshalling.version>1.4.8.Final</jboss.marshalling.version>
     <jetty.alpnAgent.version>2.0.1</jetty.alpnAgent.version>
-    <jetty.alpnAgent.path>${settings.localRepository}/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
+    <jetty.alpnAgent.path>"${settings.localRepository}"/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
     <argLine.common>
       -server
       -dsa -da -ea:io.netty...


### PR DESCRIPTION
…gent argument

Motivation:

When the user home and so the path to the local maven repository contains spaces it currently fails to run the tests (at least on windows).

Modifications:

Put double quotes around the ${settings.localRepository}

Result:

Be able to run build and tests even when user home path has spaces in it.