### PR TITLE
UnknownHostException mentions hostname with search domain added

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -69,6 +69,7 @@ abstract class DnsNameResolverContext<T> {
     private final DnsNameResolver parent;
     private final DnsServerAddressStream nameServerAddrs;
     private final String hostname;
+    protected String pristineHostname;
     private final DnsCache resolveCache;
     private final boolean traceEnabled;
     private final int maxAllowedQueries;
@@ -116,6 +117,7 @@ abstract class DnsNameResolverContext<T> {
                         String nextHostname = DnsNameResolverContext.this.hostname + "." + searchDomain;
                         DnsNameResolverContext<T> nextContext = newResolverContext(parent,
                             nextHostname, resolveCache);
+                        nextContext.pristineHostname = hostname;
                         nextContext.internalResolve(nextPromise);
                         nextPromise.addListener(this);
                     } else {
@@ -449,8 +451,13 @@ abstract class DnsNameResolverContext<T> {
         final int tries = maxAllowedQueries - allowedQueries;
         final StringBuilder buf = new StringBuilder(64);
 
-        buf.append("failed to resolve '")
-           .append(hostname).append('\'');
+        buf.append("failed to resolve '");
+        if (pristineHostname != null) {
+          buf.append(pristineHostname);
+        } else {
+          buf.append(hostname);
+        }
+        buf.append('\'');
         if (tries > 1) {
             if (tries < maxAllowedQueries) {
                 buf.append(" after ")


### PR DESCRIPTION
Motivation:

When a hostname cannot be resolved, the message in the UnknownHostException mentions the hostname with the last attempted search domain appended, which is kind of confusing. I would prefer to see the original hostname supplied to the method in the exception.

Modifications:

Store the pristine hostname in the resolver context and use it to create the exception message instead of the hostname with search domain.
Add unit test to check that the exception does not mention the search domain.

Result:

The exception mentions the unmodified hostname in the message.