### PR TITLE
Fix a bug of DnsNameResolver while working with NoopDnsCache.

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -337,7 +337,7 @@ public class DnsNameResolver extends InetNameResolver {
                                     Promise<InetAddress> promise,
                                     DnsCache resolveCache) {
         final List<DnsCacheEntry> cachedEntries = resolveCache.get(hostname);
-        if (cachedEntries == null) {
+        if (cachedEntries == null || cachedEntries.isEmpty()) {
             return false;
         }
 
@@ -443,7 +443,7 @@ public class DnsNameResolver extends InetNameResolver {
                                        Promise<List<InetAddress>> promise,
                                        DnsCache resolveCache) {
         final List<DnsCacheEntry> cachedEntries = resolveCache.get(hostname);
-        if (cachedEntries == null) {
+        if (cachedEntries == null || cachedEntries.isEmpty()) {
             return false;
         }
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -278,6 +278,12 @@ public class DnsNameResolverTest {
                 .resolvedAddressTypes(resolvedAddressTypes);
     }
 
+    private static DnsNameResolverBuilder newNonCachedResolver(InternetProtocolFamily... resolvedAddressTypes) {
+        return newResolver()
+                .resolveCache(NoopDnsCache.INSTANCE)
+                .resolvedAddressTypes(resolvedAddressTypes);
+    }
+
     @BeforeClass
     public static void init() throws Exception {
         dnsServer.start();
@@ -344,6 +350,16 @@ public class DnsNameResolverTest {
         DnsNameResolver resolver = newResolver(InternetProtocolFamily.IPv6).build();
         try {
             testResolve0(resolver, EXCLUSIONS_RESOLVE_AAAA);
+        } finally {
+            resolver.close();
+        }
+    }
+
+    @Test
+    public void testNonCachedResolve() throws Exception {
+        DnsNameResolver resolver = newNonCachedResolver(InternetProtocolFamily.IPv4).build();
+        try {
+            testResolve0(resolver, EXCLUSIONS_RESOLVE_A);
         } finally {
             resolver.close();
         }


### PR DESCRIPTION
Motivation:

If DnsNameResolver works with NoopDnsCache, IndexOutOfBoundsException will
be thrown.

Modifications:

Test if the result of DnsNameResolver.get(hostname) is empty before
accessing it's elements.