### PR TITLE
Fix the tcnative lib loading problem in OSGi

### DIFF
--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -331,8 +331,8 @@ public final class NativeLibraryLoader {
         if (classUrl == null) {
             throw new ClassNotFoundException(clazz.getName());
         }
-        byte[] buf = new byte[8192];
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buf = new byte[1024];
+        ByteArrayOutputStream out = new ByteArrayOutputStream(4096);
         InputStream in = null;
         try {
             in = classUrl.openStream();

--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -331,16 +331,12 @@ public final class NativeLibraryLoader {
         if (classUrl == null) {
             throw new ClassNotFoundException(clazz.getName());
         }
-        byte[] buf = new byte[1024];
+        byte[] buf = new byte[8192];
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         InputStream in = null;
         try {
             in = classUrl.openStream();
-            while (true) {
-                int r = in.read(buf);
-                if (r == -1) {
-                    break;
-                }
+            for (int r; (r = in.read(buf)) != -1;) {
                 out.write(buf, 0, r);
             }
             return out.toByteArray();

--- a/common/src/main/java/io/netty/util/internal/NativeLibraryUtil.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+/**
+ * A Utility to Call the System.load() or System.loadLibrary().
+ */
+public final class NativeLibraryUtil {
+    public static void loadLibrary(String libName, boolean absolute) {
+        if (absolute) {
+            System.load(libName);
+        } else {
+            System.loadLibrary(libName);
+        }
+    }
+
+    private NativeLibraryUtil() {
+        // Utility
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/NativeLibraryUtil.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryUtil.java
@@ -19,7 +19,7 @@ package io.netty.util.internal;
  * A Utility to Call the {@link System#load(String)} or {@link System#loadLibrary(String)}.
  * Because the {@link System#load(String)} and {@link System#loadLibrary(String)} are both
  * CallerSensitive, it will load the native library into its caller's {@link ClassLoader}.
- * In OSGi env, we need this helper to delegate the calling to {@link System#load(String)}
+ * In OSGi environment, we need this helper to delegate the calling to {@link System#load(String)}
  * and it should be as simple as possible. It will be injected into the native library's
  * ClassLoader when it is undefined. And therefore, when the defined new helper is invoked,
  * the native library would be loaded into the native library's ClassLoader, not the

--- a/common/src/main/java/io/netty/util/internal/NativeLibraryUtil.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,9 +16,21 @@
 package io.netty.util.internal;
 
 /**
- * A Utility to Call the System.load() or System.loadLibrary().
+ * A Utility to Call the {@link System#load(String)} or {@link System#loadLibrary(String)}.
+ * Because the {@link System#load(String)} and {@link System#loadLibrary(String)} are both
+ * CallerSensitive, it will load the native library into its caller's {@link ClassLoader}.
+ * In OSGi env, we need this helper to delegate the calling to {@link System#load(String)}
+ * and it should be as simple as possible. It will be injected into the native library's
+ * ClassLoader when it is undefined. And therefore, when the defined new helper is invoked,
+ * the native library would be loaded into the native library's ClassLoader, not the
+ * caller's ClassLoader.
  */
-/*package*/ final class NativeLibraryUtil {
+final class NativeLibraryUtil {
+    /**
+     * Delegate the calling to {@link System#load(String)} or {@link System#loadLibrary(String)}.
+     * @param libName - The native library path or name
+     * @param absolute - Whether the native library will be loaded by path or by name
+     */
     public static void loadLibrary(String libName, boolean absolute) {
         if (absolute) {
             System.load(libName);

--- a/common/src/main/java/io/netty/util/internal/NativeLibraryUtil.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryUtil.java
@@ -18,7 +18,7 @@ package io.netty.util.internal;
 /**
  * A Utility to Call the System.load() or System.loadLibrary().
  */
-public final class NativeLibraryUtil {
+/*package*/ final class NativeLibraryUtil {
     public static void loadLibrary(String libName, boolean absolute) {
         if (absolute) {
             System.load(libName);

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -322,16 +322,6 @@ public final class OpenSsl {
         // finally the default library.
         libNames.add("netty-tcnative");
 
-        for (String name : libNames) {
-            try {
-                // Load the native library by the Library.class's classloader.
-                Library.initialize(name);
-                return;
-            } catch (Throwable t) {
-                logger.debug("Unable to load the library: " + name + '.', t);
-            }
-        }
-
         NativeLibraryLoader.loadFirstAvailable(SSL.class.getClassLoader(),
             libNames.toArray(new String[libNames.size()]));
     }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -322,6 +322,16 @@ public final class OpenSsl {
         // finally the default library.
         libNames.add("netty-tcnative");
 
+        for (String name : libNames) {
+            try {
+                // Load the native library by the Library.class's classloader.
+                Library.initialize(name);
+                return;
+            } catch (Throwable t) {
+                logger.debug("Unable to load the library: " + name + '.', t);
+            }
+        }
+
         NativeLibraryLoader.loadFirstAvailable(SSL.class.getClassLoader(),
             libNames.toArray(new String[libNames.size()]));
     }


### PR DESCRIPTION
Motivation:

As the issue #5539 say, the OpenSsl.class will throw `java.lang.UnsatisfiedLinkError: org.apache.tomcat.jni.Library.version(I)I` when it is invoked. This path try to resolve the problem by modifying the native library loading logic of OpenSsl.class.

Modifications:

The OpenSsl.class loads the tcnative lib by `NativeLibraryLoader.loadFirstAvailable()`. The native library will be loaded in the bundle `netty-common`'s ClassLoader, which is diff with the native class's ClassLoader. That is the root cause of throws `UnsatisfiedLinkError` when the native method is invoked.
So, it should load the native library by the its bundle classloader firstly, then the embedded resources if failed.

Result:

First of all, the error threw by native method problem will be resolved.
Secondly, the native library should work as normal in non-OSGi env. But, this is hard. The loading logic of `Library.class` in `netty-tcnative` bundle is simple: try to load the library in PATH env. If not found, it falls back to the originally logic `NativeLibraryLoader.loadFirstAvailable()`.

BTW: this path depend on netty-tcnative-1.1.33.Fork19 version (with Bundle-NativeCode manifest entry added).

Signed-off-by: XU JINCHUAN <xsir@msn.com>