### PR TITLE
Removed HeapByteBuffer address field check.

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -63,14 +63,9 @@ final class PlatformDependent0 {
         try {
             addressField = Buffer.class.getDeclaredField("address");
             addressField.setAccessible(true);
-            if (addressField.getLong(ByteBuffer.allocate(1)) != 0) {
-                // A heap buffer must have 0 address.
+            if (addressField.getLong(direct) == 0) {
+                // A direct buffer must have non-zero address.
                 addressField = null;
-            } else {
-                if (addressField.getLong(direct) == 0) {
-                    // A direct buffer must have non-zero address.
-                    addressField = null;
-                }
             }
         } catch (Throwable t) {
             // Failed to access the address field.


### PR DESCRIPTION
In JDK9 heap byte buffers have an address field, so we have to remove the current check as it is invalid in JDK9. It doesn't look like the fact that heap byte buffers didn't use to have an address field is used anywhere, but I could be wrong.