### PR TITLE
[#5763] DefaultEventLoopGroup doesn't expose ctor variant that accept…

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/DefaultEventLoopGroup.java
@@ -36,7 +36,7 @@ public class DefaultEventLoopGroup extends MultithreadEventLoopGroup {
      * @param nThreads          the number of threads to use
      */
     public DefaultEventLoopGroup(int nThreads) {
-        this(nThreads, null);
+        this(nThreads, (ThreadFactory) null);
     }
 
     /**
@@ -47,6 +47,16 @@ public class DefaultEventLoopGroup extends MultithreadEventLoopGroup {
      */
     public DefaultEventLoopGroup(int nThreads, ThreadFactory threadFactory) {
         super(nThreads, threadFactory);
+    }
+
+    /**
+     * Create a new instance
+     *
+     * @param nThreads          the number of threads to use
+     * @param executor          the Executor to use, or {@code null} if the default should be used.
+     */
+    public DefaultEventLoopGroup(int nThreads, Executor executor) {
+        super(nThreads, executor);
     }
 
     @Override


### PR DESCRIPTION
…s custom Executor

Motivation:

The DefaultEventLoopGroup class extends MultithreadEventExecutorGroup but doesn't expose the ctor variants that accept a custom Executor like NioEventLoopGroup and EpollEventLoopGroup do.

Modifications:

Add missing constructor.

Result:

Be able to use custom Executor with DefaultEventLoopGroup.