### PR TITLE
Cleanup inappropriate @throws javadoc of some AsciiString util methods

### DIFF
--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -1690,7 +1690,6 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
      * @param startPos  the start position, negative treated as zero
      * @return the first index of the search CharSequence (always &ge; startPos),
      *  -1 if no match or {@code null} string input
-     * @throws NullPointerException if {@code cs} or {@code string} is {@code null}.
      */
     public static int indexOfIgnoreCase(final CharSequence str, final CharSequence searchStr, int startPos) {
         if (str == null || searchStr == null) {
@@ -1744,7 +1743,6 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
      * @param startPos  the start position, negative treated as zero
      * @return the first index of the search CharSequence (always &ge; startPos),
      *  -1 if no match or {@code null} string input
-     * @throws NullPointerException if {@code cs} or {@code string} is {@code null}.
      */
     public static int indexOfIgnoreCaseAscii(final CharSequence str, final CharSequence searchStr, int startPos) {
         if (str == null || searchStr == null) {


### PR DESCRIPTION
Motivation:
During the old story https://github.com/netty/netty/pull/4456 some inappropriate ```@throws``` javadocs have been produced.

Modifications:
Delete @throws lines that don't meet actual behavior.
