### PR TITLE
Add trivial timeout handler to use with client channels

### DIFF
--- a/handler/src/main/java/io/netty/handler/timeout/ReadAfterWriteTimeoutHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/ReadAfterWriteTimeoutHandler.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.timeout;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.util.ReferenceCountUtil;
+
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This handler supports trivial emulation of soTimeout for clients, measure time between
+ * last {@code write()} method invocation and first proceed {@code channelRead()}
+ *
+ * Timeout measurement in the default implementation would be cancelled just after first potentially
+ * partial {@code read()} in the channel, so, if you have a marker of a last event in the series -
+ * it's worth to override {@link #timeoutShouldBeCancelled(ChannelHandlerContext, Object)} method,
+ * otherwise - use this handler in pair with a reasonable {@link IdleStateHandler} to catch situations
+ * of extremely slow client reads or dead writes from the server side.
+ *
+ * Although this handler doesn't catch situations with very low client writes, so use this handler in pair with
+ * a reasonable {@link IdleStateHandler} to catch this situations.
+ */
+public class ReadAfterWriteTimeoutHandler extends ChannelDuplexHandler {
+    private static final long MIN_TIMEOUT_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
+
+    private final long timeoutNanos;
+    private final boolean closeOnTimeout;
+    private final boolean suppressReadAfterTimeout;
+
+    private ChannelFutureListener channelOnWriteListener;
+    private ReadTimeoutTask readTimeoutTask;
+
+    private boolean readInvokedAfterWrite;
+    private ScheduledFuture<?> timeout;
+    private boolean timedOut;
+
+    private volatile boolean removed;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param timeout read timeout after last write to the channel
+     * @param unit the {@link TimeUnit} of {@code timeout}
+     * @param closeOnTimeout if channel should be closed by this handler after firing {@link ReadTimeoutException}
+     * @param suppressReadAfterTimeout channelRead got after timeout before new write would be ignored if {@code true}.
+     * This address possible situation when we ran into timeout and get response in a very short time
+     * and timeout job executing before channelRead event.
+     * Also this addresses situation when we don't close connection after timeout ({@code closeOnTimeout == false}) and
+     * should skip next read which was received after timeout.
+     * User event {@link ReadSuppressed} will be thrown if case of read suppressing.
+     * @throws IllegalArgumentException if {@code timeout <= 0}
+     */
+    public ReadAfterWriteTimeoutHandler(long timeout, TimeUnit unit, boolean closeOnTimeout,
+                                        boolean suppressReadAfterTimeout) {
+        if (timeout <= 0) {
+            throw new IllegalArgumentException("timeout value must be positive");
+        }
+        this.timeoutNanos = Math.max(unit.toNanos(timeout), MIN_TIMEOUT_NANOS);
+        this.closeOnTimeout = closeOnTimeout;
+        this.suppressReadAfterTimeout = suppressReadAfterTimeout;
+    }
+
+    /**
+     * Creates a new instance with {@code closeOnTimeout == true} and {@code ignoreReadAfterTimeout == true}
+     *
+     * @param timeout read timeout
+     * @param unit the {@link TimeUnit} of {@code timeout}
+     */
+    public ReadAfterWriteTimeoutHandler(long timeout, TimeUnit unit) {
+        this(timeout, unit, true, true);
+    }
+
+    @Override
+    public void handlerAdded(final ChannelHandlerContext ctx) throws Exception {
+        removed = false;
+
+        if (channelOnWriteListener == null) {
+            channelOnWriteListener = new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture future) throws Exception {
+                    //ensure that only the last write listener in a batch would setup one final timeout task
+                    //or nothing in a case of error
+                    disable();
+                    timedOut = false;
+                    if (future.isSuccess()) {
+                        if (removed) {
+                            return;
+                        }
+                        readInvokedAfterWrite = false;
+                        timeout = ctx.executor().schedule(readTimeoutTask, timeoutNanos, TimeUnit.NANOSECONDS);
+                    }
+                }
+            };
+        }
+
+        if (readTimeoutTask == null) {
+            readTimeoutTask = new ReadTimeoutTask(ctx);
+        }
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        destroy();
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        destroy();
+        super.channelInactive(ctx);
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (timeoutShouldBeCancelled(ctx, msg)) {
+            readInvokedAfterWrite = true;
+            disable();
+        }
+        if (suppressReadAfterTimeout && timedOut) {
+            ctx.fireUserEventTriggered(ReadSuppressed.INSTANCE);
+            ReferenceCountUtil.release(msg);
+        } else {
+            super.channelRead(ctx, msg);
+        }
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+        ctx.write(msg, promise.addListener(channelOnWriteListener));
+    }
+
+    /**
+     * This method is called after receiving each {@link #channelRead(ChannelHandlerContext, Object)}
+     * and should define if this read should trigger
+     * timeout cancelling. Default implementation returns {@code true}.
+     * @param ctx {@link ChannelHandlerContext} of related {@link #channelRead(ChannelHandlerContext, Object)}
+     * invocation
+     * @param msg message of related {@link #channelRead} invocation
+     * @return true if timeout should be cancelled by receiving this read, false otherwise
+     */
+    protected boolean timeoutShouldBeCancelled(@SuppressWarnings("unused") ChannelHandlerContext ctx,
+                                               @SuppressWarnings("unused") Object msg) {
+        return true;
+    }
+
+    private void destroy() {
+        removed = true;
+        disable();
+    }
+
+    private void disable() {
+        if (timeout != null) {
+            timeout.cancel(false);
+            timeout = null;
+        }
+    }
+
+    /**
+     * Is called when a read timeout was detected.
+     */
+    protected void readTimedOut(ChannelHandlerContext ctx) throws Exception {
+        timedOut = true;
+        ctx.fireExceptionCaught(ReadTimeoutException.INSTANCE);
+        if (closeOnTimeout) {
+            ctx.close();
+        }
+    }
+
+    public static final class ReadSuppressed {
+        private static final ReadSuppressed INSTANCE = new ReadSuppressed();
+
+        private ReadSuppressed() {
+        }
+    }
+
+    private final class ReadTimeoutTask implements Runnable {
+        private final ChannelHandlerContext ctx;
+
+        ReadTimeoutTask(ChannelHandlerContext ctx) {
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void run() {
+            timeout = null; //cleanup to use this channel and handler further if we don't close
+            if (!ctx.channel().isOpen()) {
+                return;
+            }
+            if (!readInvokedAfterWrite && !timedOut) {
+                try {
+                    readTimedOut(ctx);
+                } catch (Throwable t) {
+                    ctx.fireExceptionCaught(t);
+                }
+            }
+        }
+    }
+}

