### PR TITLE
DnsNameResolver search domains support

### DIFF
--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -548,6 +548,18 @@ public final class StringUtil {
         return c == DOUBLE_QUOTE;
     }
 
+    /**
+     * Determine if the string {@code s} ends with the char {@code c}.
+     *
+     * @param s the string to test
+     * @param c the tested char
+     * @return true if {@code s} ends with the char {@code c}
+     */
+    public static boolean endsWith(CharSequence s, char c) {
+        int len = s.length();
+        return len > 0 && s.charAt(len - 1) == c;
+    }
+
     private StringUtil() {
         // Unused.
     }

--- a/common/src/test/java/io/netty/util/internal/StringUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/StringUtilTest.java
@@ -440,4 +440,13 @@ public class StringUtilTest {
     }
 
     private static final class TestClass { }
+
+    @Test
+    public void testEndsWith() {
+        assertFalse(StringUtil.endsWith("", 'u'));
+        assertTrue(StringUtil.endsWith("u", 'u'));
+        assertTrue(StringUtil.endsWith("-u", 'u'));
+        assertFalse(StringUtil.endsWith("-", 'u'));
+        assertFalse(StringUtil.endsWith("u-", 'u'));
+    }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -51,6 +51,8 @@ public final class DnsNameResolverBuilder {
     private int maxPayloadSize = 4096;
     private boolean optResourceEnabled = true;
     private HostsFileEntriesResolver hostsFileEntriesResolver = HostsFileEntriesResolver.DEFAULT;
+    private String[] searchDomains = DnsNameResolver.DEFAULT_SEACH_DOMAINS;
+    private int ndots = 1;
 
     /**
      * Creates a new builder.
@@ -289,6 +291,46 @@ public final class DnsNameResolverBuilder {
     }
 
     /**
+     * Set the list of search domains of the resolver.
+     *
+     * @param searchDomains the search domains
+     * @return {@code this}
+     */
+    public DnsNameResolverBuilder searchDomains(Iterable<String> searchDomains) {
+        checkNotNull(searchDomains, "searchDomains");
+
+        final List<String> list =
+            InternalThreadLocalMap.get().arrayList(4);
+
+        for (String f : searchDomains) {
+            if (f == null) {
+                break;
+            }
+
+            // Avoid duplicate entries.
+            if (list.contains(f)) {
+                continue;
+            }
+
+            list.add(f);
+        }
+
+        this.searchDomains = list.toArray(new String[list.size()]);
+        return this;
+    }
+
+  /**
+   * Set the number of dots which must appear in a name before an initial absolute query is made.
+   *
+   * @param ndots the ndots value
+   * @return {@code this}
+   */
+    public DnsNameResolverBuilder ndots(int ndots) {
+        this.ndots = ndots;
+        return this;
+    }
+
+    /**
      * Returns a new {@link DnsNameResolver} instance.
      *
      * @return a {@link DnsNameResolver}
@@ -314,6 +356,8 @@ public final class DnsNameResolverBuilder {
                 traceEnabled,
                 maxPayloadSize,
                 optResourceEnabled,
-                hostsFileEntriesResolver);
+                hostsFileEntriesResolver,
+                searchDomains,
+                ndots);
     }
 }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.util.concurrent.Future;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SearchDomainTest {
+
+    private DnsNameResolverBuilder newResolver() {
+        return new DnsNameResolverBuilder(group.next())
+            .channelType(NioDatagramChannel.class)
+            .nameServerAddresses(DnsServerAddresses.singleton(dnsServer.localAddress()))
+            .maxQueriesPerResolve(1)
+            .optResourceEnabled(false);
+    }
+
+    private TestDnsServer dnsServer;
+    private EventLoopGroup group;
+
+    @Before
+    public void before() {
+        group = new NioEventLoopGroup(1);
+    }
+
+    @After
+    public void destroy() {
+        if (dnsServer != null) {
+            dnsServer.stop();
+            dnsServer = null;
+        }
+        group.shutdownGracefully();
+    }
+
+    @Test
+    public void testResolve() throws Exception {
+        Set<String> domains = new HashSet<String>();
+        domains.add("host1.foo.com");
+        domains.add("host1");
+        domains.add("host3");
+        domains.add("host4.sub.foo.com");
+        domains.add("host5.sub.foo.com");
+        domains.add("host5.sub");
+
+        TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains);
+        dnsServer = new TestDnsServer(store);
+        dnsServer.start();
+
+        DnsNameResolver resolver = newResolver().searchDomains(Collections.singletonList("foo.com")).build();
+
+        String a = "host1.foo.com";
+        String resolved = assertResolve(resolver, a);
+        assertEquals(store.getAddress("host1.foo.com"), resolved);
+
+        // host1 resolves host1.foo.com with foo.com search domain
+        resolved = assertResolve(resolver, "host1");
+        assertEquals(store.getAddress("host1.foo.com"), resolved);
+
+        // "host1." absolute query
+        resolved = assertResolve(resolver, "host1.");
+        assertEquals(store.getAddress("host1"), resolved);
+
+        // "host2" not resolved
+        assertNotResolve(resolver, "host2");
+
+        // "host3" does not contain a dot or is not absolute
+        assertNotResolve(resolver, "host3");
+
+        // "host3." does not contain a dot but is absolute
+        resolved = assertResolve(resolver, "host3.");
+        assertEquals(store.getAddress("host3"), resolved);
+
+        // "host4.sub" contains a dot but not resolved then resolved to "host4.sub.foo.com" with "foo.com" search domain
+        resolved = assertResolve(resolver, "host4.sub");
+        assertEquals(store.getAddress("host4.sub.foo.com"), resolved);
+
+        // "host5.sub" contains a dot and is resolved
+        resolved = assertResolve(resolver, "host5.sub");
+        assertEquals(store.getAddress("host5.sub"), resolved);
+    }
+
+    @Test
+    public void testResolveAll() throws Exception {
+        Set<String> domains = new HashSet<String>();
+        domains.add("host1.foo.com");
+        domains.add("host1");
+        domains.add("host3");
+        domains.add("host4.sub.foo.com");
+        domains.add("host5.sub.foo.com");
+        domains.add("host5.sub");
+
+        TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains, 2);
+        dnsServer = new TestDnsServer(store);
+        dnsServer.start();
+
+        DnsNameResolver resolver = newResolver().searchDomains(Collections.singletonList("foo.com")).build();
+
+        String a = "host1.foo.com";
+        List<String> resolved = assertResolveAll(resolver, a);
+        assertEquals(store.getAddresses("host1.foo.com"), resolved);
+
+        // host1 resolves host1.foo.com with foo.com search domain
+        resolved = assertResolveAll(resolver, "host1");
+        assertEquals(store.getAddresses("host1.foo.com"), resolved);
+
+        // "host1." absolute query
+        resolved = assertResolveAll(resolver, "host1.");
+        assertEquals(store.getAddresses("host1"), resolved);
+
+        // "host2" not resolved
+        assertNotResolveAll(resolver, "host2");
+
+        // "host3" does not contain a dot or is not absolute
+        assertNotResolveAll(resolver, "host3");
+
+        // "host3." does not contain a dot but is absolute
+        resolved = assertResolveAll(resolver, "host3.");
+        assertEquals(store.getAddresses("host3"), resolved);
+
+        // "host4.sub" contains a dot but not resolved then resolved to "host4.sub.foo.com" with "foo.com" search domain
+        resolved = assertResolveAll(resolver, "host4.sub");
+        assertEquals(store.getAddresses("host4.sub.foo.com"), resolved);
+
+        // "host5.sub" contains a dot and is resolved
+        resolved = assertResolveAll(resolver, "host5.sub");
+        assertEquals(store.getAddresses("host5.sub"), resolved);
+    }
+
+    @Test
+    public void testMultipleSearchDomain() throws Exception {
+        Set<String> domains = new HashSet<String>();
+        domains.add("host1.foo.com");
+        domains.add("host2.bar.com");
+        domains.add("host3.bar.com");
+        domains.add("host3.foo.com");
+
+        TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains);
+        dnsServer = new TestDnsServer(store);
+        dnsServer.start();
+
+        DnsNameResolver resolver = newResolver().searchDomains(Arrays.asList("foo.com", "bar.com")).build();
+
+        // "host1" resolves via the "foo.com" search path
+        String resolved = assertResolve(resolver, "host1");
+        assertEquals(store.getAddress("host1.foo.com"), resolved);
+
+        // "host2" resolves via the "bar.com" search path
+        resolved = assertResolve(resolver, "host2");
+        assertEquals(store.getAddress("host2.bar.com"), resolved);
+
+        // "host3" resolves via the the "foo.com" search path as it is the first one
+        resolved = assertResolve(resolver, "host3");
+        assertEquals(store.getAddress("host3.foo.com"), resolved);
+
+        // "host4" does not resolve
+        assertNotResolve(resolver, "host4");
+    }
+
+    @Test
+    public void testSearchDomainWithNdots2() throws Exception {
+        Set<String> domains = new HashSet<String>();
+        domains.add("host1.sub.foo.com");
+        domains.add("host2.sub.foo.com");
+        domains.add("host2.sub");
+
+        TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains);
+        dnsServer = new TestDnsServer(store);
+        dnsServer.start();
+
+        DnsNameResolver resolver = newResolver().searchDomains(Collections.singleton("foo.com")).ndots(2).build();
+
+        String resolved = assertResolve(resolver, "host1.sub");
+        assertEquals(store.getAddress("host1.sub.foo.com"), resolved);
+
+        // "host2.sub" is resolved with the foo.com search domain as ndots = 2
+        resolved = assertResolve(resolver, "host2.sub");
+        assertEquals(store.getAddress("host2.sub.foo.com"), resolved);
+    }
+
+    private void assertNotResolve(DnsNameResolver resolver, String inetHost) throws InterruptedException {
+        Future<InetAddress> fut = resolver.resolve(inetHost);
+        assertTrue(fut.await(10, TimeUnit.SECONDS));
+        assertFalse(fut.isSuccess());
+    }
+
+    private void assertNotResolveAll(DnsNameResolver resolver, String inetHost) throws InterruptedException {
+        Future<List<InetAddress>> fut = resolver.resolveAll(inetHost);
+        assertTrue(fut.await(10, TimeUnit.SECONDS));
+        assertFalse(fut.isSuccess());
+    }
+
+    private String assertResolve(DnsNameResolver resolver, String inetHost) throws InterruptedException {
+        Future<InetAddress> fut = resolver.resolve(inetHost);
+        assertTrue(fut.await(10, TimeUnit.SECONDS));
+        return fut.getNow().getHostAddress();
+    }
+
+    private List<String> assertResolveAll(DnsNameResolver resolver, String inetHost) throws InterruptedException {
+        Future<List<InetAddress>> fut = resolver.resolveAll(inetHost);
+        assertTrue(fut.await(10, TimeUnit.SECONDS));
+        List<String> list = new ArrayList<String>();
+        for (InetAddress addr : fut.getNow()) {
+            list.add(addr.getHostAddress());
+        }
+        return list;
+    }
+}

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.util.NetUtil;
+import io.netty.util.internal.ThreadLocalRandom;
+import org.apache.directory.server.dns.DnsException;
+import org.apache.directory.server.dns.DnsServer;
+import org.apache.directory.server.dns.io.encoder.DnsMessageEncoder;
+import org.apache.directory.server.dns.io.encoder.ResourceRecordEncoder;
+import org.apache.directory.server.dns.messages.DnsMessage;
+import org.apache.directory.server.dns.messages.QuestionRecord;
+import org.apache.directory.server.dns.messages.RecordClass;
+import org.apache.directory.server.dns.messages.RecordType;
+import org.apache.directory.server.dns.messages.ResourceRecord;
+import org.apache.directory.server.dns.messages.ResourceRecordImpl;
+import org.apache.directory.server.dns.messages.ResourceRecordModifier;
+import org.apache.directory.server.dns.protocol.DnsProtocolHandler;
+import org.apache.directory.server.dns.protocol.DnsUdpDecoder;
+import org.apache.directory.server.dns.protocol.DnsUdpEncoder;
+import org.apache.directory.server.dns.store.DnsAttribute;
+import org.apache.directory.server.dns.store.RecordStore;
+import org.apache.directory.server.protocol.shared.transport.UdpTransport;
+import org.apache.mina.core.buffer.IoBuffer;
+import org.apache.mina.core.session.IoSession;
+import org.apache.mina.filter.codec.ProtocolCodecFactory;
+import org.apache.mina.filter.codec.ProtocolCodecFilter;
+import org.apache.mina.filter.codec.ProtocolDecoder;
+import org.apache.mina.filter.codec.ProtocolEncoder;
+import org.apache.mina.filter.codec.ProtocolEncoderOutput;
+import org.apache.mina.transport.socket.DatagramAcceptor;
+import org.apache.mina.transport.socket.DatagramSessionConfig;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+final class TestDnsServer extends DnsServer {
+    private static final Map<String, byte[]> BYTES = new HashMap<String, byte[]>();
+    private static final String[] IPV6_ADDRESSES;
+
+    static {
+        BYTES.put("::1", new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1});
+        BYTES.put("0:0:0:0:0:0:1:1", new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1});
+        BYTES.put("0:0:0:0:0:1:1:1", new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1});
+        BYTES.put("0:0:0:0:1:1:1:1", new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1});
+        BYTES.put("0:0:0:1:1:1:1:1", new byte[]{0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1});
+        BYTES.put("0:0:1:1:1:1:1:1", new byte[]{0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1});
+        BYTES.put("0:1:1:1:1:1:1:1", new byte[]{0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1});
+        BYTES.put("1:1:1:1:1:1:1:1", new byte[]{0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1});
+
+        IPV6_ADDRESSES = BYTES.keySet().toArray(new String[BYTES.size()]);
+    }
+
+    private final RecordStore store;
+
+    TestDnsServer(Set<String> domains) {
+        this.store = new TestRecordStore(domains);
+    }
+
+    TestDnsServer(RecordStore store) {
+        this.store = store;
+    }
+
+    @Override
+    public void start() throws IOException {
+        InetSocketAddress address = new InetSocketAddress(NetUtil.LOCALHOST4, 50000);
+        UdpTransport transport = new UdpTransport(address.getHostName(), address.getPort());
+        setTransports(transport);
+
+        DatagramAcceptor acceptor = transport.getAcceptor();
+
+        acceptor.setHandler(new DnsProtocolHandler(this, store) {
+            @Override
+            public void sessionCreated(IoSession session) throws Exception {
+                // USe our own codec to support AAAA testing
+                session.getFilterChain()
+                    .addFirst("codec", new ProtocolCodecFilter(new TestDnsProtocolUdpCodecFactory()));
+            }
+        });
+
+        ((DatagramSessionConfig) acceptor.getSessionConfig()).setReuseAddress(true);
+
+        // Start the listener
+        acceptor.bind();
+    }
+
+    public InetSocketAddress localAddress() {
+        return (InetSocketAddress) getTransports()[0].getAcceptor().getLocalAddress();
+    }
+
+    /**
+     * {@link ProtocolCodecFactory} which allows to test AAAA resolution.
+     */
+    private static final class TestDnsProtocolUdpCodecFactory implements ProtocolCodecFactory {
+        private final DnsMessageEncoder encoder = new DnsMessageEncoder();
+        private final TestAAAARecordEncoder recordEncoder = new TestAAAARecordEncoder();
+
+        @Override
+        public ProtocolEncoder getEncoder(IoSession session) throws Exception {
+            return new DnsUdpEncoder() {
+
+                @Override
+                public void encode(IoSession session, Object message, ProtocolEncoderOutput out) {
+                    IoBuffer buf = IoBuffer.allocate(1024);
+                    DnsMessage dnsMessage = (DnsMessage) message;
+                    encoder.encode(buf, dnsMessage);
+                    for (ResourceRecord record : dnsMessage.getAnswerRecords()) {
+                        // This is a hack to allow to also test for AAAA resolution as DnsMessageEncoder
+                        // does not support it and it is hard to extend, because the interesting methods
+                        // are private...
+                        // In case of RecordType.AAAA we need to encode the RecordType by ourselves.
+                        if (record.getRecordType() == RecordType.AAAA) {
+                            try {
+                                recordEncoder.put(buf, record);
+                            } catch (IOException e) {
+                                // Should never happen
+                                throw new IllegalStateException(e);
+                            }
+                        }
+                    }
+                    buf.flip();
+
+                    out.write(buf);
+                }
+            };
+        }
+
+        @Override
+        public ProtocolDecoder getDecoder(IoSession session) throws Exception {
+            return new DnsUdpDecoder();
+        }
+
+        private static final class TestAAAARecordEncoder extends ResourceRecordEncoder {
+
+            @Override
+            protected void putResourceRecordData(IoBuffer ioBuffer, ResourceRecord resourceRecord) {
+                byte[] bytes = BYTES.get(resourceRecord.get(DnsAttribute.IP_ADDRESS));
+                if (bytes == null) {
+                    throw new IllegalStateException();
+                }
+                // encode the ::1
+                ioBuffer.put(bytes);
+            }
+        }
+    }
+
+    public static final class MapRecordStoreA implements RecordStore {
+
+        private final Map<String, List<String>> domainMap;
+
+        public MapRecordStoreA(Set<String> domains, int length) {
+            domainMap = new HashMap<String, List<String>>(domains.size());
+            for (String domain : domains) {
+                List<String> addresses = new ArrayList<String>(length);
+                for (int i = 0; i < length; i++) {
+                    addresses.add(TestRecordStore.nextIp());
+                }
+                domainMap.put(domain, addresses);
+            }
+        }
+
+        public MapRecordStoreA(Set<String> domains) {
+            this(domains, 1);
+        }
+
+        public String getAddress(String domain) {
+            return domainMap.get(domain).get(0);
+        }
+
+        public List<String> getAddresses(String domain) {
+            return domainMap.get(domain);
+        }
+
+        @Override
+        public Set<ResourceRecord> getRecords(QuestionRecord questionRecord) throws DnsException {
+            String name = questionRecord.getDomainName();
+            List<String> addresses = domainMap.get(name);
+            if (addresses != null && questionRecord.getRecordType() == RecordType.A) {
+                Set<ResourceRecord> records = new LinkedHashSet<ResourceRecord>();
+                for (String address : addresses) {
+                    HashMap<String, Object> attributes = new HashMap<String, Object>();
+                    attributes.put(DnsAttribute.IP_ADDRESS.toLowerCase(), address);
+                    records.add(new ResourceRecordImpl(name, questionRecord.getRecordType(),
+                        RecordClass.IN, 100, attributes) {
+                        @Override
+                        public int hashCode() {
+                            return System.identityHashCode(this);
+                        }
+                        @Override
+                        public boolean equals(Object o) {
+                            return false;
+                        }
+                    });
+                }
+                return records;
+            }
+            return null;
+        }
+    }
+
+    private static final class TestRecordStore implements RecordStore {
+        private static final int[] NUMBERS = new int[254];
+        private static final char[] CHARS = new char[26];
+
+        static {
+            for (int i = 0; i < NUMBERS.length; i++) {
+                NUMBERS[i] = i + 1;
+            }
+
+            for (int i = 0; i < CHARS.length; i++) {
+                CHARS[i] = (char) ('a' + i);
+            }
+        }
+
+        private static int index(int arrayLength) {
+            return Math.abs(ThreadLocalRandom.current().nextInt()) % arrayLength;
+        }
+
+        private static String nextDomain() {
+            return CHARS[index(CHARS.length)] + ".netty.io";
+        }
+
+        private static String nextIp() {
+            return ipPart() + "." + ipPart() + '.' + ipPart() + '.' + ipPart();
+        }
+
+        private static int ipPart() {
+            return NUMBERS[index(NUMBERS.length)];
+        }
+
+        private static String nextIp6() {
+            return IPV6_ADDRESSES[index(IPV6_ADDRESSES.length)];
+        }
+
+        private final Set<String> domains;
+
+        public TestRecordStore(Set<String> domains) {
+            this.domains = domains;
+        }
+
+        @Override
+        public Set<ResourceRecord> getRecords(QuestionRecord questionRecord) {
+            String name = questionRecord.getDomainName();
+            if (domains.contains(name)) {
+                ResourceRecordModifier rm = new ResourceRecordModifier();
+                rm.setDnsClass(RecordClass.IN);
+                rm.setDnsName(name);
+                rm.setDnsTtl(100);
+                rm.setDnsType(questionRecord.getRecordType());
+
+                switch (questionRecord.getRecordType()) {
+                    case A:
+                        do {
+                            rm.put(DnsAttribute.IP_ADDRESS, nextIp());
+                        } while (ThreadLocalRandom.current().nextBoolean());
+                        break;
+                    case AAAA:
+                        do {
+                            rm.put(DnsAttribute.IP_ADDRESS, nextIp6());
+                        } while (ThreadLocalRandom.current().nextBoolean());
+                        break;
+                    case MX:
+                        int priority = 0;
+                        do {
+                            rm.put(DnsAttribute.DOMAIN_NAME, nextDomain());
+                            rm.put(DnsAttribute.MX_PREFERENCE, String.valueOf(++priority));
+                        } while (ThreadLocalRandom.current().nextBoolean());
+                        break;
+                    default:
+                        return null;
+                }
+                return Collections.singleton(rm.getEntry());
+            }
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

The current DnsNameResolver does not support search domains resolution. Search domains resolution is supported out of the box by the java.net resolver, making the DnsNameResolver not able to be a drop in replacement for io.netty.resolver.DefaultNameResolver.

Modifications:

The DnsNameResolverContext resolution has been modified to resolve a list of search path first when it is configured so. The resolve method now uses the following algorithm:

if (hostname is absolute (start with dot) || no search domains) {
 searchAsIs
} else {
  if (numDots(name) >= ndots) {
    searchAsIs
  }
  if (searchAsIs wasn't performed or failed) {
    searchWithSearchDomainsSequenciallyUntilOneSucceeds
  }
}

The DnsNameResolverBuilder provides configuration for the search domains and the ndots value. The default search domains value is configured with the OS search domains using the same native configuration the java.net resolver uses.

Result:

The DnsNameResolver performs search domains resolution when they are present.