### PR TITLE
Fix Assume.assumeTrue(...) checks in *UnssafeNoCleanerDirectByteBufTest

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeNoCleanerDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeNoCleanerDirectByteBufTest.java
@@ -24,7 +24,8 @@ public class BigEndianUnsafeNoCleanerDirectByteBufTest extends BigEndianDirectBy
 
     @Before
     public void checkHasUnsafe() {
-        Assume.assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
+        Assume.assumeTrue("java.nio.DirectByteBuffer.<init>(long, int) not found, skip tests",
+                PlatformDependent.useDirectBufferNoCleaner());
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeNoCleanerDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeNoCleanerDirectByteBufTest.java
@@ -23,7 +23,8 @@ public class LittleEndianUnsafeNoCleanerDirectByteBufTest extends LittleEndianDi
 
     @Before
     public void checkHasUnsafe() {
-        Assume.assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
+        Assume.assumeTrue("java.nio.DirectByteBuffer.<init>(long, int) not found, skip tests",
+                PlatformDependent.useDirectBufferNoCleaner());
     }
 
     @Override


### PR DESCRIPTION
Motivation:

We used incorrect assumeTrue(...) checks.

Modifications:

Fix check.

Result:

Be able to run tests also if java.nio.DirectByteBuffer.<init>(long, int) could not be accessed.