### PR TITLE
Removed unnecessary static instance creation and removed private cons…

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
@@ -35,15 +35,6 @@ import static io.netty.handler.codec.mqtt.MqttCodecUtil.*;
 @ChannelHandler.Sharable
 public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
 
-    public static final MqttEncoder INSTANCE = new MqttEncoder();
-
-    private MqttEncoder() { }
-
-    @Override
-    protected void encode(ChannelHandlerContext ctx, MqttMessage msg, List<Object> out) throws Exception {
-        out.add(doEncode(ctx.alloc(), msg));
-    }
-
     /**
      * This is the main encoding method.
      * It's only visible for testing.
@@ -387,5 +378,10 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
 
     private static byte[] encodeStringUtf8(String s) {
       return s.getBytes(CharsetUtil.UTF_8);
+    }
+
+    @Override
+    protected void encode(ChannelHandlerContext ctx, MqttMessage msg, List<Object> out) throws Exception {
+        out.add(doEncode(ctx.alloc(), msg));
     }
 }


### PR DESCRIPTION
Motivation:

It is up to end user to either create static instance of Sharable MqttEncoder or create separate instance when needed.

Modifications:
Removed `public static INSTANCE` variable.
Removed `private` constructor.

