### PR TITLE
Let HTTP cookie support AsciiString

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
@@ -15,13 +15,10 @@
  */
 package io.netty.handler.codec.http.cookie;
 
-import static io.netty.handler.codec.http.cookie.CookieUtil.add;
-import static io.netty.handler.codec.http.cookie.CookieUtil.addQuoted;
-import static io.netty.handler.codec.http.cookie.CookieUtil.stringBuilder;
-import static io.netty.handler.codec.http.cookie.CookieUtil.stripTrailingSeparator;
-import static io.netty.handler.codec.http.cookie.CookieUtil.stripTrailingSeparatorOrNull;
+import static io.netty.handler.codec.http.cookie.CookieUtil.*;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.util.AsciiString;
 import io.netty.util.internal.InternalThreadLocalMap;
 
 import java.util.Arrays;
@@ -74,8 +71,22 @@ public final class ClientCookieEncoder extends CookieEncoder {
      *            the cookie value
      * @return a Rfc6265 style Cookie header value
      */
+    @Deprecated
     public String encode(String name, String value) {
         return encode(new DefaultCookie(name, value));
+    }
+
+    /**
+     * Encodes the specified cookie into a Cookie header value.
+     *
+     * @param name
+     *            the cookie name
+     * @param value
+     *            the cookie value
+     * @return a Rfc6265 style Cookie header value
+     */
+    public AsciiString encode(AsciiString name, AsciiString value) {
+        return encodeAsciiString(new DefaultCookie(name, value));
     }
 
     /**
@@ -84,7 +95,18 @@ public final class ClientCookieEncoder extends CookieEncoder {
      * @param cookie the specified cookie
      * @return a Rfc6265 style Cookie header value
      */
+    @Deprecated
     public String encode(Cookie cookie) {
+        return toStringOrNull(encodeAsciiString(cookie));
+    }
+
+    /**
+     * Encodes the specified cookie into a Cookie header value.
+     *
+     * @param cookie the specified cookie
+     * @return a Rfc6265 style Cookie header value
+     */
+    public AsciiString encodeAsciiString(Cookie cookie) {
         StringBuilder buf = stringBuilder();
         encode(buf, checkNotNull(cookie, "cookie"));
         return stripTrailingSeparator(buf);
@@ -97,8 +119,8 @@ public final class ClientCookieEncoder extends CookieEncoder {
     private static final Comparator<Cookie> COOKIE_COMPARATOR = new Comparator<Cookie>() {
         @Override
         public int compare(Cookie c1, Cookie c2) {
-            String path1 = c1.path();
-            String path2 = c2.path();
+            AsciiString path1 = c1.asciiPath();
+            AsciiString path2 = c2.asciiPath();
             // Cookies with unspecified path default to the path of the request. We don't
             // know the request path here, but we assume that the length of an unspecified
             // path is longer than any specified path (i.e. pathless cookies come first),
@@ -123,7 +145,19 @@ public final class ClientCookieEncoder extends CookieEncoder {
      *            some cookies
      * @return a Rfc6265 style Cookie header value, null if no cookies are passed.
      */
+    @Deprecated
     public String encode(Cookie... cookies) {
+        return toStringOrNull(encodeAsciiString(cookies));
+    }
+
+    /**
+     * Encodes the specified cookies into a single Cookie header value.
+     *
+     * @param cookies
+     *            some cookies
+     * @return a Rfc6265 style Cookie header value, null if no cookies are passed.
+     */
+    public AsciiString encodeAsciiString(Cookie... cookies) {
         if (checkNotNull(cookies, "cookies").length == 0) {
             return null;
         }
@@ -154,7 +188,19 @@ public final class ClientCookieEncoder extends CookieEncoder {
      *            some cookies
      * @return a Rfc6265 style Cookie header value, null if no cookies are passed.
      */
+    @Deprecated
     public String encode(Collection<? extends Cookie> cookies) {
+        return toStringOrNull(encodeAsciiString(cookies));
+    }
+
+    /**
+     * Encodes the specified cookies into a single Cookie header value.
+     *
+     * @param cookies
+     *            some cookies
+     * @return a Rfc6265 style Cookie header value, null if no cookies are passed.
+     */
+    public AsciiString encodeAsciiString(Collection<? extends Cookie> cookies) {
         if (checkNotNull(cookies, "cookies").isEmpty()) {
             return null;
         }
@@ -184,7 +230,18 @@ public final class ClientCookieEncoder extends CookieEncoder {
      * @param cookies some cookies
      * @return a Rfc6265 style Cookie header value, null if no cookies are passed.
      */
+    @Deprecated
     public String encode(Iterable<? extends Cookie> cookies) {
+        return toStringOrNull(encodeAsciiString(cookies));
+    }
+
+    /**
+     * Encodes the specified cookies into a single Cookie header value.
+     *
+     * @param cookies some cookies
+     * @return a Rfc6265 style Cookie header value, null if no cookies are passed.
+     */
+    public AsciiString encodeAsciiString(Iterable<? extends Cookie> cookies) {
         Iterator<? extends Cookie> cookiesIt = checkNotNull(cookies, "cookies").iterator();
         if (!cookiesIt.hasNext()) {
             return null;
@@ -216,8 +273,8 @@ public final class ClientCookieEncoder extends CookieEncoder {
     }
 
     private void encode(StringBuilder buf, Cookie c) {
-        final String name = c.name();
-        final String value = c.value() != null ? c.value() : "";
+        final AsciiString name = c.asciiName();
+        final AsciiString value = c.asciiValue() != null ? c.asciiValue() : AsciiString.EMPTY_STRING;
 
         validateCookie(name, value);
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/Cookie.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/Cookie.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http.cookie;
 
+import io.netty.util.AsciiString;
+
 /**
  * An interface defining an
  * <a href="http://en.wikipedia.org/wiki/HTTP_cookie">HTTP cookie</a>.
@@ -26,14 +28,30 @@ public interface Cookie extends Comparable<Cookie> {
      *
      * @return The name of this {@link Cookie}
      */
+    @Deprecated
     String name();
+
+    /**
+     * Returns the name of this {@link Cookie}.
+     *
+     * @return The name of this {@link Cookie}
+     */
+    AsciiString asciiName();
 
     /**
      * Returns the value of this {@link Cookie}.
      *
-     * @return The value of this {@link Cookie}
+     * @return The value of this {@link Cookie}7u
      */
+    @Deprecated
     String value();
+
+    /**
+     * Returns the value of this {@link Cookie}.
+     *
+     * @return The value of this {@link Cookie}7u
+     */
+    AsciiString asciiValue();
 
     /**
      * Sets the value of this {@link Cookie}.
@@ -41,6 +59,13 @@ public interface Cookie extends Comparable<Cookie> {
      * @param value The value to set
      */
     void setValue(String value);
+
+    /**
+     * Sets the value of this {@link Cookie}.
+     *
+     * @param value The value to set
+     */
+    void setValue(AsciiString value);
 
     /**
      * Returns true if the raw value of this {@link Cookie},
@@ -63,7 +88,15 @@ public interface Cookie extends Comparable<Cookie> {
      *
      * @return The domain of this {@link Cookie}
      */
+    @Deprecated
     String domain();
+
+    /**
+     * Returns the domain of this {@link Cookie}.
+     *
+     * @return The domain of this {@link Cookie}
+     */
+    AsciiString asciiDomain();
 
     /**
      * Sets the domain of this {@link Cookie}.
@@ -73,11 +106,26 @@ public interface Cookie extends Comparable<Cookie> {
     void setDomain(String domain);
 
     /**
+     * Sets the domain of this {@link Cookie}.
+     *
+     * @param domain The domain to use
+     */
+    void setDomain(AsciiString domain);
+
+    /**
      * Returns the path of this {@link Cookie}.
      *
      * @return The {@link Cookie}'s path
      */
+    @Deprecated
     String path();
+
+    /**
+     * Returns the path of this {@link Cookie}.
+     *
+     * @return The {@link Cookie}'s path
+     */
+    AsciiString asciiPath();
 
     /**
      * Sets the path of this {@link Cookie}.
@@ -85,6 +133,13 @@ public interface Cookie extends Comparable<Cookie> {
      * @param path The path to use for this {@link Cookie}
      */
     void setPath(String path);
+
+    /**
+     * Sets the path of this {@link Cookie}.
+     *
+     * @param path The path to use for this {@link Cookie}
+     */
+    void setPath(AsciiString path);
 
     /**
      * Returns the maximum age of this {@link Cookie} in seconds or {@link Long#MIN_VALUE} if unspecified

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieDecoder.java
@@ -21,6 +21,7 @@ import static io.netty.handler.codec.http.cookie.CookieUtil.unwrapValue;
 
 import java.nio.CharBuffer;
 
+import io.netty.util.AsciiString;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -37,7 +38,7 @@ public abstract class CookieDecoder {
         this.strict = strict;
     }
 
-    protected DefaultCookie initCookie(String header, int nameBegin, int nameEnd, int valueBegin, int valueEnd) {
+    protected DefaultCookie initCookie(AsciiString header, int nameBegin, int nameEnd, int valueBegin, int valueEnd) {
         if (nameBegin == -1 || nameBegin == nameEnd) {
             logger.debug("Skipping cookie with null name");
             return null;
@@ -56,7 +57,7 @@ public abstract class CookieDecoder {
             return null;
         }
 
-        final String name = header.substring(nameBegin, nameEnd);
+        final AsciiString name = header.subSequence(nameBegin, nameEnd);
 
         int invalidOctetPos;
         if (strict && (invalidOctetPos = firstInvalidCookieNameOctet(name)) >= 0) {
@@ -77,7 +78,7 @@ public abstract class CookieDecoder {
             return null;
         }
 
-        DefaultCookie cookie = new DefaultCookie(name, unwrappedValue.toString());
+        DefaultCookie cookie = new DefaultCookie(name, new AsciiString(unwrappedValue));
         cookie.setWrap(wrap);
         return cookie;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieEncoder.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http.cookie;
 
+import io.netty.util.AsciiString;
+
 import static io.netty.handler.codec.http.cookie.CookieUtil.firstInvalidCookieNameOctet;
 import static io.netty.handler.codec.http.cookie.CookieUtil.firstInvalidCookieValueOctet;
 import static io.netty.handler.codec.http.cookie.CookieUtil.unwrapValue;
@@ -30,7 +32,7 @@ public abstract class CookieEncoder {
         this.strict = strict;
     }
 
-    protected void validateCookie(String name, String value) {
+    protected void validateCookie(AsciiString name, AsciiString value) {
         if (strict) {
             int pos;
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieHeaderNames.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieHeaderNames.java
@@ -15,18 +15,38 @@
  */
 package io.netty.handler.codec.http.cookie;
 
+import io.netty.util.AsciiString;
+
 public final class CookieHeaderNames {
+    @Deprecated
     public static final String PATH = "Path";
 
+    @Deprecated
     public static final String EXPIRES = "Expires";
 
+    @Deprecated
     public static final String MAX_AGE = "Max-Age";
 
+    @Deprecated
     public static final String DOMAIN = "Domain";
 
+    @Deprecated
     public static final String SECURE = "Secure";
 
+    @Deprecated
     public static final String HTTPONLY = "HTTPOnly";
+
+    public static final AsciiString PATH_ASCII = new AsciiString("Path");
+
+    public static final AsciiString EXPIRES_ASCII = new AsciiString("Expires");
+
+    public static final AsciiString MAX_AGE_ASCII = new AsciiString("Max-Age");
+
+    public static final AsciiString DOMAIN_ASCII = new AsciiString("Domain");
+
+    public static final AsciiString SECURE_ASCII = new AsciiString("Secure");
+
+    public static final AsciiString HTTPONLY_ASCII = new AsciiString("HTTPOnly");
 
     private CookieHeaderNames() {
         // Unused.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieUtil.java
@@ -16,6 +16,7 @@
 package io.netty.handler.codec.http.cookie;
 
 import io.netty.handler.codec.http.HttpConstants;
+import io.netty.util.AsciiString;
 import io.netty.util.internal.InternalThreadLocalMap;
 
 import java.util.BitSet;
@@ -84,18 +85,22 @@ final class CookieUtil {
      * @param buf a buffer where some cookies were maybe encoded
      * @return the buffer String without the trailing separator, or null if no cookie was appended.
      */
-    static String stripTrailingSeparatorOrNull(StringBuilder buf) {
+    static AsciiString stripTrailingSeparatorOrNull(StringBuilder buf) {
         return buf.length() == 0 ? null : stripTrailingSeparator(buf);
     }
 
-    static String stripTrailingSeparator(StringBuilder buf) {
+    static AsciiString stripTrailingSeparator(StringBuilder buf) {
         if (buf.length() > 0) {
             buf.setLength(buf.length() - 2);
         }
-        return buf.toString();
+        return new AsciiString(buf);
     }
 
-    static void add(StringBuilder sb, String name, long val) {
+    static String toStringOrNull(AsciiString as) {
+        return as == null ? null : as.toString();
+    }
+
+    static void add(StringBuilder sb, AsciiString name, long val) {
         sb.append(name);
         sb.append((char) HttpConstants.EQUALS);
         sb.append(val);
@@ -103,7 +108,7 @@ final class CookieUtil {
         sb.append((char) HttpConstants.SP);
     }
 
-    static void add(StringBuilder sb, String name, String val) {
+    static void add(StringBuilder sb, AsciiString name, AsciiString val) {
         sb.append(name);
         sb.append((char) HttpConstants.EQUALS);
         sb.append(val);
@@ -111,15 +116,15 @@ final class CookieUtil {
         sb.append((char) HttpConstants.SP);
     }
 
-    static void add(StringBuilder sb, String name) {
+    static void add(StringBuilder sb, AsciiString name) {
         sb.append(name);
         sb.append((char) HttpConstants.SEMICOLON);
         sb.append((char) HttpConstants.SP);
     }
 
-    static void addQuoted(StringBuilder sb, String name, String val) {
+    static void addQuoted(StringBuilder sb, AsciiString name, AsciiString val) {
         if (val == null) {
-            val = "";
+            val = AsciiString.EMPTY_STRING;
         }
 
         sb.append(name);
@@ -162,7 +167,7 @@ final class CookieUtil {
         return cs;
     }
 
-    static String validateAttributeValue(String name, String value) {
+    static AsciiString validateAttributeValue(String name, AsciiString value) {
         if (value == null) {
             return null;
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/DefaultCookie.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/DefaultCookie.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http.cookie;
 
+import io.netty.util.AsciiString;
+
 import static io.netty.handler.codec.http.cookie.CookieUtil.*;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
@@ -23,19 +25,19 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  */
 public class DefaultCookie implements Cookie {
 
-    private final String name;
-    private String value;
+    private final AsciiString name;
+    private AsciiString value;
     private boolean wrap;
-    private String domain;
-    private String path;
+    private AsciiString domain;
+    private AsciiString path;
     private long maxAge = Long.MIN_VALUE;
     private boolean secure;
     private boolean httpOnly;
 
     /**
-     * Creates a new cookie with the specified name and value.
+     * Creates a new cookie with the specified {@link AsciiString} name and value.
      */
-    public DefaultCookie(String name, String value) {
+    public DefaultCookie(AsciiString name, AsciiString value) {
         name = checkNotNull(name, "name").trim();
         if (name.isEmpty()) {
             throw new IllegalArgumentException("empty name");
@@ -44,19 +46,44 @@ public class DefaultCookie implements Cookie {
         setValue(value);
     }
 
+    /**
+     * Creates a new cookie with the specified name and value.
+     */
+    @Deprecated
+    public DefaultCookie(String name, String value) {
+        this(new AsciiString(name), new AsciiString(value));
+    }
+
     @Override
+    @Deprecated
     public String name() {
+        return toStringOrNull(name);
+    }
+
+    @Override
+    public AsciiString asciiName() {
         return name;
     }
 
     @Override
+    @Deprecated
     public String value() {
+        return toStringOrNull(value);
+    }
+
+    @Override
+    public AsciiString asciiValue() {
         return value;
     }
 
     @Override
-    public void setValue(String value) {
+    public void setValue(AsciiString value) {
         this.value = checkNotNull(value, "value");
+    }
+
+    @Override
+    public void setValue(String value) {
+        this.value = checkNotNull(new AsciiString(value), "value");
     }
 
     @Override
@@ -70,22 +97,44 @@ public class DefaultCookie implements Cookie {
     }
 
     @Override
+    @Deprecated
     public String domain() {
+        return toStringOrNull(domain);
+    }
+
+    @Override
+    public AsciiString asciiDomain() {
         return domain;
     }
 
     @Override
-    public void setDomain(String domain) {
+    public void setDomain(AsciiString domain) {
         this.domain = validateAttributeValue("domain", domain);
     }
 
     @Override
+    public void setDomain(String domain) {
+        setDomain(new AsciiString(domain));
+    }
+
+    @Override
+    @Deprecated
     public String path() {
+        return toStringOrNull(path);
+    }
+
+    @Override
+    public AsciiString asciiPath() {
         return path;
     }
 
     @Override
     public void setPath(String path) {
+        setPath(new AsciiString(path));
+    }
+
+    @Override
+    public void setPath(AsciiString path) {
         this.path = validateAttributeValue("path", path);
     }
 
@@ -135,28 +184,28 @@ public class DefaultCookie implements Cookie {
         }
 
         Cookie that = (Cookie) o;
-        if (!name().equals(that.name())) {
+        if (!asciiName().equals(that.asciiName())) {
             return false;
         }
 
-        if (path() == null) {
-            if (that.path() != null) {
+        if (asciiPath() == null) {
+            if (that.asciiPath() != null) {
                 return false;
             }
-        } else if (that.path() == null) {
+        } else if (that.asciiPath() == null) {
             return false;
-        } else if (!path().equals(that.path())) {
+        } else if (!asciiPath().equals(that.asciiPath())) {
             return false;
         }
 
-        if (domain() == null) {
-            if (that.domain() != null) {
+        if (asciiDomain() == null) {
+            if (that.asciiDomain() != null) {
                 return false;
             }
-        } else if (that.domain() == null) {
+        } else if (that.asciiDomain() == null) {
             return false;
         } else {
-            return domain().equalsIgnoreCase(that.domain());
+            return asciiDomain().contentEqualsIgnoreCase(that.asciiDomain());
         }
 
         return true;
@@ -164,32 +213,32 @@ public class DefaultCookie implements Cookie {
 
     @Override
     public int compareTo(Cookie c) {
-        int v = name().compareTo(c.name());
+        int v = asciiName().compareTo(c.asciiName());
         if (v != 0) {
             return v;
         }
 
-        if (path() == null) {
-            if (c.path() != null) {
+        if (asciiPath() == null) {
+            if (c.asciiPath() != null) {
                 return -1;
             }
-        } else if (c.path() == null) {
+        } else if (c.asciiPath() == null) {
             return 1;
         } else {
-            v = path().compareTo(c.path());
+            v = asciiPath().compareTo(c.asciiPath());
             if (v != 0) {
                 return v;
             }
         }
 
-        if (domain() == null) {
-            if (c.domain() != null) {
+        if (asciiDomain() == null) {
+            if (c.asciiDomain() != null) {
                 return -1;
             }
-        } else if (c.domain() == null) {
+        } else if (c.asciiDomain() == null) {
             return 1;
         } else {
-            v = domain().compareToIgnoreCase(c.domain());
+            v = asciiDomain().compareToIgnoreCase(c.asciiDomain());
             return v;
         }
 
@@ -206,22 +255,22 @@ public class DefaultCookie implements Cookie {
      */
     @Deprecated
     protected String validateValue(String name, String value) {
-        return validateAttributeValue(name, value);
+        return validateAttributeValue(name, new AsciiString(value)).toString();
     }
 
     @Override
     public String toString() {
         StringBuilder buf = stringBuilder()
-            .append(name())
+            .append(asciiName())
             .append('=')
-            .append(value());
-        if (domain() != null) {
+            .append(asciiValue());
+        if (asciiDomain() != null) {
             buf.append(", domain=")
-               .append(domain());
+               .append(asciiDomain());
         }
-        if (path() != null) {
+        if (asciiPath() != null) {
             buf.append(", path=")
-               .append(path());
+               .append(asciiPath());
         }
         if (maxAge() >= 0) {
             buf.append(", maxAge=")

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieDecoder.java
@@ -15,6 +15,8 @@
  */
 package io.netty.handler.codec.http.cookie;
 
+import io.netty.util.AsciiString;
+
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 import java.util.Collections;
@@ -61,7 +63,17 @@ public final class ServerCookieDecoder extends CookieDecoder {
      *
      * @return the decoded {@link Cookie}
      */
+    @Deprecated
     public Set<Cookie> decode(String header) {
+        return decodeAsciiString(new AsciiString(header));
+    }
+
+    /**
+     * Decodes the specified Set-Cookie HTTP header value into a {@link Cookie}.
+     *
+     * @return the decoded {@link Cookie}
+     */
+    public Set<Cookie> decodeAsciiString(AsciiString header) {
         final int headerLen = checkNotNull(header, "header").length();
 
         if (headerLen == 0) {
@@ -75,7 +87,7 @@ public final class ServerCookieDecoder extends CookieDecoder {
         boolean rfc2965Style = false;
         if (header.regionMatches(true, 0, RFC2965_VERSION, 0, RFC2965_VERSION.length())) {
             // RFC 2965 style cookie, move to after version value
-            i = header.indexOf(';') + 1;
+            i = header.indexOf(";") + 1;
             rfc2965Style = true;
         }
 

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -466,6 +466,33 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
     }
 
     /**
+     * Compares the specified string to this string using the ASCII values of the characters, ignoring case differences.
+     *
+     * @param string the string to compare.
+     * @return 0 if the strings are equal, a negative integer if this string is before the specified string, or a
+     *         positive integer if this string is after the specified string, ignoring case differences.
+     * @throws NullPointerException if {@code string} is {@code null}.
+     */
+    public int compareToIgnoreCase(CharSequence string) {
+        if (this == string) {
+            return 0;
+        }
+
+        int result;
+        int length1 = length();
+        int length2 = string.length();
+        int minLength = Math.min(length1, length2);
+        for (int i = 0, j = arrayOffset(); i < minLength; i++, j++) {
+            result = b2c(toLowerCase(value[j])) - toLowerCase(string.charAt(i));
+            if (result != 0) {
+                return result;
+            }
+        }
+
+        return length1 - length2;
+    }
+
+    /**
      * Concatenates this string and the specified string.
      *
      * @param string the string to concatenate


### PR DESCRIPTION
# 3538 Cookie should probably use AsciiString

Recently I have been reading on the netty project and became very interested in contributing to it. I put together this preliminary commit. I deprecated the String related operations and created a set of new methods to support AsciiString. I am not sure if this is heading to the right direction or not, could you please take a look and let me know your thoughts?
