### PR TITLE
Fix NPE in OpenSslEngine

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -1470,12 +1470,15 @@ public final class OpenSslEngine extends SSLEngine {
                     assert GET_ASCII_NAME_METHOD != null;
                     try {
                         List<?> servernames = (List<?>) GET_SERVER_NAMES_METHOD.invoke(sslParameters);
-                        for (Object serverName : servernames) {
-                            if (SNI_HOSTNAME_CLASS.isInstance(serverName)) {
-                                SSL.setTlsExtHostName(ssl, (String) GET_ASCII_NAME_METHOD.invoke(serverName));
-                            } else {
-                                throw new IllegalArgumentException("Only " + SNI_HOSTNAME_CLASS.getName()
-                                        + " instances are supported, but found: " + serverName);
+                        if (servernames != null) {
+                            for (Object serverName : servernames) {
+                                if (SNI_HOSTNAME_CLASS.isInstance(serverName)) {
+                                    SSL.setTlsExtHostName(ssl, (String) GET_ASCII_NAME_METHOD.invoke(serverName));
+                                } else {
+                                    throw new IllegalArgumentException("Only " + SNI_HOSTNAME_CLASS.getName()
+                                                                       + " instances are supported, but found: " +
+                                                                       serverName);
+                                }
                             }
                         }
                         sniHostNames = servernames;


### PR DESCRIPTION
Motivation:

The gRPC interop tests fail due to a NPE in OpenSslEngine.

Modifications:

Add a null check

Result:

No more NPE exceptions :-)