### PR TITLE
Auto-flush for channels. (`ChannelHandler` implementation)

### DIFF
--- a/microbench/src/test/java/io/netty/microbench/channel/AbstractChannelBenchmark.java
+++ b/microbench/src/test/java/io/netty/microbench/channel/AbstractChannelBenchmark.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.channel;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.microbench.util.AbstractSharedExecutorMicrobenchmark;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.Future;
+import io.netty.util.internal.ThreadLocalRandom;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.net.SocketAddress;
+
+import static java.util.concurrent.TimeUnit.*;
+
+abstract class AbstractChannelBenchmark extends AbstractSharedExecutorMicrobenchmark {
+
+    public static final ChannelInitializer<Channel> EMPTY_INITIALIZER = new ChannelInitializer<Channel>() {
+        @Override
+        protected void initChannel(Channel ch) throws Exception {
+            ch.pipeline().addLast(BufferReleaseHandler.INSTANCE);
+        }
+    };
+    protected ChannelPipeline pipeline;
+    protected ByteBuf payload;
+    protected Channel serverChannel;
+    protected Channel clientChannel;
+    protected NioEventLoopGroup serverEventloop;
+    protected NioEventLoopGroup clientEventLoop;
+
+    protected void setup0(ChannelInitializer<Channel> serverInitializer,
+                          ChannelInitializer<Channel> clientInitializer) {
+        serverEventloop = new NioEventLoopGroup(1, new DefaultThreadFactory("server", true));
+        clientEventLoop = new NioEventLoopGroup(1, new DefaultThreadFactory("client", true));
+        ServerBootstrap sb = new ServerBootstrap();
+        sb.group(serverEventloop)
+          .channel(NioServerSocketChannel.class)
+          .childHandler(serverInitializer);
+
+        payload = createData(1024);
+
+        Bootstrap cb = new Bootstrap();
+        cb.group(clientEventLoop)
+          .channel(NioSocketChannel.class)
+          .handler(clientInitializer);
+
+        ChannelFuture bind = sb.bind(0);
+        SocketAddress serverAddr;
+        try {
+            bind.sync();
+            serverChannel = bind.channel();
+            serverAddr = serverChannel.localAddress();
+            ChannelFuture clientChannelFuture = cb.connect(serverAddr);
+            clientChannelFuture.sync();
+            clientChannel = clientChannelFuture.channel();
+            pipeline = clientChannel.pipeline();
+        } catch (InterruptedException ie) {
+            throw new IllegalStateException(ie);
+        }
+
+        AbstractSharedExecutorMicrobenchmark.executor(clientEventLoop.next());
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() throws Exception {
+        if (clientChannel != null) {
+            clientChannel.close();
+        }
+        if (serverChannel != null) {
+            serverChannel.close();
+        }
+        Future<?> serverGroup = null;
+        Future<?> clientGroup = null;
+
+        if (serverEventloop != null) {
+            serverGroup = serverEventloop.shutdownGracefully(0, 0, MILLISECONDS);
+        }
+        if (clientEventLoop != null) {
+            clientGroup = clientEventLoop.shutdownGracefully(0, 0, MILLISECONDS);
+        }
+        if (serverGroup != null) {
+            serverGroup.sync();
+        }
+        if (clientGroup != null) {
+            clientGroup.sync();
+        }
+        payload.release();
+    }
+
+    protected static ByteBuf createData(int length) {
+        byte[] result = new byte[length];
+        ThreadLocalRandom.current().nextBytes(result);
+        return Unpooled.directBuffer().writeBytes(result);
+    }
+
+    protected void awaitCompletion(ChannelFuture lastWriteFuture) throws Exception {
+        if (lastWriteFuture != null) {
+            lastWriteFuture.await();
+        }
+    }
+
+    @Sharable
+    static final class BufferReleaseHandler extends SimpleChannelInboundHandler<Object> {
+
+        public static final BufferReleaseHandler INSTANCE = new BufferReleaseHandler();
+
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
+            // No Op, just to release the buffer.
+        }
+    }
+}

