### PR TITLE
Set some StackTraceElement on pre-instanced static exceptions

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
@@ -33,8 +33,8 @@ import io.netty.handler.codec.http.HttpRequestEncoder;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.ThrowableUtil;
 
 import java.net.URI;
 import java.nio.channels.ClosedChannelException;
@@ -43,11 +43,8 @@ import java.nio.channels.ClosedChannelException;
  * Base class for web socket client handshake implementations
  */
 public abstract class WebSocketClientHandshaker {
-    private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = new ClosedChannelException();
-
-    static {
-        CLOSED_CHANNEL_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-    }
+    private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new ClosedChannelException(), WebSocketClientHandshaker.class, "processHandshake(...)");
 
     private final URI uri;
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker.java
@@ -34,6 +34,7 @@ import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -47,11 +48,8 @@ import java.util.Set;
  */
 public abstract class WebSocketServerHandshaker {
     protected static final InternalLogger logger = InternalLoggerFactory.getInstance(WebSocketServerHandshaker.class);
-    private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = new ClosedChannelException();
-
-    static {
-        CLOSED_CHANNEL_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-    }
+    private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new ClosedChannelException(), WebSocketServerHandshaker.class, "handshake(...)");
 
     private final String uri;
 

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdySessionHandler.java
@@ -20,7 +20,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
-import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ThrowableUtil;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -32,13 +32,10 @@ import static io.netty.handler.codec.spdy.SpdyCodecUtil.isServerId;
  */
 public class SpdySessionHandler extends ChannelDuplexHandler {
 
-    private static final SpdyProtocolException PROTOCOL_EXCEPTION = new SpdyProtocolException();
-    private static final SpdyProtocolException STREAM_CLOSED = new SpdyProtocolException("Stream closed");
-
-    static {
-        PROTOCOL_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-        STREAM_CLOSED.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-    }
+    private static final SpdyProtocolException PROTOCOL_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new SpdyProtocolException(), SpdySessionHandler.class, "handleOutboundMessage(...)");
+    private static final SpdyProtocolException STREAM_CLOSED = ThrowableUtil.unknownStackTrace(
+            new SpdyProtocolException("Stream closed"), SpdySessionHandler.class, "removeStream(...)");
 
     private static final int DEFAULT_WINDOW_SIZE = 64 * 1024; // 64 KB default initial window size
     private int initialSendWindowSize    = DEFAULT_WINDOW_SIZE;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -28,7 +28,7 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
-import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ThrowableUtil;
 
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
@@ -46,16 +46,13 @@ abstract class AbstractHttp2StreamChannel extends AbstractChannel {
      */
     protected static final Object CLOSE_MESSAGE = new Object();
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
-    private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = new ClosedChannelException();
+    private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new ClosedChannelException(), AbstractHttp2StreamChannel.class, "doWrite(...)");
     /**
      * Number of bytes to consider non-payload messages, to determine when to stop reading. 9 is
      * arbitrary, but also the minimum size of an HTTP/2 frame. Primarily is non-zero.
      */
     private static final int ARBITRARY_MESSAGE_SIZE = 9;
-
-    static {
-        CLOSED_CHANNEL_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-    }
 
     private final ChannelConfig config = new DefaultChannelConfig(this);
     private final Queue<Object> inboundBuffer = new ArrayDeque<Object>(4);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/Decoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/Decoder.java
@@ -32,7 +32,7 @@
 package io.netty.handler.codec.http2.internal.hpack;
 
 import io.netty.handler.codec.http2.internal.hpack.HpackUtil.IndexType;
