### PR TITLE
Small performance fix : unnecessary unboxing operations removed

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -141,7 +141,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
             int equalsPos = encoding.indexOf('=');
             if (equalsPos != -1) {
                 try {
-                    q = Float.valueOf(encoding.substring(equalsPos + 1));
+                    q = Float.parseFloat(encoding.substring(equalsPos + 1));
                 } catch (NumberFormatException e) {
                     // Ignore encoding
                     q = 0.0f;

--- a/codec/src/main/java/io/netty/handler/codec/CharSequenceValueConverter.java
+++ b/codec/src/main/java/io/netty/handler/codec/CharSequenceValueConverter.java
@@ -82,7 +82,7 @@ public class CharSequenceValueConverter implements ValueConverter<CharSequence> 
         if (value instanceof AsciiString) {
             return ((AsciiString) value).byteAt(0);
         }
-        return Byte.valueOf(value.toString());
+        return Byte.parseByte(value.toString());
     }
 
     @Override
@@ -100,7 +100,7 @@ public class CharSequenceValueConverter implements ValueConverter<CharSequence> 
         if (value instanceof AsciiString) {
             return ((AsciiString) value).parseShort();
         }
-        return Short.valueOf(value.toString());
+        return Short.parseShort(value.toString());
     }
 
     @Override
@@ -139,7 +139,7 @@ public class CharSequenceValueConverter implements ValueConverter<CharSequence> 
         if (value instanceof AsciiString) {
             return ((AsciiString) value).parseFloat();
         }
-        return Float.valueOf(value.toString());
+        return Float.parseFloat(value.toString());
     }
 
     @Override
@@ -147,6 +147,6 @@ public class CharSequenceValueConverter implements ValueConverter<CharSequence> 
         if (value instanceof AsciiString) {
             return ((AsciiString) value).parseDouble();
         }
-        return Double.valueOf(value.toString());
+        return Double.parseDouble(value.toString());
     }
 }


### PR DESCRIPTION
Motivation : 

Unboxing operations allocate unnecessary objects when it could be avoided.

Modifications:
Replaced `Float.valueOf` with `Number.parseFloat` where possible.

Result:

Less unnecessary objects allocations.