### PR TITLE
Add a json example using Gson

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -132,6 +132,11 @@
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>

--- a/example/src/main/java/io/netty/example/gsonecho/GsonDecoder.java
+++ b/example/src/main/java/io/netty/example/gsonecho/GsonDecoder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.example.gsonecho;
+
+import com.google.gson.Gson;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.string.StringDecoder;
+import io.netty.handler.codec.string.StringEncoder;
+import java.util.List;
+
+/**
+ * Decode received Json {@link String} into Java objects using Gson.
+ * Please note that this decoder must be used with a proper {@link String} decoder.
+ * <p>
+ * <pre>
+ * // Decoders
+ * pipeline.addLast("frameDecoder", new {@link LengthFieldBasedFrameDecoder}(1048576, 0, 4, 0, 4));
+ * pipeline.addLast("stringDecoder", new {@link StringDecoder}(CharsetUtil.UTF_8));
+ * pipeline.addLast("gsonDecoder", new {@link GsonDecoder}&lt;MyType&gt;());
+ * </pre>
+ * <p>
+ * <pre>
+ * // Encoders
+ * pipeline.addLast("frameEncoder", new {@link LengthFieldPrepender}(4));
+ * pipeline.addLast("stringEncoder", new {@link StringEncoder}(CharsetUtil.UTF_8));
+ * pipeline.addLast("gsonEncoder", new {@link GsonEncoder}&lt;MyType&gt;());
+ * </pre>
+ */
+@Sharable
+public class GsonDecoder<T> extends MessageToMessageDecoder<String> {
+
+    private final Class clazz;
+    private final Gson gson;
+
+    public GsonDecoder(Class<T> clazz) {
+        this(new Gson(), clazz);
+    }
+
+    public GsonDecoder(Gson gson, Class<T> clazz) {
+        this.gson = gson;
+        this.clazz = clazz;
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, String msg, List<Object> out) throws Exception {
+        out.add(gson.fromJson(msg, clazz));
+    }
+}

