### PR TITLE
IdleStateHandler volatile member variables

### DIFF
--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -110,19 +110,19 @@ public class IdleStateHandler extends ChannelDuplexHandler {
     private final long writerIdleTimeNanos;
     private final long allIdleTimeNanos;
 
-    volatile ScheduledFuture<?> readerIdleTimeout;
-    volatile long lastReadTime;
+    private ScheduledFuture<?> readerIdleTimeout;
+    private long lastReadTime;
     private boolean firstReaderIdleEvent = true;
 
-    volatile ScheduledFuture<?> writerIdleTimeout;
-    volatile long lastWriteTime;
+    private ScheduledFuture<?> writerIdleTimeout;
+    private long lastWriteTime;
     private boolean firstWriterIdleEvent = true;
 
-    volatile ScheduledFuture<?> allIdleTimeout;
+    private ScheduledFuture<?> allIdleTimeout;
     private boolean firstAllIdleEvent = true;
 
-    private volatile int state; // 0 - none, 1 - initialized, 2 - destroyed
-    private volatile boolean reading;
+    private byte state; // 0 - none, 1 - initialized, 2 - destroyed
+    private boolean reading;
 
     /**
      * Creates a new instance firing {@link IdleStateEvent}s.


### PR DESCRIPTION
Motivation:
IdleStateHandler has a number of volatile member variables which are only accessed from the EventLoop thread. These do not have to be volatile. The accessibility of these member variables are not consistent between private and package private. The state variable can also use a byte instead of an int.

Modifications:
- Remove volatile from member variables
- Change access to private for member variables
- Change state from int to byte

Result:
IdleStateHandler member variables cleaned up.