### PR TITLE
	DefaultPromise make listeners not volatile

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -60,7 +60,7 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
      *
      * Threading - synchronized(this). We must support adding listeners when there is no EventExecutor.
      */
-    private volatile Object listeners;
+    private Object listeners;
     /**
      * Threading - synchronized(this). We are required to hold the monitor to use Java's underlying wait()/notifyAll().
      */
@@ -417,13 +417,6 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
     }
 
     private void notifyListeners() {
-        if (listeners == null) {
-            return;
-        }
-        notifyListenersWithStackOverFlowProtection();
-    }
-
-    private void notifyListenersWithStackOverFlowProtection() {
         EventExecutor executor = executor();
         if (executor.inEventLoop()) {
             final InternalThreadLocalMap threadLocals = InternalThreadLocalMap.get();
@@ -448,7 +441,7 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
     }
 
     /**
-     * The logic in this method should be identical to {@link #notifyListenersWithStackOverFlowProtection()} but
+     * The logic in this method should be identical to {@link #notifyListeners()} but
      * cannot share code because the listener(s) cannot be cached for an instance of {@link DefaultPromise} since the
      * listener(s) may be changed and is protected by a synchronized operation.
      */

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTest.java
@@ -455,6 +455,7 @@ public class DefaultChannelPipelineTest {
     @Test
     public void testCancelBind() throws Exception {
         ChannelPipeline pipeline = new LocalChannel().pipeline();
+        group.register(pipeline.channel());
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
@@ -465,6 +466,7 @@ public class DefaultChannelPipelineTest {
     @Test
     public void testCancelConnect() throws Exception {
         ChannelPipeline pipeline = new LocalChannel().pipeline();
+        group.register(pipeline.channel());
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
@@ -475,6 +477,7 @@ public class DefaultChannelPipelineTest {
     @Test
     public void testCancelDisconnect() throws Exception {
         ChannelPipeline pipeline = new LocalChannel().pipeline();
+        group.register(pipeline.channel());
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
@@ -485,6 +488,7 @@ public class DefaultChannelPipelineTest {
     @Test
     public void testCancelClose() throws Exception {
         ChannelPipeline pipeline = new LocalChannel().pipeline();
+        group.register(pipeline.channel());
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
@@ -495,6 +499,7 @@ public class DefaultChannelPipelineTest {
     @Test
     public void testCancelDeregister() throws Exception {
         ChannelPipeline pipeline = new LocalChannel().pipeline();
+        group.register(pipeline.channel());
 
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
@@ -505,6 +510,8 @@ public class DefaultChannelPipelineTest {
     @Test
     public void testCancelWrite() throws Exception {
         ChannelPipeline pipeline = new LocalChannel().pipeline();
+        group.register(pipeline.channel());
+
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
         ByteBuf buffer = Unpooled.buffer();
@@ -517,6 +524,8 @@ public class DefaultChannelPipelineTest {
     @Test
     public void testCancelWriteAndFlush() throws Exception {
         ChannelPipeline pipeline = new LocalChannel().pipeline();
+        group.register(pipeline.channel());
+
         ChannelPromise promise = pipeline.channel().newPromise();
         assertTrue(promise.cancel(false));
         ByteBuf buffer = Unpooled.buffer();


### PR DESCRIPTION
Motivation:
DefaultPromise has a listeners member variable which is volatile to allow for an optimization which makes notification of listeners less expensive when there are no listeners to notify. However this change makes all other operations involving the listeners member variable more costly. This optimization which requires listeners to be volatile can be removed to avoid volatile writes/reads for every access on the listeners member variable.

Modifications:
- DefaultPromise listeners is made non-volatile and the null check optimization is removed

Result:
DefaultPromise.listeners is no longer volatile.