### PR TITLE
Complete documentation of StreamBufferingEncoder.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamBufferingEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/StreamBufferingEncoder.java
@@ -47,6 +47,10 @@ import static io.netty.handler.codec.http2.Http2Exception.connectionError;
  * with an ID less than the specified {@code lastStreamId} will immediately fail with a
  * {@link Http2GoAwayException}.
  * <p/>
+ * <p>
+ * If the channel/encoder gets closed, all new and buffered writes will immediately fail with a
+ * {@link Http2ChannelClosedException}.
+ * </p>
  * <p>This implementation makes the buffering mostly transparent and is expected to be used as a
  * drop-in decorator of {@link DefaultHttp2ConnectionEncoder}.
  * </p>


### PR DESCRIPTION
Motivation:

The StreamBufferingEncoder is missing documentation of what happens
to buffered frames when it's closed.

Modifications:

Added this missing piece of documentation.

Result:

Improved documentation.

PTAL @Scottmitch @nmittler @normanmaurer 