### PR TITLE
Switch to netty-tcnative 2.0.0 which uses different package names

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateException.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateException.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.ssl;
 
-import org.apache.tomcat.jni.CertificateVerifier;
+import io.netty.tcnative.jni.CertificateVerifier;
 
 import java.security.cert.CertificateException;
 

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.ssl;
 
-import org.apache.tomcat.jni.SSL;
+import io.netty.tcnative.jni.SSL;
 
 import java.io.File;
 import java.security.PrivateKey;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialManager.java
@@ -16,8 +16,8 @@
 package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBufAllocator;
-import org.apache.tomcat.jni.CertificateRequestedCallback;
-import org.apache.tomcat.jni.SSL;
+import io.netty.tcnative.jni.CertificateRequestedCallback;
+import io.netty.tcnative.jni.SSL;
 
 import javax.net.ssl.SSLException;
 import javax.net.ssl.X509KeyManager;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -16,7 +16,7 @@
 package io.netty.handler.ssl;
 
 import io.netty.handler.ssl.ReferenceCountedOpenSslServerContext.ServerContext;
-import org.apache.tomcat.jni.SSL;
+import io.netty.tcnative.jni.SSL;
 
 import java.io.File;
 import java.security.PrivateKey;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerSessionContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerSessionContext.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.ssl;
 
-import org.apache.tomcat.jni.SSL;
-import org.apache.tomcat.jni.SSLContext;
+import io.netty.tcnative.jni.SSL;
+import io.netty.tcnative.jni.SSLContext;
 
 
 /**

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
@@ -16,12 +16,13 @@
 package io.netty.handler.ssl;
 
 import io.netty.util.internal.ObjectUtil;
-import org.apache.tomcat.jni.SSL;
-import org.apache.tomcat.jni.SSLContext;
-import org.apache.tomcat.jni.SessionTicketKey;
+import io.netty.tcnative.jni.SSL;
+import io.netty.tcnative.jni.SSLContext;
+import io.netty.tcnative.jni.SessionTicketKey;
 
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionContext;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.NoSuchElementException;
 
@@ -62,9 +63,21 @@ public abstract class OpenSslSessionContext implements SSLSessionContext {
      */
     @Deprecated
     public void setTicketKeys(byte[] keys) {
-        ObjectUtil.checkNotNull(keys, "keys");
+        if (keys.length % SessionTicketKey.TICKET_KEY_SIZE != 0) {
+            throw new IllegalArgumentException("keys.length % " + SessionTicketKey.TICKET_KEY_SIZE  + " != 0");
+        }
+        SessionTicketKey[] tickets = new SessionTicketKey[keys.length / SessionTicketKey.TICKET_KEY_SIZE];
+        for (int i = 0, a = 0; i < tickets.length; i++) {
+            byte[] name = Arrays.copyOfRange(keys, a, SessionTicketKey.NAME_SIZE);
+            a += SessionTicketKey.NAME_SIZE;
+            byte[] hmacKey = Arrays.copyOfRange(keys, a, SessionTicketKey.HMAC_KEY_SIZE);
+            i += SessionTicketKey.HMAC_KEY_SIZE;
+            byte[] aesKey = Arrays.copyOfRange(keys, a, SessionTicketKey.AES_KEY_SIZE);
+            a += SessionTicketKey.AES_KEY_SIZE;
+            tickets[i] = new SessionTicketKey(name, hmacKey, aesKey);
+        }
         SSLContext.clearOptions(context.ctx, SSL.SSL_OP_NO_TICKET);
-        SSLContext.setSessionTicketKeys(context.ctx, keys);
+        SSLContext.setSessionTicketKeys(context.ctx, tickets);
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionStats.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionStats.java
@@ -16,7 +16,7 @@
 
 package io.netty.handler.ssl;
 
-import org.apache.tomcat.jni.SSLContext;
+import io.netty.tcnative.jni.SSLContext;
 
 /**
  * Stats exposed by an OpenSSL session context.

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionTicketKey.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionTicketKey.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.ssl;
 
-import org.apache.tomcat.jni.SessionTicketKey;
+import io.netty.tcnative.jni.SessionTicketKey;
 
 /**
  * Session Ticket Key

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -17,9 +17,9 @@ package io.netty.handler.ssl;
 
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.apache.tomcat.jni.CertificateRequestedCallback;
-import org.apache.tomcat.jni.SSL;
-import org.apache.tomcat.jni.SSLContext;
+import io.netty.tcnative.jni.CertificateRequestedCallback;
+import io.netty.tcnative.jni.SSL;
+import io.netty.tcnative.jni.SSLContext;
 
 import java.security.KeyStore;
 import java.security.PrivateKey;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -29,8 +29,8 @@ import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import org.apache.tomcat.jni.Buffer;
-import org.apache.tomcat.jni.SSL;
+import io.netty.tcnative.jni.Buffer;
+import io.netty.tcnative.jni.SSL;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.ssl;
 
-import org.apache.tomcat.jni.SSL;
-import org.apache.tomcat.jni.SSLContext;
+import io.netty.tcnative.jni.SSL;
+import io.netty.tcnative.jni.SSLContext;
 
 import java.security.KeyStore;
 import java.security.PrivateKey;

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
-    <tcnative.version>1.1.33.Fork26</tcnative.version>
+    <tcnative.version>2.0.0.Beta1</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <epoll.classifier>${os.detected.name}-${os.detected.arch}</epoll.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>


### PR DESCRIPTION
Motivation:

Previous versions of netty-tcnative used the org.apache.tomcat namespace which could lead to problems when a user tried to use tomcat and netty in the same app.

Modifications:

Use netty-tcnative which now uses a different namespace and adjust code to some API changes.

Result:

Its now possible to use netty-tcnative even when running together with tomcat.
