### PR TITLE
fix 5868 - make DefaultHostsFileEntriesResolverTest.java pass without relying on there being a localhost entry in the hosts file

### DIFF
--- a/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/DefaultHostsFileEntriesResolver.java
@@ -28,6 +28,11 @@ public final class DefaultHostsFileEntriesResolver implements HostsFileEntriesRe
 
     @Override
     public InetAddress address(String inetHost) {
-        return entries.get(inetHost.toLowerCase(Locale.ENGLISH));
+        return entries.get(normalize(inetHost));
+    }
+
+    // package-private for testing purposes
+    String normalize(String inetHost) {
+        return inetHost.toLowerCase(Locale.ENGLISH);
     }
 }

--- a/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
+++ b/resolver/src/test/java/io/netty/resolver/DefaultHostsFileEntriesResolverTest.java
@@ -19,16 +19,15 @@
  */
 package io.netty.resolver;
 
+import org.junit.Assert;
 import org.junit.Test;
-
-import static org.junit.Assert.assertNotNull;
 
 public class DefaultHostsFileEntriesResolverTest {
 
     @Test
-    public void testLocalhost() {
+    public void testCaseInsensitivity() throws Exception {
         DefaultHostsFileEntriesResolver resolver = new DefaultHostsFileEntriesResolver();
-        assertNotNull("localhost doesn't resolve", resolver.address("localhost"));
-        assertNotNull("LOCALHOST doesn't resolve", resolver.address("LOCALHOST"));
+        //normalized somehow
+        Assert.assertEquals(resolver.normalize("localhost"), resolver.normalize("LOCALHOST"));
     }
 }


### PR DESCRIPTION
Signed-off-by: radai-rosenblatt radai.rosenblatt@gmail.com
