### PR TITLE
Correctly return a retained slice if called SwappedByteBuf.retainedSl…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SlicedByteBuf.java
@@ -28,6 +28,8 @@ import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 import java.nio.charset.Charset;
 
+import static io.netty.util.internal.MathUtil.isOutOfBounds;
+
 /**
  * A derived buffer which exposes its parent's sub-region only.  It is
  * recommended to use {@link ByteBuf#slice()} and
@@ -45,7 +47,7 @@ public class SlicedByteBuf extends AbstractDerivedByteBuf {
 
     public SlicedByteBuf(ByteBuf buffer, int index, int length) {
         super(length);
-        if (index < 0 || index > buffer.capacity() - length) {
+        if (isOutOfBounds(index, length, buffer.capacity())) {
             throw new IndexOutOfBoundsException(buffer + ".slice(" + index + ", " + length + ')');
         }
 

--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -896,7 +896,7 @@ public class SwappedByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf retainedSlice() {
-        return buf.slice().order(order);
+        return buf.retainedSlice().order(order);
     }
 
     @Override
@@ -906,7 +906,7 @@ public class SwappedByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf retainedSlice(int index, int length) {
-        return buf.slice(index, length).order(order);
+        return buf.retainedSlice(index, length).order(order);
     }
 
     @Override


### PR DESCRIPTION
…ice(...)

Motivation:

SwappedByteBuf.retainedSlice(...) did not return a retained buffer.

Modifications:

Correctly delegate to retainedSlice(..) calls.

Result:

Correctly return retained slice.