### PR TITLE
[#5833] Ensure direct memory is released when DirectPoolArena is coll…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -617,6 +617,29 @@ abstract class PoolArena<T> implements PoolArenaMetric {
         }
     }
 
+    @Override
+    protected final void finalize() throws Throwable {
+        try {
+            super.finalize();
+        } finally {
+            destroyPoolSubPages(smallSubpagePools);
+            destroyPoolSubPages(tinySubpagePools);
+            destroyPoolChunkLists(qInit, q000, q025, q050, q075, q100);
+        }
+    }
+
+    private static void destroyPoolSubPages(PoolSubpage<?>[] pages) {
+        for (PoolSubpage<?> page : pages) {
+            page.destroy();
+        }
+    }
+
+    private void destroyPoolChunkLists(PoolChunkList<T>... chunkLists) {
+        for (PoolChunkList<T> chunkList: chunkLists) {
+            chunkList.destroy(this);
+        }
+    }
+
     static final class HeapArena extends PoolArena<byte[]> {
 
         HeapArena(PooledByteBufAllocator parent, int pageSize, int maxOrder, int pageShifts, int chunkSize) {

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -461,4 +461,8 @@ final class PoolChunk<T> implements PoolChunkMetric {
             .append(')')
             .toString();
     }
+
+    void destroy() {
+        arena.destroyChunk(this);
+    }
 }

--- a/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunkList.java
@@ -31,7 +31,6 @@ final class PoolChunkList<T> implements PoolChunkListMetric {
     private final int minUsage;
     private final int maxUsage;
     private final int maxCapacity;
-
     private PoolChunk<T> head;
 
     // This is only update once when create the linked like list of PoolChunkList in PoolArena constructor.
@@ -222,5 +221,14 @@ final class PoolChunkList<T> implements PoolChunkListMetric {
         }
 
         return buf.toString();
+    }
+
+    void destroy(PoolArena<T> arena) {
+        PoolChunk<T> chunk = head;
+        while (chunk != null) {
+            arena.destroyChunk(chunk);
+            chunk = chunk.next;
+        }
+        head = null;
     }
 }

--- a/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolSubpage.java
@@ -227,4 +227,10 @@ final class PoolSubpage<T> implements PoolSubpageMetric {
     public int pageSize() {
         return pageSize;
     }
+
+    void destroy() {
+        if (chunk != null) {
+            chunk.destroy();
+        }
+    }
 }


### PR DESCRIPTION
…ected

Motivation:

We need to ensure we release all direct memory once the DirectPoolArena is collected. Otherwise we may never reclaim the memory and so leak memory.

Modifications:

Ensure we destroy all PoolChunk memory when DirectPoolArena is collected.

Result:

Free up unreleased memory when DirectPoolArena is collected.