### PR TITLE
 subString AsciiString hashcode problem in 4.1.1.Final

### DIFF
--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
@@ -23,6 +23,7 @@ import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.stomp.StompSubframeDecoder.State;
+import io.netty.util.AsciiString;
 import io.netty.util.internal.AppendableCharSequence;
 import io.netty.util.internal.StringUtil;
 
@@ -214,7 +215,7 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
             if (!line.isEmpty()) {
                 String[] split = StringUtil.split(line, ':');
                 if (split.length == 2) {
-                    headers.add(split[0], split[1]);
+                    headers.add(new AsciiString(split[0]), split[1]);
                 }
             } else {
                 if (headers.contains(StompHeaders.CONTENT_LENGTH))  {

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -22,14 +22,9 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.util.Random;
 
-import static io.netty.util.AsciiString.contains;
-import static io.netty.util.AsciiString.containsIgnoreCase;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static io.netty.util.AsciiString.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 /**
  * Test character encoding and case insensitivity for the {@link AsciiString} class
@@ -313,5 +308,12 @@ public class AsciiStringCharacterTest {
         assertEquals(1, AsciiString.indexOf("aabaabaa", 'a', 1));
         assertEquals(3, AsciiString.indexOf("aabaabaa", 'a', 2));
         assertEquals(3, AsciiString.indexOf("aabdabaa", 'd', 1));
+    }
+
+    @Test
+    public void testSubStringHashCode() {
+        String a = "123";
+        String b = "a123";
+        assertEquals(AsciiString.hashCode(a), AsciiString.hashCode(b.substring(1)));
     }
 }


### PR DESCRIPTION
The following issue is already fixed .So I drop previous code changes and  add a test case for this problem.

---

Motivation:
```
AsciiString.hashCode(o) ,
```
if "o" is a subString, the hash code is not always same. 

Modifications:

Avoid to use subString.

Result:

Fix the issue.
