### PR TITLE
HTTP/2: Treat MAX_CONCURRENT_STREAMS exceeded as a stream error.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -1050,7 +1050,7 @@ public class DefaultHttp2Connection implements Http2Connection {
             }
             if (state.localSideOpen() || state.remoteSideOpen()) {
                 if (!canOpenStream()) {
-                    throw connectionError(REFUSED_STREAM, "Maximum active streams violated for this endpoint.");
+                    throw streamError(streamId, REFUSED_STREAM, "Maximum active streams violated for this endpoint.");
                 }
             } else if (numStreams == maxStreams) {
                 throw streamError(streamId, REFUSED_STREAM, "Maximum streams violated for this endpoint.");


### PR DESCRIPTION
Motivation:

As per the HTTP/2 spec, exceeding the MAX_CONCURRENT_STREAMS should be treated as a stream error as opposed to a connection error.

"An endpoint that receives a HEADERS frame that causes its advertised concurrent stream limit to be exceeded MUST treat this as a stream error (Section 5.4.2) of type PROTOCOL_ERROR or REFUSED_STREAM." http://httpwg.org/specs/rfc7540.html#rfc.section.5.1.2

Modifications:

Make the error a stream error.

Result:

It's a stream error.

PTL @Scottmitch @nmittler 