### PR TITLE
Allow to disable ResourceLeak creation when worker thread is deamon i…

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -190,6 +190,26 @@ public class HashedWheelTimer implements Timer {
     public HashedWheelTimer(
             ThreadFactory threadFactory,
             long tickDuration, TimeUnit unit, int ticksPerWheel) {
+        this(threadFactory, tickDuration, unit, ticksPerWheel, true);
+    }
+
+    /**
+     * Creates a new timer.
+     *
+     * @param threadFactory  a {@link ThreadFactory} that creates a
+     *                       background {@link Thread} which is dedicated to
+     *                       {@link TimerTask} execution.
+     * @param tickDuration   the duration between tick
+     * @param unit           the time unit of the {@code tickDuration}
+     * @param ticksPerWheel  the size of the wheel
+     * @param leakDetection  {@code true} if leak detection should be enabled always, if false it will only be enabled
+     *                       if the worker thread is not a daemon thread.
+     * @throws NullPointerException     if either of {@code threadFactory} and {@code unit} is {@code null}
+     * @throws IllegalArgumentException if either of {@code tickDuration} and {@code ticksPerWheel} is &lt;= 0
+     */
+    public HashedWheelTimer(
+            ThreadFactory threadFactory,
+            long tickDuration, TimeUnit unit, int ticksPerWheel, boolean leakDetection) {
 
         if (threadFactory == null) {
             throw new NullPointerException("threadFactory");
@@ -219,7 +239,7 @@ public class HashedWheelTimer implements Timer {
         }
         workerThread = threadFactory.newThread(worker);
 
-        leak = leakDetector.open(this);
+        leak = leakDetection || !workerThread.isDaemon() ? leakDetector.open(this) : null;
     }
 
     private static HashedWheelBucket[] createWheel(int ticksPerWheel) {


### PR DESCRIPTION
…n HashedWheelTimer

Motivation:

Sometimes a shared HashedWheelTimer can not easily be stopped in a good place. If the worker thread is daemon this is not a big deal and we should allow to not log a leak.

Modifications:

Add another constructor which allows to disable resource leak detection if worker thread is used.

Result:

Not log resource leak when HashedWheelTimer is not stopped and the  worker thread is a deamon thread.