### PR TITLE
Add a test case to check sub strings' AsciiString hash code

### DIFF
--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -314,4 +314,10 @@ public class AsciiStringCharacterTest {
         assertEquals(3, AsciiString.indexOf("aabaabaa", 'a', 2));
         assertEquals(3, AsciiString.indexOf("aabdabaa", 'd', 1));
     }
+
+    @Test
+    public void testSubStringHashCode() {
+        //two "123"s
+        assertEquals(AsciiString.hashCode("123"), AsciiString.hashCode("a123".substring(1)));
+    }
 }


### PR DESCRIPTION
Motivation:

AsciiString.hashCode(o) , if "o" is a subString, the hash code is not always same, when netty’s version is 4.1.1.Final and jdk’s version is 1.6.

Modifications:

Use a test to assert hash codes are equal between a new string and any sub string (a part of  a char array),If their values are equal.

Result:

Create a test method to AsciiStringCharacterTest.