### PR TITLE
Add support for Client Subnet in DNS Queries (RFC7871)

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsOptPseudoRrRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsOptPseudoRrRecord.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.UnstableApi;
+
+/**
+ * An <a href="https://tools.ietf.org/html/rfc6891#section-6.1">OPT RR</a> record.
+ *
+ * This is used for <a href="https://tools.ietf.org/html/rfc6891#section-6.1.3">
+ *     Extension Mechanisms for DNS (EDNS(0))</a>.
+ */
+@UnstableApi
+public abstract class AbstractDnsOptPseudoRrRecord extends AbstractDnsRecord implements DnsOptPseudoRecord {
+
+    protected AbstractDnsOptPseudoRrRecord(int maxPayloadSize, int extendedRcode, int version) {
+        super(StringUtil.EMPTY_STRING, DnsRecordType.OPT, maxPayloadSize, packIntoLong(extendedRcode, version));
+    }
+
+    protected AbstractDnsOptPseudoRrRecord(int maxPayloadSize) {
+        super(StringUtil.EMPTY_STRING, DnsRecordType.OPT, maxPayloadSize, 0);
+    }
+
+    // See https://tools.ietf.org/html/rfc6891#section-6.1.3
+    private static long packIntoLong(int val, int val2) {
+        // We are currently not support DO and Z fields, just use 0.
+        return ((val & 0xff) << 24 | (val2 & 0xff) << 16 | (0 & 0xff) <<  8 | 0 & 0xff) & 0xFFFFFFFFL;
+    }
+
+    @Override
+    public int extendedRcode() {
+        return (short) (((int) timeToLive() >> 24) & 0xff);
+    }
+
+    @Override
+    public int version() {
+        return (short) (((int) timeToLive() >> 16) & 0xff);
+    }
+
+    @Override
+    public int flags() {
+       return (short) ((short) timeToLive() & 0xff);
+    }
+
+    @Override
+    public String toString() {
+        return toStringBuilder().toString();
+    }
+
+    final StringBuilder toStringBuilder() {
+        return new StringBuilder(64)
+                .append(StringUtil.simpleClassName(this))
+                .append('(')
+                .append("OPT flags:")
+                .append(flags())
+                .append(" version:")
+                .append(version())
+                .append(" extendedRecode:")
+                .append(extendedRcode())
+                .append(" udp:")
+                .append(dnsClass())
+                .append(')');
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsOptEcsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsOptEcsRecord.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.channel.socket.InternetProtocolFamily;
+import io.netty.util.internal.UnstableApi;
+
+import java.net.InetAddress;
+import java.util.Arrays;
+
+/**
+ * Default {@link DnsOptEcsRecord} implementation.
+ */
+@UnstableApi
+public final class DefaultDnsOptEcsRecord extends AbstractDnsOptPseudoRrRecord implements DnsOptEcsRecord {
+    private final int srcPrefixLength;
+    private final byte[] address;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param maxPayloadSize the suggested max payload size in bytes
+     * @param extendedRcode the extended rcode
+     * @param version the version
+     * @param srcPrefixLength the prefix length
+     * @param address the bytes of the {@link InetAddress} to use
+     */
+    public DefaultDnsOptEcsRecord(int maxPayloadSize, int extendedRcode, int version,
+                                  int srcPrefixLength, byte[] address) {
+        super(maxPayloadSize, extendedRcode, version);
+        this.srcPrefixLength = srcPrefixLength;
+        this.address = verifyAddress(address).clone();
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param maxPayloadSize the suggested max payload size in bytes
+     * @param srcPrefixLength the prefix length
+     * @param address the bytes of the {@link InetAddress} to use
+     */
+    public DefaultDnsOptEcsRecord(int maxPayloadSize, int srcPrefixLength, byte[] address) {
+        this(maxPayloadSize, 0, 0, srcPrefixLength, address);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param maxPayloadSize the suggested max payload size in bytes
+     * @param protocolFamily the {@link InternetProtocolFamily} to use. This should be the same as the one used to
+     *                       send the query.
+     */
+    public DefaultDnsOptEcsRecord(int maxPayloadSize, InternetProtocolFamily protocolFamily) {
+        this(maxPayloadSize, 0, 0, 0, protocolFamily.localhost().getAddress());
+    }
+
+    private static byte[] verifyAddress(byte[] bytes) {
+        if (bytes.length == 4 || bytes.length == 16) {
+            return bytes;
+        }
+        throw new IllegalArgumentException("bytes.length must either 4 or 16");
+    }
+
+    @Override
+    public int sourcePrefixLength() {
+        return srcPrefixLength;
+    }
+
+    @Override
+    public int scopePrefixLength() {
+        return 0;
+    }
+
+    @Override
+    public byte[] address() {
+        return address.clone();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = toStringBuilder();
+        sb.setLength(sb.length() - 1);
+        return sb.append(" address:")
+          .append(Arrays.toString(address))
+          .append(" sourcePrefixLength:")
+          .append(sourcePrefixLength())
+          .append(" scopePrefixLength:")
+          .append(scopePrefixLength())
+          .append(')').toString();
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoder.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.dns;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.handler.codec.UnsupportedMessageTypeException;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.UnstableApi;
@@ -30,6 +31,7 @@ import static io.netty.handler.codec.dns.DefaultDnsRecordDecoder.ROOT;
  */
 @UnstableApi
 public class DefaultDnsRecordEncoder implements DnsRecordEncoder {
+    private static final int PREFIX_MASK = Byte.SIZE - 1;
 
     /**
      * Creates a new instance.
@@ -49,6 +51,10 @@ public class DefaultDnsRecordEncoder implements DnsRecordEncoder {
             encodeQuestion((DnsQuestion) record, out);
         } else if (record instanceof DnsPtrRecord) {
             encodePtrRecord((DnsPtrRecord) record, out);
+        } else if (record instanceof DnsOptEcsRecord) {
+            encodeOptEcsRecord((DnsOptEcsRecord) record, out);
+        } else if (record instanceof DnsOptPseudoRecord) {
+            encodeOptPseudoRecord((DnsOptPseudoRecord) record, out);
         } else if (record instanceof DnsRawRecord) {
             encodeRawRecord((DnsRawRecord) record, out);
         } else {
@@ -56,22 +62,76 @@ public class DefaultDnsRecordEncoder implements DnsRecordEncoder {
         }
     }
 
-    private void encodePtrRecord(DnsPtrRecord record, ByteBuf out) throws Exception {
+    private void encodeRecord0(DnsRecord record, ByteBuf out) throws Exception {
         encodeName(record.name(), out);
-
         out.writeShort(record.type().intValue());
         out.writeShort(record.dnsClass());
         out.writeInt((int) record.timeToLive());
+    }
 
+    private void encodePtrRecord(DnsPtrRecord record, ByteBuf out) throws Exception {
+        encodeRecord0(record, out);
         encodeName(record.hostname(), out);
     }
 
-    private void encodeRawRecord(DnsRawRecord record, ByteBuf out) throws Exception {
-        encodeName(record.name(), out);
+    private void encodeOptPseudoRecord(DnsOptPseudoRecord record, ByteBuf out) throws Exception {
+        encodeRecord0(record, out);
+        out.writeShort(0);
+    }
 
-        out.writeShort(record.type().intValue());
-        out.writeShort(record.dnsClass());
-        out.writeInt((int) record.timeToLive());
+    private void encodeOptEcsRecord(DnsOptEcsRecord record, ByteBuf out) throws Exception {
+        encodeRecord0(record, out);
+
+        int sourcePrefixLength = record.sourcePrefixLength();
+        int scopePrefixLength = record.scopePrefixLength();
+        int lowOrderBitsToPreserve = sourcePrefixLength & PREFIX_MASK;
+
+        byte[] bytes = record.address();
+        int addressBits = bytes.length << 3;
+        if (addressBits < sourcePrefixLength || sourcePrefixLength < 0) {
+            throw new IllegalArgumentException(sourcePrefixLength + ": " +
+                    sourcePrefixLength + " (expected: 0 >= " + addressBits + ')');
+        }
+
+        // See http://www.iana.org/assignments/address-family-numbers/address-family-numbers.xhtml
+        final short addressNumber = (short) (bytes.length == 4 ?
+                InternetProtocolFamily.IPv4.addressNumber() : InternetProtocolFamily.IPv6.addressNumber());
+        int payloadLength = calculateEcsAddressLength(sourcePrefixLength, lowOrderBitsToPreserve);
+
+        int fullPayloadLength = 2 + // OPTION-CODE
+                2 + // OPTION-LENGTH
+                2 + // FAMILY
+                1 + // SOURCE PREFIX-LENGTH
+                1 + // SCOPE PREFIX-LENGTH
+                payloadLength; //  ADDRESS...
+
+        out.writeShort(fullPayloadLength);
+        out.writeShort(8); // This is the defined type for ECS.
+
+        out.writeShort(fullPayloadLength - 4); // Not include OPTION-CODE and OPTION-LENGTH
+        out.writeShort(addressNumber);
+        out.writeByte(sourcePrefixLength);
+        out.writeByte(scopePrefixLength); // Must be 0 in queries.
+
+        if (lowOrderBitsToPreserve > 0) {
+            int bytesLength = payloadLength - 1;
+            out.writeBytes(bytes, 0, bytesLength);
+
+            // Pad the leftover of the last byte with zeros.
+            out.writeByte(padWithZeros(bytes[bytesLength], lowOrderBitsToPreserve));
+        } else {
+            // The sourcePrefixLength align with Byte so just copy in the bytes directly.
+            out.writeBytes(bytes, 0, payloadLength);
+        }
+    }
+
+    // Package-Private for testing
+    static int calculateEcsAddressLength(int sourcePrefixLength, int lowOrderBitsToPreserve) {
+        return (sourcePrefixLength >>> 3) + (lowOrderBitsToPreserve != 0 ? 1 : 0);
+    }
+
+    private void encodeRawRecord(DnsRawRecord record, ByteBuf out) throws Exception {
+        encodeRecord0(record, out);
 
         ByteBuf content = record.content();
         int contentLen = content.readableBytes();
@@ -100,5 +160,31 @@ public class DefaultDnsRecordEncoder implements DnsRecordEncoder {
         }
 
         buf.writeByte(0); // marks end of name field
+    }
+
+    // Package private so it can be reused in the test.
+    static byte padWithZeros(byte b, int lowOrderBitsToPreserve) {
+        switch (lowOrderBitsToPreserve) {
+        case 0:
+            return 0;
+        case 1:
+            return (byte) (0x01 & b);
+        case 2:
+            return (byte) (0x03 & b);
+        case 3:
+            return (byte) (0x07 & b);
+        case 4:
+            return (byte) (0x0F & b);
+        case 5:
+            return (byte) (0x1F & b);
+        case 6:
+            return (byte) (0x3F & b);
+        case 7:
+            return (byte) (0x7F & b);
+        case 8:
+            return b;
+        default:
+            throw new IllegalArgumentException("lowOrderBitsToPreserve: " + lowOrderBitsToPreserve);
+        }
     }
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsOptEcsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsOptEcsRecord.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.UnstableApi;
+
+import java.net.InetAddress;
+
+/**
+ * An ECS record as defined in <a href="https://tools.ietf.org/html/rfc7871#section-6">Client Subnet in DNS Queries</a>.
+ */
+@UnstableApi
+public interface DnsOptEcsRecord extends DnsOptPseudoRecord {
+
+    /**
+     * Returns the leftmost number of significant bits of ADDRESS to be used for the lookup.
+     */
+    int sourcePrefixLength();
+
+    /**
+     * Returns the leftmost number of significant bits of ADDRESS that the response covers.
+     * In queries, it MUST be 0.
+     */
+    int scopePrefixLength();
+
+    /**
+     * Retuns the bytes of the {@link InetAddress} to use.
+     */
+    byte[] address();
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsOptPseudoRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsOptPseudoRecord.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.UnstableApi;
+
+/**
+ * An <a href="https://tools.ietf.org/html/rfc6891#section-6.1">OPT RR</a> record.
+ * <p>
+ * This is used for <a href="https://tools.ietf.org/html/rfc6891#section-6.1.3">Extension
+ * Mechanisms for DNS (EDNS(0))</a>.
+ */
+@UnstableApi
+public interface DnsOptPseudoRecord extends DnsRecord {
+
+    /**
+     * Returns the {@code EXTENDED-RCODE} which is encoded into {@link DnsOptPseudoRecord#timeToLive()}.
+     */
+    int extendedRcode();
+
+    /**
+     * Returns the {@code VERSION} which is encoded into {@link DnsOptPseudoRecord#timeToLive()}.
+     */
+    int version();
+
+    /**
+     * Returns the {@code flags} which includes {@code DO} and {@code Z} which is encoded
+     * into {@link DnsOptPseudoRecord#timeToLive()}.
+     */
+    int flags();
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
@@ -16,6 +16,7 @@
 package io.netty.resolver.dns;
 
 import io.netty.channel.EventLoop;
+import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.UnstableApi;
 
@@ -32,6 +33,7 @@ import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 /**
  * Default implementation of {@link DnsCache}, backed by a {@link ConcurrentMap}.
+ * If any additional {@link DnsRecord} is used, no caching takes place.
  */
 @UnstableApi
 public class DefaultDnsCache implements DnsCache {
@@ -115,9 +117,16 @@ public class DefaultDnsCache implements DnsCache {
         return removed;
     }
 
+    private static boolean emptyAdditionals(DnsRecord[] additionals) {
+        return additionals == null || additionals.length == 0;
+    }
+
     @Override
-    public List<DnsCacheEntry> get(String hostname) {
+    public List<DnsCacheEntry> get(String hostname, DnsRecord[] additionals) {
         checkNotNull(hostname, "hostname");
+        if (!emptyAdditionals(additionals)) {
+            return null;
+        }
         return resolveCache.get(hostname);
     }
 
@@ -135,14 +144,14 @@ public class DefaultDnsCache implements DnsCache {
     }
 
     @Override
-    public void cache(String hostname, InetAddress address, long originalTtl, EventLoop loop) {
-        if (maxTtl == 0) {
-            return;
-        }
+    public void cache(String hostname, DnsRecord[] additionals,
+                      InetAddress address, long originalTtl, EventLoop loop) {
         checkNotNull(hostname, "hostname");
         checkNotNull(address, "address");
         checkNotNull(loop, "loop");
-
+        if (maxTtl == 0 || !emptyAdditionals(additionals)) {
+            return;
+        }
         final int ttl = Math.max(minTtl, (int) Math.min(maxTtl, originalTtl));
         final List<DnsCacheEntry> entries = cachedEntries(hostname);
         final DnsCacheEntry e = new DnsCacheEntry(hostname, address);
@@ -163,14 +172,14 @@ public class DefaultDnsCache implements DnsCache {
     }
 
     @Override
-    public void cache(String hostname, Throwable cause, EventLoop loop) {
-        if (negativeTtl == 0) {
-            return;
-        }
+    public void cache(String hostname, DnsRecord[] additionals, Throwable cause, EventLoop loop) {
         checkNotNull(hostname, "hostname");
         checkNotNull(cause, "cause");
         checkNotNull(loop, "loop");
 
+        if (negativeTtl == 0 || !emptyAdditionals(additionals)) {
+            return;
+        }
         final List<DnsCacheEntry> entries = cachedEntries(hostname);
         final DnsCacheEntry e = new DnsCacheEntry(hostname, cause);
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCache.java
@@ -16,6 +16,7 @@
 package io.netty.resolver.dns;
 
 import io.netty.channel.EventLoop;
+import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.util.internal.UnstableApi;
 
 import java.net.InetAddress;
@@ -45,24 +46,27 @@ public interface DnsCache {
     /**
      * Return the cached entries for the given hostname.
      * @param hostname the hostname
+     * @param additionals the additional records
      * @return the cached entries
      */
-    List<DnsCacheEntry> get(String hostname);
+    List<DnsCacheEntry> get(String hostname, DnsRecord[] additionals);
 
     /**
      * Cache a resolved address for a given hostname.
      * @param hostname the hostname
+     * @param additionals the additional records
      * @param address the resolved adresse
      * @param originalTtl the TLL as returned by the DNS server
      * @param loop the {@link EventLoop} used to register the TTL timeout
      */
-    void cache(String hostname, InetAddress address, long originalTtl, EventLoop loop);
+    void cache(String hostname, DnsRecord[] additionals, InetAddress address, long originalTtl, EventLoop loop);
 
     /**
      * Cache the resolution failure for a given hostname.
      * @param hostname the hostname
+     * @param additionals the additional records
      * @param cause the resolution failure
      * @param loop the {@link EventLoop} used to register the TTL timeout
      */
-    void cache(String hostname, Throwable cause, EventLoop loop);
+    void cache(String hostname, DnsRecord[] additionals, Throwable cause, EventLoop loop);
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -74,6 +74,7 @@ abstract class DnsNameResolverContext<T> {
     private final boolean traceEnabled;
     private final int maxAllowedQueries;
     private final InternetProtocolFamily[] resolveAddressTypes;
+    private final DnsRecord[] additionals;
 
     private final Set<Future<AddressedEnvelope<DnsResponse, InetSocketAddress>>> queriesInProgress =
             Collections.newSetFromMap(
@@ -86,9 +87,11 @@ abstract class DnsNameResolverContext<T> {
 
     protected DnsNameResolverContext(DnsNameResolver parent,
                                      String hostname,
+                                     DnsRecord[] additionals,
                                      DnsCache resolveCache) {
         this.parent = parent;
         this.hostname = hostname;
+        this.additionals = additionals;
         this.resolveCache = resolveCache;
 
         nameServerAddrs = parent.nameServerAddresses.stream();
@@ -114,9 +117,9 @@ abstract class DnsNameResolverContext<T> {
                     } else if (count < parent.searchDomains().length) {
                         String searchDomain = parent.searchDomains()[count++];
                         Promise<T> nextPromise = parent.executor().newPromise();
-                        String nextHostname = DnsNameResolverContext.this.hostname + "." + searchDomain;
+                        String nextHostname = hostname + '.' + searchDomain;
                         DnsNameResolverContext<T> nextContext = newResolverContext(parent,
-                            nextHostname, resolveCache);
+                            nextHostname, additionals, resolveCache);
                         nextContext.pristineHostname = hostname;
                         nextContext.internalResolve(nextPromise);
                         nextPromise.addListener(this);
@@ -167,7 +170,9 @@ abstract class DnsNameResolverContext<T> {
 
         allowedQueries --;
 
-        final Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> f = parent.query(nameServerAddr, question);
+        final Future<AddressedEnvelope<DnsResponse, InetSocketAddress>> f = parent.query0(
+                nameServerAddr, question, additionals,
+                parent.ch.eventLoop().<AddressedEnvelope<? extends DnsResponse, InetSocketAddress>>newPromise());
         queriesInProgress.add(f);
 
         f.addListener(new FutureListener<AddressedEnvelope<DnsResponse, InetSocketAddress>>() {
@@ -288,7 +293,7 @@ abstract class DnsNameResolverContext<T> {
             }
 
             final DnsCacheEntry e = new DnsCacheEntry(hostname, resolved);
-            resolveCache.cache(hostname, resolved, r.timeToLive(), parent.ch.eventLoop());
+            resolveCache.cache(hostname, additionals, resolved, r.timeToLive(), parent.ch.eventLoop());
             resolvedEntries.add(e);
             found = true;
 
@@ -475,7 +480,7 @@ abstract class DnsNameResolverContext<T> {
         }
         final UnknownHostException cause = new UnknownHostException(buf.toString());
 
-        resolveCache.cache(hostname, cause, parent.ch.eventLoop());
+        resolveCache.cache(hostname, additionals, cause, parent.ch.eventLoop());
         promise.tryFailure(cause);
     }
 
@@ -483,7 +488,7 @@ abstract class DnsNameResolverContext<T> {
                                    Promise<T> promise);
 
     abstract DnsNameResolverContext<T> newResolverContext(DnsNameResolver parent, String hostname,
-                                                          DnsCache resolveCache);
+                                                          DnsRecord[] additionals, DnsCache resolveCache);
 
     static String decodeDomainName(ByteBuf in) {
         in.markReaderIndex();

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/NoopDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/NoopDnsCache.java
@@ -16,6 +16,7 @@
 package io.netty.resolver.dns;
 
 import io.netty.channel.EventLoop;
+import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.util.internal.UnstableApi;
 
 import java.net.InetAddress;
@@ -46,16 +47,17 @@ public final class NoopDnsCache implements DnsCache {
     }
 
     @Override
-    public List<DnsCacheEntry> get(String hostname) {
+    public List<DnsCacheEntry> get(String hostname, DnsRecord[] additionals) {
         return Collections.emptyList();
     }
 
     @Override
-    public void cache(String hostname, InetAddress address, long originalTtl, EventLoop loop) {
+    public void cache(String hostname, DnsRecord[] additional,
+                      InetAddress address, long originalTtl, EventLoop loop) {
     }
 
     @Override
-    public void cache(String hostname, Throwable cause, EventLoop loop) {
+    public void cache(String hostname, DnsRecord[] additional, Throwable cause, EventLoop loop) {
     }
 
     @Override

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverClientSubnetTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverClientSubnetTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.handler.codec.dns.DefaultDnsOptEcsRecord;
+import io.netty.handler.codec.dns.DnsRecord;
+import io.netty.util.concurrent.Future;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class DnsNameResolverClientSubnetTest {
+
+    // See https://www.gsic.uva.es/~jnisigl/dig-edns-client-subnet.html
+    // Ignore as this needs to query real DNS servers.
+    @Ignore
+    @Test
+    public void testSubnetQuery() throws Exception {
+        EventLoopGroup group = new NioEventLoopGroup(1);
+        DnsNameResolver resolver = newResolver(group).build();
+        try {
+            // Same as:
+            // # /.bind-9.9.3-edns/bin/dig @ns1.google.com www.google.es +client=157.88.0.0/24
+            Future<List<InetAddress>> future = resolver.resolveAll("www.google.es",
+                    Collections.<DnsRecord>singleton(
+                            // Suggest max payload size of 1024
+                            // 157.88.0.0 / 24
+                            new DefaultDnsOptEcsRecord(1024, 24, InetAddress.getByName("157.88.0.0").getAddress())));
+            for (InetAddress address: future.syncUninterruptibly().getNow()) {
+                System.err.println(address);
+            }
+        } finally {
+            resolver.close();
+            group.shutdownGracefully(0, 0, TimeUnit.SECONDS);
+        }
+    }
+
+    private static DnsNameResolverBuilder newResolver(EventLoopGroup group) {
+        return new DnsNameResolverBuilder(group.next())
+                .channelType(NioDatagramChannel.class)
+                .nameServerAddresses(DnsServerAddresses.singleton(new InetSocketAddress("8.8.8.8", 53)))
+                .maxQueriesPerResolve(1)
+                .optResourceEnabled(false);
+    }
+}

--- a/transport/src/main/java/io/netty/channel/socket/InternetProtocolFamily.java
+++ b/transport/src/main/java/io/netty/channel/socket/InternetProtocolFamily.java
@@ -15,6 +15,8 @@
  */
 package io.netty.channel.socket;
 
+import io.netty.util.NetUtil;
+
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -27,9 +29,13 @@ public enum InternetProtocolFamily {
     IPv6(Inet6Address.class);
 
     private final Class<? extends InetAddress> addressType;
+    private final int addressNumber;
+    private final InetAddress localHost;
 
     InternetProtocolFamily(Class<? extends InetAddress> addressType) {
         this.addressType = addressType;
+        addressNumber = addressNumber(addressType);
+        localHost = localhost(addressType);
     }
 
     /**
@@ -37,5 +43,54 @@ public enum InternetProtocolFamily {
      */
     public Class<? extends InetAddress> addressType() {
         return addressType;
+    }
+
+    /**
+     * Returns the
+     * <a href="http://www.iana.org/assignments/address-family-numbers/address-family-numbers.xhtml">address number</a>
+     * of the family.
+     */
+    public int addressNumber() {
+        return addressNumber;
+    }
+
+    /**
+     * Returns the {@link InetAddress} that represent the {@code LOCALHOST} for the family.
+     */
+    public InetAddress localhost() {
+        return localHost;
+    }
+
+    private static InetAddress localhost(Class<? extends InetAddress> addressType) {
+        if (addressType.isAssignableFrom(Inet4Address.class)) {
+            return NetUtil.LOCALHOST4;
+        }
+        if (addressType.isAssignableFrom(Inet6Address.class)) {
+            return NetUtil.LOCALHOST6;
+        }
+        throw new Error();
+    }
+
+    private static int addressNumber(Class<? extends InetAddress> addressType) {
+        if (addressType.isAssignableFrom(Inet4Address.class)) {
+            return 1;
+        }
+        if (addressType.isAssignableFrom(Inet6Address.class)) {
+            return 2;
+        }
+        throw new IllegalArgumentException("addressType " + addressType + " not supported");
+    }
+
+    /**
+     * Returns the {@link InternetProtocolFamily} for the given {@link InetAddress}.
+     */
+    public static InternetProtocolFamily of(InetAddress address) {
+        if (address instanceof Inet4Address) {
+            return IPv4;
+        }
+        if (address instanceof Inet6Address) {
+            return IPv6;
+        }
+        throw new IllegalArgumentException("address " + address + " not supported");
     }
 }


### PR DESCRIPTION
Motivation:

RFC7871 defines an extension which allows to request responses for a given subset.

Modifications:

- Add DnsOptPseudoRrRecord which can act as base class for extensions based on EDNS(0) as defined in RFC6891
- Add DnsOptEcsRecord to support the Client Subnet in DNS Queries extension
- Add tests

Result:

Client Subnet in DNS Queries extension is now supported.