### PR TITLE
Also wakup EventLoop for write tasks

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannelHandlerContext.java
@@ -831,7 +831,9 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap
             if (flush) {
                 task = WriteAndFlushTask.newInstance(next, m, promise);
             }  else {
-                task = WriteTask.newInstance(next, m, promise);
+                boolean wakeup = Boolean.TRUE.equals(channel().config().getOption(ChannelOption.WAKEUP_ON_WRITE));
+                task = wakeup ? WakeupWriteTask.newInstance(next, m, promise) :
+                        WriteTask.newInstance(next, m, promise);
             }
             safeExecute(executor, task, promise, m);
         }
@@ -1146,6 +1148,27 @@ abstract class AbstractChannelHandlerContext extends DefaultAttributeMap
         public void write(AbstractChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
             super.write(ctx, msg, promise);
             ctx.invokeFlush();
+        }
+    }
+
+    static final class WakeupWriteTask extends AbstractWriteTask {
+
+        private static final Recycler<WakeupWriteTask> RECYCLER = new Recycler<WakeupWriteTask>() {
+            @Override
+            protected WakeupWriteTask newObject(Handle<WakeupWriteTask> handle) {
+                return new WakeupWriteTask(handle);
+            }
+        };
+
+        private static WakeupWriteTask newInstance(
+                AbstractChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+            WakeupWriteTask task = RECYCLER.get();
+            init(task, ctx, msg, promise);
+            return task;
+        }
+
+        private WakeupWriteTask(Recycler.Handle<WakeupWriteTask> handle) {
+            super(handle);
         }
     }
 }

--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -95,6 +95,8 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
     public static final ChannelOption<WriteBufferWaterMark> WRITE_BUFFER_WATER_MARK =
             valueOf("WRITE_BUFFER_WATER_MARK");
 
+    public static final ChannelOption<Boolean> WAKEUP_ON_WRITE = valueOf("WAKEUP_ON_WRITE");
+
     public static final ChannelOption<Boolean> ALLOW_HALF_CLOSURE = valueOf("ALLOW_HALF_CLOSURE");
     public static final ChannelOption<Boolean> AUTO_READ = valueOf("AUTO_READ");
 

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -24,18 +24,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
-import static io.netty.channel.ChannelOption.ALLOCATOR;
-import static io.netty.channel.ChannelOption.AUTO_CLOSE;
-import static io.netty.channel.ChannelOption.AUTO_READ;
-import static io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS;
-import static io.netty.channel.ChannelOption.MAX_MESSAGES_PER_READ;
-import static io.netty.channel.ChannelOption.MESSAGE_SIZE_ESTIMATOR;
-import static io.netty.channel.ChannelOption.SINGLE_EVENTEXECUTOR_PER_GROUP;
-import static io.netty.channel.ChannelOption.RCVBUF_ALLOCATOR;
-import static io.netty.channel.ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK;
-import static io.netty.channel.ChannelOption.WRITE_BUFFER_LOW_WATER_MARK;
-import static io.netty.channel.ChannelOption.WRITE_BUFFER_WATER_MARK;
-import static io.netty.channel.ChannelOption.WRITE_SPIN_COUNT;
+import static io.netty.channel.ChannelOption.*;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -79,6 +68,7 @@ public class DefaultChannelConfig implements ChannelConfig {
     private volatile boolean autoClose = true;
     private volatile WriteBufferWaterMark writeBufferWaterMark = WriteBufferWaterMark.DEFAULT;
     private volatile boolean pinEventExecutor = true;
+    private volatile boolean wakeupOnWrite;
 
     public DefaultChannelConfig(Channel channel) {
         this(channel, new AdaptiveRecvByteBufAllocator());
@@ -97,7 +87,7 @@ public class DefaultChannelConfig implements ChannelConfig {
                 CONNECT_TIMEOUT_MILLIS, MAX_MESSAGES_PER_READ, WRITE_SPIN_COUNT,
                 ALLOCATOR, AUTO_READ, AUTO_CLOSE, RCVBUF_ALLOCATOR, WRITE_BUFFER_HIGH_WATER_MARK,
                 WRITE_BUFFER_LOW_WATER_MARK, WRITE_BUFFER_WATER_MARK, MESSAGE_SIZE_ESTIMATOR,
-                SINGLE_EVENTEXECUTOR_PER_GROUP);
+                SINGLE_EVENTEXECUTOR_PER_GROUP, WAKEUP_ON_WRITE);
     }
 
     protected Map<ChannelOption<?>, Object> getOptions(
@@ -171,6 +161,9 @@ public class DefaultChannelConfig implements ChannelConfig {
         if (option == SINGLE_EVENTEXECUTOR_PER_GROUP) {
             return (T) Boolean.valueOf(getPinEventExecutorPerGroup());
         }
+        if (option == WAKEUP_ON_WRITE) {
+            return (T) Boolean.valueOf(getWakeupOnWrite());
+        }
         return null;
     }
 
@@ -203,6 +196,8 @@ public class DefaultChannelConfig implements ChannelConfig {
             setMessageSizeEstimator((MessageSizeEstimator) value);
         } else if (option == SINGLE_EVENTEXECUTOR_PER_GROUP) {
             setPinEventExecutorPerGroup((Boolean) value);
+        } else if (option == WAKEUP_ON_WRITE) {
+            setWakeupOnWrite((Boolean) value);
         } else {
             return false;
         }
@@ -444,4 +439,12 @@ public class DefaultChannelConfig implements ChannelConfig {
         return pinEventExecutor;
     }
 
+    private ChannelConfig setWakeupOnWrite(boolean wakeupOnWrite) {
+        this.wakeupOnWrite = wakeupOnWrite;
+        return this;
+    }
+
+    private boolean getWakeupOnWrite() {
+        return wakeupOnWrite;
+    }
 }


### PR DESCRIPTION
Motivation:

In 64c3f58279809141a851becba445a20badc8a610 I added an optimization to not wakupe the EventLoop if an write happenede from outside the EventLoop. This optimization did not give any real performance gain while disallow some implementations like auto-flush in an ChannelHandler.

Modifications:

Always wakup the EventLoop on writes.

Result:

More flexible and generic implementation.