### PR TITLE
Set maxMessagesPerRead to 16 by default in epoll transport to be cons…

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannelConfig.java
@@ -30,6 +30,8 @@ public final class EpollDomainSocketChannelConfig extends EpollChannelConfig
 
     EpollDomainSocketChannelConfig(AbstractEpollChannel channel) {
         super(channel);
+        // Make it consistent with NIO.
+        setMaxMessagesPerRead(16);
     }
 
     @Override

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollSocketChannelConfig.java
@@ -44,6 +44,8 @@ public final class EpollSocketChannelConfig extends EpollChannelConfig implement
         if (PlatformDependent.canEnableTcpNoDelayByDefault()) {
             setTcpNoDelay(true);
         }
+        // Make it consistent with NIO.
+        setMaxMessagesPerRead(16);
     }
 
     @Override


### PR DESCRIPTION
…istent with NIO.

Motivation:

DefaultChannelConfig has a "hack" which will automatically set maxMessagesPerRead to 16 when constructed when either a ServerChannel or a AbstractNioByteChannel is used. As this instanceof check will fail with epoll we should set it there as well.

Modifications:

Set maxMessagesPerRead to 16 by default in EpollDomainSocketChannelConfig and EpollSocketChannelConfig.

Result:

More consistent behavior between epoll and nio when LT mode is used.