### PR TITLE
SocketSslEchoTest failure

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -45,7 +45,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import javax.net.ssl.SSLEngine;
 import java.io.File;
 import java.io.IOException;
 import java.security.cert.CertificateException;
@@ -57,6 +56,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLEngine;
 
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
@@ -148,11 +148,19 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                         continue;
                     }
 
-                    Renegotiation r;
-                    if (rt == RenegotiationType.NONE) {
-                        r = Renegotiation.NONE;
-                    } else {
-                        r = new Renegotiation(rt, "SSL_RSA_WITH_3DES_EDE_CBC_SHA");
+                    final Renegotiation r;
+                    switch (rt) {
+                        case NONE:
+                            r = Renegotiation.NONE;
+                            break;
+                        case SERVER_INITIATED:
+                            r = new Renegotiation(rt, sc.cipherSuites().get(sc.cipherSuites().size() - 1));
+                            break;
+                        case CLIENT_INITIATED:
+                            r = new Renegotiation(rt, cc.cipherSuites().get(cc.cipherSuites().size() - 1));
+                            break;
+                        default:
+                            throw new Error();
                     }
 
                     for (int i = 0; i < 32; i++) {


### PR DESCRIPTION
Motivation:
8ba5b5f740d0d87eebd2aedacff8bd196d6da795 removed some ciphers from the default list, and SocketSslEchoTest had one of these ciphers hard coded in the test. The test will fail if the cihper is not supported by default.

Modifications:
SocketSslEchoTest should ensure a cipher is used which will be supported by the peer

Result:
Test result no longer depends upon default cipher list.