### PR TITLE
Fix unbalanced quotes in Bundle-NativeCode manifest header

### DIFF
--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -115,7 +115,7 @@
                   <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                 </manifest>
                 <manifestEntries>
-                  <Bundle-NativeCode>META-INF/native/libnetty-transport-native-epoll.so; osname=linux, processor=x86_64"</Bundle-NativeCode>
+                  <Bundle-NativeCode>META-INF/native/libnetty-transport-native-epoll.so; osname=linux; processor=x86_64,*</Bundle-NativeCode>
                 </manifestEntries>
                 <index>true</index>
                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>


### PR DESCRIPTION
Motivation:
The previously generated manifest causes a parse exception when loaded into an Apache Felix OSGI container.

Modifications:
Fix parameter delimiter and unbalanced quotes in manifest entry. Suffixed with asterisk so the bundle is resolved on other architectures as well even if native libs won't be loaded.

Result:
Bundle will load properly in OSGI containers.
