### PR TITLE
Add NonStickyEventExecutorGroup

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutor.java
@@ -15,6 +15,9 @@
  */
 package io.netty.util.concurrent;
 
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -28,6 +31,7 @@ import java.util.concurrent.TimeUnit;
  * Abstract base class for {@link EventExecutor} implementations.
  */
 public abstract class AbstractEventExecutor extends AbstractExecutorService implements EventExecutor {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractEventExecutor.class);
 
     static final long DEFAULT_SHUTDOWN_QUIET_PERIOD = 2;
     static final long DEFAULT_SHUTDOWN_TIMEOUT = 15;
@@ -149,5 +153,16 @@ public abstract class AbstractEventExecutor extends AbstractExecutorService impl
     @Override
     public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Try to execute the given {@link Runnable} and just log if it throws a {@link Throwable}.
+     */
+    protected static void safeExecute(Runnable task) {
+        try {
+            task.run();
+        } catch (Throwable t) {
+            logger.warn("A task raised an exception. Task: {}", task, t);
+        }
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/NonStickyEventExecutorGroup.java
+++ b/common/src/main/java/io/netty/util/concurrent/NonStickyEventExecutorGroup.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.UnstableApi;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * {@link EventExecutorGroup} which will preserve {@link Runnable} execution order but makes no guarantees about what
+ * {@link EventExecutor} (and therefore {@link Thread}) will be used to execute the {@link Runnable}s.
+ *
+ * <p>The {@link EventExecutorGroup#next()} for the wrapped {@link EventExecutorGroup} must <strong>NOT</strong> return
+ * executors of type {@link OrderedEventExecutor}.
+ */
+@UnstableApi
+public final class NonStickyEventExecutorGroup implements EventExecutorGroup {
+    private final EventExecutorGroup group;
+    private final int maxTaskExecutePerRun;
+
+    /**
+     * Creates a new instance. Be aware that the given {@link EventExecutorGroup} <strong>MUST NOT</strong> contain
+     * any {@link OrderedEventExecutor}s.
+     */
+    public NonStickyEventExecutorGroup(EventExecutorGroup group) {
+        this(group, 1024);
+    }
+
+    /**
+     * Creates a new instance. Be aware that the given {@link EventExecutorGroup} <strong>MUST NOT</strong> contain
+     * any {@link OrderedEventExecutor}s.
+     */
+    public NonStickyEventExecutorGroup(EventExecutorGroup group, int maxTaskExecutePerRun) {
+        this.group = verify(group);
+        this.maxTaskExecutePerRun = ObjectUtil.checkPositive(maxTaskExecutePerRun, "maxTaskExecutePerRun");
+    }
+
+    private static EventExecutorGroup verify(EventExecutorGroup group) {
+        Iterator<EventExecutor> executors = ObjectUtil.checkNotNull(group, "group").iterator();
+        while (executors.hasNext()) {
+            EventExecutor executor = executors.next();
+            if (executor instanceof OrderedEventExecutor) {
+                throw new IllegalArgumentException("EventExecutorGroup " + group
+                        + " contains OrderedEventExecutors: " + executor);
+            }
+        }
+        return group;
+    }
+
+    private NonStickyOrderedEventExecutor newExecutor(EventExecutor executor) {
+        return new NonStickyOrderedEventExecutor(executor, maxTaskExecutePerRun);
+    }
+
+    @Override
+    public boolean isShuttingDown() {
+        return group.isShuttingDown();
+    }
+
+    @Override
+    public Future<?> shutdownGracefully() {
+        return group.shutdownGracefully();
+    }
+
+    @Override
+    public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
+        return group.shutdownGracefully(quietPeriod, timeout, unit);
+    }
+
+    @Override
+    public Future<?> terminationFuture() {
+        return group.terminationFuture();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public void shutdown() {
+        group.shutdown();
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public List<Runnable> shutdownNow() {
+        return group.shutdownNow();
+    }
+
+    @Override
+    public EventExecutor next() {
+        return newExecutor(group.next());
+    }
+
+    @Override
+    public Iterator<EventExecutor> iterator() {
+        final Iterator<EventExecutor> itr = group.iterator();
+        return new Iterator<EventExecutor>() {
+            @Override
+            public boolean hasNext() {
+                return itr.hasNext();
+            }
+
+            @Override
+            public EventExecutor next() {
+                return newExecutor(itr.next());
+            }
+
+            @Override
+            public void remove() {
+                itr.remove();
+            }
+        };
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return group.submit(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return group.submit(task, result);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return group.submit(task);
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return group.schedule(command, delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return group.schedule(callable, delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return group.scheduleAtFixedRate(command, initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return group.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return group.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return group.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return group.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> List<java.util.concurrent.Future<T>> invokeAll(
+            Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return group.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<java.util.concurrent.Future<T>> invokeAll(
+            Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return group.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return group.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return group.invokeAny(tasks, timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        group.execute(command);
+    }
+
+    private static final class NonStickyOrderedEventExecutor extends AbstractEventExecutor
+            implements Runnable, OrderedEventExecutor {
+        private final EventExecutor executor;
+        private final Queue<Runnable> tasks = PlatformDependent.newMpscQueue();
+
+        private static final int NONE = 0;
+        private static final int SUBMITTED = 1;
+        private static final int RUNNING = 2;
+
+        private final AtomicInteger state = new AtomicInteger();
+        private final int maxTaskExecutePerRun;
+
+        NonStickyOrderedEventExecutor(EventExecutor executor, int maxTaskExecutePerRun) {
+            super(executor);
+            this.executor = executor;
+            this.maxTaskExecutePerRun = maxTaskExecutePerRun;
+        }
+
+        @Override
+        public void run() {
+            if (!state.compareAndSet(SUBMITTED, RUNNING)) {
+                return;
+            }
+            for (;;) {
+                int i = 0;
+                try {
+                    for (; i < maxTaskExecutePerRun; i++) {
+                        Runnable task = tasks.poll();
+                        if (task == null) {
+                            break;
+                        }
+                        safeExecute(task);
+                    }
+                } finally {
+                    if (i == maxTaskExecutePerRun) {
+                        try {
+                            state.set(SUBMITTED);
+                            executor.execute(this);
+                            return; // done
+                        } catch (Throwable ignore) {
+                            // Reset the state back to running as we will keep on executing tasks.
+                            state.set(RUNNING);
+                            // if an error happened we should just ignore it and let the loop run again as there is not
+                            // much else we can do. Most likely this was triggered by a full task queue. In this case
+                            // we just will run more tasks and try again later.
+                        }
+                    } else {
+                        state.set(NONE);
+                        return; // done
+                    }
+                }
+            }
+        }
+
+        @Override
+        public boolean inEventLoop(Thread thread) {
+            return false;
+        }
+
+        @Override
+        public boolean inEventLoop() {
+            return false;
+        }
+
+        @Override
+        public boolean isShuttingDown() {
+            return executor.isShutdown();
+        }
+
+        @Override
+        public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
+            return executor.shutdownGracefully(quietPeriod, timeout, unit);
+        }
+
+        @Override
+        public Future<?> terminationFuture() {
+            return executor.terminationFuture();
+        }
+
+        @Override
+        public void shutdown() {
+            executor.shutdown();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            return executor.isShutdown();
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return executor.isTerminated();
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            return executor.awaitTermination(timeout, unit);
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            if (!tasks.offer(command)) {
+                throw new RejectedExecutionException();
+            }
+            if (state.compareAndSet(NONE, SUBMITTED)) {
+                // Actually it could happen that the runnable was picked up in between but we not care to much and just
+                // execute ourself. At worst this will be a NOOP when run() is called.
+                try {
+                    executor.execute(this);
+                } catch (Throwable e) {
+                    // Not reset the state as some other Runnable may be added to the queue already in the meantime.
+                    tasks.remove(command);
+                    PlatformDependent.throwException(e);
+                }
+            }
+        }
+    }
+}

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -445,15 +445,6 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
      */
     @UnstableApi
     protected void afterRunningAllTasks() { }
-
-    private static void safeExecute(Runnable task) {
-        try {
-            task.run();
-        } catch (Throwable t) {
-            logger.warn("A task raised an exception. Task: {}", task, t);
-        }
-    }
-
     /**
      * Returns the amount of time left until the scheduled task with the closest dead line is executed.
      */

--- a/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+@RunWith(Parameterized.class)
+public class NonStickyEventExecutorGroupTest {
+
+    private final int maxTaskExecutePerRun;
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidGroup() {
+        EventExecutorGroup group = new DefaultEventExecutorGroup(1);
+        try {
+            new NonStickyEventExecutorGroup(group);
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Parameterized.Parameters(name = "{index}: maxTaskExecutePerRun = {0}")
+    public static Collection<Object[]> data() throws Exception {
+        List<Object[]> params = new ArrayList<Object[]>();
+        params.add(new Object[] {64});
+        params.add(new Object[] {256});
+        params.add(new Object[] {1024});
+        params.add(new Object[] {Integer.MAX_VALUE});
+        return params;
+    }
+
+    public NonStickyEventExecutorGroupTest(int maxTaskExecutePerRun) {
+        this.maxTaskExecutePerRun = maxTaskExecutePerRun;
+    }
+
+    @Test(timeout = 10000)
+    public void testOrdering() throws Throwable {
+        final int threads = Runtime.getRuntime().availableProcessors() * 2;
+        final EventExecutorGroup group = new UnorderedThreadPoolEventExecutor(threads);
+        final NonStickyEventExecutorGroup nonStickyGroup = new NonStickyEventExecutorGroup(group, maxTaskExecutePerRun);
+        try {
+            final CountDownLatch startLatch = new CountDownLatch(1);
+            final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+            List<Thread> threadList = new ArrayList<Thread>(threads);
+            for (int i = 0 ; i < threads; i++) {
+                Thread thread = new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            execute(nonStickyGroup, startLatch);
+                        } catch (Throwable cause) {
+                            error.compareAndSet(null, cause);
+                        }
+                    }
+                });
+                threadList.add(thread);
+                thread.start();
+            }
+            startLatch.countDown();
+            for (Thread t: threadList) {
+                t.join();
+            }
+            Throwable cause = error.get();
+            if (cause != null) {
+                throw cause;
+            }
+        } finally {
+            nonStickyGroup.shutdownGracefully();
+        }
+    }
+
+    private static void execute(EventExecutorGroup group, CountDownLatch startLatch) throws Throwable {
+        EventExecutor executor = group.next();
+        Assert.assertTrue(executor instanceof OrderedEventExecutor);
+        final AtomicReference<Throwable> cause = new AtomicReference<Throwable>();
+        final AtomicInteger last = new AtomicInteger();
+        int tasks = 10000;
+        List<Future<?>> futures = new ArrayList<Future<?>>(tasks);
+        final CountDownLatch latch = new CountDownLatch(tasks);
+        startLatch.await();
+
+        for (int i = 1 ; i <= tasks; i++) {
+            final int id = i;
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        if (cause.get() == null) {
+                            int lastId = last.get();
+                            if (lastId >= id) {
+                                cause.compareAndSet(null, new AssertionError(
+                                        "Out of order execution id(" + id + ") >= lastId(" + lastId + ')'));
+                            }
+                            if (!last.compareAndSet(lastId, id)) {
+                                cause.compareAndSet(null, new AssertionError("Concurrent execution of tasks"));
+                            }
+                        }
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+            });
+        }
+        latch.await();
+        for (Future<?> future: futures) {
+            future.syncUninterruptibly();
+        }
+        Throwable error = cause.get();
+        if (error != null) {
+            throw error;
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

We offer DefaultEventExecutorGroup as an EventExecutorGroup which return OrderedEventExecutor and so provide strict ordering of event execution. One limitations of this implementation is that each contained DefaultEventExecutor will always be tied to a single thread, which can lead to a very unbalanced execution as one thread may be super busy while others are idling.

Modifications:

- Add NonStickyEventExecutorGroup which can be used to wrap another EventExecutorGroup (like UnorderedThreadPoolEventExecutor) and expose ordering while not be sticky with the thread that is used for a given EventExecutor. This basically means that Threads may change between execution of tasks for an EventExecutor but ordering is still guaranteed.

Result:

Better utalization of threads in some use-cases.