### PR TITLE
Provide extra info together with handshake complete event.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -26,6 +26,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.util.AttributeKey;
 
@@ -46,8 +47,9 @@ import static io.netty.handler.codec.http.HttpVersion.*;
  * to the <tt>io.netty.example.http.websocketx.server.WebSocketServer</tt> example.
  *
  * To know once a handshake was done you can intercept the
- * {@link ChannelInboundHandler#userEventTriggered(ChannelHandlerContext, Object)} and check if the event was of type
- * {@link ServerHandshakeStateEvent#HANDSHAKE_COMPLETE}.
+ * {@link ChannelInboundHandler#userEventTriggered(ChannelHandlerContext, Object)} and check if the event was instance
+ * of {@link HandshakeComplete}, the event will contain extra information about the handshake such as the request and
+ * selected subprotocol.
  */
 public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
 
@@ -56,9 +58,40 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
      */
     public enum ServerHandshakeStateEvent {
         /**
-         * The Handshake was complete succesful and so the channel was upgraded to websockets
+         * The Handshake was completed successfully and the channel was upgraded to websockets.
+         *
+         * @deprecated in favor of {@link HandshakeComplete} class,
+         * it provides extra information about the handshake
          */
+        @Deprecated
         HANDSHAKE_COMPLETE
+    }
+
+    /**
+     * The Handshake was completed successfully and the channel was upgraded to websockets.
+     */
+    public static final class HandshakeComplete {
+        private final String requestUri;
+        private final HttpHeaders requestHeaders;
+        private final String selectedSubprotocol;
+
+        HandshakeComplete(String requestUri, HttpHeaders requestHeaders, String selectedSubprotocol) {
+            this.requestUri = requestUri;
+            this.requestHeaders = requestHeaders;
+            this.selectedSubprotocol = selectedSubprotocol;
+        }
+
+        public String requestUri() {
+            return requestUri;
+        }
+
+        public HttpHeaders requestHeaders() {
+            return requestHeaders;
+        }
+
+        public String selectedSubprotocol() {
+            return selectedSubprotocol;
+        }
     }
 
     private static final AttributeKey<WebSocketServerHandshaker> HANDSHAKER_ATTR_KEY =

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -54,7 +54,7 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
 
     @Override
     public void channelRead(final ChannelHandlerContext ctx, Object msg) throws Exception {
-        FullHttpRequest req = (FullHttpRequest) msg;
+        final FullHttpRequest req = (FullHttpRequest) msg;
         if (!websocketPath.equals(req.uri())) {
             ctx.fireChannelRead(msg);
             return;
@@ -80,8 +80,12 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
                         if (!future.isSuccess()) {
                             ctx.fireExceptionCaught(future.cause());
                         } else {
+                            // Kept for compatibility
                             ctx.fireUserEventTriggered(
                                     WebSocketServerProtocolHandler.ServerHandshakeStateEvent.HANDSHAKE_COMPLETE);
+                            ctx.fireUserEventTriggered(
+                                    new WebSocketServerProtocolHandler.HandshakeComplete(
+                                            req.uri(), req.headers(), handshaker.selectedSubprotocol()));
                         }
                     }
                 });


### PR DESCRIPTION
Motivation:

As described in #5734

Before this change, if the server had to do some sort of setup after a
handshake was completed based on handshake's information, the only way
available was to wait (in a separate thread) for the handshaker to be
added as an attribute to the channel. Too much hassle.

Modifications:

Handshake completed event need to be stateful now, so I've added a tiny
class holding just the HTTP upgrade request and the selected subprotocol
which is fired as an event after the handshake has finished.
I've also deprecated the old enum used as stateless event and I left the
code that fires it for backward compatibility. It should be removed in
the next mayor release.

Result:

It should be much simpler now to do initialization stuff based on
subprotocol or request headers on handshake completion. No asynchronous
waiting needed anymore.