### PR TITLE
HTTP/2 HPACK Bounds Check Fix

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/Decoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/Decoder.java
@@ -213,7 +213,7 @@ public final class Decoder {
                     if (index == 0x7f) {
                         state = READ_LITERAL_HEADER_NAME_LENGTH;
                     } else {
-                        if (nameLength > maxHeadersLength - headersLength) {
+                        if (index > maxHeadersLength - headersLength) {
                             maxHeaderSizeExceeded();
                         }
                         nameLength = index;


### PR DESCRIPTION
Motivation:
21e8d84 changed the way bounds checking was done, but however a bounds check in the case of READ_LITERAL_HEADER_NAME_LENGTH_PREFIX was using an old value. This would delay when the bounds check would actually be done and potentially allow more allocation than necessary.

Modifications:
- Use the new length (index) in the bounds check instead of an old length (nameLength) which had not yet been assigned to the new value.

Result:
More correct bounds checking.