### PR TITLE
Correctly release debugData and notify the promise when goAway was al…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -677,7 +677,9 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
                 // Protect against re-entrancy. Could happen if writing the frame fails, and error handling
                 // treating this is a connection handler and doing a graceful shutdown...
                 if (lastStreamId == connection().remote().lastStreamKnownByPeer()) {
-                    return promise;
+                    // Release the data and notify the promise
+                    debugData.release();
+                    return promise.setSuccess();
                 }
                 if (lastStreamId > connection.remote().lastStreamKnownByPeer()) {
                     throw connectionError(PROTOCOL_ERROR, "Last stream identifier must not increase between " +


### PR DESCRIPTION
…ready sent

Motivation:

Commit 908464f161385361c450826bb1242c06f78d931e also introduced a change to guard against re-entrance but failed to correctly handle the debugData and promise.

Modifications:

Release debugData and correctly notify the promise.

Result:

No more buffer leak and promise is always notified.