### PR TITLE
Use the Runnable.run method to clean direct byte buffers if avaiable.

### DIFF
--- a/src/main/java/org/jboss/netty/util/internal/ByteBufferUtil.java
+++ b/src/main/java/org/jboss/netty/util/internal/ByteBufferUtil.java
@@ -31,10 +31,17 @@ public final class ByteBufferUtil {
         Method directBufferCleanerCleanX = null;
         boolean v;
         try {
-            directBufferCleanerX = Class.forName("java.nio.DirectByteBuffer").getMethod("cleaner");
+            ByteBuffer direct = ByteBuffer.allocateDirect(1);
+            directBufferCleanerX = direct.getClass().getMethod("cleaner");
             directBufferCleanerX.setAccessible(true);
-            directBufferCleanerCleanX = Class.forName("sun.misc.Cleaner").getMethod("clean");
-            directBufferCleanerCleanX.setAccessible(true);
+            Object cleaner = directBufferCleanerX.invoke(direct);
+            try {
+                Runnable runnable = (Runnable) cleaner;
+                directBufferCleanerCleanX = Runnable.class.getDeclaredMethod("run");
+            } catch (ClassCastException ignored) {
+                directBufferCleanerCleanX = cleaner.getClass().getMethod("clean");
+            }
+            directBufferCleanerCleanX.invoke(cleaner);
             v = true;
         } catch (Exception e) {
             v = false;


### PR DESCRIPTION
Motivation:

In JDK9 the Cleaner.clean method cannot be called as it is not exported
from `java.base`. `Runnable.run` should be called instead.

Modifications:
Pick `Runnable.run` if the cleaner implements `Runnable`. Otherwise try the
clean method on the class implementing the cleaner.

Result:
The cleaner for direct byte buffers is run on JDK9 as well as earlier
JDKs.