### PR TITLE
Cleanup : removed unnecessary static holders

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelOption.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelOption.java
@@ -22,25 +22,25 @@ import java.net.InetAddress;
 import java.util.Map;
 
 public final class EpollChannelOption<T> extends ChannelOption<T> {
-    @SuppressWarnings("rawtypes")
-    private static final Class<EpollChannelOption> T = EpollChannelOption.class;
 
-    public static final ChannelOption<Boolean> TCP_CORK = ChannelOption.valueOf(T, "TCP_CORK");
-    public static final ChannelOption<Boolean> SO_REUSEPORT = ChannelOption.valueOf(T, "SO_REUSEPORT");
-    public static final ChannelOption<Long> TCP_NOTSENT_LOWAT = ChannelOption.valueOf(T, "TCP_NOTSENT_LOWAT");
-    public static final ChannelOption<Integer> TCP_KEEPIDLE = ChannelOption.valueOf(T, "TCP_KEEPIDLE");
-    public static final ChannelOption<Integer> TCP_KEEPINTVL = ChannelOption.valueOf(T, "TCP_KEEPINTVL");
-    public static final ChannelOption<Integer> TCP_KEEPCNT = ChannelOption.valueOf(T, "TCP_KEEPCNT");
-    public static final ChannelOption<Integer> TCP_USER_TIMEOUT = valueOf(T, "TCP_USER_TIMEOUT");
-    public static final ChannelOption<Boolean> IP_FREEBIND = ChannelOption.valueOf("IP_FREEBIND");
-    public static final ChannelOption<Integer> TCP_FASTOPEN = valueOf(T, "TCP_FASTOPEN");
-    public static final ChannelOption<Integer> TCP_DEFER_ACCEPT = ChannelOption.valueOf(T, "TCP_DEFER_ACCEPT");
-    public static final ChannelOption<Boolean> TCP_QUICKACK = ChannelOption.valueOf(T, "TCP_QUICKACK");
+    public static final ChannelOption<Boolean> TCP_CORK = valueOf(EpollChannelOption.class, "TCP_CORK");
+    public static final ChannelOption<Boolean> SO_REUSEPORT = valueOf(EpollChannelOption.class, "SO_REUSEPORT");
+    public static final ChannelOption<Long> TCP_NOTSENT_LOWAT = valueOf(EpollChannelOption.class, "TCP_NOTSENT_LOWAT");
+    public static final ChannelOption<Integer> TCP_KEEPIDLE = valueOf(EpollChannelOption.class, "TCP_KEEPIDLE");
+    public static final ChannelOption<Integer> TCP_KEEPINTVL = valueOf(EpollChannelOption.class, "TCP_KEEPINTVL");
+    public static final ChannelOption<Integer> TCP_KEEPCNT = valueOf(EpollChannelOption.class, "TCP_KEEPCNT");
+    public static final ChannelOption<Integer> TCP_USER_TIMEOUT =
+            valueOf(EpollChannelOption.class, "TCP_USER_TIMEOUT");
+    public static final ChannelOption<Boolean> IP_FREEBIND = valueOf("IP_FREEBIND");
+    public static final ChannelOption<Integer> TCP_FASTOPEN = valueOf(EpollChannelOption.class, "TCP_FASTOPEN");
+    public static final ChannelOption<Integer> TCP_DEFER_ACCEPT =
+            ChannelOption.valueOf(EpollChannelOption.class, "TCP_DEFER_ACCEPT");
+    public static final ChannelOption<Boolean> TCP_QUICKACK = valueOf(EpollChannelOption.class, "TCP_QUICKACK");
 
     public static final ChannelOption<DomainSocketReadMode> DOMAIN_SOCKET_READ_MODE =
-            ChannelOption.valueOf(T, "DOMAIN_SOCKET_READ_MODE");
+            ChannelOption.valueOf(EpollChannelOption.class, "DOMAIN_SOCKET_READ_MODE");
     public static final ChannelOption<EpollMode> EPOLL_MODE =
-            ChannelOption.valueOf(T, "EPOLL_MODE");
+            ChannelOption.valueOf(EpollChannelOption.class, "EPOLL_MODE");
 
     public static final ChannelOption<Map<InetAddress, byte[]>> TCP_MD5SIG = valueOf("TCP_MD5SIG");
 

--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannelOption.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannelOption.java
@@ -25,17 +25,14 @@ import io.netty.channel.rxtx.RxtxChannelConfig.Stopbits;
  */
 public final class RxtxChannelOption<T> extends ChannelOption<T> {
 
-    @SuppressWarnings("rawtypes")
-    private static final Class<RxtxChannelOption> T = RxtxChannelOption.class;
-
-    public static final ChannelOption<Integer> BAUD_RATE = valueOf(T, "BAUD_RATE");
-    public static final ChannelOption<Boolean> DTR = valueOf(T, "DTR");
-    public static final ChannelOption<Boolean> RTS = valueOf(T, "RTS");
-    public static final ChannelOption<Stopbits> STOP_BITS = valueOf(T, "STOP_BITS");
-    public static final ChannelOption<Databits> DATA_BITS = valueOf(T, "DATA_BITS");
-    public static final ChannelOption<Paritybit> PARITY_BIT = valueOf(T, "PARITY_BIT");
-    public static final ChannelOption<Integer> WAIT_TIME = valueOf(T, "WAIT_TIME");
-    public static final ChannelOption<Integer> READ_TIMEOUT = valueOf(T, "READ_TIMEOUT");
+    public static final ChannelOption<Integer> BAUD_RATE = valueOf(RxtxChannelOption.class, "BAUD_RATE");
+    public static final ChannelOption<Boolean> DTR = valueOf(RxtxChannelOption.class, "DTR");
+    public static final ChannelOption<Boolean> RTS = valueOf(RxtxChannelOption.class, "RTS");
+    public static final ChannelOption<Stopbits> STOP_BITS = valueOf(RxtxChannelOption.class, "STOP_BITS");
+    public static final ChannelOption<Databits> DATA_BITS = valueOf(RxtxChannelOption.class, "DATA_BITS");
+    public static final ChannelOption<Paritybit> PARITY_BIT = valueOf(RxtxChannelOption.class, "PARITY_BIT");
+    public static final ChannelOption<Integer> WAIT_TIME = valueOf(RxtxChannelOption.class, "WAIT_TIME");
+    public static final ChannelOption<Integer> READ_TIMEOUT = valueOf(RxtxChannelOption.class, "READ_TIMEOUT");
 
     @SuppressWarnings({ "unused", "deprecation" })
     private RxtxChannelOption() {

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpChannelOption.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpChannelOption.java
@@ -25,18 +25,21 @@ import java.net.SocketAddress;
  */
 public final class SctpChannelOption<T> extends ChannelOption<T> {
 
-    @SuppressWarnings("rawtypes")
-    private static final Class<SctpChannelOption> T = SctpChannelOption.class;
+    public static final ChannelOption<Boolean> SCTP_DISABLE_FRAGMENTS =
+            valueOf(SctpChannelOption.class, "SCTP_DISABLE_FRAGMENTS");
+    public static final ChannelOption<Boolean> SCTP_EXPLICIT_COMPLETE =
+            valueOf(SctpChannelOption.class, "SCTP_EXPLICIT_COMPLETE");
+    public static final ChannelOption<Integer> SCTP_FRAGMENT_INTERLEAVE =
+            valueOf(SctpChannelOption.class, "SCTP_FRAGMENT_INTERLEAVE");
+    public static final ChannelOption<InitMaxStreams> SCTP_INIT_MAXSTREAMS =
+            valueOf(SctpChannelOption.class, "SCTP_INIT_MAXSTREAMS");
 
-    public static final ChannelOption<Boolean> SCTP_DISABLE_FRAGMENTS = valueOf(T, "SCTP_DISABLE_FRAGMENTS");
-    public static final ChannelOption<Boolean> SCTP_EXPLICIT_COMPLETE = valueOf(T, "SCTP_EXPLICIT_COMPLETE");
-    public static final ChannelOption<Integer> SCTP_FRAGMENT_INTERLEAVE = valueOf(T, "SCTP_FRAGMENT_INTERLEAVE");
-    public static final ChannelOption<InitMaxStreams> SCTP_INIT_MAXSTREAMS = valueOf(T, "SCTP_INIT_MAXSTREAMS");
-
-    public static final ChannelOption<Boolean> SCTP_NODELAY = valueOf(T, "SCTP_NODELAY");
-    public static final ChannelOption<SocketAddress> SCTP_PRIMARY_ADDR = valueOf(T, "SCTP_PRIMARY_ADDR");
+    public static final ChannelOption<Boolean> SCTP_NODELAY =
+            valueOf(SctpChannelOption.class, "SCTP_NODELAY");
+    public static final ChannelOption<SocketAddress> SCTP_PRIMARY_ADDR =
+            valueOf(SctpChannelOption.class, "SCTP_PRIMARY_ADDR");
     public static final ChannelOption<SocketAddress> SCTP_SET_PEER_PRIMARY_ADDR =
-            valueOf(T, "SCTP_SET_PEER_PRIMARY_ADDR");
+            valueOf(SctpChannelOption.class, "SCTP_SET_PEER_PRIMARY_ADDR");
 
     @SuppressWarnings({ "unused", "deprecation" })
     private SctpChannelOption() {

--- a/transport-udt/src/main/java/io/netty/channel/udt/UdtChannelOption.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/UdtChannelOption.java
@@ -23,29 +23,29 @@ import io.netty.channel.ChannelOption;
  */
 public final class UdtChannelOption<T> extends ChannelOption<T> {
 
-    @SuppressWarnings("rawtypes")
-    private static final Class<UdtChannelOption> T = UdtChannelOption.class;
-
     /**
      * See {@link OptionUDT#Protocol_Receive_Buffer_Size}.
      */
     public static final ChannelOption<Integer> PROTOCOL_RECEIVE_BUFFER_SIZE =
-            valueOf(T, "PROTOCOL_RECEIVE_BUFFER_SIZE");
+            valueOf(UdtChannelOption.class, "PROTOCOL_RECEIVE_BUFFER_SIZE");
 
     /**
      * See {@link OptionUDT#Protocol_Send_Buffer_Size}.
      */
-    public static final ChannelOption<Integer> PROTOCOL_SEND_BUFFER_SIZE = valueOf(T, "PROTOCOL_SEND_BUFFER_SIZE");
+    public static final ChannelOption<Integer> PROTOCOL_SEND_BUFFER_SIZE =
+            valueOf(UdtChannelOption.class, "PROTOCOL_SEND_BUFFER_SIZE");
 
     /**
      * See {@link OptionUDT#System_Receive_Buffer_Size}.
      */
-    public static final ChannelOption<Integer> SYSTEM_RECEIVE_BUFFER_SIZE = valueOf(T, "SYSTEM_RECEIVE_BUFFER_SIZE");
+    public static final ChannelOption<Integer> SYSTEM_RECEIVE_BUFFER_SIZE =
+            valueOf(UdtChannelOption.class, "SYSTEM_RECEIVE_BUFFER_SIZE");
 
     /**
      * See {@link OptionUDT#System_Send_Buffer_Size}.
      */
-    public static final ChannelOption<Integer> SYSTEM_SEND_BUFFER_SIZE = valueOf(T, "SYSTEM_SEND_BUFFER_SIZE");
+    public static final ChannelOption<Integer> SYSTEM_SEND_BUFFER_SIZE =
+            valueOf(UdtChannelOption.class, "SYSTEM_SEND_BUFFER_SIZE");
 
     @SuppressWarnings({ "unused", "deprecation" })
     private UdtChannelOption() {


### PR DESCRIPTION
Motivation : 

`public static final Class<>` variables are not inlined during compile time so they take memory.

Modifications : 

static reference replaced with direct class refrence.

Result : 

less static holders.