### PR TITLE
Enable setContentLength(...) to remove a Content-Length header field

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -242,6 +242,24 @@ public final class HttpUtil {
         message.headers().set(HttpHeaderNames.CONTENT_LENGTH, length);
     }
 
+    /**
+     * Set a {@link HttpHeaderNames#CONTENT_LENGTH} with a value of {@code length} if
+     * {@code contentLength} is {@code true}, or remove a {@link HttpHeaderNames#CONTENT_LENGTH}
+     * if {@code contentLength} is {@code false}.
+     *
+     * @param message The message which contains the headers to modify.
+     * @param length The Content-Length value.
+     * @param contentLength if {@code true} then set {@code length} in the headers. otherwise remove
+     * {@link HttpHeaderNames#CONTENT_LENGTH} from the headers.
+     */
+    public static void setContentLength(HttpMessage message, long length, boolean contentLength) {
+        if (contentLength) {
+            message.headers().set(HttpHeaderNames.CONTENT_LENGTH, length);
+        } else {
+            message.headers().remove(HttpHeaderNames.CONTENT_LENGTH);
+        }
+    }
+
     public static boolean isContentLengthSet(HttpMessage m) {
         return m.headers().contains(HttpHeaderNames.CONTENT_LENGTH);
     }


### PR DESCRIPTION
Motivation:

As RFC7230-section3.3.2[1] describes, there's some response status code, such as 1xx, 204 ~~and 304~~, where we must not contain a Content-Length header field. To handle these responses, it'd be nice if we can not only set but remove a Content-Length header field.

Modifications:

We can overload a method `setContentLength(...)` with an additional argument named `contentLength` that indicates whether or not we set or remove the header field.

Result:

Now we can either set or remove a Content-Length header field without breaking compatibility.

[1] https://tools.ietf.org/html/rfc7230#section-3.3.2

P.S.
I think, _if_ we can add the removal functionality, it's clear to add a method named `removeContentLength(message)` or something else that indicates _removal_ of the header field rather than overloading `setContentLength(message, length, setOrRemove)`.

I've overloaded `setContentLength` as we have functions, such as [setKeepAlive(...)](https://github.com/netty/netty/blob/4.1/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java#L106) and [set100ContinueExpected(...)](https://github.com/netty/netty/blob/4.1/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java#L284), which also have a `boolean` argument to set or remove a corresponding header field.

Update(5 July 2016):
We can send a Content-Length header field in a 304 response as the RFC section says;
`
 A server MAY send a Content-Length header field in a 304 (Not
   Modified) response to a conditional GET request (Section 4.1 of
   [RFC7232]); a server MUST NOT send Content-Length in such a response
   unless its field-value equals the decimal number of octets that would
   have been sent in the payload body of a 200 (OK) response to the same
   request.
`
I'll fix my commit message if this PR modification is ok :)
