### PR TITLE
AbstractByteBuf forEach minimize byte code

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1240,39 +1240,31 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public int forEachByte(ByteProcessor processor) {
-        int index = readerIndex;
-        int length = writerIndex - index;
         ensureAccessible();
-        return forEachByteAsc0(index, length, processor);
+        try {
+            return forEachByteAsc0(readerIndex, writerIndex, processor);
+        } catch (Exception e) {
+            PlatformDependent.throwException(e);
+            return -1;
+        }
     }
 
     @Override
     public int forEachByte(int index, int length, ByteProcessor processor) {
         checkIndex(index, length);
-        return forEachByteAsc0(index, length, processor);
-    }
-
-    private int forEachByteAsc0(int index, int length, ByteProcessor processor) {
-        if (processor == null) {
-            throw new NullPointerException("processor");
-        }
-
-        if (length == 0) {
-            return -1;
-        }
-
-        final int endIndex = index + length;
-        int i = index;
         try {
-            do {
-                if (processor.process(_getByte(i))) {
-                    i ++;
-                } else {
-                    return i;
-                }
-            } while (i < endIndex);
+            return forEachByteAsc0(index, index + length, processor);
         } catch (Exception e) {
             PlatformDependent.throwException(e);
+            return -1;
+        }
+    }
+
+    private int forEachByteAsc0(int start, int end, ByteProcessor processor) throws Exception {
+        for (; start < end; ++start) {
+            if (!processor.process(_getByte(start))) {
+                return start;
+            }
         }
 
         return -1;
@@ -1280,42 +1272,32 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public int forEachByteDesc(ByteProcessor processor) {
-        int index = readerIndex;
-        int length = writerIndex - index;
         ensureAccessible();
-        return forEachByteDesc0(index, length, processor);
+        try {
+            return forEachByteDesc0(writerIndex, readerIndex, processor);
+        } catch (Exception e) {
+            PlatformDependent.throwException(e);
+            return -1;
+        }
     }
 
     @Override
     public int forEachByteDesc(int index, int length, ByteProcessor processor) {
         checkIndex(index, length);
-
-        return forEachByteDesc0(index, length, processor);
-    }
-
-    private int forEachByteDesc0(int index, int length, ByteProcessor processor) {
-
-        if (processor == null) {
-            throw new NullPointerException("processor");
-        }
-
-        if (length == 0) {
-            return -1;
-        }
-
-        int i = index + length - 1;
         try {
-            do {
-                if (processor.process(_getByte(i))) {
-                    i --;
-                } else {
-                    return i;
-                }
-            } while (i >= index);
+            return forEachByteDesc0(index + length - 1, index, processor);
         } catch (Exception e) {
             PlatformDependent.throwException(e);
+            return -1;
         }
+    }
 
+    private int forEachByteDesc0(int rStart, final int rEnd, ByteProcessor processor) throws Exception {
+        for (; rStart >= rEnd; --rStart) {
+            if (!processor.process(_getByte(rStart))) {
+                return rStart;
+            }
+        }
         return -1;
     }
 


### PR DESCRIPTION
Motivation:
The default limit for the maximum amount of bytes that a method will be inlined is 35 bytes. AbstractByteBuf#forEach and AbstractByteBuf#forEachDesc comprise of method calls which are more than this maximum default threshold and may prevent or delay inlining for occuring. The byte code for these methods can be reduced to allow for easier inlining. Here are the current byte code sizes:

AbstractByteBuf::forEachByte (24 bytes)
AbstractByteBuf::forEachByte(int,int,..) (14 bytes)
AbstractByteBuf::forEachByteAsc0 (71 bytes)
AbstractByteBuf::forEachByteDesc (24 bytes)
AbstractByteBuf::forEachByteDesc(int,int,.) (24 bytes)
AbstractByteBuf::forEachByteDesc0 (69 bytes)

Modifications:
- Reduce the code for each method in the AbstractByteBuf#forEach and AbstractByteBuf#forEachDesc call stack

Result:
AbstractByteBuf::forEachByte (25 bytes)
AbstractByteBuf::forEachByte(int,int,..) (25 bytes)
AbstractByteBuf::forEachByteAsc0 (29 bytes)
AbstractByteBuf::forEachByteDesc (25 bytes)
AbstractByteBuf::forEachByteDesc(int,int,..) (27 bytes)
AbstractByteBuf::forEachByteDesc0 (29 bytes)