### PR TITLE
Never expose user.dir to the web on directory listing

### DIFF
--- a/example/src/main/java/io/netty/example/http/file/HttpStaticFileServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/file/HttpStaticFileServerHandler.java
@@ -137,7 +137,7 @@ public class HttpStaticFileServerHandler extends SimpleChannelInboundHandler<Ful
 
         if (file.isDirectory()) {
             if (uri.endsWith("/")) {
-                sendListing(ctx, file);
+                sendListing(ctx, file, uri);
             } else {
                 sendRedirect(ctx, uri + '/');
             }
@@ -264,11 +264,10 @@ public class HttpStaticFileServerHandler extends SimpleChannelInboundHandler<Ful
 
     private static final Pattern ALLOWED_FILE_NAME = Pattern.compile("[A-Za-z0-9][-_A-Za-z0-9\\.]*");
 
-    private static void sendListing(ChannelHandlerContext ctx, File dir) {
+    private static void sendListing(ChannelHandlerContext ctx, File dir, String dirPath) {
         FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, OK);
         response.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8");
 
-        String dirPath = dir.getPath();
         StringBuilder buf = new StringBuilder()
             .append("<!DOCTYPE html>\r\n")
             .append("<html><head><title>")


### PR DESCRIPTION
When Netty HTTP Static File Server does directory listing, it does expose the user.dir environment variable to the user. Although it doesn't a security issue, it is a bad practice to show it, and the user does expect to see the server virtual root instead, which is the *absolute path* as mentioned in the RFC. 
  
    http_URL = "http:" "//" host [ ":" port ] [ abs_path [ "?" query ]] 

I am attaching a fix for this issue. ~~I've created a `sendListing(ChannelHandlerContext,File)` method for backward compatibility, so nothing should fail because of this change.~~

This PR is against the 4.1 branch. Should I PR it against 4.0 as well?