### PR TITLE
Allow setting non-default Http/2 server initial settings

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Codec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Codec.java
@@ -45,19 +45,44 @@ public final class Http2Codec extends ChannelDuplexHandler {
     }
 
     /**
+     * Construct a new handler whose child channels run in the same event loop as this handler.
+     *
+     * @param server {@code true} this is a server
+     * @param streamHandler the handler added to channels for remotely-created streams. It must be
+     *     {@link ChannelHandler.Sharable}. {@code null} if the event loop from the parent channel should be used.
+     * @param initialSettings non default initial settings to send to peer
+     */
+    public Http2Codec(boolean server, ChannelHandler streamHandler, Http2Settings initialSettings) {
+        this(server, new Http2StreamChannelBootstrap().handler(streamHandler), HTTP2_FRAME_LOGGER,
+            initialSettings);
+    }
+
+    /**
      * Construct a new handler whose child channels run in a different event loop.
      *
      * @param server {@code true} this is a server
      * @param bootstrap bootstrap used to instantiate child channels for remotely-created streams.
      */
     public Http2Codec(boolean server, Http2StreamChannelBootstrap bootstrap, Http2FrameLogger frameLogger) {
-        this(server, bootstrap, new DefaultHttp2FrameWriter(), frameLogger);
+        this(server, bootstrap, new DefaultHttp2FrameWriter(), frameLogger, new Http2Settings());
+    }
+
+    /**
+     * Construct a new handler whose child channels run in a different event loop.
+     *
+     * @param server {@code true} this is a server
+     * @param bootstrap bootstrap used to instantiate child channels for remotely-created streams.
+     * @param initialSettings non default initial settings to send to peer
+     */
+    public Http2Codec(boolean server, Http2StreamChannelBootstrap bootstrap, Http2FrameLogger frameLogger,
+                      Http2Settings initialSettings) {
+        this(server, bootstrap, new DefaultHttp2FrameWriter(), frameLogger, initialSettings);
     }
 
     // Visible for testing
     Http2Codec(boolean server, Http2StreamChannelBootstrap bootstrap, Http2FrameWriter frameWriter,
-               Http2FrameLogger frameLogger) {
-        frameCodec = new Http2FrameCodec(server, frameWriter, frameLogger);
+               Http2FrameLogger frameLogger, Http2Settings initialSettings) {
+        frameCodec = new Http2FrameCodec(server, frameWriter, frameLogger, initialSettings);
         multiplexCodec = new Http2MultiplexCodec(server, bootstrap);
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -127,11 +127,12 @@ public class Http2FrameCodec extends ChannelDuplexHandler {
      * @param server {@code true} this is a server
      */
     public Http2FrameCodec(boolean server, Http2FrameLogger frameLogger) {
-        this(server, new DefaultHttp2FrameWriter(), frameLogger);
+        this(server, new DefaultHttp2FrameWriter(), frameLogger, new Http2Settings());
     }
 
     // Visible for testing
-    Http2FrameCodec(boolean server, Http2FrameWriter frameWriter, Http2FrameLogger frameLogger) {
+    Http2FrameCodec(boolean server, Http2FrameWriter frameWriter, Http2FrameLogger frameLogger,
+                    Http2Settings initialSettings) {
         Http2Connection connection = new DefaultHttp2Connection(server);
         frameWriter = new Http2OutboundFrameLogger(frameWriter, frameLogger);
         Http2ConnectionEncoder encoder = new DefaultHttp2ConnectionEncoder(connection, frameWriter);
@@ -139,7 +140,7 @@ public class Http2FrameCodec extends ChannelDuplexHandler {
         Http2FrameReader reader = new Http2InboundFrameLogger(frameReader, frameLogger);
         Http2ConnectionDecoder decoder = new DefaultHttp2ConnectionDecoder(connection, encoder, reader);
         decoder.frameListener(new FrameListener());
-        http2Handler = new InternalHttp2ConnectionHandler(decoder, encoder, new Http2Settings());
+        http2Handler = new InternalHttp2ConnectionHandler(decoder, encoder, initialSettings);
         http2Handler.connection().addListener(new ConnectionListener());
         this.server = server;
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -70,7 +70,8 @@ public class Http2FrameCodecTest {
     @Before
     public void setUp() throws Exception {
         frameWriter = spy(new VerifiableHttp2FrameWriter());
-        framingCodec = new Http2FrameCodec(true, frameWriter, new Http2FrameLogger(LogLevel.TRACE));
+        framingCodec = new Http2FrameCodec(true, frameWriter, new Http2FrameLogger(LogLevel.TRACE),
+                                           new Http2Settings());
         frameListener = ((DefaultHttp2ConnectionDecoder) framingCodec.connectionHandler().decoder())
                 .internalFrameListener();
         inboundHandler = new LastInboundHandler();


### PR DESCRIPTION
Allow setting non-default Http/2 server initial settings

Motivation:

Currently it is not possible to have an Http/2 server send non default initial settings to clients when doing the initial connection handshake

Modifications:

Add additional constructors to Http2Codec allowing users to specify the initial settings to send to the client and apply locally

Result:

You can now specify non default initial settings