### PR TITLE
[#5773] AbstractByteBuf.forEachByteDesc(ByteProcessor) starts from wr…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1274,7 +1274,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
     public int forEachByteDesc(ByteProcessor processor) {
         ensureAccessible();
         try {
-            return forEachByteDesc0(writerIndex, readerIndex, processor);
+            return forEachByteDesc0(writerIndex - 1, readerIndex, processor);
         } catch (Exception e) {
             PlatformDependent.throwException(e);
             return -1;

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -3203,6 +3203,52 @@ public abstract class AbstractByteBufTest {
         assertEquals(0, buffer2.refCnt());
     }
 
+    @Test
+    public void testForEachByteDesc2() {
+        byte[] expected = {1, 2, 3, 4};
+        ByteBuf buf = newBuffer(expected.length);
+        try {
+            buf.writeBytes(expected);
+            final byte[] bytes = new byte[expected.length];
+            int i = buf.forEachByteDesc(new ByteProcessor() {
+                private int index = bytes.length - 1;
+
+                @Override
+                public boolean process(byte value) throws Exception {
+                    bytes[index--] = value;
+                    return true;
+                }
+            });
+            assertEquals(-1, i);
+            assertArrayEquals(expected, bytes);
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test
+    public void testForEachByte2() {
+        byte[] expected = {1, 2, 3, 4};
+        ByteBuf buf = newBuffer(expected.length);
+        try {
+            buf.writeBytes(expected);
+            final byte[] bytes = new byte[expected.length];
+            int i = buf.forEachByte(new ByteProcessor() {
+                private int index;
+
+                @Override
+                public boolean process(byte value) throws Exception {
+                    bytes[index++] = value;
+                    return true;
+                }
+            });
+            assertEquals(-1, i);
+            assertArrayEquals(expected, bytes);
+        } finally {
+            buf.release();
+        }
+    }
+
     private static void assertTrueAndRelease(ByteBuf buf, boolean actual) {
         try {
             assertTrue(actual);

--- a/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
@@ -126,6 +126,18 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
         // ignore for SlicedByteBuf
     }
 
+    @Test
+    @Override
+    public void testForEachByteDesc2() {
+        // Ignore for SlicedByteBuf
+    }
+
+    @Test
+    @Override
+    public void testForEachByte2() {
+        // Ignore for SlicedByteBuf
+    }
+
     @Test(expected = UnsupportedOperationException.class)
     @Override
     public void testDuplicateCapacityChange() {

--- a/buffer/src/test/java/io/netty/buffer/WrappedUnpooledUnsafeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/WrappedUnpooledUnsafeByteBufTest.java
@@ -123,4 +123,16 @@ public class WrappedUnpooledUnsafeByteBufTest extends BigEndianUnsafeDirectByteB
     public void testLittleEndianWithExpand() {
         super.testLittleEndianWithExpand();
     }
+
+    @Test
+    @Override
+    public void testForEachByteDesc2() {
+        // Ignore
+    }
+
+    @Test
+    @Override
+    public void testForEachByte2() {
+        // Ignore
+    }
 }


### PR DESCRIPTION
…ong index

Motivation:

We introduced a regression in 1abdbe6f6798732447df6dd3af15f6cd871d6279 which let the iteration start from the wrong index.

Modifications:

Fix start index and add tests.

Result:

Fix regression.