### PR TITLE
[#5431] Fix HTTP version and Host header in HttpProxyHandler

### DIFF
--- a/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/HttpProxyHandler.java
@@ -119,16 +119,13 @@ public final class HttpProxyHandler extends ProxyHandler {
             rhost = raddr.getAddress().getHostAddress();
         }
 
+        final String host = rhost + ':' + raddr.getPort();
         FullHttpRequest req = new DefaultFullHttpRequest(
-                HttpVersion.HTTP_1_0, HttpMethod.CONNECT,
-                rhost + ':' + raddr.getPort(),
+                HttpVersion.HTTP_1_1, HttpMethod.CONNECT,
+                host,
                 Unpooled.EMPTY_BUFFER, false);
 
-        SocketAddress proxyAddress = proxyAddress();
-        if (proxyAddress instanceof InetSocketAddress) {
-            InetSocketAddress hostAddr = (InetSocketAddress) proxyAddress;
-            req.headers().set(HttpHeaderNames.HOST, hostAddr.getHostString() + ':' + hostAddr.getPort());
-        }
+        req.headers().set(HttpHeaderNames.HOST, host);
 
         if (authorization != null) {
             req.headers().set(HttpHeaderNames.PROXY_AUTHORIZATION, authorization);


### PR DESCRIPTION
Motivation:

  The current implementation does not comply with RFC2817 on two points:

  - The HTTP version required to support the CONNECT method is 1.1,
    but the current implementation specifies 1.0.

  - The HOST header should hold the name or address of the Target Host,
    but the current implementation uses the proxy address instead.

Modifications:

  - Specify HTTP version 1.1,
  - The HOST header is now set using the Target Host's name (or address,
    if it is resolved).

Result:

  The CONNECT request is RFC2817-compliant.