### PR TITLE
Upgrade JMH to 1.14.1

### DIFF
--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -92,12 +92,12 @@
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
-      <version>1.12</version>
+      <version>1.14.1</version>
     </dependency>
     <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-generator-annprocess</artifactId>
-      <version>1.12</version>
+      <version>1.14.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Motivation:
It'd be usually good to use the latest library version.

Modification:
Bumped JMH to the latest version as of today.

Result:
Now we use JMH version 1.14.1 for our benchmark.