### PR TITLE
[#5712] Allow clients to override userDefinedWritabilityIndex from Ab…

### DIFF
--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -145,7 +145,7 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
      *              for GlobalChannel TSH it is defined as
      *              {@value #GLOBALCHANNEL_DEFAULT_USER_DEFINED_WRITABILITY_INDEX}.
      */
-    int userDefinedWritabilityIndex() {
+    protected int userDefinedWritabilityIndex() {
         if (this instanceof GlobalChannelTrafficShapingHandler) {
             return GLOBALCHANNEL_DEFAULT_USER_DEFINED_WRITABILITY_INDEX;
         } else if (this instanceof GlobalTrafficShapingHandler) {

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
@@ -156,7 +156,7 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
     }
 
     @Override
-    int userDefinedWritabilityIndex() {
+    protected int userDefinedWritabilityIndex() {
         return AbstractTrafficShapingHandler.GLOBALCHANNEL_DEFAULT_USER_DEFINED_WRITABILITY_INDEX;
     }
 


### PR DESCRIPTION
…stractTrafficShapingHandler

Motivation:

AbstractTrafficShapingHandler has a package-private method called "userDefinedWritabilityIndex()" which a user may need to override if two sub-classes wants to be used in the ChannelPipeline.

Modifications:

Mark method protected.

Result:

Easier to extend AbstractTrafficShapingHandler.