### PR TITLE
[#5904] Disable the Recycler by default

### DIFF
--- a/common/src/main/java/io/netty/util/Recycler.java
+++ b/common/src/main/java/io/netty/util/Recycler.java
@@ -49,7 +49,7 @@ public abstract class Recycler<T> {
     };
     private static final AtomicInteger ID_GENERATOR = new AtomicInteger(Integer.MIN_VALUE);
     private static final int OWN_THREAD_ID = ID_GENERATOR.getAndIncrement();
-    private static final int DEFAULT_INITIAL_MAX_CAPACITY_PER_THREAD = 32768; // Use 32k instances as default.
+    private static final int DEFAULT_INITIAL_MAX_CAPACITY_PER_THREAD = 0; // Use 0 by default, so disable it.
     private static final int DEFAULT_MAX_CAPACITY_PER_THREAD;
     private static final int INITIAL_CAPACITY;
     private static final int MAX_SHARED_CAPACITY_FACTOR;


### PR DESCRIPTION
Motivation:

The Recycler was introduced as a light-weight object pool, to reduce GC pressure. We use it in various places, like pooling ByteBuf objects (not the actual memory, just the container), write tasks (When you call write(...) from outside the EventLoop) and many more.

This usage gave us a lot of trouble in the past and also users a hard time when they ended up with a lot of objects in the Reycler due writing to fast etc.

Modifications:

Disable the recycler by default so users need to explicit enable it to use it.

Result:

Recycler is not used anymore by default.