### PR TITLE
DnsNameResolver should not bind locally. Fixes #5457

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -17,12 +17,14 @@ package io.netty.resolver.dns;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.AddressedEnvelope;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoop;
 import io.netty.channel.FixedRecvByteBufAllocator;
 import io.netty.channel.socket.DatagramChannel;
@@ -65,8 +67,6 @@ public class DnsNameResolver extends InetNameResolver {
     private static final String LOCALHOST = "localhost";
     private static final InetAddress LOCALHOST_ADDRESS;
 
-    static final InetSocketAddress ANY_LOCAL_ADDR = new InetSocketAddress(0);
-
     static final InternetProtocolFamily[] DEFAULT_RESOLVE_ADDRESS_TYPES = new InternetProtocolFamily[2];
 
     static {
@@ -88,7 +88,7 @@ public class DnsNameResolver extends InetNameResolver {
     private static final DatagramDnsQueryEncoder ENCODER = new DatagramDnsQueryEncoder();
 
     final DnsServerAddresses nameServerAddresses;
-    final ChannelFuture bindFuture;
+    final Future<Channel> channelFuture;
     final DatagramChannel ch;
 
     /**
@@ -123,7 +123,6 @@ public class DnsNameResolver extends InetNameResolver {
      *
      * @param eventLoop the {@link EventLoop} which will perform the communication with the DNS servers
      * @param channelFactory the {@link ChannelFactory} that will create a {@link DatagramChannel}
-     * @param localAddress the local address of the {@link DatagramChannel}
      * @param nameServerAddresses the addresses of the DNS server. For each DNS query, a new stream is created from
      *                            this to determine which DNS server should be contacted for the next retry in case
      *                            of failure.
@@ -140,9 +139,8 @@ public class DnsNameResolver extends InetNameResolver {
     public DnsNameResolver(
             EventLoop eventLoop,
             ChannelFactory<? extends DatagramChannel> channelFactory,
-            InetSocketAddress localAddress,
             DnsServerAddresses nameServerAddresses,
-            DnsCache resolveCache,
+            final DnsCache resolveCache,
             long queryTimeoutMillis,
             InternetProtocolFamily[] resolvedAddressTypes,
             boolean recursionDesired,
@@ -154,7 +152,6 @@ public class DnsNameResolver extends InetNameResolver {
 
         super(eventLoop);
         checkNotNull(channelFactory, "channelFactory");
-        checkNotNull(localAddress, "localAddress");
         this.nameServerAddresses = checkNotNull(nameServerAddresses, "nameServerAddresses");
         this.queryTimeoutMillis = checkPositive(queryTimeoutMillis, "queryTimeoutMillis");
         this.resolvedAddressTypes = checkNonEmpty(resolvedAddressTypes, "resolvedAddressTypes");
@@ -166,18 +163,11 @@ public class DnsNameResolver extends InetNameResolver {
         this.hostsFileEntriesResolver = checkNotNull(hostsFileEntriesResolver, "hostsFileEntriesResolver");
         this.resolveCache = resolveCache;
 
-        bindFuture = newChannel(channelFactory, localAddress);
-        ch = (DatagramChannel) bindFuture.channel();
-        ch.config().setRecvByteBufAllocator(new FixedRecvByteBufAllocator(maxPayloadSize));
-    }
-
-    private ChannelFuture newChannel(
-            ChannelFactory<? extends DatagramChannel> channelFactory, InetSocketAddress localAddress) {
-
         Bootstrap b = new Bootstrap();
         b.group(executor());
         b.channelFactory(channelFactory);
-        final DnsResponseHandler responseHandler = new DnsResponseHandler();
+        b.option(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION, true);
+        final DnsResponseHandler responseHandler = new DnsResponseHandler(executor().<Channel>newPromise());
         b.handler(new ChannelInitializer<DatagramChannel>() {
             @Override
             protected void initChannel(DatagramChannel ch) throws Exception {
@@ -185,15 +175,16 @@ public class DnsNameResolver extends InetNameResolver {
             }
         });
 
-        ChannelFuture bindFuture = b.bind(localAddress);
-        bindFuture.channel().closeFuture().addListener(new ChannelFutureListener() {
+        channelFuture = responseHandler.channelActivePromise;
+        ch = (DatagramChannel) b.register().channel();
+        ch.config().setRecvByteBufAllocator(new FixedRecvByteBufAllocator(maxPayloadSize));
+
+        ch.closeFuture().addListener(new ChannelFutureListener() {
             @Override
             public void operationComplete(ChannelFuture future) throws Exception {
                 resolveCache.clear();
             }
         });
-
-        return bindFuture;
     }
 
     /**
@@ -606,6 +597,13 @@ public class DnsNameResolver extends InetNameResolver {
     }
 
     private final class DnsResponseHandler extends ChannelInboundHandlerAdapter {
+
+        private final Promise<Channel> channelActivePromise;
+
+        public DnsResponseHandler(Promise<Channel> channelActivePromise) {
+            this.channelActivePromise = channelActivePromise;
+        }
+
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
             try {
@@ -626,6 +624,12 @@ public class DnsNameResolver extends InetNameResolver {
             } finally {
                 ReferenceCountUtil.safeRelease(msg);
             }
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            super.channelActive(ctx);
+            channelActivePromise.setSuccess(ctx.channel());
         }
 
         @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -600,7 +600,7 @@ public class DnsNameResolver extends InetNameResolver {
 
         private final Promise<Channel> channelActivePromise;
 
-        public DnsResponseHandler(Promise<Channel> channelActivePromise) {
+        DnsResponseHandler(Promise<Channel> channelActivePromise) {
             this.channelActivePromise = channelActivePromise;
         }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -26,7 +26,6 @@ import io.netty.resolver.HostsFileEntriesResolver;
 import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.UnstableApi;
 
-import java.net.InetSocketAddress;
 import java.util.List;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -39,7 +38,6 @@ public final class DnsNameResolverBuilder {
 
     private final EventLoop eventLoop;
     private ChannelFactory<? extends DatagramChannel> channelFactory;
-    private InetSocketAddress localAddress = DnsNameResolver.ANY_LOCAL_ADDR;
     private DnsServerAddresses nameServerAddresses = DnsServerAddresses.defaultAddresses();
     private DnsCache resolveCache;
     private Integer minTtl;
@@ -84,17 +82,6 @@ public final class DnsNameResolverBuilder {
      */
     public DnsNameResolverBuilder channelType(Class<? extends DatagramChannel> channelType) {
         return channelFactory(new ReflectiveChannelFactory<DatagramChannel>(channelType));
-    }
-
-    /**
-     * Sets the local address of the {@link DatagramChannel}
-     *
-     * @param localAddress the local address
-     * @return {@code this}
-     */
-    public DnsNameResolverBuilder localAddress(InetSocketAddress localAddress) {
-        this.localAddress = localAddress;
-        return this;
     }
 
     /**
@@ -318,7 +305,6 @@ public final class DnsNameResolverBuilder {
         return new DnsNameResolver(
                 eventLoop,
                 channelFactory,
-                localAddress,
                 nameServerAddresses,
                 cache,
                 queryTimeoutMillis,

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -17,6 +17,7 @@ package io.netty.resolver.dns;
 
 import io.netty.buffer.Unpooled;
 import io.netty.channel.AddressedEnvelope;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.handler.codec.dns.DatagramDnsQuery;
@@ -27,6 +28,8 @@ import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
 import io.netty.handler.codec.dns.DnsResponse;
 import io.netty.handler.codec.dns.DnsSection;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.concurrent.ScheduledFuture;
 import io.netty.util.internal.StringUtil;
@@ -107,12 +110,12 @@ final class DnsQueryContext {
     }
 
     private void sendQuery(final DnsQuery query) {
-        if (parent.bindFuture.isDone()) {
+        if (parent.channelFuture.isDone()) {
             writeQuery(query);
         } else {
-            parent.bindFuture.addListener(new ChannelFutureListener() {
+            parent.channelFuture.addListener(new GenericFutureListener<Future<? super Channel>>() {
                 @Override
-                public void operationComplete(ChannelFuture future) throws Exception {
+                public void operationComplete(Future<? super Channel> future) throws Exception {
                     if (future.isSuccess()) {
                         writeQuery(query);
                     } else {


### PR DESCRIPTION
Motivation:
Dns resolution failures happen when using the DnsNameResolver and the JVM is not authorized to bind datagram channels. The current DnsNameResolver binds locally a DatagramChannel which is not necessary (and not always permitted).

Modifications:
The DnsNameResolver Bootstrap does not bind anymore, instead it registers and use the channel directly. The localAddress has also been removed from the DnsAddressResolverGroup, DnsNameResolver and DnsNameResolverBuilder as it is not necessary anymore and the API is marked as @UnstableApi.

Result:
Dns resolution does not require anymore to bind locally.