### PR TITLE
Ensure we only call ReferenceCountUtil.safeRelease(...) in finalize()…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -18,6 +18,8 @@ package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.ReferenceCounted;
 import io.netty.util.internal.NativeLibraryLoader;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
@@ -431,5 +433,11 @@ public final class OpenSsl {
 
     private static String normalize(String value) {
         return value.toLowerCase(Locale.US).replaceAll("[^a-z0-9]+", "");
+    }
+
+    static void releaseIfNeeded(ReferenceCounted counted) {
+        if (counted.refCnt() > 0) {
+            ReferenceCountUtil.safeRelease(counted);
+        }
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslContext.java
@@ -24,8 +24,6 @@ import java.security.cert.Certificate;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
-import static io.netty.util.ReferenceCountUtil.safeRelease;
-
 /**
  * This class will use a finalizer to ensure native resources are automatically cleaned up. To avoid finalizers
  * and manually release the native memory see {@link ReferenceCountedOpenSslContext}.
@@ -55,6 +53,6 @@ public abstract class OpenSslContext extends ReferenceCountedOpenSslContext {
     @SuppressWarnings("FinalizeDeclaration")
     protected final void finalize() throws Throwable {
         super.finalize();
-        safeRelease(this);
+        OpenSsl.releaseIfNeeded(this);
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslEngine.java
@@ -39,6 +39,6 @@ public final class OpenSslEngine extends ReferenceCountedOpenSslEngine {
     @SuppressWarnings("FinalizeDeclaration")
     protected void finalize() throws Throwable {
         super.finalize();
-        safeRelease(this);
+        OpenSsl.releaseIfNeeded(this);
     }
 }


### PR DESCRIPTION
… if the refCnt() > 0

Motivation:

We need to ensure we only call ReferenceCountUtil.safeRelease(...) in finalize() if the refCnt() > 0 as otherwise we will log a message about IllegalReferenceCountException.

Modification:

Check for a refCnt() > 0 before try to release

Result:

No more IllegalReferenceCountException produced when run finalize() on OpenSsl* objects that where explicit released before.