### PR TITLE
SniHandler reference count leak if pipeline replace fails

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -869,7 +869,7 @@ public abstract class SslContext {
         return newHandler(newEngine(alloc, peerHost, peerPort));
     }
 
-    private static SslHandler newHandler(SSLEngine engine) {
+    static SslHandler newHandler(SSLEngine engine) {
         return new SslHandler(engine);
     }
 


### PR DESCRIPTION
Motivation:
The SniHandler attempts to generate a new SslHandler from the selected SslContext in a and insert that SslHandler into the pipeline. However if the underlying channel has been closed or the pipeline has been modified the pipeline.replace(..) operation may fail. Creating the SslHandler may also create a SSLEngine which is of type ReferenceCounted. The SslHandler states that if it is not inserted into a pipeline that it will not take reference count ownership of the SSLEngine. Under these conditions we will leak the SSLEngine if it is reference counted.

Modifications:
- If the pipeline.replace(..) operation fails we should release the SSLEngine object.

Result:
Fixes netty#5678