### PR TITLE
Read if needed on ProxyHandler's handshake

### DIFF
--- a/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
@@ -208,6 +208,8 @@ public abstract class ProxyHandler extends ChannelDuplexHandler {
         if (initialMessage != null) {
             sendToProxyServer(initialMessage);
         }
+
+        readIfNeeded(ctx);
     }
 
     /**
@@ -384,9 +386,7 @@ public abstract class ProxyHandler extends ChannelDuplexHandler {
         if (suppressChannelReadComplete) {
             suppressChannelReadComplete = false;
 
-            if (!ctx.channel().config().isAutoRead()) {
-                ctx.read();
-            }
+            readIfNeeded(ctx);
         } else {
             ctx.fireChannelReadComplete();
         }
@@ -409,6 +409,12 @@ public abstract class ProxyHandler extends ChannelDuplexHandler {
             ctx.flush();
         } else {
             flushedPrematurely = true;
+        }
+    }
+
+    private void readIfNeeded(ChannelHandlerContext ctx) {
+        if (!ctx.channel().config().isAutoRead()) {
+            ctx.read();
         }
     }
 

--- a/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
+++ b/handler-proxy/src/main/java/io/netty/handler/proxy/ProxyHandler.java
@@ -412,7 +412,7 @@ public abstract class ProxyHandler extends ChannelDuplexHandler {
         }
     }
 
-    private void readIfNeeded(ChannelHandlerContext ctx) {
+    private static void readIfNeeded(ChannelHandlerContext ctx) {
         if (!ctx.channel().config().isAutoRead()) {
             ctx.read();
         }


### PR DESCRIPTION
Fixes #5933.

## Motivation:

When auto-read is disabled and no reads are issued by a user, `ProxyHandler` will stall the connection on the proxy handshake phase waiting for the first response from a server (that was never read).

## Modifications:

Read if needed when very first handshake message is send by `ProxyHandler`.

## Result:

Proxy handshake now succeeds no matter if auto-read disabled or enabled. Without the fix, the new test is failing on master.

Notes (on testing):

Given that `ProxyHandlerTest` is essentially an integration test I decided to slightly extend it and handle its cases with randomized auto-read settings. Basically, we randomly assign an auto-read setting to the channel in the test just to make sure the original test works regardless of what the auto-read value is.

I know, this adds some "randomness"  to the test suite, but I think we should be fine here because 

 a) "the integration tests" implies some reasonable level of randomness and
 b) we fully cover the space of generated values (our test is total on the input)
