### PR TITLE
Fix typo for max leak records system property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <profile>
       <id>leak</id>
       <properties>
-        <argLine.leak>-Dio.netty.leakDetectionLevel=paranoid -Dio.netty.leakDetection.maxRecord=32</argLine.leak>
+        <argLine.leak>-Dio.netty.leakDetectionLevel=paranoid -Dio.netty.leakDetection.maxRecords=32</argLine.leak>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
Motivation:
For the leak profile we attempted to increase the number of leak hints that were retained to make debugging easier, but there was a typo.

Modifications:
- maxRecord -> maxRecords

Result:
Fix typo in pom.xml so leak profile provides more context for leaks.