### PR TITLE
https://github.com/cloudera/flume-ng

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/stream/AbstractStream.java
+++ b/buffer/src/main/java/io/netty/buffer/stream/AbstractStream.java
@@ -1,0 +1,497 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer.stream;
+
+import io.netty.buffer.Buf;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.util.Random;
+
+public abstract class AbstractStream<T extends Buf> implements Stream<T> {
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractStream.class);
+
+    private static final Random random = new Random();
+
+    private static final ThreadLocal<Boolean> IN_CONSUMER = new ThreadLocal<Boolean>() {
+        @Override
+        protected Boolean initialValue() {
+            return Boolean.FALSE;
+        }
+    };
+
+    /**
+     * Generate a random string that can be used for correlating a group of log messages.
+     */
+    private static String nextLogKey() {
+        return Long.toHexString(random.nextInt() & 0xFFFFFFFFL);
+    }
+
+    private final StreamProducerContextImpl producerCtx;
+    private StreamConsumerContextImpl consumerCtx;
+    private Runnable invokeStreamConsumedTask;
+
+    /**  0 - init, 1 - accepted, 2 - discarded, 3 - rejected, 4 - closed */
+    int state;
+    T buffer;
+
+    @SuppressWarnings("unchecked")
+    protected AbstractStream(EventExecutor executor, StreamProducer<? super T> producer) {
+        producerCtx = new StreamProducerContextImpl(executor, producer);
+    }
+
+    T buffer() {
+        T buffer = this.buffer;
+        if (buffer == null) {
+            fail();
+        }
+        return buffer;
+    }
+
+    @Override
+    public void accept(EventExecutor executor, StreamConsumer<? super T> consumer) {
+        if (executor == null) {
+            throw new NullPointerException("executor");
+        }
+        if (consumer == null) {
+            throw new NullPointerException("handler");
+        }
+
+        if (state != 0) {
+            fail();
+        }
+
+        StreamConsumerContextImpl consumerCtx = new StreamConsumerContextImpl(executor, consumer);
+
+        @SuppressWarnings("unchecked")
+        StreamConsumer<T> h = (StreamConsumer<T>) consumer;
+        try {
+            buffer = h.newStreamBuffer(consumerCtx);
+        } catch (Throwable t) {
+            PlatformDependent.throwException(t);
+        }
+
+        this.consumerCtx = consumerCtx;
+        state = 1;
+
+        fireStreamAccepted();
+    }
+
+    private void fireStreamAccepted() {
+        EventExecutor e = producerCtx.executor;
+        if (e.inEventLoop()) {
+            invokeStreamAccepted();
+        } else {
+            e.execute(new Runnable() {
+                @Override
+                public void run() {
+                    invokeStreamAccepted();
+                }
+            });
+        }
+    }
+
+    private void invokeStreamAccepted() {
+        StreamProducerContextImpl producerCtx = this.producerCtx;
+        try {
+            producerCtx.producer.streamAccepted(producerCtx);
+        } catch (Throwable t) {
+            safeAbort(producerCtx, t);
+            return;
+        }
+
+        if (consumerCtx.nextCalled) {
+            consumerCtx.invokeStreamConsumed();
+        }
+    }
+
+    void safeAbort(StreamProducerContextImpl producerCtx, Throwable cause) {
+        try {
+            producerCtx.abort(cause);
+        } catch (Throwable t) {
+            if (logger.isWarnEnabled()) {
+                String key = nextLogKey();
+                logger.warn("[{}] Failed to auto-abort a stream.", key, t);
+                logger.warn("[{}] .. when invoked with the following cause:", key, cause);
+            }
+        }
+    }
+
+    @Override
+    public void discard() {
+        StreamConsumerContextImpl consumerCtx = this.consumerCtx;
+        if (consumerCtx == null) {
+            fail();
+        }
+        consumerCtx.discard();
+    }
+
+    @Override
+    public void reject(Throwable cause) {
+        StreamConsumerContextImpl consumerCtx = this.consumerCtx;
+        if (consumerCtx == null) {
+            fail();
+        }
+        consumerCtx.reject(cause);
+    }
+
+    private void fail() {
+        switch (state) {
+            case 0:
+                throw new IllegalStateException("stream not accepted yet");
+            case 1:
+                throw new IllegalStateException("stream accepted already");
+            case 2:
+                throw new IllegalStateException("stream discarded already");
+            case 3:
+                throw new IllegalStateException("stream rejected already");
+            case 4:
+                throw new IllegalStateException("stream closed already");
+            default:
+                throw new Error();
+        }
+    }
+
+    private final class StreamProducerContextImpl implements StreamProducerContext<T> {
+
+        final EventExecutor executor;
+        final StreamProducer<T> producer;
+        boolean invokedStreamOpen;
+        Runnable invokeStreamUpdatedTask;
+
+        @SuppressWarnings("unchecked")
+        StreamProducerContextImpl(EventExecutor executor, StreamProducer<? super T> producer) {
+            if (executor == null) {
+                throw new NullPointerException("executor");
+            }
+            if (producer == null) {
+                throw new NullPointerException("producer");
+            }
+
+            this.executor = executor;
+            this.producer = (StreamProducer<T>) producer;
+        }
+
+        @Override
+        public EventExecutor executor() {
+            return executor;
+        }
+
+        @Override
+        public T buffer() {
+            return AbstractStream.this.buffer();
+        }
+
+        @Override
+        public StreamProducerContext<T> update() {
+            if (state != 1) {
+                fail();
+            }
+
+            fireStreamUpdated();
+            return this;
+        }
+
+        private void fireStreamUpdated() {
+            EventExecutor e = consumerCtx.executor;
+            if (e.inEventLoop()) {
+                invokeStreamUpdated();
+            } else {
+                Runnable task = invokeStreamUpdatedTask;
+                if (task == null) {
+                    invokeStreamUpdatedTask = task = new Runnable() {
+                        @Override
+                        public void run() {
+                            invokeStreamUpdated();
+                        }
+                    };
+                }
+                e.execute(task);
+            }
+        }
+
+        private void invokeStreamUpdated() {
+            StreamConsumerContextImpl consumerCtx = AbstractStream.this.consumerCtx;
+            StreamConsumer<T> consumer = consumerCtx.consumer;
+            if (consumerCtx.singleThreaded) {
+                IN_CONSUMER.set(Boolean.TRUE);
+            }
+            try {
+                if (!invokedStreamOpen) {
+                    invokedStreamOpen = true;
+                    try {
+                        consumer.streamOpen(consumerCtx);
+                    } catch (Throwable t) {
+                        safeAbort(producerCtx, new StreamConsumerException(t));
+                        return;
+                    }
+                }
+
+                try {
+                    consumer.streamUpdated(consumerCtx);
+                } catch (Throwable t) {
+                    safeAbort(producerCtx, new StreamConsumerException(t));
+                }
+            } finally {
+                if (consumerCtx.singleThreaded) {
+                    IN_CONSUMER.set(Boolean.FALSE);
+                }
+            }
+        }
+
+        @Override
+        public void close() {
+            if (state == 1) {
+                state = 4;
+                fireStreamClosed();
+            }
+        }
+
+        private void fireStreamClosed() {
+            EventExecutor e = consumerCtx.executor;
+            if (e.inEventLoop()) {
+                invokeStreamClosed();
+            } else {
+                e.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        invokeStreamClosed();
+                    }
+                });
+            }
+        }
+
+        private void invokeStreamClosed() {
+            StreamConsumerContextImpl consumerCtx = AbstractStream.this.consumerCtx;
+            try {
+                consumerCtx.consumer.streamClosed(consumerCtx);
+            } catch (Throwable t) {
+                logger.warn("StreamConsumer.streamClosed() raised an exception.", t);
+            }
+        }
+
+        @Override
+        public void abort(Throwable cause) {
+            if (cause == null) {
+                throw new NullPointerException("cause");
+            }
+
+            if (state != 1) {
+                fail();
+            }
+
+            fireStreamAborted(cause);
+        }
+
+        private void fireStreamAborted(final Throwable cause) {
+            StreamConsumerContextImpl consumerCtx = AbstractStream.this.consumerCtx;
+            EventExecutor e = consumerCtx.executor;
+            if (e.inEventLoop()) {
+                invokeStreamAborted(cause);
+            } else {
+                e.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        invokeStreamAborted(cause);
+                    }
+                });
+            }
+        }
+
+        private void invokeStreamAborted(Throwable cause) {
+            StreamConsumerContextImpl consumerCtx = AbstractStream.this.consumerCtx;
+            try {
+                consumerCtx.consumer.streamAborted(consumerCtx, cause);
+            } catch (Throwable t) {
+                if (logger.isWarnEnabled()) {
+                    String key = nextLogKey();
+                    logger.warn("[{}] StreamConsumer.streamAborted() raised an exception.", key, t);
+                    logger.warn("[{}] .. when invoked with the following cause:", key, cause);
+                }
+            } finally {
+                invokeStreamClosed();
+            }
+        }
+    }
+
+    private final class StreamConsumerContextImpl implements StreamConsumerContext<T> {
+
+        final EventExecutor executor;
+        final StreamConsumer<T> consumer;
+        final boolean singleThreaded;
+        boolean nextCalled;
+
+        @SuppressWarnings("unchecked")
+        StreamConsumerContextImpl(EventExecutor executor, StreamConsumer<? super T> consumer) {
+            if (executor == null) {
+                throw new NullPointerException("executor");
+            }
+            if (consumer == null) {
+                throw new NullPointerException("consumer");
+            }
+            this.executor = executor;
+            this.consumer = (StreamConsumer<T>) consumer;
+            singleThreaded = executor == producerCtx.executor;
+        }
+
+        @Override
+        public EventExecutor executor() {
+            return executor;
+        }
+
+        @Override
+        public T buffer() {
+            return AbstractStream.this.buffer();
+        }
+
+        @Override
+        public void discard() {
+            switch (state) {
+                case 2:
+                    return;
+                case 3:
+                case 4:
+                    fail();
+            }
+
+            T buffer = AbstractStream.this.buffer;
+            if (buffer != null) {
+                buffer.release();
+            }
+
+            state = 2;
+
+            fireStreamDiscarded();
+        }
+
+        private void fireStreamDiscarded() {
+            EventExecutor e = producerCtx.executor;
+            if (e.inEventLoop()) {
+                invokeStreamDiscarded();
+            } else {
+                e.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        invokeStreamDiscarded();
+                    }
+                });
+            }
+        }
+
+        private void invokeStreamDiscarded() {
+            StreamProducerContextImpl producerCtx = AbstractStream.this.producerCtx;
+            try {
+                producerCtx.producer.streamDiscarded(producerCtx);
+            } catch (Throwable t) {
+                logger.warn("StreamProducer.streamDiscarded() raised an exception.", t);
+            }
+        }
+
+        @Override
+        public void reject(Throwable cause) {
+            if (cause == null) {
+                throw new NullPointerException("cause");
+            }
+
+            if (state != 1) {
+                fail();
+            }
+
+            T buffer = AbstractStream.this.buffer;
+            if (buffer != null) {
+                buffer.release();
+            }
+
+            state = 3;
+
+            fireStreamRejected(cause);
+        }
+
+        private void fireStreamRejected(final Throwable cause) {
+            EventExecutor e = producerCtx.executor;
+            if (e.inEventLoop()) {
+                invokeStreamRejected(cause);
+            } else {
+                e.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        invokeStreamRejected(cause);
+                    }
+                });
+            }
+        }
+
+        private void invokeStreamRejected(Throwable cause) {
+            StreamProducerContextImpl producerCtx = AbstractStream.this.producerCtx;
+            try {
+                producerCtx.producer.streamRejected(producerCtx, cause);
+            } catch (Throwable t) {
+                if (logger.isWarnEnabled()) {
+                    String key = nextLogKey();
+                    logger.warn("[{}] StreamProducer.streamRejected() raised an exception.", key, t);
+                    logger.warn("[{}] .. when invoked with the following cause:", key, cause);
+                }
+            }
+        }
+
+        @Override
+        public void next() {
+            if (state != 1) {
+                fail();
+            }
+
+            if (singleThreaded && IN_CONSUMER.get()) {
+                nextCalled = true;
+            } else {
+                fireStreamConsumed();
+            }
+        }
+
+        private void fireStreamConsumed() {
+            EventExecutor e = producerCtx.executor;
+            if (e.inEventLoop()) {
+                invokeStreamConsumed();
+            } else {
+                Runnable task = invokeStreamConsumedTask;
+                if (task == null) {
+                    invokeStreamConsumedTask = task = new Runnable() {
+                        @Override
+                        public void run() {
+                            invokeStreamConsumed();
+                        }
+                    };
+                }
+                e.execute(task);
+            }
+        }
+
+        private void invokeStreamConsumed() {
+            StreamProducerContextImpl producerCtx = AbstractStream.this.producerCtx;
+            try {
+                do {
+                    consumerCtx.nextCalled = false;
+                    producerCtx.producer.streamConsumed(producerCtx);
+                } while (consumerCtx.nextCalled);
+            } catch (Throwable t) {
+                reject(new StreamProducerException(t));
+            }
+        }
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/stream/Stream.java
+++ b/buffer/src/main/java/io/netty/buffer/stream/Stream.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer.stream;
+
+import io.netty.buffer.Buf;
+import io.netty.util.concurrent.EventExecutor;
+
+public interface Stream<T extends Buf> {
+    void accept(EventExecutor executor, StreamConsumer<? super T> consumer);
+    void discard();
+    void reject(Throwable cause);
+}

