### PR TITLE
Remove memory copy when checksum non heap backed ByteBuf implementati…

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/Crc32c.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Crc32c.java
@@ -15,8 +15,6 @@
  */
 package io.netty.handler.codec.compression;
 
-import java.util.zip.Checksum;
-
 /**
  * Implements CRC32-C as defined in:
  * "Optimization of Cyclic Redundancy-CHeck Codes with 24 and 32 Parity Bits",
@@ -25,7 +23,7 @@ import java.util.zip.Checksum;
  * The implementation of this class has been sourced from the Appendix of RFC 3309,
  * but with masking due to Java not being able to support unsigned types.
  */
-class Crc32c implements Checksum {
+class Crc32c extends ByteBufChecksum {
     private static final int[] CRC_TABLE = {
             0x00000000, 0xF26B8303, 0xE13B70F7, 0x1350F3F4,
             0xC79A971F, 0x35F1141C, 0x26A1E7E8, 0xD4CA64EB,
@@ -105,8 +103,9 @@ class Crc32c implements Checksum {
 
     @Override
     public void update(byte[] buffer, int offset, int length) {
-        for (int i = offset; i < offset + length; i++) {
-            crc = crc32c(crc, buffer[i]);
+        int end = offset + length;
+        for (int i = offset; i < end; i++) {
+            update(buffer[i]);
         }
     }
 

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoder.java
@@ -223,12 +223,7 @@ public class Lz4FrameDecoder extends ByteToMessageDecoder {
                             uncompressed = in.retainedSlice(in.readerIndex(), decompressedLength);
                             break;
                         case BLOCK_TYPE_COMPRESSED:
-                            uncompressed = checksum == null || checksum.isSupportingByteBuffer()
-                                    // We can allocate whatever buffer if we either not need to do checksum processing
-                                    // or if our ByteBufChecksum implementation supports ByteBuffer.
-                                    // This is needed as Checksum implementations itself only support byte[].
-                                    ? ctx.alloc().buffer(decompressedLength, decompressedLength)
-                                    : ctx.alloc().heapBuffer(decompressedLength, decompressedLength);
+                            uncompressed = ctx.alloc().buffer(decompressedLength, decompressedLength);
 
                             decompressor.decompress(CompressionUtil.safeNioBuffer(in),
                                     uncompressed.internalNioBuffer(uncompressed.writerIndex(), decompressedLength));

--- a/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Snappy.java
@@ -611,14 +611,7 @@ public final class Snappy {
     static int calculateChecksum(ByteBuf data, int offset, int length) {
         Crc32c crc32 = new Crc32c();
         try {
-            if (data.hasArray()) {
-                crc32.update(data.array(), data.arrayOffset() + offset, length);
-            } else {
-                byte[] array = new byte[length];
-                data.getBytes(offset, array);
-                crc32.update(array, 0, length);
-            }
-
+            crc32.update(data, offset, length);
             return maskChecksum((int) crc32.getValue());
         } finally {
             crc32.reset();


### PR DESCRIPTION
…ons using Snappy

Motivation:

We should try to minimize memory copies whenever possible.

Modifications:

- Refactor ByteBufChecksum to work with heap and direct ByteBuf always
- Remove memory copy in Snappy by let Crc32c extend ByteBufChecksum

Result:

Less memory copies when using Snappy