### PR TITLE
Dns search domains

### DIFF
--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -548,6 +548,18 @@ public final class StringUtil {
         return c == DOUBLE_QUOTE;
     }
 
+    /**
+     * Determine if the string {@code s} ends with the char {@code c}.
+     *
+     * @param s the string to test
+     * @param c the tested char
+     * @return true if {@code s} ends with the char {@code c}
+     */
+    public static boolean endsWith(CharSequence s, char c) {
+        int len = s.length();
+        return len > 0 && s.charAt(len - 1) == c;
+    }
+
     private StringUtil() {
         // Unused.
     }

--- a/common/src/test/java/io/netty/util/internal/StringUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/StringUtilTest.java
@@ -440,4 +440,13 @@ public class StringUtilTest {
     }
 
     private static final class TestClass { }
+
+    @Test
+    public void testEndsWith() {
+        assertFalse(StringUtil.endsWith("", 'u'));
+        assertTrue(StringUtil.endsWith("u", 'u'));
+        assertTrue(StringUtil.endsWith("-u", 'u'));
+        assertFalse(StringUtil.endsWith("-", 'u'));
+        assertFalse(StringUtil.endsWith("u-", 'u'));
+    }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -410,23 +410,6 @@ public class DnsNameResolver extends InetNameResolver {
         }
     }
 
