### PR TITLE
[#5760] Do not change writerIndex when decode DnsPtrRecord

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
@@ -91,11 +91,10 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
             ByteBuf in, int offset, int length) throws Exception {
 
         if (type == DnsRecordType.PTR) {
-            in.setIndex(offset, offset + length);
-            return new DefaultDnsPtrRecord(name, dnsClass, timeToLive, decodeName0(in));
+            return new DefaultDnsPtrRecord(name, dnsClass, timeToLive, decodeName0(in.slice(offset, length)));
         }
         return new DefaultDnsRawRecord(
-                name, type, dnsClass, timeToLive, in.retainedDuplicate().setIndex(offset, offset + length));
+                name, type, dnsClass, timeToLive, in.retainedSlice(offset, length));
     }
 
     /**


### PR DESCRIPTION
Motivation:

We need to not change the original writerIndex when decode a DnsPtrRecord as otherwise we will not be able to decode other records that follow it.

Modifications:

Slice the data out and so not increase the writerIndex.

Result:

No more problems when decoding.