### PR TITLE
OpenSslSession#initPeerCerts creates too long almost empty arrays.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslJavaxX509Certificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslJavaxX509Certificate.java
@@ -30,7 +30,7 @@ import java.util.Date;
 
 final class OpenSslJavaxX509Certificate extends X509Certificate {
     private final byte[] bytes;
-    private X509Certificate wrapped;
+    private volatile X509Certificate wrapped;
 
     public OpenSslJavaxX509Certificate(byte[] bytes) {
         this.bytes = bytes;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslX509Certificate.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslX509Certificate.java
@@ -34,7 +34,7 @@ import java.util.Set;
 final class OpenSslX509Certificate extends X509Certificate {
 
     private final byte[] bytes;
-    private X509Certificate wrapped;
+    private volatile X509Certificate wrapped;
 
     public OpenSslX509Certificate(byte[] bytes) {
         this.bytes = bytes;


### PR DESCRIPTION
Motivation:

https://github.com/netty/netty/issues/5945#issuecomment-256674821

Modifications:

Added volatile for correct initialization of actual certificates: https://github.com/netty/netty/issues/5945#issuecomment-256674821

Result:

Concurrency issue fixed