### PR TITLE
Include maxStreams and maxActiveStreams in the Http2Exception thrown …

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -501,7 +501,8 @@ public class DefaultHttp2Connection implements Http2Connection {
         public Http2Stream open(boolean halfClosed) throws Http2Exception {
             state = activeState(id, state, isLocal(), halfClosed);
             if (!createdBy().canOpenStream()) {
-                throw connectionError(PROTOCOL_ERROR, "Maximum active streams violated for this endpoint.");
+                throw connectionError(PROTOCOL_ERROR, String.format(
+                    "Maximum active streams %d violated for this endpoint.", createdBy().maxActiveStreams()));
             }
             activate();
             return this;
@@ -1050,10 +1051,12 @@ public class DefaultHttp2Connection implements Http2Connection {
             }
             if (state.localSideOpen() || state.remoteSideOpen()) {
                 if (!canOpenStream()) {
-                    throw streamError(streamId, REFUSED_STREAM, "Maximum active streams violated for this endpoint.");
+                    throw streamError(streamId, REFUSED_STREAM, String.format(
+                        "Maximum active streams %d violated for this endpoint.", maxActiveStreams));
                 }
             } else if (numStreams == maxStreams) {
-                throw streamError(streamId, REFUSED_STREAM, "Maximum streams violated for this endpoint.");
+                throw streamError(streamId, REFUSED_STREAM, String.format(
+                    "Maximum streams %d violated for this endpoint.", activeStreams));
             }
             if (isClosed()) {
                 throw connectionError(INTERNAL_ERROR, "Attempted to create stream id %d after connection was closed",


### PR DESCRIPTION
…when SETTINGS_MAX_CONCURRENT_STREAMS is violated at an endpoint

Motivation

To provide additional diagnostics insight when SETTINGS_MAX_CONCURRENT_STREAMS is violated at an endpoint.

Modifications

Included the current snapshot of maxStreams or maxActiveStreams information in the exception message.

Result

The current snapshot of maxStreams or maxActiveStreams is captured in the exception message.
