### PR TITLE
Ensure flowController().writePendingBytes() is triggered when writing…

### DIFF
--- a/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp2Handler.java
@@ -78,7 +78,11 @@ public final class HelloWorldHttp2Handler extends Http2ConnectionHandler impleme
         Http2Headers headers = new DefaultHttp2Headers().status(OK.codeAsText());
         encoder().writeHeaders(ctx, streamId, headers, 0, false, ctx.newPromise());
         encoder().writeData(ctx, streamId, payload, 0, true, ctx.newPromise());
-        ctx.flush();
+        try {
+            flush(ctx);
+        } catch (Throwable cause) {
+            onError(ctx, cause);
+        }
     }
 
     @Override


### PR DESCRIPTION
… response in example

Motivation:

We called ctx.flush() which is not correct as it will not call flowController().writePendingBytes().

Modifications:

Call flush(ChannelHandlerContext) and so also call flowController().writePendingBytes().

Result:

Correct http2 example