--- a/microbench/src/test/java/io/netty/microbench/channel/AutoFlushBenchmark.java
+++ b/microbench/src/test/java/io/netty/microbench/channel/AutoFlushBenchmark.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.channel;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.AutoFlushHandler;
+import io.netty.util.concurrent.ScheduledFuture;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import static java.util.concurrent.TimeUnit.*;
+
+@State(Scope.Benchmark)
+public class AutoFlushBenchmark extends AbstractChannelBenchmark {
+
+    @Param({ "true", "false" })
+    public boolean autoFlush;
+
+    @Param({ "1", "10", "100" })
+    public int writeCount;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        setup0(EMPTY_INITIALIZER, new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ch.pipeline().addFirst(new AutoFlushHandler());
+                ch.pipeline().addLast(BufferReleaseHandler.INSTANCE);
+            }
+        });
+    }
+
+    @Benchmark
+    public void compareWithFlushOnEach() throws Exception {
+        ChannelFuture lastWriteFuture = null;
+        if (!autoFlush) {
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.writeAndFlush(payload.retainedDuplicate());
+            }
+        } else {
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+            }
+        }
+
+        awaitCompletion(lastWriteFuture);
+    }
+
+    @Benchmark
+    public void compareWithFlushAtEnd() throws Exception {
+        ChannelFuture lastWriteFuture = null;
+        if (!autoFlush) {
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+            }
+            pipeline.flush();
+        } else {
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+            }
+        }
+
+        awaitCompletion(lastWriteFuture);
+    }
+
+    @Benchmark
+    public void compareWithFlushEvery5() throws Exception {
+        ChannelFuture lastWriteFuture = null;
+        if (!autoFlush) {
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+                if (i % 5 == 0) {
+                    pipeline.flush();
+                }
+            }
+            pipeline.flush();
+        } else {
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+            }
+        }
+
+        awaitCompletion(lastWriteFuture);
+    }
+
+    @Benchmark
+    public void compareWithFlushEverySecond() throws Exception {
+        ChannelFuture lastWriteFuture = null;
+        ScheduledFuture<?> scheduledFuture = null;
+        if (!autoFlush) {
+            scheduledFuture = pipeline.channel().eventLoop().scheduleWithFixedDelay(new Runnable() {
+                @Override
+                public void run() {
+                    pipeline.flush();
+                }
+            }, 1, 1, SECONDS);
+
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+            }
+            pipeline.flush();
+        } else {
+            for (int i = 0; i < writeCount; i++) {
+                lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+            }
+        }
+
+        awaitCompletion(lastWriteFuture);
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(true);
+        }
+    }
+}

--- a/microbench/src/test/java/io/netty/microbench/channel/ChannelWriteBenchmark.java
+++ b/microbench/src/test/java/io/netty/microbench/channel/ChannelWriteBenchmark.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.channel;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class ChannelWriteBenchmark extends AbstractChannelBenchmark {
+
+    @Param({ "1", "5", "10" })
+    public int handlerCount;
+
+    @Param({ "1", "10" })
+    public int writeCount;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        setup0(EMPTY_INITIALIZER, new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                for (int i = 0; i < handlerCount; i++) {
+                    ch.pipeline().addLast(new ChannelDuplexHandler());
+                }
+                ch.pipeline().addFirst(BufferReleaseHandler.INSTANCE);
+            }
+        });
+    }
+
+    @Benchmark
+    public void measureWriteWithFlushAtEnd() throws Exception {
+        ChannelFuture lastWriteFuture = null;
+        for (int i = 0; i < writeCount; i++) {
+            lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+        }
+        pipeline.flush();
+        awaitCompletion(lastWriteFuture);
+    }
+
+    @Benchmark
+    public void measureWriteWithFlushOnEach() throws Exception {
+        ChannelFuture lastWriteFuture = null;
+        for (int i = 0; i < writeCount; i++) {
+            lastWriteFuture = pipeline.writeAndFlush(payload.retainedDuplicate());
+        }
+        awaitCompletion(lastWriteFuture);
+    }
+}

--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -833,6 +833,14 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap
                 task = WriteTask.newInstance(next, m, promise);
             }
             safeExecute(executor, task, promise, m);