-import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ThrowableUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,21 +41,22 @@ import static io.netty.util.internal.EmptyArrays.EMPTY_BYTES;
 
 public final class Decoder {
 
-    private static final IOException DECOMPRESSION_EXCEPTION =
-            new IOException("HPACK - decompression failure");
-    private static final IOException ILLEGAL_INDEX_VALUE =
-            new IOException("HPACK - illegal index value");
-    private static final IOException INVALID_MAX_DYNAMIC_TABLE_SIZE =
-            new IOException("HPACK - invalid max dynamic table size");
-    private static final IOException MAX_DYNAMIC_TABLE_SIZE_CHANGE_REQUIRED =
-            new IOException("HPACK - max dynamic table size change required");
-
-    static {
-        DECOMPRESSION_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-        ILLEGAL_INDEX_VALUE.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-        INVALID_MAX_DYNAMIC_TABLE_SIZE.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-        MAX_DYNAMIC_TABLE_SIZE_CHANGE_REQUIRED.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-    }
+    private static final IOException DECODE_DECOMPRESSION_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new IOException("HPACK - decompression failure"), Decoder.class, "decode(...)");
+    private static final IOException DECODE_ULE_128_DECOMPRESSION_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new IOException("HPACK - decompression failure"), Decoder.class, "decodeULE128(...)");
+    private static final IOException READ_STRING_LITERAL_DECOMPRESSION_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new IOException("HPACK - decompression failure"), Decoder.class, "readStringLiteral(...)");
+    private static final IOException DECODE_ILLEGAL_INDEX_VALUE = ThrowableUtil.unknownStackTrace(
+            new IOException("HPACK - illegal index value"), Decoder.class, "decode(...)");
+    private static final IOException INDEX_HEADER_ILLEGAL_INDEX_VALUE = ThrowableUtil.unknownStackTrace(
+            new IOException("HPACK - illegal index value"), Decoder.class, "indexHeader(...)");
+    private static final IOException READ_NAME_ILLEGAL_INDEX_VALUE = ThrowableUtil.unknownStackTrace(
+            new IOException("HPACK - illegal index value"), Decoder.class, "readName(...)");
+    private static final IOException INVALID_MAX_DYNAMIC_TABLE_SIZE = ThrowableUtil.unknownStackTrace(
+            new IOException("HPACK - invalid max dynamic table size"), Decoder.class, "setDynamicTableSize(...)");
+    private static final IOException MAX_DYNAMIC_TABLE_SIZE_CHANGE_REQUIRED = ThrowableUtil.unknownStackTrace(
+            new IOException("HPACK - max dynamic table size change required"), Decoder.class, "decode(...)");
 
     private final DynamicTable dynamicTable;
 
