### PR TITLE
Cleanup : removed unused empty arrays and simplified initialization

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
@@ -482,7 +482,7 @@ public class UnpooledTest {
         assertFalse(buffer.isReadable());
 
         assertEquals(0, copyInt(null).capacity());
-        assertEquals(0, copyInt(EMPTY_INTS).capacity());
+        assertEquals(0, copyInt(new int[] {}).capacity());
     }
 
     @Test
@@ -502,7 +502,7 @@ public class UnpooledTest {
         assertFalse(buffer.isReadable());
 
         assertEquals(0, copyShort((short[]) null).capacity());
-        assertEquals(0, copyShort(EMPTY_SHORTS).capacity());
+        assertEquals(0, copyShort(new short[] {}).capacity());
     }
 
     @Test
@@ -514,7 +514,7 @@ public class UnpooledTest {
         assertFalse(buffer.isReadable());
 
         assertEquals(0, copyShort((int[]) null).capacity());
-        assertEquals(0, copyShort(EMPTY_INTS).capacity());
+        assertEquals(0, copyShort(new int[] {}).capacity());
     }
 
     @Test
@@ -534,7 +534,7 @@ public class UnpooledTest {
         assertFalse(buffer.isReadable());
 
         assertEquals(0, copyMedium(null).capacity());
-        assertEquals(0, copyMedium(EMPTY_INTS).capacity());
+        assertEquals(0, copyMedium(new int[] {}).capacity());
     }
 
     @Test
@@ -554,7 +554,7 @@ public class UnpooledTest {
         assertFalse(buffer.isReadable());
 
         assertEquals(0, copyLong(null).capacity());
-        assertEquals(0, copyLong(EMPTY_LONGS).capacity());
+        assertEquals(0, copyLong(new long[] {}).capacity());
     }
 
     @Test
@@ -574,7 +574,7 @@ public class UnpooledTest {
         assertFalse(buffer.isReadable());
 
         assertEquals(0, copyFloat(null).capacity());
-        assertEquals(0, copyFloat(EMPTY_FLOATS).capacity());
+        assertEquals(0, copyFloat(new float[] {}).capacity());
     }
 
     @Test
@@ -594,7 +594,7 @@ public class UnpooledTest {
         assertFalse(buffer.isReadable());
 
         assertEquals(0, copyDouble(null).capacity());
-        assertEquals(0, copyDouble(EMPTY_DOUBLES).capacity());
+        assertEquals(0, copyDouble(new double[] {}).capacity());
     }
 
     @Test
@@ -606,7 +606,7 @@ public class UnpooledTest {
         assertFalse(buffer.isReadable());
 
         assertEquals(0, copyBoolean(null).capacity());
-        assertEquals(0, copyBoolean(EMPTY_BOOLEANS).capacity());
+        assertEquals(0, copyBoolean(new boolean[] {}).capacity());
     }
 
     @Test

--- a/common/src/main/java/io/netty/util/internal/EmptyArrays.java
+++ b/common/src/main/java/io/netty/util/internal/EmptyArrays.java
@@ -22,23 +22,16 @@ import java.security.cert.X509Certificate;
 
 public final class EmptyArrays {
 
-    public static final byte[] EMPTY_BYTES = new byte[0];
-    public static final char[] EMPTY_CHARS = new char[0];
-    public static final boolean[] EMPTY_BOOLEANS = new boolean[0];
-    public static final double[] EMPTY_DOUBLES = new double[0];
-    public static final float[] EMPTY_FLOATS = new float[0];
-    public static final int[] EMPTY_INTS = new int[0];
-    public static final short[] EMPTY_SHORTS = new short[0];
-    public static final long[] EMPTY_LONGS = new long[0];
-    public static final Object[] EMPTY_OBJECTS = new Object[0];
-    public static final Class<?>[] EMPTY_CLASSES = new Class[0];
-    public static final String[] EMPTY_STRINGS = new String[0];
-    public static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
-    public static final ByteBuffer[] EMPTY_BYTE_BUFFERS = new ByteBuffer[0];
-    public static final Certificate[] EMPTY_CERTIFICATES = new Certificate[0];
-    public static final X509Certificate[] EMPTY_X509_CERTIFICATES = new X509Certificate[0];
-    public static final javax.security.cert.X509Certificate[] EMPTY_JAVAX_X509_CERTIFICATES =
-            new javax.security.cert.X509Certificate[0];
+    public static final byte[] EMPTY_BYTES = {};
+    public static final char[] EMPTY_CHARS = {};
+    public static final Object[] EMPTY_OBJECTS = {};
+    public static final Class<?>[] EMPTY_CLASSES = {};
+    public static final String[] EMPTY_STRINGS = {};
+    public static final StackTraceElement[] EMPTY_STACK_TRACE = {};
+    public static final ByteBuffer[] EMPTY_BYTE_BUFFERS = {};
+    public static final Certificate[] EMPTY_CERTIFICATES = {};
+    public static final X509Certificate[] EMPTY_X509_CERTIFICATES = {};
+    public static final javax.security.cert.X509Certificate[] EMPTY_JAVAX_X509_CERTIFICATES = {};
 
     private EmptyArrays() { }
 }


### PR DESCRIPTION
Motivation:

Simplified code, less memory usage for static holders.

Modifications:

Replaced `new byte[0]` with `{}`
Removed unused empty array static holders.

Result:

Simpler, clear code.