--- a/buffer/src/main/java/io/netty/buffer/stream/StreamConsumer.java
+++ b/buffer/src/main/java/io/netty/buffer/stream/StreamConsumer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer.stream;
+
+import io.netty.buffer.Buf;
+
+public interface StreamConsumer<T extends Buf> {
+    T newStreamBuffer(StreamConsumerContext<T> ctx) throws Exception;
+
+    void streamOpen(StreamConsumerContext<T> ctx) throws Exception;
+    void streamUpdated(StreamConsumerContext<T> ctx) throws Exception;
+    void streamAborted(StreamConsumerContext<T> ctx, Throwable cause) throws Exception;
+    void streamClosed(StreamConsumerContext<T> ctx) throws Exception;
+}

--- a/buffer/src/main/java/io/netty/buffer/stream/StreamConsumerContext.java
+++ b/buffer/src/main/java/io/netty/buffer/stream/StreamConsumerContext.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer.stream;
+
+import io.netty.buffer.Buf;
+import io.netty.util.concurrent.EventExecutor;
+
+public interface StreamConsumerContext<T extends Buf> {
+    EventExecutor executor();
+    T buffer();
+    void next();
+    void discard();
+    void reject(Throwable cause);
+}

--- a/buffer/src/main/java/io/netty/buffer/stream/StreamConsumerException.java
+++ b/buffer/src/main/java/io/netty/buffer/stream/StreamConsumerException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer.stream;
+
+public class StreamConsumerException extends StreamException {
+
+    private static final long serialVersionUID = -7688455132621735741L;
+
+    public StreamConsumerException() { }
+
+    public StreamConsumerException(String message) {
+        super(message);
+    }
+
+    public StreamConsumerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public StreamConsumerException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/stream/StreamException.java
+++ b/buffer/src/main/java/io/netty/buffer/stream/StreamException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer.stream;
+
+public class StreamException extends RuntimeException {
+
+    private static final long serialVersionUID = -8529582560484984135L;
+
+    public StreamException() { }
+
+    public StreamException(String message) {
+        super(message);
+    }
+
+    public StreamException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public StreamException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/stream/StreamProducer.java
+++ b/buffer/src/main/java/io/netty/buffer/stream/StreamProducer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer.stream;
+
+import io.netty.buffer.Buf;
+
+public interface StreamProducer<T extends Buf> {
+    void streamAccepted(StreamProducerContext<T> ctx) throws Exception;
+    void streamConsumed(StreamProducerContext<T> ctx) throws Exception;
+    void streamDiscarded(StreamProducerContext<T> ctx) throws Exception;
+    void streamRejected(StreamProducerContext<T> ctx, Throwable cause) throws Exception;
+}

--- a/buffer/src/main/java/io/netty/buffer/stream/StreamProducerContext.java
+++ b/buffer/src/main/java/io/netty/buffer/stream/StreamProducerContext.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer.stream;
+
+import io.netty.buffer.Buf;
+import io.netty.util.concurrent.EventExecutor;
+
+public interface StreamProducerContext<T extends Buf> {
+    EventExecutor executor();
+    T buffer();
+    StreamProducerContext<T> update();
+    void close();
+    void abort(Throwable cause);
+}

--- a/buffer/src/main/java/io/netty/buffer/stream/StreamProducerException.java
+++ b/buffer/src/main/java/io/netty/buffer/stream/StreamProducerException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer.stream;
+
+public class StreamProducerException extends StreamException {
+
+    private static final long serialVersionUID = 8830744325775707415L;
+
+    public StreamProducerException() { }
+
+    public StreamProducerException(String message) {
+        super(message);
+    }
+
+    public StreamProducerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public StreamProducerException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/stream/package-info.java
+++ b/buffer/src/main/java/io/netty/buffer/stream/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Enables exchanging a very large stream between a producer and a consumer.
+ */
+package io.netty.buffer.stream;

--- a/buffer/src/test/java/io/netty/buffer/stream/StreamTest.java
+++ b/buffer/src/test/java/io/netty/buffer/stream/StreamTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.buffer.stream;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.DefaultPromise;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.Promise;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class StreamTest {
+
+    private static EventExecutor executorA;
+    private static EventExecutor executorB;
+
+    @BeforeClass
+    public static void setUp() {
+        executorA = new DefaultEventExecutorGroup(1).next();
+        executorB = new DefaultEventExecutorGroup(1).next();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        executorB.shutdown();
+        executorA.shutdown();
+    }
+
+    @Test(timeout = 5000)
+    public void testSimpleWithSameExecutor() throws Exception {
+        final long size = 1048576L * 1024L * 1024L; // Transfer whooping 1 TiB of garbage
+        testSimple0(executorA, executorA, size);
+    }
+
+    @Test(timeout = 10000)
+    public void testSimpleWithDifferentExecutors() throws Exception {
+        final long size = 1048576L * 1024L * 16L; // Transfer 16 GiB of garbage
+        testSimple0(executorA, executorB, size);
+    }
+
+    private static void testSimple0(EventExecutor executorA, EventExecutor executorB, long size) throws Exception {
+        LargeByteStreamConsumer consumer = new LargeByteStreamConsumer(size);
+        Stream<ByteBuf> stream = new LargeByteStream(executorA, size);
+        stream.accept(executorB, consumer);
+
+        for (;;) {
+            if (consumer.future.await(1000)) {
+                break;
+            }
+
+            System.err.println(consumer.counter + " / " + size);
+        }
+
+        consumer.future.sync();
+    }
+
+    private static class LargeByteStream extends AbstractStream<ByteBuf> {
+        LargeByteStream(EventExecutor executor, long size) {
+            super(executor, new LargeByteStreamProducer(size));
+        }
+    }
+
+    private static class LargeByteStreamProducer implements StreamProducer<ByteBuf> {
+
+        private final long size;
+        private long counter;
+
+        LargeByteStreamProducer(long size) {
+            this.size = size;
+        }
+
+        @Override
+        public void streamAccepted(StreamProducerContext<ByteBuf> ctx) throws Exception {
+            generate(ctx);
+        }
+
+        @Override
+        public void streamConsumed(StreamProducerContext<ByteBuf> ctx) throws Exception {
+            generate(ctx);
+        }
+
+        private void generate(StreamProducerContext<ByteBuf> ctx) {
+            ByteBuf buf = ctx.buffer();
+            int chunkSize = (int) Math.min(size - counter, buf.maxWritableBytes());
+            buf.ensureWritable(chunkSize);
+            buf.writerIndex(buf.writerIndex() + chunkSize);
+            ctx.update();
+            counter += chunkSize;
+            if (counter == size) {
+                ctx.close();
+                return;
+            }
+
+            if (counter > size) {
+                throw new AssertionError("counter > size");
+            }
+        }
+
+        @Override
+        public void streamDiscarded(StreamProducerContext<ByteBuf> ctx) throws Exception {
+            throw new AssertionError("stream discarded");
+        }
+
+        @Override
+        public void streamRejected(StreamProducerContext<ByteBuf> ctx, Throwable cause) throws Exception {
+            throw new AssertionError("stream rejected", cause);
+        }
+    }
+
+    private static class LargeByteStreamConsumer implements StreamConsumer<ByteBuf> {
+
+        private final long size;
+        volatile Promise future;
+        volatile long counter;
+
+        LargeByteStreamConsumer(long size) {
+            this.size = size;
+        }
+
+        @Override
+        public ByteBuf newStreamBuffer(StreamConsumerContext<ByteBuf> ctx) throws Exception {
+            future = new DefaultPromise(ctx.executor());
+            return Unpooled.buffer(0, 65536); // Only use 64 KiB at max.
+        }
+
+        @Override
+        public void streamOpen(StreamConsumerContext<ByteBuf> ctx) throws Exception { }
+
+        @Override
+        public void streamUpdated(StreamConsumerContext<ByteBuf> ctx) throws Exception {
+            ByteBuf buf = ctx.buffer();
+            int chunkSize = buf.readableBytes();
+            buf.skipBytes(chunkSize);
+            buf.discardReadBytes();
+            counter += chunkSize;
+            if (counter == size) {
+                future.setSuccess();
+            } else if (counter > size) {
+                AssertionError error = new AssertionError("counter > size");
+                ctx.reject(error);
+                future.setFailure(error);
+            } else {
+                ctx.next();
+            }
+        }
+
+        @Override
+        public void streamAborted(StreamConsumerContext<ByteBuf> ctx, Throwable cause) throws Exception {
+            future.setFailure(cause);
+        }
+
+        @Override
+        public void streamClosed(StreamConsumerContext<ByteBuf> ctx) throws Exception {
+            future.tryFailure(new AssertionError("tryFailure() must return false."));
+        }
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/AbstractHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/AbstractHttpHeaders.java
@@ -1,0 +1,567 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.httpx;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+
+import java.text.ParseException;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Represent the start line and headers of an HTTP message.
+ */
+public abstract class AbstractHttpHeaders implements HttpHeaders {
+
+    private final HttpMessageType type;
+
+    protected AbstractHttpHeaders(HttpMessageType type) {
+        if (type == null) {
+            throw new NullPointerException("type");
+        }
+        this.type = type;
+    }
+
+    // Properties related with a start line.
+
+    @Override
+    public HttpMessageType getType() {
+        return type;
+    }
+
+    @Override
+    public boolean isRequest() {
+        return type == HttpMessageType.REQUEST;
+    }
+
+    @Override
+    public boolean isResponse() {
+        return type == HttpMessageType.RESPONSE;
+    }
+
+    @Override
+    public String getHost() {
+        return get(Names.HOST);
+    }
+
+    @Override
+    public String getHost(String defaultValue) {
+        return get(Names.HOST, defaultValue);
+    }
+
+    @Override
+    public HttpHeaders setContentLength(long length) {
+        return set(Names.CONTENT_LENGTH, length);
+    }
+
+    @Override
+    public HttpHeaders setHost(String value) {
+        return set(Names.HOST, value);
+    }
+
+    // Properties related with message flow.
+
+    @Override
+    public boolean isKeepAlive() {
+        String connection = get(Names.CONNECTION);
+        if (Values.CLOSE.equalsIgnoreCase(connection)) {
+            return false;
+        }
+
+        if (getVersion().isKeepAliveDefault()) {
+            return !Values.CLOSE.equalsIgnoreCase(connection);
+        } else {
+            return Values.KEEP_ALIVE.equalsIgnoreCase(connection);
+        }
+    }
+
+    @Override
+    public HttpHeaders setKeepAlive(boolean keepAlive) {
+        if (getVersion().isKeepAliveDefault()) {
+            if (keepAlive) {
+                remove(Names.CONNECTION);
+            } else {
+                set(Names.CONNECTION, Values.CLOSE);
+            }
+        } else {
+            if (keepAlive) {
+                set(Names.CONNECTION, Values.KEEP_ALIVE);
+            } else {
+                remove(Names.CONNECTION);
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public boolean is100ContinueExpected() {
+        // Expect: 100-continue is for requests only.
+        if (getType() != HttpMessageType.REQUEST) {
+            return false;
+        }
+
+        // It works only on HTTP/1.1 or later.
+        if (getVersion().compareTo(HttpVersion.HTTP_1_1) < 0) {
+            return false;
+        }
+
+        // In most cases, there will be one or zero 'Expect' header.
+        String value = get(Names.EXPECT);
+        if (value == null) {
+            return false;
+        }
+        if (Values.CONTINUE.equalsIgnoreCase(value)) {
+            return true;
+        }
+
+        // Multiple 'Expect' headers.  Search through them.
+        for (String v: getAll(Names.EXPECT)) {
+            if (Values.CONTINUE.equalsIgnoreCase(v)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public HttpHeaders set100ContinueExpected(boolean expected) {
+        if (expected) {
+            return set(Names.EXPECT, Values.CONTINUE);
+        } else {
+            return remove(Names.EXPECT, Values.CONTINUE);
+        }
+    }
+
+    // Validation methods
+
+    @Override
+    public HttpHeaders validateName(String name) {
+        //Check to see if the name is null
+        if (name == null) {
+            throw new NullPointerException("name");
+        }
+        //Go through each of the characters in the name
+        for (int index = 0; index < name.length(); index ++) {
+            //Actually get the character
+            char character = name.charAt(index);
+
+            //Check to see if the character is not an ASCII character
+            if (character > 127) {
+                throw new IllegalArgumentException(
+                        "name cannot contain non-ASCII characters: " + name);
+            }
+
+            //Check for prohibited characters.
+            switch (character) {
+                case '\t': case '\n': case 0x0b: case '\f': case '\r':
+                case ' ':  case ',':  case ':':  case ';':  case '=':
+                    throw new IllegalArgumentException(
+                            "name cannot contain the following prohibited characters: " +
+                                    "=,;: \\t\\r\\n\\v\\f: " + name);
+            }
+        }
+
+        return this;
+    }
+
+    @Override
+    public HttpHeaders validateValue(String value) {
+        //Check to see if the value is null
+        if (value == null) {
+            throw new NullPointerException("value");
+        }
+
+        /*
+         * Set up the state of the validation
+         *
+         * States are as follows:
+         *
+         * 0: Previous character was neither CR nor LF
+         * 1: The previous character was CR
+         * 2: The previous character was LF
+         */
+        int state = 0;
+
+        //Start looping through each of the character
+
+        for (int index = 0; index < value.length(); index ++) {
+            char character = value.charAt(index);
+
+            //Check the absolutely prohibited characters.
+            switch (character) {
+                case 0x0b: // Vertical tab
+                    throw new IllegalArgumentException(
+                            "value contains a prohibited character '\\v': " + value);
+                case '\f':
+                    throw new IllegalArgumentException(
+                            "value contains a prohibited character '\\f': " + value);
+            }
+
+            // Check the CRLF (HT | SP) pattern
+            switch (state) {
+                case 0:
+                    switch (character) {
+                        case '\r':
+                            state = 1;
+                            break;
+                        case '\n':
+                            state = 2;
+                            break;
+                    }
+                    break;
+                case 1:
+                    switch (character) {
+                        case '\n':
+                            state = 2;
+                            break;
+                        default:
+                            throw new IllegalArgumentException(
+                                    "Only '\\n' is allowed after '\\r': " + value);
+                    }
+                    break;
+                case 2:
+                    switch (character) {
+                        case '\t': case ' ':
+                            state = 0;
+                            break;
+                        default:
+                            throw new IllegalArgumentException(
+                                    "Only ' ' and '\\t' are allowed after '\\n': " + value);
+                    }
+            }
+        }
+
+        if (state != 0) {
+            throw new IllegalArgumentException(
+                    "value must not end with '\\r' or '\\n':" + value);
+        }
+
+        return this;
+    }
+
+    @Override
+    public boolean isTransferEncodingChunked() {
+        List<String> transferEncodingHeaders = getAll(Names.TRANSFER_ENCODING);
+        if (transferEncodingHeaders.isEmpty()) {
+            return false;
+        }
+
+        for (String value: transferEncodingHeaders) {
+            if (value.equalsIgnoreCase(Values.CHUNKED)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public HttpHeaders setTransferEncodingChunked(boolean chunked) {
+        if (chunked) {
+            add(Names.TRANSFER_ENCODING, Values.CHUNKED);
+            remove(Names.CONTENT_LENGTH);
+        } else {
+            remove(Names.TRANSFER_ENCODING, Values.CHUNKED);
+        }
+
+        return this;
+    }
+
+    // Generic property accessors
+
+    @Override
+    public String get(String name, Object defaultValue) {
+        String value = get(name);
+        if (value == null) {
+            return toString(defaultValue);
+        }
+        return value;
+    }
+
+    @Override
+    public int getInt(String name) {
+        String value = get(name);
+        if (value == null) {
+            throw new NumberFormatException("header not found: " + name);
+        }
+        return Integer.parseInt(value);
+    }
+
+    @Override
+    public int getInt(String name, int defaultValue) {
+        String value = get(name);
+        if (value == null) {
+            return defaultValue;
+        }
+
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    @Override
+    public Date getDate(String name) throws ParseException {
+        String value = get(name);
+        if (value == null) {
+            throw new ParseException("header not found: " + name, 0);
+        }
+        return new HttpHeaderDateFormat().parse(value);
+    }
+
+    @Override
+    public Date getDate(String name, Date defaultValue) {
+        final String value = get(name);
+        if (value == null) {
+            return defaultValue;
+        }
+
+        try {
+            return new HttpHeaderDateFormat().parse(value);
+        } catch (ParseException e) {
+            return defaultValue;
+        }
+    }
+
+    @Override
+    public long getContentLength() {
+        String value = get(Names.CONTENT_LENGTH);
+        if (value != null) {
+            return Long.parseLong(value);
+        }
+
+        // We know the content length if it's a Web Socket message even if
+        // Content-Length header is missing.
+        long webSocketContentLength = getWebSocketContentLength();
+        if (webSocketContentLength >= 0) {
+            return webSocketContentLength;
+        }
+
+        // Otherwise we don't.
+        throw new NumberFormatException("header not found: " + Names.CONTENT_LENGTH);
+    }
+
+    @Override
+    public long getContentLength(long defaultValue) {
+        String contentLength = get(Names.CONTENT_LENGTH);
+        if (contentLength != null) {
+            try {
+                return Long.parseLong(contentLength);
+            } catch (NumberFormatException e) {
+                return defaultValue;
+            }
+        }
+
+        // We know the content length if it's a Web Socket message even if
+        // Content-Length header is missing.
+        long webSocketContentLength = getWebSocketContentLength();
+        if (webSocketContentLength >= 0) {
+            return webSocketContentLength;
+        }
+
+        // Otherwise we don't.
+        return defaultValue;
+    }
+
+    /**
+     * Returns the content length of the specified web socket message.  If the
+     * specified message is not a web socket message, {@code -1} is returned.
+     */
+    private int getWebSocketContentLength() {
+        // WebSockset messages have constant content-lengths.
+        switch (getType()) {
+            case REQUEST:
+                if (HttpMethod.GET.equals(getMethod()) &&
+                    contains(Names.SEC_WEBSOCKET_KEY1) && contains(Names.SEC_WEBSOCKET_KEY2)) {
+                    return 8;
+                }
+                break;
+            case RESPONSE:
+                if (getStatus().code() == 101 &&
+                    contains(Names.SEC_WEBSOCKET_ORIGIN) && contains(Names.SEC_WEBSOCKET_LOCATION)) {
+                    return 16;
+                }
+                break;
+        }
+
+        // Not a web socket message
+        return -1;
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator() {
+        return entries().iterator();
+    }
+
+    @Override
+    public boolean contains(String name) {
+        return get(name) != null;
+    }
+
+    @Override
+    public final HttpHeaders add(String name, Object value) {
+        validateName(name);
+        String strValue = toString(value);
+        validateValue(strValue);
+        add0(name, strValue);
+        return this;
+    }
+
+    protected abstract void add0(String name, String value);
+
+    @Override
+    public HttpHeaders add(String name, Iterable<?> values) {
+        if (values == null) {
+            throw new NullPointerException("values");
+        }
+
+        validateName(name);
+        for (Object v: values) {
+            if (v == null) {
+                break;
+            }
+            String strValue = toString(v);
+            validateValue(strValue);
+            add0(name, strValue);
+        }
+
+        return this;
+    }
+
+    @Override
+    public HttpHeaders add(HttpHeaders headers) {
+        if (headers == null) {
+            throw new NullPointerException("headers");
+        }
+        for (Map.Entry<String, String> e: headers) {
+            add0(e.getKey(), e.getValue());
+        }
+        return this;
+    }
+
+    @Override
+    public final HttpHeaders set(String name, Object value) {
+        validateName(name);
+        String strValue = toString(value);
+        validateValue(strValue);
+        set0(name, strValue);
+        return this;
+    }
+
+    protected abstract void set0(String name, String value);
+
+    @Override
+    public HttpHeaders set(String name, Iterable<?> values) {
+        if (values == null) {
+            throw new NullPointerException("values");
+        }
+
+        validateName(name);
+        for (Object v: values) {
+            if (v == null) {
+                break;
+            }
+            String strValue = toString(v);
+            validateValue(strValue);
+            set0(name, strValue);
+        }
+
+        return this;
+    }
+
+    @Override
+    public HttpHeaders set(HttpHeaders headers) {
+        if (headers == null) {
+            throw new NullPointerException("headers");
+        }
+        clear();
+        for (Map.Entry<String, String> e: headers) {
+            add0(e.getKey(), e.getValue());
+        }
+        return this;
+    }
+
+    @Override
+    public final HttpHeaders remove(String name, Object value) {
+        if (name == null) {
+            throw new NullPointerException("name");
+        }
+        if (value == null) {
+            throw new NullPointerException("value");
+        }
+
+        String strValue = toString(value);
+        remove0(name, strValue);
+        return this;
+    }
+
+    protected abstract void remove0(String name, String value);
+
+    @Override
+    public String toString(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String) {
+            return (String) value;
+        }
+        if (value instanceof Number) {
+            return value.toString();
+        }
+        if (value instanceof Date) {
+            return new HttpHeaderDateFormat().format((Date) value);
+        }
+        if (value instanceof Calendar) {
+            return new HttpHeaderDateFormat().format(((Calendar) value).getTime());
+        }
+        return value.toString();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder buf = new StringBuilder(512);
+        buf.append(getClass().getSimpleName());
+        buf.append("(type: ");
+        buf.append(getType());
+        switch (getType()) {
+            case REQUEST:
+                buf.append(", method: ");
+                buf.append(getMethod());
+                buf.append(", path: ");
+                buf.append(getUri());
+                buf.append(", version: ");
+                buf.append(getVersion());
+                break;
+            case RESPONSE:
+                buf.append(", version: ");
+                buf.append(getVersion());
+                buf.append(", status: ");
+                buf.append(getStatus());
+                break;
+        }
+
+        buf.append(", entries: ");
+        buf.append(entries());
+        buf.append(')');
+
+        return buf.toString();
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/DecodedHttpMessage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/DecodedHttpMessage.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.httpx;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.stream.Stream;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.HttpVersion;
+
+public interface DecodedHttpMessage extends HttpMessage {
+
+    /**
+     * Returns the result of decoding this message.
+     */
+    DecoderResult getDecoderResult();
+
+    /**
+     * Updates the result of decoding this message. This method is supposed to be invoked by {@link HttpMessageDecoder}.
+     * Do not call this method unless you know what you are doing.
+     */
+    DecodedHttpMessage setDecoderResult(DecoderResult result);
+
+    @Override
+    DecodedHttpMessage setVersion(HttpVersion version);
+
+    @Override
+    DecodedHttpMessage setContent(ByteBuf content);
+
+    @Override
+    DecodedHttpMessage setContent(Stream<ByteBuf> content);
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/DecodedHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/DecodedHttpRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.httpx;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.stream.Stream;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+
+public interface DecodedHttpRequest extends DecodedHttpMessage, HttpRequest {
+    @Override
+    DecodedHttpRequest setVersion(HttpVersion version);
+
+    @Override
+    DecodedHttpRequest setDecoderResult(DecoderResult result);
+
+    @Override
+    DecodedHttpRequest setMethod(HttpMethod method);
+
+    @Override
+    DecodedHttpRequest setUri(String uri);
+
+    @Override
+    DecodedHttpRequest setContent(ByteBuf content);
+
+    @Override
+    DecodedHttpRequest setContent(Stream<ByteBuf> content);
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/DecodedHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/DecodedHttpResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.httpx;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.stream.Stream;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+
+public interface DecodedHttpResponse extends DecodedHttpMessage, HttpResponse {
+    @Override
+    DecodedHttpResponse setVersion(HttpVersion version);
+
+    @Override
+    DecodedHttpResponse setDecoderResult(DecoderResult result);
+
+    @Override
+    DecodedHttpResponse setStatus(HttpResponseStatus status);
+
+    @Override
+    DecodedHttpResponse setContent(ByteBuf content);
+
+    @Override
+    DecodedHttpResponse setContent(Stream<ByteBuf> content);
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/DefaultDecodedHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/DefaultDecodedHttpRequest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.httpx;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.stream.Stream;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+
+public class DefaultDecodedHttpRequest extends DefaultHttpRequest implements DecodedHttpRequest {
+
+    private DecoderResult decoderResult = DecoderResult.UNFINISHED;
+
+    public DefaultDecodedHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri) {
+        super(httpVersion, method, uri);
+    }
+
+    @Override
+    public DecoderResult getDecoderResult() {
+        return decoderResult;
+    }
+
+    @Override
+    public DecodedHttpRequest setDecoderResult(DecoderResult decoderResult) {
+        if (decoderResult == null) {
+            throw new NullPointerException("decoderResult");
+        }
+        this.decoderResult = decoderResult;
+        return this;
+    }
+
+    @Override
+    public DecodedHttpRequest setVersion(HttpVersion version) {
+        return (DecodedHttpRequest) super.setVersion(version);
+    }
+
+    @Override
+    public DecodedHttpRequest setMethod(HttpMethod method) {
+        return (DecodedHttpRequest) super.setMethod(method);
+    }
+
+    @Override
+    public DecodedHttpRequest setUri(String uri) {
+        return (DecodedHttpRequest) super.setUri(uri);
+    }
+
+    @Override
+    public DecodedHttpRequest setContent(ByteBuf content) {
+        return (DecodedHttpRequest) super.setContent(content);
+    }
+
+    @Override
+    public DecodedHttpRequest setContent(Stream<ByteBuf> content) {
+        return (DecodedHttpRequest) super.setContent(content);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/DefaultDecodedHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/DefaultDecodedHttpResponse.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.httpx;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.stream.Stream;
+import io.netty.handler.codec.DecoderResult;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+
+public class DefaultDecodedHttpResponse extends DefaultHttpResponse implements DecodedHttpResponse {
+
+    private DecoderResult decoderResult = DecoderResult.UNFINISHED;
+
+    public DefaultDecodedHttpResponse(HttpVersion version, HttpResponseStatus status) {
+        super(version, status);
+    }
+
+    @Override
+    public DecoderResult getDecoderResult() {
+        return decoderResult;
+    }
+
+    @Override
+    public DecodedHttpResponse setDecoderResult(DecoderResult decoderResult) {
+        if (decoderResult == null) {
+            throw new NullPointerException("decoderResult");
+        }
+        this.decoderResult = decoderResult;
+        return this;
+    }
+
+    @Override
+    public DecodedHttpResponse setVersion(HttpVersion version) {
+        return (DecodedHttpResponse) super.setVersion(version);
+    }
+
+    @Override
+    public DecodedHttpResponse setStatus(HttpResponseStatus status) {
+        return (DecodedHttpResponse) super.setStatus(status);
+    }
+
+    @Override
+    public DecodedHttpResponse setContent(ByteBuf content) {
+        return (DecodedHttpResponse) super.setContent(content);
+    }
+
+    @Override
+    public DecodedHttpResponse setContent(Stream<ByteBuf> content) {
+        return (DecodedHttpResponse) super.setContent(content);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/DefaultHttpHeaders.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.httpx;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+
+public class DefaultHttpHeaders extends HashedHttpHeaders {
+
+    private HttpVersion version;
+    private HttpMethod method;
+    private HttpResponseStatus status;
+    private String uri;
+
+    public DefaultHttpHeaders(HttpMessageType type) {
+        super(type);
+    }
+
+    @Override
+    public HttpVersion getVersion() {
+        return version;
+    }
+
+    @Override
+    public HttpHeaders setVersion(HttpVersion version) {
+        if (version == null) {
+            throw new NullPointerException("version");
+        }
+        this.version = version;
+        return this;
+    }
+
+    @Override
+    public HttpMethod getMethod() {
+        return method;
+    }
+
+    @Override
+    public HttpHeaders setMethod(HttpMethod method) {
+        if (method == null) {
+            throw new NullPointerException("method");
+        }
+        this.method = method;
+        return this;
+    }
+
+    @Override
+    public HttpResponseStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public HttpHeaders setStatus(HttpResponseStatus status) {
+        if (status == null) {
+            throw new NullPointerException("status");
+        }
+        this.status = status;
+        return this;
+    }
+
+    @Override
+    public String getUri() {
+        return uri;
+    }
+
+    @Override
+    public HttpHeaders setUri(String uri) {
+        if (uri == null) {
+            throw new NullPointerException("uri");
+        }
+        this.uri = uri;
+        return this;
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/DefaultHttpMessage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/DefaultHttpMessage.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.httpx;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.stream.Stream;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.internal.StringUtil;
+
+/**
+ * Default implementation of {@link HttpMessage}.
+ */
+class DefaultHttpMessage implements HttpMessage {
+
+    private final HttpHeaders headers;
+    private HttpHeaders trailingHeaders;
+    private Object content = Unpooled.EMPTY_BUFFER;
+
+    protected DefaultHttpMessage(HttpVersion httpVersion, HttpMethod method, String path) {
+        headers = new DefaultHttpHeaders(HttpMessageType.REQUEST);
+        headers.setVersion(httpVersion);
+        headers.setMethod(method);
+        headers.setUri(path);
+    }
+
+    protected DefaultHttpMessage(HttpVersion httpVersion, HttpResponseStatus status) {
+        headers = new DefaultHttpHeaders(HttpMessageType.RESPONSE);
+        headers.setVersion(httpVersion);
+        headers.setStatus(status);
+    }
+
+    @Override
+    public HttpMessageType getType() {
+        return getHeaders().getType();
+    }
+
+    @Override
+    public HttpHeaders getHeaders() {
+        return headers;
+    }
+
+    @Override
+    public HttpHeaders getTrailingHeaders() {
+        HttpHeaders trailingHeaders = this.trailingHeaders;
+        if (trailingHeaders == null) {
+            this.trailingHeaders = trailingHeaders = new DefaultHttpHeaders(HttpMessageType.TRAILER);
+        }
+        return trailingHeaders;
+    }
+
+    @Override
+    public boolean hasTrailingHeaders() {
+        return trailingHeaders != null && !trailingHeaders.isEmpty();
+    }
+
+    @Override
+    public boolean isContentStream() {
+        return content instanceof Stream;
+    }
+
+    @Override
+    public Object getContent() {
+        return content;
+    }
+
+    @Override
+    public HttpMessage setContent(Stream<ByteBuf> content) {
+        setContent0(content);
+        return this;
+    }
+
+    @Override
+    public HttpMessage setContent(ByteBuf content) {
+        setContent0(content);
+        return this;
+    }
+
+    private void setContent0(Object content) {
+        if (content == null) {
+            throw new NullPointerException("content");
+        }
+        this.content = content;
+    }
+
+    @Override
+    public HttpVersion getVersion() {
+        return getHeaders().getVersion();
+    }
+
+    @Override
+    public HttpMessage setVersion(HttpVersion version) {
+        getHeaders().setVersion(version);
+        return this;
+    }
+
+    String getUri() {
+        return getHeaders().getUri();
+    }
+
+    HttpRequest setUri(String uri) {
+        getHeaders().setUri(uri);
+        return (HttpRequest) this;
+    }
+
+    HttpMethod getMethod() {
+        return getHeaders().getMethod();
+    }
+
+    HttpRequest setMethod(HttpMethod method) {
+        getHeaders().setMethod(method);
+        return (HttpRequest) this;
+    }
+
+    HttpResponseStatus getStatus() {
+        return getHeaders().getStatus();
+    }
+
+    HttpResponse setStatus(HttpResponseStatus status) {
+        getHeaders().setStatus(status);
+        return (HttpResponse) this;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder buf = new StringBuilder();
+        buf.append(getHeaders());
+        buf.append(StringUtil.NEWLINE);
+        buf.append(getContent());
+        if (hasTrailingHeaders()) {
+            buf.append(StringUtil.NEWLINE);
+            buf.append(getTrailingHeaders());
+        }
+        return buf.toString();
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/DefaultHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/DefaultHttpRequest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.httpx;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.stream.Stream;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+
+/**
+ * The default {@link HttpRequest} implementation.
+ */
+public class DefaultHttpRequest extends DefaultHttpMessage implements HttpRequest {
+
+    /**
+     * Creates a new instance.
+     *
+     * @param httpVersion the HTTP version of the request
+     * @param method      the HTTP getMethod of the request
+     * @param uri         the URI or path of the request
+     */
+    public DefaultHttpRequest(HttpVersion httpVersion, HttpMethod method, String uri) {
+        super(httpVersion, method, uri);
+    }
+
+    @Override
+    public String getUri() {
+        return super.getUri();
+    }
+
+    @Override
+    public HttpRequest setUri(String uri) {
+        return super.setUri(uri);
+    }
+
+    @Override
+    public HttpMethod getMethod() {
+        return super.getMethod();
+    }
+
+    @Override
+    public HttpRequest setMethod(HttpMethod method) {
+        return super.setMethod(method);
+    }
+
+    @Override
+    public HttpRequest setVersion(HttpVersion version) {
+        return (HttpRequest) super.setVersion(version);
+    }
+
+    @Override
+    public HttpRequest setContent(ByteBuf content) {
+        return (HttpRequest) super.setContent(content);
+    }
+
+    @Override
+    public HttpRequest setContent(Stream<ByteBuf> content) {
+        return (HttpRequest) super.setContent(content);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/DefaultHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/DefaultHttpResponse.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.httpx;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.stream.Stream;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+
+/**
+ * The default {@link HttpResponse} implementation.
+ */
+public class DefaultHttpResponse extends DefaultHttpMessage implements HttpResponse {
+
+    /**
+     * Creates a new instance.
+     *
+     * @param version the HTTP version of this response
+     * @param status  the getStatus of this response
+     */
+    public DefaultHttpResponse(HttpVersion version, HttpResponseStatus status) {
+        super(version, status);
+    }
+
+    @Override
+    public HttpResponseStatus getStatus() {
+        return super.getStatus();
+    }
+
+    @Override
+    public HttpResponse setStatus(HttpResponseStatus status) {
+        return super.setStatus(status);
+    }
+
+    @Override
+    public HttpResponse setVersion(HttpVersion version) {
+        return (HttpResponse) super.setVersion(version);
+    }
+
+    @Override
+    public HttpResponse setContent(ByteBuf content) {
+        return (HttpResponse) super.setContent(content);
+    }
+
+    @Override
+    public HttpResponse setContent(Stream<ByteBuf> content) {
+        return (HttpResponse) super.setContent(content);
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/EmptyTrailingHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/EmptyTrailingHeaders.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.httpx;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+
+final class EmptyTrailingHeaders extends AbstractHttpHeaders {
+
+    static final HttpHeaders INSTANCE = new EmptyTrailingHeaders();
+
+    private EmptyTrailingHeaders() {
+        super(HttpMessageType.TRAILER);
+    }
+
+    private static HttpHeaders fail() {
+        throw new UnsupportedOperationException("read-only");
+    }
+
+    @Override
+    protected void add0(String name, String value) {
+        fail();
+    }
+
+    @Override
+    protected void set0(String name, String value) {
+        fail();
+    }
+
+    @Override
+    protected void remove0(String name, String value) {
+        fail();
+    }
+
+    @Override
+    public HttpVersion getVersion() {
+        return null;
+    }
+
+    @Override
+    public HttpHeaders setVersion(HttpVersion version) {
+        return fail();
+    }
+
+    @Override
+    public HttpMethod getMethod() {
+        return null;
+    }
+
+    @Override
+    public HttpHeaders setMethod(HttpMethod method) {
+        return fail();
+    }
+
+    @Override
+    public HttpResponseStatus getStatus() {
+        return null;
+    }
+
+    @Override
+    public HttpHeaders setStatus(HttpResponseStatus status) {
+        return fail();
+    }
+
+    @Override
+    public String getUri() {
+        return null;
+    }
+
+    @Override
+    public HttpHeaders setUri(String uri) {
+        return fail();
+    }
+
+    @Override
+    public String get(String name) {
+        return null;
+    }
+
+    @Override
+    public List<String> getAll(String name) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Entry<String, String>> entries() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
+
+    @Override
+    public Set<String> names() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public HttpHeaders remove(String name) {
+        return fail();
+    }
+
+    @Override
+    public HttpHeaders clear() {
+        return fail();
+    }
+
+    @Override
+    public HttpHeaders set(HttpHeaders headers) {
+        return fail();
+    }
+
+    @Override
+    public HttpHeaders add(HttpHeaders headers) {
+        return fail();
+    }
+
+    @Override
+    public HttpHeaders set(String name, Iterable<?> values) {
+        return fail();
+    }
+
+    @Override
+    public HttpHeaders add(String name, Iterable<?> values) {
+        return fail();
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/HashedHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/HashedHttpHeaders.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.httpx;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+public abstract class HashedHttpHeaders extends AbstractHttpHeaders {
+
+    private static final int BUCKET_SIZE = 17;
+
+    private static int hash(String name) {
+        int h = 0;
+        for (int i = name.length() - 1; i >= 0; i --) {
+            char c = name.charAt(i);
+            if (c >= 'A' && c <= 'Z') {
+                c += 32;
+            }
+            h = 31 * h + c;
+        }
+
+        if (h > 0) {
+            return h;
+        } else if (h == Integer.MIN_VALUE) {
+            return Integer.MAX_VALUE;
+        } else {
+            return -h;
+        }
+    }
+
+    private static boolean eq(String name1, String name2) {
+        int nameLen = name1.length();
+        if (nameLen != name2.length()) {
+            return false;
+        }
+
+        for (int i = nameLen - 1; i >= 0; i --) {
+            char c1 = name1.charAt(i);
+            char c2 = name2.charAt(i);
+            if (c1 != c2) {
+                if (c1 >= 'A' && c1 <= 'Z') {
+                    c1 += 32;
+                }
+                if (c2 >= 'A' && c2 <= 'Z') {
+                    c2 += 32;
+                }
+                if (c1 != c2) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static int index(int hash) {
+        return hash % BUCKET_SIZE;
+    }
+
+    private final HeaderEntry[] entries = new HeaderEntry[BUCKET_SIZE];
+    private final HeaderEntry head = new HeaderEntry(-1, null, null);
+
+    protected HashedHttpHeaders(HttpMessageType type) {
+        super(type);
+        head.before = head.after = head;
+    }
+
+    @Override
+    protected void add0(String name, String value) {
+        int h = hash(name);
+        int i = index(h);
+        add0(h, i, name, value);
+    }
+
+    @Override
+    public HttpHeaders add(String name, Iterable<?> values) {
+        validateName(name);
+        int h = hash(name);
+        int i = index(h);
+        for (Object v: values) {
+            String vstr = toString(v);
+            validateValue(vstr);
+            add0(h, i, name, vstr);
+        }
+        return this;
+    }
+
+    private void add0(int h, int i, final String name, final String value) {
+        // Update the hash table.
+        HeaderEntry e = entries[i];
+        HeaderEntry newEntry;
+        entries[i] = newEntry = new HeaderEntry(h, name, value);
+        newEntry.next = e;
+
+        // Update the linked list.
+        newEntry.addBefore(head);
+    }
+
+    @Override
+    public HttpHeaders remove(final String name) {
+        if (name == null) {
+            throw new NullPointerException("name");
+        }
+        int h = hash(name);
+        int i = index(h);
+        remove0(h, i, name);
+        return this;
+    }
+
+    private void remove0(int h, int i, String name) {
+        HeaderEntry e = entries[i];
+        if (e == null) {
+            return;
+        }
+
+        for (;;) {
+            if (e.hash == h && eq(name, e.key)) {
+                e.remove();
+                HeaderEntry next = e.next;
+                if (next != null) {
+                    entries[i] = next;
+                    e = next;
+                } else {
+                    entries[i] = null;
+                    return;
+                }
+            } else {
+                break;
+            }
+        }
+
+        for (;;) {
+            HeaderEntry next = e.next;
+            if (next == null) {
+                break;
+            }
+            if (next.hash == h && eq(name, next.key)) {
+                e.next = next.next;
+                next.remove();
+            } else {
+                e = next;
+            }
+        }
+    }
+
+    @Override
+    protected void remove0(String name, String value) {
+        int h = hash(name);
+        int i = index(h);
+        HeaderEntry e = entries[i];
+        if (e == null) {
+            return;
+        }
+
+        if (e.hash == h && eq(name, e.key) && e.value.equals(value)) {
+            e.remove();
+            HeaderEntry next = e.next;
+            if (next != null) {
+                entries[i] = next;
+            } else {
+                entries[i] = null;
+            }
+        } else {
+            for (;;) {
+                HeaderEntry next = e.next;
+                if (next == null) {
+                    break;
+                }
+                if (next.hash == h && eq(name, next.key) && next.value.equals(value)) {
+                    e.next = next.next;
+                    next.remove();
+                    break;
+                } else {
+                    e = next;
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void set0(String name, String value) {
+        int h = hash(name);
+        int i = index(h);
+        remove0(h, i, name);
+        add0(h, i, name, value);
+    }
+
+    @Override
+    public HttpHeaders set(final String name, final Iterable<?> values) {
+        if (values == null) {
+            throw new NullPointerException("values");
+        }
+
+        validateName(name);
+
+        int h = hash(name);
+        int i = index(h);
+
+        remove0(h, i, name);
+        for (Object v: values) {
+            if (v == null) {
+                break;
+            }
+            String strVal = toString(v);
+            validateValue(strVal);
+            add0(h, i, name, strVal);
+        }
+
+        return this;
+    }
+
+    @Override
+    public HttpHeaders clear() {
+        for (int i = 0; i < entries.length; i ++) {
+            entries[i] = null;
+        }
+        head.before = head.after = head;
+        return this;
+    }
+
+    @Override
+    public String get(final String name) {
+        if (name == null) {
+            throw new NullPointerException("name");
+        }
+
+        int h = hash(name);
+        int i = index(h);
+        HeaderEntry e = entries[i];
+        while (e != null) {
+            if (e.hash == h && eq(name, e.key)) {
+                return e.value;
+            }
+
+            e = e.next;
+        }
+        return null;
+    }
+
+    @Override
+    public List<String> getAll(final String name) {
+        if (name == null) {
+            throw new NullPointerException("name");
+        }
+
+        LinkedList<String> values = new LinkedList<String>();
+
+        int h = hash(name);
+        int i = index(h);
+        HeaderEntry e = entries[i];
+        while (e != null) {
+            if (e.hash == h && eq(name, e.key)) {
+                values.addFirst(e.value);
+            }
+            e = e.next;
+        }
+        return values;
+    }
+
+    @Override
+    public List<Map.Entry<String, String>> entries() {
+        List<Map.Entry<String, String>> all =
+            new LinkedList<Map.Entry<String, String>>();
+
+        HeaderEntry e = head.after;
+        while (e != head) {
+            all.add(e);
+            e = e.after;
+        }
+        return all;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return head == head.after;
+    }
+
+    @Override
+    public Set<String> names() {
+        Set<String> names = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
+        HeaderEntry e = head.after;
+        while (e != head) {
+            names.add(e.key);
+            e = e.after;
+        }
+        return names;
+    }
+
+    private final class HeaderEntry implements Map.Entry<String, String> {
+        final int hash;
+        final String key;
+        String value;
+        HeaderEntry next;
+        HeaderEntry before, after;
+
+        HeaderEntry(int hash, String key, String value) {
+            this.hash = hash;
+            this.key = key;
+            this.value = value;
+        }
+
+        void remove() {
+            before.after = after;
+            after.before = before;
+        }
+
+        void addBefore(HeaderEntry e) {
+            after  = e;
+            before = e.before;
+            before.after = this;
+            after.before = this;
+        }
+
+        @Override
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String setValue(String value) {
+            if (value == null) {
+                throw new NullPointerException("value");
+            }
+            validateValue(value);
+            String oldValue = this.value;
+            this.value = value;
+            return oldValue;
+        }
+
+        @Override
+        public String toString() {
+            return key + '=' + value;
+        }
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/HttpHeaderDateFormat.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/HttpHeaderDateFormat.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.httpx;
+
+import java.text.ParsePosition;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+/**
+ * This DateFormat decodes 3 formats of {@link Date}, but only encodes the one,
+ * the first:
+ * <ul>
+ * <li>Sun, 06 Nov 1994 08:49:37 GMT: standard specification, the only one with
+ * valid generation</li>
+ * <li>Sun, 06 Nov 1994 08:49:37 GMT: obsolete specification</li>
+ * <li>Sun Nov 6 08:49:37 1994: obsolete specification</li>
+ * </ul>
+ */
+final class HttpHeaderDateFormat extends SimpleDateFormat {
+    private static final long serialVersionUID = -925286159755905325L;
+
+    private final SimpleDateFormat format1 = new HttpHeaderDateFormatObsolete1();
+    private final SimpleDateFormat format2 = new HttpHeaderDateFormatObsolete2();
+
+    /**
+     * Standard date format<p>
+     * Sun, 06 Nov 1994 08:49:37 GMT -> E, d MMM yyyy HH:mm:ss z
+     */
+    HttpHeaderDateFormat() {
+        super("E, dd MMM yyyy HH:mm:ss z", Locale.ENGLISH);
+        setTimeZone(TimeZone.getTimeZone("GMT"));
+    }
+
+    @Override
+    public Date parse(String text, ParsePosition pos) {
+        Date date = super.parse(text, pos);
+        if (date == null) {
+            date = format1.parse(text, pos);
+        }
+        if (date == null) {
+            date = format2.parse(text, pos);
+        }
+        return date;
+    }
+
+    /**
+     * First obsolete format<p>
+     * Sunday, 06-Nov-94 08:49:37 GMT -> E, d-MMM-y HH:mm:ss z
+     */
+    private static final class HttpHeaderDateFormatObsolete1 extends SimpleDateFormat {
+        private static final long serialVersionUID = -3178072504225114298L;
+
+        HttpHeaderDateFormatObsolete1() {
+            super("E, dd-MMM-y HH:mm:ss z", Locale.ENGLISH);
+            setTimeZone(TimeZone.getTimeZone("GMT"));
+        }
+    }
+
+    /**
+     * Second obsolete format
+     * <p>
+     * Sun Nov 6 08:49:37 1994 -> EEE, MMM d HH:mm:ss yyyy
+     */
+    private static final class HttpHeaderDateFormatObsolete2 extends SimpleDateFormat {
+        private static final long serialVersionUID = 3010674519968303714L;
+
+        HttpHeaderDateFormatObsolete2() {
+            super("E MMM d HH:mm:ss yyyy", Locale.ENGLISH);
+            setTimeZone(TimeZone.getTimeZone("GMT"));
+        }
+    }
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/HttpHeaders.java
@@ -1,0 +1,845 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.httpx;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+
+import java.text.ParseException;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+/**
+ * Represent the start line and headers of an HTTP message.
+ */
+public interface HttpHeaders extends Iterable<Map.Entry<String, String>> {
+
+    /**
+     * Standard HTTP header names.
+     */
+    final class Names {
+        /**
+         * {@code "Accept"}
+         */
+        public static final String ACCEPT = "Accept";
+        /**
+         * {@code "Accept-Charset"}
+         */
+        public static final String ACCEPT_CHARSET = "Accept-Charset";
+        /**
+         * {@code "Accept-Encoding"}
+         */
+        public static final String ACCEPT_ENCODING = "Accept-Encoding";
+        /**
+         * {@code "Accept-Language"}
+         */
+        public static final String ACCEPT_LANGUAGE = "Accept-Language";
+        /**
+         * {@code "Accept-Ranges"}
+         */
+        public static final String ACCEPT_RANGES = "Accept-Ranges";
+        /**
+         * {@code "Accept-Patch"}
+         */
+        public static final String ACCEPT_PATCH = "Accept-Patch";
+        /**
+         * {@code "Access-Control-Allow-Credentials"}
+         */
+        public static final String ACCESS_CONTROL_ALLOW_CREDENTIALS = "Access-Control-Allow-Credentials";
+        /**
+         * {@code "Access-Control-Allow-Headers"}
+         */
+        public static final String ACCESS_CONTROL_ALLOW_HEADERS = "Access-Control-Allow-Headers";
+        /**
+         * {@code "Access-Control-Allow-Methods"}
+         */
+        public static final String ACCESS_CONTROL_ALLOW_METHODS = "Access-Control-Allow-Methods";
+        /**
+         * {@code "Access-Control-Allow-Origin"}
+         */
+        public static final String ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
+        /**
+         * {@code "Access-Control-Expose-Headers"}
+         */
+        public static final String ACCESS_CONTROL_EXPOSE_HEADERS = "Access-Control-Expose-Headers";
+        /**
+         * {@code "Access-Control-Max-Age"}
+         */
+        public static final String ACCESS_CONTROL_MAX_AGE = "Access-Control-Max-Age";
+        /**
+         * {@code "Access-Control-Request-Headers"}
+         */
+        public static final String ACCESS_CONTROL_REQUEST_HEADERS = "Access-Control-Request-Headers";
+        /**
+         * {@code "Access-Control-Request-Method"}
+         */
+        public static final String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
+        /**
+         * {@code "Age"}
+         */
+        public static final String AGE = "Age";
+        /**
+         * {@code "Allow"}
+         */
+        public static final String ALLOW = "Allow";
+        /**
+         * {@code "Authorization"}
+         */
+        public static final String AUTHORIZATION = "Authorization";
+        /**
+         * {@code "Cache-Control"}
+         */
+        public static final String CACHE_CONTROL = "Cache-Control";
+        /**
+         * {@code "Connection"}
+         */
+        public static final String CONNECTION = "Connection";
+        /**
+         * {@code "Content-Base"}
+         */
+        public static final String CONTENT_BASE = "Content-Base";
+        /**
+         * {@code "Content-Encoding"}
+         */
+        public static final String CONTENT_ENCODING = "Content-Encoding";
+        /**
+         * {@code "Content-Language"}
+         */
+        public static final String CONTENT_LANGUAGE = "Content-Language";
+        /**
+         * {@code "Content-Length"}
+         */
+        public static final String CONTENT_LENGTH = "Content-Length";
+        /**
+         * {@code "Content-Location"}
+         */
+        public static final String CONTENT_LOCATION = "Content-Location";
+        /**
+         * {@code "Content-Transfer-Encoding"}
+         */
+        public static final String CONTENT_TRANSFER_ENCODING = "Content-Transfer-Encoding";
+        /**
+         * {@code "Content-MD5"}
+         */
+        public static final String CONTENT_MD5 = "Content-MD5";
+        /**
+         * {@code "Content-Range"}
+         */
+        public static final String CONTENT_RANGE = "Content-Range";
+        /**
+         * {@code "Content-Type"}
+         */
+        public static final String CONTENT_TYPE = "Content-Type";
+        /**
+         * {@code "Cookie"}
+         */
+        public static final String COOKIE = "Cookie";
+        /**
+         * {@code "Date"}
+         */
+        public static final String DATE = "Date";
+        /**
+         * {@code "ETag"}
+         */
+        public static final String ETAG = "ETag";
+        /**
+         * {@code "Expect"}
+         */
+        public static final String EXPECT = "Expect";
+        /**
+         * {@code "Expires"}
+         */
+        public static final String EXPIRES = "Expires";
+        /**
+         * {@code "From"}
+         */
+        public static final String FROM = "From";
+        /**
+         * {@code "Host"}
+         */
+        public static final String HOST = "Host";
+        /**
+         * {@code "If-Match"}
+         */
+        public static final String IF_MATCH = "If-Match";
+        /**
+         * {@code "If-Modified-Since"}
+         */
+        public static final String IF_MODIFIED_SINCE = "If-Modified-Since";
+        /**
+         * {@code "If-None-Match"}
+         */
+        public static final String IF_NONE_MATCH = "If-None-Match";
+        /**
+         * {@code "If-Range"}
+         */
+        public static final String IF_RANGE = "If-Range";
+        /**
+         * {@code "If-Unmodified-Since"}
+         */
+        public static final String IF_UNMODIFIED_SINCE = "If-Unmodified-Since";
+        /**
+         * {@code "Last-Modified"}
+         */
+        public static final String LAST_MODIFIED = "Last-Modified";
+        /**
+         * {@code "Location"}
+         */
+        public static final String LOCATION = "Location";
+        /**
+         * {@code "Max-Forwards"}
+         */
+        public static final String MAX_FORWARDS = "Max-Forwards";
+        /**
+         * {@code "Origin"}
+         */
+        public static final String ORIGIN = "Origin";
+        /**
+         * {@code "Pragma"}
+         */
+        public static final String PRAGMA = "Pragma";
+        /**
+         * {@code "Proxy-Authenticate"}
+         */
+        public static final String PROXY_AUTHENTICATE = "Proxy-Authenticate";
+        /**
+         * {@code "Proxy-Authorization"}
+         */
+        public static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
+        /**
+         * {@code "Range"}
+         */
+        public static final String RANGE = "Range";
+        /**
+         * {@code "Referer"}
+         */
+        public static final String REFERER = "Referer";
+        /**
+         * {@code "Retry-After"}
+         */
+        public static final String RETRY_AFTER = "Retry-After";
+        /**
+         * {@code "Sec-WebSocket-Key1"}
+         */
+        public static final String SEC_WEBSOCKET_KEY1 = "Sec-WebSocket-Key1";
+        /**
+         * {@code "Sec-WebSocket-Key2"}
+         */
+        public static final String SEC_WEBSOCKET_KEY2 = "Sec-WebSocket-Key2";
+        /**
+         * {@code "Sec-WebSocket-Location"}
+         */
+        public static final String SEC_WEBSOCKET_LOCATION = "Sec-WebSocket-Location";
+        /**
+         * {@code "Sec-WebSocket-Origin"}
+         */
+        public static final String SEC_WEBSOCKET_ORIGIN = "Sec-WebSocket-Origin";
+        /**
+         * {@code "Sec-WebSocket-Protocol"}
+         */
+        public static final String SEC_WEBSOCKET_PROTOCOL = "Sec-WebSocket-Protocol";
+        /**
+         * {@code "Sec-WebSocket-Version"}
+         */
+        public static final String SEC_WEBSOCKET_VERSION = "Sec-WebSocket-Version";
+        /**
+         * {@code "Sec-WebSocket-Key"}
+         */
+        public static final String SEC_WEBSOCKET_KEY = "Sec-WebSocket-Key";
+        /**
+         * {@code "Sec-WebSocket-Accept"}
+         */
+        public static final String SEC_WEBSOCKET_ACCEPT = "Sec-WebSocket-Accept";
+        /**
+         * {@code "Server"}
+         */
+        public static final String SERVER = "Server";
+        /**
+         * {@code "Set-Cookie"}
+         */
+        public static final String SET_COOKIE = "Set-Cookie";
+        /**
+         * {@code "Set-Cookie2"}
+         */
+        public static final String SET_COOKIE2 = "Set-Cookie2";
+        /**
+         * {@code "TE"}
+         */
+        public static final String TE = "TE";
+        /**
+         * {@code "Trailer"}
+         */
+        public static final String TRAILER = "Trailer";
+        /**
+         * {@code "Transfer-Encoding"}
+         */
+        public static final String TRANSFER_ENCODING = "Transfer-Encoding";
+        /**
+         * {@code "Upgrade"}
+         */
+        public static final String UPGRADE = "Upgrade";
+        /**
+         * {@code "User-Agent"}
+         */
+        public static final String USER_AGENT = "User-Agent";
+        /**
+         * {@code "Vary"}
+         */
+        public static final String VARY = "Vary";
+        /**
+         * {@code "Via"}
+         */
+        public static final String VIA = "Via";
+        /**
+         * {@code "Warning"}
+         */
+        public static final String WARNING = "Warning";
+        /**
+         * {@code "WebSocket-Location"}
+         */
+        public static final String WEBSOCKET_LOCATION = "WebSocket-Location";
+        /**
+         * {@code "WebSocket-Origin"}
+         */
+        public static final String WEBSOCKET_ORIGIN = "WebSocket-Origin";
+        /**
+         * {@code "WebSocket-Protocol"}
+         */
+        public static final String WEBSOCKET_PROTOCOL = "WebSocket-Protocol";
+        /**
+         * {@code "WWW-Authenticate"}
+         */
+        public static final String WWW_AUTHENTICATE = "WWW-Authenticate";
+
+        private Names() {
+        }
+    }
+
+    /**
+     * Standard HTTP header values.
+     */
+    final class Values {
+        /**
+         * {@code "application/x-www-form-urlencoded"}
+         */
+        public static final String APPLICATION_X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded";
+        /**
+         * {@code "base64"}
+         */
+        public static final String BASE64 = "base64";
+        /**
+         * {@code "binary"}
+         */
+        public static final String BINARY = "binary";
+        /**
+         * {@code "boundary"}
+         */
+        public static final String BOUNDARY = "boundary";
+        /**
+         * {@code "bytes"}
+         */
+        public static final String BYTES = "bytes";
+        /**
+         * {@code "charset"}
+         */
+        public static final String CHARSET = "charset";
+        /**
+         * {@code "chunked"}
+         */
+        public static final String CHUNKED = "chunked";
+        /**
+         * {@code "close"}
+         */
+        public static final String CLOSE = "close";
+        /**
+         * {@code "compress"}
+         */
+        public static final String COMPRESS = "compress";
+        /**
+         * {@code "100-continue"}
+         */
+        public static final String CONTINUE =  "100-continue";
+        /**
+         * {@code "deflate"}
+         */
+        public static final String DEFLATE = "deflate";
+        /**
+         * {@code "gzip"}
+         */
+        public static final String GZIP = "gzip";
+        /**
+         * {@code "identity"}
+         */
+        public static final String IDENTITY = "identity";
+        /**
+         * {@code "keep-alive"}
+         */
+        public static final String KEEP_ALIVE = "keep-alive";
+        /**
+         * {@code "max-age"}
+         */
+        public static final String MAX_AGE = "max-age";
+        /**
+         * {@code "max-stale"}
+         */
+        public static final String MAX_STALE = "max-stale";
+        /**
+         * {@code "min-fresh"}
+         */
+        public static final String MIN_FRESH = "min-fresh";
+        /**
+         * {@code "multipart/form-data"}
+         */
+        public static final String MULTIPART_FORM_DATA = "multipart/form-data";
+        /**
+         * {@code "must-revalidate"}
+         */
+        public static final String MUST_REVALIDATE = "must-revalidate";
+        /**
+         * {@code "no-cache"}
+         */
+        public static final String NO_CACHE = "no-cache";
+        /**
+         * {@code "no-store"}
+         */
+        public static final String NO_STORE = "no-store";
+        /**
+         * {@code "no-transform"}
+         */
+        public static final String NO_TRANSFORM = "no-transform";
+        /**
+         * {@code "none"}
+         */
+        public static final String NONE = "none";
+        /**
+         * {@code "only-if-cached"}
+         */
+        public static final String ONLY_IF_CACHED = "only-if-cached";
+        /**
+         * {@code "private"}
+         */
+        public static final String PRIVATE = "private";
+        /**
+         * {@code "proxy-revalidate"}
+         */
+        public static final String PROXY_REVALIDATE = "proxy-revalidate";
+        /**
+         * {@code "public"}
+         */
+        public static final String PUBLIC = "public";
+        /**
+         * {@code "quoted-printable"}
+         */
+        public static final String QUOTED_PRINTABLE = "quoted-printable";
+        /**
+         * {@code "s-maxage"}
+         */
+        public static final String S_MAXAGE = "s-maxage";
+        /**
+         * {@code "trailers"}
+         */
+        public static final String TRAILERS = "trailers";
+        /**
+         * {@code "Upgrade"}
+         */
+        public static final String UPGRADE = "Upgrade";
+        /**
+         * {@code "WebSocket"}
+         */
+        public static final String WEBSOCKET = "WebSocket";
+
+        private Values() {
+        }
+    }
+
+    // Properties related with a start line.
+
+    /**
+     * Tells if the current message is a request or a response.
+     */
+    HttpMessageType getType();
+
+    boolean isRequest();
+
+    boolean isResponse();
+
+    /**
+     * Returns the protocol version of the current message.
+     */
+    HttpVersion getVersion();
+
+    /**
+     * Sets the protocol version of the current message.
+     */
+    HttpHeaders setVersion(HttpVersion version);
+
+    /**
+     * Returns the method of the current message.
+     */
+    HttpMethod getMethod();
+
+    /**
+     * Sets the method of the current message.
+     */
+    HttpHeaders setMethod(HttpMethod method);
+
+    /**
+     * Returns the status of the current message.
+     */
+    HttpResponseStatus getStatus();
+
+    /**
+     * Sets the status of the current message.
+     */
+    HttpHeaders setStatus(HttpResponseStatus status);
+
+    /**
+     * Returns the URI of the current message.
+     */
+    String getUri();
+
+    /**
+     * Sets the URI of the current message.
+     */
+    HttpHeaders setUri(String uri);
+
+    /**
+     * Returns the value of the {@code "Host"} header.
+     */
+    String getHost();
+
+    /**
+     * Returns the value of the {@code "Host"} header.  If there is no such
+     * header, the {@code defaultValue} is returned.
+     */
+    String getHost(String defaultValue);
+
+    /**
+     * Sets the {@code "Host"} header.
+     */
+    HttpHeaders setHost(String value);
+
+    // Properties related with message flow.
+
+    /**
+     * Returns {@code true} if and only if the connection can remain open and
+     * thus 'kept alive'.  This methods respects the value of the
+     * {@code "Connection"} header first and then the return value of
+     * {@link HttpVersion#isKeepAliveDefault()}.
+     */
+    boolean isKeepAlive();
+
+    /**
+     * Sets the value of the {@code "Connection"} header depending on the
+     * protocol version of the specified message.  This getMethod sets or removes
+     * the {@code "Connection"} header depending on what the default keep alive
+     * mode of the message's protocol version is, as specified by
+     * {@link HttpVersion#isKeepAliveDefault()}.
+     * <ul>
+     * <li>If the connection is kept alive by default:
+     *     <ul>
+     *     <li>set to {@code "close"} if {@code keepAlive} is {@code false}.</li>
+     *     <li>remove otherwise.</li>
+     *     </ul></li>
+     * <li>If the connection is closed by default:
+     *     <ul>
+     *     <li>set to {@code "keep-alive"} if {@code keepAlive} is {@code true}.</li>
+     *     <li>remove otherwise.</li>
+     *     </ul></li>
+     * </ul>
+     */
+    HttpHeaders setKeepAlive(boolean keepAlive);
+
+    /**
+     * Returns {@code true} if and only if the specified message contains the
+     * {@code "Expect: 100-continue"} header.
+     */
+    boolean is100ContinueExpected();
+
+    /**
+     * Sets the {@code "Expect: 100-continue"} header to the specified message.
+     * If there is any existing {@code "Expect"} header, they are replaced with
+     * the new one.
+     */
+    HttpHeaders set100ContinueExpected(boolean expected);
+
+    // Validation methods
+
+    /**
+     * Validates the name of a header.  The default implementation conforms to HTTP/1.1.
+     *
+     * @param name The header name being validated
+     */
+    HttpHeaders validateName(String name);
+
+    /**
+     * Validates the specified header value.  The default implementation conforms to HTTP/1.1.
+     *
+     * @param value The value being validated
+     */
+    HttpHeaders validateValue(String value);
+
+    /**
+     * Returns the length of the content retrieved from the {@code "Content-Length"} header.
+     *
+     * @return the content length
+     *
+     * @throws NumberFormatException
+     *         if the message does not have the {@code "Content-Length"} header
+     *         or its value is not a number
+     */
+    long getContentLength();
+
+    /**
+     * Returns the length of the content retrieved from the {@code "Content-Length"} header.
+     *
+     * @return the content length or {@code defaultValue} if this message does
+     *         not have the {@code "Content-Length"} header or its value is not
+     *         a number
+     */
+    long getContentLength(long defaultValue);
+
+    /**
+     * Sets the {@code "Content-Length"} header.
+     */
+    HttpHeaders setContentLength(long length);
+
+    /**
+     * Checks to see if the transfer encoding in the current message is chunked
+     *
+     * @return {@code true} if and only if transfer encoding is chunked
+     */
+    boolean isTransferEncodingChunked();
+
+    HttpHeaders setTransferEncodingChunked(boolean chunked);
+
+    // Generic property accessors
+
+    /**
+     * Returns the value of a header with the specified name.  If there are
+     * more than one values for the specified name, the first value is returned.
+     *
+     * @param name The name of the header to search
+     * @return The first header value or {@code null} if there is no such header
+     */
+    String get(String name);
+
+    /**
+     * Returns the header value with the specified header name.  If there are
+     * more than one header value for the specified header name, the first
+     * value is returned.
+     *
+     * @return the header value or the {@code defaultValue} if there is no such
+     *         header
+     */
+    String get(String name, Object defaultValue);
+
+    /**
+     * Returns the integer header value with the specified header name.  If
+     * there are more than one header value for the specified header name, the
+     * first value is returned.
+     *
+     * @return the header value
+     * @throws NumberFormatException
+     *         if there is no such header or the header value is not a number
+     */
+    int getInt(String name);
+
+    /**
+     * Returns the integer header value with the specified header name.  If
+     * there are more than one header value for the specified header name, the
+     * first value is returned.
+     *
+     * @return the header value or the {@code defaultValue} if there is no such
+     *         header or the header value is not a number
+     */
+    int getInt(String name, int defaultValue);
+
+    /**
+     * Returns the date header value with the specified header name.  If
+     * there are more than one header value for the specified header name, the
+     * first value is returned.
+     *
+     * @return the header value
+     * @throws ParseException
+     *         if there is no such header or the header value is not a formatted date
+     */
+    Date getDate(String name) throws ParseException;
+
+    /**
+     * Returns the date header value with the specified header name.  If
+     * there are more than one header value for the specified header name, the
+     * first value is returned.
+     *
+     * @return the header value or the {@code defaultValue} if there is no such
+     *         header or the header value is not a formatted date
+     */
+    Date getDate(String name, Date defaultValue);
+
+    /**
+     * Returns the values of headers with the specified name
+     *
+     * @param name The name of the headers to search
+     * @return A {@link List} of header values which will be empty if no values
+     *         are found
+     */
+    List<String> getAll(String name);
+
+    /**
+     * Returns the all headers that this message contains.
+     *
+     * @return A {@link List} of the header name-value entries, which will be
+     *         empty if no pairs are found
+     */
+    List<Map.Entry<String, String>> entries();
+
+    /**
+     * Checks to see if there is a header with the specified name
+     *
+     * @param name The name of the header to search for
+     * @return True if at least one header is found
+     */
+    boolean contains(String name);
+
+    /**
+     * Checks if no header exists.
+     */
+    boolean isEmpty();
+
+    /**
+     * Gets a {@link Set} of all header names that this message contains
+     *
+     * @return A {@link Set} of all header names
+     */
+    Set<String> names();
+
+    /**
+     * Adds a new header with the specified name and value.
+     *
+     * If the specified value is not a {@link String}, it is converted
+     * into a {@link String} by {@link Object#toString()}, except in the cases
+     * of {@link Date} and {@link Calendar}, which are formatted to the date
+     * format defined in <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1">RFC2616</a>.
+     *
+     * @param name The name of the header being added
+     * @param value The value of the header being added
+     *
+     * @return {@code this}
+     */
+    HttpHeaders add(String name, Object value);
+
+    /**
+     * Adds a new header with the specified name and values.
+     *
+     * This getMethod can be represented approximately as the following code:
+     * <pre>
+     * for (Object v: values) {
+     *     if (v == null) {
+     *         break;
+     *     }
+     *     headers.add(name, v);
+     * }
+     * </pre>
+     *
+     * @param name The name of the headers being set
+     * @param values The values of the headers being set
+     * @return {@code this}
+     */
+    HttpHeaders add(String name, Iterable<?> values);
+
+    /**
+     * Adds all header entries of the specified {@code headers}.
+     *
+     * @return {@code this}
+     */
+    HttpHeaders add(HttpHeaders headers);
+
+    /**
+     * Sets a header with the specified name and value.
+     *
+     * If there is an existing header with the same name, it is removed.
+     * If the specified value is not a {@link String}, it is converted into a
+     * {@link String} by {@link Object#toString()}, except for {@link Date}
+     * and {@link Calendar}, which are formatted to the date format defined in
+     * <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1">RFC2616</a>.
+     *
+     * @param name The name of the header being set
+     * @param value The value of the header being set
+     * @return {@code this}
+     */
+    HttpHeaders set(String name, Object value);
+
+    /**
+     * Sets a header with the specified name and values.
+     *
+     * If there is an existing header with the same name, it is removed.
+     * This getMethod can be represented approximately as the following code:
+     * <pre>
+     * headers.remove(name);
+     * for (Object v: values) {
+     *     if (v == null) {
+     *         break;
+     *     }
+     *     headers.add(name, v);
+     * }
+     * </pre>
+     *
+     * @param name The name of the headers being set
+     * @param values The values of the headers being set
+     * @return {@code this}
+     */
+    HttpHeaders set(String name, Iterable<?> values);
+
+    /**
+     * Cleans the current header entries and copies all header entries of the specified {@code headers}.
+     *
+     * @return {@code this}
+     */
+    HttpHeaders set(HttpHeaders headers);
+
+    /**
+     * Removes the header with the specified name.
+     *
+     * @param name The name of the header to remove
+     * @return {@code this}
+     */
+    HttpHeaders remove(String name);
+
+    /**
+     * Removes the header with the specified name and value.
+     *
+     * @param name The name of the header to remove
+     * @return {@code this}
+     */
+    HttpHeaders remove(String name, Object value);
+
+    /**
+     * Removes all headers from this message.
+     *
+     * @return {@code this}
+     */
+    HttpHeaders clear();
+
+    /**
+     * Converts the specified object into a header value string.
+     */
+    String toString(Object value);
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/HttpMessage.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/HttpMessage.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.httpx;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.stream.Stream;
+import io.netty.handler.codec.http.HttpVersion;
+
+/**
+ */
+public interface HttpMessage {
+    HttpMessageType getType();
+
+    HttpVersion getVersion();
+    HttpMessage setVersion(HttpVersion version);
+
+    HttpHeaders getHeaders();
+
+    boolean hasTrailingHeaders();
+    HttpHeaders getTrailingHeaders();
+
+    boolean isContentStream();
+    Object getContent();
+    HttpMessage setContent(ByteBuf content);
+    HttpMessage setContent(Stream<ByteBuf> content);
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/HttpMessageType.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/HttpMessageType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.httpx;
+
+public enum HttpMessageType {
+    REQUEST,
+    RESPONSE,
+    TRAILER,
+    ;
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/HttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/HttpRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.httpx;
+
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.stream.Stream;
+import io.netty.handler.codec.http.ClientCookieEncoder;
+import io.netty.handler.codec.http.Cookie;
+import io.netty.handler.codec.http.CookieDecoder;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.codec.http.QueryStringEncoder;
+import io.netty.handler.codec.http.ServerCookieEncoder;
+
+/**
+ * An HTTP request.
+ *
+ * <h3>Accessing Query Parameters and Cookie</h3>
+ * <p>
+ * Unlike the Servlet API, a query string is constructed and decomposed by
+ * {@link QueryStringEncoder} and {@link QueryStringDecoder}.  {@link Cookie}
+ * support is also provided separately via {@link CookieDecoder}, {@link ClientCookieEncoder},
+ * and {@link @ServerCookieEncoder}.
+ *
+ * @see HttpResponse
+ * @see ClientCookieEncoder
+ * @see ServerCookieEncoder
+ * @see CookieDecoder
+ */
+public interface HttpRequest extends HttpMessage {
+
+    /**
+     * Returns the {@link HttpMethod} of this {@link HttpRequest}.
+     *
+     * @return The {@link HttpMethod} of this {@link HttpRequest}
+     */
+    HttpMethod getMethod();
+
+    /**
+     * Set the {@link HttpMethod} of this {@link HttpRequest}.
+     */
+    HttpRequest setMethod(HttpMethod method);
+
+    /**
+     * Returns the requested URI (or alternatively, path)
+     *
+     * @return The URI being requested
+     */
+    String getUri();
+
+    /**
+     *  Set the requested URI (or alternatively, path)
+     */
+    HttpRequest setUri(String uri);
+
+    @Override
+    HttpRequest setVersion(HttpVersion version);
+
+    @Override
+    HttpRequest setContent(ByteBuf content);
+
+    @Override
+    HttpRequest setContent(Stream<ByteBuf> content);
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/HttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/HttpResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.httpx;
+
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.stream.Stream;
+import io.netty.handler.codec.http.ClientCookieEncoder;
+import io.netty.handler.codec.http.Cookie;
+import io.netty.handler.codec.http.CookieDecoder;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.ServerCookieEncoder;
+
+/**
+ * An HTTP response.
+ *
+ * <h3>Accessing Cookies</h3>
+ * <p>
+ * Unlike the Servlet API, {@link Cookie} support is provided separately via {@link CookieDecoder},
+ * {@link ClientCookieEncoder}, and {@link ServerCookieEncoder}.
+ *
+ * @see HttpRequest
+ * @see CookieDecoder
+ * @see ClientCookieEncoder
+ * @see ServerCookieEncoder
+ */
+public interface HttpResponse extends HttpMessage {
+
+    /**
+     * Returns the status of this {@link HttpResponse}.
+     *
+     * @return The {@link HttpResponseStatus} of this {@link HttpResponse}
+     */
+    HttpResponseStatus getStatus();
+
+    /**
+     * Set the status of this {@link HttpResponse}.
+     */
+    HttpResponse setStatus(HttpResponseStatus status);
+
+    @Override
+    HttpResponse setVersion(HttpVersion version);
+
+    @Override
+    HttpResponse setContent(ByteBuf content);
+
+    @Override
+    HttpResponse setContent(Stream<ByteBuf> content);
+}

--- a/codec-http/src/main/java/io/netty/handler/codec/httpx/package-info.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/httpx/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Encoder, decoder and their related message types for HTTP.
+ */
+package io.netty.handler.codec.httpx;


### PR DESCRIPTION
This pull request provides a framework for exchanging a very large
stream between handlers, typically between a decoder and an inbound
handler (or between a handler that writes a message and an encoder that
encodes that message).

For example, an HTTP decoder, previously, generates multiple
micro-messages to decode an HTTP message (i.e. HttpRequest +
HttpChunks). With the streaming API, The HTTP decoder can simply
generate a single HTTP message whose content is a Stream. And then the
inbound handler can consume the Stream via the buffer you created when
you begin to read the stream. If you create a buffer whose capacity is
bounded, you can handle a very large stream without allocating a lot of
memory. If you just want to wait until the whole content is ready, you
can also do that with an unbounded buffer.

The streaming API also supports a limited form of communication between
a producer (i.e. decoder) and a consumer. A producer can abort the
stream if the stream is not valid anymore. A consumer can choose to
reject or discard the stream, where rejection is for unrecoverable
failure and discard is for recoverable failure.

P.S. Special thanks to @jpinner for the initial input.