### PR TITLE
Deprecate methods in AbstractChannel that have no real usage.

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -174,6 +174,10 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
         return localAddress;
     }
 
+    /**
+     * @deprecated no use-case for this.
+     */
+    @Deprecated
     protected void invalidateLocalAddress() {
         localAddress = null;
     }
@@ -193,8 +197,9 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     }
 
     /**
-     * Reset the stored remoteAddress
+     * @deprecated no use-case for this.
      */
+    @Deprecated
     protected void invalidateRemoteAddress() {
         remoteAddress = null;
     }


### PR DESCRIPTION
Motivation:

We should deprecate methods that are not used.

Modifications:

Add @Deprecated to methods

Result:

Be able to cleanup stuff sooner.