+            if (!flush) {
+                /**
+                 * Whenever there is a write, if auto-flush is enabled, the eventloop is required to be woken up,
+                 * otherwise the write may never be flushed or have latency.
+                 * This method just wakes up the eventloop once till the next auto-flush task is run.
+                 */
+                pipeline.wakeUpForAutoFlushIfRequired();
+            }
         }
     }
 

--- a/transport/src/main/java/io/netty/channel/AutoFlushHandler.java
+++ b/transport/src/main/java/io/netty/channel/AutoFlushHandler.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel;
+
+/**
+ * Netty is extremely flexible in providing a way to batch writes on the physical socket by providing a means to write
+ * and flush writes separately. This works for the usecases when the application pattern is one that provides
+ * predictable finite streams of data. In cases, when an infinite stream of data is to be written on a channel which
+ * does not have any predictable length and duration of writes, a user has the following choices:
+ * <ol>
+ * <li>Flush every write. </li>
+ * <li>Flush batches based on time and count (eg: Flush every 10 message or 1 second) . </li>
+ * </ol>
+ *
+ * Neither of the above is ideal as the nature of stream is completely unpredictable.
+ * Flushing every write is costly as flush is a system call.
+ * Flushing batches is arbitrary and has to be deviced for each stream in an arbitrary way.  
+ *
+ * This handler addresses the above usecase by providing a way to batch writes and flush them at the following points:
+ * <ol>
+ * <li>At the end of the eventloop iteration.</li>
+ * <li>If the channel becomes unwritable determined via {@link #channelWritabilityChanged(ChannelHandlerContext)}
+ * callback.</li>
+ * </ol>
+ *
+ * Any explicit flushes are honored as usual.
+ *
+ * <h2>Restrictions</h2>
+ *
+ * Due to limitation of existing APIs, {@link AutoFlushHandler} can only be used if the following conditions are met:
+ *
+ * <ol>
+ *     <li>Channel is registered with an {@link EventLoop} that extends {@link SingleThreadEventLoop}.</li>
+ *     <li>{@link ChannelPipeline} is an instance of {@link DefaultChannelPipeline}</li>
+ *     <li>This handler is not executed by any executor apart from the channel's eventloop.</li>
+ * </ol>
+ *
+ * If any of the above conditions are not met, this handler will fail on
+ * {@link #channelRegistered(ChannelHandlerContext)}.
+ *
+ * <h2>Recommendations</h2>
+ *
+ * The {@link AutoFlushHandler} should be put as first {@link ChannelHandler} in the
+ * {@link ChannelPipeline} to have the best effect.
+ */
+public class AutoFlushHandler extends ChannelDuplexHandler implements Runnable {
+    private boolean flushPending;
+    private boolean flushScheduled;
+    private SingleThreadEventLoop eventLoop;
+    private Channel channel;
+    private DefaultChannelPipeline pipeline;
+
+    @Override
+    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+        channel = ctx.channel();
+        ChannelPipeline pipeline = ctx.channel().pipeline();
+        if (!(pipeline instanceof DefaultChannelPipeline)) {
+            throw new IllegalStateException(
+                    "Auto flush is only supported with " + DefaultChannelPipeline.class.getName());
+        }
+        this.pipeline = (DefaultChannelPipeline) pipeline;
+        EventLoop eventLoop = ctx.channel().eventLoop();
+        if (!(eventLoop instanceof SingleThreadEventLoop)) {
+            throw new IllegalStateException(
+                    "Auto flush is only supported for " + SingleThreadEventLoop.class.getName() + " eventloops.");
+        }
+        this.eventLoop = (SingleThreadEventLoop) eventLoop;
+        if (this.eventLoop != ctx.executor()) {
+            throw new IllegalStateException(AutoFlushHandler.class.getName() + " must run on the channel eventloop.");
+        }
+        super.channelRegistered(ctx);
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        flushPending = true;
+        super.write(ctx, msg, promise);
+        scheduleFlushIfRequired();
+    }
+
+    @Override
+    public void flush(ChannelHandlerContext ctx) throws Exception {
+        flushIfPending(ctx);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        // To ensure we not miss to flush anything, do it now.
+        flushIfPending(ctx);
+        ctx.fireExceptionCaught(cause);
+    }
+
+    @Override
+    public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        // Try to flush one last time if flushes are pending before disconnect the channel.
+        flushIfPending(ctx);
+        ctx.disconnect(promise);
+    }
+
+    @Override
+    public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        // Try to flush one last time if flushes are pending before close the channel.
+        flushIfPending(ctx);
+        ctx.close(promise);
+    }
+
+    @Override
+    public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+        if (!ctx.channel().isWritable()) {
+            // The writability of the channel changed to false, so flush immediately to free up memory.
+            flushIfPending(ctx);
+        }
+        ctx.fireChannelWritabilityChanged();
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        flushIfPending(ctx);
+    }
+
+    /**
+     * Executed at the end of an eventloop iteration and flush the channel.
+     */
+    @Override
+    public void run() {
+        /**
+         * Task is only scheduled if there are any writes pending and the pending status is cleared only after the flush
+         * call reaches this handler. This makes sure that writes are not lost without a flush since the handler is
+         * single-threaded.
+         */
+        flushScheduled = false;
+        /**
+         * Flush from the start of the pipeline and not from this handler onwards as many handlers would expect a flush
+         * and calling flush from this handler onwards will most likely break that assumption because there is no
+         * explicit flush from user and this handler is recommended to be at the head of the pipeline.
+         */
+        channel.pipeline().flush();
+        /**
+         * Reset the status on the pipeline so that a subsequent write will wake up the selector if required.
+         */
+        pipeline.postAutoFlush();
+    }
+
+    private void scheduleFlushIfRequired() {
+        if (!flushScheduled) {
+            eventLoop.executeAfterEventLoopIteration(this);
+            flushScheduled = true;
+        }
+    }
+
+    private void flushIfPending(ChannelHandlerContext ctx) {
+        assert eventLoop != null && eventLoop.inEventLoop();
+
+        if (flushPending) {
+            /**
+             * This flush call will actually flush the channel as this must be at the pipeline head, so clear the
+             * pending status.
+             */
+            flushPending = false;
+            ctx.flush();
+        }
+    }
+}

