### PR TITLE
Allow ndots=0 in DnsNameResolver and search domains - fixes #5570

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -191,7 +191,7 @@ public class DnsNameResolver extends InetNameResolver {
         this.hostsFileEntriesResolver = checkNotNull(hostsFileEntriesResolver, "hostsFileEntriesResolver");
         this.resolveCache = resolveCache;
         this.searchDomains = checkNotNull(searchDomains, "searchDomains").clone();
-        this.ndots = checkPositive(ndots, "ndots");
+        this.ndots = checkPositiveOrZero(ndots, "ndots");
 
         Bootstrap b = new Bootstrap();
         b.group(executor());

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -321,6 +321,7 @@ public final class DnsNameResolverBuilder {
 
   /**
    * Set the number of dots which must appear in a name before an initial absolute query is made.
+   * The default value is {@code 1}.
    *
    * @param ndots the ndots value
    * @return {@code this}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -123,14 +123,18 @@ abstract class DnsNameResolverContext<T> {
                     }
                 }
             });
-            int dots = 0;
-            for (int idx = hostname.length() - 1; idx >= 0; idx--) {
-                if (hostname.charAt(idx) == '.' && ++dots >= parent.ndots()) {
-                    internalResolve(promise);
-                    return;
+            if (parent.ndots() == 0) {
+                internalResolve(promise);
+            } else {
+                int dots = 0;
+                for (int idx = hostname.length() - 1; idx >= 0; idx--) {
+                    if (hostname.charAt(idx) == '.' && ++dots >= parent.ndots()) {
+                        internalResolve(promise);
+                        return;
+                    }
                 }
+                promise.tryFailure(new UnknownHostException(hostname));
             }
-            promise.tryFailure(new UnknownHostException(hostname));
         }
     }
 


### PR DESCRIPTION
Motivation:

The ndots = 0 is a valid value for ndots, it means that when using a non dotted name, the resolution should first try using a search and if it fails then use subdomains. Currently it is not allowed. Docker compose uses this when wiring up containers as names have usually no dots inside.

Modification:

Modify DnsNameResolver to accept ndots = 0 and handle the case in the resolution procedure. In this case a direct search is done and then a fallback on the search path is performed.

Result:

The ndots = 0 case is implemented.