### PR TITLE
[#5759] Allow websocket extensions in websocketx example.

### DIFF
--- a/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
+++ b/example/src/main/java/io/netty/example/http/websocketx/client/WebSocketClient.java
@@ -98,7 +98,7 @@ public final class WebSocketClient {
             final WebSocketClientHandler handler =
                     new WebSocketClientHandler(
                             WebSocketClientHandshakerFactory.newHandshaker(
-                                    uri, WebSocketVersion.V13, null, false, new DefaultHttpHeaders()));
+                                    uri, WebSocketVersion.V13, null, true, new DefaultHttpHeaders()));
 
             Bootstrap b = new Bootstrap();
             b.group(group)


### PR DESCRIPTION
Motivation:

As we use compression in the websocketx example we need to allow extensions as ohterwise the example not works.

Modifications:

Allow extensions.

Result:

websocketx example does work.