### PR TITLE
Remove OSGi import of JCTools since it is shaded.

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -49,8 +49,6 @@
       <artifactId>jctools-core</artifactId>
       <!-- Need compile scope to be taken into account by shade plugin -->
       <scope>compile</scope>
-      <!-- Mark as optional as otherwise the bundle plugin will add strict import statements and so fail in OSGI containers-->
-      <optional>true</optional>
     </dependency>
 
     <!-- Logging frameworks - completely optional -->
@@ -187,6 +185,8 @@
                 <!-- NativeLibraryLoader can be used to manually load native libraries from other bundles that this bundle does not depend on,
                 hence use DynamicImport-Package instruction to ensure the loading is successful -->
                 <DynamicImport-Package>*</DynamicImport-Package>
+                <!-- JCTools is shaded -->
+                <Import-Package>!org.jctools.*;sun.misc;resolution:=optional;*</Import-Package>
               </instructions>
             </configuration>
           </execution>
@@ -195,4 +195,3 @@
     </plugins>
   </build>
 </project>
-

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -124,14 +124,6 @@
       <artifactId>logback-classic</artifactId>
       <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>org.jctools</groupId>
-      <artifactId>jctools-core</artifactId>
-      <!-- Need runtime scope as otherwise idea is not able to run the examples -->
-      <!-- This is most likely a bug in idea -->
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -599,13 +599,6 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <!-- Provided dependency for tests inside IDEs -->
-    <dependency>
-      <groupId>org.jctools</groupId>
-      <artifactId>jctools-core</artifactId>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Motivation:

Since netty shaded JCTools the OSGi manifest no longer is correct. It claims to
have an optional import "org.jctools.queues;resolution:=optional,org.jctools.qu
eues.atomic;resolution:=optional,org.jctools.util;resolution:=optional"
However since it is shaded, this is no longer true.
This was noticed when making JCTools a real bundle and netty resolved it as
optional import.

Modifications:

Modify the generated manifest by no longer analyzing org.jctools for imports.
A manual setting of sun.misc as optional was required.

Result:

Netty OSGi bundle will no longer interfere with a JCTools bundle.