### PR TITLE
Construct LOCALHOST4 and LOCALHOST6 object with hostname "localhost"

### DIFF
--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -134,7 +134,7 @@ public final class NetUtil {
         // Create IPv4 loopback address.
         Inet4Address localhost4 = null;
         try {
-            localhost4 = (Inet4Address) InetAddress.getByAddress(LOCALHOST4_BYTES);
+            localhost4 = (Inet4Address) InetAddress.getByAddress("localhost", LOCALHOST4_BYTES);
         } catch (Exception e) {
             // We should not get here as long as the length of the address is correct.
             PlatformDependent.throwException(e);
@@ -144,7 +144,7 @@ public final class NetUtil {
         // Create IPv6 loopback address.
         Inet6Address localhost6 = null;
         try {
-            localhost6 = (Inet6Address) InetAddress.getByAddress(LOCALHOST6_BYTES);
+            localhost6 = (Inet6Address) InetAddress.getByAddress("localhost", LOCALHOST6_BYTES);
         } catch (Exception e) {
             // We should not get here as long as the length of the address is correct.
             PlatformDependent.throwException(e);

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -166,7 +166,8 @@ public class DnsNameResolverTest {
             "cnet.com",
             "vimeo.com",
             "redtube.com",
-            "blogspot.in")));
+            "blogspot.in",
+            "localhost")));
 
     /**
      * The list of the domain names to exclude from {@link #testResolveAorAAAA()}.
@@ -232,6 +233,7 @@ public class DnsNameResolverTest {
                 "people.com.cn",
                 "googleusercontent.com",
                 "blogspot.in",
+                "localhost",
                 StringUtil.EMPTY_STRING);
     }
 


### PR DESCRIPTION
Motivation:

When resolving localhost on Windows where the hosts file does not contain a localhost entry by default, the resulting InetAddress object returned by the resolver does not have the hostname set so that getHostName returns the ip address 127.0.0.1. This behaviour is inconsistent with Windows where the hosts file does contain a localhost entry and with Linux in any case. It breaks at least some unit tests.

Modifications:

Create the LOCALHOST4 and LOCALHOST6 objects with hostname localhost in addition to the address.
Add unit test domain localhost to DnsNameResolverTest to check the resolution of localhost with ipv4 at least.

Result:

The resolver returns a InetAddress object for localhost with the hostname localhost in all cases.