### PR TITLE
[#5541] Ensure failing a Promise in SimpleChannelPool will not result…

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -149,7 +149,7 @@ public class SimpleChannelPool implements ChannelPool {
                 });
             }
         } catch (Throwable cause) {
-            promise.setFailure(cause);
+            promise.tryFailure(cause);
         }
         return promise;
     }
@@ -162,7 +162,7 @@ public class SimpleChannelPool implements ChannelPool {
                 release(channel);
             }
         } else {
-            promise.setFailure(future.cause());
+            promise.tryFailure(future.cause());
         }
     }
 
@@ -310,7 +310,7 @@ public class SimpleChannelPool implements ChannelPool {
 
     private static void closeAndFail(Channel channel, Throwable cause, Promise<?> promise) {
         closeChannel(channel);
-        promise.setFailure(cause);
+        promise.tryFailure(cause);
     }
 
     /**


### PR DESCRIPTION
… in stack overflow.

Motivation:

We used Promise.setFailure(...) when fail a Promise in SimpleChannelPool. As this happens in multiple levels this can result in stackoverflow as setFailure(...) may throw an IllegalStateException which then again is propergated.

Modifications:

Use tryFailure(...)

Result:

No more possibility to cause a stack overflow when failing the promise.