--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -22,6 +22,7 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.EventExecutorGroup;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -36,6 +37,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.WeakHashMap;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 /**
  * The default {@link ChannelPipeline} implementation.  It is usually created
@@ -83,6 +85,27 @@ public class DefaultChannelPipeline implements ChannelPipeline {
      * change.
      */
     private boolean registered;
+
+    private static final AtomicIntegerFieldUpdater<DefaultChannelPipeline> ENQUEUE_WAKEUP_TASK_UPDATER;
+    private static final Runnable WAKEUP_TASK = new Runnable() {
+        @Override
+        public void run() {
+            // No Op
+        }
+    };
+
+    static {
+        AtomicIntegerFieldUpdater<DefaultChannelPipeline> enqueueWakeupTaskUpdater =
+                PlatformDependent.newAtomicIntegerFieldUpdater(DefaultChannelPipeline.class, "enqueueWakeupTask");
+        if (enqueueWakeupTaskUpdater == null) {
+            enqueueWakeupTaskUpdater = AtomicIntegerFieldUpdater.newUpdater(DefaultChannelPipeline.class,
+                                                                            "enqueueWakeupTask");
+        }
+        ENQUEUE_WAKEUP_TASK_UPDATER = enqueueWakeupTaskUpdater;
+    }
+
+    @SuppressWarnings("unused")
+    private volatile int enqueueWakeupTask;
 
     protected DefaultChannelPipeline(Channel channel) {
         this.channel = ObjectUtil.checkNotNull(channel, "channel");
@@ -1138,6 +1161,37 @@ public class DefaultChannelPipeline implements ChannelPipeline {
             }
             pending.next = task;
         }
