### PR TITLE
Ensure examples are runnable in the ide

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -124,6 +124,14 @@
       <artifactId>logback-classic</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jctools</groupId>
+      <artifactId>jctools-core</artifactId>
+      <!-- Need runtime scope as otherwise idea is not able to run the examples -->
+      <!-- This is most likely a bug in idea -->
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Motivation:

It seems like intellij / idea is confused because of shading of jctools.

Modifications:

Add jctools as dependency with scope runtime to the examples as workaround

Result:

Its possible again to run the examples in the ide.