### PR TITLE
Fix native library loading in Windows

### DIFF
--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -213,6 +213,11 @@ public final class NativeLibraryLoader {
             }
             out.flush();
 
+            // Close the output stream before loading the unpacked library,
+            // because otherwise Windows will refuse to load it when it's in use by other process.
+            closeQuietly(out);
+            out = null;
+
             loadLibrary(loader, tmpFile.getPath(), true);
         } catch (Exception e) {
             throw (UnsatisfiedLinkError) new UnsatisfiedLinkError(


### PR DESCRIPTION
Motivation:

Windows refuses to load a .DLL file when it's opened by other process.
Recent modification in NativeLibraryLoader causes NativeLibraryLoader to
attempt to load a .DLL before closing its OutputStream. As a result,
loading a .DLL file in Windows always fails.

Modifications:

Close the OutputStream explicitly before loading a shared library.

Result:

Native library loading in Windows works again.