### PR TITLE
HTTP/2 limit streams in all states

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -386,7 +386,8 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
             Long maxConcurrentStreams = settings.maxConcurrentStreams();
             if (maxConcurrentStreams != null) {
                 int value = (int) Math.min(maxConcurrentStreams, Integer.MAX_VALUE);
-                connection.remote().maxActiveStreams(value);
+                // By default just enforce the SETTINGS_MAX_CONCURRENT_STREAMS limit for stream in all states.
+                connection.remote().maxStreams(value, value);
             }
 
             Long headerTableSize = settings.headerTableSize();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoder.java
@@ -29,6 +29,7 @@ import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGH
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static java.lang.Integer.MAX_VALUE;
 import static java.lang.Math.min;
 
 /**
@@ -87,12 +88,13 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
 
         Long maxConcurrentStreams = settings.maxConcurrentStreams();
         if (maxConcurrentStreams != null) {
-            connection.local().maxActiveStreams((int) min(maxConcurrentStreams, Integer.MAX_VALUE));
+            // TODO(scott): define an extension setting so we can communicate/enforce the maxStreams limit locally.
+            connection.local().maxStreams((int) min(maxConcurrentStreams, MAX_VALUE), MAX_VALUE);
         }
 
         Long headerTableSize = settings.headerTableSize();
         if (headerTableSize != null) {
-            outboundHeaderTable.maxHeaderTableSize((int) min(headerTableSize, Integer.MAX_VALUE));
+            outboundHeaderTable.maxHeaderTableSize((int) min(headerTableSize, MAX_VALUE));
         }
 
         Integer maxHeaderListSize = settings.maxHeaderListSize();
@@ -384,7 +386,7 @@ public class DefaultHttp2ConnectionEncoder implements Http2ConnectionEncoder {
         public boolean merge(ChannelHandlerContext ctx, Http2RemoteFlowController.FlowControlled next) {
             FlowControlledData nextData;
             if (FlowControlledData.class != next.getClass() ||
-                Integer.MAX_VALUE - (nextData = (FlowControlledData) next).size() < size()) {
+                MAX_VALUE - (nextData = (FlowControlledData) next).size() < size()) {
                 return false;
             }
             nextData.queue.copyTo(queue);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2RemoteFlowController.java
@@ -276,7 +276,7 @@ public class DefaultHttp2RemoteFlowController implements Http2RemoteFlowControll
         private BooleanSupplier isWritableSupplier = new BooleanSupplier() {
             @Override
             public boolean get() throws Exception {
-                return windowSize() - pendingBytes() > 0;
+                return windowSize() > pendingBytes();
             }
         };
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -195,7 +195,6 @@ public interface Http2Connection {
          * <ul>
          * <li>The requested stream ID is not the next sequential ID for this endpoint.</li>
          * <li>The stream already exists.</li>
-         * <li>{@link #isExhausted()} is {@code true}</li>
          * <li>{@link #canOpenStream()} is {@code false}.</li>
          * <li>The connection is marked as going away.</li>
          * </ul>
@@ -257,11 +256,22 @@ public interface Http2Connection {
         int maxActiveStreams();
 
         /**
-         * Sets the maximum number of streams (created by this endpoint) that are allowed to be active at once.
-         * This is the {@code SETTINGS_MAX_CONCURRENT_STREAMS} value sent from the opposite endpoint to
-         * restrict stream creation by this endpoint.
+         * The limit imposed by {@link #maxActiveStreams()} does not apply to streams in the IDLE state. Since IDLE
+         * streams can still consume resources this limit will include streams in all states.
+         * @return The maximum number of streams that can exist at any given time.
          */
-        void maxActiveStreams(int maxActiveStreams);
+        int maxStreams();
+
+        /**
+         * Sets the limit for {@code SETTINGS_MAX_CONCURRENT_STREAMS} and the limit for {@link #maxStreams()}.
+         * @param maxActiveStreams The maximum number of streams (created by this endpoint) that are allowed to be
+         * active at once. This is the {@code SETTINGS_MAX_CONCURRENT_STREAMS} value sent from the opposite endpoint to
+         * restrict stream creation by this endpoint.
+         * @param maxStreams The limit imposed by {@link #maxActiveStreams()} does not apply to streams in the IDLE
+         * state. Since IDLE streams can still consume resources this limit will include streams in all states.
+         * @throws Http2Exception if {@code maxStreams < maxActiveStream}.
+         */
+        void maxStreams(int maxActiveStreams, int maxStreams) throws Http2Exception;
 
         /**
          * Gets the ID of the stream last successfully created by this endpoint.

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -453,9 +453,9 @@ public class StreamBufferingEncoderTest {
     }
 
     @Test
-    public void closeShouldCancelAllBufferedStreams() {
+    public void closeShouldCancelAllBufferedStreams() throws Http2Exception {
         encoder.writeSettingsAck(ctx, newPromise());
-        connection.local().maxActiveStreams(0);
+        connection.local().maxStreams(0, 0);
 
         ChannelFuture f1 = encoderWriteHeaders(3, newPromise());
         ChannelFuture f2 = encoderWriteHeaders(5, newPromise());


### PR DESCRIPTION
Motivation:
SETTINGS_MAX_CONCURRENT_STREAMS does not apply to idle streams and thus we do not apply any explicit limitations on how many idle streams can be created. This may allow a peer to consume an undesirable amount of resources.

Modifications:
- Each Endpoint should enforce a limit for streams in a any state. By default this limit will be the same as SETTINGS_MAX_CONCURRENT_STREAMS but can be overridden if necessary.

Result:
There is now a limit to how many IDLE streams can be created.