### PR TITLE
Catch+fire Exceptions thrown from SniHandler's select() method

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
@@ -244,8 +244,12 @@ public class SniHandler extends ByteToMessageDecoder implements ChannelOutboundH
                                             final String hostname = in.toString(offset, serverNameLength,
                                                                                 CharsetUtil.UTF_8);
 
-                                            select(ctx, IDN.toASCII(hostname,
-                                                                    IDN.ALLOW_UNASSIGNED).toLowerCase(Locale.US));
+                                            try {
+                                                select(ctx, IDN.toASCII(hostname,
+                                                                        IDN.ALLOW_UNASSIGNED).toLowerCase(Locale.US));
+                                            } catch (Throwable t) {
+                                                ctx.fireExceptionCaught(t);
+                                            }
                                             return;
                                         } else {
                                             // invalid enum value


### PR DESCRIPTION
Motivation

Give the user the ability to back out from SNI negoations.

Modifications

Put a try-catch around the select() call and re-fire any caught Exceptions.

Result

Fixes #5787