### PR TITLE
[#5520] Correctly include all PoolSubpage metrics

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -433,7 +433,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
     private static List<PoolSubpageMetric> subPageMetricList(PoolSubpage<?>[] pages) {
         List<PoolSubpageMetric> metrics = new ArrayList<PoolSubpageMetric>();
-        for (int i = 1; i < pages.length; i ++) {
+        for (int i = 0; i < pages.length; i ++) {
             PoolSubpage<?> head = pages[i];
             if (head.next == head) {
                 continue;
@@ -589,47 +589,34 @@ abstract class PoolArena<T> implements PoolArenaMetric {
             .append(q100)
             .append(StringUtil.NEWLINE)
             .append("tiny subpages:");
-        for (int i = 1; i < tinySubpagePools.length; i ++) {
-            PoolSubpage<T> head = tinySubpagePools[i];
-            if (head.next == head) {
-                continue;
-            }
-
-            buf.append(StringUtil.NEWLINE)
-               .append(i)
-               .append(": ");
-            PoolSubpage<T> s = head.next;
-            for (;;) {
-                buf.append(s);
-                s = s.next;
-                if (s == head) {
-                    break;
-                }
-            }
-        }
+        appendPoolSubPages(buf, tinySubpagePools);
         buf.append(StringUtil.NEWLINE)
            .append("small subpages:");
-        for (int i = 1; i < smallSubpagePools.length; i ++) {
-            PoolSubpage<T> head = smallSubpagePools[i];
-            if (head.next == head) {
-                continue;
-            }
-
-            buf.append(StringUtil.NEWLINE)
-               .append(i)
-               .append(": ");
-            PoolSubpage<T> s = head.next;
-            for (;;) {
-                buf.append(s);
-                s = s.next;
-                if (s == head) {
-                    break;
-                }
-            }
-        }
+        appendPoolSubPages(buf, smallSubpagePools);
         buf.append(StringUtil.NEWLINE);
 
         return buf.toString();
+    }
+
+    private static void appendPoolSubPages(StringBuilder buf, PoolSubpage<?>[] subpages) {
+        for (int i = 0; i < subpages.length; i ++) {
+            PoolSubpage<?> head = subpages[i];
+            if (head.next == head) {
+                continue;
+            }
+
+            buf.append(StringUtil.NEWLINE)
+                    .append(i)
+                    .append(": ");
+            PoolSubpage<?> s = head.next;
+            for (;;) {
+                buf.append(s);
+                s = s.next;
+                if (s == head) {
+                    break;
+                }
+            }
+        }
     }
 
     static final class HeapArena extends PoolArena<byte[]> {

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -95,6 +95,32 @@ public class PooledByteBufAllocatorTest {
     }
 
     @Test
+    public void testSmallSubpageMetric() {
+        PooledByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 1, 8192, 11, 0, 0, 0);
+        ByteBuf buffer = allocator.heapBuffer(500);
+        try {
+            PoolArenaMetric metric = allocator.heapArenas().get(0);
+            PoolSubpageMetric subpageMetric = metric.smallSubpages().get(0);
+            assertEquals(1, subpageMetric.maxNumElements() - subpageMetric.numAvailable());
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testTinySubpageMetric() {
+        PooledByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 1, 8192, 11, 0, 0, 0);
+        ByteBuf buffer = allocator.heapBuffer(1);
+        try {
+            PoolArenaMetric metric = allocator.heapArenas().get(0);
+            PoolSubpageMetric subpageMetric = metric.tinySubpages().get(0);
+            assertEquals(1, subpageMetric.maxNumElements() - subpageMetric.numAvailable());
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
     public void testFreePoolChunk() {
         int chunkSize = 16 * 1024 * 1024;
         PooledByteBufAllocator allocator = new PooledByteBufAllocator(true, 1, 0, 8192, 11, 0, 0, 0);


### PR DESCRIPTION
Motivation:

Because of a bug we missed to include the first PoolSubpage when collection metrics.

Modifications:

- Correctly include all subpages
- Add unit test

Result:

Correctly include all subpages