### PR TITLE
Include Bundle-NativeCode manifest entry in transport-native-epoll jar.

### DIFF
--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -114,6 +114,9 @@
                 <manifest>
                   <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                 </manifest>
+                <manifestEntries>
+                  <Bundle-NativeCode>META-INF/native/libnetty-transport-native-epoll.so; osname=linux, processor=x86_64"</Bundle-NativeCode>
+                </manifestEntries>
                 <index>true</index>
                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
               </archive>


### PR DESCRIPTION
Motivation:

The build generates a OSGi bundle with missing Bundle-NativeCode manifest entry.

Modifications:

Add missing manifest entry.

Result:

Be able to use transport-native-epoll in osgi container.