### PR TITLE
HPACK Encoder headerFields improvements

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/internal/hpack/TestCase.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/internal/hpack/TestCase.java
@@ -161,7 +161,7 @@ final class TestCase {
             maxHeaderTableSize = Integer.MAX_VALUE;
         }
 
-        return new Encoder(maxHeaderTableSize, useIndexing, forceHuffmanOn, forceHuffmanOff);
+        return new Encoder(maxHeaderTableSize, useIndexing, forceHuffmanOn, forceHuffmanOff, 16);
     }
 
     private Decoder createDecoder() {

--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -50,12 +50,6 @@ import static java.lang.Math.max;
  */
 public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers<K, V, T> {
     /**
-     * Enforce an upper bound of 128 because {@link #hashMask} is a byte.
-     * The max possible value of {@link #hashMask} is one less than this value.
-     */
-    private static final int ARRAY_SIZE_HINT_MAX = min(128,
-                            max(1, SystemPropertyUtil.getInt("io.netty.DefaultHeaders.arraySizeHintMax", 16)));
-    /**
      * Constant used to seed the hash code generation. Could be anything but this was borrowed from murmur3.
      */
     static final int HASH_CODE_SEED = 0xc2b2ae35;
@@ -120,7 +114,9 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         this.valueConverter = checkNotNull(valueConverter, "valueConverter");
         this.nameValidator = checkNotNull(nameValidator, "nameValidator");
         this.hashingStrategy = checkNotNull(nameHashingStrategy, "nameHashingStrategy");
-        entries = new DefaultHeaders.HeaderEntry[findNextPositivePowerOfTwo(min(arraySizeHint, ARRAY_SIZE_HINT_MAX))];
+        // Enforce a bound of [2, 128] because hashMask is a byte. The max possible value of hashMask is one less
+        // than the length of this array, and we want the mask to be > 0.
+        entries = new DefaultHeaders.HeaderEntry[findNextPositivePowerOfTwo(max(2, min(arraySizeHint, 128)))];
         hashMask = (byte) (entries.length - 1);
         head = new HeaderEntry<K, V>();
     }

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -1394,7 +1394,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
             return 0;
         }
         if (value.getClass() == AsciiString.class) {
-            return ((AsciiString) value).hashCode();
+            return value.hashCode();
         }
 
         return PlatformDependent.hashCodeAscii(value);

--- a/microbench/src/main/java/io/netty/microbench/http2/internal/hpack/EncoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/internal/hpack/EncoderBenchmark.java
@@ -36,16 +36,24 @@ import io.netty.handler.codec.http2.internal.hpack.Encoder;
 import io.netty.microbench.util.AbstractMicrobenchmark;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 import java.io.IOException;
 import java.util.List;
 
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 public class EncoderBenchmark extends AbstractMicrobenchmark {
 
     @Param


### PR DESCRIPTION
Motivation:
HPACK Encoder has a data structure which is similar to a previous version of DefaultHeaders. Some of the same improvements can be made.

Motivation:
- Enforce the restriction that the Encoder's headerFields length must be a power of two so we can use masking instead of modulo
- Use AsciiString.hashCode which already has optimizations instead of having yet another hash code algorithm in Encoder

Result:
Fixes https://github.com/netty/netty/issues/5357