### PR TITLE
codec-http2: Let users configure per-frame logs

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Codec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Codec.java
@@ -21,12 +21,15 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.internal.UnstableApi;
 
+import static io.netty.handler.logging.LogLevel.INFO;
+
 /**
  * An HTTP/2 channel handler that adds a {@link Http2FrameCodec} and {@link Http2MultiplexCodec} to the pipeline before
  * removing itself.
  */
 @UnstableApi
 public final class Http2Codec extends ChannelDuplexHandler {
+    private static final Http2FrameLogger HTTP2_FRAME_LOGGER = new Http2FrameLogger(INFO, Http2Codec.class);
 
     private final Http2FrameCodec frameCodec;
     private final Http2MultiplexCodec multiplexCodec;
@@ -39,7 +42,7 @@ public final class Http2Codec extends ChannelDuplexHandler {
      *     {@link ChannelHandler.Sharable}.
      */
     public Http2Codec(boolean server, ChannelHandler streamHandler) {
-        this(server, streamHandler, null);
+        this(server, streamHandler, null, HTTP2_FRAME_LOGGER);
     }
 
     /**
@@ -51,14 +54,15 @@ public final class Http2Codec extends ChannelDuplexHandler {
      * @param streamGroup event loop for registering child channels
      */
     public Http2Codec(boolean server, ChannelHandler streamHandler,
-                      EventLoopGroup streamGroup) {
-        this(server, streamHandler, streamGroup, new DefaultHttp2FrameWriter());
+                      EventLoopGroup streamGroup, Http2FrameLogger frameLogger) {
+        this(server, streamHandler, streamGroup, new DefaultHttp2FrameWriter(), frameLogger);
     }
 
     // Visible for testing
     Http2Codec(boolean server, ChannelHandler streamHandler,
-               EventLoopGroup streamGroup, Http2FrameWriter frameWriter) {
-        frameCodec = new Http2FrameCodec(server, frameWriter);
+               EventLoopGroup streamGroup, Http2FrameWriter frameWriter,
+               Http2FrameLogger frameLogger) {
+        frameCodec = new Http2FrameCodec(server, frameWriter, frameLogger);
         multiplexCodec = new Http2MultiplexCodec(server, streamGroup, streamHandler);
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -57,15 +57,25 @@ public class Http2FrameCodec extends ChannelDuplexHandler {
      * @param server {@code true} this is a server
      */
     public Http2FrameCodec(boolean server) {
-        this(server, new DefaultHttp2FrameWriter());
+        this(server, HTTP2_FRAME_LOGGER);
+    }
+
+    /**
+     * Construct a new handler.
+     *
+     * @param server {@code true} this is a server
+     */
+    public Http2FrameCodec(boolean server, Http2FrameLogger frameLogger) {
+        this(server, new DefaultHttp2FrameWriter(), frameLogger);
     }
 
     // Visible for testing
-    Http2FrameCodec(boolean server, Http2FrameWriter frameWriter) {
+    Http2FrameCodec(boolean server, Http2FrameWriter frameWriter, Http2FrameLogger frameLogger) {
         Http2Connection connection = new DefaultHttp2Connection(server);
-        frameWriter = new Http2OutboundFrameLogger(frameWriter, HTTP2_FRAME_LOGGER);
+        frameWriter = new Http2OutboundFrameLogger(frameWriter, frameLogger);
         Http2ConnectionEncoder encoder = new DefaultHttp2ConnectionEncoder(connection, frameWriter);
-        Http2FrameReader reader = new Http2InboundFrameLogger(new DefaultHttp2FrameReader(), HTTP2_FRAME_LOGGER);
+        Http2FrameReader frameReader = new DefaultHttp2FrameReader();
+        Http2FrameReader reader = new Http2InboundFrameLogger(frameReader, frameLogger);
         Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(connection, encoder, reader);
         decoder.frameListener(new FrameListener());
         http2Handler = new InternalHttp2ConnectionHandler(decoder, encoder, new Http2Settings());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -30,6 +30,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http2.Http2Exception.StreamException;
 import io.netty.handler.codec.http2.Http2Stream.State;
+import io.netty.handler.logging.LogLevel;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.AsciiString;
 import io.netty.util.ReferenceCountUtil;
@@ -75,7 +76,7 @@ public class Http2FrameCodecTest {
     @Before
     public void setUp() throws Exception {
         frameWriter = spy(new VerifiableHttp2FrameWriter());
-        framingCodec = new Http2FrameCodec(true, frameWriter);
+        framingCodec = new Http2FrameCodec(true, frameWriter, new Http2FrameLogger(LogLevel.TRACE));
         frameListener = ((DefaultHttp2ConnectionDecoder) framingCodec.connectionHandler().decoder())
                 .internalFrameListener();
         inboundHandler = new LastInboundHandler();


### PR DESCRIPTION
Motivation:

codec-http2 is really loud!

Modification:

Allow users to select how to log in the Http2Codec.

Result:

We can run Http2Codec and log however we like.