### PR TITLE
Bug in ReferenceCountedOpenSslServerContext#setKeyMaterial 

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/PemEncodedTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PemEncodedTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.ssl;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.netty.util.ReferenceCountUtil;
+
+@RunWith(Parameterized.class)
+public class PemEncodedTest {
+
+    private static PemPrivateKey PEM_ENCODED_PRIVATE_KEY;
+
+    private static PemX509Certificate PEM_ENCODED_CERTIFICATE;
+
+    @Parameters
+    public static Collection<SslProvider> providers() {
+        return Arrays.asList(SslProvider.OPENSSL, SslProvider.OPENSSL_REFCNT);
+    }
+
+    private final SslProvider provider;
+
+    public PemEncodedTest(SslProvider provider) {
+        this.provider = provider;
+    }
+
+    @BeforeClass
+    public static void init() throws Exception {
+        assumeTrue(OpenSsl.isAvailable());
+
+        SelfSignedCertificate ssc = new SelfSignedCertificate();
+        try {
+            PEM_ENCODED_PRIVATE_KEY = PemPrivateKey.valueOf(toByteArray(ssc.privateKey()));
+            PEM_ENCODED_CERTIFICATE = PemX509Certificate.valueOf(toByteArray(ssc.certificate()));
+        } finally {
+            ssc.delete();
+        }
+    }
+
+    @Test
+    public void testPemEncoded() throws Exception {
+        Assume.assumeTrue(OpenSsl.isAvailable());
+        SslContext context = SslContextBuilder.forServer(PEM_ENCODED_PRIVATE_KEY, PEM_ENCODED_CERTIFICATE)
+                .sslProvider(provider)
+                .build();
+        try {
+            assertTrue("context=" + context, context instanceof ReferenceCountedOpenSslContext);
+        } finally {
+            ReferenceCountUtil.release(context);
+        }
+    }
+
+    private static byte[] toByteArray(File file) throws Exception {
+        FileInputStream in = new FileInputStream(file);
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try {
+                byte[] buf = new byte[1024];
+                int len = -1;
+                while ((len = in.read(buf)) != -1) {
+                    baos.write(buf, 0, len);
+                }
+            } finally {
+                baos.close();
+            }
+
+            return baos.toByteArray();
+        } finally {
+            in.close();
+        }
+    }
+}


### PR DESCRIPTION
The private key and certificate that are passed into `#serKeyMaterial()` could be `PemEncoded` in which case the `#toPEM()` methods return the identity of the value.

That in turn will fail in the `#toBIO()` step because the underlying ByteBuf is not necessarily direct.

Attached is a new Unit Test shows the problem.

The test will fail with the following error if `assert` are turned on:
```java
13:42:38.595 [main] DEBUG io.netty.handler.ssl.JdkSslContext - Default cipher suites (JDK): [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_128_GCM_SHA256, TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_256_CBC_SHA, SSL_RSA_WITH_3DES_EDE_CBC_SHA]
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.121 sec - in io.netty.handler.ssl.JdkSslClientContextTest
Running io.netty.handler.ssl.PemEncodedTest
java.lang.AssertionError
	at io.netty.handler.ssl.OpenSsl.memoryAddress(OpenSsl.java:359)
	at io.netty.handler.ssl.ReferenceCountedOpenSslContext.newBIO(ReferenceCountedOpenSslContext.java:751)
	at io.netty.handler.ssl.ReferenceCountedOpenSslContext.setKeyMaterial(ReferenceCountedOpenSslContext.java:645)
	at io.netty.handler.ssl.ReferenceCountedOpenSslServerContext.newSessionContext(ReferenceCountedOpenSslServerContext.java:110)
	at io.netty.handler.ssl.OpenSslServerContext.<init>(OpenSslServerContext.java:349)
	at io.netty.handler.ssl.OpenSslServerContext.<init>(OpenSslServerContext.java:334)
	at io.netty.handler.ssl.SslContext.newServerContextInternal(SslContext.java:412)
	at io.netty.handler.ssl.SslContextBuilder.build(SslContextBuilder.java:393)
	at io.netty.handler.ssl.PemEncodedTest.testPemEncoded(PemEncodedTest.java:75)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:367)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:274)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:161)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:290)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:242)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:121)
java.lang.AssertionError
	at io.netty.handler.ssl.OpenSsl.memoryAddress(OpenSsl.java:359)
	at io.netty.handler.ssl.ReferenceCountedOpenSslContext.newBIO(ReferenceCountedOpenSslContext.java:751)
	at io.netty.handler.ssl.ReferenceCountedOpenSslContext.setKeyMaterial(ReferenceCountedOpenSslContext.java:645)
	at io.netty.handler.ssl.ReferenceCountedOpenSslServerContext.newSessionContext(ReferenceCountedOpenSslServerContext.java:110)
	at io.netty.handler.ssl.ReferenceCountedOpenSslServerContext.<init>(ReferenceCountedOpenSslServerContext.java:63)
	at io.netty.handler.ssl.ReferenceCountedOpenSslServerContext.<init>(ReferenceCountedOpenSslServerContext.java:49)
	at io.netty.handler.ssl.SslContext.newServerContextInternal(SslContext.java:417)
	at io.netty.handler.ssl.SslContextBuilder.build(SslContextBuilder.java:393)
	at io.netty.handler.ssl.PemEncodedTest.testPemEncoded(PemEncodedTest.java:75)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:367)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:274)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:161)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:290)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:242)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:121)
```

In our testing environment (with no `assert` enabled) it's failing something like along these lines.

```java
Caused by: javax.net.ssl.SSLException: failed to set certificate and key
    at io.netty.handler.ssl.ReferenceCountedOpenSslServerContext.newSessionContext(ReferenceCountedOpenSslServerContext.java:125)
    at io.netty.handler.ssl.ReferenceCountedOpenSslServerContext.<init>(ReferenceCountedOpenSslServerContext.java:63)
    at io.netty.handler.ssl.ReferenceCountedOpenSslServerContext.<init>(ReferenceCountedOpenSslServerContext.java:49)
    at io.netty.handler.ssl.SslContext.newServerContextInternal(SslContext.java:417)
    at io.netty.handler.ssl.SslContextBuilder.build(SslContextBuilder.java:393)
    at com.squarespace.xxx(xxx.java:192)
    at com.squarespace.xxx(xxx.java:133)
    at com.squarespace.xxx(xxx.java:111)
    at com.squarespace.xxx(xxx.java:177)
    at com.squarespace.xxx(xxx.java:147)
    at com.squarespace.xxx(xxx.java:27)
    at com.squarespace.xxx(xxx.java:78)
    ... 10 common frames omitted
Caused by: javax.net.ssl.SSLException: failed to set certificate and key
    at io.netty.handler.ssl.ReferenceCountedOpenSslContext.setKeyMaterial(ReferenceCountedOpenSslContext.java:660)
    at io.netty.handler.ssl.ReferenceCountedOpenSslServerContext.newSessionContext(ReferenceCountedOpenSslServerContext.java:110)
    ... 21 common frames omitted
Caused by: java.lang.Exception: wbuf is null
    at org.apache.tomcat.jni.SSL.$$YJP$$writeToBIO(Native Method)
    at org.apache.tomcat.jni.SSL.writeToBIO(SSL.java)
    at io.netty.handler.ssl.ReferenceCountedOpenSslContext.newBIO(ReferenceCountedOpenSslContext.java:751)
    at io.netty.handler.ssl.ReferenceCountedOpenSslContext.setKeyMaterial(ReferenceCountedOpenSslContext.java:645)
    ... 22 common frames omitted
```