### PR TITLE
[#5486] Not operate on serial execution assumption when using EventEx…

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -18,7 +18,7 @@ package io.netty.util.concurrent;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.Callable;
 import java.util.concurrent.RunnableFuture;
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
  * Abstract base class for {@link EventExecutor} implementations.
  */
 public abstract class AbstractEventExecutor extends AbstractExecutorService implements EventExecutor {
+    private final Set<EventExecutor> executorSet = Collections.singleton((EventExecutor) this);
 
     @Override
     public EventExecutor next() {
@@ -41,7 +42,7 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
 
     @Override
     public Iterator<EventExecutor> iterator() {
-        return new EventExecutorIterator();
+        return executorSet.iterator();
     }
 
     @Override
@@ -130,28 +131,5 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
     @Override
     public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
         throw new UnsupportedOperationException();
-    }
-
-    private final class EventExecutorIterator implements Iterator<EventExecutor> {
-        private boolean nextCalled;
-
-        @Override
-        public boolean hasNext() {
-            return !nextCalled;
-        }
-
-        @Override
-        public EventExecutor next() {
-            if (!hasNext()) {
-                throw new NoSuchElementException();
-            }
-            nextCalled = true;
-            return AbstractEventExecutor.this;
-        }
-
-        @Override
-        public void remove() {
-            throw new UnsupportedOperationException("read-only");
-        }
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/OrderedEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/OrderedEventExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,18 +13,10 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.channel;
-
-import io.netty.util.concurrent.OrderedEventExecutor;
+package io.netty.util.concurrent;
 
 /**
- * Will handle all the I/O operations for a {@link Channel} once registered.
- *
- * One {@link EventLoop} instance will usually handle more than one {@link Channel} but this may depend on
- * implementation details and internals.
- *
+ * Marker interface for {@link EventExecutor}s that will process all submitted tasks in an ordered / serial fashion.
  */
-public interface EventLoop extends OrderedEventExecutor, EventLoopGroup {
-    @Override
-    EventLoopGroup parent();
+public interface OrderedEventExecutor extends EventExecutor {
 }

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -36,10 +36,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 /**
- * Abstract base class for {@link EventExecutor}'s that execute all its submitted tasks in a single thread.
+ * Abstract base class for {@link OrderedEventExecutor}'s that execute all its submitted tasks in a single thread.
  *
  */
-public abstract class SingleThreadEventExecutor extends AbstractScheduledEventExecutor {
+public abstract class SingleThreadEventExecutor extends AbstractScheduledEventExecutor implements OrderedEventExecutor {
 
     static final int DEFAULT_MAX_PENDING_EXECUTOR_TASKS = Math.max(16,
             SystemPropertyUtil.getInt("io.netty.eventexecutor.maxPendingTasks", Integer.MAX_VALUE));

--- a/common/src/main/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/UnorderedThreadPoolEventExecutor.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.RunnableScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * {@link EventExecutor} implementation which makes no guarantees about the ordering of task execution that
+ * are submitted because there may be multiple threads executing these tasks.
+ * This implementation is most useful for protocols that do not need strict ordering.
+ *
+ * <strong>Because it provides no ordering care should be taken when using it!</strong>
+ */
+public final class UnorderedThreadPoolEventExecutor extends ScheduledThreadPoolExecutor implements EventExecutor {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(
+            UnorderedThreadPoolEventExecutor.class);
+
+    private final Promise<?> terminationFuture = GlobalEventExecutor.INSTANCE.newPromise();
+    private final Set<EventExecutor> executorSet = Collections.singleton((EventExecutor) this);
+
+    /**
+     * Calls {@link UnorderedThreadPoolEventExecutor#UnorderedThreadPoolEventExecutor(int, ThreadFactory)}
+     * using {@link DefaultThreadFactory}.
+     */
+    public UnorderedThreadPoolEventExecutor(int corePoolSize) {
+        this(corePoolSize, new DefaultThreadFactory(UnorderedThreadPoolEventExecutor.class));
+    }
+
+    /**
+     * See {@link ScheduledThreadPoolExecutor#ScheduledThreadPoolExecutor(int, ThreadFactory)}
+     */
+    public UnorderedThreadPoolEventExecutor(int corePoolSize, ThreadFactory threadFactory) {
+        super(corePoolSize, threadFactory);
+    }
+
+    /**
+     * Calls {@link UnorderedThreadPoolEventExecutor#UnorderedThreadPoolEventExecutor(int,
+     * ThreadFactory, java.util.concurrent.RejectedExecutionHandler)} using {@link DefaultThreadFactory}.
+     */
+    public UnorderedThreadPoolEventExecutor(int corePoolSize, RejectedExecutionHandler handler) {
+        this(corePoolSize, new DefaultThreadFactory(UnorderedThreadPoolEventExecutor.class), handler);
+    }
+
+    /**
+     * See {@link ScheduledThreadPoolExecutor#ScheduledThreadPoolExecutor(int, ThreadFactory, RejectedExecutionHandler)}
+     */
+    public UnorderedThreadPoolEventExecutor(int corePoolSize, ThreadFactory threadFactory,
+                                            RejectedExecutionHandler handler) {
+        super(corePoolSize, threadFactory, handler);
+    }
+
+    @Override
+    public EventExecutor next() {
+        return this;
+    }
+
+    @Override
+    public EventExecutorGroup parent() {
+        return this;
+    }
+
+    @Override
+    public boolean inEventLoop() {
+        return false;
+    }
+
+    @Override
+    public boolean inEventLoop(Thread thread) {
+        return false;
+    }
+
+    @Override
+    public <V> Promise<V> newPromise() {
+        return new DefaultPromise<V>(this);
+    }
+
+    @Override
+    public <V> ProgressivePromise<V> newProgressivePromise() {
+        return new DefaultProgressivePromise<V>(this);
+    }
+
+    @Override
+    public <V> Future<V> newSucceededFuture(V result) {
+        return new SucceededFuture<V>(this, result);
+    }
+
+    @Override
+    public <V> Future<V> newFailedFuture(Throwable cause) {
+        return new FailedFuture<V>(this, cause);
+    }
+
+    @Override
+    public boolean isShuttingDown() {
+        return isShutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        List<Runnable> tasks = super.shutdownNow();
+        terminationFuture.trySuccess(null);
+        return tasks;
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        terminationFuture.trySuccess(null);
+    }
+
+    @Override
+    public Future<?> shutdownGracefully() {
+        return shutdownGracefully(2, 15, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
+        // TODO: At the moment this just calls shutdown but we may be able to do something more smart here which
+        //       respects the quietPeriod and timeout.
+        shutdown();
+        return terminationFuture();
+    }
+
+    @Override
+    public Future<?> terminationFuture() {
+        return terminationFuture;
+    }
+
+    @Override
+    public Iterator<EventExecutor> iterator() {
+        return executorSet.iterator();
+    }
+
+    @Override
+    protected <V> RunnableScheduledFuture<V> decorateTask(Runnable runnable, RunnableScheduledFuture<V> task) {
+        return new RunnableScheduledFutureTask<V>(this, runnable, task);
+    }
+
+    @Override
+    protected <V> RunnableScheduledFuture<V> decorateTask(Callable<V> callable, RunnableScheduledFuture<V> task) {
+        return new RunnableScheduledFutureTask<V>(this, callable, task);
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return (ScheduledFuture<?>) super.schedule(command, delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return (ScheduledFuture<V>) super.schedule(callable, delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return (ScheduledFuture<?>) super.scheduleAtFixedRate(command, initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return (ScheduledFuture<?>) super.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return (Future<?>) super.submit(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return (Future<T>) super.submit(task, result);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return (Future<T>) super.submit(task);
+    }
+
+    private static final class RunnableScheduledFutureTask<V> extends PromiseTask<V>
+            implements RunnableScheduledFuture<V>, ScheduledFuture<V> {
+        private final RunnableScheduledFuture<V> future;
+
+        RunnableScheduledFutureTask(EventExecutor executor, Runnable runnable,
+                                           RunnableScheduledFuture<V> future) {
+            super(executor, runnable, null);
+            this.future = future;
+        }
+
+        RunnableScheduledFutureTask(EventExecutor executor, Callable<V> callable,
+                                           RunnableScheduledFuture<V> future) {
+            super(executor, callable);
+            this.future = future;
+        }
+
+        @Override
+        public void run() {
+            if (!isPeriodic()) {
+                super.run();
+            } else if (!isDone()) {
+                try {
+                    // Its a periodic task so we need to ignore the return value
+                    task.call();
+                } catch (Throwable cause) {
+                    if (!tryFailureInternal(cause)) {
+                        logger.warn("Failure during execution of task", cause);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public boolean isPeriodic() {
+            return future.isPeriodic();
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            return future.getDelay(unit);
+        }
+
+        @Override
+        public int compareTo(Delayed o) {
+            return future.compareTo(o);
+        }
+    }
+}

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -143,12 +143,14 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             // In this case we add the context to the pipeline and add a task that will call
             // ChannelHandler.handlerAdded(...) once the channel is registered.
             if (!registered) {
+                newCtx.setAddPending();
                 callHandlerCallbackLater(newCtx, true);
                 return this;
             }
 
             EventExecutor executor = newCtx.executor();
             if (!executor.inEventLoop()) {
+                newCtx.setAddPending();
                 executor.execute(new Runnable() {
                     @Override
                     public void run() {
@@ -189,12 +191,14 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             // In this case we add the context to the pipeline and add a task that will call
             // ChannelHandler.handlerAdded(...) once the channel is registered.
             if (!registered) {
+                newCtx.setAddPending();
                 callHandlerCallbackLater(newCtx, true);
                 return this;
             }
 
             EventExecutor executor = newCtx.executor();
             if (!executor.inEventLoop()) {
+                newCtx.setAddPending();
                 executor.execute(new Runnable() {
                     @Override
                     public void run() {
@@ -239,12 +243,14 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             // In this case we add the context to the pipeline and add a task that will call
             // ChannelHandler.handlerAdded(...) once the channel is registered.
             if (!registered) {
+                newCtx.setAddPending();
                 callHandlerCallbackLater(newCtx, true);
                 return this;
             }
 
             EventExecutor executor = newCtx.executor();
             if (!executor.inEventLoop()) {
+                newCtx.setAddPending();
                 executor.execute(new Runnable() {
                     @Override
                     public void run() {
@@ -297,11 +303,13 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             // In this case we remove the context from the pipeline and add a task that will call
             // ChannelHandler.handlerRemoved(...) once the channel is registered.
             if (!registered) {
+                newCtx.setAddPending();
                 callHandlerCallbackLater(newCtx, true);
                 return this;
             }
             EventExecutor executor = newCtx.executor();
             if (!executor.inEventLoop()) {
+                newCtx.setAddPending();
                 executor.execute(new Runnable() {
                     @Override
                     public void run() {
@@ -568,7 +576,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     private void callHandlerAdded0(final AbstractChannelHandlerContext ctx) {
         try {
             ctx.handler().handlerAdded(ctx);
-            ctx.setAdded();
+            ctx.setAddComplete();
         } catch (Throwable t) {
             boolean removed = false;
             try {
@@ -1113,7 +1121,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
         TailContext(DefaultChannelPipeline pipeline) {
             super(pipeline, null, TAIL_NAME, true, false);
-            setAdded();
+            setAddComplete();
         }
 
         @Override
@@ -1172,7 +1180,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         HeadContext(DefaultChannelPipeline pipeline) {
             super(pipeline, null, HEAD_NAME, false, true);
             unsafe = pipeline.channel().unsafe();
-            setAdded();
+            setAddComplete();
         }
 
         @Override


### PR DESCRIPTION
…ecutor in the DefaultChannelPipeline.

Motivation:

In commit f984870ccca133d6056e8b0df0b2352f8f90b0fe I made a change which operated under invalide assumption that tasks executed by an EventExecutor will always be processed in a serial fashion. This is true for SingleThreadEventExecutor sub-classes but not part of the EventExecutor interface contract.

Because of this change implementations of EventExecutor which not strictly execute tasks in a serial fashion may miss events before handlerAdded(...) is called. This is strictly speaking not correct as there is not guarantee in this case that handlerAdded(...) will be called as first task (as there is no ordering guarentee).

Cassandra itself ships such an EventExecutor implementation which has no strict ordering to spread load across multiple threads.

Modifications:

- Add new OrderedEventExecutor interface and let SingleThreadEventExecutor / EventLoop implement / extend it.
- Only expose "restriction" of skipping events until handlerAdded(...) is called for OrderedEventExecutor implementations
- Add ThreadPoolEventExecutor implementation which executes tasks in an unordered fashion. This is used in added unit test but can also be used for protocols which not expose an strict ordering.
- Add unit test.

Result:

Resurrect the possibility to implement an EventExecutor which does not enforce serial execution of events and be able to use it with the DefaultChannelPipeline.