### PR TITLE
No need to do a memory copy to verify snappy identifier

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java
@@ -19,7 +19,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static io.netty.handler.codec.compression.Snappy.validateChecksum;
@@ -45,7 +44,7 @@ public class SnappyFrameDecoder extends ByteToMessageDecoder {
         RESERVED_SKIPPABLE
     }
 
-    private static final byte[] SNAPPY = { 's', 'N', 'a', 'P', 'p', 'Y' };
+    private static final int SNAPPY_IDENTIFIER_LEN = 6;
     private static final int MAX_UNCOMPRESSED_DATA_SIZE = 65536 + 4;
 
     private final Snappy snappy = new Snappy();
@@ -98,21 +97,24 @@ public class SnappyFrameDecoder extends ByteToMessageDecoder {
 
             switch (chunkType) {
                 case STREAM_IDENTIFIER:
-                    if (chunkLength != SNAPPY.length) {
+                    if (chunkLength != SNAPPY_IDENTIFIER_LEN) {
                         throw new DecompressionException("Unexpected length of stream identifier: " + chunkLength);
                     }
 
-                    if (inSize < 4 + SNAPPY.length) {
+                    if (inSize < 4 + SNAPPY_IDENTIFIER_LEN) {
                         break;
                     }
 
-                    byte[] identifier = new byte[chunkLength];
-                    in.skipBytes(4).readBytes(identifier);
+                    in.skipBytes(4);
+                    int offset = in.readerIndex();
+                    in.skipBytes(SNAPPY_IDENTIFIER_LEN);
 
-                    if (!Arrays.equals(identifier, SNAPPY)) {
-                        throw new DecompressionException("Unexpected stream identifier contents. Mismatched snappy " +
-                                "protocol version?");
-                    }
+                    checkByte(in.getByte(offset++), (byte) 's');
+                    checkByte(in.getByte(offset++), (byte) 'N');
+                    checkByte(in.getByte(offset++), (byte) 'a');
+                    checkByte(in.getByte(offset++), (byte) 'P');
+                    checkByte(in.getByte(offset++), (byte) 'p');
+                    checkByte(in.getByte(offset), (byte) 'Y');
 
                     started = true;
                     break;
@@ -186,6 +188,13 @@ public class SnappyFrameDecoder extends ByteToMessageDecoder {
         } catch (Exception e) {
             corrupted = true;
             throw e;
+        }
+    }
+
+    private static void checkByte(byte actual, byte expect) {
+        if (actual != expect) {
+            throw new DecompressionException("Unexpected stream identifier contents. Mismatched snappy " +
+                    "protocol version?");
         }
     }
 


### PR DESCRIPTION
Motivation:

We are currently doing a memory copy to verify the snapy version. This is not needed.

Modifications:

Remove memory copy and just compare byte per byte.

Result:

Less memory copies and allocations