### PR TITLE
Avoid implicit "flush" calls in EmbeddedChannel#writeInbound() and #writeOutbound()

### DIFF
--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -15,6 +15,23 @@
  */
 package io.netty.channel.embedded;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.nio.channels.ClosedChannelException;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
@@ -29,22 +46,10 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.ScheduledFuture;
-import org.junit.Test;
-
-import java.util.ArrayDeque;
-import java.util.Queue;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 
 public class EmbeddedChannelTest {
 
@@ -378,6 +383,162 @@ public class EmbeddedChannelTest {
         assertTrue(channel.finish());
         assertSame(msg, channel.readOutbound());
         assertNull(channel.readOutbound());
+    }
+
+    @Test
+    public void testFlushInbound() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
+            @Override
+            public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+              latch.countDown();
+            }
+        });
+
+        channel.flushInbound();
+
+        if (!latch.await(1L, TimeUnit.SECONDS)) {
+            fail("Nobody called #channelReadComplete() in time.");
+        }
+    }
+
+    @Test
+    public void testWriteOneInbound() throws InterruptedException {
+      final CountDownLatch latch = new CountDownLatch(1);
+      final AtomicInteger flushCount = new AtomicInteger(0);
+
+      EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter() {
+          @Override
+          public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+              ReferenceCountUtil.release(msg);
+              latch.countDown();
+          }
+
+          @Override
+          public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+              flushCount.incrementAndGet();
+          }
+      });
+
+      channel.writeOneInbound("Hello, Netty!");
+
+      if (!latch.await(1L, TimeUnit.SECONDS)) {
+          fail("Nobody called #channelRead() in time.");
+      }
+
+      channel.close().syncUninterruptibly();
+
+      // There was no #flushInbound() call so nobody should have called
+      // #channelReadComplete()
+      assertEquals(flushCount.get(), 0);
+    }
+
+    @Test
+    public void testFlushOutbound() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void flush(ChannelHandlerContext ctx) throws Exception {
+                latch.countDown();
+            }
+        });
+
+        channel.flushOutbound();
+
+        if (!latch.await(1L, TimeUnit.SECONDS)) {
+            fail("Nobody called #flush() in time.");
+        }
+    }
+
+    @Test
+    public void testWriteOneOutbound() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicInteger flushCount = new AtomicInteger(0);
+
+        EmbeddedChannel channel = new EmbeddedChannel(new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+                ctx.write(msg, promise);
+                latch.countDown();
+            }
+
+            @Override
+            public void flush(ChannelHandlerContext ctx) throws Exception {
+                flushCount.incrementAndGet();
+            }
+        });
+
+        // This shouldn't trigger a #flush()
+        channel.writeOneOutbound("Hello, Netty!");
+
+        if (!latch.await(1L, TimeUnit.SECONDS)) {
+            fail("Nobody called #write() in time.");
+        }
+
+        channel.close().syncUninterruptibly();
+
+        // There was no #flushOutbound() call so nobody should have called #flush()
+        assertEquals(0, flushCount.get());
+    }
+
+    @Test
+    public void testEnsureOpen() throws InterruptedException {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        channel.close().syncUninterruptibly();
+
+        try {
+            channel.writeOutbound("Hello, Netty!");
+            fail("This should have failed with a ClosedChannelException");
+        } catch (Exception expected) {
+            assertTrue(expected instanceof ClosedChannelException);
+        }
+
+        try {
+            channel.writeInbound("Hello, Netty!");
+            fail("This should have failed with a ClosedChannelException");
+        } catch (Exception expected) {
+            assertTrue(expected instanceof ClosedChannelException);
+        }
+    }
+
+    @Test
+    public void testHandleInboundMessage() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        EmbeddedChannel channel = new EmbeddedChannel() {
+            @Override
+            protected void handleInboundMessage(Object msg) {
+                latch.countDown();
+            }
+        };
+
+        channel.writeOneInbound("Hello, Netty!");
+
+        if (!latch.await(1L, TimeUnit.SECONDS)) {
+            fail("Nobody called #handleInboundMessage() in time.");
+        }
+    }
+
+    @Test
+    public void testHandleOutboundMessage() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        EmbeddedChannel channel = new EmbeddedChannel() {
+            @Override
+            protected void handleOutboundMessage(Object msg) {
+                latch.countDown();
+            }
+        };
+
+        channel.writeOneOutbound("Hello, Netty!");
+        if (latch.await(50L, TimeUnit.MILLISECONDS)) {
+            fail("Somebody called unexpectedly #flush()");
+        }
+
+        channel.flushOutbound();
+        if (!latch.await(1L, TimeUnit.SECONDS)) {
+            fail("Nobody called #handleOutboundMessage() in time.");
+        }
     }
 
     private static void release(ByteBuf... buffers) {


### PR DESCRIPTION
Adding ability omit the implicit #flush() call in EmbeddedChannel#writeOutbound() the implicit #fireChannelReadComplete() in EmbeddedChannel#writeInbound().

Motivation

We use EmbeddedChannels to implement a ProxyChannel of some sorts that shovels
messages between a source and a destination Channel. The latter are real network
channels (such as Epoll) and they may or may not be managed in a ChannelPool. We
could fuse both ends directly together but the EmbeddedChannel provides a nice
disposable section of a ChannelPipeline that can be used to instrument the messages
that are passing through the proxy portion.

The ideal flow looks abount like this:

source#channelRead() -> proxy#writeOutbound() -> destination#write()
source#channelReadComplete() -> proxy#flushOutbound() -> destination#flush()

destination#channelRead() -> proxy#writeInbound() -> source#write()
destination#channelReadComplete() -> proxy#flushInbound() -> source#flush()

The problem is that #writeOutbound() and #writeInbound() emit surplus #flush()
and #fireChannelReadComplete() events which in turn yield to surplus #flush()
calls on both ends of the pipeline.

Modifications

Introduce a new #flushOutbound() and #flushInbound() method and give the user
the option opt-out from implicit #flush() calls that happen in #writeOutbound()
and #writeInbound()

Result

It's possible to implement the above ideal flow.