### PR TITLE
Correctly add futures to list in test

### DIFF
--- a/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/NonStickyEventExecutorGroupTest.java
@@ -104,7 +104,7 @@ public class NonStickyEventExecutorGroupTest {
 
         for (int i = 1 ; i <= tasks; i++) {
             final int id = i;
-            executor.execute(new Runnable() {
+            futures.add(executor.submit(new Runnable() {
                 @Override
                 public void run() {
                     try {
@@ -122,7 +122,7 @@ public class NonStickyEventExecutorGroupTest {
                         latch.countDown();
                     }
                 }
-            });
+            }));
         }
         latch.await();
         for (Future<?> future: futures) {


### PR DESCRIPTION
Motivation:

We missed to add the futures to the list in the test.

Modifications:

Add futures to list.

Result:

More correct test.