### PR TITLE
http2: Make MAX_HEADER_LIST_SIZE exceeded a stream error when encoding.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriter.java
@@ -303,7 +303,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
 
             // Encode the entire header block into an intermediate buffer.
             headerBlock = ctx.alloc().buffer();
-            headersEncoder.encodeHeaders(headers, headerBlock);
+            headersEncoder.encodeHeaders(streamId, headers, headerBlock);
 
             // Read the first fragment (possibly everything).
             Http2Flags flags = new Http2Flags().paddingPresent(padding > 0);
@@ -427,7 +427,7 @@ public class DefaultHttp2FrameWriter implements Http2FrameWriter, Http2FrameSize
 
             // Encode the entire header block.
             headerBlock = ctx.alloc().buffer();
-            headersEncoder.encodeHeaders(headers, headerBlock);
+            headersEncoder.encodeHeaders(streamId, headers, headerBlock);
 
             Http2Flags flags =
                     new Http2Flags().endOfStream(endStream).priorityPresent(hasPriority).paddingPresent(padding > 0);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoder.java
@@ -59,7 +59,7 @@ public class DefaultHttp2HeadersEncoder implements Http2HeadersEncoder, Http2Hea
     }
 
     @Override
-    public void encodeHeaders(Http2Headers headers, ByteBuf buffer) throws Http2Exception {
+    public void encodeHeaders(int streamId, Http2Headers headers, ByteBuf buffer) throws Http2Exception {
         try {
             // If there was a change in the table size, serialize the output from the encoder
             // resulting from that change.
@@ -68,7 +68,7 @@ public class DefaultHttp2HeadersEncoder implements Http2HeadersEncoder, Http2Hea
                 tableSizeChangeOutput.clear();
             }
 
-            encoder.encodeHeaders(buffer, headers, sensitivityDetector);
+            encoder.encodeHeaders(streamId, buffer, headers, sensitivityDetector);
         } catch (Http2Exception e) {
             throw e;
         } catch (Throwable t) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersEncoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2HeadersEncoder.java
@@ -54,10 +54,11 @@ public interface Http2HeadersEncoder {
     /**
      * Encodes the given headers and writes the output headers block to the given output buffer.
      *
+     * @param streamId  the identifier of the stream for which the headers are encoded.
      * @param headers the headers to be encoded.
      * @param buffer the buffer to receive the encoded headers.
      */
-    void encodeHeaders(Http2Headers headers, ByteBuf buffer) throws Http2Exception;
+    void encodeHeaders(int streamId, Http2Headers headers, ByteBuf buffer) throws Http2Exception;
 
     /**
      * Get the {@link Configuration} for this {@link Http2HeadersEncoder}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
@@ -77,7 +77,7 @@ public class DefaultHttp2HeadersDecoderTest {
         for (int ix = 0; ix < entries.length;) {
             http2Headers.add(new AsciiString(entries[ix++], false), new AsciiString(entries[ix++], false));
         }
-        encoder.encodeHeaders(out, http2Headers, NEVER_SENSITIVE);
+        encoder.encodeHeaders(3 /* randomly chosen */, out, http2Headers, NEVER_SENSITIVE);
         return out;
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersEncoderTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec.http2;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http2.Http2Exception.StreamException;
 import io.netty.util.AsciiString;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,18 +42,18 @@ public class DefaultHttp2HeadersEncoderTest {
         Http2Headers headers = headers();
         ByteBuf buf = Unpooled.buffer();
         try {
-            encoder.encodeHeaders(headers, buf);
+            encoder.encodeHeaders(3 /* randomly chosen */, headers, buf);
             assertTrue(buf.writerIndex() > 0);
         } finally {
             buf.release();
         }
     }
 
-    @Test(expected = Http2Exception.class)
+    @Test(expected = StreamException.class)
     public void headersExceedMaxSetSizeShouldFail() throws Http2Exception {
         Http2Headers headers = headers();
         encoder.headerTable().maxHeaderListSize(2);
-        encoder.encodeHeaders(headers, Unpooled.buffer());
+        encoder.encodeHeaders(3 /* randomly chosen */, headers, Unpooled.buffer());
     }
 
     private static Http2Headers headers() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2HeaderBlockIOTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2HeaderBlockIOTest.java
@@ -81,7 +81,7 @@ public class Http2HeaderBlockIOTest {
     }
 
     private void assertRoundtripSuccessful(Http2Headers in) throws Http2Exception {
-        encoder.encodeHeaders(in, buffer);
+        encoder.encodeHeaders(3 /* randomly chosen */, in, buffer);
 
         Http2Headers out = decoder.decodeHeaders(0, buffer);
         assertEquals(in, out);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/internal/hpack/TestCase.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/internal/hpack/TestCase.java
@@ -195,7 +195,7 @@ final class TestCase {
                 encoder.setMaxHeaderTableSize(buffer, maxHeaderTableSize);
             }
 
-            encoder.encodeHeaders(buffer, http2Headers, sensitivityDetector);
+            encoder.encodeHeaders(3 /* randomly chosen */, buffer, http2Headers, sensitivityDetector);
             byte[] bytes = new byte[buffer.readableBytes()];
             buffer.readBytes(bytes);
             return bytes;

--- a/microbench/src/main/java/io/netty/microbench/http2/internal/hpack/DecoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/internal/hpack/DecoderBenchmark.java
@@ -96,8 +96,9 @@ public class DecoderBenchmark extends AbstractMicrobenchmark {
         Encoder encoder = newTestEncoder();
         ByteBuf out = size.newOutBuffer();
         try {
-            encoder.encodeHeaders(out, headers, sensitive ? Http2HeadersEncoder.ALWAYS_SENSITIVE
-                                                          : Http2HeadersEncoder.NEVER_SENSITIVE);
+            encoder.encodeHeaders(3 /* randomly chosen */, out, headers,
+                                  sensitive ? Http2HeadersEncoder.ALWAYS_SENSITIVE
+                                            : Http2HeadersEncoder.NEVER_SENSITIVE);
             byte[] bytes = new byte[out.readableBytes()];
             out.readBytes(bytes);
             return bytes;

--- a/microbench/src/main/java/io/netty/microbench/http2/internal/hpack/EncoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/http2/internal/hpack/EncoderBenchmark.java
@@ -110,7 +110,7 @@ public class EncoderBenchmark extends AbstractMicrobenchmark {
     public void encode(Blackhole bh) throws Exception {
         Encoder encoder = newTestEncoder();
         output.clear();
-        encoder.encodeHeaders(output, http2Headers, sensitivityDetector);
+        encoder.encodeHeaders(3 /*randomly chosen*/, output, http2Headers, sensitivityDetector);
         bh.consume(output);
     }
 }


### PR DESCRIPTION
Motivation:

The SETTINGS_MAX_HEADER_LIST_SIZE limit, as enforced by the HPACK Encoder, should be a stream error and not apply to the whole connection.

Modifications:

Made the necessary changes for the exception to be of type StreamException.

Result:

A HEADERS frame exceeding the limit, only affects a specific stream.