### PR TITLE
Allow to explicit disable usage of KeyManagerFactory when using OpenSsl

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
@@ -204,7 +204,7 @@ public final class OpenSslClientContext extends OpenSslContext {
             }
             synchronized (OpenSslContext.class) {
                 try {
-                    if (!OpenSsl.supportsKeyManagerFactory()) {
+                    if (!OpenSsl.useKeyManagerFactory()) {
                         if (keyManagerFactory != null) {
                             throw new IllegalArgumentException(
                                     "KeyManagerFactory not supported");

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -352,7 +352,7 @@ public final class OpenSslServerContext extends OpenSslContext {
             synchronized (OpenSslContext.class) {
                 try {
                     SSLContext.setVerify(ctx, SSL.SSL_CVERIFY_NONE, VERIFY_DEPTH);
-                    if (!OpenSsl.supportsKeyManagerFactory()) {
+                    if (!OpenSsl.useKeyManagerFactory()) {
                         if (keyManagerFactory != null) {
                             throw new IllegalArgumentException(
                                     "KeyManagerFactory not supported");


### PR DESCRIPTION
Motivation:

Sometimes it may be useful to explicit disable the usage of the KeyManagerFactory when using OpenSsl.

Modifications:

Add io.netty.handler.ssl.openssl.useKeyManagerFactory which can be used to explicit disable KeyManagerFactory usage.

Result:

More flexible usage.