### PR TITLE
Fix unbounded expansion of cumulative buffer in SslHandler

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -925,7 +925,10 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         readIfNeeded(ctx);
 
         firedChannelRead = false;
-        ctx.fireChannelReadComplete();
+        // The super class has a buffer which accumulates data and will discard bytes upon read complete.
+        // We need to call super.channelReadComplete(ctx) to prevent memory for accumulating.
+        // See https://github.com/netty/netty/issues/5928
+        super.channelReadComplete(ctx);
     }
 
     private void readIfNeeded(ChannelHandlerContext ctx) {


### PR DESCRIPTION
Motivation:
62057f73d6cda6294c44f562ba0ae8bde1923c96 introduced a regression where large amounts of memory could accumulate, and not be cleaned up in a timely manner.

Modifications:
- Call super.channelReadComplete() instead of calling ctx.fireChannelReadComplete()

Result:
Fixes https://github.com/netty/netty/issues/5928