+    }
+
+    /**
+     * Wakes up the selector, if the following conditions are met:
+     * <ul>
+     *   <li>{@link #isAutoFlush()} is {@code true}</li>
+     *   <li>This is the first write, since the last time {@link #postAutoFlush()} was called, which is called, after
+     *   an auto-flush task has run.</li>
+     * </ul>
+     */
+    final void wakeUpForAutoFlushIfRequired() {
+        if (isAutoFlush() && ENQUEUE_WAKEUP_TASK_UPDATER.compareAndSet(this, 0, 1)) {
+            channel().eventLoop().execute(WAKEUP_TASK);
+        }
+    }
+
+    /**
+     * Whether this pipeline contains {@link AutoFlushHandler}.
+     *
+     * @return {@code true} if this pipeline contains {@link AutoFlushHandler}.
+     */
+    final boolean isAutoFlush() {
+        return get(AutoFlushHandler.class) != null;
+    }
+
+    /**
+     * Callback when an auto-flush task has run. This will make sure that the next invocation of
+     * {@link #wakeUpForAutoFlushIfRequired()} will wakeup the selector, if auto-flush is still enabled.
+     */
+    final void postAutoFlush() {
+        ENQUEUE_WAKEUP_TASK_UPDATER.set(this, 0);
     }
 
     /**

--- a/transport/src/test/java/io/netty/channel/AutoFlushTest.java
+++ b/transport/src/test/java/io/netty/channel/AutoFlushTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.concurrent.PromiseCombiner;
+import io.netty.util.internal.ThreadLocalRandom;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.SocketAddress;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class AutoFlushTest {
+
+    public static TestEnvironment environment;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        environment = new TestEnvironment((SingleThreadEventLoop) new NioEventLoopGroup().next(),
+                                          (SingleThreadEventLoop) new NioEventLoopGroup().next(),
+                                          NioServerSocketChannel.class, NioSocketChannel.class);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        environment.shutdown();
+    }
+
+    @Test(timeout = 20000)
+    public void testSingleWrite() throws Exception {
+        environment.connect();
+        environment.pipeline.write(newDataBuffer()).sync();
+    }
+
+    @Test(timeout = 20000)
+    public void testWithWriteOnContext() throws Exception {
+        environment.connect();
+        environment.pipeline.lastContext().write(newDataBuffer()).sync();
+    }
+
+    @Test(timeout = 20000)
+    public void testWriteFromFlush() throws Exception {
+        environment.connect();
+        environment.clientChannel.pipeline().addLast(new ChannelDuplexHandler() {
+            private boolean written;
+            @Override
+            public void flush(ChannelHandlerContext ctx) throws Exception {
+                if (!written) {
+                    written = true;
+                    environment.pipeline.write(newDataBuffer());
+                }
+                super.flush(ctx);
+            }
+        });
+        environment.pipeline.write(newDataBuffer()).sync();
+    }
+
+    @Test(timeout = 20000)
+    public void testMultipleWrites() throws Exception {
+        environment.connect();
+        final ChannelPromise aggreggatedPromise = environment.clientChannel.newPromise();
+        ByteBuf data = newDataBuffer();
+        doMultipleWrites(aggreggatedPromise, data);
+        data.release();
+    }
+
+    @Test(timeout = 20000)
+    public void testMultipleWritesOnTwoIterations() throws Exception {
+        environment.connect();
+        final ChannelPromise aggreggatedPromise = environment.clientChannel.newPromise();
+        ByteBuf data = newDataBuffer();
+        doMultipleWrites(aggreggatedPromise, data);
+
+        doMultipleWrites(aggreggatedPromise, data);
+        data.release();
+    }
+
+    private static void doMultipleWrites(ChannelPromise aggreggatedPromise, ByteBuf data) throws InterruptedException {
+        PromiseCombiner promiseCombiner = new PromiseCombiner();
+        for (int i = 0; i < 10; i++) {
+            ChannelPromise promise = environment.clientChannel.newPromise();
+            promiseCombiner.add(promise);
+            environment.clientChannel.write(data.retainedDuplicate(), promise);
+        }
+        promiseCombiner.finish(aggreggatedPromise);
+        aggreggatedPromise.sync();
+    }
+
+    @Test(timeout = 20000)
+    public void testFromWithinEventloop() throws Exception {
+        environment.connect();
+        final AtomicReference<ChannelFuture> writeResult = new AtomicReference<ChannelFuture>();
+        environment.clientChannel.eventLoop().submit(new Runnable() {
+            @Override
+            public void run() {
+                writeResult.set(environment.pipeline.write(newDataBuffer()));
+            }
+        }).sync();
+
+        writeResult.get().sync();
+    }
+
+    private static ByteBuf newDataBuffer() {
+        byte[] dataArr = new byte[32];
+        ThreadLocalRandom.current().nextBytes(dataArr);
+        return Unpooled.wrappedBuffer(dataArr);
+    }
+
+    public static final class TestEnvironment {
+
+        private final SingleThreadEventLoop serverEventloop;
+        private final SingleThreadEventLoop clientEventloop;
+        private final ServerBootstrap serverBootstrap;
+        private final Bootstrap bootstrap;
+        private ChannelPipeline pipeline;
+        private Channel clientChannel;
+        private Channel serverChannel;
+
+        private TestEnvironment(SingleThreadEventLoop serverEventloop, SingleThreadEventLoop clientEventloop,
+                                Class<? extends ServerChannel> serverChannelClass,
+                                Class<? extends Channel> clientChannelClass) {
+            this.serverEventloop = serverEventloop;
+            this.clientEventloop = clientEventloop;
+            serverBootstrap = new ServerBootstrap();
+            serverBootstrap.group(serverEventloop)
+                           .channel(serverChannelClass)
+                           .childHandler(new ChannelInitializer<Channel>() {
+                               @Override
+                               protected void initChannel(Channel ch) throws Exception {
+                                   ch.pipeline().addFirst(new AutoFlushHandler());
+                                   ch.pipeline().addLast(BufferReleaseHandler.INSTANCE);
+                               }
+                           });
+            bootstrap = new Bootstrap();
+            bootstrap.group(clientEventloop)
+                     .channel(clientChannelClass)
+                     .handler(new ChannelInitializer<Channel>() {
+                         @Override
+                         protected void initChannel(Channel ch) throws Exception {
+                             ch.pipeline().addFirst(new AutoFlushHandler());
+                             ch.pipeline().addLast(BufferReleaseHandler.INSTANCE);
+                         }
+                     });
+        }
+
+        public void connect() {
+            ChannelFuture bind = serverBootstrap.bind(0);
+            SocketAddress serverAddr;
+            try {
+                bind.sync();
+                serverChannel = bind.channel();
+                serverAddr = serverChannel.localAddress();
+                ChannelFuture clientChannelFuture = bootstrap.connect(serverAddr);
+                clientChannelFuture.sync();
+                clientChannel = clientChannelFuture.channel();
+            } catch (InterruptedException ie) {
+                throw new RuntimeException(ie);
+            }
+            pipeline = clientChannel.pipeline();
+            if (clientChannel.pipeline().get(AutoFlushHandler.class) == null) {
+                throw new IllegalStateException("Auto-flush not set.");
+            }
+        }
+
+        private void shutdown() throws InterruptedException {
+            clientChannel.close().sync();
+            serverChannel.close().sync();
+            serverEventloop.shutdownGracefully();
+            clientEventloop.shutdownGracefully();
+        }
+    }
+
+    @Sharable
+    private static final class BufferReleaseHandler extends SimpleChannelInboundHandler<Object> {
+
+        public static final BufferReleaseHandler INSTANCE = new BufferReleaseHandler();
+
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
+            // No Op, just to release the buffer.
+        }
+    }
+}


### PR DESCRIPTION
This is an alternate approach to #5395. As suggested in the other PR by @buchgr, this change implements auto-flush as a `ChannelHandler` as opposed to a `ChannelOption`.

#### Motivation

  Netty is extremely flexible in providing a way to batch writes on the physical socket by providing a means to `write` and `flush` writes separately. This works for the usecases when the application pattern is one that provides predictable finite streams of data. In cases, when an infinite stream of data is to be written on a channel which does not have any predictable length and duration of writes, a user has the following choices:

 - Flush every write. 
 - Flush batches based on time and count (eg: Flush every 10 message or 1 second)   

Neither of the above is ideal as the nature of stream is completely unpredictable. Flushing every write is costly as `flush` is a system call. Flushing batches is arbitrary and has to be deviced for each stream in an arbitrary way.  

#### Modifications

A new handler `AutoFlushHandler` is added which must be added as the first handler in the `ChannelPipeline` to achieve this batching technique.
This handler flushes writes at the end of an eventloop iteration and when the channel becomes unwritable.

#### Result

This results in a much better model for infinite streams written to a channel.

I wrote a micro-benchmark(`io.netty.microbench.channel.AutoFlushBenchmark`) to demonstrate the throughput variations between all possible current alternatives.
Here are the results for the same:

```
Benchmark                                       (autoFlush)  (writeCount)   Mode  Cnt      Score      Error  Units
AutoFlushBenchmark.compareWithFlushAtEnd               true             1  thrpt   10  47460.595 ±  884.360  ops/s
AutoFlushBenchmark.compareWithFlushAtEnd               true            10  thrpt   10  41769.552 ±  509.156  ops/s
AutoFlushBenchmark.compareWithFlushAtEnd               true           100  thrpt   10  11431.234 ±  124.230  ops/s
AutoFlushBenchmark.compareWithFlushAtEnd              false             1  thrpt   10  47029.181 ± 1324.622  ops/s
AutoFlushBenchmark.compareWithFlushAtEnd              false            10  thrpt   10  41443.218 ±  569.993  ops/s
AutoFlushBenchmark.compareWithFlushAtEnd              false           100  thrpt   10  11186.934 ±  151.784  ops/s
AutoFlushBenchmark.compareWithFlushEvery5              true             1  thrpt   10  46541.047 ±  779.492  ops/s
AutoFlushBenchmark.compareWithFlushEvery5              true            10  thrpt   10  41148.699 ±  811.419  ops/s
AutoFlushBenchmark.compareWithFlushEvery5              true           100  thrpt   10  11227.447 ±  113.237  ops/s
AutoFlushBenchmark.compareWithFlushEvery5             false             1  thrpt   10  46859.571 ± 2536.977  ops/s
AutoFlushBenchmark.compareWithFlushEvery5             false            10  thrpt   10  27549.307 ±  501.463  ops/s
AutoFlushBenchmark.compareWithFlushEvery5             false           100  thrpt   10   5012.850 ±  245.910  ops/s
AutoFlushBenchmark.compareWithFlushEverySecond         true             1  thrpt   10  46605.384 ± 1146.755  ops/s
AutoFlushBenchmark.compareWithFlushEverySecond         true            10  thrpt   10  40687.203 ±  393.613  ops/s
AutoFlushBenchmark.compareWithFlushEverySecond         true           100  thrpt   10  11128.321 ±  383.451  ops/s
AutoFlushBenchmark.compareWithFlushEverySecond        false             1  thrpt   10  47122.981 ± 2056.204  ops/s
AutoFlushBenchmark.compareWithFlushEverySecond        false            10  thrpt   10  42489.389 ±  604.065  ops/s
AutoFlushBenchmark.compareWithFlushEverySecond        false           100  thrpt   10  10699.283 ± 2776.768  ops/s
AutoFlushBenchmark.compareWithFlushOnEach              true             1  thrpt   10  46467.370 ±  884.730  ops/s
AutoFlushBenchmark.compareWithFlushOnEach              true            10  thrpt   10  40345.107 ±  675.270  ops/s
AutoFlushBenchmark.compareWithFlushOnEach              true           100  thrpt   10  11120.811 ±  299.829  ops/s
AutoFlushBenchmark.compareWithFlushOnEach             false             1  thrpt   10  48094.632 ±  755.758  ops/s
AutoFlushBenchmark.compareWithFlushOnEach             false            10  thrpt   10  12648.450 ±  258.287  ops/s
AutoFlushBenchmark.compareWithFlushOnEach             false           100  thrpt   10   1392.127 ±   16.210  ops/s
```
This was done on MBP with 16GB of memory and 8 processors.