### PR TITLE
Make SocksServer example compatible with `curl --socks5-hostname`

### DIFF
--- a/example/src/main/java/io/netty/example/socksproxy/SocksServerConnectHandler.java
+++ b/example/src/main/java/io/netty/example/socksproxy/SocksServerConnectHandler.java
@@ -102,7 +102,10 @@ public final class SocksServerConnectHandler extends SimpleChannelInboundHandler
                             if (future.isSuccess()) {
                                 ChannelFuture responseFuture =
                                         ctx.channel().writeAndFlush(new DefaultSocks5CommandResponse(
-                                                Socks5CommandStatus.SUCCESS, request.dstAddrType()));
+                                                Socks5CommandStatus.SUCCESS,
+                                                request.dstAddrType(),
+                                                request.dstAddr(),
+                                                request.dstPort()));
 
                                 responseFuture.addListener(new ChannelFutureListener() {
                                     @Override


### PR DESCRIPTION
The example doesn't work with `curl --socks5-hostname`. Tested with chrome and curl.