### PR TITLE
Deprecated commons logger

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/CommonsLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/CommonsLogger.java
@@ -44,7 +44,11 @@ import org.apache.commons.logging.Log;
 /**
  * <a href="http://commons.apache.org/logging/">Apache Commons Logging</a>
  * logger.
+ *
+ * @deprecated Please use {@link Log4J2Logger} or {@link Log4JLogger} or
+ * {@link Slf4JLogger}.
  */
+@Deprecated
 class CommonsLogger extends AbstractInternalLogger {
 
     private static final long serialVersionUID = 8647838678388394885L;

--- a/common/src/main/java/io/netty/util/internal/logging/CommonsLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/CommonsLoggerFactory.java
@@ -18,14 +18,15 @@ package io.netty.util.internal.logging;
 
 import org.apache.commons.logging.LogFactory;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Logger factory which creates an
  * <a href="http://commons.apache.org/logging/">Apache Commons Logging</a>
  * logger.
+ *
+ * @deprecated Please use {@link Log4J2LoggerFactory} or {@link Log4JLoggerFactory} or
+ * {@link Slf4JLoggerFactory}.
  */
+@Deprecated
 public class CommonsLoggerFactory extends InternalLoggerFactory {
 
     public static final InternalLoggerFactory INSTANCE = new CommonsLoggerFactory();


### PR DESCRIPTION
Motivation : 

Commons logger is dead and not updated for more than 2 years. #5615.

Modifications : 

Added @Deprecated annotation to `CommonsLoggerFactory` and `CommonsLogger`.

Result : 

Commons logger now deprecated.