### PR TITLE
Update dependencies and plugins to latest possible versions.

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -561,7 +561,7 @@
             -link http://code.google.com/apis/protocolbuffers/docs/reference/java/
             -link http://docs.oracle.com/javaee/6/api/
             -link http://www.slf4j.org/apidocs/
-            -link http://commons.apache.org/proper/commons-logging/javadocs/api-1.1.2/
+            -link https://commons.apache.org/proper/commons-logging/apidocs/
             -link http://logging.apache.org/log4j/1.2/apidocs/
 
             -group "Low-level data representation" io.netty.buffer*

--- a/codec/src/test/resources/io/netty/handler/codec/xml/sample-04.xml
+++ b/codec/src/test/resources/io/netty/handler/codec/xml/sample-04.xml
@@ -125,12 +125,12 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>2.5.0</version>
+        <version>2.6.1</version>
       </dependency>
       <dependency>
         <groupId>com.jcraft</groupId>
         <artifactId>jzlib</artifactId>
-          <version>1.1.2</version>
+        <version>1.1.3</version>
       </dependency>
 
       <dependency>
@@ -154,12 +154,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.5</version>
+        <version>1.7.21</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.1.3</version>
+        <version>1.2</version>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>
@@ -229,13 +229,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
-      <version>3.2</version>
+      <version>3.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -247,13 +247,13 @@
     <dependency>
       <groupId>org.jmock</groupId>
       <artifactId>jmock-junit4</artifactId>
-      <version>2.6.0</version>
+      <version>2.8.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.13</version>
+      <version>1.1.7</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -262,7 +262,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3</version>
+        <version>1.4.1</version>
         <executions>
           <execution>
             <id>enforce-tools</id>
@@ -286,7 +286,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.5.1</version>
         <configuration>
           <compilerVersion>1.7</compilerVersion>
           <fork>true</fork>
@@ -314,12 +314,12 @@
              be used even when compiling with java 1.7+ -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.9</version>
+        <version>1.15</version>
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
             <artifactId>java16</artifactId>
-            <version>1.0</version>
+            <version>1.1</version>
           </signature>
           <ignores>
             <ignore>sun.misc.Unsafe</ignore>
@@ -354,7 +354,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.10</version>
+        <version>2.12.1</version>
         <executions>
           <execution>
             <id>check-style</id>
@@ -399,7 +399,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.4</version>
         <executions>
           <execution>
             <id>generate-manifest</id>
@@ -421,7 +421,7 @@
       </plugin>             
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.0.1</version>
         <executions>
           <!--
             ~ This workaround prevents Maven from executing the 'generate-sources' phase twice.
@@ -446,7 +446,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>2.10.4</version>
         <configuration>
           <detectOfflineLinks>false</detectOfflineLinks>
           <breakiterator>true</breakiterator>
@@ -457,14 +457,15 @@
       </plugin>
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
+        <version>2.8.2</version>
         <configuration>
           <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.4.1</version>
+        <!-- Downgrade to 2.4.1 if release fails -->
+        <version>2.5.3</version>
         <configuration>
           <useReleaseProfile>false</useReleaseProfile>
           <arguments>-P release,sonatype-oss-release,full,no-osgi</arguments>
@@ -587,12 +588,12 @@
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.8.2</version>
+            <version>1.9.7</version>
           </dependency>
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-launcher</artifactId>
-            <version>1.8.2</version>
+            <version>1.9.7</version>
           </dependency>
           <dependency>
             <groupId>ant-contrib</groupId>
@@ -614,24 +615,24 @@
         <!-- keep surefire and failsafe in sync -->
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.15</version>
+          <version>2.19.1</version>
         </plugin>
         <!-- keep surefire and failsafe in sync -->
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.15</version>
+          <version>2.19.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>2.5</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>2.6</version>
+          <version>3.0.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.4</version>
+          <version>3.0.2</version>
           <executions>
             <execution>
               <id>default-jar</id>
@@ -649,11 +650,11 @@
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.8</version>
+          <version>2.10</version>
         </plugin>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.4</version>
+          <version>2.6</version>
         </plugin>
         <plugin>
           <!-- Do NOT upgrade -->
@@ -662,7 +663,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>1.7</version>
+          <version>1.8</version>
           <dependencies>
             <dependency>
               <groupId>ant-contrib</groupId>
@@ -680,7 +681,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>1.8</version>
+          <version>1.10</version>
         </plugin>               
 
         <!-- Workaround for the 'M2E plugin execution not covered' problem.

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -112,7 +112,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.9.1</version>
+        <version>1.10</version>
         <executions>
           <execution>
             <id>add-source</id>
@@ -150,7 +150,7 @@
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.3</version>
+            <version>2.4.7</version>
           </dependency>
           <dependency>
             <groupId>ant</groupId>
@@ -174,7 +174,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.4</version>
         <executions>
           <execution>
             <id>generate-manifest</id>

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -26,6 +26,7 @@ import org.jctools.queues.SpscLinkedQueue;
 import org.jctools.queues.atomic.MpscAtomicArrayQueue;
 import org.jctools.queues.atomic.MpscLinkedAtomicQueue;
 import org.jctools.queues.atomic.SpscLinkedAtomicQueue;
