### PR TITLE
Use latest centos/redhat version to verify against when release.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
                       <files>
                         <file>/etc/redhat-release</file>
                       </files>
-                      <content>release 6.7</content>
+                      <content>release 6.8</content>
                     </requireFilesContent>
                   </rules>
                 </configuration>


### PR DESCRIPTION
Motivation:

A new version of centos was released we should verify against it when release.

Modifications:

Bump up version.

Result:

Release on latest centos version.