### PR TITLE
[#5629] Ensure direct ByteBuffer are wrapped in as direct ByteBuf.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/Unpooled.java
+++ b/buffer/src/main/java/io/netty/buffer/Unpooled.java
@@ -183,7 +183,7 @@ public final class Unpooled {
         if (!buffer.hasRemaining()) {
             return EMPTY_BUFFER;
         }
-        if (buffer.hasArray()) {
+        if (!buffer.isDirect() && buffer.hasArray()) {
             return wrappedBuffer(
                     buffer.array(),
                     buffer.arrayOffset() + buffer.position(),


### PR DESCRIPTION
Motivation:

We need to check if a ByteBuffer is direct via isDirect() to detect if its direct as hasArray() may also return true for a direct ByteBuffer.

See also:
https://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html#allocateDirect-int-

Modifications:

Add isDirect() check.

Result:

Correct wrap a direct ByteBuffer in all cases.