+import org.jctools.util.Pow2;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -87,12 +88,11 @@ public final class PlatformDependent {
     private static final boolean DIRECT_BUFFER_PREFERRED =
             HAS_UNSAFE && !SystemPropertyUtil.getBoolean("io.netty.noPreferDirect", false);
     private static final long MAX_DIRECT_MEMORY = maxDirectMemory0();
+
     private static final int MPSC_CHUNK_SIZE =  1024;
     private static final int MIN_MAX_MPSC_CAPACITY =  MPSC_CHUNK_SIZE * 2;
     private static final int DEFAULT_MAX_MPSC_CAPACITY =  MPSC_CHUNK_SIZE * MPSC_CHUNK_SIZE;
-    // This is currently the maximal allowed capacity in JCTools.
-    // See https://github.com/JCTools/JCTools/issues/115
-    private static final int MAX_ALLOWED_MPSC_CAPACITY =  Integer.MAX_VALUE >> 2;
+    private static final int MAX_ALLOWED_MPSC_CAPACITY = Pow2.MAX_POW2;
 
     private static final long BYTE_ARRAY_BASE_OFFSET = PlatformDependent0.byteArrayBaseOffset();
 

--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -101,9 +101,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>uk.co.real-logic</groupId>
+      <groupId>org.agrona</groupId>
       <artifactId>Agrona</artifactId>
-      <version>0.1</version>
+      <version>0.5.1</version>
     </dependency>
   </dependencies>
 
@@ -164,7 +164,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.2.3.Final</version>
+        <version>1.5.0.Final</version>
       </extension>
     </extensions>
   </build>

--- a/microbench/src/main/java/io/netty/microbenchmark/common/IntObjectHashMapBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbenchmark/common/IntObjectHashMapBenchmark.java
@@ -16,6 +16,7 @@ package io.netty.microbenchmark.common;
 
 import io.netty.microbench.util.AbstractMicrobenchmark;
 import io.netty.util.collection.IntObjectHashMap;
+import org.agrona.collections.Int2ObjectHashMap;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Level;
@@ -23,7 +24,6 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.infra.Blackhole;
-import uk.co.real_logic.agrona.collections.Int2ObjectHashMap;
 
 import java.util.HashSet;
 import java.util.Random;

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
           <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.7.5.201505241946</version>
+            <version>0.7.7.201606060606</version>
             <executions>
               <execution>
                 <id>jacoco-prepare-agent</id>
@@ -202,7 +202,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <netty.build.version>22</netty.build.version>
-    <jboss.marshalling.version>1.4.8.Final</jboss.marshalling.version>
+    <jboss.marshalling.version>1.4.11.Final</jboss.marshalling.version>
     <jetty.alpnAgent.version>2.0.1</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>"${settings.localRepository}"/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
     <argLine.common>
@@ -229,6 +229,7 @@
     <epoll.classifier>${os.detected.name}-${os.detected.arch}</epoll.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>
     <logging.logLevel>debug</logging.logLevel>
+    <log4j2.version>2.6.1</log4j2.version>
   </properties>
 
   <modules>
@@ -362,7 +363,7 @@
       <dependency>
         <groupId>org.jctools</groupId>
         <artifactId>jctools-core</artifactId>
-        <version>1.2</version>
+        <version>1.2.1</version>
       </dependency>
 
       <dependency>
@@ -396,7 +397,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.5</version>
+        <version>${log4j2.version}</version>
       </dependency>
       <dependency>
         <groupId>log4j</groupId>
@@ -452,7 +453,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>3.2</version>
+        <version>3.4</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -512,7 +513,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.9</version>
+        <version>1.12</version>
         <scope>test</scope>
       </dependency>
 
@@ -520,7 +521,7 @@
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.6.2</version>
+        <version>2.7</version>
         <scope>test</scope>
       </dependency>
 
@@ -543,7 +544,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.5</version>
+        <version>${log4j2.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>
@@ -612,7 +613,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.4.1.Final</version>
+        <version>1.5.0.Final</version>
       </extension>
     </extensions>
 
@@ -649,7 +650,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.5.1</version>
         <configuration>
           <compilerVersion>1.7</compilerVersion>
           <fork>true</fork>
@@ -680,20 +681,20 @@
              be used even when compiling with java 1.7+ -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.9</version>
+        <version>1.11</version>
         <dependencies>
           <!-- Upgrade ASM and support Java 8 bytecode -->
           <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-all</artifactId>
-            <version>5.0.3</version>
+            <version>5.1</version>
           </dependency>
         </dependencies>
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
             <artifactId>java16</artifactId>
-            <version>1.0</version>
+            <version>1.1</version>
           </signature>
           <ignores>
             <ignore>sun.misc.Unsafe</ignore>
@@ -742,7 +743,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.10</version>
+        <version>2.12.1</version>
         <executions>
           <execution>
             <id>check-style</id>
@@ -840,7 +841,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.4.0</version>
+        <version>2.5.4</version>
         <executions>
           <execution>
             <id>generate-manifest</id>
@@ -868,7 +869,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.8</version>
+        <version>1.10</version>
         <executions>
           <execution>
             <id>parse-version</id>
@@ -881,7 +882,7 @@
 
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.0.1</version>
         <!-- Eclipse-related OSGi manifests
              See https://github.com/netty/netty/issues/3886
              More information: http://rajakannappan.blogspot.ie/2010/03/automating-eclipse-source-bundle.html -->
@@ -922,7 +923,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>2.10.4</version>
         <configuration>
           <detectOfflineLinks>false</detectOfflineLinks>
           <breakiterator>true</breakiterator>
@@ -933,14 +934,15 @@
       </plugin>
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.7</version>
+        <version>2.8.2</version>
         <configuration>
           <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.4.2</version>
+        <!-- Downgrade to 2.4.1 if release fails -->
+        <version>2.5.3</version>
         <configuration>
           <useReleaseProfile>false</useReleaseProfile>
           <arguments>-P restricted-release,sonatype-oss-release,full</arguments>
@@ -952,12 +954,12 @@
           <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-api</artifactId>
-            <version>1.8.1</version>
+            <version>1.9.4</version>
           </dependency>
           <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-provider-gitexe</artifactId>
-            <version>1.8.1</version>
+            <version>1.9.4</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -1040,12 +1042,12 @@
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.8.2</version>
+            <version>1.9.7</version>
           </dependency>
           <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-launcher</artifactId>
-            <version>1.8.2</version>
+            <version>1.9.7</version>
           </dependency>
           <dependency>
             <groupId>ant-contrib</groupId>
@@ -1066,33 +1068,33 @@
       <plugins>
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.3.1</version>
+          <version>1.4.1</version>
           <dependencies>
             <!-- Provides the 'requireFilesContent' enforcer rule. -->
             <dependency>
               <groupId>com.ceilfors.maven.plugin</groupId>
               <artifactId>enforcer-rules</artifactId>
-              <version>1.1.0</version>
+              <version>1.2.0</version>
             </dependency>
           </dependencies>
         </plugin>
         <!-- keep surefire and failsafe in sync -->
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.15</version>
+          <version>2.19.1</version>
         </plugin>
         <!-- keep surefire and failsafe in sync -->
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.15</version>
+          <version>2.19.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>2.5</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>2.6</version>
+          <version>3.0.1</version>
         </plugin>
         <plugin>
           <groupId>org.ops4j.pax.exam</groupId>
@@ -1101,7 +1103,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>2.5</version>
+          <version>3.0.2</version>
           <executions>
             <execution>
               <id>default-jar</id>
@@ -1119,11 +1121,11 @@
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.8</version>
+          <version>2.10</version>
         </plugin>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.4</version>
+          <version>2.6</version>
         </plugin>
         <plugin>
           <!-- Do NOT upgrade -->
@@ -1132,7 +1134,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>1.7</version>
+          <version>1.8</version>
           <dependencies>
             <dependency>
               <groupId>ant-contrib</groupId>
@@ -1150,12 +1152,12 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>1.8</version>
+          <version>1.10</version>
         </plugin>
         <plugin>
           <groupId>org.fusesource.hawtjni</groupId>
           <artifactId>maven-hawtjni-plugin</artifactId>
-          <version>1.10</version>
+          <version>1.14</version>
         </plugin>
         <plugin>
           <groupId>kr.motd.maven</groupId>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -29,7 +29,7 @@
   <name>Netty/Testsuite/OSGI</name>
 
   <properties>
-    <exam.version>4.4.0</exam.version>
+    <exam.version>4.9.1</exam.version>
     <skipOsgiTestsuite>false</skipOsgiTestsuite>
   </properties>
 
@@ -197,19 +197,19 @@
     <dependency>
       <groupId>org.ops4j.pax.url</groupId>
       <artifactId>pax-url-wrap</artifactId>
-      <version>2.3.0</version>
+      <version>2.4.7</version>
     </dependency>
 
     <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.core</artifactId>
-      <version>5.0.0</version>
+      <version>6.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.framework</artifactId>
-      <version>4.6.0</version>
+      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Update dependencies and plugins to latest possible versions.

**Motivation:**
It is good to have used dependencies and plugins up-to-date to fix any undiscovered bug fixed by the authors.

**Modification:**
Scanned dependencies and plugins and carefully updated one by one.

**Result:**
Dependencies and plugins are up-to-date.

**Relevant updates:**
- JCtools from 1.2 to 1.2.1
- Agrona from old `uk.co.real-logic` to new `org.agrona` which seems to be the appropriate dependency used by `Aeron` for its data-structures.

**Note about `maven-jxr-plugin`:**
It was marked as "Do NOT upgrade" but I tracked that comment and it was made at the beginning of 2013, latest `maven-jxr-plugin` was released at the end of 2014, can someone verify that such plugin cannot still be upgraded as there is no reason stated with the comment, if so I can restore that version and force push.