### PR TITLE
Remove @Deprecated for DefaultChannelConfig.getWriteBuffer(Low|High)W…

### DIFF
--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/DefaultRxtxChannelConfig.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/DefaultRxtxChannelConfig.java
@@ -250,14 +250,12 @@ final class DefaultRxtxChannelConfig extends DefaultChannelConfig implements Rxt
     }
 
     @Override
-    @Deprecated
     public RxtxChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
         super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
         return this;
     }
 
     @Override
-    @Deprecated
     public RxtxChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
         super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
         return this;

--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannelConfig.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannelConfig.java
@@ -294,11 +294,9 @@ public interface RxtxChannelConfig extends ChannelConfig {
     RxtxChannelConfig setAutoClose(boolean autoClose);
 
     @Override
-    @Deprecated
     RxtxChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
 
     @Override
-    @Deprecated
     RxtxChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
 
     @Override

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpChannelConfig.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpChannelConfig.java
@@ -222,14 +222,12 @@ public class DefaultSctpChannelConfig extends DefaultChannelConfig implements Sc
     }
 
     @Override
-    @Deprecated
     public SctpChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
         super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
         return this;
     }
 
     @Override
-    @Deprecated
     public SctpChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
         super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
         return this;

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpServerChannelConfig.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/DefaultSctpServerChannelConfig.java
@@ -203,14 +203,12 @@ public class DefaultSctpServerChannelConfig extends DefaultChannelConfig impleme
     }
 
     @Override
-    @Deprecated
     public SctpServerChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
         super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
         return this;
     }
 
     @Override
-    @Deprecated
     public SctpServerChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
         super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
         return this;

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpChannelConfig.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpChannelConfig.java
@@ -122,11 +122,9 @@ public interface SctpChannelConfig extends ChannelConfig {
     SctpChannelConfig setAutoClose(boolean autoClose);
 
     @Override
-    @Deprecated
     SctpChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
 
     @Override
-    @Deprecated
     SctpChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
 
     @Override

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/SctpServerChannelConfig.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/SctpServerChannelConfig.java
@@ -117,11 +117,9 @@ public interface SctpServerChannelConfig extends ChannelConfig {
     SctpServerChannelConfig setAutoClose(boolean autoClose);
 
     @Override
-    @Deprecated
     SctpServerChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
 
     @Override
-    @Deprecated
     SctpServerChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
 
     @Override

--- a/transport-udt/src/main/java/io/netty/channel/udt/DefaultUdtChannelConfig.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/DefaultUdtChannelConfig.java
@@ -285,14 +285,12 @@ public class DefaultUdtChannelConfig extends DefaultChannelConfig implements
     }
 
     @Override
-    @Deprecated
     public UdtChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
         super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
         return this;
     }
 
     @Override
-    @Deprecated
     public UdtChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
         super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
         return this;

--- a/transport-udt/src/main/java/io/netty/channel/udt/DefaultUdtServerChannelConfig.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/DefaultUdtServerChannelConfig.java
@@ -181,14 +181,12 @@ public class DefaultUdtServerChannelConfig extends DefaultUdtChannelConfig
     }
 
     @Override
-    @Deprecated
     public UdtServerChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
         super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
         return this;
     }
 
     @Override
-    @Deprecated
     public UdtServerChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
         super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
         return this;