-    boolean searchDomains(String hostname) {
-        if (searchDomains.length == 0 || (hostname.length() > 0 && hostname.charAt(hostname.length() - 1) == '.')) {
-            return false;
-        }
-        int idx = hostname.length();
-        int dots = 0;
-        while (idx-- > 0) {
-            if (hostname.charAt(idx) == '.') {
-                dots++;
-            }
-            if (dots >= ndots) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     private void doResolveUncached(String hostname,
                                    Promise<InetAddress> promise,
                                    DnsCache resolveCache) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -581,7 +581,12 @@ public class DnsNameResolver extends InetNameResolver {
     }
 
     private static String hostname(String inetHost) {
-        return IDN.toASCII(inetHost);
+        String hostname = IDN.toASCII(inetHost);
+        // Check for http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6894622
+        if (inetHost.endsWith(".") && !hostname.endsWith(".")) {
+            hostname += ".";
+        }
+        return hostname;
     }
 
     /**

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -44,6 +44,7 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -567,7 +568,7 @@ public class DnsNameResolver extends InetNameResolver {
     private static String hostname(String inetHost) {
         String hostname = IDN.toASCII(inetHost);
         // Check for http://bugs.java.com/bugdatabase/view_bug.do?bug_id=6894622
-        if (inetHost.endsWith(".") && !hostname.endsWith(".")) {
+        if (StringUtil.endsWith(inetHost, '.') && !StringUtil.endsWith(hostname, '.')) {
             hostname += ".";
         }
         return hostname;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -42,6 +42,7 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
@@ -99,7 +100,7 @@ public class DnsNameResolver extends InetNameResolver {
             searchDomains = list.toArray(new String[list.size()]);
         } catch (Exception ignore) {
             // Failed to get the system name search domain list.
-            searchDomains = new String[0];
+            searchDomains = EmptyArrays.EMPTY_STRINGS;
         }
         DEFAULT_SEACH_DOMAINS = searchDomains;
     }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -51,6 +51,8 @@ public final class DnsNameResolverBuilder {
     private int maxPayloadSize = 4096;
     private boolean optResourceEnabled = true;
     private HostsFileEntriesResolver hostsFileEntriesResolver = HostsFileEntriesResolver.DEFAULT;
+    private String[] searchDomains = DnsNameResolver.DEFAULT_SEACH_DOMAINS;
+    private int ndots = 1;
 
     /**
      * Creates a new builder.
@@ -288,6 +290,34 @@ public final class DnsNameResolverBuilder {
         return this;
     }
 
+    public DnsNameResolverBuilder searchDomains(Iterable<String> searchDomains) {
+        checkNotNull(searchDomains, "searchDomains");
+
+        final List<String> list =
+            InternalThreadLocalMap.get().arrayList(4);
+
+        for (String f : searchDomains) {
+            if (f == null) {
+                break;
+            }
+
+            // Avoid duplicate entries.
+            if (list.contains(f)) {
+                continue;
+            }
+
+            list.add(f);
+        }
+
+        this.searchDomains = list.toArray(new String[list.size()]);
+        return this;
+    }
+
+    public DnsNameResolverBuilder ndots(int ndots) {
+        this.ndots = ndots;
+        return this;
+    }
+
     /**
      * Returns a new {@link DnsNameResolver} instance.
      *
@@ -314,6 +344,8 @@ public final class DnsNameResolverBuilder {
                 traceEnabled,
                 maxPayloadSize,
                 optResourceEnabled,
-                hostsFileEntriesResolver);
+                hostsFileEntriesResolver,
+                searchDomains,
+                ndots);
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -290,6 +290,12 @@ public final class DnsNameResolverBuilder {
         return this;
     }
 
+    /**
+     * Set the list of search domains of the resolver.
+     *
+     * @param searchDomains the search domains
+     * @return {@code this}
+     */
     public DnsNameResolverBuilder searchDomains(Iterable<String> searchDomains) {
         checkNotNull(searchDomains, "searchDomains");
 
@@ -313,6 +319,12 @@ public final class DnsNameResolverBuilder {
         return this;
     }
 
+  /**
+   * Set the number of dots which must appear in a name before an initial absolute query is made.
+   *
+   * @param ndots the ndots value
+   * @return {@code this}
+   */
     public DnsNameResolverBuilder ndots(int ndots) {
         this.ndots = ndots;
         return this;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -138,12 +138,9 @@ abstract class DnsNameResolverContext<T> {
             int idx = hostname.length();
             int dots = 0;
             while (idx-- > 0) {
-                if (hostname.charAt(idx) == '.') {
-                    dots++;
-                    if (dots >= parent.ndots()) {
-                        internalResolve(promise);
-                        return;
-                    }
+                if (hostname.charAt(idx) == '.' && ++dots >= parent.ndots()) {
+                    internalResolve(promise);
+                    return;
                 }
             }
             promise.tryFailure(new UnknownHostException(hostname));

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -31,7 +31,6 @@ import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
 import io.netty.handler.codec.dns.DnsResponse;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -98,8 +98,7 @@ abstract class DnsNameResolverContext<T> {
     }
 
     void resolve(Promise<T> promise) {
-        boolean directSearch = parent.searchDomains().length == 0 ||
-            (hostname.length() > 0 && hostname.charAt(hostname.length() - 1) == '.');
+        boolean directSearch = parent.searchDomains().length == 0 || StringUtil.endsWith(hostname, '.');
         if (directSearch) {
             internalResolve(promise);
         } else {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -471,11 +471,11 @@ abstract class DnsNameResolverContext<T> {
         promise.tryFailure(cause);
     }
 
-    abstract boolean finishResolve(
-            Class<? extends InetAddress> addressType, List<DnsCacheEntry> resolvedEntries, Promise<T> promise);
+    abstract boolean finishResolve(Class<? extends InetAddress> addressType, List<DnsCacheEntry> resolvedEntries,
+                                   Promise<T> promise);
 
     abstract DnsNameResolverContext<T> newResolverContext(DnsNameResolver parent, String hostname,
-                                                                    DnsCache resolveCache);
+                                                          DnsCache resolveCache);
 
     static String decodeDomainName(ByteBuf in) {
         in.markReaderIndex();

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -105,7 +105,7 @@ abstract class DnsNameResolverContext<T> {
     private void resolve(Promise<T> promise, boolean trySearchDomain) {
         if (trySearchDomain) {
             final Promise<T> original = promise;
-            promise = new DefaultPromise<T>(parent.executor());
+            promise = parent.executor().newPromise();
             promise.addListener(new FutureListener<T>() {
                 @Override
                 public void operationComplete(Future<T> future) throws Exception {
@@ -121,7 +121,7 @@ abstract class DnsNameResolverContext<T> {
                                 } else {
                                     if (count < parent.searchDomains().length) {
                                         String searchDomain = parent.searchDomains()[count++];
-                                        Promise<T> nextPromise = new DefaultPromise<T>(parent.executor());
+                                        Promise<T> nextPromise = parent.executor().newPromise();
                                         String nextHostname = DnsNameResolverContext.this.hostname + "." + searchDomain;
                                         DnsNameResolverContext<T> nextContext = newResolverContext(parent,
                                             nextHostname, resolveCache);

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -31,6 +31,7 @@ import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
 import io.netty.handler.codec.dns.DnsResponse;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
@@ -68,7 +69,6 @@ abstract class DnsNameResolverContext<T> {
 
     private final DnsNameResolver parent;
     private final DnsServerAddressStream nameServerAddrs;
-    private final Promise<T> promise;
     private final String hostname;
     private final DnsCache resolveCache;
     private final boolean traceEnabled;
@@ -86,10 +86,8 @@ abstract class DnsNameResolverContext<T> {
 
     protected DnsNameResolverContext(DnsNameResolver parent,
                                      String hostname,
-                                     Promise<T> promise,
                                      DnsCache resolveCache) {
         this.parent = parent;
-        this.promise = promise;
         this.hostname = hostname;
         this.resolveCache = resolveCache;
 
@@ -100,11 +98,55 @@ abstract class DnsNameResolverContext<T> {
         allowedQueries = maxAllowedQueries;
     }
 
-    protected Promise<T> promise() {
-        return promise;
+    void resolve(Promise<T> promise) {
+        resolve(promise, parent.searchDomains().length > 0 && !hostname.endsWith("."));
     }
 
-    void resolve() {
+    void resolve(Promise<T> promise, boolean trySearchDomain) {
+        if (trySearchDomain) {
+            final Promise<T> original = promise;
+            promise = new DefaultPromise<T>(parent.executor());
+            FutureListener<T> globalListener = new FutureListener<T>() {
+                @Override
+                public void operationComplete(Future<T> future) throws Exception {
+                    if (future.isSuccess()) {
+                        original.setSuccess(future.getNow());
+                    } else {
+                        FutureListener<T> sdListener = new FutureListener<T>() {
+                            int count;
+                            @Override
+                            public void operationComplete(Future<T> future) throws Exception {
+                                if (future.isSuccess()) {
+                                    original.trySuccess(future.getNow());
+                                } else {
+                                    if (count < parent.searchDomains().length) {
+                                        String searchDomain = parent.searchDomains()[count++];
+                                        Promise<T> nextPromise = new DefaultPromise<T>(parent.executor());
+                                        String nextHostname = DnsNameResolverContext.this.hostname + "." + searchDomain;
+                                        DnsNameResolverContext<T> nextContext = newResolverContext(parent,
+                                            nextHostname, resolveCache);
+                                        nextContext.resolve(nextPromise, false);
+                                        nextPromise.addListener(this);
+                                    } else {
+                                        original.tryFailure(future.cause());
+                                    }
+                                }
+                            }
+                        };
+                        future.addListener(sdListener);
+                    }
+                }
+            };
+            promise.addListener(globalListener);
+        }
+        if (parent.searchDomains(hostname)) {
+            promise.tryFailure(new UnknownHostException(hostname));
+        } else {
+            internalResolve(promise);
+        }
+    }
+
+    private void internalResolve(Promise<T> promise) {
         InetSocketAddress nameServerAddrToTry = nameServerAddrs.next();
         for (InternetProtocolFamily f: resolveAddressTypes) {
             final DnsRecordType type;
@@ -119,13 +161,13 @@ abstract class DnsNameResolverContext<T> {
                 throw new Error();
             }
 
-            query(nameServerAddrToTry, new DefaultDnsQuestion(hostname, type));
+            query(nameServerAddrToTry, new DefaultDnsQuestion(hostname, type), promise);
         }
     }
 
-    private void query(InetSocketAddress nameServerAddr, final DnsQuestion question) {
+    private void query(InetSocketAddress nameServerAddr, final DnsQuestion question, final Promise<T> promise) {
         if (allowedQueries == 0 || promise.isCancelled()) {
-            tryToFinishResolve();
+            tryToFinishResolve(promise);
             return;
         }
 
@@ -145,31 +187,32 @@ abstract class DnsNameResolverContext<T> {
 
                 try {
                     if (future.isSuccess()) {
-                        onResponse(question, future.getNow());
+                        onResponse(question, future.getNow(), promise);
                     } else {
                         // Server did not respond or I/O error occurred; try again.
                         if (traceEnabled) {
                             addTrace(future.cause());
                         }
-                        query(nameServerAddrs.next(), question);
+                        query(nameServerAddrs.next(), question, promise);
                     }
                 } finally {
-                    tryToFinishResolve();
+                    tryToFinishResolve(promise);
                 }
             }
         });
     }
 
-    void onResponse(final DnsQuestion question, AddressedEnvelope<DnsResponse, InetSocketAddress> envelope) {
+    void onResponse(final DnsQuestion question, AddressedEnvelope<DnsResponse, InetSocketAddress> envelope,
+                    Promise<T> promise) {
         try {
             final DnsResponse res = envelope.content();
             final DnsResponseCode code = res.code();
             if (code == DnsResponseCode.NOERROR) {
                 final DnsRecordType type = question.type();
                 if (type == DnsRecordType.A || type == DnsRecordType.AAAA) {
-                    onResponseAorAAAA(type, question, envelope);
+                    onResponseAorAAAA(type, question, envelope, promise);
                 } else if (type == DnsRecordType.CNAME) {
-                    onResponseCNAME(question, envelope);
+                    onResponseCNAME(question, envelope, promise);
                 }
                 return;
             }
@@ -182,7 +225,7 @@ abstract class DnsNameResolverContext<T> {
 
             // Retry with the next server if the server did not tell us that the domain does not exist.
             if (code != DnsResponseCode.NXDOMAIN) {
-                query(nameServerAddrs.next(), question);
+                query(nameServerAddrs.next(), question, promise);
             }
         } finally {
             ReferenceCountUtil.safeRelease(envelope);
@@ -190,7 +233,8 @@ abstract class DnsNameResolverContext<T> {
     }
 
     private void onResponseAorAAAA(
-            DnsRecordType qType, DnsQuestion question, AddressedEnvelope<DnsResponse, InetSocketAddress> envelope) {
+            DnsRecordType qType, DnsQuestion question, AddressedEnvelope<DnsResponse, InetSocketAddress> envelope,
+            Promise<T> promise) {
 
         // We often get a bunch of CNAMES as well when we asked for A/AAAA.
         final DnsResponse response = envelope.content();
@@ -267,17 +311,18 @@ abstract class DnsNameResolverContext<T> {
 
         // We aked for A/AAAA but we got only CNAME.
         if (!cnames.isEmpty()) {
-            onResponseCNAME(question, envelope, cnames, false);
+            onResponseCNAME(question, envelope, cnames, false, promise);
         }
     }
 
-    private void onResponseCNAME(DnsQuestion question, AddressedEnvelope<DnsResponse, InetSocketAddress> envelope) {
-        onResponseCNAME(question, envelope, buildAliasMap(envelope.content()), true);
+    private void onResponseCNAME(DnsQuestion question, AddressedEnvelope<DnsResponse, InetSocketAddress> envelope,
+                                 Promise<T> promise) {
+        onResponseCNAME(question, envelope, buildAliasMap(envelope.content()), true, promise);
     }
 
     private void onResponseCNAME(
             DnsQuestion question, AddressedEnvelope<DnsResponse, InetSocketAddress> response,
-            Map<String, String> cnames, boolean trace) {
+            Map<String, String> cnames, boolean trace, Promise<T> promise) {
 
         // Resolve the host name in the question into the real host name.
         final String name = question.name().toLowerCase(Locale.US);
@@ -296,7 +341,7 @@ abstract class DnsNameResolverContext<T> {
         }
 
         if (found) {
-            followCname(response.sender(), name, resolved);
+            followCname(response.sender(), name, resolved, promise);
         } else if (trace && traceEnabled) {
             addTrace(response.sender(), "no matching CNAME record found");
         }
@@ -332,12 +377,12 @@ abstract class DnsNameResolverContext<T> {
         return cnames != null? cnames : Collections.<String, String>emptyMap();
     }
 
-    void tryToFinishResolve() {
+    void tryToFinishResolve(Promise<T> promise) {
         if (!queriesInProgress.isEmpty()) {
             // There are still some queries we did not receive responses for.
             if (gotPreferredAddress()) {
                 // But it's OK to finish the resolution process if we got a resolved address of the preferred type.
-                finishResolve();
+                finishResolve(promise);
             }
 
             // We did not get any resolved address of the preferred type, so we can't finish the resolution process.
@@ -350,13 +395,13 @@ abstract class DnsNameResolverContext<T> {
             if (!triedCNAME) {
                 // As the last resort, try to query CNAME, just in case the name server has it.
                 triedCNAME = true;
-                query(nameServerAddrs.next(), new DefaultDnsQuestion(hostname, DnsRecordType.CNAME));
+                query(nameServerAddrs.next(), new DefaultDnsQuestion(hostname, DnsRecordType.CNAME), promise);
                 return;
             }
         }
 
         // We have at least one resolved address or tried CNAME as the last resort..
-        finishResolve();
+        finishResolve(promise);
     }
 
     private boolean gotPreferredAddress() {
@@ -385,7 +430,7 @@ abstract class DnsNameResolverContext<T> {
         return false;
     }
 
-    private void finishResolve() {
+    private void finishResolve(Promise<T> promise) {
         if (!queriesInProgress.isEmpty()) {
             // If there are queries in progress, we should cancel it because we already finished the resolution.
             for (Iterator<Future<AddressedEnvelope<DnsResponse, InetSocketAddress>>> i = queriesInProgress.iterator();
@@ -402,7 +447,7 @@ abstract class DnsNameResolverContext<T> {
         if (resolvedEntries != null) {
             // Found at least one resolved address.
             for (InternetProtocolFamily f: resolveAddressTypes) {
-                if (finishResolve(f.addressType(), resolvedEntries)) {
+                if (finishResolve(f.addressType(), resolvedEntries, promise)) {
                     return;
                 }
             }
@@ -436,7 +481,10 @@ abstract class DnsNameResolverContext<T> {
     }
 
     protected abstract boolean finishResolve(
-            Class<? extends InetAddress> addressType, List<DnsCacheEntry> resolvedEntries);
+            Class<? extends InetAddress> addressType, List<DnsCacheEntry> resolvedEntries, Promise<T> promise);
+
+    protected abstract DnsNameResolverContext<T> newResolverContext(DnsNameResolver parent, String hostname,
+                                                                    DnsCache resolveCache);
 
     static String decodeDomainName(ByteBuf in) {
         in.markReaderIndex();
@@ -450,7 +498,7 @@ abstract class DnsNameResolverContext<T> {
         }
     }
 
-    private void followCname(InetSocketAddress nameServerAddr, String name, String cname) {
+    private void followCname(InetSocketAddress nameServerAddr, String name, String cname, Promise<T> promise) {
 
         if (traceEnabled) {
             if (trace == null) {
@@ -467,8 +515,8 @@ abstract class DnsNameResolverContext<T> {
         }
 
         final InetSocketAddress nextAddr = nameServerAddrs.next();
-        query(nextAddr, new DefaultDnsQuestion(cname, DnsRecordType.A));
-        query(nextAddr, new DefaultDnsQuestion(cname, DnsRecordType.AAAA));
+        query(nextAddr, new DefaultDnsQuestion(cname, DnsRecordType.A), promise);
+        query(nextAddr, new DefaultDnsQuestion(cname, DnsRecordType.AAAA), promise);
     }
 
     private void addTrace(InetSocketAddress nameServerAddr, String msg) {

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import org.junit.After;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class SearchDomainTest {
+
+  private DnsNameResolverBuilder newResolver() {
+    return new DnsNameResolverBuilder(group.next())
+        .channelType(NioDatagramChannel.class)
+        .nameServerAddresses(DnsServerAddresses.singleton(dnsServer.localAddress()))
+        .maxQueriesPerResolve(1)
+        .optResourceEnabled(false);
+  }
+
+  private TestDnsServer dnsServer;
+  private final EventLoopGroup group = new NioEventLoopGroup(1);
+
+  @After
+  public void destroy() {
+    if (dnsServer != null) {
+      dnsServer.stop();
+    }
+    group.shutdownGracefully();
+  }
+
+  @Test
+  public void testSearchDomain() throws Exception {
+    Set<String> domains = new HashSet<String>();
+    domains.add("host1.foo.com");
+    domains.add("host1");
+    domains.add("host3");
+    domains.add("host4.sub.foo.com");
+    domains.add("host5.sub.foo.com");
+    domains.add("host5.sub");
+
+    TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains);
+    dnsServer = new TestDnsServer(store);
+    dnsServer.start();
+
+    DnsNameResolver resolver = newResolver().searchDomains(Collections.singletonList("foo.com")).build();
+
+    InetAddress resolved = resolver.resolve("host1.foo.com").sync().getNow();
+    assertEquals(store.getAddress("host1.foo.com"), resolved.getHostAddress());
+
+    // host1 resolves host1.foo.com with foo.com search domain
+    resolved = resolver.resolve("host1").sync().getNow();
+    assertEquals(store.getAddress("host1.foo.com"), resolved.getHostAddress());
+
+    // "host1." absolute query
+    resolved = resolver.resolve("host1.").sync().getNow();
+    assertEquals(store.getAddress("host1"), resolved.getHostAddress());
+
+    // "host2" not resolved
+    assertFalse(resolver.resolve("host2").await().isSuccess());
+
+    // "host3" does not contain a dot or is not absolute
+    assertFalse(resolver.resolve("host3").await().isSuccess());
+
+    // "host3." does not contain a dot but is absolute
+    resolved = resolver.resolve("host3.").sync().getNow();
+    assertEquals(store.getAddress("host3"), resolved.getHostAddress());
+
+    // "host4.sub" contains a dot but not resolved then resolved to "host4.sub.foo.com" with "foo.com" search domain
+    resolved = resolver.resolve("host4.sub").sync().getNow();
+    assertEquals(store.getAddress("host4.sub.foo.com"), resolved.getHostAddress());
+
+    // "host5.sub" contains a dot and is resolved
+    resolved = resolver.resolve("host5.sub").sync().getNow();
+    assertEquals(store.getAddress("host5.sub"), resolved.getHostAddress());
+  }
+
+  @Test
+  public void testMultipleSearchDomain() throws Exception {
+    Set<String> domains = new HashSet<String>();
+    domains.add("host1.foo.com");
+    domains.add("host2.bar.com");
+    domains.add("host3.bar.com");
+    domains.add("host3.foo.com");
+
+    TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains);
+    dnsServer = new TestDnsServer(store);
+    dnsServer.start();
+
+    DnsNameResolver resolver = newResolver().searchDomains(Arrays.asList("foo.com", "bar.com")).build();
+
+    // "host1" resolves via the "foo.com" search path
+    InetAddress resolved = resolver.resolve("host1").sync().getNow();
+    assertEquals(store.getAddress("host1.foo.com"), resolved.getHostAddress());
+
+    // "host2" resolves via the "bar.com" search path
+    resolved = resolver.resolve("host2").sync().getNow();
+    assertEquals(store.getAddress("host2.bar.com"), resolved.getHostAddress());
+
+    // "host3" resolves via the the "foo.com" search path as it is the first one
+    resolved = resolver.resolve("host3").sync().getNow();
+    assertEquals(store.getAddress("host3.foo.com"), resolved.getHostAddress());
+
+    // "host4" does not resolve
+    assertFalse(resolver.resolve("host4").await().isSuccess());
+  }
+
+  @Test
+  public void testSearchDomainWithNdots2() throws Exception {
+    Set<String> domains = new HashSet<String>();
+    domains.add("host1.sub.foo.com");
+    domains.add("host2.sub.foo.com");
+    domains.add("host2.sub");
+
+    TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains);
+    dnsServer = new TestDnsServer(store);
+    dnsServer.start();
+
+    DnsNameResolver resolver = newResolver().searchDomains(Collections.singleton("foo.com")).ndots(2).build();
+
+    InetAddress resolved = resolver.resolve("host1.sub").sync().getNow();
+    assertEquals(store.getAddress("host1.sub.foo.com"), resolved.getHostAddress());
+
+    // "host2.sub" is resolved with the foo.com search domain as ndots = 2
+    resolved = resolver.resolve("host2.sub").sync().getNow();
+    assertEquals(store.getAddress("host2.sub.foo.com"), resolved.getHostAddress());
+  }
+}

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
@@ -100,7 +100,6 @@ public class SearchDomainTest {
         assertEquals(store.getAddress("host5.sub"), resolved.getHostAddress());
     }
 
-
     @Test
     public void testMultipleSearchDomain() throws Exception {
         Set<String> domains = new HashSet<String>();

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -34,176 +34,132 @@ import static org.junit.Assert.assertFalse;
 
 public class SearchDomainTest {
 
-  private DnsNameResolverBuilder newResolver() {
-    return new DnsNameResolverBuilder(group.next())
-        .channelType(NioDatagramChannel.class)
-        .nameServerAddresses(DnsServerAddresses.singleton(dnsServer.localAddress()))
-        .maxQueriesPerResolve(1)
-        .optResourceEnabled(false);
-  }
-
-  private TestDnsServer dnsServer;
-  private final EventLoopGroup group = new NioEventLoopGroup(1);
-
-  @After
-  public void destroy() {
-    if (dnsServer != null) {
-      dnsServer.stop();
+    private DnsNameResolverBuilder newResolver() {
+        return new DnsNameResolverBuilder(group.next())
+            .channelType(NioDatagramChannel.class)
+            .nameServerAddresses(DnsServerAddresses.singleton(dnsServer.localAddress()))
+            .maxQueriesPerResolve(1)
+            .optResourceEnabled(false);
     }
-    group.shutdownGracefully();
-  }
 
-  @Test
-  public void testResolve() throws Exception {
-    Set<String> domains = new HashSet<String>();
-    domains.add("host1.foo.com");
-    domains.add("host1");
-    domains.add("host3");
-    domains.add("host4.sub.foo.com");
-    domains.add("host5.sub.foo.com");
-    domains.add("host5.sub");
+    private TestDnsServer dnsServer;
+    private final EventLoopGroup group = new NioEventLoopGroup(1);
 
-    TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains);
-    dnsServer = new TestDnsServer(store);
-    dnsServer.start();
-
-    DnsNameResolver resolver = newResolver().searchDomains(Collections.singletonList("foo.com")).build();
-
-    InetAddress resolved = resolver.resolve("host1.foo.com").sync().getNow();
-    assertEquals(store.getAddress("host1.foo.com"), resolved.getHostAddress());
-
-    // host1 resolves host1.foo.com with foo.com search domain
-    resolved = resolver.resolve("host1").sync().getNow();
-    assertEquals(store.getAddress("host1.foo.com"), resolved.getHostAddress());
-
-    // "host1." absolute query
-    resolved = resolver.resolve("host1.").sync().getNow();
-    assertEquals(store.getAddress("host1"), resolved.getHostAddress());
-
-    // "host2" not resolved
-    assertFalse(resolver.resolve("host2").await().isSuccess());
-
-    // "host3" does not contain a dot or is not absolute
-    assertFalse(resolver.resolve("host3").await().isSuccess());
-
-    // "host3." does not contain a dot but is absolute
-    resolved = resolver.resolve("host3.").sync().getNow();
-    assertEquals(store.getAddress("host3"), resolved.getHostAddress());
-
-    // "host4.sub" contains a dot but not resolved then resolved to "host4.sub.foo.com" with "foo.com" search domain
-    resolved = resolver.resolve("host4.sub").sync().getNow();
-    assertEquals(store.getAddress("host4.sub.foo.com"), resolved.getHostAddress());
-
-    // "host5.sub" contains a dot and is resolved
-    resolved = resolver.resolve("host5.sub").sync().getNow();
-    assertEquals(store.getAddress("host5.sub"), resolved.getHostAddress());
-  }
-
-  @Test
-  public void testResolveAll() throws Exception {
-    Set<String> domains = new HashSet<String>();
-    domains.add("host1.foo.com");
-    domains.add("host1");
-    domains.add("host3");
-    domains.add("host4.sub.foo.com");
-    domains.add("host5.sub.foo.com");
-    domains.add("host5.sub");
-
-    TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains, 2);
-    dnsServer = new TestDnsServer(store);
-    dnsServer.start();
-
-    DnsNameResolver resolver = newResolver().searchDomains(Collections.singletonList("foo.com")).build();
-
-    List<InetAddress> resolved = resolver.resolveAll("host1.foo.com").sync().getNow();
-    assertEquals(store.getAddresses("host1.foo.com"), asStrings(resolved));
-
-    // host1 resolves host1.foo.com with foo.com search domain
-    resolved = resolver.resolveAll("host1").sync().getNow();
-    assertEquals(store.getAddresses("host1.foo.com"), asStrings(resolved));
-
-    // "host1." absolute query
-    resolved = resolver.resolveAll("host1.").sync().getNow();
-    assertEquals(store.getAddresses("host1"), asStrings(resolved));
-
-    // "host2" not resolved
-    assertFalse(resolver.resolveAll("host2").await().isSuccess());
-
-    // "host3" does not contain a dot or is not absolute
-    assertFalse(resolver.resolveAll("host3").await().isSuccess());
-
-    // "host3." does not contain a dot but is absolute
-    resolved = resolver.resolveAll("host3.").sync().getNow();
-    assertEquals(store.getAddresses("host3"), asStrings(resolved));
-
-    // "host4.sub" contains a dot but not resolved then resolved to "host4.sub.foo.com" with "foo.com" search domain
-    resolved = resolver.resolveAll("host4.sub").sync().getNow();
-    assertEquals(store.getAddresses("host4.sub.foo.com"), asStrings(resolved));
-
-    // "host5.sub" contains a dot and is resolved
-    resolved = resolver.resolveAll("host5.sub").sync().getNow();
-    assertEquals(store.getAddresses("host5.sub"), asStrings(resolved));
-  }
-
-  @Test
-  public void testMultipleSearchDomain() throws Exception {
-    Set<String> domains = new HashSet<String>();
-    domains.add("host1.foo.com");
-    domains.add("host2.bar.com");
-    domains.add("host3.bar.com");
-    domains.add("host3.foo.com");
-
-    TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains);
-    dnsServer = new TestDnsServer(store);
-    dnsServer.start();
-
-    DnsNameResolver resolver = newResolver().searchDomains(Arrays.asList("foo.com", "bar.com")).build();
-
-    // "host1" resolves via the "foo.com" search path
-    InetAddress resolved = resolver.resolve("host1").sync().getNow();
-    assertEquals(store.getAddress("host1.foo.com"), resolved.getHostAddress());
-
-    // "host2" resolves via the "bar.com" search path
-    resolved = resolver.resolve("host2").sync().getNow();
-    assertEquals(store.getAddress("host2.bar.com"), resolved.getHostAddress());
-
-    // "host3" resolves via the the "foo.com" search path as it is the first one
-    resolved = resolver.resolve("host3").sync().getNow();
-    assertEquals(store.getAddress("host3.foo.com"), resolved.getHostAddress());
-
-    // "host4" does not resolve
-    assertFalse(resolver.resolve("host4").await().isSuccess());
-  }
-
-  @Test
-  public void testSearchDomainWithNdots2() throws Exception {
-    Set<String> domains = new HashSet<String>();
-    domains.add("host1.sub.foo.com");
-    domains.add("host2.sub.foo.com");
-    domains.add("host2.sub");
-
-    TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains);
-    dnsServer = new TestDnsServer(store);
-    dnsServer.start();
-
-    DnsNameResolver resolver = newResolver().searchDomains(Collections.singleton("foo.com")).ndots(2).build();
-
-    InetAddress resolved = resolver.resolve("host1.sub").sync().getNow();
-    assertEquals(store.getAddress("host1.sub.foo.com"), resolved.getHostAddress());
-
-    // "host2.sub" is resolved with the foo.com search domain as ndots = 2
-    resolved = resolver.resolve("host2.sub").sync().getNow();
-    assertEquals(store.getAddress("host2.sub.foo.com"), resolved.getHostAddress());
-  }
-
-  private List<String> asStrings(List<InetAddress> list) {
-    if (list != null) {
-      List<String> ret = new ArrayList<String>();
-      for (InetAddress addr : list) {
-        ret.add(addr.getHostAddress());
-      }
-      return ret;
+    @After
+    public void destroy() {
+        if (dnsServer != null) {
+            dnsServer.stop();
+            dnsServer = null;
+        }
+        group.shutdownGracefully();
     }
-    return null;
-  }
+
+    @Test
+    public void testResolve() throws Exception {
+        Set<String> domains = new HashSet<String>();
+        domains.add("host1.foo.com");
+        domains.add("host1");
+        domains.add("host3");
+        domains.add("host4.sub.foo.com");
+        domains.add("host5.sub.foo.com");
+        domains.add("host5.sub");
+
+        TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains);
+        dnsServer = new TestDnsServer(store);
+        dnsServer.start();
+
+        DnsNameResolver resolver = newResolver().searchDomains(Collections.singletonList("foo.com")).build();
+
+        InetAddress resolved = resolver.resolve("host1.foo.com").sync().getNow();
+        assertEquals(store.getAddress("host1.foo.com"), resolved.getHostAddress());
+
+        // host1 resolves host1.foo.com with foo.com search domain
+        resolved = resolver.resolve("host1").sync().getNow();
+        assertEquals(store.getAddress("host1.foo.com"), resolved.getHostAddress());
+
+        // "host1." absolute query
+        resolved = resolver.resolve("host1.").sync().getNow();
+        assertEquals(store.getAddress("host1"), resolved.getHostAddress());
+
+        // "host2" not resolved
+        assertFalse(resolver.resolve("host2").await().isSuccess());
+
+        // "host3" does not contain a dot or is not absolute
+        assertFalse(resolver.resolve("host3").await().isSuccess());
+
+        // "host3." does not contain a dot but is absolute
+        resolved = resolver.resolve("host3.").sync().getNow();
+        assertEquals(store.getAddress("host3"), resolved.getHostAddress());
+
+        // "host4.sub" contains a dot but not resolved then resolved to "host4.sub.foo.com" with "foo.com" search domain
+        resolved = resolver.resolve("host4.sub").sync().getNow();
+        assertEquals(store.getAddress("host4.sub.foo.com"), resolved.getHostAddress());
+
+        // "host5.sub" contains a dot and is resolved
+        resolved = resolver.resolve("host5.sub").sync().getNow();
+        assertEquals(store.getAddress("host5.sub"), resolved.getHostAddress());
+    }
+
+
+    @Test
+    public void testMultipleSearchDomain() throws Exception {
+        Set<String> domains = new HashSet<String>();
+        domains.add("host1.foo.com");
+        domains.add("host2.bar.com");
+        domains.add("host3.bar.com");
+        domains.add("host3.foo.com");
+
+        TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains);
+        dnsServer = new TestDnsServer(store);
+        dnsServer.start();
+
+        DnsNameResolver resolver = newResolver().searchDomains(Arrays.asList("foo.com", "bar.com")).build();
+
+        // "host1" resolves via the "foo.com" search path
+        InetAddress resolved = resolver.resolve("host1").sync().getNow();
+        assertEquals(store.getAddress("host1.foo.com"), resolved.getHostAddress());
+
+        // "host2" resolves via the "bar.com" search path
+        resolved = resolver.resolve("host2").sync().getNow();
+        assertEquals(store.getAddress("host2.bar.com"), resolved.getHostAddress());
+
+        // "host3" resolves via the the "foo.com" search path as it is the first one
+        resolved = resolver.resolve("host3").sync().getNow();
+        assertEquals(store.getAddress("host3.foo.com"), resolved.getHostAddress());
+
+        // "host4" does not resolve
+        assertFalse(resolver.resolve("host4").await().isSuccess());
+    }
+
+    @Test
+    public void testSearchDomainWithNdots2() throws Exception {
+        Set<String> domains = new HashSet<String>();
+        domains.add("host1.sub.foo.com");
+        domains.add("host2.sub.foo.com");
+        domains.add("host2.sub");
+
+        TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains);
+        dnsServer = new TestDnsServer(store);
+        dnsServer.start();
+
+        DnsNameResolver resolver = newResolver().searchDomains(Collections.singleton("foo.com")).ndots(2).build();
+
+        InetAddress resolved = resolver.resolve("host1.sub").sync().getNow();
+        assertEquals(store.getAddress("host1.sub.foo.com"), resolved.getHostAddress());
+
+        // "host2.sub" is resolved with the foo.com search domain as ndots = 2
+        resolved = resolver.resolve("host2.sub").sync().getNow();
+        assertEquals(store.getAddress("host2.sub.foo.com"), resolved.getHostAddress());
+    }
+
+    private static List<String> asStrings(List<InetAddress> list) {
+        if (list != null) {
+            List<String> ret = new ArrayList<String>();
+            for (InetAddress addr : list) {
+              ret.add(addr.getHostAddress());
+            }
+            return ret;
+        }
+        return null;
+    }
 }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
@@ -73,11 +73,11 @@ final class TestDnsServer extends DnsServer {
 
     private final RecordStore store;
 
-    public TestDnsServer(Set<String> domains) {
+    TestDnsServer(Set<String> domains) {
         this.store = new TestRecordStore(domains);
     }
 
-    public TestDnsServer(RecordStore store) {
+    TestDnsServer(RecordStore store) {
         this.store = store;
     }
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.util.NetUtil;
+import io.netty.util.internal.ThreadLocalRandom;
+import org.apache.directory.server.dns.DnsException;
+import org.apache.directory.server.dns.DnsServer;
+import org.apache.directory.server.dns.io.encoder.DnsMessageEncoder;
+import org.apache.directory.server.dns.io.encoder.ResourceRecordEncoder;
+import org.apache.directory.server.dns.messages.DnsMessage;
+import org.apache.directory.server.dns.messages.QuestionRecord;
+import org.apache.directory.server.dns.messages.RecordClass;
+import org.apache.directory.server.dns.messages.RecordType;
+import org.apache.directory.server.dns.messages.ResourceRecord;
+import org.apache.directory.server.dns.messages.ResourceRecordModifier;
+import org.apache.directory.server.dns.protocol.DnsProtocolHandler;
+import org.apache.directory.server.dns.protocol.DnsUdpDecoder;
+import org.apache.directory.server.dns.protocol.DnsUdpEncoder;
+import org.apache.directory.server.dns.store.DnsAttribute;
+import org.apache.directory.server.dns.store.RecordStore;
+import org.apache.directory.server.protocol.shared.transport.UdpTransport;
+import org.apache.mina.core.buffer.IoBuffer;
+import org.apache.mina.core.session.IoSession;
+import org.apache.mina.filter.codec.ProtocolCodecFactory;
+import org.apache.mina.filter.codec.ProtocolCodecFilter;
+import org.apache.mina.filter.codec.ProtocolDecoder;
+import org.apache.mina.filter.codec.ProtocolEncoder;
+import org.apache.mina.filter.codec.ProtocolEncoderOutput;
+import org.apache.mina.transport.socket.DatagramAcceptor;
+import org.apache.mina.transport.socket.DatagramSessionConfig;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+final class TestDnsServer extends DnsServer {
+    private static final Map<String, byte[]> BYTES = new HashMap<String, byte[]>();
+    private static final String[] IPV6_ADDRESSES;
+
+    static {
+        BYTES.put("::1", new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
+        BYTES.put("0:0:0:0:0:0:1:1", new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1});
+        BYTES.put("0:0:0:0:0:1:1:1", new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1});
+        BYTES.put("0:0:0:0:1:1:1:1", new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1});
+        BYTES.put("0:0:0:1:1:1:1:1", new byte[]{0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1});
+        BYTES.put("0:0:1:1:1:1:1:1", new byte[]{0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1});
+        BYTES.put("0:1:1:1:1:1:1:1", new byte[]{0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1});
+        BYTES.put("1:1:1:1:1:1:1:1", new byte[]{0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1});
+
+        IPV6_ADDRESSES = BYTES.keySet().toArray(new String[BYTES.size()]);
+    }
+
+    private final RecordStore store;
+
+    public TestDnsServer(Set<String> domains) {
+        this.store = new TestRecordStore(domains);
+    }
+
+    public TestDnsServer(RecordStore store) {
+        this.store = store;
+    }
+
+    @Override
+    public void start() throws IOException {
+        InetSocketAddress address = new InetSocketAddress(NetUtil.LOCALHOST4, 0);
+        UdpTransport transport = new UdpTransport(address.getHostName(), address.getPort());
+        setTransports(transport);
+
+        DatagramAcceptor acceptor = transport.getAcceptor();
+
+        acceptor.setHandler(new DnsProtocolHandler(this, store) {
+            @Override
+            public void sessionCreated(IoSession session) throws Exception {
+                // USe our own codec to support AAAA testing
+                session.getFilterChain()
+                    .addFirst("codec", new ProtocolCodecFilter(new TestDnsProtocolUdpCodecFactory()));
+            }
+        });
+
+        ((DatagramSessionConfig) acceptor.getSessionConfig()).setReuseAddress(true);
+
+        // Start the listener
+        acceptor.bind();
+    }
+
+    public InetSocketAddress localAddress() {
+        return (InetSocketAddress) getTransports()[0].getAcceptor().getLocalAddress();
+    }
+
+    /**
+     * {@link ProtocolCodecFactory} which allows to test AAAA resolution.
+     */
+    private static final class TestDnsProtocolUdpCodecFactory implements ProtocolCodecFactory {
+        private final DnsMessageEncoder encoder = new DnsMessageEncoder();
+        private final TestAAAARecordEncoder recordEncoder = new TestAAAARecordEncoder();
+
+        @Override
+        public ProtocolEncoder getEncoder(IoSession session) throws Exception {
+            return new DnsUdpEncoder() {
+
+                @Override
+                public void encode(IoSession session, Object message, ProtocolEncoderOutput out) {
+                    IoBuffer buf = IoBuffer.allocate(1024);
+                    DnsMessage dnsMessage = (DnsMessage) message;
+                    encoder.encode(buf, dnsMessage);
+                    for (ResourceRecord record : dnsMessage.getAnswerRecords()) {
+                        // This is a hack to allow to also test for AAAA resolution as DnsMessageEncoder
+                        // does not support it and it is hard to extend, because the interesting methods
+                        // are private...
+                        // In case of RecordType.AAAA we need to encode the RecordType by ourselves.
+                        if (record.getRecordType() == RecordType.AAAA) {
+                            try {
+                                recordEncoder.put(buf, record);
+                            } catch (IOException e) {
+                                // Should never happen
+                                throw new IllegalStateException(e);
+                            }
+                        }
+                    }
+                    buf.flip();
+
+                    out.write(buf);
+                }
+            };
+        }
+
+        @Override
+        public ProtocolDecoder getDecoder(IoSession session) throws Exception {
+            return new DnsUdpDecoder();
+        }
+
+        private static final class TestAAAARecordEncoder extends ResourceRecordEncoder {
+
+            @Override
+            protected void putResourceRecordData(IoBuffer ioBuffer, ResourceRecord resourceRecord) {
+                byte[] bytes = BYTES.get(resourceRecord.get(DnsAttribute.IP_ADDRESS));
+                if (bytes == null) {
+                    throw new IllegalStateException();
+                }
+                // encode the ::1
+                ioBuffer.put(bytes);
+            }
+        }
+    }
+
+    public static final class MapRecordStoreA implements RecordStore {
+
+        private final Map<String, String> domainMap;
+
+        public MapRecordStoreA(Set<String> domains) {
+            domainMap = new HashMap<String, String>(domains.size());
+            for (String domain : domains) {
+                domainMap.put(domain, TestRecordStore.nextIp());
+            }
+        }
+
+        public String getAddress(String domain) {
+            return domainMap.get(domain);
+        }
+
+        @Override
+        public Set<ResourceRecord> getRecords(QuestionRecord questionRecord) throws DnsException {
+            String name = questionRecord.getDomainName();
+            if (domainMap.containsKey(name)) {
+                ResourceRecordModifier rm = new ResourceRecordModifier();
+                rm.setDnsClass(RecordClass.IN);
+                rm.setDnsName(name);
+                rm.setDnsTtl(100);
+                rm.setDnsType(questionRecord.getRecordType());
+                if (questionRecord.getRecordType() == RecordType.A) {
+                    rm.put(DnsAttribute.IP_ADDRESS, domainMap.get(name));
+                    return Collections.singleton(rm.getEntry());
+                }
+            }
+            return null;
+        }
+    }
+
+    private static final class TestRecordStore implements RecordStore {
+        private static final int[] NUMBERS = new int[254];
+        private static final char[] CHARS = new char[26];
+
+        static {
+            for (int i = 0; i < NUMBERS.length; i++) {
+                NUMBERS[i] = i + 1;
+            }
+
+            for (int i = 0; i < CHARS.length; i++) {
+                CHARS[i] = (char) ('a' + i);
+            }
+        }
+
+        private static int index(int arrayLength) {
+            return Math.abs(ThreadLocalRandom.current().nextInt()) % arrayLength;
+        }
+
+        private static String nextDomain() {
+            return CHARS[index(CHARS.length)] + ".netty.io";
+        }
+
+        private static String nextIp() {
+            return ipPart() + "." + ipPart() + '.' + ipPart() + '.' + ipPart();
+        }
+
+        private static int ipPart() {
+            return NUMBERS[index(NUMBERS.length)];
+        }
+
+        private static String nextIp6() {
+            return IPV6_ADDRESSES[index(IPV6_ADDRESSES.length)];
+        }
+
+        private final Set<String> domains;
+
+        public TestRecordStore(Set<String> domains) {
+            this.domains = domains;
+        }
+
+        @Override
+        public Set<ResourceRecord> getRecords(QuestionRecord questionRecord) {
+            String name = questionRecord.getDomainName();
+            if (domains.contains(name)) {
+                ResourceRecordModifier rm = new ResourceRecordModifier();
+                rm.setDnsClass(RecordClass.IN);
+                rm.setDnsName(name);
+                rm.setDnsTtl(100);
+                rm.setDnsType(questionRecord.getRecordType());
+
+                switch (questionRecord.getRecordType()) {
+                    case A:
+                        do {
+                            rm.put(DnsAttribute.IP_ADDRESS, nextIp());
+                        } while (ThreadLocalRandom.current().nextBoolean());
+                        break;
+                    case AAAA:
+                        do {
+                            rm.put(DnsAttribute.IP_ADDRESS, nextIp6());
+                        } while (ThreadLocalRandom.current().nextBoolean());
+                        break;
+                    case MX:
+                        int priority = 0;
+                        do {
+                            rm.put(DnsAttribute.DOMAIN_NAME, nextDomain());
+                            rm.put(DnsAttribute.MX_PREFERENCE, String.valueOf(++priority));
+                        } while (ThreadLocalRandom.current().nextBoolean());
+                        break;
+                    default:
+                        return null;
+                }
+                return Collections.singleton(rm.getEntry());
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
The current DNSNameResolver resolves only the hostname and ignore totally the OS search domains. The Java resolver uses the list of search domain provided by the OS and implements hostname resolution using search domains.

Modifications:
- modify the DNSNameResolver algorithm to use search domains when any
- configure the default list of search domains using the sun.net.dns.ResolverConfiguration#searchlist

Result:
The DNSNameResolver resolves properly hostname when search domains are configured.
