### PR TITLE
Added `isText` to validate if a ByteBuf is compliant with the specifi…

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -27,6 +27,7 @@ import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class ByteBufUtilTest {
     @Test
@@ -303,6 +304,102 @@ public class ByteBufUtilTest {
             buffer.addComponent(Unpooled.buffer(bytes.length).writeBytes(bytes));
             buffer.addComponent(Unpooled.buffer(bytes.length).writeBytes(bytes));
             assertEquals("1234", buffer.toString(bytes.length, bytes.length, CharsetUtil.UTF_8));
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testIsTextWithUtf8() {
+        byte[][] validUtf8Bytes = new byte[][]{
+                "netty".getBytes(CharsetUtil.UTF_8),
+                new byte[]{(byte) 0x24},
+                new byte[]{(byte) 0xC2, (byte) 0xA2},
+                new byte[]{(byte) 0xE2, (byte) 0x82, (byte) 0xAC},
+                new byte[]{(byte) 0xF0, (byte) 0x90, (byte) 0x8D, (byte) 0x88},
+                new byte[]{(byte) 0x24,
+                        (byte) 0xC2, (byte) 0xA2,
+                        (byte) 0xE2, (byte) 0x82, (byte) 0xAC,
+                        (byte) 0xF0, (byte) 0x90, (byte) 0x8D, (byte) 0x88} // multiple characters
+        };
+        for (byte[] bytes : validUtf8Bytes) {
+            assertIsText(bytes, true, CharsetUtil.UTF_8);
+        }
+        byte[][] invalidUtf8Bytes = new byte[][]{
+                new byte[]{(byte) 0x80},
+                new byte[]{(byte) 0xF0, (byte) 0x82, (byte) 0x82, (byte) 0xAC}, // Overlong encodings
+                new byte[]{(byte) 0xC2},                                        // not enough bytes
+                new byte[]{(byte) 0xE2, (byte) 0x82},                           // not enough bytes
+                new byte[]{(byte) 0xF0, (byte) 0x90, (byte) 0x8D},              // not enough bytes
+                new byte[]{(byte) 0xC2, (byte) 0xC0},                           // not correct bytes
+                new byte[]{(byte) 0xE2, (byte) 0x82, (byte) 0xC0},              // not correct bytes
+                new byte[]{(byte) 0xF0, (byte) 0x90, (byte) 0x8D, (byte) 0xC0}, // not correct bytes
+                new byte[]{(byte) 0xC1, (byte) 0x80},                           // out of lower bound
+                new byte[]{(byte) 0xE0, (byte) 0x80, (byte) 0x80},              // out of lower bound
+                new byte[]{(byte) 0xED, (byte) 0xAF, (byte) 0x80}               // out of upper bound
+        };
+        for (byte[] bytes : invalidUtf8Bytes) {
+            assertIsText(bytes, false, CharsetUtil.UTF_8);
+        }
+    }
+
+    @Test
+    public void testIsTextWithoutOptimization() {
+        byte[] validBytes = new byte[]{(byte) 0x01, (byte) 0xD8, (byte) 0x37, (byte) 0xDC};
+        byte[] invalidBytes = new byte[]{(byte) 0x01, (byte) 0xD8};
+
+        assertIsText(validBytes, true, CharsetUtil.UTF_16LE);
+        assertIsText(invalidBytes, false, CharsetUtil.UTF_16LE);
+    }
+
+    @Test
+    public void testIsTextWithAscii() {
+        byte[] validBytes = new byte[]{(byte) 0x00, (byte) 0x01, (byte) 0x37, (byte) 0x7F};
+        byte[] invalidBytes = new byte[]{(byte) 0x80, (byte) 0xFF};
+
+        assertIsText(validBytes, true, CharsetUtil.US_ASCII);
+        assertIsText(invalidBytes, false, CharsetUtil.US_ASCII);
+    }
+
+    @Test
+    public void testIsTextWithInvalidIndexAndLength() {
+        ByteBuf buffer = Unpooled.buffer();
+        try {
+            buffer.writeBytes(new byte[4]);
+            int[][] validIndexLengthPairs = new int[][] {
+                    new int[]{4, 0},
+                    new int[]{0, 4},
+                    new int[]{1, 3},
+            };
+            for (int[] pair : validIndexLengthPairs) {
+                assertTrue(ByteBufUtil.isText(buffer, pair[0], pair[1], CharsetUtil.US_ASCII));
+            }
+            int[][] invalidIndexLengthPairs = new int[][]{
+                    new int[]{4, 1},
+                    new int[]{-1, 2},
+                    new int[]{3, -1},
+                    new int[]{3, -2},
+                    new int[]{5, 0},
+                    new int[]{1, 5},
+            };
+            for (int[] pair : invalidIndexLengthPairs) {
+                try {
+                    ByteBufUtil.isText(buffer, pair[0], pair[1], CharsetUtil.US_ASCII);
+                    fail("Expected IndexOutOfBoundsException");
+                } catch (IndexOutOfBoundsException e) {
+                    // expected
+                }
+            }
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private static void assertIsText(byte[] bytes, boolean expected, Charset charset) {
+        ByteBuf buffer = Unpooled.buffer();
+        try {
+            buffer.writeBytes(bytes);
+            assertEquals(expected, ByteBufUtil.isText(buffer, charset));
         } finally {
             buffer.release();
         }


### PR DESCRIPTION
…ed charset.

Motivation:

See #82.

Modifications:

- Added `isText` to validate if the given ByteBuf is compliant with the specified charset.
- Optimized for UTF-8 and ASCII. For other cases, `CharsetDecoder.decoder` is used.

Result:

Users can validate ByteBuf with given charset.