--- a/handler/src/test/java/io/netty/handler/timeout/ReadAfterWriteTimeoutHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/timeout/ReadAfterWriteTimeoutHandlerTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.timeout;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ReadAfterWriteTimeoutHandlerTest {
+    private static EventLoopGroup GROUP;
+
+    /**
+     * We should get {@link io.netty.handler.timeout.ReadTimeoutException} after specified timeout value if server
+     * response with larger latency than the specified timeout.
+     */
+    @Test
+    public void testTrivialTimeoutCase() throws Exception {
+        final int TIMEOUT_MS = 300;
+        final CountDownLatch timeoutGotLatch = new CountDownLatch(1);
+        final CountDownLatch clientClosedChannelLatch = new CountDownLatch(1);
+        final AtomicBoolean unexpectedExceptionInServerHandler = new AtomicBoolean();
+        final AtomicBoolean unexpectedExceptionInClientHandler = new AtomicBoolean();
+
+        ReadAfterWriteTimeoutHandler readAfterWriteTimeoutHandler =
+                new ReadAfterWriteTimeoutHandler(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        ChannelInboundHandler pongHandler = new ChannelInboundHandlerAdapter() {
+            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                Thread.sleep(2 * TIMEOUT_MS);
+                ctx.writeAndFlush(newOneMessage());
+            }
+
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                if (cause instanceof IOException && "Connection reset by peer".equals(cause.getMessage())) {
+                    //it's client closed connection already when we tried to send a message back - ignore
+                } else {
+                    unexpectedExceptionInServerHandler.set(true);
+                }
+            }
+
+            @Override
+            public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+                clientClosedChannelLatch.countDown();
+            }
+        };
+
+        ChannelInboundHandler trackingHandler = new ChannelInboundHandlerAdapter() {
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                if (cause instanceof ReadTimeoutException) {
+                    timeoutGotLatch.countDown();
+                } else {
+                    unexpectedExceptionInClientHandler.set(true);
+                }
+            }
+        };
+
+        Channel server = newServer(pongHandler);
+        Channel client = newClient(server.localAddress(), readAfterWriteTimeoutHandler, trackingHandler);
+        try {
+            client.writeAndFlush(newOneMessage());
+            assertTrue("No ReadTimeoutException produced by ReadAfterWriteTimeoutHandler",
+                       timeoutGotLatch.await(5 * TIMEOUT_MS, TimeUnit.MILLISECONDS));
+            assertTrue("ReadAfterWriteTimeoutHandler should close channel by default",
+                       clientClosedChannelLatch.await(3 * TIMEOUT_MS, TimeUnit.MILLISECONDS));
+            assertFalse("Unexpected exception in server handler", unexpectedExceptionInServerHandler.get());
+            assertFalse("Unexpected exception in client handler", unexpectedExceptionInClientHandler.get());
+        } finally {
+            client.close();
+            server.close();
+        }
+    }
+
+    @Test
+    public void testOnlyOneTimeoutProducedForMultipleConsecutiveWrites() throws Exception {
+        final int TIMEOUT_MS = 300;
+        final int MESSAGES_COUNT = 2;
+
+        final AtomicInteger serverReads = new AtomicInteger();
+        final CountDownLatch timeoutGotLatch = new CountDownLatch(MESSAGES_COUNT);
+        final AtomicBoolean unexpectedExceptionInServerHandler = new AtomicBoolean();
+        final AtomicBoolean unexpectedExceptionInClientHandler = new AtomicBoolean();
+
+        ReadAfterWriteTimeoutHandler readAfterWriteTimeoutHandler =
+                new ReadAfterWriteTimeoutHandler(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        ChannelInboundHandler pongAfterTwoMessagesHandler = new ChannelInboundHandlerAdapter() {
+            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                serverReads.incrementAndGet();
+                //response once only after MESSAGES_COUNT messages and sleeping
+                if (serverReads.get() == MESSAGES_COUNT) {
+                    Thread.sleep(2 * TIMEOUT_MS);
+                    ctx.writeAndFlush(newOneMessage());
+                }
+            }
+
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                if (cause instanceof IOException && "Connection reset by peer".equals(cause.getMessage())) {
+                    //it's client closed connection already when we tried to send a message back - ignore
+                } else {
+                    fail();
+                }
+            }
+        };
+
+        ChannelInboundHandler trackingHandler = new ChannelInboundHandlerAdapter() {
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                if (cause instanceof ReadTimeoutException) {
+                    timeoutGotLatch.countDown();
+                } else {
+                    unexpectedExceptionInClientHandler.set(true);
+                }
+            }
+        };
+
+        Channel server = newServer(pongAfterTwoMessagesHandler);
+        Channel client = newClient(server.localAddress(), readAfterWriteTimeoutHandler, trackingHandler);
+        try {
+            client.writeAndFlush(newOneMessage());
+            Thread.sleep(TIMEOUT_MS / 10);
+            client.writeAndFlush(newOneMessage());
+            assertFalse("We should get only one timeout on the client side, while this latch initiated with value > 1",
+                        timeoutGotLatch.await(2 * TIMEOUT_MS, TimeUnit.MILLISECONDS));
+            assertEquals("Server should get 2 messages already", MESSAGES_COUNT, serverReads.get());
+            assertEquals("We should get only one timeout on the client side (latch value decreased by 1)",
+                         MESSAGES_COUNT - 1, timeoutGotLatch.getCount());
+            assertFalse("Unexpected exception in server handler", unexpectedExceptionInServerHandler.get());
+            assertFalse("Unexpected exception in client handler", unexpectedExceptionInClientHandler.get());
+        } finally {
+            client.close();
+            server.close();
+        }
+    }
+
+    @Test
+    public void testNoTimeoutInCaseOfResponseInTime() throws Exception {
+        final int TIMEOUT_MS = 300;
+        final int MESSAGES_COUNT = 1;
+
+        final AtomicBoolean clientReads = new AtomicBoolean();
+        final AtomicBoolean unexpectedExceptionInServerHandler = new AtomicBoolean();
+        final CountDownLatch unexpectedExceptionInClientHandlerLatch = new CountDownLatch(MESSAGES_COUNT);
+
+        ReadAfterWriteTimeoutHandler readAfterWriteTimeoutHandler =
+                new ReadAfterWriteTimeoutHandler(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        ChannelInboundHandler pongAfterTwoMessagesHandler = new ChannelInboundHandlerAdapter() {
+            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                ctx.writeAndFlush(newOneMessage());
+            }
+
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                //shouldn't be any channel closing, RST, etc from client and no ReadTimeoutExceptions in this test
+                unexpectedExceptionInServerHandler.set(true);
+            }
+        };
+
+        ChannelInboundHandler trackingHandler = new ChannelInboundHandlerAdapter() {
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                clientReads.set(true);
+            }
+
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                unexpectedExceptionInClientHandlerLatch.countDown();
+            }
+        };
+
+        Channel server = newServer(pongAfterTwoMessagesHandler);
+        Channel client = newClient(server.localAddress(), readAfterWriteTimeoutHandler, trackingHandler);
+        try {
+            client.writeAndFlush(newOneMessage());
+            assertFalse("Shouldn't get any timeouts or exceptions in client channel",
+                        unexpectedExceptionInClientHandlerLatch.await(2 * TIMEOUT_MS, TimeUnit.MILLISECONDS));
+            assertTrue("Client should get server response already", clientReads.get());
+            assertFalse("Unexpected exception in server handler", unexpectedExceptionInServerHandler.get());
+        } finally {
+            client.close();
+            server.close();
+        }
+    }
+
+    /**
+     * We should continue work after ReadTimeout
+     */
+    @Test
+    public void testContinueCommunicationAfterTimeout() throws Exception {
+        final int TIMEOUT_MS = 300;
+        final int MESSAGES_COUNT = 2;
+
+        final AtomicInteger serverReads = new AtomicInteger();
+        final CountDownLatch timeoutGotLatch = new CountDownLatch(1);
+        final CountDownLatch clientReadsLatch = new CountDownLatch(1);
+        final CountDownLatch suppressedReadsLatch = new CountDownLatch(1);
+        final AtomicBoolean unexpectedExceptionInServerHandler = new AtomicBoolean();
+        final AtomicBoolean unexpectedExceptionInClientHandler = new AtomicBoolean();
+
+        ReadAfterWriteTimeoutHandler readAfterWriteTimeoutHandler =
+                new ReadAfterWriteTimeoutHandler(TIMEOUT_MS, TimeUnit.MILLISECONDS, false, true);
+
+        ChannelInboundHandler pongHandler = new ChannelInboundHandlerAdapter() {
+            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                serverReads.incrementAndGet();
+                if (serverReads.get() != MESSAGES_COUNT) {
+                    Thread.sleep(2 * TIMEOUT_MS);
+                }
+                ctx.writeAndFlush(newOneMessage());
+            }
+
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                unexpectedExceptionInServerHandler.set(true);
+            }
+        };
+
+        ChannelInboundHandler trackingHandler = new ChannelInboundHandlerAdapter() {
+            @Override
+            public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                clientReadsLatch.countDown();
+            }
+
+            @Override
+            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                if (cause instanceof ReadTimeoutException) {
+                    timeoutGotLatch.countDown();
+                } else {
+                    unexpectedExceptionInClientHandler.set(true);
+                }
+            }
+
+            @Override
+            public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+                if (evt instanceof ReadAfterWriteTimeoutHandler.ReadSuppressed) {
+                    suppressedReadsLatch.countDown();
+                }
+            }
+        };
+
+        Channel server = newServer(pongHandler);
+        Channel client = newClient(server.localAddress(), readAfterWriteTimeoutHandler, trackingHandler);
+        try {
+            client.writeAndFlush(newOneMessage());
+            assertTrue("No ReadTimeoutException got", timeoutGotLatch.await(3 * TIMEOUT_MS, TimeUnit.MILLISECONDS));
+            assertFalse("No reads should be on client after timeout," +
+                       "because ReadAfterWriteTimeoutHandler#ignoreReadAfterTimeout == true",
+                       clientReadsLatch.await(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+            assertTrue("SuppressedRead event should be fired after getting response after timeout",
+                       suppressedReadsLatch.await(2 * TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+            client.writeAndFlush(newOneMessage());
+            assertTrue("Read should be got after write after timeout",
+                        clientReadsLatch.await(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+            assertFalse("Unexpected exception in server handler", unexpectedExceptionInServerHandler.get());
+            assertFalse("Unexpected exception in client handler", unexpectedExceptionInClientHandler.get());
+        } finally {
+            client.close();
+            server.close();
+        }
+    }
+
+    @BeforeClass
+    public static void init() {
+        GROUP = new NioEventLoopGroup();
+    }
+
+    @AfterClass
+    public static void destroy() {
+        GROUP.shutdownGracefully();
+    }
+
+    private static Channel newServer(final ChannelHandler... handlers) {
+        assertTrue(handlers.length >= 1);
+
+        ServerBootstrap serverBootstrap = new ServerBootstrap();
+        serverBootstrap.group(GROUP)
+                       .channel(NioServerSocketChannel.class)
+                       .childHandler(new ChannelInitializer<Channel>() {
+                           @Override
+                           protected void initChannel(Channel ch) throws Exception {
+                               ChannelPipeline pipeline = ch.pipeline();
+                               pipeline.addLast(handlers);
+                           }
+                       });
+
+        return serverBootstrap.bind(0)
+                              .syncUninterruptibly()
+                              .channel();
+    }
+
+    private static Channel newClient(SocketAddress server, final ChannelHandler... handlers) {
+        Bootstrap bootstrap = new Bootstrap();
+
+        bootstrap.group(GROUP)
+                 .channel(NioSocketChannel.class)
+                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
+                 .handler(
+                     new ChannelInitializer<Channel>() {
+                         @Override
+                         protected void initChannel(Channel ch) throws Exception {
+                             ChannelPipeline pipeline = ch.pipeline();
+                             pipeline.addLast(handlers);
+                         }
+                     }
+                 );
+
+        return bootstrap.connect(server)
+                        .syncUninterruptibly()
+                        .channel();
+    }
+
+    private static ByteBuf newOneMessage() {
+        return Unpooled.wrappedBuffer(new byte[]{ 1 });
+    }
+}


### PR DESCRIPTION
Motivation:

Writing client with netty everybody want to catch and control a situation of request timeout, or socket timeout at least. Now there are no suitable handlers in netty standard distribution for this. IdleStateHandler is suitable only for server sockets.

Modifications:

Add an extendable handler that makes it possible to mark write() call as a start point for timeout task and cancel this task on the first read from a channel (response received). “First read” policy could be overridden with other logic, for example, read of LastHttpContent message.

Result:

Users that implement own clients based on netty have trivial read timeout handler in standard netty classes.
