### PR TITLE
Remove unused imports and not needed throws declarations.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -16,8 +16,6 @@
 package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.security.cert.Certificate;
 

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -16,8 +16,6 @@
 package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import javax.net.ssl.SSLEngine;
 

--- a/handler/src/main/java/io/netty/handler/ssl/PemX509Certificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemX509Certificate.java
@@ -16,16 +16,9 @@
 package io.netty.handler.ssl;
 
 import java.math.BigInteger;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
 import java.security.Principal;
 import java.security.PublicKey;
-import java.security.SignatureException;
 import java.security.cert.CertificateEncodingException;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateExpiredException;
-import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Date;
@@ -261,7 +254,7 @@ public final class PemX509Certificate extends X509Certificate implements PemEnco
     }
 
     @Override
-    public byte[] getEncoded() throws CertificateEncodingException {
+    public byte[] getEncoded() {
         throw new UnsupportedOperationException();
     }
 
@@ -286,14 +279,12 @@ public final class PemX509Certificate extends X509Certificate implements PemEnco
     }
 
     @Override
-    public void checkValidity() throws CertificateExpiredException,
-            CertificateNotYetValidException {
+    public void checkValidity() {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void checkValidity(Date date) throws CertificateExpiredException,
-            CertificateNotYetValidException {
+    public void checkValidity(Date date) {
         throw new UnsupportedOperationException();
     }
 
@@ -328,7 +319,7 @@ public final class PemX509Certificate extends X509Certificate implements PemEnco
     }
 
     @Override
-    public byte[] getTBSCertificate() throws CertificateEncodingException {
+    public byte[] getTBSCertificate() {
         throw new UnsupportedOperationException();
     }
 
@@ -373,16 +364,12 @@ public final class PemX509Certificate extends X509Certificate implements PemEnco
     }
 
     @Override
-    public void verify(PublicKey key)
-            throws CertificateException, NoSuchAlgorithmException,
-            InvalidKeyException, NoSuchProviderException, SignatureException {
+    public void verify(PublicKey key) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void verify(PublicKey key, String sigProvider)
-            throws CertificateException, NoSuchAlgorithmException,
-            InvalidKeyException, NoSuchProviderException, SignatureException {
+    public void verify(PublicKey key, String sigProvider) {
         throw new UnsupportedOperationException();
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
@@ -37,7 +37,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * <p>Instances of this class must be {@link #release() released} or else native memory will leak!
  */
 public final class ReferenceCountedOpenSslServerContext extends ReferenceCountedOpenSslContext {
-    private static final byte[] ID = new byte[] {'n', 'e', 't', 't', 'y'};
+    private static final byte[] ID = {'n', 'e', 't', 't', 'y'};
     private final OpenSslServerSessionContext sessionContext;
     private final OpenSslKeyMaterialManager keyMaterialManager;
 


### PR DESCRIPTION
Motivation:

In latest refeactoring we failed to cleanup imports and also there are some throws declarations which are not needed.

Modifications:

Cleanup imports and throws declarations

Result:

Cleaner code.