--- a/transport-udt/src/main/java/io/netty/channel/udt/UdtChannelConfig.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/UdtChannelConfig.java
@@ -136,11 +136,9 @@ public interface UdtChannelConfig extends ChannelConfig {
     UdtChannelConfig setAutoClose(boolean autoClose);
 
     @Override
-    @Deprecated
     UdtChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
 
     @Override
-    @Deprecated
     UdtChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
 
     @Override

--- a/transport-udt/src/main/java/io/netty/channel/udt/UdtServerChannelConfig.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/UdtServerChannelConfig.java
@@ -94,11 +94,9 @@ public interface UdtServerChannelConfig extends UdtChannelConfig {
     UdtServerChannelConfig setSystemSendBufferSize(int size);
 
     @Override
-    @Deprecated
     UdtServerChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
 
     @Override
-    @Deprecated
     UdtServerChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
 
     @Override

--- a/transport/src/main/java/io/netty/channel/ChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/ChannelConfig.java
@@ -220,13 +220,11 @@ public interface ChannelConfig {
     int getWriteBufferHighWaterMark();
 
     /**
-     * @deprecated Use {@link #setWriteBufferWaterMark(WriteBufferWaterMark)}
      * <p>
      * Sets the high water mark of the write buffer.  If the number of bytes
      * queued in the write buffer exceeds this value, {@link Channel#isWritable()}
      * will start to return {@code false}.
      */
-    @Deprecated
     ChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
 
     /**
@@ -239,7 +237,6 @@ public interface ChannelConfig {
     int getWriteBufferLowWaterMark();
 
     /**
-     * @deprecated Use {@link #setWriteBufferWaterMark(WriteBufferWaterMark)}
      * <p>
      * Sets the low water mark of the write buffer.  Once the number of bytes
      * queued in the write buffer exceeded the
@@ -247,7 +244,6 @@ public interface ChannelConfig {
      * dropped down below this value, {@link Channel#isWritable()} will start to return
      * {@code true} again.
      */
-    @Deprecated
     ChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
 
     /**

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -359,13 +359,11 @@ public class DefaultChannelConfig implements ChannelConfig {
     }
 
     @Override
-    @Deprecated
     public int getWriteBufferHighWaterMark() {
         return writeBufferWaterMark.high();
     }
 
     @Override
-    @Deprecated
     public ChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
         if (writeBufferHighWaterMark < 0) {
             throw new IllegalArgumentException(
@@ -387,13 +385,11 @@ public class DefaultChannelConfig implements ChannelConfig {
     }
 
     @Override
-    @Deprecated
     public int getWriteBufferLowWaterMark() {
         return writeBufferWaterMark.low();
     }
 
     @Override
-    @Deprecated
     public ChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
         if (writeBufferLowWaterMark < 0) {
             throw new IllegalArgumentException(

--- a/transport/src/main/java/io/netty/channel/socket/DefaultDatagramChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DefaultDatagramChannelConfig.java
@@ -402,14 +402,12 @@ public class DefaultDatagramChannelConfig extends DefaultChannelConfig implement
     }
 
     @Override
-    @Deprecated
     public DatagramChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
         super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
         return this;
     }
 
     @Override
-    @Deprecated
     public DatagramChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
         super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
         return this;

--- a/transport/src/main/java/io/netty/channel/socket/DefaultServerSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DefaultServerSocketChannelConfig.java
@@ -186,14 +186,12 @@ public class DefaultServerSocketChannelConfig extends DefaultChannelConfig
     }
 
     @Override
-    @Deprecated
     public ServerSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
         super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
         return this;
     }
 
     @Override
-    @Deprecated
     public ServerSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
         super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
         return this;

--- a/transport/src/main/java/io/netty/channel/socket/DefaultSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/DefaultSocketChannelConfig.java
@@ -324,14 +324,12 @@ public class DefaultSocketChannelConfig extends DefaultChannelConfig
     }
 
     @Override
-    @Deprecated
     public SocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
         super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
         return this;
     }
 
     @Override
-    @Deprecated
     public SocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
         super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
         return this;

--- a/transport/src/main/java/io/netty/channel/socket/ServerSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/ServerSocketChannelConfig.java
@@ -107,18 +107,10 @@ public interface ServerSocketChannelConfig extends ChannelConfig {
     @Override
     ServerSocketChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator);
 
-    /**
-     * @deprecated Use {@link #setWriteBufferWaterMark(WriteBufferWaterMark)}
-     */
     @Override
-    @Deprecated
     ServerSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
 
-    /**
-     * @deprecated Use {@link #setWriteBufferWaterMark(WriteBufferWaterMark)}
-     */
     @Override
-    @Deprecated
     ServerSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioServerSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioServerSocketChannelConfig.java
@@ -166,14 +166,12 @@ public class DefaultOioServerSocketChannelConfig extends DefaultServerSocketChan
     }
 
     @Override
-    @Deprecated
     public OioServerSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
         super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
         return this;
     }
 
     @Override
-    @Deprecated
     public OioServerSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
         super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
         return this;

--- a/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioSocketChannelConfig.java
@@ -194,14 +194,12 @@ public class DefaultOioSocketChannelConfig extends DefaultSocketChannelConfig im
     }
 
     @Override
-    @Deprecated
     public OioSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
         super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
         return this;
     }
 
     @Override
-    @Deprecated
     public OioSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
         super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
         return this;

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioServerSocketChannelConfig.java
@@ -87,11 +87,9 @@ public interface OioServerSocketChannelConfig extends ServerSocketChannelConfig 
     OioServerSocketChannelConfig setAutoClose(boolean autoClose);
 
     @Override
-    @Deprecated
     OioServerSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
 
     @Override
-    @Deprecated
     OioServerSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannelConfig.java
@@ -102,11 +102,9 @@ public interface OioSocketChannelConfig extends SocketChannelConfig {
     OioSocketChannelConfig setAutoClose(boolean autoClose);
 
     @Override
-    @Deprecated
     OioSocketChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
 
     @Override
-    @Deprecated
     OioSocketChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
 
     @Override


### PR DESCRIPTION
…aterMark

Motivation:

The methods are deprecated in DefaultChannelConfig but not in ChannelConfig.
They are used in ChannelOutboundBuffer. I believe they were deprecated in
error.

Modifications:

Remove @Deprecated tag.

Result:

Methods are no longer deprecated in DefaultChannelConfig. That's useful if
you need to implement your own ChannelConfig and want to extend DefaultChannelConfig
for that.