### PR TITLE
Fix set100ContinueExpected(...) javadoc

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -1088,7 +1088,7 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
      * @deprecated Use {@link HttpUtil#set100ContinueExpected(HttpMessage, boolean)} instead.
      *
      * Sets or removes the {@code "Expect: 100-continue"} header to / from the
-     * specified message.  If the specified {@code value} is {@code true},
+     * specified message.  If {@code set} is {@code true},
      * the {@code "Expect: 100-continue"} header is set and all other previous
      * {@code "Expect"} headers are removed.  Otherwise, all {@code "Expect"}
      * headers are removed completely.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -276,7 +276,7 @@ public final class HttpUtil {
 
     /**
      * Sets or removes the {@code "Expect: 100-continue"} header to / from the
-     * specified message. If the specified {@code value} is {@code true},
+     * specified message. If {@code expected} is {@code true},
      * the {@code "Expect: 100-continue"} header is set and all other previous
      * {@code "Expect"} headers are removed.  Otherwise, all {@code "Expect"}
      * headers are removed completely.


### PR DESCRIPTION
Motivation: Minor javadoc fix

We don't have an argument named {@code value} but have {@code set} and
{@code expected} in HttpHeaders and HttpUtil respectively.

Modifications:

I replaced {@code value} to {@code set} and {@code expected} in HttpHeaders and HttpUtil respectively, which I hope cleaner :)

Result:

Now javadoc says;
`If {@code set} is {@code true}, the {@code "Expect: 100-continue"} header is set and all other previous {@code "Expect"} headers are removed.  Otherwise, all {@code "Expect"} headers are removed completely.` in HttpHeaders

`If {@code expected} is {@code true},  the {@code "Expect: 100-continue"} header is set and all other previous {@code "Expect"} headers are removed.  Otherwise, all {@code "Expect"} headers are removed completely.` in HttpUtil