### PR TITLE
Adding ability to get Peer Creds on a UnixDomainSocket

### DIFF
--- a/transport-native-epoll/src/main/c/netty_unix_socket.c
+++ b/transport-native-epoll/src/main/c/netty_unix_socket.c
@@ -13,6 +13,12 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+ /* 
+ * Since glibc 2.8, the _GNU_SOURCE feature test macro must be defined
+ * (before including any header files) in order to obtain the
+ * definition of this structure. See <a href=https://linux.die.net/man/7/unix>
+ */
+#define _GNU_SOURCE
 #include <fcntl.h>
 #include <errno.h>
 #include <unistd.h>
@@ -29,8 +35,10 @@
 #include "netty_unix_util.h"
 
 static jclass datagramSocketAddressClass = NULL;
+static jclass peerCredentialsClass = NULL;
 static jmethodID datagramSocketAddrMethodId = NULL;
 static jmethodID inetSocketAddrMethodId = NULL;
+static jmethodID peerCredentialsMethodId = NULL;
 static jclass inetSocketAddressClass = NULL;
 static jclass netUtilClass = NULL;
 static jmethodID netUtilClassIpv4PreferredMethodId = NULL;
@@ -647,6 +655,14 @@ static jint netty_unix_socket_isTcpQuickAck(JNIEnv* env, jclass clazz, jint fd) 
     }
     return optval;
 }
+
+static jobject netty_channel_unix_socket_peerCredentials(JNIEnv *env, jclass clazz, jint fd) {
+     struct ucred credentials;
+     if(netty_unix_socket_getOption(env,fd, SOL_SOCKET, SO_PEERCRED, &credentials, sizeof (credentials))) {
+         return NULL;
+     }
+     return (*env)->NewObject(env, peerCredentialsClass, peerCredentialsMethodId, credentials.pid, credentials.uid, credentials.gid);
+}
 // JNI Registered Methods End
 
 // JNI Method Registration Table Begin
