### PR TITLE
[#5861] HttpUtil.getContentLength(HttpMessage, long) throws unexpecte…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -184,7 +184,11 @@ public final class HttpUtil {
     public static long getContentLength(HttpMessage message, long defaultValue) {
         String value = message.headers().get(HttpHeaderNames.CONTENT_LENGTH);
         if (value != null) {
-            return Long.parseLong(value);
+            try {
+                return Long.parseLong(value);
+            } catch (NumberFormatException ignore) {
+                return defaultValue;
+            }
         }
 
         // We know the content length if it's a Web Socket message even if

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -100,4 +100,13 @@ public class HttpUtilTest {
         message.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=utf-8");
         assertEquals("text/html", HttpUtil.getMimeType(message));
     }
+
+    @Test
+    public void testGetContentLengthDefaultValue() {
+        HttpMessage message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        assertNull(message.headers().get(HttpHeaderNames.CONTENT_LENGTH));
+        message.headers().set(HttpHeaderNames.CONTENT_LENGTH, "bar");
+        assertEquals("bar", message.headers().get(HttpHeaderNames.CONTENT_LENGTH));
+        assertEquals(1L, HttpUtil.getContentLength(message, 1L));
+    }
 }


### PR DESCRIPTION
…d NumberFormatException

Motivation:

The Javadocs of HttpUtil.getContentLength(HttpMessage, long) and its int overload state that the provided default value is returned if the Content-Length value is not a number. NumberFormatException is thrown instead.

Modifications:

Correctly handle when the value is not a number.

Result:

API works as stated in javadocs.