### PR TITLE
Allow customization of LocalChannel instances that are being created …

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -107,7 +107,7 @@ public class LocalChannel extends AbstractChannel {
         config().setAllocator(new PreferHeapByteBufAllocator(config.getAllocator()));
     }
 
-    LocalChannel(LocalServerChannel parent, LocalChannel peer) {
+    protected LocalChannel(LocalServerChannel parent, LocalChannel peer) {
         super(parent);
         config().setAllocator(new PreferHeapByteBufAllocator(config.getAllocator()));
         this.peer = peer;

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -137,7 +137,7 @@ public class LocalServerChannel extends AbstractServerChannel {
     }
 
     LocalChannel serve(final LocalChannel peer) {
-        final LocalChannel child = new LocalChannel(this, peer);
+        final LocalChannel child = newLocalChannel(peer);
         if (eventLoop().inEventLoop()) {
             serve0(child);
         } else {
@@ -149,6 +149,14 @@ public class LocalServerChannel extends AbstractServerChannel {
             });
         }
         return child;
+    }
+
+    /**
+     * A factory method for {@link LocalChannel}s. Users may override it
+     * to create custom instances of {@link LocalChannel}s.
+     */
+    protected LocalChannel newLocalChannel(LocalChannel peer) {
+        return new LocalChannel(this, peer);
     }
 
     private void serve0(final LocalChannel child) {


### PR DESCRIPTION
…by LocalServerChannel.

Motivation

It's possible to extend LocalChannel as well as LocalServerChannel but the LocalServerChannel's
serve(peer) method is hardcoded to create only instances of LocalChannel.

Modifications

Add a protected factory method that returns by default new LocalChannel(...) but users may override
it to customize it.

Result

It's possible to customize the LocalChannel instance on either end of the virtual connection.