### PR TITLE
Use ResourceLeakDetectorFactory in HashedWheelTimer

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -76,9 +76,8 @@ public class HashedWheelTimer implements Timer {
     static final InternalLogger logger =
             InternalLoggerFactory.getInstance(HashedWheelTimer.class);
 
-    private static final ResourceLeakDetector<HashedWheelTimer> leakDetector =
-            new ResourceLeakDetector<HashedWheelTimer>(
-                    HashedWheelTimer.class, 1, Runtime.getRuntime().availableProcessors() * 4);
+    private static final ResourceLeakDetector<HashedWheelTimer> leakDetector = ResourceLeakDetectorFactory.instance()
+            .newResourceLeakDetector(HashedWheelTimer.class, 1, Runtime.getRuntime().availableProcessors() * 4L);
 
     private static final AtomicIntegerFieldUpdater<HashedWheelTimer> WORKER_STATE_UPDATER;
     static {

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -109,7 +109,7 @@ public class ResourceLeakDetector<T> {
     }
 
     // Should be power of two.
-    private static final int DEFAULT_SAMPLING_INTERVAL = 128;
+    static final int DEFAULT_SAMPLING_INTERVAL = 128;
 
     /**
      * @deprecated Use {@link #setLevel(Level)} instead.
@@ -159,18 +159,36 @@ public class ResourceLeakDetector<T> {
 
     private long leakCheckCnt;
 
+    /**
+     * @deprecated use {@link ResourceLeakDetectorFactory#newResourceLeakDetector(Class, int, long)}.
+     */
+    @Deprecated
     public ResourceLeakDetector(Class<?> resourceType) {
         this(simpleClassName(resourceType));
     }
 
+    /**
+     * @deprecated use {@link ResourceLeakDetectorFactory#newResourceLeakDetector(Class, int, long)}.
+     */
+    @Deprecated
     public ResourceLeakDetector(String resourceType) {
         this(resourceType, DEFAULT_SAMPLING_INTERVAL, Long.MAX_VALUE);
     }
 
+    /**
+     * This should not be used directly by users of {@link ResourceLeakDetector}.
+     * Please use {@link ResourceLeakDetectorFactory#newResourceLeakDetector(Class)}
+     * or {@link ResourceLeakDetectorFactory#newResourceLeakDetector(Class, int, long)}
+     */
+    @SuppressWarnings("deprecation")
     public ResourceLeakDetector(Class<?> resourceType, int samplingInterval, long maxActive) {
         this(simpleClassName(resourceType), samplingInterval, maxActive);
     }
 
+    /**
+     * @deprecated use {@link ResourceLeakDetectorFactory#newResourceLeakDetector(Class, int, long)}.
+     */
+    @Deprecated
     public ResourceLeakDetector(String resourceType, int samplingInterval, long maxActive) {
         if (resourceType == null) {
             throw new NullPointerException("resourceType");
@@ -199,7 +217,7 @@ public class ResourceLeakDetector<T> {
      *
      * @return the {@link ResourceLeak} or {@code null}
      */
-    public ResourceLeak open(T obj) {
+    public final ResourceLeak open(T obj) {
         Level level = ResourceLeakDetector.level;
         if (level == Level.DISABLED) {
             return null;


### PR DESCRIPTION
Motivation:

We recently added the ResourceLeakDetectorFactory but missed to updated HashedWheelTimer to use it.

Modifications:

- Add new abstract method to ResourceLeakDetectorFactory that allows to provide also samplingInterval and maxActive args.
- Deprecate most constructors in ResourceLeakDetector and add doc explaining that people should use ResourceLeakDetectorFactory

Result:

Custom ResourceLeakDetectorFactory will also be used in HashedWheelTimer if configured.