### PR TITLE
Remove volatile from field as its not needed.

### DIFF
--- a/example/src/main/java/io/netty/example/proxy/HexDumpProxyFrontendHandler.java
+++ b/example/src/main/java/io/netty/example/proxy/HexDumpProxyFrontendHandler.java
@@ -29,7 +29,9 @@ public class HexDumpProxyFrontendHandler extends ChannelInboundHandlerAdapter {
     private final String remoteHost;
     private final int remotePort;
 
-    private volatile Channel outboundChannel;
+    // As we use inboundChannel.eventLoop() when buildling the Bootstrap this does not need to be volatile as
+    // the outboundChannel will use the same EventLoop (and therefore Thread) as the inboundChannel.
+    private Channel outboundChannel;
 
     public HexDumpProxyFrontendHandler(String remoteHost, int remotePort) {
         this.remoteHost = remoteHost;


### PR DESCRIPTION
Motivation:

We not need to mark the field as volatile and so this may confuse people.

Modifications:

Remove volatile and add comment to explain why its not needed.

Result:

More correct example.