### PR TITLE
Upgrade log4j2 dependency to 2.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
     <epoll.classifier>${os.detected.name}-${os.detected.arch}</epoll.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>
     <logging.logLevel>debug</logging.logLevel>
-    <log4j2.version>2.6.1</log4j2.version>
+    <log4j2.version>2.6.2</log4j2.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
Motivation:

The log4j2 project has released version 2.6.2, a bug fix release of
log4j2.

Modifications:

The commit upgrades the log4j2 dependency by modifying the
log4j2.version property in the parent POM to contain version 2.6.2.

Result:

The log4j2 dependency is upgraded to version 2.6.2.