### PR TITLE
Ability to run a task at the end of an eventloop iteration.

### DIFF
--- a/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/SingleThreadEventLoop.java
@@ -20,7 +20,9 @@ import io.netty.util.concurrent.RejectedExecutionHandlers;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.UnstableApi;
 
+import java.util.Queue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 
@@ -32,6 +34,8 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
 
     protected static final int DEFAULT_MAX_PENDING_TASKS = Math.max(16,
             SystemPropertyUtil.getInt("io.netty.eventLoop.maxPendingTasks", Integer.MAX_VALUE));
+
+    private final Queue<Runnable> tailTasks;
 
     protected SingleThreadEventLoop(EventLoopGroup parent, ThreadFactory threadFactory, boolean addTaskWakesUp) {
         this(parent, threadFactory, addTaskWakesUp, DEFAULT_MAX_PENDING_TASKS, RejectedExecutionHandlers.reject());
@@ -45,12 +49,14 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
                                     boolean addTaskWakesUp, int maxPendingTasks,
                                     RejectedExecutionHandler rejectedExecutionHandler) {
         super(parent, threadFactory, addTaskWakesUp, maxPendingTasks, rejectedExecutionHandler);
+        tailTasks = newTaskQueue(maxPendingTasks);
     }
 
     protected SingleThreadEventLoop(EventLoopGroup parent, Executor executor,
                                     boolean addTaskWakesUp, int maxPendingTasks,
                                     RejectedExecutionHandler rejectedExecutionHandler) {
         super(parent, executor, addTaskWakesUp, maxPendingTasks, rejectedExecutionHandler);
+        tailTasks = newTaskQueue(maxPendingTasks);
     }
 
     @Override
@@ -89,9 +95,57 @@ public abstract class SingleThreadEventLoop extends SingleThreadEventExecutor im
         return promise;
     }
 
+    /**
+     * Adds a task to be run once at the end of next (or current) {@code eventloop} iteration.
+     *
+     * @param task to be added.
+     */
+    @UnstableApi
+    final void executeAfterEventLoopIteration(Runnable task) {
+        ObjectUtil.checkNotNull(task, "task");
+        if (isShutdown()) {
+            reject();
+        }
+
+        if (!tailTasks.offer(task)) {
+            reject(task);
+        }
+
+        if (wakesUpForTask(task)) {
+            wakeup(inEventLoop());
+        }
+    }
+
+    /**
+     * Removes a task that was added previously via {@link #executeAfterEventLoopIteration(Runnable)}.
+     *
+     * @param task to be removed.
+     *
+     * @return {@code true} if the task was removed as a result of this call.
+     */
+    @UnstableApi
+    final boolean removeAfterEventLoopIterationTask(Runnable task) {
+        return tailTasks.remove(ObjectUtil.checkNotNull(task, "task"));
+    }
+
     @Override
     protected boolean wakesUpForTask(Runnable task) {
         return !(task instanceof NonWakeupRunnable);
+    }
+
+    @Override
+    protected void afterRunningAllTasks() {
+        runAllTasksFrom(tailTasks);
+    }
+
+    @Override
+    protected boolean hasTasks() {
+        return super.hasTasks() || !tailTasks.isEmpty();
+    }
+
+    @Override
+    public int pendingTasks() {
+        return super.pendingTasks() + tailTasks.size();
     }
 
     /**


### PR DESCRIPTION
####   Motivation:

This change is part of the change done in PR #5395 to provide an `AUTO_FLUSH` capability.
Splitting this change will enable to try other ways of implementing `AUTO_FLUSH`.

#### Modifications:  

Two methods:

```java
void executeAfterEventLoopIteration(Runnable task);
  boolean removeAfterEventLoopIterationTask(Runnable task);
```
are added to `SingleThreadEventLoop` class for adding/removing a task to be executed at the end of current/next iteration of this `eventloop`.

In order to support the above, a few methods are added to `SingleThreadEventExecutor`

```java
protected void afterRunningAllTasks(boolean timedOut) { }
```

This is invoked after all tasks are run for this executor OR if the passed timeout value for `runAllTasks(long timeoutNanos)` is expired. In case of `timeout` the argument to this method is `true`.

These two methods are added to reduce code duplication between `SingleThreadEventLoop` and `SingleThreadEventExecutor` which does the same work on different queues.

```java
protected DeadlineRunResult runAllTasksFrom(Queue<Runnable> taskQueue, long timeoutNanos,
                                                LongBiConsumer executionTimeCallback){}
protected boolean runAllTasksFrom(Queue<Runnable> taskQueue)
```
Added a queue of `tailTasks` to `SingleThreadEventLoop` to hold all tasks to be executed at the end of every iteration.
In the case if `afterRunningAllTasks` is invoked as a result of a timeout, no tail tasks are executed. Instead, the tail tasks are executed at the start of the next iteration.
 
#### Result:  

`SingleThreadEventLoop` now has the ability to execute tasks at the end of an eventloop iteration.