### PR TITLE
Cleanup : removed duplicated logic in ConstantPool

### DIFF
--- a/common/src/main/java/io/netty/util/AbstractConstant.java
+++ b/common/src/main/java/io/netty/util/AbstractConstant.java
@@ -15,25 +15,32 @@
  */
 package io.netty.util;
 
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Base implementation of {@link Constant}.
  */
 public abstract class AbstractConstant<T extends AbstractConstant<T>> implements Constant<T> {
 
-    private static final AtomicLong uniqueIdGenerator = new AtomicLong();
+    private static final AtomicInteger uniqueIdGenerator = new AtomicInteger();
     private final int id;
     private final String name;
-    private final long uniquifier;
 
     /**
      * Creates a new instance.
      */
+    protected AbstractConstant(String name) {
+        this.id = uniqueIdGenerator.getAndIncrement();
+        this.name = name;
+    }
+
+    /**
+     * @deprecated please use {@link AbstractConstant(String)}
+     */
+    @Deprecated
     protected AbstractConstant(int id, String name) {
         this.id = id;
         this.name = name;
-        this.uniquifier = uniqueIdGenerator.getAndIncrement();
     }
 
     @Override
@@ -76,10 +83,10 @@ public abstract class AbstractConstant<T extends AbstractConstant<T>> implements
             return returnCode;
         }
 
-        if (uniquifier < other.uniquifier) {
+        if (id < other.id) {
             return -1;
         }
-        if (uniquifier > other.uniquifier) {
+        if (id > other.id) {
             return 1;
         }
 

--- a/common/src/main/java/io/netty/util/AttributeKey.java
+++ b/common/src/main/java/io/netty/util/AttributeKey.java
@@ -27,7 +27,7 @@ public final class AttributeKey<T> extends AbstractConstant<AttributeKey<T>> {
     private static final ConstantPool<AttributeKey<Object>> pool = new ConstantPool<AttributeKey<Object>>() {
         @Override
         protected AttributeKey<Object> newConstant(int id, String name) {
-            return new AttributeKey<Object>(id, name);
+            return new AttributeKey<Object>(name);
         }
     };
 
@@ -60,7 +60,7 @@ public final class AttributeKey<T> extends AbstractConstant<AttributeKey<T>> {
         return (AttributeKey<T>) pool.valueOf(firstNameComponent, secondNameComponent);
     }
 
-    private AttributeKey(int id, String name) {
-        super(id, name);
+    private AttributeKey(String name) {
+        super(name);
     }
 }

--- a/common/src/main/java/io/netty/util/ConstantPool.java
+++ b/common/src/main/java/io/netty/util/ConstantPool.java
@@ -68,7 +68,7 @@ public abstract class ConstantPool<T extends Constant<T>> {
     private T getOrCreate(String name) {
         T constant = constants.get(name);
         if (constant == null) {
-            final T tempConstant = newConstant(nextId(), name);
+            final T tempConstant = newConstant(0, name);
             constant = constants.putIfAbsent(name, tempConstant);
             if (constant == null) {
                 return tempConstant;
@@ -103,7 +103,7 @@ public abstract class ConstantPool<T extends Constant<T>> {
     private T createOrThrow(String name) {
         T constant = constants.get(name);
         if (constant == null) {
-            final T tempConstant = newConstant(nextId(), name);
+            final T tempConstant = newConstant(0, name);
             constant = constants.putIfAbsent(name, tempConstant);
             if (constant == null) {
                 return tempConstant;

--- a/common/src/main/java/io/netty/util/Signal.java
+++ b/common/src/main/java/io/netty/util/Signal.java
@@ -27,7 +27,7 @@ public final class Signal extends Error implements Constant<Signal> {
     private static final ConstantPool<Signal> pool = new ConstantPool<Signal>() {
         @Override
         protected Signal newConstant(int id, String name) {
-            return new Signal(id, name);
+            return new Signal(name);
         }
     };
 
@@ -50,8 +50,8 @@ public final class Signal extends Error implements Constant<Signal> {
     /**
      * Creates a new {@link Signal} with the specified {@code name}.
      */
-    private Signal(int id, String name) {
-        constant = new SignalConstant(id, name);
+    private Signal(String name) {
+        constant = new SignalConstant(name);
     }
 
     /**
@@ -109,8 +109,8 @@ public final class Signal extends Error implements Constant<Signal> {
     }
 
     private static final class SignalConstant extends AbstractConstant<SignalConstant> {
-        SignalConstant(int id, String name) {
-            super(id, name);
+        SignalConstant(String name) {
+            super(name);
         }
     }
 }

--- a/common/src/test/java/io/netty/util/ConstantPoolTest.java
+++ b/common/src/test/java/io/netty/util/ConstantPoolTest.java
@@ -28,15 +28,15 @@ import static org.junit.Assert.*;
 public class ConstantPoolTest {
 
     static final class TestConstant extends AbstractConstant<TestConstant> {
-        TestConstant(int id, String name) {
-            super(id, name);
+        TestConstant(String name) {
+            super(name);
         }
     }
 
     private static final ConstantPool<TestConstant> pool = new ConstantPool<TestConstant>() {
         @Override
         protected TestConstant newConstant(int id, String name) {
-            return new TestConstant(id, name);
+            return new TestConstant(name);
         }
     };
 

--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -35,7 +35,7 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
     private static final ConstantPool<ChannelOption<Object>> pool = new ConstantPool<ChannelOption<Object>>() {
         @Override
         protected ChannelOption<Object> newConstant(int id, String name) {
-            return new ChannelOption<Object>(id, name);
+            return new ChannelOption<Object>(name);
         }
     };
 
@@ -134,13 +134,8 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
     /**
      * Creates a new {@link ChannelOption} with the specified unique {@code name}.
      */
-    private ChannelOption(int id, String name) {
-        super(id, name);
-    }
-
-    @Deprecated
     protected ChannelOption(String name) {
-        this(pool.nextId(), name);
+        super(name);
     }
 
     /**


### PR DESCRIPTION
Motivation : 

`ConstantPool` and `AbstractConstant` had duplicated logic for id generation. Made code harder to understand.

Modifications : 

Id generation removed from `ConstantPool`.
Uniquifier variable of `AbstractConstant` for `compareTo` method removed and replaced with `id` variable.

Result : 

Code cleaner and simpler. AbstractConstant has -1 field.

