### PR TITLE
[#5455] Clarify ChannelPool javadocs

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/ChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/ChannelPool.java
@@ -29,12 +29,18 @@ public interface ChannelPool extends Closeable {
     /**
      * Acquire a {@link Channel} from this {@link ChannelPool}. The returned {@link Future} is notified once
      * the acquire is successful and failed otherwise.
+     *
+     * <strong>Its important that an acquired is always released to the pool again, even if the {@link Channel}
+     * is explicitly closed..</strong>
      */
     Future<Channel> acquire();
 
     /**
      * Acquire a {@link Channel} from this {@link ChannelPool}. The given {@link Promise} is notified once
      * the acquire is successful and failed otherwise.
+     *
+     * <strong>Its important that an acquired is always released to the pool again, even if the {@link Channel}
+     * is explicitly closed..</strong>
      */
     Future<Channel> acquire(Promise<Channel> promise);
 


### PR DESCRIPTION
Motivation:

We should make it clear that each acquired Channel needs to be released in all cases.

Modifications:

More clear javadocs.

Result:

Harder for users to leak Channel.