### PR TITLE
EPOLL Cached ECONNREFUSED Exception

### DIFF
--- a/transport-native-epoll/src/main/c/netty_unix_errors.c
+++ b/transport-native-epoll/src/main/c/netty_unix_errors.c
@@ -100,6 +100,10 @@ static jint netty_unix_errors_errnoEINPROGRESS(JNIEnv* env, jclass clazz) {
     return EINPROGRESS;
 }
 
+static jint netty_unix_errors_errorECONNREFUSED(JNIEnv* env, jclass clazz) {
+    return ECONNREFUSED;
+}
+
 static jstring netty_unix_errors_strError(JNIEnv* env, jclass clazz, jint error) {
     return (*env)->NewStringUTF(env, strerror(error));
 }
@@ -114,6 +118,7 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "errnoEAGAIN", "()I", (void *) netty_unix_errors_errnoEAGAIN },
   { "errnoEWOULDBLOCK", "()I", (void *) netty_unix_errors_errnoEWOULDBLOCK },
   { "errnoEINPROGRESS", "()I", (void *) netty_unix_errors_errnoEINPROGRESS },
+  { "errorECONNREFUSED", "()I", (void *) netty_unix_errors_errorECONNREFUSED },
   { "strError", "(I)Ljava/lang/String;", (void *) netty_unix_errors_strError }
 };
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);

--- a/transport-native-epoll/src/main/java/io/netty/channel/unix/ErrorsStaticallyReferencedJniMethods.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/unix/ErrorsStaticallyReferencedJniMethods.java
@@ -37,5 +37,6 @@ final class ErrorsStaticallyReferencedJniMethods {
     static native int errnoEAGAIN();
     static native int errnoEWOULDBLOCK();
     static native int errnoEINPROGRESS();
+    static native int errorECONNREFUSED();
     static native String strError(int err);
 }


### PR DESCRIPTION
Motivation:
ECONNREFUSED can be a common type of exception when attempting to finish the connection process. Generating a new exception each time can be costly and quickly bloat memory usage.

Modifications:
- Expose ECONNREFUSED from JNI and cache this exception in Socket.finishConnect

Result:
ECONNREFUSED during finish connect doesn't create a new exception each time.