### PR TITLE
[#4204] Broken support of SCTP_INIT_MAXSTREAMS in *SctpServerChannel

### DIFF
--- a/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpChannelConfig.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpChannelConfig.java
@@ -74,6 +74,9 @@ public class DefaultSctpChannelConfig extends DefaultChannelConfig implements Sc
         if (option == SCTP_NODELAY) {
             return (T) Boolean.valueOf(isSctpNoDelay());
         }
+        if (option == SCTP_INIT_MAXSTREAMS) {
+            return (T) getInitMaxStreams();
+        }
         return super.getOption(option);
     }
 

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpServerChannelConfig.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpServerChannelConfig.java
@@ -16,6 +16,7 @@
 package io.netty.channel.sctp;
 
 import com.sun.nio.sctp.SctpServerChannel;
+import com.sun.nio.sctp.SctpStandardSocketOptions;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
@@ -26,8 +27,6 @@ import io.netty.util.NetUtil;
 
 import java.io.IOException;
 import java.util.Map;
-
-import static com.sun.nio.sctp.SctpStandardSocketOptions.*;
 
 /**
  * The default {@link SctpServerChannelConfig} implementation for SCTP.
@@ -65,6 +64,9 @@ public class DefaultSctpServerChannelConfig extends DefaultChannelConfig impleme
         if (option == ChannelOption.SO_SNDBUF) {
             return (T) Integer.valueOf(getSendBufferSize());
         }
+        if (option == SctpChannelOption.SCTP_INIT_MAXSTREAMS) {
+            return (T) getInitMaxStreams();
+        }
         return super.getOption(option);
     }
 
@@ -76,8 +78,8 @@ public class DefaultSctpServerChannelConfig extends DefaultChannelConfig impleme
             setReceiveBufferSize((Integer) value);
         } else if (option == ChannelOption.SO_SNDBUF) {
             setSendBufferSize((Integer) value);
-        } else if (option == SCTP_INIT_MAXSTREAMS) {
-            setInitMaxStreams((InitMaxStreams) value);
+        } else if (option == SctpChannelOption.SCTP_INIT_MAXSTREAMS) {
+            setInitMaxStreams((SctpStandardSocketOptions.InitMaxStreams) value);
         } else {
             return super.setOption(option, value);
         }
@@ -88,7 +90,7 @@ public class DefaultSctpServerChannelConfig extends DefaultChannelConfig impleme
     @Override
     public int getSendBufferSize() {
         try {
-            return javaChannel.getOption(SO_SNDBUF);
+            return javaChannel.getOption(SctpStandardSocketOptions.SO_SNDBUF);
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -97,7 +99,7 @@ public class DefaultSctpServerChannelConfig extends DefaultChannelConfig impleme
     @Override
     public SctpServerChannelConfig setSendBufferSize(int sendBufferSize) {
         try {
-            javaChannel.setOption(SO_SNDBUF, sendBufferSize);
+            javaChannel.setOption(SctpStandardSocketOptions.SO_SNDBUF, sendBufferSize);
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -107,7 +109,7 @@ public class DefaultSctpServerChannelConfig extends DefaultChannelConfig impleme
     @Override
     public int getReceiveBufferSize() {
         try {
-            return javaChannel.getOption(SO_RCVBUF);
+            return javaChannel.getOption(SctpStandardSocketOptions.SO_RCVBUF);
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -116,7 +118,7 @@ public class DefaultSctpServerChannelConfig extends DefaultChannelConfig impleme
     @Override
     public SctpServerChannelConfig setReceiveBufferSize(int receiveBufferSize) {
         try {
-            javaChannel.setOption(SO_RCVBUF, receiveBufferSize);
+            javaChannel.setOption(SctpStandardSocketOptions.SO_RCVBUF, receiveBufferSize);
         } catch (IOException e) {
             throw new ChannelException(e);
         }
@@ -124,18 +126,18 @@ public class DefaultSctpServerChannelConfig extends DefaultChannelConfig impleme
     }
 
     @Override
-    public InitMaxStreams getInitMaxStreams() {
+    public SctpStandardSocketOptions.InitMaxStreams getInitMaxStreams() {
         try {
-            return javaChannel.getOption(SCTP_INIT_MAXSTREAMS);
+            return javaChannel.getOption(SctpStandardSocketOptions.SCTP_INIT_MAXSTREAMS);
         } catch (IOException e) {
             throw new ChannelException(e);
         }
     }
 
     @Override
-    public SctpServerChannelConfig setInitMaxStreams(InitMaxStreams initMaxStreams) {
+    public SctpServerChannelConfig setInitMaxStreams(SctpStandardSocketOptions.InitMaxStreams initMaxStreams) {
         try {
-            javaChannel.setOption(SCTP_INIT_MAXSTREAMS, initMaxStreams);
+            javaChannel.setOption(SctpStandardSocketOptions.SCTP_INIT_MAXSTREAMS, initMaxStreams);
         } catch (IOException e) {
             throw new ChannelException(e);
         }

--- a/transport-sctp/src/main/test/io/netty/channel/sctp/SctpLimitStreamsTest.java
+++ b/transport-sctp/src/main/test/io/netty/channel/sctp/SctpLimitStreamsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.sctp;
+
+import com.sun.nio.sctp.SctpStandardSocketOptions;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import org.junit.Test;
+import java.net.InetSocketAddress;
+
+import static org.junit.Assert.*;
+
+public abstract class SctpLimitStreamsTest {
+
+    @Test(timeout = 5000)
+    public void testSctpInitMaxstreams() throws Exception {
+        EventLoopGroup loop = newEventLoopGroup();
+        try {
+            ServerBootstrap serverBootstrap = new ServerBootstrap();
+            serverBootstrap.group(loop)
+                    .channel(serverClass())
+                    .option(ChannelOption.SO_REUSEADDR, true)
+                    .option(SctpChannelOption.SCTP_INIT_MAXSTREAMS,
+                            SctpStandardSocketOptions.InitMaxStreams.create(1, 1))
+                    .localAddress(new InetSocketAddress(0))
+                    .childHandler(new ChannelInboundHandlerAdapter());
+
+            Bootstrap clientBootstrap = new Bootstrap()
+                    .group(loop)
+                    .channel(clientClass())
+                    .option(SctpChannelOption.SCTP_INIT_MAXSTREAMS,
+                            SctpStandardSocketOptions.InitMaxStreams.create(112, 112))
+                    .handler(new ChannelInboundHandlerAdapter());
+
+            Channel serverChannel = serverBootstrap.bind()
+                    .syncUninterruptibly().channel();
+            SctpChannel clientChannel = (SctpChannel) clientBootstrap.connect(serverChannel.localAddress())
+                    .syncUninterruptibly().channel();
+            assertEquals(1, clientChannel.association().maxOutboundStreams());
+            assertEquals(1, clientChannel.association().maxInboundStreams());
+            serverChannel.close().syncUninterruptibly();
+            clientChannel.close().syncUninterruptibly();
+        } finally {
+            loop.shutdownGracefully();
+        }
+    }
+
+    protected abstract EventLoopGroup newEventLoopGroup();
+    protected abstract Class<? extends SctpChannel> clientClass();
+    protected abstract Class<? extends SctpServerChannel> serverClass();
+}

--- a/transport-sctp/src/main/test/io/netty/channel/sctp/nio/NioSctpLimitStreamsTest.java
+++ b/transport-sctp/src/main/test/io/netty/channel/sctp/nio/NioSctpLimitStreamsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.sctp.nio;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.sctp.SctpChannel;
+import io.netty.channel.sctp.SctpLimitStreamsTest;
+import io.netty.channel.sctp.SctpServerChannel;
+
+public class NioSctpLimitStreamsTest extends SctpLimitStreamsTest {
+    @Override
+    protected EventLoopGroup newEventLoopGroup() {
+        return new NioEventLoopGroup();
+    }
+
+    @Override
+    protected Class<? extends SctpChannel> clientClass() {
+        return NioSctpChannel.class;
+    }
+
+    @Override
+    protected Class<? extends SctpServerChannel> serverClass() {
+        return NioSctpServerChannel.class;
+    }
+}

--- a/transport-sctp/src/main/test/io/netty/channel/sctp/oio/OioSctpLimitStreamsTest.java
+++ b/transport-sctp/src/main/test/io/netty/channel/sctp/oio/OioSctpLimitStreamsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.sctp.oio;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.oio.OioEventLoopGroup;
+import io.netty.channel.sctp.SctpChannel;
+import io.netty.channel.sctp.SctpLimitStreamsTest;
+import io.netty.channel.sctp.SctpServerChannel;
+
+public class OioSctpLimitStreamsTest extends SctpLimitStreamsTest {
+    @Override
+    protected EventLoopGroup newEventLoopGroup() {
+        return new OioEventLoopGroup();
+    }
+
+    @Override
+    protected Class<? extends SctpChannel> clientClass() {
+        return OioSctpChannel.class;
+    }
+
+    @Override
+    protected Class<? extends SctpServerChannel> serverClass() {
+        return OioSctpServerChannel.class;
+    }
+}


### PR DESCRIPTION
Motivation:

The SCTP_INIT_MAXSTREAMS property is ignored on NioSctpServerChannel / OioSctpServerChannel.

Modifications:

- Correctly use the netty ChannelOption
- Ensure getOption(...) works
- Add testcase.

Result:

SCTP_INIT_MAXSTREAMS works.