### PR TITLE
PlatformDependent does not prefer JDK8 LongAdder

### DIFF
--- a/common/src/main/java/io/netty/util/internal/LongAdderFactory.java
+++ b/common/src/main/java/io/netty/util/internal/LongAdderFactory.java
@@ -1,0 +1,39 @@
+/*
+* Copyright 2016 The Netty Project
+*
+* The Netty Project licenses this file to you under the Apache License,
+* version 2.0 (the "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at:
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+package io.netty.util.internal;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * LongCounter factory which provides indirection for {@link PlatformDependent}
+ * to avoid classloading {@link LongAdder} in JDK 6/7.
+ */
+final class LongAdderFactory {
+
+    private LongAdderFactory() {
+    }
+
+    public static LongCounter newLongCounter() {
+        return new LongAdderCounter();
+    }
+
+    private static final class LongAdderCounter extends LongAdder implements LongCounter {
+        @Override
+        public long value() {
+            return sum();
+        }
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -289,10 +289,12 @@ public final class PlatformDependent {
     }
 
     /**
-     * Creates a new fastest {@link LongCounter} implementaion for the current platform.
+     * Creates a new fastest {@link LongCounter} implementation for the current platform.
      */
     public static LongCounter newLongCounter() {
-        if (HAS_UNSAFE) {
+        if (JAVA_VERSION >= 8) {
+            return LongAdderFactory.newLongCounter();
+        } else if (HAS_UNSAFE) {
             return new LongAdderV8();
         } else {
             return new AtomicLongCounter();


### PR DESCRIPTION
Motivation:

Prefer JDK8 LongAdder if it is available.

Modifications:

Introduce LongAdderFactory which provides JDK8 LongAdder via indirection.

Result:

JDK8 LongAdder is used if available.