### PR TITLE
[#5598] Ensure SslHandler not log false-positives when try to close t…

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/ChannelPromiseNotifier.java
@@ -18,7 +18,7 @@ package io.netty.channel;
 import io.netty.util.concurrent.PromiseNotifier;
 
 /**
- * ChannelFutureListener implementation which takes other {@link ChannelFuture}(s) and notifies them on completion.
+ * ChannelFutureListener implementation which takes other {@link ChannelPromise}(s) and notifies them on completion.
  */
 public final class ChannelPromiseNotifier
     extends PromiseNotifier<Void, ChannelFuture>
@@ -31,5 +31,15 @@ public final class ChannelPromiseNotifier
      */
     public ChannelPromiseNotifier(ChannelPromise... promises) {
         super(promises);
+    }
+
+    /**
+     * Create a new instance
+     *
+     * @param logNotifyFailure {@code true} if logging should be done in case notification fails.
+     * @param promises  the {@link ChannelPromise}s to notify once this {@link ChannelFutureListener} is notified.
+     */
+    public ChannelPromiseNotifier(boolean logNotifyFailure, ChannelPromise... promises) {
+        super(logNotifyFailure, promises);
     }
 }


### PR DESCRIPTION
…he channel due timeout.

Motivation:

When we try to close the Channel due a timeout we need to ensure we not log if the notification of the promise fails as it may be completed in the meantime.

Modifications:

Add another constructor to ChannelPromiseNotifier and PromiseNotifier which allows to log on notification failure.

Result:

No more miss-leading logs.