### PR TITLE
Cleanup javadocs

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -103,8 +103,6 @@ public final class ByteBufUtil {
     }
 
     /**
-<<<<<<< HEAD
-=======
      * Returns a <a href="http://en.wikipedia.org/wiki/Hex_dump">hex dump</a>
      * of the specified byte array.
      */
@@ -121,7 +119,6 @@ public final class ByteBufUtil {
     }
 
     /**
->>>>>>> e5386b0... Move Hex dump related util from ByteBufUtil to inner class
      * Calculates the hash code of the specified buffer.  This method is
      * useful when implementing a new buffer type.
      */


### PR DESCRIPTION
Motivation:

Due some unclean merge we had merge messages in the javadocs

Modifications:

cleanup.

Result:

Correct javadoc.