--- a/example/src/main/java/io/netty/example/gsonecho/GsonEchoClient.java
+++ b/example/src/main/java/io/netty/example/gsonecho/GsonEchoClient.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.example.gsonecho;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.example.echo.EchoClient;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
+import io.netty.handler.codec.string.StringDecoder;
+import io.netty.handler.codec.string.StringEncoder;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.util.CharsetUtil;
+import java.util.Map;
+
+
+/**
+ * Modification of {@link EchoClient} which utilizes Gson serialization.
+ */
+public class GsonEchoClient {
+    static final boolean SSL = System.getProperty("ssl") != null;
+    static final String HOST = System.getProperty("host", "127.0.0.1");
+    static final int PORT = Integer.parseInt(System.getProperty("port", "8007"));
+
+    public static void main(String[] args) throws Exception {
+        // Configure SSL.
+        final SslContext sslCtx;
+        if (SSL) {
+            sslCtx = SslContextBuilder.forClient()
+                    .trustManager(InsecureTrustManagerFactory.INSTANCE).build();
+        } else {
+            sslCtx = null;
+        }
+
+        EventLoopGroup group = new NioEventLoopGroup();
+        try {
+            Bootstrap b = new Bootstrap();
+            b.group(group)
+                    .channel(NioSocketChannel.class)
+                    .handler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        public void initChannel(SocketChannel ch) throws Exception {
+                            ChannelPipeline p = ch.pipeline();
+                            if (sslCtx != null) {
+                                p.addLast(sslCtx.newHandler(ch.alloc(), HOST, PORT));
+                            }
+                            p.addLast(
+                                    new LengthFieldPrepender(4),
+                                    new StringEncoder(CharsetUtil.UTF_8),
+                                    new GsonEncoder<Map>(Map.class),
+                                    new LengthFieldBasedFrameDecoder(1048576, 0, 4, 0, 4),
+                                    new StringDecoder(CharsetUtil.UTF_8),
+                                    new LoggingHandler(),
+                                    new GsonDecoder<Map>(Map.class),
+                                    new LoggingHandler(),
+                                    new GsonEchoClientHandler());
+                        }
+                    });
+
+            // Start the connection attempt.
+            b.connect(HOST, PORT).sync().channel().closeFuture().sync();
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/gsonecho/GsonEchoClientHandler.java
+++ b/example/src/main/java/io/netty/example/gsonecho/GsonEchoClientHandler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.gsonecho;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Handler implementation for the Gson echo client.  It initiates the
+ * ping-pong traffic between the Gson echo client and server by sending the
+ * message to the server.
+ */
+public class GsonEchoClientHandler extends ChannelInboundHandlerAdapter {
+
+    private final Map<String, String> message;
+
+    /**
+     * Creates a client-side handler.
+     */
+    public GsonEchoClientHandler() {
+        Map<String, String> message = new HashMap<String, String>();
+        message.put("firstName", "John");
+        message.put("lastName", "Snow");
+        this.message = Collections.unmodifiableMap(message);
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) {
+        // Send the message if this handler is a client-side handler.
+        ctx.writeAndFlush(message);
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        // Echo back the received object to the server.
+        ctx.write(msg);
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.flush();
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        cause.printStackTrace();
+        ctx.close();
+    }
+}

--- a/example/src/main/java/io/netty/example/gsonecho/GsonEchoServer.java
+++ b/example/src/main/java/io/netty/example/gsonecho/GsonEchoServer.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.example.gsonecho;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.example.echo.EchoServer;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
+import io.netty.handler.codec.string.StringDecoder;
+import io.netty.handler.codec.string.StringEncoder;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.CharsetUtil;
+import java.util.Map;
+
+/**
+ * Modification of {@link EchoServer} which utilizes Gson serialization.
+ */
+
+public class GsonEchoServer {
+    static final boolean SSL = System.getProperty("ssl") != null;
+    static final int PORT = Integer.parseInt(System.getProperty("port", "8007"));
+
+    public static void main(String[] args) throws Exception {
+        // Configure SSL.
+        final SslContext sslCtx;
+        if (SSL) {
+            SelfSignedCertificate ssc = new SelfSignedCertificate();
+            sslCtx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build();
+        } else {
+            sslCtx = null;
+        }
+
+        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
+        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        try {
+            ServerBootstrap b = new ServerBootstrap();
+            b.group(bossGroup, workerGroup)
+                    .channel(NioServerSocketChannel.class)
+                    .handler(new LoggingHandler(LogLevel.INFO))
+                    .childHandler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        public void initChannel(SocketChannel ch) throws Exception {
+                            ChannelPipeline p = ch.pipeline();
+                            if (sslCtx != null) {
+                                p.addLast(sslCtx.newHandler(ch.alloc()));
+                            }
+                            p.addLast(new LengthFieldPrepender(4),
+                                    new StringEncoder(CharsetUtil.UTF_8),
+                                    new GsonEncoder<Map>(Map.class),
+                                    new LengthFieldBasedFrameDecoder(1048576, 0, 4, 0, 4),
+                                    new StringDecoder(CharsetUtil.UTF_8),
+                                    new GsonDecoder<Map>(Map.class),
+                                    new GsonEchoServerHandler());
+                        }
+                    });
+
+            // Bind and start to accept incoming connections.
+            b.bind(PORT).sync().channel().closeFuture().sync();
+        } finally {
+            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully();
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/gsonecho/GsonEchoServerHandler.java
+++ b/example/src/main/java/io/netty/example/gsonecho/GsonEchoServerHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.gsonecho;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+/**
+ * Handler implementation for the Gson echo server. It echos any request from client.
+ */
+public class GsonEchoServerHandler extends ChannelInboundHandlerAdapter {
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        // Echo back the received object to the client.
+        ctx.write(msg);
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.flush();
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        cause.printStackTrace();
+        ctx.close();
+    }
+}

--- a/example/src/main/java/io/netty/example/gsonecho/GsonEncoder.java
+++ b/example/src/main/java/io/netty/example/gsonecho/GsonEncoder.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.example.gsonecho;
+
+import com.google.gson.Gson;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
+import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.string.StringDecoder;
+import io.netty.handler.codec.string.StringEncoder;
+import java.util.List;
+
+/**
+ * Encode the requested Java objects into Json {@link String} using Gson.
+ * Please note that this encoder must be used with a proper {@link String} encoder.
+ * <p>
+ * <pre>
+ * // Decoders
+ * pipeline.addLast("frameDecoder", new {@link LengthFieldBasedFrameDecoder}(1048576, 0, 4, 0, 4));
+ * pipeline.addLast("stringDecoder", new {@link StringDecoder}(CharsetUtil.UTF_8));
+ * pipeline.addLast("gsonDecoder", new {@link GsonDecoder}&lt;MyType&gt;());
+ * </pre>
+ * <p>
+ * <pre>
+ * // Encoders
+ * pipeline.addLast("frameEncoder", new {@link LengthFieldPrepender}(4));
+ * pipeline.addLast("stringEncoder", new {@link StringEncoder}(CharsetUtil.UTF_8));
+ * pipeline.addLast("gsonEncoder", new {@link GsonEncoder}&lt;MyType&gt;());
+ * </pre>
+ */
+@Sharable
+public class GsonEncoder<T> extends MessageToMessageEncoder<T> {
+
+    private final Class clazz;
+    private final Gson gson;
+
+    public GsonEncoder(Class<T> clazz) {
+        super(clazz);
+        this.clazz = clazz;
+        this.gson = new Gson();
+    }
+
+    public GsonEncoder(Gson gson, Class<T> clazz) {
+        super(clazz);
+        this.clazz = clazz;
+        this.gson = gson;
+    }
+
+    @Override
+    protected void encode(ChannelHandlerContext ctx, T msg, List<Object> out) throws Exception {
+        out.add(gson.toJson(msg, clazz));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -422,6 +422,12 @@
         </exclusions>
         <optional>true</optional>
       </dependency>
+      <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>2.7</version>
+        <optional>true</optional>
+      </dependency>
 
       <!-- Metrics providers -->
       <dependency>


### PR DESCRIPTION
Motivation:

Add a codec implementation example using Gson. See #1129.

Modifications:

Add an echo sever and client that decode/encode json using Gson.

Result:

Add an example to show how to implement a json codec.