### PR TITLE
Improvement : avoid unnecessary class casting on payload for mqtt message

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnectMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnectMessage.java
@@ -16,16 +16,21 @@
 
 package io.netty.handler.codec.mqtt;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * See <a href="http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#connect">MQTTV3.1/connect</a>
  */
 public final class MqttConnectMessage extends MqttMessage {
 
+    private final MqttConnectPayload payload;
+
     public MqttConnectMessage(
             MqttFixedHeader mqttFixedHeader,
             MqttConnectVariableHeader variableHeader,
             MqttConnectPayload payload) {
-        super(mqttFixedHeader, variableHeader, payload);
+        super(mqttFixedHeader, variableHeader);
+        this.payload = ObjectUtil.checkNotNull(payload, "payload");
     }
 
     @Override
@@ -35,6 +40,6 @@ public final class MqttConnectMessage extends MqttMessage {
 
     @Override
     public MqttConnectPayload payload() {
-        return (MqttConnectPayload) super.payload();
+        return payload;
     }
 }

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessage.java
@@ -26,29 +26,22 @@ public class MqttMessage {
 
     private final MqttFixedHeader mqttFixedHeader;
     private final Object variableHeader;
-    private final Object payload;
     private final DecoderResult decoderResult;
 
     public MqttMessage(MqttFixedHeader mqttFixedHeader) {
-        this(mqttFixedHeader, null, null);
+        this(mqttFixedHeader, null);
     }
 
     public MqttMessage(MqttFixedHeader mqttFixedHeader, Object variableHeader) {
-        this(mqttFixedHeader, variableHeader, null);
-    }
-
-    public MqttMessage(MqttFixedHeader mqttFixedHeader, Object variableHeader, Object payload) {
-        this(mqttFixedHeader, variableHeader, payload, DecoderResult.SUCCESS);
+        this(mqttFixedHeader, variableHeader, DecoderResult.SUCCESS);
     }
 
     public MqttMessage(
             MqttFixedHeader mqttFixedHeader,
             Object variableHeader,
-            Object payload,
             DecoderResult decoderResult) {
         this.mqttFixedHeader = mqttFixedHeader;
         this.variableHeader = variableHeader;
-        this.payload = payload;
         this.decoderResult = decoderResult;
     }
 
@@ -61,7 +54,7 @@ public class MqttMessage {
     }
 
     public Object payload() {
-        return payload;
+        return null;
     }
 
     public DecoderResult decoderResult() {
@@ -74,7 +67,7 @@ public class MqttMessage {
             .append('[')
             .append("fixedHeader=").append(fixedHeader() != null ? fixedHeader().toString() : "")
             .append(", variableHeader=").append(variableHeader() != null ? variableHeader.toString() : "")
-            .append(", payload=").append(payload() != null ? payload.toString() : "")
+            .append(", payload=").append(payload() != null ? payload().toString() : "")
             .append(']')
             .toString();
     }

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageFactory.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageFactory.java
@@ -82,7 +82,7 @@ public final class MqttMessageFactory {
     }
 
     public static MqttMessage newInvalidMessage(Throwable cause) {
-        return new MqttMessage(null, null, null, DecoderResult.failure(cause));
+        return new MqttMessage(null, null, DecoderResult.failure(cause));
     }
 
     private MqttMessageFactory() { }

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPublishMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPublishMessage.java
@@ -19,17 +19,21 @@ package io.netty.handler.codec.mqtt;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.util.IllegalReferenceCountException;
+import io.netty.util.internal.ObjectUtil;
 
 /**
  * See <a href="http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#publish">MQTTV3.1/publish</a>
  */
 public class MqttPublishMessage extends MqttMessage implements ByteBufHolder {
 
+    private final ByteBuf payload;
+
     public MqttPublishMessage(
             MqttFixedHeader mqttFixedHeader,
             MqttPublishVariableHeader variableHeader,
             ByteBuf payload) {
-        super(mqttFixedHeader, variableHeader, payload);
+        super(mqttFixedHeader, variableHeader);
+        this.payload = ObjectUtil.checkNotNull(payload, "payload");
     }
 
     @Override
@@ -44,11 +48,10 @@ public class MqttPublishMessage extends MqttMessage implements ByteBufHolder {
 
     @Override
     public ByteBuf content() {
-        final ByteBuf data = (ByteBuf) super.payload();
-        if (data.refCnt() <= 0) {
-            throw new IllegalReferenceCountException(data.refCnt());
+        if (payload.refCnt() <= 0) {
+            throw new IllegalReferenceCountException(payload.refCnt());
         }
-        return data;
+        return payload;
     }
 
     @Override

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubAckMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubAckMessage.java
@@ -16,16 +16,21 @@
 
 package io.netty.handler.codec.mqtt;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * See <a href="http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#suback">MQTTV3.1/suback</a>
  */
 public final class MqttSubAckMessage extends MqttMessage {
 
+    private final MqttSubAckPayload payload;
+
     public MqttSubAckMessage(
             MqttFixedHeader mqttFixedHeader,
             MqttMessageIdVariableHeader variableHeader,
             MqttSubAckPayload payload) {
-        super(mqttFixedHeader, variableHeader, payload);
+        super(mqttFixedHeader, variableHeader);
+        this.payload = ObjectUtil.checkNotNull(payload, "payload");
     }
 
     @Override
@@ -35,6 +40,6 @@ public final class MqttSubAckMessage extends MqttMessage {
 
     @Override
     public MqttSubAckPayload payload() {
-        return (MqttSubAckPayload) super.payload();
+        return payload;
     }
 }

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscribeMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttSubscribeMessage.java
@@ -16,17 +16,22 @@
 
 package io.netty.handler.codec.mqtt;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * See <a href="http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#subscribe">
  *     MQTTV3.1/subscribe</a>
  */
 public final class MqttSubscribeMessage extends MqttMessage {
 
+    private final MqttSubscribePayload payload;
+
     public MqttSubscribeMessage(
             MqttFixedHeader mqttFixedHeader,
             MqttMessageIdVariableHeader variableHeader,
             MqttSubscribePayload payload) {
-        super(mqttFixedHeader, variableHeader, payload);
+        super(mqttFixedHeader, variableHeader);
+        this.payload = ObjectUtil.checkNotNull(payload, "payload");
     }
 
     @Override
@@ -36,6 +41,6 @@ public final class MqttSubscribeMessage extends MqttMessage {
 
     @Override
     public MqttSubscribePayload payload() {
-        return (MqttSubscribePayload) super.payload();
+        return payload;
     }
 }

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnsubAckMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnsubAckMessage.java
@@ -22,7 +22,7 @@ package io.netty.handler.codec.mqtt;
 public final class MqttUnsubAckMessage extends MqttMessage {
 
     public MqttUnsubAckMessage(MqttFixedHeader mqttFixedHeader, MqttMessageIdVariableHeader variableHeader) {
-        super(mqttFixedHeader, variableHeader, null);
+        super(mqttFixedHeader, variableHeader);
     }
 
     @Override

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnsubscribeMessage.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttUnsubscribeMessage.java
@@ -16,17 +16,22 @@
 
 package io.netty.handler.codec.mqtt;
 
+import io.netty.util.internal.ObjectUtil;
+
 /**
  * See <a href="http://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html#unsubscribe">
  *     MQTTV3.1/unsubscribe</a>
  */
 public final class MqttUnsubscribeMessage extends MqttMessage {
 
+    private final MqttUnsubscribePayload payload;
+
     public MqttUnsubscribeMessage(
             MqttFixedHeader mqttFixedHeader,
             MqttMessageIdVariableHeader variableHeader,
             MqttUnsubscribePayload payload) {
-        super(mqttFixedHeader, variableHeader, payload);
+        super(mqttFixedHeader, variableHeader);
+        this.payload = ObjectUtil.checkNotNull(payload, "payload");
     }
 
     @Override
@@ -36,6 +41,6 @@ public final class MqttUnsubscribeMessage extends MqttMessage {
 
     @Override
     public MqttUnsubscribePayload payload() {
-        return (MqttUnsubscribePayload) super.payload();
+        return payload;
     }
 }


### PR DESCRIPTION
Motivation : 

Right now in order to get mqtt payload - class casting should be done (while it was already done on mqtt message creation) + payload field should be only for some mqtt messages and not for all.

Modifications : 

`payload` field moved out from `MqttMessage` to only those messages that should have payload.

Result : 

No class casting when getting `payload`. Non-payload messages now has -1 field.
