### PR TITLE
Support aggressive round-robin dns

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
@@ -108,7 +108,7 @@ public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddr
      * implementation or override the default configuration.
      */
     protected AddressResolver<InetSocketAddress> newAddressResolver(EventLoop eventLoop,
-                                                                          NameResolver<InetAddress> resolver)
+                                                                    NameResolver<InetAddress> resolver)
             throws Exception {
         return new InetSocketAddressResolver(eventLoop, resolver);
     }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolverGroup.java
@@ -87,7 +87,7 @@ public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddr
                 resolvesInProgress,
                 resolveAllsInProgress);
 
-        return new InetSocketAddressResolver(eventLoop, resolver);
+        return newAddressResolver(eventLoop, resolver);
     }
 
     /**
@@ -101,5 +101,15 @@ public class DnsAddressResolverGroup extends AddressResolverGroup<InetSocketAddr
                 .channelFactory(channelFactory)
                 .nameServerAddresses(nameServerAddresses)
                 .build();
+    }
+
+    /**
+     * Creates a new {@link AddressResolver}. Override this method to create an alternative {@link AddressResolver}
+     * implementation or override the default configuration.
+     */
+    protected AddressResolver<InetSocketAddress> newAddressResolver(EventLoop eventLoop,
+                                                                          NameResolver<InetAddress> resolver)
+            throws Exception {
+        return new InetSocketAddressResolver(eventLoop, resolver);
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/RoundRobinDnsAddressResolverGroup.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/RoundRobinDnsAddressResolverGroup.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.resolver.dns;
+
+import io.netty.channel.ChannelFactory;
+import io.netty.channel.EventLoop;
+import io.netty.channel.socket.DatagramChannel;
+import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.RoundRobinInetSocketAddressResolver;
+import io.netty.resolver.NameResolver;
+import io.netty.util.internal.UnstableApi;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+/**
+ * A {@link AddressResolverGroup} of {@link DnsNameResolver}s that supports random selection of destination addresses if
+ * multiple are provided by the nameserver. This is ideal for use in applications that use a pool of connections, for
+ * which connecting to a single resolved address would be inefficient.
+ */
+@UnstableApi
+public class RoundRobinDnsAddressResolverGroup extends DnsAddressResolverGroup {
+
+    public RoundRobinDnsAddressResolverGroup(
+            Class<? extends DatagramChannel> channelType,
+            DnsServerAddresses nameServerAddresses) {
+        super(channelType, nameServerAddresses);
+    }
+
+    public RoundRobinDnsAddressResolverGroup(
+            ChannelFactory<? extends DatagramChannel> channelFactory,
+            DnsServerAddresses nameServerAddresses) {
+        super(channelFactory, nameServerAddresses);
+    }
+
+    @Override
+    protected final AddressResolver<InetSocketAddress> newAddressResolver(EventLoop eventLoop,
+                                                                          NameResolver<InetAddress> resolver)
+            throws Exception {
+        return new RoundRobinInetSocketAddressResolver(eventLoop, resolver);
+    }
+}

--- a/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
@@ -30,7 +30,7 @@ import java.util.List;
  */
 public class InetSocketAddressResolver extends AbstractAddressResolver<InetSocketAddress> {
 
-    private final NameResolver<InetAddress> nameResolver;
+    protected final NameResolver<InetAddress> nameResolver;
 
     /**
      * @param executor the {@link EventExecutor} which is used to notify the listeners of the {@link Future} returned

--- a/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
@@ -30,7 +30,7 @@ import java.util.List;
  */
 public class InetSocketAddressResolver extends AbstractAddressResolver<InetSocketAddress> {
 
-    protected final NameResolver<InetAddress> nameResolver;
+    final NameResolver<InetAddress> nameResolver;
 
     /**
      * @param executor the {@link EventExecutor} which is used to notify the listeners of the {@link Future} returned

--- a/resolver/src/main/java/io/netty/resolver/RoundRobinInetSocketAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/RoundRobinInetSocketAddressResolver.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver;
+
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.ThreadLocalRandom;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+/**
+ * A {@link AbstractAddressResolver} that resolves {@link InetAddress} and chooses a single address randomly if multiple
+ * are returned by the {@link NameResolver}.
+ */
+public class RoundRobinInetSocketAddressResolver extends InetSocketAddressResolver {
+
+    /**
+     * @param executor the {@link EventExecutor} which is used to notify the listeners of the {@link Future} returned by
+     * {@link #resolve(java.net.SocketAddress)}
+     * @param nameResolver the {@link NameResolver} used for name resolution
+     */
+    public RoundRobinInetSocketAddressResolver(EventExecutor executor, NameResolver<InetAddress> nameResolver) {
+        super(executor, nameResolver);
+    }
+
+    @Override
+    protected void doResolve(final InetSocketAddress unresolvedAddress, final Promise<InetSocketAddress> promise)
+            throws Exception {
+        // hijack the doResolve request, but do a doResolveAll request under the hood
+        // Note that InetSocketAddress.getHostName() will never incur a reverse lookup here,
+        // because an unresolved address always has a host name.
+        nameResolver.resolveAll(unresolvedAddress.getHostName())
+                    .addListener(new FutureListener<List<InetAddress>>() {
+                        @Override
+                        public void operationComplete(Future<List<InetAddress>> future) throws Exception {
+                            if (future.isSuccess()) {
+                                List<InetAddress> inetAddresses = future.getNow();
+                                int numAddresses = inetAddresses.size();
+                                if (numAddresses == 0) {
+                                    // this should not happen
+                                    promise.setSuccess(null);
+                                } else {
+                                    int index = 0;
+                                    if (numAddresses > 1) {
+                                        // there are multiple addresses: we shall pick one at random
+                                        // this is to support the round robin distribution
+                                        index = ThreadLocalRandom.current().nextInt(numAddresses);
+                                    }
+                                    promise.setSuccess(new InetSocketAddress(inetAddresses.get(index),
+                                                                             unresolvedAddress.getPort()));
+                                }
+                            } else {
+                                promise.setFailure(future.cause());
+                            }
+                        }
+                    });
+    }
+}

--- a/resolver/src/main/java/io/netty/resolver/RoundRobinInetSocketAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/RoundRobinInetSocketAddressResolver.java
@@ -23,6 +23,7 @@ import io.netty.util.internal.ThreadLocalRandom;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.List;
 
 /**
@@ -54,8 +55,7 @@ public class RoundRobinInetSocketAddressResolver extends InetSocketAddressResolv
                                 List<InetAddress> inetAddresses = future.getNow();
                                 int numAddresses = inetAddresses.size();
                                 if (numAddresses == 0) {
-                                    // this should not happen
-                                    promise.setSuccess(null);
+                                    promise.setFailure(new UnknownHostException(unresolvedAddress.getHostName()));
                                 } else {
                                     int index = 0;
                                     if (numAddresses > 1) {

--- a/resolver/src/main/java/io/netty/resolver/RoundRobinInetSocketAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/RoundRobinInetSocketAddressResolver.java
@@ -20,6 +20,7 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.ThreadLocalRandom;
+import io.netty.util.internal.UnstableApi;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -30,6 +31,7 @@ import java.util.List;
  * A {@link AbstractAddressResolver} that resolves {@link InetAddress} and chooses a single address randomly if multiple
  * are returned by the {@link NameResolver}.
  */
+@UnstableApi
 public class RoundRobinInetSocketAddressResolver extends InetSocketAddressResolver {
 
     /**
@@ -57,12 +59,10 @@ public class RoundRobinInetSocketAddressResolver extends InetSocketAddressResolv
                                 if (numAddresses == 0) {
                                     promise.setFailure(new UnknownHostException(unresolvedAddress.getHostName()));
                                 } else {
-                                    int index = 0;
-                                    if (numAddresses > 1) {
-                                        // there are multiple addresses: we shall pick one at random
-                                        // this is to support the round robin distribution
-                                        index = ThreadLocalRandom.current().nextInt(numAddresses);
-                                    }
+                                    // if there are multiple addresses: we shall pick one at random
+                                    // this is to support the round robin distribution
+                                    int index =
+                                            (numAddresses == 1)? 0 : ThreadLocalRandom.current().nextInt(numAddresses);
                                     promise.setSuccess(new InetSocketAddress(inetAddresses.get(index),
                                                                              unresolvedAddress.getPort()));
                                 }


### PR DESCRIPTION
Motivation:

Suppose the domain `foo.example.com` resolves to the following ip
addresses `10.0.0.1`, `10.0.0.2`, `10.0.0.3`. Round robin DNS works by
having each client probabilistically getting a different ordering of
the set of target IP’s, so connections from different clients (across
the world) would be split up across each of the addresses. Example: In
a `ChannelPool` to manage connections to `foo.example.com`, it may be
desirable for high QPS applications to spread the requests across all
available network addresses. Currently, Netty’s resolver would return
only the first address (`10.0.0.1`) to use. Let say we are making
dozens of connections. The name would be resolved to a single IP and
all of the connections would be made to `10.0.0.1`. The other two
addresses would not see any connections. (they may see it later if new
connections are made and `10.0.0.2` is the first in the list at that
time of a subsequent resolution). In these changes, I add support to
select a random one of the resolved addresses to use on each resolve
call, all while leveraging the existing caching and inflight request
detection. This way in my example, the connections would be make to
random selections of the resolved IP addresses.

Modifications:

I added another method `newAddressResolver` to
`DnsAddressResolverGroup` which can be overriden much like
`newNameResolver`. The current functionality which creates
`InetSocketAddressResolver` is still used. I added
`RoundRobinDnsAddressResolverGroup` which extends
`DnsAddressResolverGroup` and overrides the `newAddressResolver` method
to return a subclass of the `InetSocketAddressResolver`. This subclass
is called `RoundRobinInetSocketAddressResolver` and it contains logic
that takes a `resolve` request, does a `resolveAll` under the hood, and
returns a single element at random from the result of the `resolveAll`.

Result:

The existing functionality of `DnsAddressResolverGroup` is left
unchanged. All new functionality is in the
`RoundRobinDnsAddressResolverGroup ` which users will now have the
option to use.

edit:typo