### PR TITLE
[#5893] Ensure we not close NioDatagramChannel when SocketException i…

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
@@ -97,11 +97,7 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
                 pipeline.fireChannelReadComplete();
 
                 if (exception != null) {
-                    if (exception instanceof IOException && !(exception instanceof PortUnreachableException)) {
-                        // ServerChannel should not be closed even on IOException because it can often continue
-                        // accepting incoming connections. (e.g. too many open files)
-                        closed = !(AbstractNioMessageChannel.this instanceof ServerChannel);
-                    }
+                    closed = closeOnReadError(exception);
 
                     pipeline.fireExceptionCaught(exception);
                 }
@@ -173,6 +169,14 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
      */
     protected boolean continueOnWriteError() {
         return false;
+    }
+
+    protected boolean closeOnReadError(Throwable cause) {
+        // ServerChannel should not be closed even on IOException because it can often continue
+        // accepting incoming connections. (e.g. too many open files)
+        return cause instanceof IOException &&
+                !(cause instanceof PortUnreachableException) &&
+                this instanceof ServerChannel;
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -595,4 +595,14 @@ public final class NioDatagramChannel
     void clearReadPending0() {
         clearReadPending();
     }
+
+    @Override
+    protected boolean closeOnReadError(Throwable cause) {
+        // We do not want to close on SocketException when using DatagramChannel as we usually can continue receiving.
+        // See https://github.com/netty/netty/issues/5893
+        if (cause instanceof SocketException) {
+            return false;
+        }
+        return super.closeOnReadError(cause);
+    }
 }


### PR DESCRIPTION
…s received.

Motivation:

When using java.nio.DatagramChannel we should not close the channel when a SocketException was thrown as we can still use the channel.

Modifications:

Not close the Channel when SocketException is thrown

Result:

More robust and correct handling of exceptions when using NioDatagramChannel.