### PR TITLE
http2: count pad length field toward flow control. Fixes #5434

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
@@ -20,6 +20,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.IllegalReferenceCountException;
 import io.netty.util.internal.UnstableApi;
 
+import static io.netty.handler.codec.http2.Http2CodecUtil.verifyPadding;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -64,14 +65,13 @@ public final class DefaultHttp2DataFrame extends AbstractHttp2StreamFrame implem
      *
      * @param content non-{@code null} payload
      * @param endStream whether this data should terminate the stream
-     * @param padding additional bytes that should be added to obscure the true content size
+     * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
+     *                256 (inclusive).
      */
     public DefaultHttp2DataFrame(ByteBuf content, boolean endStream, int padding) {
         this.content = checkNotNull(content, "content");
         this.endStream = endStream;
-        if (padding < 0 || padding > Http2CodecUtil.MAX_UNSIGNED_BYTE) {
-            throw new IllegalArgumentException("padding must be non-negative and less than 256");
-        }
+        verifyPadding(padding);
         this.padding = padding;
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersFrame.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http2;
 
 import io.netty.util.internal.UnstableApi;
 
+import static io.netty.handler.codec.http2.Http2CodecUtil.verifyPadding;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -51,14 +52,13 @@ public final class DefaultHttp2HeadersFrame extends AbstractHttp2StreamFrame imp
      *
      * @param headers the non-{@code null} headers to send
      * @param endStream whether these headers should terminate the stream
-     * @param padding additional bytes that should be added to obscure the true content size
+     * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
+     *                256 (inclusive).
      */
     public DefaultHttp2HeadersFrame(Http2Headers headers, boolean endStream, int padding) {
         this.headers = checkNotNull(headers, "headers");
         this.endStream = endStream;
-        if (padding < 0 || padding > Http2CodecUtil.MAX_UNSIGNED_BYTE) {
-            throw new IllegalArgumentException("padding must be non-negative and less than 256");
-        }
+        verifyPadding(padding);
         this.padding = padding;
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -46,6 +46,11 @@ public final class Http2CodecUtil {
 
     public static final int PING_FRAME_PAYLOAD_LENGTH = 8;
     public static final short MAX_UNSIGNED_BYTE = 0xFF;
+    /**
+     * The maximum number of padding bytes. That is the 255 padding bytes appended to the end of a frame and the 1 byte
+     * pad length field.
+     */
+    public static final int MAX_PADDING = 256;
     public static final int MAX_UNSIGNED_SHORT = 0xFFFF;
     public static final long MAX_UNSIGNED_INT = 0xFFFFFFFFL;
     public static final int FRAME_HEADER_LENGTH = 9;
@@ -340,5 +345,11 @@ public final class Http2CodecUtil {
         }
     }
 
+    public static void verifyPadding(int padding) {
+        if (padding < 0 || padding > MAX_PADDING) {
+            throw new IllegalArgumentException(String.format("Invalid padding '%d'. Padding must be between 0 and " +
+                                                             "%d (inclusive).", padding, MAX_PADDING));
+        }
+    }
     private Http2CodecUtil() { }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2DataWriter.java
@@ -32,7 +32,10 @@ public interface Http2DataWriter {
      * @param ctx the context to use for writing.
      * @param streamId the stream for which to send the frame.
      * @param data the payload of the frame. This will be released by this method.
-     * @param padding the amount of padding to be added to the end of the frame
+     * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
+     *                256 (inclusive). A 1 byte padding is encoded as just the pad length field with value 0.
+     *                A 256 byte padding is encoded as the pad length field with value 255 and 255 padding bytes
+     *                appended to the end of the frame.
      * @param endStream indicates if this is the last frame to be sent for the stream.
      * @param promise the promise for the write.
      * @return the future for the write.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameListener.java
@@ -30,7 +30,8 @@ public interface Http2FrameListener {
      * @param ctx the context from the handler where the frame was read.
      * @param streamId the subject stream for the frame.
      * @param data payload buffer for the frame. This buffer will be released by the codec.
-     * @param padding the number of padding bytes found at the end of the frame.
+     * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
+     *                256 (inclusive).
      * @param endOfStream Indicates whether this is the last frame to be sent from the remote endpoint for this stream.
      * @return the number of bytes that have been processed by the application. The returned bytes are used by the
      * inbound flow controller to determine the appropriate time to expand the inbound flow control window (i.e. send
@@ -60,7 +61,8 @@ public interface Http2FrameListener {
      * @param ctx the context from the handler where the frame was read.
      * @param streamId the subject stream for the frame.
      * @param headers the received headers.
-     * @param padding the number of padding bytes found at the end of the frame.
+     * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
+     *                256 (inclusive).
      * @param endOfStream Indicates whether this is the last frame to be sent from the remote endpoint
      *            for this stream.
      */
@@ -89,7 +91,8 @@ public interface Http2FrameListener {
      *            connection.
      * @param weight the new weight for the stream.
      * @param exclusive whether or not the stream should be the exclusive dependent of its parent.
-     * @param padding the number of padding bytes found at the end of the frame.
+     * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
+     *                256 (inclusive).
      * @param endOfStream Indicates whether this is the last frame to be sent from the remote endpoint
      *            for this stream.
      */
@@ -176,7 +179,8 @@ public interface Http2FrameListener {
      * @param streamId the stream the frame was sent on.
      * @param promisedStreamId the ID of the promised stream.
      * @param headers the received headers.
-     * @param padding the number of padding bytes found at the end of the frame.
+     * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
+     *                256 (inclusive).
      */
     void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
             Http2Headers headers, int padding) throws Http2Exception;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameWriter.java
@@ -51,7 +51,8 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      * @param ctx the context to use for writing.
      * @param streamId the stream for which to send the frame.
      * @param headers the headers to be sent.
-     * @param padding the amount of padding to be added to the end of the frame
+     * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
+     *                256 (inclusive).
      * @param endStream indicates if this is the last frame to be sent for the stream.
      * @param promise the promise for the write.
      * @return the future for the write.
@@ -69,7 +70,8 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      *            depend on the connection.
      * @param weight the weight for this stream.
      * @param exclusive whether this stream should be the exclusive dependant of its parent.
-     * @param padding the amount of padding to be added to the end of the frame
+     * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
+     *                256 (inclusive).
      * @param endStream indicates if this is the last frame to be sent for the stream.
      * @param promise the promise for the write.
      * @return the future for the write.
@@ -145,7 +147,8 @@ public interface Http2FrameWriter extends Http2DataWriter, Closeable {
      * @param streamId the stream for which to send the frame.
      * @param promisedStreamId the ID of the promised stream.
      * @param headers the headers to be sent.
-     * @param padding the amount of padding to be added to the end of the frame
+     * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
+     *                256 (inclusive).
      * @param promise the promise for the write.
      * @return the future for the write.
      */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2LocalFlowController.java
@@ -42,7 +42,8 @@ public interface Http2LocalFlowController extends Http2FlowController {
      * stream} is {@code null} or closed, flow control should only be applied to the connection window and the bytes are
      * immediately consumed.
      * @param data payload buffer for the frame.
-     * @param padding the number of padding bytes found at the end of the frame.
+     * @param padding additional bytes that should be added to obscure the true content size. Must be between 0 and
+     *                256 (inclusive).
      * @param endOfStream Indicates whether this is the last frame to be sent from the remote endpoint for this stream.
      * @throws Http2Exception if any flow control errors are encountered.
      */

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameRoundtripTest.java
@@ -39,7 +39,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
-import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_MAX_HEADER_SIZE;
+import static io.netty.handler.codec.http2.Http2CodecUtil.*;
 import static io.netty.handler.codec.http2.Http2TestUtil.randomString;
 import static io.netty.util.CharsetUtil.UTF_8;
 import static java.lang.Math.min;
@@ -148,17 +148,17 @@ public class Http2FrameRoundtripTest {
     @Test
     public void dataShouldMatch() throws Exception {
         final ByteBuf data = data(10);
-        writer.writeData(ctx, STREAM_ID, data.slice(), 0, false, ctx.newPromise());
+        writer.writeData(ctx, STREAM_ID, data.slice(), 1, false, ctx.newPromise());
         readFrames();
-        verify(listener).onDataRead(eq(ctx), eq(STREAM_ID), eq(data), eq(0), eq(false));
+        verify(listener).onDataRead(eq(ctx), eq(STREAM_ID), eq(data), eq(1), eq(false));
     }
 
     @Test
     public void dataWithPaddingShouldMatch() throws Exception {
         final ByteBuf data = data(10);
-        writer.writeData(ctx, STREAM_ID, data.slice(), 0xFF, true, ctx.newPromise());
+        writer.writeData(ctx, STREAM_ID, data.slice(), MAX_PADDING, true, ctx.newPromise());
         readFrames();
-        verify(listener).onDataRead(eq(ctx), eq(STREAM_ID), eq(data), eq(0xFF), eq(true));
+        verify(listener).onDataRead(eq(ctx), eq(STREAM_ID), eq(data), eq(MAX_PADDING), eq(true));
     }
 
     @Test
@@ -210,9 +210,9 @@ public class Http2FrameRoundtripTest {
     @Test
     public void emptyHeadersWithPaddingShouldMatch() throws Exception {
         final Http2Headers headers = EmptyHttp2Headers.INSTANCE;
-        writer.writeHeaders(ctx, STREAM_ID, headers, 0xFF, true, ctx.newPromise());
+        writer.writeHeaders(ctx, STREAM_ID, headers, MAX_PADDING, true, ctx.newPromise());
         readFrames();
-        verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(0xFF), eq(true));
+        verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(MAX_PADDING), eq(true));
     }
 
     @Test
@@ -243,18 +243,18 @@ public class Http2FrameRoundtripTest {
     @Test
     public void headersWithPaddingWithoutPriorityShouldMatch() throws Exception {
         final Http2Headers headers = headers();
-        writer.writeHeaders(ctx, STREAM_ID, headers, 0xFF, true, ctx.newPromise());
+        writer.writeHeaders(ctx, STREAM_ID, headers, MAX_PADDING, true, ctx.newPromise());
         readFrames();
-        verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(0xFF), eq(true));
+        verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(MAX_PADDING), eq(true));
     }
 
     @Test
     public void headersWithPaddingWithPriorityShouldMatch() throws Exception {
         final Http2Headers headers = headers();
-        writer.writeHeaders(ctx, STREAM_ID, headers, 2, (short) 3, true, 0xFF, true, ctx.newPromise());
+        writer.writeHeaders(ctx, STREAM_ID, headers, 2, (short) 3, true, 1, true, ctx.newPromise());
         readFrames();
         verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(2), eq((short) 3), eq(true),
-                eq(0xFF), eq(true));
+                eq(1), eq(true));
     }
 
     @Test
@@ -269,16 +269,16 @@ public class Http2FrameRoundtripTest {
     @Test
     public void continuedHeadersWithPaddingShouldMatch() throws Exception {
         final Http2Headers headers = largeHeaders();
-        writer.writeHeaders(ctx, STREAM_ID, headers, 2, (short) 3, true, 0xFF, true, ctx.newPromise());
+        writer.writeHeaders(ctx, STREAM_ID, headers, 2, (short) 3, true, MAX_PADDING, true, ctx.newPromise());
         readFrames();
         verify(listener).onHeadersRead(eq(ctx), eq(STREAM_ID), eq(headers), eq(2), eq((short) 3), eq(true),
-                eq(0xFF), eq(true));
+                eq(MAX_PADDING), eq(true));
     }
 
     @Test
     public void headersThatAreTooBigShouldFail() throws Exception {
         final Http2Headers headers = headersOfSize(DEFAULT_MAX_HEADER_SIZE + 1);
-        writer.writeHeaders(ctx, STREAM_ID, headers, 2, (short) 3, true, 0xFF, true, ctx.newPromise());
+        writer.writeHeaders(ctx, STREAM_ID, headers, 2, (short) 3, true, MAX_PADDING, true, ctx.newPromise());
         try {
             readFrames();
             fail();
@@ -308,9 +308,9 @@ public class Http2FrameRoundtripTest {
     @Test
     public void pushPromiseWithPaddingShouldMatch() throws Exception {
         final Http2Headers headers = headers();
-        writer.writePushPromise(ctx, STREAM_ID, 2, headers, 0xFF, ctx.newPromise());
+        writer.writePushPromise(ctx, STREAM_ID, 2, headers, MAX_PADDING, ctx.newPromise());
         readFrames();
-        verify(listener).onPushPromiseRead(eq(ctx), eq(STREAM_ID), eq(2), eq(headers), eq(0xFF));
+        verify(listener).onPushPromiseRead(eq(ctx), eq(STREAM_ID), eq(2), eq(headers), eq(MAX_PADDING));
     }
 
     @Test


### PR DESCRIPTION
Motivation:
The HTTP/2 specification requires the pad length field of DATA, HEADERS and PUSH_PROMISE frames to be counted towards the flow control window. The current implementation doesn't do so (See #5434).

Furthermore, it's currently not possible to add one byte padding, as this would add the one byte pad length field as well as append one padding byte to the end of the frame.

Modifications:
Include the one byte pad length field in the padding parameter of the API. Thereby extending the allowed value range by one byte to 256 (inclusive). On the wire, a one byte padding is encoded with a pad length field with value zero and a 256 byte padding is encoded with a pad length field with value 255 and 255 bytes append to the end of the frame.

Result:
More correct padding.