### PR TITLE
	HTTP/2 HPACK Decoder VarInt Improvement

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/internal/hpack/DecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/internal/hpack/DecoderTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 
 import static io.netty.util.AsciiString.EMPTY_STRING;
 import static io.netty.util.AsciiString.of;
+import static java.lang.Integer.MAX_VALUE;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -148,7 +149,7 @@ public class DecoderTest {
     @Test(expected = Http2Exception.class)
     public void testInsidiousIndex() throws Http2Exception {
         // Insidious index so the last shift causes sign overflow
-        decode("FF8080808008");
+        decode("FF8080808007");
     }
 
     @Test
@@ -174,8 +175,18 @@ public class DecoderTest {
 
     @Test(expected = Http2Exception.class)
     public void testInsidiousMaxDynamicTableSize() throws Http2Exception {
+        decoder.setMaxHeaderTableSize(MAX_VALUE);
         // max header table size sign overflow
         decode("3FE1FFFFFF07");
+    }
+
+    @Test
+    public void testMaxValidDynamicTableSize() throws Http2Exception {
+        decoder.setMaxHeaderTableSize(MAX_VALUE);
+        String baseValue = "3FE1FFFFFF0";
+        for (int i = 0; i < 7; ++i) {
+            decode(baseValue + i);
+        }
     }
 
     @Test


### PR DESCRIPTION
Motivation:
HTTP/2 Decoder#decodeULE128 current will tolerate more bytes than necessary when attempted to detect overflow. The usage of this method also currently requires an additional overflow conditional.

Modifications:
- Integrate the first byte into Decoder#decodeULE128 which allows us to detect overflow reliably and avoid overflow checks outside of this method.

Result:
Less conditionals and earlier overflow detection in Decoder#decodeULE128