### PR TITLE
Fix javadoc for AbstractChannel.toString()

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -364,7 +364,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
     /**
      * Returns the {@link String} representation of this channel.  The returned
-     * string contains the {@linkplain #hashCode()} ID}, {@linkplain #localAddress() local address},
+     * string contains the {@linkplain #hashCode() ID}, {@linkplain #localAddress() local address},
      * and {@linkplain #remoteAddress() remote address} of this channel for
      * easier identification.
      */


### PR DESCRIPTION
Netty version: 4.1.5.Final

Context:
The javadoc for AbstractChannel.toString() has an extra right brace as seen at http://netty.io/4.1/api/io/netty/channel/AbstractChannel.html#toString(). 