### PR TITLE
Fix IndexOutOfBoundsException in HelloWorldHttp2Handler

### DIFF
--- a/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/HelloWorldHttp2Handler.java
@@ -76,7 +76,7 @@ public class HelloWorldHttp2Handler extends ChannelDuplexHandler {
             throws Exception {
         if (headers.isEndStream()) {
             ByteBuf content = ctx.alloc().buffer();
-            content.writeBytes(RESPONSE_BYTES);
+            content.writeBytes(RESPONSE_BYTES.duplicate());
             ByteBufUtil.writeAscii(content, " - via HTTP/2");
             sendResponse(ctx, content);
         }


### PR DESCRIPTION
Motivation:

We need to duplicate the buffer before passing it to writeBytes(...) as it will increase the readerIndex().

Modifications:

Call duplicate().

Result:

No more IndexOutOfBoundsException when runing the multiplex example.