### PR TITLE
Avoid inaccessible object exception replacing set

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -208,6 +208,15 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                     return e;
                 } catch (IllegalAccessException e) {
                     return e;
+                } catch (RuntimeException e) {
+                    // JDK 9 can throw an inaccessible object exception here; since Netty compiles
+                    // against JDK 7 and this exception was only added in JDK 9, we have to weakly
+                    // check the type
+                    if ("java.lang.reflect.InaccessibleObjectException".equals(e.getClass().getName())) {
+                        return e;
+                    } else {
+                        throw e;
+                    }
                 }
             }
         });


### PR DESCRIPTION
Motivation:

When attempting to set the selectedKeys fields on the selector
implementation, JDK 9 can throw an inaccessible object exception.

Modications:

Catch and log this exception as an possible course of action if the
sun.nio.ch package is not exported from java.base.

Result:

The selector replacement will fail gracefully as an expected course of
action if the sun.nio.ch package is not exported from java.base.