### PR TITLE
Cookie name must be case sensitive

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/DefaultCookie.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/DefaultCookie.java
@@ -135,7 +135,7 @@ public class DefaultCookie implements Cookie {
         }
 
         Cookie that = (Cookie) o;
-        if (!name().equalsIgnoreCase(that.name())) {
+        if (!name().equals(that.name())) {
             return false;
         }
 
@@ -164,7 +164,7 @@ public class DefaultCookie implements Cookie {
 
     @Override
     public int compareTo(Cookie c) {
-        int v = name().compareToIgnoreCase(c.name());
+        int v = name().compareTo(c.name());
         if (v != 0) {
             return v;
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieDecoderTest.java
@@ -73,6 +73,10 @@ public class ServerCookieDecoderTest {
         Cookie c;
 
         c = it.next();
+        assertEquals("ARPT", c.name());
+        assertEquals("LWUKQPSWRTUN04CKKJI", c.value());
+
+        c = it.next();
         assertEquals("__utma", c.name());
         assertEquals("48461872.1094088325.1258140131.1258140131.1258140131.1", c.value());
 
@@ -89,10 +93,6 @@ public class ServerCookieDecoderTest {
         assertEquals("48461872.1258140131.1.1.utmcsr=overstock.com|" +
                 "utmccn=(referral)|utmcmd=referral|utmcct=/Home-Garden/Furniture/Clearance/clearance/32/dept.html",
                 c.value());
-
-        c = it.next();
-        assertEquals("ARPT", c.name());
-        assertEquals("LWUKQPSWRTUN04CKKJI", c.value());
 
         c = it.next();
         assertEquals("kw-2E343B92-B097-442c-BFA5-BE371E0325A2", c.name());
@@ -181,5 +181,22 @@ public class ServerCookieDecoderTest {
     public void testRejectCookieValueWithSemicolon() {
         Set<Cookie> cookies = ServerCookieDecoder.STRICT.decode("name=\"foo;bar\";");
         assertTrue(cookies.isEmpty());
+    }
+
+    @Test
+    public void testCaseSensitiveNames() {
+        Set<Cookie> cookies = ServerCookieDecoder.STRICT.decode("session_id=a; Session_id=b;");
+        Iterator<Cookie> it = cookies.iterator();
+        Cookie c;
+
+        c = it.next();
+        assertEquals("Session_id", c.name());
+        assertEquals("b", c.value());
+
+        c = it.next();
+        assertEquals("session_id", c.name());
+        assertEquals("a", c.value());
+
+        assertFalse(it.hasNext());
     }
 }


### PR DESCRIPTION
Motivation:

RFC 6265 does not state that cookie names must be case insensitive.

Modifications:

Fix io.netty.handler.codec.http.cookie.DefaultCookie#equals() method to
use case sensitive String#equals() and String#compareTo().

Result:

It is possible to parse several cookies with same names but with
different cases.