### PR TITLE
Acquire Java version simply

### DIFF
--- a/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
+++ b/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
@@ -17,6 +17,7 @@ package io.netty.util.internal;
 
 import org.junit.Test;
 
+import java.security.Permission;
 import java.util.Random;
 
 import static io.netty.util.internal.PlatformDependent.hashCodeAscii;
@@ -128,5 +129,41 @@ public class PlatformDependentTest {
                     hashCodeAscii(bytes, 0, bytes.length),
                     hashCodeAscii(string));
         }
+    }
+
+    @Test
+    public void testMajorVersionFromJavaSpecificationVersion() {
+        final SecurityManager current = System.getSecurityManager();
+
+        try {
+            System.setSecurityManager(new SecurityManager() {
+                @Override
+                public void checkPropertyAccess(String key) {
+                    if (key.equals("java.specification.version")) {
+                        // deny
+                        throw new SecurityException(key);
+                    }
+                }
+
+                // so we can restore the security manager
+                @Override
+                public void checkPermission(Permission perm) {
+                }
+            });
+
+            assertEquals(6, PlatformDependent.majorVersionFromJavaSpecificationVersion());
+        } finally {
+            System.setSecurityManager(current);
+        }
+    }
+
+    @Test
+    public void testMajorVersion() {
+        assertEquals(6, PlatformDependent.majorVersion("1.6"));
+        assertEquals(7, PlatformDependent.majorVersion("1.7"));
+        assertEquals(8, PlatformDependent.majorVersion("1.8"));
+        assertEquals(8, PlatformDependent.majorVersion("8"));
+        assertEquals(9, PlatformDependent.majorVersion("1.9")); // early version of JDK 9 before Project Verona
+        assertEquals(9, PlatformDependent.majorVersion("9"));
     }
 }


### PR DESCRIPTION
Motivation:

The Java version is used for platform dependent logic. Yet, the logic
for acquiring the Java version requires special permissions (the runtime
permission "getClassLoader") that some downstream projects will never
grant. As such, these projects are doomed to have Netty act is their
Java major version is six.  While there are ways to maintain the same
logic without requiring these special permissions, the logic is
needlessly complicated because it relies on loading classes that exist
in version n but not version n - 1. This complexity can be removed. As a
bonanza, the dangerous permission is no longer required.

Modifications:

Rather than attempting to load classes that exist in version n but not
in version n - 1, we can just parse the Java specification version. This
only requires a begign property (property permission
"java.specification.version") and is simple.

Result:

Acquisition of the Java version is safe and simple.