@@ -690,7 +706,7 @@ static const JNINativeMethod fixed_method_table[] = {
 static const jint fixed_method_table_size = sizeof(fixed_method_table) / sizeof(fixed_method_table[0]);
 
 static jint dynamicMethodsTableSize() {
-    return fixed_method_table_size + 2;
+    return fixed_method_table_size + 3;
 }
 
 static JNINativeMethod* createDynamicMethodsTable(const char* packagePrefix) {
@@ -707,6 +723,12 @@ static JNINativeMethod* createDynamicMethodsTable(const char* packagePrefix) {
     dynamicMethod->name = "recvFromAddress";
     dynamicMethod->signature = netty_unix_util_prepend("(IJII)L", dynamicTypeName);
     dynamicMethod->fnPtr = (void *) netty_unix_socket_recvFromAddress;
+    free(dynamicTypeName);
+    ++dynamicMethod;
+    dynamicTypeName = netty_unix_util_prepend(packagePrefix, "io/netty/channel/unix/PeerCredentials;");
+    dynamicMethod->name = "peerCredentials";
+    dynamicMethod->signature = netty_unix_util_prepend("(I)L", dynamicTypeName);
+    dynamicMethod->fnPtr = (void *) netty_channel_unix_socket_peerCredentials;
     free(dynamicTypeName);
     return dynamicMethods;
 }
@@ -788,6 +810,26 @@ jint netty_unix_socket_JNI_OnLoad(JNIEnv* env, const char* packagePrefix) {
         netty_unix_errors_throwRuntimeException(env, "failed to get method ID: NetUild.isIpV4StackPreferred()");
         return JNI_ERR;
     }
+    
+    nettyClassName = netty_unix_util_prepend(packagePrefix, "io/netty/channel/unix/PeerCredentials");
+    jclass localPeerCredsClass = (*env)->FindClass(env, nettyClassName);
+    free(nettyClassName);
+    nettyClassName = NULL;
+    if (localPeerCredsClass == NULL) {
+        // pending exception...
+        return JNI_ERR;
+    }
+    peerCredentialsClass = (jclass) (*env)->NewGlobalRef(env, localPeerCredsClass);
+    if (peerCredentialsClass == NULL) {
+        // out-of-memory!
+        netty_unix_errors_throwOutOfMemoryError(env);
+        return JNI_ERR;
+    }
+    peerCredentialsMethodId = (*env)->GetMethodID(env, peerCredentialsClass, "<init>", "(III)V");
+    if (peerCredentialsMethodId == NULL) {
+        netty_unix_errors_throwRuntimeException(env, "failed to get method ID: PeerCredentials.<init>(int, int, int)");
+        return JNI_ERR;
+    }
 
     void* mem = malloc(1);
     if (mem == NULL) {
@@ -825,5 +867,9 @@ void netty_unix_socket_JNI_OnUnLoad(JNIEnv* env) {
     if (netUtilClass != NULL) {
         (*env)->DeleteGlobalRef(env, netUtilClass);
         netUtilClass = NULL;
+    }
+    if (peerCredentialsClass != NULL) {
+        (*env)->DeleteGlobalRef(env,peerCredentialsClass);
+        peerCredentialsClass = NULL;
     }
 }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDomainSocketChannel.java
@@ -22,11 +22,13 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.DomainSocketChannel;
 import io.netty.channel.unix.FileDescriptor;
+import io.netty.channel.unix.PeerCredentials;
 import io.netty.channel.unix.Socket;
 
 import java.net.SocketAddress;
 
 import static io.netty.channel.unix.Socket.newSocketDomain;
+import java.io.IOException;
 
 public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel implements DomainSocketChannel {
     private final EpollDomainSocketChannelConfig config = new EpollDomainSocketChannelConfig(this);
@@ -130,6 +132,17 @@ public final class EpollDomainSocketChannel extends AbstractEpollStreamChannel i
             return msg;
         }
         return super.filterOutboundMessage(msg);
+    }
+
+    /*
+    * returns the unix credentials (uid, gid, pid) of the peer
+    * <a href=http://man7.org/linux/man-pages/man7/socket.7.html>SO_PEERCRED</a>
+    *
+    * @returns PeerCredentials
+    * @throws IOException
+    */
+    public PeerCredentials peerCredentials() throws IOException {
+        return fd().getPeerCredentials();
     }
 
     private final class EpollDomainUnsafe extends EpollStreamUnsafe {

--- a/transport-native-epoll/src/main/java/io/netty/channel/unix/PeerCredentials.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/unix/PeerCredentials.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.unix;
+
+/**
+ * User credentials discovered for the peer unix domain socket.
+ *
+ * The PID, UID and GID of the user connected on the other side of the unix domain socket
+ * For details see:
+ * <a href=http://man7.org/linux/man-pages/man7/socket.7.html>SO_PEERCRED</a>
+ */
+public final class PeerCredentials {
+    private final int pid;
+    private final int uid;
+    private final int gid;
+
+    // These values are set by JNI via Socket.peerCredentials()
+    PeerCredentials(int p, int u, int g) {
+        pid = p;
+        uid = u;
+        gid = g;
+    }
+
+    public int pid() {
+        return pid;
+    }
+
+    public int uid() {
+        return uid;
+    }
+
+    public int gid() {
+        return gid;
+    }
+
+    @Override
+    public String toString() {
+        return "UserCredentials["
+        + "pid=" + pid
+        + "; uid=" + uid
+        + "; gid=" + gid
+        + "]";
+    }
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/unix/Socket.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/unix/Socket.java
@@ -319,6 +319,15 @@ public final class Socket extends FileDescriptor {
         return getSoError(fd);
     }
 
+    /*
+    * Returns the credentials of the peer unix domain socket
+    * encapsulated in the PeerCredentials class.
+    * @return PeerCredentials
+    */
+    public PeerCredentials getPeerCredentials() throws IOException {
+        return peerCredentials(fd);
+    }
+
     public void setKeepAlive(boolean keepAlive) throws IOException {
         setKeepAlive(fd, keepAlive ? 1 : 0);
     }
@@ -428,4 +437,5 @@ public final class Socket extends FileDescriptor {
     private static native void setSoLinger(int fd, int soLinger) throws IOException;
     private static native void setTcpDeferAccept(int fd, int deferAccept) throws IOException;
     private static native void setTcpQuickAck(int fd, int quickAck) throws IOException;
+    private static native PeerCredentials peerCredentials(int fd) throws IOException;
 }


### PR DESCRIPTION
Background:
  Added the ability to a unix domain socket to get Peer Creds (SO_PEERCRED).

Updated the Socket class contain a call that return you a PeerCredential class.  Then exposed the call in the EpollDomainSocketChannel.
