### PR TITLE
h2childchan: Outbound flow control. Fixes #4941

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -16,36 +16,51 @@
 package io.netty.handler.codec.http2;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
+import io.netty.channel.MessageSizeEstimator;
 import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.ThrowableUtil;
 
 import java.net.SocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.util.ArrayDeque;
 import java.util.Queue;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 /**
  * Child {@link Channel} of another channel, for use for modeling streams as channels.
  */
 abstract class AbstractHttp2StreamChannel extends AbstractChannel {
+
+    private static final AtomicLongFieldUpdater<AbstractHttp2StreamChannel> OUTBOUND_FLOW_CONTROL_WINDOW_UPDATER;
+
     /**
      * Used by subclasses to queue a close channel within the read queue. When read, it will close
      * the channel (using Unsafe) instead of notifying handlers of the message with {@code
      * channelRead()}. Additional inbound messages must not arrive after this one.
      */
     protected static final Object CLOSE_MESSAGE = new Object();
+    /**
+     * Used to add a message to the {@link ChannelOutboundBuffer}, so as to have it re-evaluate its writability state.
+     */
+    private static final Object REEVALUATE_WRITABILITY_MESSAGE = new Object();
     private static final ChannelMetadata METADATA = new ChannelMetadata(false, 16);
     private static final ClosedChannelException CLOSED_CHANNEL_EXCEPTION = ThrowableUtil.unknownStackTrace(
             new ClosedChannelException(), AbstractHttp2StreamChannel.class, "doWrite(...)");
@@ -55,7 +70,7 @@ abstract class AbstractHttp2StreamChannel extends AbstractChannel {
      */
     private static final int ARBITRARY_MESSAGE_SIZE = 9;
 
-    private final ChannelConfig config = new DefaultChannelConfig(this);
+    private final Http2StreamChannelConfig config = new Http2StreamChannelConfig(this);
     private final Queue<Object> inboundBuffer = new ArrayDeque<Object>(4);
     private final Runnable fireChildReadCompleteTask = new Runnable() {
         @Override
@@ -68,10 +83,29 @@ abstract class AbstractHttp2StreamChannel extends AbstractChannel {
         }
     };
 
-    // Volatile, as parent and child channel may be on different eventloops.
+    /**
+     * Volatile, as parent and child channel may be on different eventloops.
+     */
     private volatile int streamId = -1;
     private boolean closed;
     private boolean readInProgress;
+
+    /**
+     * The flow control window of the remote side i.e. the number of bytes this channel is allowed to send to the remote
+     * peer. The window can become negative if a channel handler ignores the channel's writability. We are using a long
+     * so that we realistically don't have to worry about underflow.
+     */
+    @SuppressWarnings("UnusedDeclaration")
+    private volatile long outboundFlowControlWindow;
+
+    static {
+        AtomicLongFieldUpdater<AbstractHttp2StreamChannel> updater = PlatformDependent.newAtomicLongFieldUpdater(
+                AbstractHttp2StreamChannel.class, "outboundFlowControlWindow");
+        if (updater == null) {
+            updater = AtomicLongFieldUpdater.newUpdater(AbstractHttp2StreamChannel.class, "outboundFlowControlWindow");
+        }
+        OUTBOUND_FLOW_CONTROL_WINDOW_UPDATER = updater;
+    }
 
     protected AbstractHttp2StreamChannel(Channel parent) {
         super(parent);
@@ -95,6 +129,14 @@ abstract class AbstractHttp2StreamChannel extends AbstractChannel {
     @Override
     public boolean isActive() {
         return isOpen();
+    }
+
+    @Override
+    public boolean isWritable() {
+        return hasStreamId()
+               // So that the channel doesn't become active before the initial flow control window has been set.
+               && outboundFlowControlWindow > 0
+               && unsafe().outboundBuffer().isWritable();
     }
 
     @Override
@@ -168,70 +210,52 @@ abstract class AbstractHttp2StreamChannel extends AbstractChannel {
         if (closed) {
             throw CLOSED_CHANNEL_EXCEPTION;
         }
-
-        EventExecutor preferredExecutor = preferredEventExecutor();
-
-        // TODO: this is pretty broken; futures should only be completed after they are processed on
-        // the parent channel. However, it isn't currently possible due to ChannelOutboundBuffer's
-        // behavior which requires completing the current future before getting the next message. It
-        // should become easier once we have outbound flow control support.
-        // https://github.com/netty/netty/issues/4941
-        if (preferredExecutor.inEventLoop()) {
-            for (;;) {
-                Object msg = in.current();
-                if (msg == null) {
-                    break;
-                }
-                try {
-                    doWrite(ReferenceCountUtil.retain(msg));
-                } catch (Throwable t) {
-                    // It would be nice to fail the future, but we can't do that if not on the event
-                    // loop. So we instead opt for a solution that is consistent.
-                    pipeline().fireExceptionCaught(t);
-                }
-                in.remove();
+        final MessageSizeEstimator.Handle sizeEstimator = config().getMessageSizeEstimator().newHandle();
+        for (;;) {
+            final Object msg = in.current();
+            if (msg == null) {
+                break;
             }
-            doWriteComplete();
-        } else {
-            // Use a copy because the original msgs will be recycled by AbstractChannel.
-            final Object[] msgsCopy = new Object[in.size()];
-            for (int i = 0; i < msgsCopy.length; i ++) {
-                msgsCopy[i] = ReferenceCountUtil.retain(in.current());
+            // TODO(buchgr): Detecting cancellation relies on ChannelOutboundBuffer internals. NOT COOL!
+            if (msg == Unpooled.EMPTY_BUFFER /* The write was cancelled. */
+                || msg == REEVALUATE_WRITABILITY_MESSAGE /* Write to trigger writability after window update. */) {
                 in.remove();
+                continue;
             }
-
-            preferredExecutor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    for (Object msg : msgsCopy) {
-                        try {
-                            doWrite(msg);
-                        } catch (Throwable t) {
-                            pipeline().fireExceptionCaught(t);
-                        }
-                    }
-                    doWriteComplete();
-                }
-            });
+            final int bytes = sizeEstimator.size(msg);
+            /**
+             * The flow control window needs to be decrement before stealing the message from the buffer (and thereby
+             * decrementing the number of pending bytes). Else, when calling steal() the number of pending bytes could
+             * be less than the writebuffer watermark (=flow control window) and thus trigger a writability change.
+             *
+             * This code must never trigger a writability change. Only reading window updates or channel writes may
+             * change the channel's writability.
+             */
+            incrementOutboundFlowControlWindow(-bytes);
+            final ChannelPromise promise = in.steal();
+            if (bytes > 0) {
+                promise.addListener(new ReturnFlowControlWindowOnFailureListener(bytes));
+            }
+            // TODO(buchgr): Should we also the change the writability if END_STREAM is set?
+            try {
+                doWrite(msg, promise);
+            } catch (Throwable t) {
+                promise.tryFailure(t);
+            }
         }
+        doWriteComplete();
     }
 
     /**
      * Process a single write. Guaranteed to eventually be followed by a {@link #doWriteComplete()},
      * which denotes the end of the batch of writes. May be called from any thread.
      */
-    protected abstract void doWrite(Object msg) throws Exception;
+    protected abstract void doWrite(Object msg, ChannelPromise promise) throws Exception;
 
     /**
-     * Process end of batch of {@link #doWrite()}s. May be called from any thread.
+     * Process end of batch of {@link #doWrite}s. May be called from any thread.
      */
     protected abstract void doWriteComplete();
-
-    /**
-     * The ideal thread for events like {@link #doWrite()} to be processed on. May be used for
-     * efficient batching, but not required.
-     */
-    protected abstract EventExecutor preferredEventExecutor();
 
     /**
      * {@code bytes}-count of bytes provided to {@link #fireChildRead} have been read. May be called
@@ -298,6 +322,18 @@ abstract class AbstractHttp2StreamChannel extends AbstractChannel {
         return streamId != -1;
     }
 
+    protected void incrementOutboundFlowControlWindow(int bytes) {
+        if (bytes == 0) {
+            return;
+        }
+        OUTBOUND_FLOW_CONTROL_WINDOW_UPDATER.addAndGet(this, bytes);
+    }
+
+    // Visible for testing
+    long getOutboundFlowControlWindow() {
+        return outboundFlowControlWindow;
+    }
+
     /**
      * Returns whether reads should continue. The only reason reads shouldn't continue is that the
      * channel was just closed.
@@ -309,10 +345,15 @@ abstract class AbstractHttp2StreamChannel extends AbstractChannel {
             unsafe().close(voidPromise());
             return false;
         }
+        if (msg instanceof Http2WindowUpdateFrame) {
+            Http2WindowUpdateFrame windowUpdate = (Http2WindowUpdateFrame) msg;
+            incrementOutboundFlowControlWindow(windowUpdate.windowSizeIncrement());
+            reevaluateWritability();
+            return true;
+        }
         int numBytesToBeConsumed = 0;
         if (msg instanceof Http2DataFrame) {
-            Http2DataFrame data = (Http2DataFrame) msg;
-            numBytesToBeConsumed = data.content().readableBytes() + data.padding();
+            numBytesToBeConsumed = dataFrameFlowControlBytes((Http2DataFrame) msg);
             allocHandle.lastBytesRead(numBytesToBeConsumed);
         } else {
             allocHandle.lastBytesRead(ARBITRARY_MESSAGE_SIZE);
@@ -325,11 +366,133 @@ abstract class AbstractHttp2StreamChannel extends AbstractChannel {
         return true;
     }
 
+    private void reevaluateWritability() {
+        ChannelOutboundBuffer buffer = unsafe().outboundBuffer();
+        // If the buffer is not writable but should be writable, then write and flush a dummy object
+        // to trigger a writability change.
+        if (!buffer.isWritable() && buffer.totalPendingWriteBytes() < config.getWriteBufferHighWaterMark()) {
+            unsafe().outboundBuffer().addMessage(REEVALUATE_WRITABILITY_MESSAGE, 1, voidPromise());
+            unsafe().flush();
+        }
+    }
+
+    private static int dataFrameFlowControlBytes(Http2DataFrame frame) {
+        return frame.content().readableBytes()
+               + frame.padding()
+               // +1 to account for the pad length field. See http://httpwg.org/specs/rfc7540.html#DATA
+               + (frame.padding() & 1);
+    }
+
     private final class Unsafe extends AbstractUnsafe {
         @Override
         public void connect(final SocketAddress remoteAddress,
                 SocketAddress localAddress, final ChannelPromise promise) {
             promise.setFailure(new UnsupportedOperationException());
+        }
+    }
+
+    /**
+     * Returns the flow-control size for DATA frames, and 0 for all other frames.
+     */
+    private static final class FlowControlledFrameSizeEstimator implements MessageSizeEstimator {
+
+        private static final FlowControlledFrameSizeEstimator INSTANCE = new FlowControlledFrameSizeEstimator();
+
+        private static final class EstimatorHandle implements MessageSizeEstimator.Handle {
+
+            private static final EstimatorHandle INSTANCE = new EstimatorHandle();
+
+            @Override
+            public int size(Object msg) {
+                if (msg instanceof Http2DataFrame) {
+                    return dataFrameFlowControlBytes((Http2DataFrame) msg);
+                }
+                return 0;
+            }
+        }
+
+        @Override
+        public Handle newHandle() {
+            return EstimatorHandle.INSTANCE;
+        }
+    }
+
+    /**
+     * {@link ChannelConfig} so that the high and low writebuffer watermarks can reflect the outbound flow control
+     * window, without having to create a new {@link WriteBufferWaterMark} object whenever the flow control window
+     * changes.
+     */
+    private final class Http2StreamChannelConfig extends DefaultChannelConfig {
+
+        // TODO(buchgr): Overwrite the RecvByteBufAllocator. We only need it to implement max messages per read.
+        Http2StreamChannelConfig(Channel channel) {
+            super(channel);
+        }
+
+        @Override
+        @Deprecated
+        public int getWriteBufferHighWaterMark() {
+            int window = (int) min(Integer.MAX_VALUE, outboundFlowControlWindow);
+            return max(0, window);
+        }
+
+        @Override
+        @Deprecated
+        public int getWriteBufferLowWaterMark() {
+            return getWriteBufferHighWaterMark();
+        }
+
+        @Override
+        public MessageSizeEstimator getMessageSizeEstimator() {
+            return FlowControlledFrameSizeEstimator.INSTANCE;
+        }
+
+        // TODO(buchgr): Throwing exceptions is not ideal. Maybe NO-OP and log a warning?
+        @Override
+        public WriteBufferWaterMark getWriteBufferWaterMark() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @Deprecated
+        public ChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @Deprecated
+        public ChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        @Deprecated
+        public ChannelConfig setWriteBufferWaterMark(WriteBufferWaterMark writeBufferWaterMark) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private class ReturnFlowControlWindowOnFailureListener implements ChannelFutureListener {
+        private final int bytes;
+
+        ReturnFlowControlWindowOnFailureListener(int bytes) {
+            this.bytes = bytes;
+        }
+
+        @Override
+        public void operationComplete(ChannelFuture future) throws Exception {
+            if (!future.isSuccess()) {
+                /**
+                 * Return the flow control window of the failed data frame. We expect this code to be rarely executed
+                 * and by implementing it as a window update, we don't have to worry about thread-safety.
+                 */
+                fireChildRead(new DefaultHttp2WindowUpdateFrame(bytes).setStreamId(getStreamId()));
+            }
         }
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamChannel.java
@@ -28,6 +28,7 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.ThrowableUtil;
 
 import java.net.SocketAddress;
@@ -67,10 +68,12 @@ abstract class AbstractHttp2StreamChannel extends AbstractChannel {
         }
     };
 
+    // Volatile, as parent and child channel may be on different eventloops.
+    private volatile int streamId = -1;
     private boolean closed;
     private boolean readInProgress;
 
-    public AbstractHttp2StreamChannel(Channel parent) {
+    protected AbstractHttp2StreamChannel(Channel parent) {
         super(parent);
     }
 
@@ -91,7 +94,7 @@ abstract class AbstractHttp2StreamChannel extends AbstractChannel {
 
     @Override
     public boolean isActive() {
-        return !closed;
+        return isOpen();
     }
 
     @Override
@@ -278,6 +281,21 @@ abstract class AbstractHttp2StreamChannel extends AbstractChannel {
         } else {
             eventLoop().execute(fireChildReadCompleteTask);
         }
+    }
+
+    protected void setStreamId(int streamId) {
+        if (this.streamId != -1) {
+            throw new IllegalStateException("Stream identifier may only be set once.");
+        }
+        this.streamId = ObjectUtil.checkPositiveOrZero(streamId, "streamId");
+    }
+
+    protected int getStreamId() {
+        return streamId;
+    }
+
+    protected boolean hasStreamId() {
+        return streamId != -1;
     }
 
     /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/AbstractHttp2StreamFrame.java
@@ -24,7 +24,8 @@ import io.netty.util.internal.UnstableApi;
 @UnstableApi
 public abstract class AbstractHttp2StreamFrame implements Http2StreamFrame {
 
-    private int streamId = -1;
+    // Volatile as parent and child channel may be on different eventloops.
+    private volatile int streamId = -1;
 
     @Override
     public AbstractHttp2StreamFrame setStreamId(int streamId) {
@@ -36,8 +37,13 @@ public abstract class AbstractHttp2StreamFrame implements Http2StreamFrame {
     }
 
     @Override
-    public int streamId() {
+    public int getStreamId() {
         return streamId;
+    }
+
+    @Override
+    public boolean hasStreamId() {
+        return streamId != -1;
     }
 
     /**
@@ -49,7 +55,7 @@ public abstract class AbstractHttp2StreamFrame implements Http2StreamFrame {
             return false;
         }
         Http2StreamFrame other = (Http2StreamFrame) o;
-        return streamId == other.streamId();
+        return streamId == other.getStreamId();
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2DataFrame.java
@@ -153,8 +153,8 @@ public final class DefaultHttp2DataFrame extends AbstractHttp2StreamFrame implem
 
     @Override
     public String toString() {
-        return "DefaultHttp2DataFrame(streamId=" + streamId() + ", content=" + content
-            + ", endStream=" + endStream + ", padding=" + padding + ")";
+        return "DefaultHttp2DataFrame(streamId=" + getStreamId() + ", content=" + content
+               + ", endStream=" + endStream + ", padding=" + padding + ")";
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersFrame.java
@@ -90,8 +90,8 @@ public final class DefaultHttp2HeadersFrame extends AbstractHttp2StreamFrame imp
 
     @Override
     public String toString() {
-        return "DefaultHttp2HeadersFrame(streamId=" + streamId() + ", headers=" + headers
-            + ", endStream=" + endStream + ", padding=" + padding + ")";
+        return "DefaultHttp2HeadersFrame(streamId=" + getStreamId() + ", headers=" + headers
+               + ", endStream=" + endStream + ", padding=" + padding + ")";
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ResetFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ResetFrame.java
@@ -62,7 +62,7 @@ public final class DefaultHttp2ResetFrame extends AbstractHttp2StreamFrame imple
 
     @Override
     public String toString() {
-        return "DefaultHttp2ResetFrame(stream=" + streamId() + "errorCode=" + errorCode + ")";
+        return "DefaultHttp2ResetFrame(stream=" + getStreamId() + "errorCode=" + errorCode + ")";
     }
 
     @Override

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Codec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Codec.java
@@ -36,30 +36,26 @@ public final class Http2Codec extends ChannelDuplexHandler {
      *
      * @param server {@code true} this is a server
      * @param streamHandler the handler added to channels for remotely-created streams. It must be
-     *     {@link ChannelHandler.Sharable}.
+     *     {@link ChannelHandler.Sharable}. {@code null} if the event loop from the parent channel should be used.
      */
     public Http2Codec(boolean server, ChannelHandler streamHandler) {
-        this(server, streamHandler, null);
+        this(server, new Http2StreamChannelBootstrap().handler(streamHandler));
     }
 
     /**
      * Construct a new handler whose child channels run in a different event loop.
      *
      * @param server {@code true} this is a server
-     * @param streamHandler the handler added to channels for remotely-created streams. It must be
-     *     {@link ChannelHandler.Sharable}.
-     * @param streamGroup event loop for registering child channels
+     * @param bootstrap bootstrap used to instantiate child channels for remotely-created streams.
      */
-    public Http2Codec(boolean server, ChannelHandler streamHandler,
-                      EventLoopGroup streamGroup) {
-        this(server, streamHandler, streamGroup, new DefaultHttp2FrameWriter());
+    public Http2Codec(boolean server, Http2StreamChannelBootstrap bootstrap) {
+        this(server, bootstrap, new DefaultHttp2FrameWriter());
     }
 
     // Visible for testing
-    Http2Codec(boolean server, ChannelHandler streamHandler,
-               EventLoopGroup streamGroup, Http2FrameWriter frameWriter) {
+    Http2Codec(boolean server, Http2StreamChannelBootstrap bootstrap, Http2FrameWriter frameWriter) {
         frameCodec = new Http2FrameCodec(server, frameWriter);
-        multiplexCodec = new Http2MultiplexCodec(server, streamGroup, streamHandler);
+        multiplexCodec = new Http2MultiplexCodec(server, bootstrap);
     }
 
     Http2FrameCodec frameCodec() {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.UnsupportedMessageTypeException;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler.UpgradeEvent;
+import io.netty.handler.codec.http2.Http2Connection.Endpoint;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.UnstableApi;
 
@@ -28,7 +29,7 @@ import static io.netty.handler.logging.LogLevel.INFO;
 
 /**
  * An HTTP/2 handler that maps HTTP/2 frames to {@link Http2Frame} objects and vice versa. For every incoming HTTP/2
- * frame a {@link Http2Frame} object is created and propagated via {@link #channelRead}. Outgoing {@link Http2Frame}
+ * frame a {@link Http2Frame} object is created and propagated via {@link #channelRead}. Outbound {@link Http2Frame}
  * objects received via {@link #write} are converted to the HTTP/2 wire format.
  *
  * <p>A change in stream state is propagated through the channel pipeline as a user event via
@@ -40,6 +41,63 @@ import static io.netty.handler.logging.LogLevel.INFO;
  *
  * <p><em>This API is very immature.</em> The Http2Connection-based API is currently preferred over
  * this API. This API is targeted to eventually replace or reduce the need for the Http2Connection-based API.
+ *
+ * <h3>Opening and Closing Streams</h3>
+ *
+ * <p>When the remote side opens a new stream, the frame codec first emits a {@link Http2StreamActiveEvent} with the
+ * stream identifier set.
+ * <pre>
+ * Http2FrameCodec                                             Http2MultiplexCodec
+ *        +                                                             +
+ *        |         Http2StreamActiveEvent(streamId=3, headers=null)    |
+ *        +------------------------------------------------------------->
+ *        |                                                             |
+ *        |         Http2HeadersFrame(streamId=3)                       |
+ *        +------------------------------------------------------------->
+ *        |                                                             |
+ *        +                                                             +
+ * </pre>
+ *
+ * <p>When a stream is closed either due to a reset frame by the remote side, or due to both sides having sent frames
+ * with the END_STREAM flag, then the frame codec emits a {@link Http2StreamClosedEvent}.
+ * <pre>
+ * Http2FrameCodec                                         Http2MultiplexCodec
+ *        +                                                         +
+ *        |         Http2StreamClosedEvent(streamId=3)              |
+ *        +--------------------------------------------------------->
+ *        |                                                         |
+ *        +                                                         +
+ * </pre>
+ *
+ * <p>When the local side wants to close a stream, it has to write a {@link Http2ResetFrame} to which the frame codec
+ * will respond to with a {@link Http2StreamClosedEvent}.
+ * <pre>
+ * Http2FrameCodec                                         Http2MultiplexCodec
+ *        +                                                         +
+ *        |         Http2ResetFrame(streamId=3)                     |
+ *        <---------------------------------------------------------+
+ *        |                                                         |
+ *        |         Http2StreamClosedEvent(streamId=3)              |
+ *        +--------------------------------------------------------->
+ *        |                                                         |
+ *        +                                                         +
+ * </pre>
+ *
+ * <p>Opening an outbound/local stream works by first sending the frame codec a {@link Http2HeadersFrame} with no
+ * stream identifier set (such that {@link Http2HeadersFrame#hasStreamId()} returns false). If opening the stream
+ * was successful, the frame codec responds with a {@link Http2StreamActiveEvent} that contains the stream's new
+ * identifier as well as the <em>same</em> {@link Http2HeadersFrame} object that opened the stream.
+ * <pre>
+ * Http2FrameCodec                                                                               Http2MultiplexCodec
+ *        +                                                                                               +
+ *        |         Http2HeadersFrame(streamId=-1)                                                        |
+ *        <-----------------------------------------------------------------------------------------------+
+ *        |                                                                                               |
+ *        |         Http2StreamActiveEvent(streamId=2, headers=Http2HeadersFrame(streamId=-1))            |
+ *        +----------------------------------------------------------------------------------------------->
+ *        |                                                                                               |
+ *        +                                                                                               +
+ * </pre>
  */
 @UnstableApi
 public class Http2FrameCodec extends ChannelDuplexHandler {
@@ -47,6 +105,7 @@ public class Http2FrameCodec extends ChannelDuplexHandler {
     private static final Http2FrameLogger HTTP2_FRAME_LOGGER = new Http2FrameLogger(INFO, Http2FrameCodec.class);
 
     private final Http2ConnectionHandler http2Handler;
+    private final boolean server;
 
     private ChannelHandlerContext ctx;
     private ChannelHandlerContext http2HandlerCtx;
@@ -70,6 +129,7 @@ public class Http2FrameCodec extends ChannelDuplexHandler {
         decoder.frameListener(new FrameListener());
         http2Handler = new InternalHttp2ConnectionHandler(decoder, encoder, new Http2Settings());
         http2Handler.connection().addListener(new ConnectionListener());
+        this.server = server;
     }
 
     Http2ConnectionHandler connectionHandler() {
@@ -134,14 +194,10 @@ public class Http2FrameCodec extends ChannelDuplexHandler {
      */
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
-        if (!(msg instanceof Http2Frame)) {
-            ctx.write(msg, promise);
-            return;
-        }
         try {
             if (msg instanceof Http2WindowUpdateFrame) {
                 Http2WindowUpdateFrame frame = (Http2WindowUpdateFrame) msg;
-                consumeBytes(frame.streamId(), frame.windowSizeIncrement(), promise);
+                consumeBytes(frame.getStreamId(), frame.windowSizeIncrement(), promise);
             } else if (msg instanceof Http2StreamFrame) {
                 writeStreamFrame((Http2StreamFrame) msg, promise);
             } else if (msg instanceof Http2GoAwayFrame) {
@@ -181,22 +237,39 @@ public class Http2FrameCodec extends ChannelDuplexHandler {
     }
 
     private void writeStreamFrame(Http2StreamFrame frame, ChannelPromise promise) {
-        int streamId = frame.streamId();
         if (frame instanceof Http2DataFrame) {
             Http2DataFrame dataFrame = (Http2DataFrame) frame;
-            http2Handler.encoder().writeData(http2HandlerCtx, streamId, dataFrame.content().retain(),
+            http2Handler.encoder().writeData(http2HandlerCtx, frame.getStreamId(), dataFrame.content().retain(),
                                              dataFrame.padding(), dataFrame.isEndStream(), promise);
         } else if (frame instanceof Http2HeadersFrame) {
-            Http2HeadersFrame headerFrame = (Http2HeadersFrame) frame;
-            http2Handler.encoder().writeHeaders(
-                    http2HandlerCtx, streamId, headerFrame.headers(), headerFrame.padding(), headerFrame.isEndStream(),
-                    promise);
+            writeHeadersFrame((Http2HeadersFrame) frame, promise);
         } else if (frame instanceof Http2ResetFrame) {
             Http2ResetFrame rstFrame = (Http2ResetFrame) frame;
-            http2Handler.resetStream(http2HandlerCtx, streamId, rstFrame.errorCode(), promise);
+            http2Handler.resetStream(http2HandlerCtx, frame.getStreamId(), rstFrame.errorCode(), promise);
         } else {
             throw new UnsupportedMessageTypeException(frame);
         }
+    }
+
+    private void writeHeadersFrame(Http2HeadersFrame headersFrame, ChannelPromise promise) {
+        final int streamId;
+        if (headersFrame.hasStreamId()) {
+            streamId = headersFrame.getStreamId();
+        } else {
+            final Endpoint<Http2LocalFlowController> localEndpoint = http2Handler.connection().local();
+            streamId = localEndpoint.incrementAndGetNextStreamId();
+            try {
+                // Try to create a stream in OPEN state before writing headers, to catch errors on stream creation
+                // early on i.e. max concurrent streams limit reached, stream id exhaustion, etc.
+                localEndpoint.createStream(streamId, false);
+            } catch (Http2Exception e) {
+                promise.setFailure(e);
+                return;
+            }
+            ctx.fireUserEventTriggered(new Http2StreamActiveEvent(streamId, headersFrame));
+        }
+        http2Handler.encoder().writeHeaders(http2HandlerCtx, streamId, headersFrame.headers(),
+                                            headersFrame.padding(), headersFrame.isEndStream(), promise);
     }
 
     private final class ConnectionListener extends Http2ConnectionAdapter {
@@ -204,6 +277,10 @@ public class Http2FrameCodec extends ChannelDuplexHandler {
         public void onStreamActive(Http2Stream stream) {
             if (ctx == null) {
                 // UPGRADE stream is active before handlerAdded().
+                return;
+            }
+            if (isOutbound(stream.id())) {
+                // Creation of outbound streams is notified in writeHeadersFrame().
                 return;
             }
             ctx.fireUserEventTriggered(new Http2StreamActiveEvent(stream.id()));
@@ -241,7 +318,7 @@ public class Http2FrameCodec extends ChannelDuplexHandler {
         }
     }
 
-    private final class FrameListener extends Http2FrameAdapter {
+    private static final class FrameListener extends Http2FrameAdapter {
         @Override
         public void onRstStreamRead(ChannelHandlerContext ctx, int streamId, long errorCode) {
             Http2ResetFrame rstFrame = new DefaultHttp2ResetFrame(errorCode);
@@ -274,5 +351,10 @@ public class Http2FrameCodec extends ChannelDuplexHandler {
             // We return the bytes in bytesConsumed() once the stream channel consumed the bytes.
             return 0;
         }
+    }
+
+    private boolean isOutbound(int streamId) {
+        boolean even = (streamId & 1) == 0;
+        return streamId > 0 && server == even;
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -20,13 +20,16 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.handler.codec.UnsupportedMessageTypeException;
 import io.netty.handler.codec.http2.Http2Exception.StreamException;
+import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
@@ -38,18 +41,21 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
+import static io.netty.handler.codec.http2.AbstractHttp2StreamChannel.CLOSE_MESSAGE;
 import static io.netty.handler.codec.http2.Http2Error.STREAM_CLOSED;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static java.lang.String.format;
 
 /**
- * An HTTP/2 handler that creates child channels for each stream. Creating outgoing streams is not
- * yet supported.
+ * An HTTP/2 handler that creates child channels for each stream.
  *
  * <p>When a new stream is created, a new {@link Channel} is created for it. Applications send and
  * receive {@link Http2StreamFrame}s on the created channel. {@link ByteBuf}s cannot be processed by the channel;
- * all writes that reach the head of the pipeline must be an instance of {@link Http2Frame}. Writes that reach the
- * head of the pipeline are processed directly by this handler and cannot be intercepted.
+ * all writes that reach the head of the pipeline must be an instance of {@link Http2StreamFrame}. Writes that reach
+ * the head of the pipeline are processed directly by this handler and cannot be intercepted.
  *
  * <p>The child channel will be notified of user events that impact the stream, such as {@link
  * Http2GoAwayFrame} and {@link Http2ResetFrame}, as soon as they occur. Although {@code
@@ -59,6 +65,8 @@ import static java.lang.String.format;
  * free to close the channel in response to such events if they don't have use for any queued
  * messages.
  *
+ * <p>Outbound streams are supported via the {@link Http2StreamChannelBootstrap}.
+ *
  * <p>{@link ChannelConfig#setMaxMessagesPerRead(int)} and {@link ChannelConfig#setAutoRead(boolean)} are supported.
  */
 @UnstableApi
@@ -66,8 +74,8 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Http2MultiplexCodec.class);
 
-    private final ChannelHandler streamHandler;
-    private final EventLoopGroup streamGroup;
+    private final Http2StreamChannelBootstrap bootstrap;
+
     private final List<Http2StreamChannel> channelsToFireChildReadComplete = new ArrayList<Http2StreamChannel>();
     private final boolean server;
     private ChannelHandlerContext ctx;
@@ -79,25 +87,20 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
      * Construct a new handler whose child channels run in a different event loop.
      *
      * @param server {@code true} this is a server
-     * @param streamHandler the handler added to channels for remotely-created streams. It must be
-     *     {@link ChannelHandler.Sharable}.
-     * @param streamGroup event loop for registering child channels
+     * @param bootstrap bootstrap used to instantiate child channels for remotely-created streams.
      */
-    public Http2MultiplexCodec(boolean server,
-                               EventLoopGroup streamGroup,
-                               ChannelHandler streamHandler) {
-        if (!streamHandler.getClass().isAnnotationPresent(Sharable.class)) {
-            throw new IllegalArgumentException("streamHandler must be Sharable");
-        }
-
+    public Http2MultiplexCodec(boolean server, Http2StreamChannelBootstrap bootstrap) {
         this.server = server;
-        this.streamHandler = streamHandler;
-        this.streamGroup = streamGroup;
+        this.bootstrap = new Http2StreamChannelBootstrap(checkNotNull(bootstrap, "bootstrap must not be null"));
+        if (bootstrap.parentChannel() != null) {
+            throw new IllegalStateException("The parent channel must not be set on the bootstrap.");
+        }
     }
 
     @Override
-    public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+    public void handlerAdded(ChannelHandlerContext ctx) {
         this.ctx = ctx;
+        bootstrap.parentChannel(ctx.channel());
     }
 
     @Override
@@ -113,7 +116,8 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
             if (childChannel != null) {
                 childChannel.pipeline().fireExceptionCaught(streamEx);
             } else {
-                logger.warn(format("Exception caught for unknown HTTP/2 stream '%d'", streamEx.streamId()), streamEx);
+                logger.warn(format("Exception caught for unknown HTTP/2 stream '%d'", streamEx.streamId()),
+                            streamEx);
             }
         } finally {
             onStreamClosed(streamEx.streamId());
@@ -134,7 +138,7 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
         }
         if (msg instanceof Http2StreamFrame) {
             Http2StreamFrame frame = (Http2StreamFrame) msg;
-            int streamId = frame.streamId();
+            int streamId = frame.getStreamId();
             Http2StreamChannel childChannel = childChannels.get(streamId);
             if (childChannel == null) {
                 // TODO: Combine with DefaultHttp2ConnectionDecoder.shouldIgnoreHeadersOrDataFrame logic.
@@ -148,7 +152,7 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
             for (PrimitiveEntry<Http2StreamChannel> entry : childChannels.entries()) {
                 Http2StreamChannel childChannel = entry.value();
                 int streamId = entry.key();
-                if (streamId > goAwayFrame.lastStreamId() && isLocalStream(streamId)) {
+                if (streamId > goAwayFrame.lastStreamId() && isOutbound(streamId)) {
                     childChannel.pipeline().fireUserEventTriggered(goAwayFrame.retainedDuplicate());
                 }
             }
@@ -172,17 +176,12 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
 
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-        if (!(evt instanceof Http2StreamStateEvent)) {
-            ctx.fireUserEventTriggered(evt);
-            return;
-        }
-
         try {
-            int streamId = ((Http2StreamStateEvent) evt).streamId();
             if (evt instanceof Http2StreamActiveEvent) {
-                onStreamActive(streamId);
+                Http2StreamActiveEvent activeEvent = (Http2StreamActiveEvent) evt;
+                onStreamActive(activeEvent.streamId(), activeEvent.headers());
             } else if (evt instanceof Http2StreamClosedEvent) {
-                onStreamClosed(streamId);
+                onStreamClosed(((Http2StreamClosedEvent) evt).streamId());
             } else {
                 throw new UnsupportedMessageTypeException(evt);
             }
@@ -191,11 +190,21 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
         }
     }
 
-    private void onStreamActive(int streamId) {
-        ChannelFuture future = createStreamChannel(ctx, streamId, streamHandler);
-        Http2StreamChannel childChannel = (Http2StreamChannel) future.channel();
-        Http2StreamChannel oldChannel = childChannels.put(streamId, childChannel);
-        assert oldChannel == null;
+    private void onStreamActive(int streamId, Http2HeadersFrame headersFrame) {
+        final Http2StreamChannel childChannel;
+        if (isOutbound(streamId)) {
+            if (!(headersFrame instanceof ChannelCarryingHeadersFrame)) {
+                throw new IllegalArgumentException("needs to be wrapped");
+            }
+            childChannel = ((ChannelCarryingHeadersFrame) headersFrame).channel();
+            childChannel.setStreamId(streamId);
+        } else {
+            ChannelFuture future = bootstrap.connect(streamId);
+            childChannel = (Http2StreamChannel) future.channel();
+        }
+
+        Http2StreamChannel existing = childChannels.put(streamId, childChannel);
+        assert existing == null;
     }
 
     private void onStreamClosed(int streamId) {
@@ -219,7 +228,7 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
         assert childChannel.eventLoop().inEventLoop();
 
         childChannel.onStreamClosedFired = true;
-        childChannel.fireChildRead(AbstractHttp2StreamChannel.CLOSE_MESSAGE);
+        childChannel.fireChildRead(CLOSE_MESSAGE);
     }
 
     void flushFromStreamChannel() {
@@ -240,8 +249,11 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
         }
     }
 
-    void writeFromStreamChannel(final Object msg, final boolean flush) {
-        final ChannelPromise promise = ctx.newPromise();
+    void writeFromStreamChannel(Object msg, boolean flush) {
+        writeFromStreamChannel(msg, ctx.newPromise(), flush);
+    }
+
+    void writeFromStreamChannel(final Object msg, final ChannelPromise promise, final boolean flush) {
         EventExecutor executor = ctx.executor();
         if (executor.inEventLoop()) {
             writeFromStreamChannel0(msg, flush, promise);
@@ -270,25 +282,6 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
         }
     }
 
-    private ChannelFuture createStreamChannel(ChannelHandlerContext ctx, int streamId,
-                                      ChannelHandler handler) {
-        EventLoopGroup group = streamGroup != null ? streamGroup : ctx.channel().eventLoop();
-        Http2StreamChannel channel = new Http2StreamChannel(streamId);
-        channel.pipeline().addLast(handler);
-        ChannelFuture future = group.register(channel);
-        // Handle any errors that occurred on the local thread while registering. Even though
-        // failures can happen after this point, they will be handled by the channel by closing the
-        // channel.
-        if (future.cause() != null) {
-            if (channel.isRegistered()) {
-                channel.close();
-            } else {
-                channel.unsafe().closeForcibly();
-            }
-        }
-        return future;
-    }
-
     /**
      * Notifies any child streams of the read completion.
      */
@@ -303,8 +296,64 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
         channelsToFireChildReadComplete.clear();
     }
 
-    final class Http2StreamChannel extends AbstractHttp2StreamChannel {
-        private final int streamId;
+    ChannelFuture createStreamChannel(Channel parentChannel, EventLoopGroup group, ChannelHandler handler,
+                                              Map<ChannelOption<?>, Object> options,
+                                              Map<AttributeKey<?>, Object> attrs,
+                                              int streamId) {
+        final Http2StreamChannel channel = new Http2StreamChannel(parentChannel);
+        if (streamId != -1) {
+            assert !isOutbound(streamId);
+            assert ctx.channel().eventLoop().inEventLoop();
+            channel.setStreamId(streamId);
+        }
+        channel.pipeline().addLast(handler);
+
+        initOpts(channel, options);
+        initAttrs(channel, attrs);
+
+        ChannelFuture future = group.register(channel);
+        // Handle any errors that occurred on the local thread while registering. Even though
+        // failures can happen after this point, they will be handled by the channel by closing the
+        // channel.
+        if (future.cause() != null) {
+            if (channel.isRegistered()) {
+                channel.close();
+            } else {
+                channel.unsafe().closeForcibly();
+            }
+        }
+        return future;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void initOpts(Channel channel, Map<ChannelOption<?>, Object> opts) {
+        if (opts != null) {
+            synchronized (opts) {
+                for (Entry<ChannelOption<?>, Object> e: opts.entrySet()) {
+                    try {
+                        if (!channel.config().setOption((ChannelOption<Object>) e.getKey(), e.getValue())) {
+                            logger.warn("Unknown channel option: " + e);
+                        }
+                    } catch (Throwable t) {
+                        logger.warn("Failed to set a channel option: " + channel, t);
+                    }
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void initAttrs(Channel channel, Map<AttributeKey<?>, Object> attrs) {
+        if (attrs != null) {
+            synchronized (attrs) {
+                for (Entry<AttributeKey<?>, Object> e: attrs.entrySet()) {
+                    channel.attr((AttributeKey<Object>) e.getKey()).set(e.getValue());
+                }
+            }
+        }
+    }
+
+    final class Http2StreamChannel extends AbstractHttp2StreamChannel implements ChannelFutureListener {
         boolean onStreamClosedFired;
 
         /**
@@ -312,15 +361,14 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
          */
         boolean inStreamsToFireChildReadComplete;
 
-        Http2StreamChannel(int streamId) {
-            super(ctx.channel());
-            this.streamId = streamId;
+        Http2StreamChannel(Channel parentChannel) {
+            super(parentChannel);
         }
 
         @Override
         protected void doClose() throws Exception {
-            if (!onStreamClosedFired) {
-                Http2StreamFrame resetFrame = new DefaultHttp2ResetFrame(Http2Error.CANCEL).setStreamId(streamId);
+            if (!onStreamClosedFired && hasStreamId()) {
+                Http2StreamFrame resetFrame = new DefaultHttp2ResetFrame(Http2Error.CANCEL).setStreamId(getStreamId());
                 writeFromStreamChannel(resetFrame, true);
             }
             super.doClose();
@@ -332,15 +380,23 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
                 ReferenceCountUtil.release(msg);
                 throw new IllegalArgumentException("Message must be an Http2StreamFrame: " + msg);
             }
-
             Http2StreamFrame frame = (Http2StreamFrame) msg;
-            if (frame.streamId() != -1) {
+            ChannelPromise promise = ctx.newPromise();
+            if (frame.hasStreamId()) {
                 ReferenceCountUtil.release(frame);
-                throw new IllegalArgumentException("Stream must not be set on the frame");
+                throw new IllegalArgumentException("Stream identifier must not be set on the frame.");
             }
-            frame.setStreamId(streamId);
-
-            writeFromStreamChannel(msg, false);
+            if (!hasStreamId()) {
+                if (!(frame instanceof Http2HeadersFrame)) {
+                    throw new IllegalArgumentException("The first frame must be a headers frame.");
+                }
+                frame = new ChannelCarryingHeadersFrame((Http2HeadersFrame) frame, this);
+                // Handle errors on stream creation
+                promise.addListener(this);
+            } else {
+                frame.setStreamId(getStreamId());
+            }
+            writeFromStreamChannel(frame, promise, false);
         }
 
         @Override
@@ -355,11 +411,73 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
 
         @Override
         protected void bytesConsumed(final int bytes) {
-            ctx.write(new DefaultHttp2WindowUpdateFrame(bytes).setStreamId(streamId));
+            ctx.write(new DefaultHttp2WindowUpdateFrame(bytes).setStreamId(getStreamId()));
+        }
+
+        @Override
+        public void operationComplete(ChannelFuture future) throws Exception {
+            if (future.cause() != null) {
+                pipeline().fireExceptionCaught(future.cause());
+                close();
+            }
         }
     }
 
-    private boolean isLocalStream(int streamId) {
+    /**
+     * Wraps the first {@link Http2HeadersFrame} of local/outbound stream. This allows us to get to the child channel
+     * when receiving the {@link Http2StreamActiveEvent} from the frame codec. See {@link #onStreamActive}.
+     */
+    private static final class ChannelCarryingHeadersFrame implements Http2HeadersFrame {
+
+        private final Http2HeadersFrame frame;
+        private final Http2StreamChannel childChannel;
+
+        ChannelCarryingHeadersFrame(Http2HeadersFrame frame, Http2StreamChannel childChannel) {
+            this.frame = frame;
+            this.childChannel = childChannel;
+        }
+
+        @Override
+        public Http2Headers headers() {
+            return frame.headers();
+        }
+
+        @Override
+        public boolean isEndStream() {
+            return frame.isEndStream();
+        }
+
+        @Override
+        public int padding() {
+            return frame.padding();
+        }
+
+        @Override
+        public Http2StreamFrame setStreamId(int streamId) {
+            return frame.setStreamId(streamId);
+        }
+
+        @Override
+        public int getStreamId() {
+            return frame.getStreamId();
+        }
+
+        @Override
+        public boolean hasStreamId() {
+            return frame.hasStreamId();
+        }
+
+        @Override
+        public String name() {
+            return frame.name();
+        }
+
+        Http2StreamChannel channel() {
+            return childChannel;
+        }
+    }
+
+    private boolean isOutbound(int streamId) {
         boolean even = (streamId & 1) == 0;
         return streamId > 0 && server == even;
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamActiveEvent.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamActiveEvent.java
@@ -13,13 +13,33 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package io.netty.handler.codec.http2;
 
 import io.netty.util.internal.UnstableApi;
 
+/**
+ * This event is emitted by the {@link Http2FrameCodec} when a stream becomes active.
+ */
 @UnstableApi
 public class Http2StreamActiveEvent extends AbstractHttp2StreamStateEvent {
+
+    private final Http2HeadersFrame headers;
+
     public Http2StreamActiveEvent(int streamId) {
+        this(streamId, null);
+    }
+
+    public Http2StreamActiveEvent(int streamId, Http2HeadersFrame headers) {
         super(streamId);
+        this.headers = headers;
+    }
+
+    /**
+     * For outbound streams, this method returns the <em>same</em> {@link Http2HeadersFrame} object as the one that
+     * made the stream active. For inbound streams, this method returns {@code null}.
+     */
+    public Http2HeadersFrame headers() {
+        return headers;
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamActiveEvent.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamActiveEvent.java
@@ -16,6 +16,7 @@
 
 package io.netty.handler.codec.http2;
 
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.UnstableApi;
 
 /**
@@ -24,14 +25,16 @@ import io.netty.util.internal.UnstableApi;
 @UnstableApi
 public class Http2StreamActiveEvent extends AbstractHttp2StreamStateEvent {
 
+    private final int initialFlowControlWindow;
     private final Http2HeadersFrame headers;
 
-    public Http2StreamActiveEvent(int streamId) {
-        this(streamId, null);
+    public Http2StreamActiveEvent(int streamId, int initialFlowControlWindow) {
+        this(streamId, initialFlowControlWindow, null);
     }
 
-    public Http2StreamActiveEvent(int streamId, Http2HeadersFrame headers) {
+    public Http2StreamActiveEvent(int streamId, int initialFlowControlWindow, Http2HeadersFrame headers) {
         super(streamId);
+        this.initialFlowControlWindow = ObjectUtil.checkPositive(initialFlowControlWindow, "initialFlowControlWindow");
         this.headers = headers;
     }
 
@@ -41,5 +44,9 @@ public class Http2StreamActiveEvent extends AbstractHttp2StreamStateEvent {
      */
     public Http2HeadersFrame headers() {
         return headers;
+    }
+
+    public int initialFlowControlWindow() {
+        return initialFlowControlWindow;
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.http2;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.AttributeKey;
+import io.netty.util.internal.UnstableApi;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static java.util.Collections.unmodifiableMap;
+
+/**
+ * A class that makes it easy to bootstrap a new HTTP/2 stream as a {@link Channel}.
+ *
+ * <p>The bootstrap requires a registered parent {@link Channel} with a {@link ChannelPipeline} that contains the
+ * {@link Http2MultiplexCodec}.
+ *
+ * <p>A child channel becomes active as soon as it is registered to an eventloop. Therefore, an active channel does not
+ * map to an active HTTP/2 stream immediately. Only once a {@link Http2HeadersFrame} has been sent or received, does
+ * the channel map to an active HTTP/2 stream. In case it was not possible to open a new HTTP/2 stream (i.e. due to
+ * the maximum number of active streams being exceeded), the child channel receives an exception indicating the reason
+ * and is closed immediately thereafter.
+ *
+ * <p>This class is thread-safe.
+ */
+// TODO(buchgr): Should we deliver a user event when the stream becomes active? For all stream states?
+@UnstableApi
+public class Http2StreamChannelBootstrap {
+
+    private volatile Channel parentChannel;
+    private volatile Http2MultiplexCodec multiplexCodec;
+    private volatile ChannelHandler handler;
+    private volatile EventLoopGroup group;
+    private final Map<ChannelOption<?>, Object> options;
+    private final Map<AttributeKey<?>, Object> attributes;
+
+    // Lock for parentChannel and multiplexCodec
+    private final Object lock = new Object();
+
+    public Http2StreamChannelBootstrap() {
+        options = new LinkedHashMap<ChannelOption<?>, Object>();
+        attributes = new LinkedHashMap<AttributeKey<?>, Object>();
+    }
+
+    // Copy constructor
+    Http2StreamChannelBootstrap(Http2StreamChannelBootstrap bootstrap0) {
+        synchronized (bootstrap0.lock) {
+            parentChannel = bootstrap0.parentChannel;
+            multiplexCodec = bootstrap0.multiplexCodec;
+        }
+        handler = bootstrap0.handler;
+        group = bootstrap0.group;
+        synchronized (bootstrap0.options) {
+            options = new LinkedHashMap<ChannelOption<?>, Object>(bootstrap0.options);
+        }
+        synchronized (bootstrap0.attributes) {
+            attributes = new LinkedHashMap<AttributeKey<?>, Object>(bootstrap0.attributes);
+        }
+    }
+
+    /**
+     * Creates a new channel that will eventually map to a local/outbound HTTP/2 stream.
+     */
+    public ChannelFuture connect() {
+        return connect(-1);
+    }
+
+    /**
+     * Used by the {@link Http2MultiplexCodec} to instantiate incoming/remotely-created streams.
+     */
+    ChannelFuture connect(int streamId) {
+        validateState();
+
+        Channel parentChannel0;
+        Http2MultiplexCodec multiplexCodec0;
+        synchronized (lock) {
+            parentChannel0 = parentChannel;
+            multiplexCodec0 = multiplexCodec;
+        }
+        EventLoopGroup group0 = group;
+        group0 = group0 == null ? parentChannel.eventLoop() : group0;
+        ChannelHandler handler0 = handler;
+
+        return multiplexCodec0.createStreamChannel(parentChannel0, group0, handler0, options, attributes, streamId);
+    }
+
+    /**
+     * Sets the parent channel that must have the {@link Http2MultiplexCodec} in its pipeline.
+     *
+     * @param parent a registered channel with the {@link Http2MultiplexCodec} in its pipeline. This channel will
+     *               be the {@link Channel#parent()} of all channels created via {@link #connect()}.
+     * @return {@code this}
+     */
+    public Http2StreamChannelBootstrap parentChannel(Channel parent) {
+        synchronized (lock) {
+            parentChannel = checkRegistered(checkNotNull(parent, "parent"));
+            multiplexCodec = requireMultiplexCodec(parentChannel.pipeline());
+        }
+        return this;
+    }
+
+    /**
+     * Sets the channel handler that should be added to the channels's pipeline.
+     *
+     * @param handler   the channel handler to add to the channel's pipeline. The handler must be
+     *                  {@link Sharable}.
+     * @return {@code this}
+     */
+    public Http2StreamChannelBootstrap handler(ChannelHandler handler) {
+        this.handler = checkSharable(checkNotNull(handler, "handler"));
+        return this;
+    }
+
+    /**
+     * Sets the {@link EventLoop} to which channels created with this bootstrap are registered.
+     *
+     * @param group the eventloop or {@code null} if the eventloop of the parent channel should be used.
+     * @return {@code this}
+     */
+    public Http2StreamChannelBootstrap group(EventLoopGroup group) {
+        this.group = group;
+        return this;
+    }
+
+    /**
+     * Specify {@link ChannelOption}s to be set on newly created channels. An option can be removed by specifying a
+     * value of {@code null}.
+     */
+    public <T> Http2StreamChannelBootstrap option(ChannelOption<T> option, T value) {
+        checkNotNull(option, "option must not be null");
+        if (value == null) {
+            synchronized (options) {
+                options.remove(option);
+            }
+        } else {
+            synchronized (options) {
+                options.put(option, value);
+            }
+        }
+        return this;
+    }
+    /**
+     * Specify attributes with an initial value to be set on newly created channels. An attribute can be removed by
+     * specifying a value of {@code null}.
+     */
+    public <T> Http2StreamChannelBootstrap attr(AttributeKey<T> key, T value) {
+        checkNotNull(key, "key must not be null");
+        if (value == null) {
+            synchronized (attributes) {
+                attributes.remove(key);
+            }
+        } else {
+            synchronized (attributes) {
+                attributes.put(key, value);
+            }
+        }
+        return this;
+    }
+
+    public Channel parentChannel() {
+        return parentChannel;
+    }
+
+    public ChannelHandler handler() {
+        return handler;
+    }
+
+    public EventLoopGroup group() {
+        return group;
+    }
+
+    public Map<ChannelOption<?>, Object> options() {
+        synchronized (options) {
+            return unmodifiableMap(new LinkedHashMap<ChannelOption<?>, Object>(options));
+        }
+    }
+
+    public Map<AttributeKey<?>, Object> attributes() {
+        synchronized (attributes) {
+            return unmodifiableMap(new LinkedHashMap<AttributeKey<?>, Object>(attributes));
+        }
+    }
+
+    private void validateState() {
+        checkNotNull(handler, "handler must be set");
+        checkNotNull(parentChannel, "parent channel must be set");
+        checkNotNull(multiplexCodec, "multiplex codec must be set");
+    }
+
+    private static Channel checkRegistered(Channel channel) {
+        if (!channel.isRegistered()) {
+            throw new IllegalArgumentException("The channel must be registered to an eventloop.");
+        }
+        return channel;
+    }
+
+    private static ChannelHandler checkSharable(ChannelHandler handler) {
+        if (!handler.getClass().isAnnotationPresent(Sharable.class)) {
+            throw new IllegalArgumentException("The handler must be Sharable");
+        }
+        return handler;
+    }
+
+    private static Http2MultiplexCodec requireMultiplexCodec(ChannelPipeline pipeline) {
+        ChannelHandlerContext ctx = pipeline.context(Http2MultiplexCodec.class);
+        if (ctx == null) {
+            throw new IllegalArgumentException(Http2MultiplexCodec.class.getSimpleName()
+                                               + " was not found in the channel pipeline.");
+        }
+        return (Http2MultiplexCodec) ctx.handler();
+    }
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelBootstrap.java
@@ -40,11 +40,23 @@ import static java.util.Collections.unmodifiableMap;
  * <p>The bootstrap requires a registered parent {@link Channel} with a {@link ChannelPipeline} that contains the
  * {@link Http2MultiplexCodec}.
  *
- * <p>A child channel becomes active as soon as it is registered to an eventloop. Therefore, an active channel does not
- * map to an active HTTP/2 stream immediately. Only once a {@link Http2HeadersFrame} has been sent or received, does
- * the channel map to an active HTTP/2 stream. In case it was not possible to open a new HTTP/2 stream (i.e. due to
- * the maximum number of active streams being exceeded), the child channel receives an exception indicating the reason
- * and is closed immediately thereafter.
+ * <h3>Channel Events</h3>
+ *
+ * A child channel becomes active as soon as it is registered to an {@link EventLoop}. Therefore, an active channel
+ * does not map to an active HTTP/2 stream immediately. Only once a {@link Http2HeadersFrame} has been successfully sent
+ * or received, does the channel map to an active HTTP/2 stream. In case it is not possible to open a new HTTP/2 stream
+ * (i.e. due to the maximum number of active streams being exceeded), the child channel receives an exception
+ * indicating the cause and is closed immediately thereafter.
+ *
+ * <h3>Writability and Flow Control</h3>
+ *
+ * A child channel observes outbound/remote flow control via the channel's writability. A channel only becomes writable
+ * when it maps to an active HTTP/2 stream and the stream's flow control window is greater than zero. A child channel
+ * does not know about the connection-level flow control window. {@link ChannelHandler}s are free to ignore the
+ * channel's writability, in which case the excessive writes will be buffered by the parent channel. It's important to
+ * note that only {@link Http2DataFrame}s are subject to HTTP/2 flow control. So it's perfectly legal (and expected)
+ * by a handler that aims to respect the channel's writability to e.g. write a {@link Http2DataFrame} even if the
+ * channel is marked unwritable.
  *
  * <p>This class is thread-safe.
  */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrame.java
@@ -27,7 +27,10 @@ import io.netty.util.internal.UnstableApi;
 public interface Http2StreamFrame extends Http2Frame {
 
     /**
-     * Sets the identifier of the stream this frame applies to.
+     * Sets the identifier of the stream this frame applies to. This method may be called at most once.
+     *
+     * <p><em>NOTE:</em> This method is supposed to be called by the HTTP/2 transport only. It must not be called by
+     * users.
      *
      * @return {@code this}
      */

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrame.java
@@ -20,8 +20,8 @@ import io.netty.util.internal.UnstableApi;
 /**
  * A frame whose meaning <em>may</em> apply to a particular stream, instead of the entire
  * connection. It is still possible for this frame type to apply to the entire connection. In such
- * cases, the {@link #streamId()} must return {@code 0}. If the frame applies to a stream, the
- * {@link #streamId()} must be greater than zero.
+ * cases, the {@link #getStreamId()} must return {@code 0}. If the frame applies to a stream, the
+ * {@link #getStreamId()} must be greater than zero.
  */
 @UnstableApi
 public interface Http2StreamFrame extends Http2Frame {
@@ -40,5 +40,7 @@ public interface Http2StreamFrame extends Http2Frame {
      * applies to a particular stream, or a value less than {@code 0} if the frame has yet to be associated with
      * the connection or a stream.
      */
-    int streamId();
+    int getStreamId();
+
+    boolean hasStreamId();
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2CodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2CodecTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyShort;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link Http2Codec}.
+ */
+public class Http2CodecTest {
+
+    private EmbeddedChannel channel;
+
+    private Http2FrameWriter frameWriter;
+    private TestChannelInitializer testChannelInitializer;
+
+    @Before
+    public void setUp() {
+        frameWriter = spy(new VerifiableHttp2FrameWriter());
+        testChannelInitializer = new TestChannelInitializer();
+        Http2StreamChannelBootstrap bootstrap = new Http2StreamChannelBootstrap().handler(testChannelInitializer);
+        channel = new EmbeddedChannel();
+        channel.connect(new InetSocketAddress(0));
+        channel.pipeline().addLast(new Http2Codec(true, bootstrap, frameWriter));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void multipleOutboundStreams() {
+        Http2StreamChannelBootstrap b = new Http2StreamChannelBootstrap();
+        b.parentChannel(channel).handler(testChannelInitializer);
+
+        Channel channel1 = b.connect().channel();
+        assertTrue(channel1.isActive());
+        assertFalse(((AbstractHttp2StreamChannel) channel1).hasStreamId());
+        Channel channel2 = b.connect().channel();
+        assertTrue(channel2.isActive());
+        assertFalse(((AbstractHttp2StreamChannel) channel2).hasStreamId());
+
+        Http2Headers headers1 = new DefaultHttp2Headers();
+        Http2Headers headers2 = new DefaultHttp2Headers();
+        // Test that streams can be made active (headers sent) in different order than the corresponding channels
+        // have been created.
+        channel2.writeAndFlush(new DefaultHttp2HeadersFrame(headers2));
+        channel1.writeAndFlush(new DefaultHttp2HeadersFrame(headers1));
+
+        verify(frameWriter).writeHeaders(any(ChannelHandlerContext.class), eq(2), same(headers2), anyInt(), anyShort(),
+                                         eq(false), eq(0), eq(false), any(ChannelPromise.class));
+        verify(frameWriter).writeHeaders(any(ChannelHandlerContext.class), eq(4), same(headers1), anyInt(), anyShort(),
+                                         eq(false), eq(0), eq(false), any(ChannelPromise.class));
+
+        assertTrue(((AbstractHttp2StreamChannel) channel1).hasStreamId());
+        assertTrue(((AbstractHttp2StreamChannel) channel2).hasStreamId());
+
+        channel1.close();
+        channel2.close();
+    }
+
+    @Test
+    public void createOutboundStream() {
+        Http2StreamChannelBootstrap b = new Http2StreamChannelBootstrap();
+        ChannelFuture channelFuture = b.parentChannel(channel).handler(testChannelInitializer).connect();
+        assertTrue(channelFuture.isSuccess());
+        Channel childChannel = channelFuture.channel();
+        assertTrue(childChannel.isRegistered());
+        assertTrue(childChannel.isActive());
+
+        Http2Headers headers = new DefaultHttp2Headers();
+        childChannel.write(new DefaultHttp2HeadersFrame(headers));
+        ByteBuf data = Unpooled.buffer(100).writeZero(100);
+        childChannel.writeAndFlush(new DefaultHttp2DataFrame(data));
+        verify(frameWriter).writeHeaders(any(ChannelHandlerContext.class), eq(2), eq(headers), anyInt(), anyShort(),
+                                         eq(false), eq(0), eq(false), any(ChannelPromise.class));
+        verify(frameWriter).writeData(any(ChannelHandlerContext.class), eq(2), eq(data), eq(0), eq(false),
+                                      any(ChannelPromise.class));
+        childChannel.close();
+        verify(frameWriter).writeRstStream(any(ChannelHandlerContext.class), eq(2), eq(Http2Error.CANCEL.code()),
+                                           any(ChannelPromise.class));
+    }
+
+    @Sharable
+    private static class TestChannelInitializer extends ChannelInitializer<Channel> {
+        ChannelHandler handler;
+
+        @Override
+        public void initChannel(Channel channel) {
+            if (handler != null) {
+                channel.pipeline().addLast(handler);
+                handler = null;
+            }
+        }
+    }
+
+    private static class VerifiableHttp2FrameWriter extends DefaultHttp2FrameWriter {
+        @Override
+        public ChannelFuture writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
+                                       int padding, boolean endStream, ChannelPromise promise) {
+            // duplicate 'data' to prevent readerIndex from being changed, to ease verification
+            return super.writeData(ctx, streamId, data.duplicate(), padding, endStream, promise);
+        }
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -321,7 +321,7 @@ public class Http2FrameCodecTest {
     }
 
     @Test
-    public void outgoingStreamActiveShouldFireUserEvent() throws Exception {
+    public void outboundStreamShouldNotFireStreamActiveEvent() throws Exception {
         Http2ConnectionEncoder encoder = framingCodec.connectionHandler().encoder();
 
         encoder.writeHeaders(http2HandlerCtx, 2, request, 31, false, channel.newPromise());
@@ -329,9 +329,6 @@ public class Http2FrameCodecTest {
         Http2Stream stream = framingCodec.connectionHandler().connection().stream(2);
         assertNotNull(stream);
         assertEquals(State.OPEN, stream.state());
-
-        Http2StreamActiveEvent streamActiveEvent = inboundHandler.readUserEvent();
-        assertEquals(stream.id(), streamActiveEvent.streamId());
 
         assertNull(inboundHandler.readInbound());
         assertNull(inboundHandler.readUserEvent());
@@ -532,7 +529,7 @@ public class Http2FrameCodecTest {
         }
     }
 
-    public static class VerifiableHttp2FrameWriter extends DefaultHttp2FrameWriter {
+    private static class VerifiableHttp2FrameWriter extends DefaultHttp2FrameWriter {
         @Override
         public ChannelFuture writeData(ChannelHandlerContext ctx, int streamId, ByteBuf data,
                                        int padding, boolean endStream, ChannelPromise promise) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
@@ -16,6 +16,7 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
@@ -48,6 +49,7 @@ import org.junit.Test;
 
 import static io.netty.util.ReferenceCountUtil.release;
 import static io.netty.util.ReferenceCountUtil.releaseLater;
+import static io.netty.util.ReferenceCountUtil.safeRelease;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -69,7 +71,9 @@ public class Http2MultiplexCodecTest {
             .method(HttpMethod.GET.asciiName()).scheme(HttpScheme.HTTPS.name())
             .authority(new AsciiString("example.org")).path(new AsciiString("/foo"));
 
-    private static final int streamId = 3;
+    private static final int incomingStreamId = 3;
+    private static final int outgoingStreamId = 2;
+    private static final int initialWindowSize = 1024;
 
     @Before
     public void setUp() {
@@ -99,10 +103,10 @@ public class Http2MultiplexCodecTest {
         LastInboundHandler inboundHandler = new LastInboundHandler();
         childChannelInitializer.handler = inboundHandler;
 
-        Http2StreamActiveEvent streamActive = new Http2StreamActiveEvent(streamId);
-        Http2HeadersFrame headersFrame = new DefaultHttp2HeadersFrame(request).setStreamId(streamId);
-        Http2DataFrame dataFrame1 = releaseLater(new DefaultHttp2DataFrame(bb("hello")).setStreamId(streamId));
-        Http2DataFrame dataFrame2 = releaseLater(new DefaultHttp2DataFrame(bb("world")).setStreamId(streamId));
+        Http2StreamActiveEvent streamActive = new Http2StreamActiveEvent(incomingStreamId, initialWindowSize);
+        Http2HeadersFrame headersFrame = new DefaultHttp2HeadersFrame(request).setStreamId(incomingStreamId);
+        Http2DataFrame dataFrame1 = releaseLater(new DefaultHttp2DataFrame(bb("hello")).setStreamId(incomingStreamId));
+        Http2DataFrame dataFrame2 = releaseLater(new DefaultHttp2DataFrame(bb("world")).setStreamId(incomingStreamId));
 
         assertFalse(inboundHandler.channelActive);
         parentChannel.pipeline().fireUserEventTriggered(streamActive);
@@ -140,23 +144,24 @@ public class Http2MultiplexCodecTest {
 
     @Test
     public void inboundDataFrameShouldEmitWindowUpdateFrame() {
-        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(streamId);
+        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(incomingStreamId);
         ByteBuf tenBytes = bb("0123456789");
-        parentChannel.pipeline().fireChannelRead(new DefaultHttp2DataFrame(tenBytes, true).setStreamId(streamId));
+        parentChannel.pipeline().fireChannelRead(
+                new DefaultHttp2DataFrame(tenBytes, true).setStreamId(incomingStreamId));
         parentChannel.pipeline().flush();
 
         Http2WindowUpdateFrame windowUpdate = parentChannel.readOutbound();
         assertNotNull(windowUpdate);
-        assertEquals(streamId, windowUpdate.getStreamId());
+        assertEquals(incomingStreamId, windowUpdate.getStreamId());
         assertEquals(10, windowUpdate.windowSizeIncrement());
 
         // headers and data frame
-        verifyFramesMultiplexedToCorrectChannel(streamId, inboundHandler, 2);
+        verifyFramesMultiplexedToCorrectChannel(incomingStreamId, inboundHandler, 2);
     }
 
     @Test
     public void channelReadShouldRespectAutoRead() {
-        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(streamId);
+        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(incomingStreamId);
         Channel childChannel = inboundHandler.channel();
         assertTrue(childChannel.config().isAutoRead());
         Http2HeadersFrame headersFrame = inboundHandler.readInbound();
@@ -164,21 +169,23 @@ public class Http2MultiplexCodecTest {
 
         childChannel.config().setAutoRead(false);
         parentChannel.pipeline().fireChannelRead(
-                new DefaultHttp2DataFrame(bb("hello world"), false).setStreamId(streamId));
+                new DefaultHttp2DataFrame(bb("hello world"), false).setStreamId(incomingStreamId));
         parentChannel.pipeline().fireChannelReadComplete();
         Http2DataFrame dataFrame0 = inboundHandler.readInbound();
         assertNotNull(dataFrame0);
         release(dataFrame0);
 
-        parentChannel.pipeline().fireChannelRead(new DefaultHttp2DataFrame(bb("foo"), false).setStreamId(streamId));
-        parentChannel.pipeline().fireChannelRead(new DefaultHttp2DataFrame(bb("bar"), true).setStreamId(streamId));
+        parentChannel.pipeline().fireChannelRead(new DefaultHttp2DataFrame(bb("foo"), false).setStreamId(
+                incomingStreamId));
+        parentChannel.pipeline().fireChannelRead(new DefaultHttp2DataFrame(bb("bar"), true).setStreamId(
+                incomingStreamId));
         parentChannel.pipeline().fireChannelReadComplete();
 
         dataFrame0 = inboundHandler.readInbound();
         assertNull(dataFrame0);
 
         childChannel.config().setAutoRead(true);
-        verifyFramesMultiplexedToCorrectChannel(streamId, inboundHandler, 2);
+        verifyFramesMultiplexedToCorrectChannel(incomingStreamId, inboundHandler, 2);
     }
 
     /**
@@ -222,7 +229,8 @@ public class Http2MultiplexCodecTest {
         assertNotNull(headersFrame);
         assertFalse(headersFrame.hasStreamId());
 
-        parentChannel.pipeline().fireUserEventTriggered(new Http2StreamActiveEvent(2, headersFrame));
+        parentChannel.pipeline().fireUserEventTriggered(
+                new Http2StreamActiveEvent(outgoingStreamId, initialWindowSize, headersFrame));
 
         childChannel.close();
         parentChannel.runPendingTasks();
@@ -234,10 +242,10 @@ public class Http2MultiplexCodecTest {
 
     @Test
     public void inboundStreamClosedShouldFireChannelInactive() {
-        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(streamId);
+        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(incomingStreamId);
         assertTrue(inboundHandler.channelActive);
 
-        parentChannel.pipeline().fireUserEventTriggered(new Http2StreamClosedEvent(streamId));
+        parentChannel.pipeline().fireUserEventTriggered(new Http2StreamClosedEvent(incomingStreamId));
         parentChannel.runPendingTasks();
         parentChannel.flush();
 
@@ -248,9 +256,9 @@ public class Http2MultiplexCodecTest {
 
     @Test(expected = StreamException.class)
     public void streamExceptionTriggersChildChannelExceptionCaught() throws Exception {
-        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(streamId);
+        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(incomingStreamId);
 
-        StreamException e = new StreamException(streamId, Http2Error.PROTOCOL_ERROR, "baaam!");
+        StreamException e = new StreamException(incomingStreamId, Http2Error.PROTOCOL_ERROR, "baaam!");
         parentChannel.pipeline().fireExceptionCaught(e);
 
         inboundHandler.checkException();
@@ -258,10 +266,10 @@ public class Http2MultiplexCodecTest {
 
     @Test
     public void streamExceptionClosesChildChannel() {
-        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(streamId);
+        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(incomingStreamId);
 
         assertTrue(inboundHandler.channelActive);
-        StreamException e = new StreamException(streamId, Http2Error.PROTOCOL_ERROR, "baaam!");
+        StreamException e = new StreamException(incomingStreamId, Http2Error.PROTOCOL_ERROR, "baaam!");
         parentChannel.pipeline().fireExceptionCaught(e);
         parentChannel.runPendingTasks();
 
@@ -290,12 +298,13 @@ public class Http2MultiplexCodecTest {
         assertSame(headers, headersFrame.headers());
         assertFalse(headersFrame.hasStreamId());
 
-        parentChannel.pipeline().fireUserEventTriggered(new Http2StreamActiveEvent(2, headersFrame));
+        parentChannel.pipeline().fireUserEventTriggered(
+                new Http2StreamActiveEvent(outgoingStreamId, initialWindowSize, headersFrame));
 
         // Read from the child channel
         headers = new DefaultHttp2Headers().scheme("https").status("200");
-        parentChannel.pipeline().fireChannelRead(new DefaultHttp2HeadersFrame(headers).setStreamId(
-                childChannel.getStreamId()));
+        parentChannel.pipeline().fireChannelRead(
+                new DefaultHttp2HeadersFrame(headers).setStreamId(childChannel.getStreamId()));
         parentChannel.pipeline().fireChannelReadComplete();
 
         headersFrame = inboundHandler.readInbound();
@@ -359,21 +368,161 @@ public class Http2MultiplexCodecTest {
         WriteBufferWaterMark mark = new WriteBufferWaterMark(1024, 4096);
         Http2StreamChannelBootstrap b = new Http2StreamChannelBootstrap();
         b.parentChannel(parentChannel).handler(childChannelInitializer)
-         .option(ChannelOption.AUTO_READ, false).option(ChannelOption.WRITE_BUFFER_WATER_MARK, mark)
+         .option(ChannelOption.AUTO_READ, false).option(ChannelOption.WRITE_SPIN_COUNT, 1000)
          .attr(key, "bar");
 
         Channel channel = b.connect().channel();
 
         assertFalse(channel.config().isAutoRead());
-        assertSame(mark, channel.config().getWriteBufferWaterMark());
+        assertEquals(1000, channel.config().getWriteSpinCount());
         assertEquals("bar", channel.attr(key).get());
+    }
+
+    @Test
+    public void outboundFlowControlWindowShouldBeSetAndUpdated() {
+        Http2StreamChannelBootstrap b = new Http2StreamChannelBootstrap();
+        b.parentChannel(parentChannel).handler(childChannelInitializer);
+        AbstractHttp2StreamChannel childChannel = (AbstractHttp2StreamChannel) b.connect().channel();
+        assertTrue(childChannel.isActive());
+
+        assertEquals(0, childChannel.getOutboundFlowControlWindow());
+        childChannel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers()));
+        parentChannel.flush();
+        Http2HeadersFrame headers = parentChannel.readOutbound();
+        assertNotNull(headers);
+
+        parentChannel.pipeline().fireUserEventTriggered(
+                new Http2StreamActiveEvent(outgoingStreamId, initialWindowSize, headers));
+        // Test for initial window size
+        assertEquals(initialWindowSize, childChannel.getOutboundFlowControlWindow());
+
+        // Test for increment via WINDOW_UPDATE
+        parentChannel.pipeline().fireChannelRead(new DefaultHttp2WindowUpdateFrame(1).setStreamId(outgoingStreamId));
+        parentChannel.pipeline().fireChannelReadComplete();
+
+        assertEquals(initialWindowSize + 1, childChannel.getOutboundFlowControlWindow());
+    }
+
+    @Test
+    public void onlyDataFramesShouldBeFlowControlled() {
+        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(incomingStreamId);
+        AbstractHttp2StreamChannel childChannel = (AbstractHttp2StreamChannel) inboundHandler.channel();
+        assertTrue(childChannel.isWritable());
+        assertEquals(initialWindowSize, childChannel.getOutboundFlowControlWindow());
+
+        childChannel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers()));
+        assertTrue(childChannel.isWritable());
+        assertEquals(initialWindowSize, childChannel.getOutboundFlowControlWindow());
+
+        childChannel.writeAndFlush(new DefaultHttp2ResetFrame(Http2Error.INTERNAL_ERROR));
+        assertTrue(childChannel.isWritable());
+        assertEquals(initialWindowSize, childChannel.getOutboundFlowControlWindow());
+
+        ByteBuf data = Unpooled.buffer(100).writeZero(100);
+        releaseLater(data);
+        childChannel.writeAndFlush(new DefaultHttp2DataFrame(data));
+        assertTrue(childChannel.isWritable());
+        assertEquals(initialWindowSize - 100, childChannel.getOutboundFlowControlWindow());
+    }
+
+    @Test
+    public void writabilityAndFlowControl() {
+        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(incomingStreamId);
+        AbstractHttp2StreamChannel childChannel = (AbstractHttp2StreamChannel) inboundHandler.channel();
+        verifyFlowControlWindowAndWritability(childChannel, initialWindowSize);
+        assertEquals("true", inboundHandler.writabilityStates);
+
+        // HEADERS frames are not flow controlled, so they should not affect the flow control window.
+        childChannel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers()));
+        verifyFlowControlWindowAndWritability(childChannel, initialWindowSize);
+        assertEquals("true", inboundHandler.writabilityStates);
+
+        ByteBuf data = Unpooled.buffer(initialWindowSize - 1).writeZero(initialWindowSize - 1);
+        releaseLater(data);
+        childChannel.writeAndFlush(new DefaultHttp2DataFrame(data));
+        verifyFlowControlWindowAndWritability(childChannel, 1);
+        assertEquals("true", inboundHandler.writabilityStates);
+
+        ByteBuf data1 = Unpooled.buffer(100).writeZero(100);
+        releaseLater(data1);
+        childChannel.writeAndFlush(new DefaultHttp2DataFrame(data1));
+        verifyFlowControlWindowAndWritability(childChannel, -99);
+        assertEquals("true,false", inboundHandler.writabilityStates);
+
+        parentChannel.pipeline().fireChannelRead(new DefaultHttp2WindowUpdateFrame(99).setStreamId(incomingStreamId));
+        parentChannel.pipeline().fireChannelReadComplete();
+        // the flow control window should be updated, but the channel should still not be writable.
+        verifyFlowControlWindowAndWritability(childChannel, 0);
+        assertEquals("true,false", inboundHandler.writabilityStates);
+
+        parentChannel.pipeline().fireChannelRead(new DefaultHttp2WindowUpdateFrame(1).setStreamId(incomingStreamId));
+        parentChannel.pipeline().fireChannelReadComplete();
+        verifyFlowControlWindowAndWritability(childChannel, 1);
+        assertEquals("true,false,true", inboundHandler.writabilityStates);
+    }
+
+    @Test
+    public void failedWriteShouldReturnFlowControlWindow() {
+        ByteBuf data = Unpooled.buffer().writeZero(initialWindowSize);
+        final Http2DataFrame frameToCancel = new DefaultHttp2DataFrame(releaseLater(data));
+        parentChannel.pipeline().addFirst(new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+                if (msg == frameToCancel) {
+                    promise.tryFailure(new Throwable());
+                } else {
+                    super.write(ctx, msg, promise);
+                }
+            }
+        });
+
+        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(incomingStreamId);
+        Channel childChannel = inboundHandler.channel();
+
+        childChannel.write(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers()));
+        data = Unpooled.buffer().writeZero(initialWindowSize / 2);
+        childChannel.write(new DefaultHttp2DataFrame(releaseLater(data)));
+        assertEquals("true", inboundHandler.writabilityStates);
+
+        childChannel.write(frameToCancel);
+        assertEquals("true,false", inboundHandler.writabilityStates);
+        assertFalse(childChannel.isWritable());
+        childChannel.flush();
+
+        assertTrue(childChannel.isWritable());
+        assertEquals("true,false,true", inboundHandler.writabilityStates);
+    }
+
+    @Test
+    public void cancellingWritesBeforeFlush() {
+        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(incomingStreamId);
+        Channel childChannel = inboundHandler.channel();
+
+        Http2HeadersFrame headers1 = new DefaultHttp2HeadersFrame(new DefaultHttp2Headers());
+        Http2HeadersFrame headers2 = new DefaultHttp2HeadersFrame(new DefaultHttp2Headers());
+        ChannelPromise writePromise = childChannel.newPromise();
+        childChannel.write(headers1, writePromise);
+        childChannel.write(headers2);
+        assertTrue(writePromise.cancel(false));
+        childChannel.flush();
+
+        Http2HeadersFrame headers = parentChannel.readOutbound();
+        assertSame(headers, headers2);
+    }
+
+    private static void verifyFlowControlWindowAndWritability(AbstractHttp2StreamChannel channel,
+                                                              int expectedWindowSize) {
+        assertEquals(expectedWindowSize, channel.getOutboundFlowControlWindow());
+        assertEquals(Math.max(0, expectedWindowSize), channel.config().getWriteBufferHighWaterMark());
+        assertEquals(channel.config().getWriteBufferHighWaterMark(), channel.config().getWriteBufferLowWaterMark());
+        assertEquals(expectedWindowSize > 0, channel.isWritable());
     }
 
     private LastInboundHandler streamActiveAndWriteHeaders(int streamId) {
         LastInboundHandler inboundHandler = new LastInboundHandler();
         childChannelInitializer.handler = inboundHandler;
         assertFalse(inboundHandler.channelActive);
-        parentChannel.pipeline().fireUserEventTriggered(new Http2StreamActiveEvent(streamId));
+        parentChannel.pipeline().fireUserEventTriggered(new Http2StreamActiveEvent(streamId, initialWindowSize));
         assertTrue(inboundHandler.channelActive);
         parentChannel.pipeline().fireChannelRead(new DefaultHttp2HeadersFrame(request).setStreamId(streamId));
         parentChannel.pipeline().fireChannelReadComplete();
@@ -415,6 +564,7 @@ public class Http2MultiplexCodecTest {
         private Throwable lastException;
         private ChannelHandlerContext ctx;
         private boolean channelActive;
+        private String writabilityStates = "";
 
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
@@ -432,6 +582,16 @@ public class Http2MultiplexCodecTest {
             }
             channelActive = false;
             super.channelInactive(ctx);
+        }
+
+        @Override
+        public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+            if (writabilityStates == "") {
+                writabilityStates = String.valueOf(ctx.channel().isWritable());
+            } else {
+                writabilityStates += "," + ctx.channel().isWritable();
+            }
+            super.channelWritabilityChanged(ctx);
         }
 
         @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
@@ -22,28 +22,42 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http2.Http2Exception.StreamException;
 import io.netty.util.AsciiString;
+import io.netty.util.AttributeKey;
 import io.netty.util.internal.PlatformDependent;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayDeque;
 import java.util.Queue;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import static io.netty.util.ReferenceCountUtil.release;
 import static io.netty.util.ReferenceCountUtil.releaseLater;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
- * Unit tests for {@link Http2MultiplexCodec}.
+ * Unit tests for {@link Http2MultiplexCodec} and {@link Http2StreamChannelBootstrap}.
  */
 public class Http2MultiplexCodecTest {
 
@@ -60,9 +74,10 @@ public class Http2MultiplexCodecTest {
     @Before
     public void setUp() {
         childChannelInitializer = new TestChannelInitializer();
+        Http2StreamChannelBootstrap bootstrap = new Http2StreamChannelBootstrap().handler(childChannelInitializer);
         parentChannel = new EmbeddedChannel();
         parentChannel.connect(new InetSocketAddress(0));
-        parentChannel.pipeline().addLast(new Http2MultiplexCodec(true, null, childChannelInitializer));
+        parentChannel.pipeline().addLast(new Http2MultiplexCodec(true, bootstrap));
     }
 
     @After
@@ -77,7 +92,6 @@ public class Http2MultiplexCodecTest {
     // TODO(buchgr): Flush from child channel
     // TODO(buchgr): ChildChannel.childReadComplete()
     // TODO(buchgr): GOAWAY Logic
-    // TODO(buchgr): Reset frame on close
     // TODO(buchgr): Test ChannelConfig.setMaxMessagesPerRead
 
     @Test
@@ -133,7 +147,7 @@ public class Http2MultiplexCodecTest {
 
         Http2WindowUpdateFrame windowUpdate = parentChannel.readOutbound();
         assertNotNull(windowUpdate);
-        assertEquals(streamId, windowUpdate.streamId());
+        assertEquals(streamId, windowUpdate.getStreamId());
         assertEquals(10, windowUpdate.windowSizeIncrement());
 
         // headers and data frame
@@ -167,17 +181,69 @@ public class Http2MultiplexCodecTest {
         verifyFramesMultiplexedToCorrectChannel(streamId, inboundHandler, 2);
     }
 
+    /**
+     * A child channel for a HTTP/2 stream in IDLE state (that is no headers sent or received),
+     * should not emit a RST_STREAM frame on close, as this is a connection error of type protocol error.
+     */
     @Test
-    public void streamClosedShouldFireChannelInactive() {
+    public void idleOutboundStreamShouldNotWriteResetFrameOnClose() {
+        childChannelInitializer.handler = new LastInboundHandler();
+
+        Http2StreamChannelBootstrap b = new Http2StreamChannelBootstrap();
+        b.parentChannel(parentChannel).handler(childChannelInitializer);
+        Channel childChannel = b.connect().channel();
+        assertTrue(childChannel.isActive());
+
+        childChannel.close();
+        parentChannel.runPendingTasks();
+
+        assertFalse(childChannel.isOpen());
+        assertFalse(childChannel.isActive());
+        assertNull(parentChannel.readOutbound());
+    }
+
+    @Test
+    public void outboundStreamShouldWriteResetFrameOnClose_headersSent() {
+        childChannelInitializer.handler = new ChannelInboundHandlerAdapter() {
+            @Override
+            public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                ctx.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers()));
+                ctx.fireChannelActive();
+            }
+        };
+
+        Http2StreamChannelBootstrap b = new Http2StreamChannelBootstrap();
+        b.parentChannel(parentChannel).handler(childChannelInitializer);
+        Channel childChannel = b.connect().channel();
+        assertTrue(childChannel.isActive());
+
+        parentChannel.flush();
+        Http2HeadersFrame headersFrame = parentChannel.readOutbound();
+        assertNotNull(headersFrame);
+        assertFalse(headersFrame.hasStreamId());
+
+        parentChannel.pipeline().fireUserEventTriggered(new Http2StreamActiveEvent(2, headersFrame));
+
+        childChannel.close();
+        parentChannel.runPendingTasks();
+
+        Http2ResetFrame reset = parentChannel.readOutbound();
+        assertEquals(2, reset.getStreamId());
+        assertEquals(Http2Error.CANCEL.code(), reset.errorCode());
+    }
+
+    @Test
+    public void inboundStreamClosedShouldFireChannelInactive() {
         LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(streamId);
         assertTrue(inboundHandler.channelActive);
 
         parentChannel.pipeline().fireUserEventTriggered(new Http2StreamClosedEvent(streamId));
-
         parentChannel.runPendingTasks();
-        parentChannel.checkException();
+        parentChannel.flush();
 
         assertFalse(inboundHandler.channelActive);
+        // A RST_STREAM frame should NOT be emitted, as we received the close.
+        assertNull(parentChannel.readOutbound());
     }
 
     @Test(expected = StreamException.class)
@@ -197,11 +263,110 @@ public class Http2MultiplexCodecTest {
         assertTrue(inboundHandler.channelActive);
         StreamException e = new StreamException(streamId, Http2Error.PROTOCOL_ERROR, "baaam!");
         parentChannel.pipeline().fireExceptionCaught(e);
-
         parentChannel.runPendingTasks();
-        parentChannel.checkException();
 
         assertFalse(inboundHandler.channelActive);
+    }
+
+    @Test
+    public void creatingWritingReadingAndClosingOutboundStreamShouldWork() {
+        LastInboundHandler inboundHandler = new LastInboundHandler();
+        childChannelInitializer.handler = inboundHandler;
+
+        Http2StreamChannelBootstrap b = new Http2StreamChannelBootstrap();
+        b.parentChannel(parentChannel).handler(childChannelInitializer);
+        AbstractHttp2StreamChannel childChannel = (AbstractHttp2StreamChannel) b.connect().channel();
+        assertThat(childChannel, Matchers.instanceOf(Http2MultiplexCodec.Http2StreamChannel.class));
+        assertTrue(childChannel.isActive());
+        assertTrue(inboundHandler.channelActive);
+
+        // Write to the child channel
+        Http2Headers headers = new DefaultHttp2Headers().scheme("https").method("GET").path("/foo.txt");
+        childChannel.writeAndFlush(new DefaultHttp2HeadersFrame(headers));
+        parentChannel.flush();
+
+        Http2HeadersFrame headersFrame = parentChannel.readOutbound();
+        assertNotNull(headersFrame);
+        assertSame(headers, headersFrame.headers());
+        assertFalse(headersFrame.hasStreamId());
+
+        parentChannel.pipeline().fireUserEventTriggered(new Http2StreamActiveEvent(2, headersFrame));
+
+        // Read from the child channel
+        headers = new DefaultHttp2Headers().scheme("https").status("200");
+        parentChannel.pipeline().fireChannelRead(new DefaultHttp2HeadersFrame(headers).setStreamId(
+                childChannel.getStreamId()));
+        parentChannel.pipeline().fireChannelReadComplete();
+
+        headersFrame = inboundHandler.readInbound();
+        assertNotNull(headersFrame);
+
+        // Close the child channel.
+        childChannel.close();
+
+        parentChannel.flush();
+        parentChannel.runPendingTasks();
+        // An active outbound stream should emit a RST_STREAM frame.
+        Http2ResetFrame rstFrame = parentChannel.readOutbound();
+        assertNotNull(rstFrame);
+        assertEquals(childChannel.getStreamId(), rstFrame.getStreamId());
+        assertFalse(childChannel.isOpen());
+        assertFalse(childChannel.isActive());
+        assertFalse(inboundHandler.channelActive);
+    }
+
+    /**
+     * Test failing the promise of the first headers frame of an outbound stream. In pratice this error case would most
+     * likely happen due to the max concurrent streams limit being hit or the channel running out of stream identifiers.
+     */
+    @Test(expected = Http2NoMoreStreamIdsException.class)
+    public void failedOutboundStreamCreationThrowsAndClosesChannel() throws Exception {
+        final AtomicReference<ChannelPromise> promiseRef = new AtomicReference<ChannelPromise>();
+        // This is a hack, as promises for writes in a child channel are currently not implemented correctly, as they
+        // are always completed successfully. We need to install our own handler on the parent channel in order to get
+        // to the channel promise were write errors are signaled.
+        parentChannel.pipeline().addFirst(new ChannelOutboundHandlerAdapter() {
+            @Override
+            public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+                promise.tryFailure(new Http2NoMoreStreamIdsException());
+                promiseRef.set(promise);
+            }
+        });
+
+        LastInboundHandler inboundHandler = new LastInboundHandler();
+        childChannelInitializer.handler = inboundHandler;
+
+        Http2StreamChannelBootstrap b = new Http2StreamChannelBootstrap();
+        Channel childChannel = b.parentChannel(parentChannel).handler(childChannelInitializer).connect().channel();
+        assertTrue(childChannel.isActive());
+
+        childChannel.writeAndFlush(new DefaultHttp2HeadersFrame(new DefaultHttp2Headers()));
+        parentChannel.flush();
+        ChannelPromise promise = promiseRef.get();
+        assertNotNull(promise);
+
+        parentChannel.runPendingTasks();
+
+        assertFalse(childChannel.isActive());
+        assertFalse(childChannel.isOpen());
+
+        inboundHandler.checkException();
+    }
+
+    @Test
+    public void settingChannelOptsAndAttrsOnBootstrap() {
+        AttributeKey<String> key = AttributeKey.newInstance("foo");
+        WriteBufferWaterMark mark = new WriteBufferWaterMark(1024, 4096);
+        Http2StreamChannelBootstrap b = new Http2StreamChannelBootstrap();
+        b.parentChannel(parentChannel).handler(childChannelInitializer)
+         .option(ChannelOption.AUTO_READ, false).option(ChannelOption.WRITE_BUFFER_WATER_MARK, mark)
+         .attr(key, "bar");
+
+        Channel channel = b.connect().channel();
+
+        assertFalse(channel.config().isAutoRead());
+        assertSame(mark, channel.config().getWriteBufferWaterMark());
+        assertEquals("bar", channel.attr(key).get());
     }
 
     private LastInboundHandler streamActiveAndWriteHeaders(int streamId) {
@@ -221,7 +386,7 @@ public class Http2MultiplexCodecTest {
         for (int i = 0; i < numFrames; i++) {
             Http2StreamFrame frame = inboundHandler.readInbound();
             assertNotNull(frame);
-            assertEquals(streamId, frame.streamId());
+            assertEquals(streamId, frame.getStreamId());
             release(frame);
         }
         assertNull(inboundHandler.readInbound());
@@ -253,12 +418,18 @@ public class Http2MultiplexCodecTest {
 
         @Override
         public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            if (channelActive) {
+                throw new IllegalStateException("channelActive may only be fired once.");
+            }
             channelActive = true;
             super.channelActive(ctx);
         }
 
         @Override
         public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+            if (!channelActive) {
+                throw new IllegalStateException("channelInactive may only be fired once after channelActive.");
+            }
             channelActive = false;
             super.channelInactive(ctx);
         }

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -270,6 +270,33 @@ public final class ChannelOutboundBuffer {
     }
 
     /**
+     * Removes the current flushed message and returns its {@link ChannelPromise}. Unlike {@link #remove()} this method
+     * does not release the message or complete the promise. If no flushed message exist, this method returns
+     * {@code null}.
+     */
+    public ChannelPromise steal() {
+        Entry e = flushedEntry;
+        if (e == null) {
+            clearNioBuffers();
+            return null;
+        }
+
+        ChannelPromise promise = e.promise;
+        final int size = e.pendingSize;
+
+        removeEntry(e);
+
+        if (!e.cancelled && size > 0) {
+            decrementPendingOutboundBytes(size, false, true);
+        }
+
+        // recycle the entry
+        e.recycle();
+
+        return promise;
+    }
+
+    /**
      * Will remove the current message, mark its {@link ChannelPromise} as failure using the given {@link Throwable}
      * and return {@code true}. If no   flushed message exists at the time this method is called it will return
      * {@code false} to signal that no more messages are ready to be handled.


### PR DESCRIPTION
_NOTE:_ This change builds on https://github.com/netty/netty/pull/5709 (the first commit) and the outbound flow control changes are only in the second commit. We should first get #5709 merged, before looking at this. I am just opening it as it's ready and I don't know where else to put it :-).

---------------------------
Motivation:

The HTTP/2 child channel API should interact with HTTP/2 outbound/remote flow control. That is,
if a H2 stream used up all its flow control window, the corresponding child channel should be
marked unwritable and a writability-changed event should be fired. Similarly, a unwritable
child channel should be marked writable and a writability-event should be fired, once a
WINDOW_UPDATE frame has been received.

Modifications:

A child channel's writability and a H2 stream's outbound flow control window interact, as described
in the motivation. A channel handler is free to ignore the channel's writability, in which case the
parent channel is reponsible for buffering writes until a WINDOW_UPDATE is received.

The connection-level flow control window is ignored for now. That is, a child channel's writability
is only affected by the stream-level flow control window. So a child channel could be marked writable,
even though the connection-level flow control window is zero.

Result:

A child channel interacts with stream-level flow control.

PTL @ejona86 @Scottmitch @nmittler @mosesn @normanmaurer 