### PR TITLE
make the http2 codec void promise ready.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -413,6 +413,7 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
 
     @Override
     public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+        promise = promise.unvoid();
         // Avoid NotYetConnectedException
         if (!ctx.channel().isActive()) {
             ctx.close(promise);
@@ -629,7 +630,8 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
 
     @Override
     public ChannelFuture resetStream(final ChannelHandlerContext ctx, int streamId, long errorCode,
-                                     final ChannelPromise promise) {
+                                     ChannelPromise promise) {
+        promise = promise.unvoid();
         final Http2Stream stream = connection().stream(streamId);
         if (stream == null) {
             return resetUnknownStream(ctx, streamId, errorCode, promise);
@@ -669,12 +671,21 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     public ChannelFuture goAway(final ChannelHandlerContext ctx, final int lastStreamId, final long errorCode,
                                 final ByteBuf debugData, ChannelPromise promise) {
         try {
+            promise = promise.unvoid();
             final Http2Connection connection = connection();
-            if (connection.goAwaySent() && lastStreamId > connection.remote().lastStreamKnownByPeer()) {
-                throw connectionError(PROTOCOL_ERROR, "Last stream identifier must not increase between " +
-                                                      "sending multiple GOAWAY frames (was '%d', is '%d').",
-                                      connection.remote().lastStreamKnownByPeer(), lastStreamId);
+            if (connection().goAwaySent()) {
+                // Protect against re-entrancy. Could happen if writing the frame fails, and error handling
+                // treating this is a connection handler and doing a graceful shutdown...
+                if (lastStreamId == connection().remote().lastStreamKnownByPeer()) {
+                    return promise;
+                }
+                if (lastStreamId > connection.remote().lastStreamKnownByPeer()) {
+                    throw connectionError(PROTOCOL_ERROR, "Last stream identifier must not increase between " +
+                                                          "sending multiple GOAWAY frames (was '%d', is '%d').",
+                                          connection.remote().lastStreamKnownByPeer(), lastStreamId);
+                }
             }
+
             connection.goAwaySent(lastStreamId, errorCode, debugData);
 
             // Need to retain before we write the buffer because if we do it after the refCnt could already be 0 and

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -22,8 +22,10 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
+import io.netty.handler.codec.http2.Http2CodecUtil.SimpleChannelPromiseAggregator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.GenericFutureListener;
@@ -47,10 +49,10 @@ import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.STREAM_CLOSED;
 import static io.netty.handler.codec.http2.Http2Stream.State.CLOSED;
 import static io.netty.handler.codec.http2.Http2Stream.State.IDLE;
+import static io.netty.handler.codec.http2.Http2TestUtil.newVoidPromise;
 import static io.netty.util.CharsetUtil.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
@@ -106,6 +108,9 @@ public class Http2ConnectionHandlerTest {
     private Channel channel;
 
     @Mock
+    private ChannelPipeline pipeline;
+
+    @Mock
     private ChannelFuture future;
 
     @Mock
@@ -155,6 +160,7 @@ public class Http2ConnectionHandlerTest {
         when(future.cause()).thenReturn(fakeException);
         when(future.channel()).thenReturn(channel);
         when(channel.isActive()).thenReturn(true);
+        when(channel.pipeline()).thenReturn(pipeline);
         when(connection.remote()).thenReturn(remote);
         when(remote.flowController()).thenReturn(remoteFlowController);
         when(connection.local()).thenReturn(local);
@@ -437,6 +443,31 @@ public class Http2ConnectionHandlerTest {
     }
 
     @Test
+    public void canSendGoAwayUsingVoidPromise() throws Exception {
+        handler = newHandler();
+        ByteBuf data = dummyData();
+        long errorCode = Http2Error.INTERNAL_ERROR.code();
+        handler = newHandler();
+        final Throwable cause = new RuntimeException("fake exception");
+        doAnswer(new Answer<ChannelFuture>() {
+            @Override
+            public ChannelFuture answer(InvocationOnMock invocation) throws Throwable {
+                ChannelPromise promise = invocation.getArgumentAt(4, ChannelPromise.class);
+                assertFalse(promise.isVoid());
+                // This is what DefaultHttp2FrameWriter does... I hate mocking :-(.
+                SimpleChannelPromiseAggregator aggregatedPromise =
+                        new SimpleChannelPromiseAggregator(promise, channel, ImmediateEventExecutor.INSTANCE);
+                aggregatedPromise.newPromise();
+                aggregatedPromise.doneAllocatingPromises();
+                return aggregatedPromise.setFailure(cause);
+            }
+        }).when(frameWriter).writeGoAway(
+                any(ChannelHandlerContext.class), anyInt(), anyInt(), any(ByteBuf.class), any(ChannelPromise.class));
+        handler.goAway(ctx, STREAM_ID, errorCode, data, newVoidPromise(channel));
+        verify(pipeline).fireExceptionCaught(cause);
+    }
+
+    @Test
     public void channelReadCompleteTriggersFlush() throws Exception {
         handler = newHandler();
         handler.channelReadComplete(ctx);
@@ -453,6 +484,33 @@ public class Http2ConnectionHandlerTest {
                                                  any(ByteBuf.class), any(ChannelPromise.class));
         verify(frameWriter, never()).writeRstStream(any(ChannelHandlerContext.class), anyInt(), anyLong(),
                                                     any(ChannelPromise.class));
+    }
+
+    @Test
+    public void writeRstStreamForUnkownStreamUsingVoidPromise() throws Exception {
+        writeRstStreamUsingVoidPromise(NON_EXISTANT_STREAM_ID);
+    }
+
+    @Test
+    public void writeRstStreamForKnownStreamUsingVoidPromise() throws Exception {
+        writeRstStreamUsingVoidPromise(STREAM_ID);
+    }
+
+    private void writeRstStreamUsingVoidPromise(int streamId) throws Exception {
+        handler = newHandler();
+        final Throwable cause = new RuntimeException("fake exception");
+        when(frameWriter.writeRstStream(eq(ctx), eq(streamId), anyLong(), any(ChannelPromise.class)))
+                .then(new Answer<ChannelFuture>() {
+                    @Override
+                    public ChannelFuture answer(InvocationOnMock invocationOnMock) throws Throwable {
+                        ChannelPromise promise = invocationOnMock.getArgumentAt(3, ChannelPromise.class);
+                        assertFalse(promise.isVoid());
+                        return promise.setFailure(cause);
+                    }
+                });
+        handler.resetStream(ctx, streamId, STREAM_CLOSED.code(), newVoidPromise(channel));
+        verify(frameWriter).writeRstStream(eq(ctx), eq(streamId), anyLong(), any(ChannelPromise.class));
+        verify(pipeline).fireExceptionCaught(cause);
     }
 
     private static ByteBuf dummyData() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2TestUtil.java
@@ -16,9 +16,17 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.util.AsciiString;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import io.netty.util.concurrent.ImmediateEventExecutor;
+import junit.framework.AssertionFailedError;
 
 import java.util.List;
 import java.util.Random;
@@ -381,5 +389,53 @@ final class Http2TestUtil {
             listener.onUnknownFrame(ctx, frameType, streamId, flags, payload);
             messageLatch.countDown();
         }
+    }
+
+    static ChannelPromise newVoidPromise(final Channel channel) {
+        return new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE) {
+            @Override
+            public ChannelPromise addListener(
+                    GenericFutureListener<? extends Future<? super Void>> listener) {
+                throw new AssertionFailedError();
+            }
+
+            @Override
+            public ChannelPromise addListeners(
+                    GenericFutureListener<? extends Future<? super Void>>... listeners) {
+                throw new AssertionFailedError();
+            }
+
+            @Override
+            public boolean isVoid() {
+                return true;
+            }
+
+            @Override
+            public boolean tryFailure(Throwable cause) {
+                channel().pipeline().fireExceptionCaught(cause);
+                return true;
+            }
+
+            @Override
+            public ChannelPromise setFailure(Throwable cause) {
+                tryFailure(cause);
+                return this;
+            }
+
+            @Override
+            public ChannelPromise unvoid() {
+                ChannelPromise promise =
+                        new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
+                promise.addListener(new ChannelFutureListener() {
+                    @Override
+                    public void operationComplete(ChannelFuture future) throws Exception {
+                        if (!future.isSuccess()) {
+                            channel().pipeline().fireExceptionCaught(future.cause());
+                        }
+                    }
+                });
+                return promise;
+            }
+        };
     }
 }


### PR DESCRIPTION
Motivation:

Void promises need special treatment, as they don't behave like normal promises. One
cannot add a listener to a void promise for example.

Modifications:

Inspected the code for addListener() calls, and added extra logic for void promises
where necessary. Essentially, when writing a frame with a void promise, any errors
are reported via the channel pipeline's exceptionCaught event.

Result:

The HTTP/2 codec has better support for void promises.