@@ -123,7 +124,7 @@ public final class Decoder {
                         // Indexed Header Field
                         index = b & 0x7F;
                         if (index == 0) {
-                            throw ILLEGAL_INDEX_VALUE;
+                            throw DECODE_ILLEGAL_INDEX_VALUE;
                         } else if (index == 0x7F) {
                             state = State.READ_INDEXED_HEADER;
                         } else {
@@ -175,7 +176,7 @@ public final class Decoder {
 
                     // Check for numerical overflow
                     if (maxSize > Integer.MAX_VALUE - index) {
-                        throw DECOMPRESSION_EXCEPTION;
+                        throw DECODE_DECOMPRESSION_EXCEPTION;
                     }
 
                     setDynamicTableSize(index + maxSize);
@@ -190,7 +191,7 @@ public final class Decoder {
 
                     // Check for numerical overflow
                     if (headerIndex > Integer.MAX_VALUE - index) {
-                        throw DECOMPRESSION_EXCEPTION;
+                        throw DECODE_DECOMPRESSION_EXCEPTION;
                     }
 
                     indexHeader(index + headerIndex, headerListener);
@@ -206,7 +207,7 @@ public final class Decoder {
 
                     // Check for numerical overflow
                     if (nameIndex > Integer.MAX_VALUE - index) {
-                        throw DECOMPRESSION_EXCEPTION;
+                        throw DECODE_DECOMPRESSION_EXCEPTION;
                     }
 
                     readName(index + nameIndex);
@@ -255,7 +256,7 @@ public final class Decoder {
 
                     // Check for numerical overflow
                     if (nameLength > Integer.MAX_VALUE - index) {
-                        throw DECOMPRESSION_EXCEPTION;
+                        throw DECODE_DECOMPRESSION_EXCEPTION;
                     }
                     nameLength += index;
 
@@ -348,7 +349,7 @@ public final class Decoder {
 
                     // Check for numerical overflow
                     if (valueLength > Integer.MAX_VALUE - index) {
-                        throw DECOMPRESSION_EXCEPTION;
+                        throw DECODE_DECOMPRESSION_EXCEPTION;
                     }
                     valueLength += index;
 
@@ -469,7 +470,7 @@ public final class Decoder {
             HeaderField headerField = dynamicTable.getEntry(index - StaticTable.length);
             name = headerField.name;
         } else {
-            throw ILLEGAL_INDEX_VALUE;
+            throw READ_NAME_ILLEGAL_INDEX_VALUE;
         }
     }
 
@@ -481,7 +482,7 @@ public final class Decoder {
             HeaderField headerField = dynamicTable.getEntry(index - StaticTable.length);
             addHeader(headerListener, headerField.name, headerField.value, false);
         } else {
-            throw ILLEGAL_INDEX_VALUE;
+            throw INDEX_HEADER_ILLEGAL_INDEX_VALUE;
         }
     }
 
@@ -529,7 +530,7 @@ public final class Decoder {
     private byte[] readStringLiteral(InputStream in, int length) throws IOException {
         byte[] buf = new byte[length];
         if (in.read(buf) != length) {
-            throw DECOMPRESSION_EXCEPTION;
+            throw READ_STRING_LITERAL_DECOMPRESSION_EXCEPTION;
         }
 
         if (huffmanEncoded) {
@@ -563,6 +564,6 @@ public final class Decoder {
         }
         // Value exceeds Integer.MAX_VALUE
         in.reset();
-        throw DECOMPRESSION_EXCEPTION;
+        throw DECODE_ULE_128_DECOMPRESSION_EXCEPTION;
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/HuffmanDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/HuffmanDecoder.java
@@ -31,20 +31,17 @@
  */
 package io.netty.handler.codec.http2.internal.hpack;
 
-import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ThrowableUtil;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 final class HuffmanDecoder {
 
-    private static final IOException EOS_DECODED = new IOException("HPACK - EOS Decoded");
-    private static final IOException INVALID_PADDING = new IOException("HPACK - Invalid Padding");
-
-    static {
-        EOS_DECODED.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-        INVALID_PADDING.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-    }
+    private static final IOException EOS_DECODED = ThrowableUtil.unknownStackTrace(
+            new IOException("HPACK - EOS Decoded"), HuffmanDecoder.class, "decode(...)");
+    private static final IOException INVALID_PADDING = ThrowableUtil.unknownStackTrace(
+            new IOException("HPACK - Invalid Padding"), HuffmanDecoder.class, "decode(...)");
 
     private final Node root;
 

--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -16,10 +16,10 @@
 package io.netty.util.concurrent;
 
 import io.netty.util.Signal;
-import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -39,7 +39,8 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
     private static final AtomicReferenceFieldUpdater<DefaultPromise, Object> RESULT_UPDATER;
     private static final Signal SUCCESS = Signal.valueOf(DefaultPromise.class, "SUCCESS");
     private static final Signal UNCANCELLABLE = Signal.valueOf(DefaultPromise.class, "UNCANCELLABLE");
-    private static final CauseHolder CANCELLATION_CAUSE_HOLDER = new CauseHolder(new CancellationException());
+    private static final CauseHolder CANCELLATION_CAUSE_HOLDER = new CauseHolder(ThrowableUtil.unknownStackTrace(
+            new CancellationException(), DefaultPromise.class, "cancel(...)"));
 
     static {
         @SuppressWarnings("rawtypes")
@@ -47,7 +48,6 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
                 PlatformDependent.newAtomicReferenceFieldUpdater(DefaultPromise.class, "result");
         RESULT_UPDATER = updater == null ? AtomicReferenceFieldUpdater.newUpdater(DefaultPromise.class,
                                                                                   Object.class, "result") : updater;
-        CANCELLATION_CAUSE_HOLDER.cause.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
     }
 
     private volatile Object result;

--- a/common/src/main/java/io/netty/util/internal/ThrowableUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ThrowableUtil.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+public final class ThrowableUtil {
+
+    private ThrowableUtil() { }
+
+    /**
+     * Set the {@link StackTraceElement} for the given {@link Throwable}, using the {@link Class} and method name.
+     */
+    public static <T extends Throwable> T unknownStackTrace(T cause, Class<?> clazz, String method) {
+        cause.setStackTrace(new StackTraceElement[] { new StackTraceElement(clazz.getName(), method, null, -1)});
+        return cause;
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -40,8 +40,8 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.ImmediateExecutor;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -177,15 +177,12 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      * {@link #unwrap(ChannelHandlerContext, ByteBuf, int,  int)}.  Using this static instance reduce object
      * creation as {@link Unpooled#EMPTY_BUFFER#nioBuffer()} creates a new {@link ByteBuffer} everytime.
      */
-    private static final SSLException SSLENGINE_CLOSED = new SSLException("SSLEngine closed already");
-    private static final SSLException HANDSHAKE_TIMED_OUT = new SSLException("handshake timed out");
-    private static final ClosedChannelException CHANNEL_CLOSED = new ClosedChannelException();
-
-    static {
-        SSLENGINE_CLOSED.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-        HANDSHAKE_TIMED_OUT.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-        CHANNEL_CLOSED.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-    }
+    private static final SSLException SSLENGINE_CLOSED = ThrowableUtil.unknownStackTrace(
+            new SSLException("SSLEngine closed already"), SslHandler.class, "wrap(...)");
+    private static final SSLException HANDSHAKE_TIMED_OUT = ThrowableUtil.unknownStackTrace(
+            new SSLException("handshake timed out"), SslHandler.class, "handshake(...)");
+    private static final ClosedChannelException CHANNEL_CLOSED = ThrowableUtil.unknownStackTrace(
+            new ClosedChannelException(), SslHandler.class, "channelInactive(...)");
 
     private volatile ChannelHandlerContext ctx;
     private final SSLEngine engine;

--- a/transport-native-epoll/src/main/java/io/netty/channel/unix/FileDescriptor.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/unix/FileDescriptor.java
@@ -16,15 +16,14 @@
 package io.netty.channel.unix;
 
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.ThrowableUtil;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
-import static io.netty.channel.unix.Errors.CONNECTION_RESET_EXCEPTION_READ;
-import static io.netty.channel.unix.Errors.CONNECTION_RESET_EXCEPTION_WRITE;
-import static io.netty.channel.unix.Errors.CONNECTION_RESET_EXCEPTION_WRITEV;
 import static io.netty.channel.unix.Errors.ioResult;
 import static io.netty.channel.unix.Errors.newIOException;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -34,6 +33,37 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * {@link FileDescriptor} for it.
  */
 public class FileDescriptor {
+    private static final ClosedChannelException WRITE_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new ClosedChannelException(), FileDescriptor.class, "write(...)");
+    private static final ClosedChannelException WRITE_ADDRESS_CLOSED_CHANNEL_EXCEPTION =
+            ThrowableUtil.unknownStackTrace(new ClosedChannelException(), FileDescriptor.class, "writeAddress(...)");
+    private static final ClosedChannelException WRITEV_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new ClosedChannelException(), FileDescriptor.class, "writev(...)");
+    private static final ClosedChannelException WRITEV_ADDRESSES_CLOSED_CHANNEL_EXCEPTION =
+            ThrowableUtil.unknownStackTrace(new ClosedChannelException(), FileDescriptor.class, "writevAddresses(...)");
+    private static final ClosedChannelException READ_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new ClosedChannelException(), FileDescriptor.class, "read(...)");
+    private static final ClosedChannelException READ_ADDRESS_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new ClosedChannelException(), FileDescriptor.class, "readAddress(...)");
+    private static final Errors.NativeIoException WRITE_CONNECTION_RESET_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            Errors.newConnectionResetException("syscall:write(...)", Errors.ERRNO_EPIPE_NEGATIVE),
+            FileDescriptor.class, "write(...)");
+    private static final Errors.NativeIoException WRITE_ADDRESS_CONNECTION_RESET_EXCEPTION =
+            ThrowableUtil.unknownStackTrace(Errors.newConnectionResetException("syscall:write(...)",
+                    Errors.ERRNO_EPIPE_NEGATIVE), FileDescriptor.class, "writeAddress(...)");
+    private static final Errors.NativeIoException WRITEV_CONNECTION_RESET_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            Errors.newConnectionResetException("syscall:writev(...)", Errors.ERRNO_EPIPE_NEGATIVE),
+            FileDescriptor.class, "writev(...)");
+    private static final Errors.NativeIoException WRITEV_ADDRESSES_CONNECTION_RESET_EXCEPTION =
+            ThrowableUtil.unknownStackTrace(Errors.newConnectionResetException("syscall:writev(...)",
+                    Errors.ERRNO_EPIPE_NEGATIVE), FileDescriptor.class, "writeAddresses(...)");
+    private static final Errors.NativeIoException READ_CONNECTION_RESET_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            Errors.newConnectionResetException("syscall:read(...)", Errors.ERRNO_ECONNRESET_NEGATIVE),
+            FileDescriptor.class, "read(...)");
+    private static final Errors.NativeIoException READ_ADDRESS_CONNECTION_RESET_EXCEPTION =
+            ThrowableUtil.unknownStackTrace(Errors.newConnectionResetException("syscall:read(...)",
+                    Errors.ERRNO_ECONNRESET_NEGATIVE), FileDescriptor.class, "readAddress(...)");
+
     private static final AtomicIntegerFieldUpdater<FileDescriptor> stateUpdater;
     static {
         AtomicIntegerFieldUpdater<FileDescriptor> updater
@@ -43,6 +73,7 @@ public class FileDescriptor {
         }
         stateUpdater = updater;
     }
+
     private static final int STATE_CLOSED_MASK = 1;
     private static final int STATE_INPUT_SHUTDOWN_MASK = 1 << 1;
     private static final int STATE_OUTPUT_SHUTDOWN_MASK = 1 << 2;
@@ -101,7 +132,7 @@ public class FileDescriptor {
         if (res >= 0) {
             return res;
         }
-        return ioResult("write", res, CONNECTION_RESET_EXCEPTION_WRITE);
+        return ioResult("write", res, WRITE_CONNECTION_RESET_EXCEPTION, WRITE_CLOSED_CHANNEL_EXCEPTION);
     }
 
     public final int writeAddress(long address, int pos, int limit) throws IOException {
@@ -109,7 +140,8 @@ public class FileDescriptor {
         if (res >= 0) {
             return res;
         }
-        return ioResult("writeAddress", res, CONNECTION_RESET_EXCEPTION_WRITE);
+        return ioResult("writeAddress", res,
+                WRITE_ADDRESS_CONNECTION_RESET_EXCEPTION, WRITE_ADDRESS_CLOSED_CHANNEL_EXCEPTION);
     }
 
     public final long writev(ByteBuffer[] buffers, int offset, int length) throws IOException {
@@ -117,7 +149,7 @@ public class FileDescriptor {
         if (res >= 0) {
             return res;
         }
-        return ioResult("writev", (int) res, CONNECTION_RESET_EXCEPTION_WRITEV);
+        return ioResult("writev", (int) res, WRITEV_CONNECTION_RESET_EXCEPTION, WRITEV_CLOSED_CHANNEL_EXCEPTION);
     }
 
     public final long writevAddresses(long memoryAddress, int length) throws IOException {
@@ -125,7 +157,8 @@ public class FileDescriptor {
         if (res >= 0) {
             return res;
         }
-        return ioResult("writevAddresses", (int) res, CONNECTION_RESET_EXCEPTION_WRITEV);
+        return ioResult("writevAddresses", (int) res,
+                WRITEV_ADDRESSES_CONNECTION_RESET_EXCEPTION, WRITEV_ADDRESSES_CLOSED_CHANNEL_EXCEPTION);
     }
 
     public final int read(ByteBuffer buf, int pos, int limit) throws IOException {
@@ -136,7 +169,7 @@ public class FileDescriptor {
         if (res == 0) {
             return -1;
         }
-        return ioResult("read", res, CONNECTION_RESET_EXCEPTION_READ);
+        return ioResult("read", res, READ_CONNECTION_RESET_EXCEPTION, READ_CLOSED_CHANNEL_EXCEPTION);
     }
 
     public final int readAddress(long address, int pos, int limit) throws IOException {
@@ -147,7 +180,8 @@ public class FileDescriptor {
         if (res == 0) {
             return -1;
         }
-        return ioResult("readAddress", res, CONNECTION_RESET_EXCEPTION_READ);
+        return ioResult("readAddress", res,
+                READ_ADDRESS_CONNECTION_RESET_EXCEPTION, READ_ADDRESS_CLOSED_CHANNEL_EXCEPTION);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -18,8 +18,8 @@ package io.netty.channel;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.DefaultAttributeMap;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -41,13 +41,16 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractChannel.class);
 
-    static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = new ClosedChannelException();
-    static final NotYetConnectedException NOT_YET_CONNECTED_EXCEPTION = new NotYetConnectedException();
-
-    static {
-        CLOSED_CHANNEL_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-        NOT_YET_CONNECTED_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-    }
+    private static final ClosedChannelException FLUSH0_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new ClosedChannelException(), AbstractUnsafe.class, "flush0()");
+    private static final ClosedChannelException ENSURE_OPEN_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new ClosedChannelException(), AbstractUnsafe.class, "ensureOpen(...)");
+    private static final ClosedChannelException CLOSE_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new ClosedChannelException(), AbstractUnsafe.class, "close(...)");
+    private static final ClosedChannelException WRITE_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new ClosedChannelException(), AbstractUnsafe.class, "write(...)");
+    private static final NotYetConnectedException FLUSH0_NOT_YET_CONNECTED_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new NotYetConnectedException(), AbstractUnsafe.class, "flush0()");
 
     private final Channel parent;
     private final ChannelId id;
@@ -592,10 +595,11 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         public final void close(final ChannelPromise promise) {
             assertEventLoop();
 
-            close(promise, CLOSED_CHANNEL_EXCEPTION, false);
+            close(promise, CLOSE_CLOSED_CHANNEL_EXCEPTION, CLOSE_CLOSED_CHANNEL_EXCEPTION, false);
         }
 
-        private void close(final ChannelPromise promise, final Throwable cause, final boolean notify) {
+        private void close(final ChannelPromise promise, final Throwable cause,
+                           final ClosedChannelException closeCause, final boolean notify) {
             if (!promise.setUncancellable()) {
                 return;
             }
@@ -638,7 +642,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                                 public void run() {
                                     // Fail all the queued messages
                                     outboundBuffer.failFlushed(cause, notify);
-                                    outboundBuffer.close(CLOSED_CHANNEL_EXCEPTION);
+                                    outboundBuffer.close(closeCause);
                                     fireChannelInactiveAndDeregister(wasActive);
                                 }
                             });
@@ -652,7 +656,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 } finally {
                     // Fail all the queued messages.
                     outboundBuffer.failFlushed(cause, notify);
-                    outboundBuffer.close(CLOSED_CHANNEL_EXCEPTION);
+                    outboundBuffer.close(closeCause);
                 }
                 if (inFlush0) {
                     invokeLater(new Runnable() {
@@ -775,7 +779,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                 // need to fail the future right away. If it is not null the handling of the rest
                 // will be done in flush0()
                 // See https://github.com/netty/netty/issues/2362
-                safeSetFailure(promise, CLOSED_CHANNEL_EXCEPTION);
+                safeSetFailure(promise, WRITE_CLOSED_CHANNEL_EXCEPTION);
                 // release message now to prevent resource-leak
                 ReferenceCountUtil.release(msg);
                 return;
@@ -828,10 +832,10 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             if (!isActive()) {
                 try {
                     if (isOpen()) {
-                        outboundBuffer.failFlushed(NOT_YET_CONNECTED_EXCEPTION, true);
+                        outboundBuffer.failFlushed(FLUSH0_NOT_YET_CONNECTED_EXCEPTION, true);
                     } else {
                         // Do not trigger channelWritabilityChanged because the channel is closed already.
-                        outboundBuffer.failFlushed(CLOSED_CHANNEL_EXCEPTION, false);
+                        outboundBuffer.failFlushed(FLUSH0_CLOSED_CHANNEL_EXCEPTION, false);
                     }
                 } finally {
                     inFlush0 = false;
@@ -851,7 +855,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                      * This is needed as otherwise {@link #isActive()} , {@link #isOpen()} and {@link #isWritable()}
                      * may still return {@code true} even if the channel should be closed as result of the exception.
                      */
-                    close(voidPromise(), t, false);
+                    close(voidPromise(), t, FLUSH0_CLOSED_CHANNEL_EXCEPTION, false);
                 } else {
                     outboundBuffer.failFlushed(t, true);
                 }
@@ -867,12 +871,13 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             return unsafeVoidPromise;
         }
 
+        @Deprecated
         protected final boolean ensureOpen(ChannelPromise promise) {
             if (isOpen()) {
                 return true;
             }
 
-            safeSetFailure(promise, CLOSED_CHANNEL_EXCEPTION);
+            safeSetFailure(promise, ENSURE_OPEN_CLOSED_CHANNEL_EXCEPTION);
             return false;
         }
 

--- a/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoopGroup.java
@@ -27,6 +27,7 @@ import io.netty.util.concurrent.ThreadPerTaskExecutor;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.ReadOnlyIterator;
+import io.netty.util.internal.ThrowableUtil;
 
 import java.util.Collections;
 import java.util.Iterator;
@@ -130,8 +131,9 @@ public class ThreadPerChannelEventLoopGroup extends AbstractEventExecutorGroup i
         this.maxChannels = maxChannels;
         this.executor = executor;
 
-        tooManyChannels = new ChannelException("too many channels (max: " + maxChannels + ')');
-        tooManyChannels.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
+        tooManyChannels = ThrowableUtil.unknownStackTrace(
+                new ChannelException("too many channels (max: " + maxChannels + ')'),
+                ThreadPerChannelEventLoopGroup.class, "nextChild()");
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -29,7 +29,7 @@ import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoop;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
-import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -50,11 +50,8 @@ public abstract class AbstractNioChannel extends AbstractChannel {
     private static final InternalLogger logger =
             InternalLoggerFactory.getInstance(AbstractNioChannel.class);
 
-    private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = new ClosedChannelException();
-
-    static {
-        CLOSED_CHANNEL_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-    }
+    private static final ClosedChannelException DO_CLOSE_CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new ClosedChannelException(), AbstractNioChannel.class, "doClose()");
 
     private final SelectableChannel ch;
     protected final int readInterestOp;
@@ -503,7 +500,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         ChannelPromise promise = connectPromise;
         if (promise != null) {
             // Use tryFailure() instead of setFailure() to avoid the race against cancel().
-            promise.tryFailure(CLOSED_CHANNEL_EXCEPTION);
+            promise.tryFailure(DO_CLOSE_CLOSED_CHANNEL_EXCEPTION);
             connectPromise = null;
         }
 

--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -21,7 +21,7 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.ThrowableUtil;
 
 import java.nio.channels.ClosedChannelException;
 import java.util.ArrayDeque;
@@ -35,15 +35,12 @@ import java.util.concurrent.TimeoutException;
  * number of concurrent connections.
  */
 public final class FixedChannelPool extends SimpleChannelPool {
-    private static final IllegalStateException FULL_EXCEPTION =
-            new IllegalStateException("Too many outstanding acquire operations");
-    private static final TimeoutException TIMEOUT_EXCEPTION =
-            new TimeoutException("Acquire operation took longer then configured maximum time");
-
-    static {
-        FULL_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-        TIMEOUT_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-    }
+    private static final IllegalStateException FULL_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new IllegalStateException("Too many outstanding acquire operations"),
+            FixedChannelPool.class, "acquire0(...)");
+    private static final TimeoutException TIMEOUT_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new TimeoutException("Acquire operation took longer then configured maximum time"),
+            FixedChannelPool.class, "<init>(...)");
 
     public enum AcquireTimeoutAction {
         /**

--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -25,8 +25,8 @@ import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
-import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.ThrowableUtil;
 
 import java.util.Deque;
 
@@ -41,13 +41,12 @@ import static io.netty.util.internal.ObjectUtil.*;
  */
 public class SimpleChannelPool implements ChannelPool {
     private static final AttributeKey<SimpleChannelPool> POOL_KEY = AttributeKey.newInstance("channelPool");
-    private static final IllegalStateException FULL_EXCEPTION = new IllegalStateException("ChannelPool full");
-    private static final IllegalStateException UNHEALTHY_NON_OFFERED_TO_POOL =
-            new IllegalStateException("Channel is unhealthy not offering it back to pool");
-    static {
-        FULL_EXCEPTION.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-        UNHEALTHY_NON_OFFERED_TO_POOL.setStackTrace(EmptyArrays.EMPTY_STACK_TRACE);
-    }
+    private static final IllegalStateException FULL_EXCEPTION = ThrowableUtil.unknownStackTrace(
+            new IllegalStateException("ChannelPool full"), SimpleChannelPool.class, "releaseAndOffer(...)");
+    private static final IllegalStateException UNHEALTHY_NON_OFFERED_TO_POOL = ThrowableUtil.unknownStackTrace(
+            new IllegalStateException("Channel is unhealthy not offering it back to pool"),
+            SimpleChannelPool.class, "releaseAndOffer(...)");
+
     private final Deque<Channel> deque = PlatformDependent.newConcurrentDeque();
     private final ChannelPoolHandler handler;
     private final ChannelHealthChecker healthCheck;


### PR DESCRIPTION
Motivation:

We use pre-instanced exceptions in various places for performance reasons. These exceptions don't care a stacktrace atm which makes it hard to know where the exception was thrown. This is especially true as we use the same exception type (for example ChannelClosedException) in different places. We should better set some StackTraceElement which gives us at least an idea where the exception was thrown / used.

Modifications:

Set a generated StackTraceElement on these pre-instanced exceptions which at least contains the origin class and method name. The filename and linenumber are specified as unkown (as stated in the javadocs of StackTraceElement).

Result:

Easier to find the origin of a pre-instanced exception.