### PR TITLE
Correct throw ClosedChannelException when attempt to call shutdown*(.…

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/unix/Socket.java
@@ -82,6 +82,9 @@ public final class Socket extends FileDescriptor {
             // represents the previous incarnation of the FD we need to be sure we don't inadvertently shutdown the
             // "new" FD without explicitly having a change.
             final int oldState = this.state;
+            if (isClosed(oldState)) {
+                throw new ClosedChannelException();
+            }
             int newState = oldState;
             if (read && !isInputShutdown(newState)) {
                 newState = inputShutdown(newState);


### PR DESCRIPTION
…..) on closed EpollSocketChannel.

Motivition:

NIO throws ClosedChannelException when a user tries to call shutdown*() on a closed Channel. We should do the same for the EPOLL transport

Modification:

Throw ClosedChannelException when a user tries to call shutdown*() on a closed channel.

Result:

Consistent behavior.