### PR TITLE
HTTP/2: Fix some errors reported by h2spec.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -453,6 +453,11 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
         @Override
         public void onPushPromiseRead(ChannelHandlerContext ctx, int streamId, int promisedStreamId,
                 Http2Headers headers, int padding) throws Http2Exception {
+            // A client cannot push.
+            if (connection().isServer()) {
+                throw connectionError(PROTOCOL_ERROR, "A client cannot push.");
+            }
+
             Http2Stream parentStream = connection.stream(streamId);
 
             if (shouldIgnoreHeadersOrDataFrame(ctx, streamId, parentStream, "PUSH_PROMISE")) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -179,7 +179,8 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
         // Read the header and prepare the unmarshaller to read the frame.
         payloadLength = in.readUnsignedMedium();
         if (payloadLength > maxFrameSize) {
-            throw connectionError(PROTOCOL_ERROR, "Frame length: %d exceeds maximum: %d", payloadLength, maxFrameSize);
+            throw connectionError(FRAME_SIZE_ERROR, "Frame length: %d exceeds maximum: %d", payloadLength,
+                                  maxFrameSize);
         }
         frameType = in.readByte();
         flags = new Http2Flags(in.readUnsignedByte());
@@ -277,6 +278,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
     }
 
     private void verifyDataFrame() throws Http2Exception {
+        verifyAssociatedWithAStream();
         verifyNotProcessingHeaders();
         verifyPayloadLength(payloadLength);
 
@@ -287,6 +289,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
     }
 
     private void verifyHeadersFrame() throws Http2Exception {
+        verifyAssociatedWithAStream();
         verifyNotProcessingHeaders();
         verifyPayloadLength(payloadLength);
 
@@ -298,6 +301,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
     }
 
     private void verifyPriorityFrame() throws Http2Exception {
+        verifyAssociatedWithAStream();
         verifyNotProcessingHeaders();
 
         if (payloadLength != PRIORITY_ENTRY_LENGTH) {
@@ -307,11 +311,11 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
     }
 
     private void verifyRstStreamFrame() throws Http2Exception {
+        verifyAssociatedWithAStream();
         verifyNotProcessingHeaders();
 
         if (payloadLength != INT_FIELD_LENGTH) {
-            throw streamError(streamId, FRAME_SIZE_ERROR,
-                    "Invalid frame length %d.", payloadLength);
+            throw connectionError(FRAME_SIZE_ERROR, "Invalid frame length %d.", payloadLength);
         }
     }
 
@@ -322,7 +326,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
             throw connectionError(PROTOCOL_ERROR, "A stream ID must be zero.");
         }
         if (flags.ack() && payloadLength > 0) {
-            throw connectionError(PROTOCOL_ERROR, "Ack settings frame must have an empty payload.");
+            throw connectionError(FRAME_SIZE_ERROR, "Ack settings frame must have an empty payload.");
         }
         if (payloadLength % SETTING_ENTRY_LENGTH > 0) {
             throw connectionError(FRAME_SIZE_ERROR, "Frame length %d invalid.", payloadLength);
@@ -370,12 +374,12 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
         verifyStreamOrConnectionId(streamId, "Stream ID");
 
         if (payloadLength != INT_FIELD_LENGTH) {
-            throw streamError(streamId, FRAME_SIZE_ERROR,
-                    "Invalid frame length %d.", payloadLength);
+            throw connectionError(FRAME_SIZE_ERROR, "Invalid frame length %d.", payloadLength);
         }
     }
 
     private void verifyContinuationFrame() throws Http2Exception {
+        verifyAssociatedWithAStream();
         verifyPayloadLength(payloadLength);
 
         if (headersContinuation == null) {
@@ -397,14 +401,11 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
     private void readDataFrame(ChannelHandlerContext ctx, ByteBuf payload,
             Http2FrameListener listener) throws Http2Exception {
         int padding = readPadding(payload);
+        verifyPadding(padding);
 
         // Determine how much data there is to read by removing the trailing
         // padding.
         int dataLength = lengthWithoutTrailingPadding(payload.readableBytes(), padding);
-        if (dataLength < 0) {
-            throw streamError(streamId, FRAME_SIZE_ERROR,
-                    "Frame payload too small for padding.");
-        }
 
         ByteBuf data = payload.readSlice(dataLength);
         listener.onDataRead(ctx, streamId, data, padding, flags.endOfStream());
@@ -416,6 +417,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
         final int headersStreamId = streamId;
         final Http2Flags headersFlags = flags;
         final int padding = readPadding(payload);
+        verifyPadding(padding);
 
         // The callback that is invoked is different depending on whether priority information
         // is present in the headers frame.
@@ -423,6 +425,9 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
             long word1 = payload.readUnsignedInt();
             final boolean exclusive = (word1 & 0x80000000L) != 0;
             final int streamDependency = (int) (word1 & 0x7FFFFFFFL);
+            if (streamDependency == streamId) {
+                throw streamError(streamId, PROTOCOL_ERROR, "A stream cannot depend on itself.");
+            }
             final short weight = (short) (payload.readUnsignedByte() + 1);
             final ByteBuf fragment = payload.readSlice(lengthWithoutTrailingPadding(payload.readableBytes(), padding));
 
@@ -480,6 +485,9 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
         long word1 = payload.readUnsignedInt();
         boolean exclusive = (word1 & 0x80000000L) != 0;
         int streamDependency = (int) (word1 & 0x7FFFFFFFL);
+        if (streamDependency == streamId) {
+            throw streamError(streamId, PROTOCOL_ERROR, "A stream cannot depend on itself.");
+        }
         short weight = (short) (payload.readUnsignedByte() + 1);
         listener.onPriorityRead(ctx, streamId, streamDependency, weight, exclusive);
     }
@@ -505,7 +513,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
                 } catch (IllegalArgumentException e) {
                     switch(id) {
                     case SETTINGS_MAX_FRAME_SIZE:
-                        throw connectionError(FRAME_SIZE_ERROR, e, e.getMessage());
+                        throw connectionError(PROTOCOL_ERROR, e, e.getMessage());
                     case SETTINGS_INITIAL_WINDOW_SIZE:
                         throw connectionError(FLOW_CONTROL_ERROR, e, e.getMessage());
                     default:
@@ -521,6 +529,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
             Http2FrameListener listener) throws Http2Exception {
         final int pushPromiseStreamId = streamId;
         final int padding = readPadding(payload);
+        verifyPadding(padding);
         final int promisedStreamId = readUnsignedInt(payload);
 
         // Create a handler that invokes the listener when the header block is complete.
@@ -597,6 +606,13 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
             return 0;
         }
         return payload.readUnsignedByte() + 1;
+    }
+
+    private void verifyPadding(int padding) throws Http2Exception {
+        int len = lengthWithoutTrailingPadding(payloadLength, padding);
+        if (len < 0) {
+            throw connectionError(PROTOCOL_ERROR, "Frame payload too small for padding.");
+        }
     }
 
     /**
@@ -737,6 +753,12 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
     private void verifyPayloadLength(int payloadLength) throws Http2Exception {
         if (payloadLength > maxFrameSize) {
             throw connectionError(PROTOCOL_ERROR, "Total payload length %d exceeds max frame length.", payloadLength);
+        }
+    }
+
+    private void verifyAssociatedWithAStream() throws Http2Exception {
+        if (streamId == 0) {
+            throw connectionError(PROTOCOL_ERROR, "Frame of type %s must be associated with a stream.", frameType);
         }
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -313,13 +313,10 @@ public class Http2ConnectionHandlerTest {
     @Test
     public void writeRstOnNonExistantStreamShouldSucceed() throws Exception {
         handler = newHandler();
+        when(frameWriter.writeRstStream(eq(ctx), eq(NON_EXISTANT_STREAM_ID),
+                                        eq(STREAM_CLOSED.code()), eq(promise))).thenReturn(future);
         handler.resetStream(ctx, NON_EXISTANT_STREAM_ID, STREAM_CLOSED.code(), promise);
-        verify(frameWriter, never())
-            .writeRstStream(any(ChannelHandlerContext.class), anyInt(), anyLong(),
-                    any(ChannelPromise.class));
-        assertTrue(promise.isDone());
-        assertTrue(promise.isSuccess());
-        assertNull(promise.cause());
+        verify(frameWriter).writeRstStream(eq(ctx), eq(NON_EXISTANT_STREAM_ID), eq(STREAM_CLOSED.code()), eq(promise));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

h2spec [1] reported 32 issues [2] with Netty's HTTP/2 implementation.

Modifications:

Fixed 9 of those issues. Mostly wrong error codes or added missing validation
code in the frame reader.

Result:

11 fewer errors. h2spec now reports: 70 tests, 48 passed, 1 skipped, 21 failed

[1] https://github.com/summerwind/h2spec
[2] https://github.com/netty/netty/issues/5761

PTL @Scottmitch @nmittler 