### PR TITLE
Reduce conditionals in AbstractReferenceCounted

### DIFF
--- a/common/src/main/java/io/netty/util/AbstractReferenceCounted.java
+++ b/common/src/main/java/io/netty/util/AbstractReferenceCounted.java
@@ -53,11 +53,8 @@ public abstract class AbstractReferenceCounted implements ReferenceCounted {
     public ReferenceCounted retain() {
         for (;;) {
             int refCnt = this.refCnt;
-            if (refCnt == 0) {
-                throw new IllegalReferenceCountException(0, 1);
-            }
-            if (refCnt == Integer.MAX_VALUE) {
-                throw new IllegalReferenceCountException(Integer.MAX_VALUE, 1);
+            if (refCnt == 0 || refCnt == Integer.MAX_VALUE) {
+                throw new IllegalReferenceCountException(refCnt, 1);
             }
             if (refCntUpdater.compareAndSet(this, refCnt, refCnt + 1)) {
                 break;
@@ -73,14 +70,12 @@ public abstract class AbstractReferenceCounted implements ReferenceCounted {
         }
 
         for (;;) {
+            final int nextCnt;
             int refCnt = this.refCnt;
-            if (refCnt == 0) {
-                throw new IllegalReferenceCountException(0, 1);
-            }
-            if (refCnt > Integer.MAX_VALUE - increment) {
+            if (refCnt == 0 || (nextCnt = refCnt + increment) < 0) {
                 throw new IllegalReferenceCountException(refCnt, increment);
             }
-            if (refCntUpdater.compareAndSet(this, refCnt, refCnt + increment)) {
+            if (refCntUpdater.compareAndSet(this, refCnt, nextCnt)) {
                 break;
             }
         }


### PR DESCRIPTION
Motivation:
AbstractReferenceCounted as independent conditional statements to check the bounds of the retain IllegalReferenceCountException condition. One of the exceptions also uses the incorrect increment.

Modifications:
- Combined independent conditional checks into 1 where possible
- Correct IllegalReferenceCountException with incorrect increment

Result:
AbstractReferenceCounted has less independent branch statements and more correct IllegalReferenceCountException. Compilation size of AbstractReferenceCounted.retain() is reduced from 58 bytes to 47 bytes.