### PR TITLE
Eliminate usage of releaseLater(...) to reduce memory usage during tests

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -1142,7 +1142,7 @@ public abstract class AbstractByteBufTest {
     @Test
     public void testRandomDirectBufferTransfer() {
         byte[] tmp = new byte[BLOCK_SIZE * 2];
-        ByteBuf value = releaseLater(directBuffer(BLOCK_SIZE * 2));
+        ByteBuf value = directBuffer(BLOCK_SIZE * 2);
         for (int i = 0; i < buffer.capacity() - BLOCK_SIZE + 1; i += BLOCK_SIZE) {
             random.nextBytes(tmp);
             value.setBytes(0, tmp, 0, value.capacity());
@@ -1150,7 +1150,7 @@ public abstract class AbstractByteBufTest {
         }
 
         random.setSeed(seed);
-        ByteBuf expectedValue = releaseLater(directBuffer(BLOCK_SIZE * 2));
+        ByteBuf expectedValue = directBuffer(BLOCK_SIZE * 2);
         for (int i = 0; i < buffer.capacity() - BLOCK_SIZE + 1; i += BLOCK_SIZE) {
             random.nextBytes(tmp);
             expectedValue.setBytes(0, tmp, 0, expectedValue.capacity());
@@ -1160,6 +1160,8 @@ public abstract class AbstractByteBufTest {
                 assertEquals(expectedValue.getByte(j), value.getByte(j));
             }
         }
+        value.release();
+        expectedValue.release();
     }
 
     @Test
@@ -1306,7 +1308,7 @@ public abstract class AbstractByteBufTest {
     @Test
     public void testSequentialDirectBufferTransfer1() {
         byte[] valueContent = new byte[BLOCK_SIZE * 2];
-        ByteBuf value = releaseLater(directBuffer(BLOCK_SIZE * 2));
+        ByteBuf value = directBuffer(BLOCK_SIZE * 2);
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity() - BLOCK_SIZE + 1; i += BLOCK_SIZE) {
             random.nextBytes(valueContent);
@@ -1320,7 +1322,7 @@ public abstract class AbstractByteBufTest {
 
         random.setSeed(seed);
         byte[] expectedValueContent = new byte[BLOCK_SIZE * 2];
-        ByteBuf expectedValue = releaseLater(wrappedBuffer(expectedValueContent));
+        ByteBuf expectedValue = wrappedBuffer(expectedValueContent);
         for (int i = 0; i < buffer.capacity() - BLOCK_SIZE + 1; i += BLOCK_SIZE) {
             random.nextBytes(expectedValueContent);
             int valueOffset = random.nextInt(BLOCK_SIZE);
@@ -1334,12 +1336,14 @@ public abstract class AbstractByteBufTest {
             assertEquals(0, value.readerIndex());
             assertEquals(0, value.writerIndex());
         }
+        value.release();
+        expectedValue.release();
     }
 
     @Test
     public void testSequentialDirectBufferTransfer2() {
         byte[] valueContent = new byte[BLOCK_SIZE * 2];
-        ByteBuf value = releaseLater(directBuffer(BLOCK_SIZE * 2));
+        ByteBuf value = directBuffer(BLOCK_SIZE * 2);
         buffer.writerIndex(0);
         for (int i = 0; i < buffer.capacity() - BLOCK_SIZE + 1; i += BLOCK_SIZE) {
             random.nextBytes(valueContent);
@@ -1357,7 +1361,7 @@ public abstract class AbstractByteBufTest {
 
         random.setSeed(seed);
         byte[] expectedValueContent = new byte[BLOCK_SIZE * 2];
-        ByteBuf expectedValue = releaseLater(wrappedBuffer(expectedValueContent));
+        ByteBuf expectedValue = wrappedBuffer(expectedValueContent);
         for (int i = 0; i < buffer.capacity() - BLOCK_SIZE + 1; i += BLOCK_SIZE) {
             random.nextBytes(expectedValueContent);
             value.setBytes(0, valueContent);
@@ -1373,6 +1377,8 @@ public abstract class AbstractByteBufTest {
             assertEquals(valueOffset, value.readerIndex());
             assertEquals(valueOffset + BLOCK_SIZE, value.writerIndex());
         }
+        value.release();
+        expectedValue.release();
     }
 
     @Test
@@ -1563,7 +1569,7 @@ public abstract class AbstractByteBufTest {
         for (int i = 0; i < buffer.capacity(); i += 4) {
             buffer.writeInt(i);
         }
-        ByteBuf copy = releaseLater(copiedBuffer(buffer));
+        ByteBuf copy = copiedBuffer(buffer);
 
         // Make sure there's no effect if called when readerIndex is 0.
         buffer.readerIndex(CAPACITY / 4);
@@ -1603,6 +1609,7 @@ public abstract class AbstractByteBufTest {
         assertEquals(CAPACITY / 4 - 1, buffer.readerIndex());
         buffer.resetWriterIndex();
         assertEquals(CAPACITY / 3 - 1, buffer.writerIndex());
+        copy.release();
     }
 
     /**
@@ -1615,7 +1622,7 @@ public abstract class AbstractByteBufTest {
         for (int i = 0; i < buffer.capacity(); i ++) {
             buffer.writeByte((byte) i);
         }
-        ByteBuf copy = releaseLater(copiedBuffer(buffer));
+        ByteBuf copy = copiedBuffer(buffer);
 
         // Discard the first (CAPACITY / 2 - 1) bytes.
         buffer.setIndex(CAPACITY / 2 - 1, CAPACITY - 1);
@@ -1625,6 +1632,7 @@ public abstract class AbstractByteBufTest {
         for (int i = 0; i < CAPACITY / 2; i ++) {
             assertEquals(copy.slice(CAPACITY / 2 - 1 + i, CAPACITY / 2 - i), buffer.slice(i, CAPACITY / 2 - i));
         }
+        copy.release();
     }
 
     @Test
@@ -1681,7 +1689,7 @@ public abstract class AbstractByteBufTest {
         buffer.setIndex(readerIndex, writerIndex);
 
         // Make sure all properties are copied.
-        ByteBuf copy = releaseLater(buffer.copy());
+        ByteBuf copy = buffer.copy();
         assertEquals(0, copy.readerIndex());
         assertEquals(buffer.readableBytes(), copy.writerIndex());
         assertEquals(buffer.readableBytes(), copy.capacity());
@@ -1695,6 +1703,7 @@ public abstract class AbstractByteBufTest {
         assertTrue(buffer.getByte(readerIndex) != copy.getByte(0));
         copy.setByte(1, (byte) (copy.getByte(1) + 1));
         assertTrue(buffer.getByte(readerIndex + 1) != copy.getByte(1));
+        copy.release();
     }
 
     @Test
@@ -1847,9 +1856,11 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testToString() {
+        ByteBuf copied = copiedBuffer("Hello, World!", CharsetUtil.ISO_8859_1);
         buffer.clear();
-        buffer.writeBytes(releaseLater(copiedBuffer("Hello, World!", CharsetUtil.ISO_8859_1)));
+        buffer.writeBytes(copied);
         assertEquals("Hello, World!", buffer.toString(CharsetUtil.ISO_8859_1));
+        copied.release();
     }
 
     @Test
@@ -1932,8 +1943,8 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testHashCode() {
-        ByteBuf elemA = releaseLater(buffer(15));
-        ByteBuf elemB = releaseLater(directBuffer(15));
+        ByteBuf elemA = buffer(15);
+        ByteBuf elemB = directBuffer(15);
         elemA.writeBytes(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5 });
         elemB.writeBytes(new byte[] { 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9 });
 
@@ -1942,9 +1953,10 @@ public abstract class AbstractByteBufTest {
         set.add(elemB);
 
         assertEquals(2, set.size());
-        assertTrue(set.contains(releaseLater(elemA.copy())));
+        ByteBuf elemACopy = elemA.copy();
+        assertTrue(set.contains(elemACopy));
 
-        ByteBuf elemBCopy = releaseLater(elemB.copy());
+        ByteBuf elemBCopy = elemB.copy();
         assertTrue(set.contains(elemBCopy));
 
         buffer.clear();
@@ -1959,6 +1971,10 @@ public abstract class AbstractByteBufTest {
         assertTrue(set.remove(buffer));
         assertFalse(set.contains(elemB));
         assertEquals(0, set.size());
+        elemA.release();
+        elemB.release();
+        elemACopy.release();
+        elemBCopy.release();
     }
 
     // Test case for https://github.com/netty/netty/issues/325
@@ -2051,7 +2067,7 @@ public abstract class AbstractByteBufTest {
     }
 
     private void testInternalNioBuffer(int a) {
-        ByteBuf buffer = releaseLater(newBuffer(2));
+        ByteBuf buffer = newBuffer(2);
         ByteBuffer buf = buffer.internalNioBuffer(0, 1);
         assertEquals(1, buf.remaining());
 
@@ -2066,6 +2082,7 @@ public abstract class AbstractByteBufTest {
             assertEquals(data[i], buf.get());
         }
         assertFalse(buf.hasRemaining());
+        buffer.release();
     }
 
     @Test
@@ -2082,7 +2099,7 @@ public abstract class AbstractByteBufTest {
         final byte[] bytes = new byte[8];
         random.nextBytes(bytes);
 
-        final ByteBuf buffer = releaseLater(newBuffer(8));
+        final ByteBuf buffer = newBuffer(8);
         buffer.writeBytes(bytes);
         final CountDownLatch latch = new CountDownLatch(60000);
         final CyclicBarrier barrier = new CyclicBarrier(11);
@@ -2120,6 +2137,7 @@ public abstract class AbstractByteBufTest {
         }
         latch.await(10, TimeUnit.SECONDS);
         barrier.await(5, TimeUnit.SECONDS);
+        buffer.release();
     }
 
     @Test
@@ -2136,7 +2154,7 @@ public abstract class AbstractByteBufTest {
         final byte[] bytes = new byte[8];
         random.nextBytes(bytes);
 
-        final ByteBuf buffer = releaseLater(newBuffer(8));
+        final ByteBuf buffer = newBuffer(8);
         buffer.writeBytes(bytes);
         final CountDownLatch latch = new CountDownLatch(60000);
         final CyclicBarrier barrier = new CyclicBarrier(11);
@@ -2174,6 +2192,7 @@ public abstract class AbstractByteBufTest {
         }
         latch.await(10, TimeUnit.SECONDS);
         barrier.await(5, TimeUnit.SECONDS);
+        buffer.release();
     }
 
     @Test
@@ -2190,7 +2209,7 @@ public abstract class AbstractByteBufTest {
         final byte[] bytes = new byte[8];
         random.nextBytes(bytes);
 
-        final ByteBuf buffer = releaseLater(newBuffer(8));
+        final ByteBuf buffer = newBuffer(8);
         buffer.writeBytes(bytes);
         final AtomicReference<Throwable> cause = new AtomicReference<Throwable>();
         final CountDownLatch latch = new CountDownLatch(60000);
@@ -2229,20 +2248,25 @@ public abstract class AbstractByteBufTest {
         latch.await(10, TimeUnit.SECONDS);
         barrier.await(5, TimeUnit.SECONDS);
         assertNull(cause.get());
+        buffer.release();
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void readByteThrowsIndexOutOfBoundsException() {
-        final ByteBuf buffer = releaseLater(newBuffer(8));
-        buffer.writeByte(0);
-        assertEquals((byte) 0, buffer.readByte());
-        buffer.readByte();
+        final ByteBuf buffer = newBuffer(8);
+        try {
+            buffer.writeByte(0);
+            assertEquals((byte) 0, buffer.readByte());
+            buffer.readByte();
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test
     @SuppressWarnings("ForLoopThatDoesntUseLoopVariable")
     public void testNioBufferExposeOnlyRegion() {
-        final ByteBuf buffer = releaseLater(newBuffer(8));
+        final ByteBuf buffer = newBuffer(8);
         byte[] data = new byte[8];
         random.nextBytes(data);
         buffer.writeBytes(data);
@@ -2254,6 +2278,7 @@ public abstract class AbstractByteBufTest {
         for (int i = 1; nioBuf.hasRemaining(); i++) {
             assertEquals(data[i], nioBuf.get());
         }
+        buffer.release();
     }
 
     // See:
@@ -2261,9 +2286,10 @@ public abstract class AbstractByteBufTest {
     // - https://github.com/netty/netty/issues/2580
     @Test
     public void testLittleEndianWithExpand() {
-        ByteBuf buffer = releaseLater(newBuffer(0)).order(LITTLE_ENDIAN);
+        ByteBuf buffer = newBuffer(0).order(LITTLE_ENDIAN);
         buffer.writeInt(0x12345678);
         assertEquals("78563412", ByteBufUtil.hexDump(buffer));
+        buffer.release();
     }
 
     private ByteBuf releasedBuffer() {
@@ -2384,17 +2410,32 @@ public abstract class AbstractByteBufTest {
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testGetBytesAfterRelease() {
-        releasedBuffer().getBytes(0, releaseLater(buffer(8)));
+        ByteBuf buffer = buffer(8);
+        try {
+            releasedBuffer().getBytes(0, buffer);
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testGetBytesAfterRelease2() {
-        releasedBuffer().getBytes(0, releaseLater(buffer()), 1);
+        ByteBuf buffer = buffer();
+        try {
+            releasedBuffer().getBytes(0, buffer, 1);
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testGetBytesAfterRelease3() {
-        releasedBuffer().getBytes(0, releaseLater(buffer()), 0, 1);
+        ByteBuf buffer = buffer();
+        try {
+            releasedBuffer().getBytes(0, buffer, 0, 1);
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2489,17 +2530,32 @@ public abstract class AbstractByteBufTest {
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testSetBytesAfterRelease() {
-        releasedBuffer().setBytes(0, releaseLater(buffer()));
+        ByteBuf buffer = buffer();
+        try {
+            releasedBuffer().setBytes(0, buffer);
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testSetBytesAfterRelease2() {
-        releasedBuffer().setBytes(0, releaseLater(buffer()), 1);
+        ByteBuf buffer = buffer();
+        try {
+            releasedBuffer().setBytes(0, buffer, 1);
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testSetBytesAfterRelease3() {
-        releasedBuffer().setBytes(0, releaseLater(buffer()), 0, 1);
+        ByteBuf buffer = buffer();
+        try {
+            releasedBuffer().setBytes(0, buffer, 0, 1);
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2639,17 +2695,32 @@ public abstract class AbstractByteBufTest {
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testReadBytesAfterRelease2() {
-        releasedBuffer().readBytes(releaseLater(buffer(8)));
+        ByteBuf buffer = buffer(8);
+        try {
+            releasedBuffer().readBytes(buffer);
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testReadBytesAfterRelease3() {
-        releasedBuffer().readBytes(releaseLater(buffer(8), 1));
+        ByteBuf buffer = buffer(8);
+        try {
+            releasedBuffer().readBytes(buffer);
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testReadBytesAfterRelease4() {
-        releasedBuffer().readBytes(releaseLater(buffer(8)), 0, 1);
+        ByteBuf buffer = buffer(8);
+        try {
+            releasedBuffer().readBytes(buffer, 0, 1);
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2749,17 +2820,32 @@ public abstract class AbstractByteBufTest {
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testWriteBytesAfterRelease() {
-        releasedBuffer().writeBytes(releaseLater(buffer(8)));
+        ByteBuf buffer = buffer(8);
+        try {
+            releasedBuffer().writeBytes(buffer);
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testWriteBytesAfterRelease2() {
-        releasedBuffer().writeBytes(releaseLater(copiedBuffer(new byte[8])), 1);
+        ByteBuf buffer = copiedBuffer(new byte[8]);
+        try {
+            releasedBuffer().writeBytes(buffer, 1);
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testWriteBytesAfterRelease3() {
-        releasedBuffer().writeBytes(releaseLater(buffer(8)), 0, 1);
+        ByteBuf buffer = buffer(8);
+        try {
+            releasedBuffer().writeBytes(buffer, 0, 1);
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test(expected = IllegalReferenceCountException.class)
@@ -2962,7 +3048,7 @@ public abstract class AbstractByteBufTest {
     }
 
     private void testDuplicateCapacityChange(boolean retainedDuplicate) {
-        ByteBuf buf = releaseLater(newBuffer(8));
+        ByteBuf buf = newBuffer(8);
         ByteBuf dup = retainedDuplicate ? buf.retainedDuplicate() : buf.duplicate();
         try {
             dup.capacity(10);
@@ -2973,11 +3059,12 @@ public abstract class AbstractByteBufTest {
             if (retainedDuplicate) {
                 dup.release();
             }
+            buf.release();
         }
     }
 
     private void testSliceCapacityChange(boolean retainedSlice) {
-        ByteBuf buf = releaseLater(newBuffer(8));
+        ByteBuf buf = newBuffer(8);
         ByteBuf slice = retainedSlice ? buf.retainedSlice(buf.readerIndex() + 1, 3)
                                       : buf.slice(buf.readerIndex() + 1, 3);
         try {
@@ -2986,11 +3073,12 @@ public abstract class AbstractByteBufTest {
             if (retainedSlice) {
                 slice.release();
             }
+            buf.release();
         }
     }
 
     private void testSliceOutOfBounds(boolean initRetainedSlice, boolean finalRetainedSlice, boolean indexOutOfBounds) {
-        ByteBuf buf = releaseLater(newBuffer(8));
+        ByteBuf buf = newBuffer(8);
         ByteBuf slice = initRetainedSlice ? buf.retainedSlice(buf.readerIndex() + 1, 2)
                                           : buf.slice(buf.readerIndex() + 1, 2);
         try {
@@ -3008,12 +3096,13 @@ public abstract class AbstractByteBufTest {
             if (initRetainedSlice) {
                 slice.release();
             }
+            buf.release();
         }
     }
 
     private void testSliceContents(boolean retainedSlice) {
-        ByteBuf buf = releaseLater(newBuffer(8)).resetWriterIndex();
-        ByteBuf expected = releaseLater(newBuffer(3)).resetWriterIndex();
+        ByteBuf buf = newBuffer(8).resetWriterIndex();
+        ByteBuf expected = newBuffer(3).resetWriterIndex();
         buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
         expected.writeBytes(new byte[] {4, 5, 6});
         ByteBuf slice = retainedSlice ? buf.retainedSlice(buf.readerIndex() + 3, 3)
@@ -3021,28 +3110,35 @@ public abstract class AbstractByteBufTest {
         try {
             assertEquals(0, slice.compareTo(expected));
             assertEquals(0, slice.compareTo(slice.duplicate()));
-            assertEquals(0, slice.compareTo(releaseLater(slice.retainedDuplicate())));
+            ByteBuf b = slice.retainedDuplicate();
+            assertEquals(0, slice.compareTo(b));
+            b.release();
             assertEquals(0, slice.compareTo(slice.slice(0, slice.capacity())));
         } finally {
             if (retainedSlice) {
                 slice.release();
             }
+            buf.release();
+            expected.release();
         }
     }
 
     private void testDuplicateContents(boolean retainedDuplicate) {
-        ByteBuf buf = releaseLater(newBuffer(8)).resetWriterIndex();
+        ByteBuf buf = newBuffer(8).resetWriterIndex();
         buf.writeBytes(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
         ByteBuf dup = retainedDuplicate ? buf.retainedDuplicate() : buf.duplicate();
         try {
             assertEquals(0, dup.compareTo(buf));
             assertEquals(0, dup.compareTo(dup.duplicate()));
-            assertEquals(0, dup.compareTo(releaseLater(dup.retainedDuplicate())));
+            ByteBuf b = dup.retainedDuplicate();
+            assertEquals(0, dup.compareTo(b));
+            b.release();
             assertEquals(0, dup.compareTo(dup.slice(0, dup.capacity())));
         } finally {
             if (retainedDuplicate) {
                 dup.release();
             }
+            buf.release();
         }
     }
 
@@ -3070,12 +3166,13 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testEmptyNioBuffers() throws Exception {
-        ByteBuf buffer = releaseLater(newBuffer(8));
+        ByteBuf buffer = newBuffer(8);
         buffer.clear();
         assertFalse(buffer.isReadable());
         ByteBuffer[] nioBuffers = buffer.nioBuffers();
         assertEquals(1, nioBuffers.length);
         assertFalse(nioBuffers[0].hasRemaining());
+        buffer.release();
     }
 
     @Test
@@ -3091,7 +3188,7 @@ public abstract class AbstractByteBufTest {
     private void testGetReadOnlyDst(boolean direct) {
         byte[] bytes = { 'a', 'b', 'c', 'd' };
 
-        ByteBuf buffer = releaseLater(newBuffer(bytes.length));
+        ByteBuf buffer = newBuffer(bytes.length);
         buffer.writeBytes(bytes);
 
         ByteBuffer dst = direct ? ByteBuffer.allocateDirect(bytes.length) : ByteBuffer.allocate(bytes.length);
@@ -3103,6 +3200,7 @@ public abstract class AbstractByteBufTest {
             // expected
         }
         assertEquals(0, readOnlyDst.position());
+        buffer.release();
     }
 
     @Test
@@ -3117,7 +3215,7 @@ public abstract class AbstractByteBufTest {
 
             byte[] bytes = {'a', 'b', 'c', 'd'};
             int len = bytes.length;
-            ByteBuf buffer = releaseLater(newBuffer(len));
+            ByteBuf buffer = newBuffer(len);
             buffer.resetReaderIndex();
             buffer.resetWriterIndex();
             buffer.writeBytes(bytes);
@@ -3127,7 +3225,7 @@ public abstract class AbstractByteBufTest {
             assertEquals(oldReaderIndex + len, buffer.readerIndex());
             assertEquals(channelPosition, channel.position());
 
-            ByteBuf buffer2 = releaseLater(newBuffer(len));
+            ByteBuf buffer2 = newBuffer(len);
             buffer2.resetReaderIndex();
             buffer2.resetWriterIndex();
             int oldWriterIndex = buffer2.writerIndex();
@@ -3138,6 +3236,8 @@ public abstract class AbstractByteBufTest {
             assertEquals('b', buffer2.getByte(1));
             assertEquals('c', buffer2.getByte(2));
             assertEquals('d', buffer2.getByte(3));
+            buffer.release();
+            buffer2.release();
         } finally {
             if (randomAccessFile != null) {
                 randomAccessFile.close();
@@ -3158,7 +3258,7 @@ public abstract class AbstractByteBufTest {
 
             byte[] bytes = {'a', 'b', 'c', 'd'};
             int len = bytes.length;
-            ByteBuf buffer = releaseLater(newBuffer(len));
+            ByteBuf buffer = newBuffer(len);
             buffer.resetReaderIndex();
             buffer.resetWriterIndex();
             buffer.writeBytes(bytes);
@@ -3168,7 +3268,7 @@ public abstract class AbstractByteBufTest {
             assertEquals(oldReaderIndex, buffer.readerIndex());
             assertEquals(channelPosition, channel.position());
 
-            ByteBuf buffer2 = releaseLater(newBuffer(len));
+            ByteBuf buffer2 = newBuffer(len);
             buffer2.resetReaderIndex();
             buffer2.resetWriterIndex();
             int oldWriterIndex = buffer2.writerIndex();
@@ -3180,6 +3280,9 @@ public abstract class AbstractByteBufTest {
             assertEquals('b', buffer2.getByte(oldWriterIndex + 1));
             assertEquals('c', buffer2.getByte(oldWriterIndex + 2));
             assertEquals('d', buffer2.getByte(oldWriterIndex + 3));
+
+            buffer.release();
+            buffer2.release();
         } finally {
             if (randomAccessFile != null) {
                 randomAccessFile.close();

--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import static io.netty.buffer.Unpooled.*;
-import static io.netty.util.ReferenceCountUtil.*;
 import static io.netty.util.internal.EmptyArrays.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
@@ -96,8 +95,8 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
      */
     @Test
     public void testComponentAtOffset() {
-        CompositeByteBuf buf = releaseLater((CompositeByteBuf) wrappedBuffer(new byte[]{1, 2, 3, 4, 5},
-                new byte[]{4, 5, 6, 7, 8, 9, 26}));
+        CompositeByteBuf buf = (CompositeByteBuf) wrappedBuffer(new byte[]{1, 2, 3, 4, 5},
+                new byte[]{4, 5, 6, 7, 8, 9, 26});
 
         //Ensure that a random place will be fine
         assertEquals(5, buf.componentAtOffset(2).capacity());
@@ -113,15 +112,17 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
             assertNotNull(_buf.getByte(0));
             assertNotNull(_buf.getByte(_buf.readableBytes() - 1));
         }
+
+        buf.release();
     }
 
     @Test
     public void testDiscardReadBytes3() {
         ByteBuf a, b;
         a = wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).order(order);
-        b = releaseLater(wrappedBuffer(
+        b = wrappedBuffer(
                 wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, 0, 5).order(order),
-                wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, 5, 5).order(order)));
+                wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, 5, 5).order(order));
         a.skipBytes(6);
         a.markReaderIndex();
         b.skipBytes(6);
@@ -152,11 +153,14 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         b.resetWriterIndex();
         assertEquals(a.writerIndex(), b.writerIndex());
         assertTrue(ByteBufUtil.equals(a, b));
+
+        a.release();
+        b.release();
     }
 
     @Test
     public void testAutoConsolidation() {
-        CompositeByteBuf buf = releaseLater(compositeBuffer(2));
+        CompositeByteBuf buf = compositeBuffer(2);
 
         buf.addComponent(wrappedBuffer(new byte[] { 1 }));
         assertEquals(1, buf.numComponents());
@@ -170,11 +174,13 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         assertTrue(buf.hasArray());
         assertNotNull(buf.array());
         assertEquals(0, buf.arrayOffset());
+
+        buf.release();
     }
 
     @Test
     public void testCompositeToSingleBuffer() {
-        CompositeByteBuf buf = releaseLater(compositeBuffer(3));
+        CompositeByteBuf buf = compositeBuffer(3);
 
         buf.addComponent(wrappedBuffer(new byte[] {1, 2, 3}));
         assertEquals(1, buf.numComponents());
@@ -191,11 +197,13 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         byte[] bytes = nioBuffer.array();
         assertEquals(6, bytes.length);
         assertArrayEquals(new byte[] {1, 2, 3, 4, 5, 6}, bytes);
+
+        buf.release();
     }
 
     @Test
     public void testFullConsolidation() {
-        CompositeByteBuf buf = releaseLater(compositeBuffer(Integer.MAX_VALUE));
+        CompositeByteBuf buf = compositeBuffer(Integer.MAX_VALUE);
         buf.addComponent(wrappedBuffer(new byte[] { 1 }));
         buf.addComponent(wrappedBuffer(new byte[] { 2, 3 }));
         buf.addComponent(wrappedBuffer(new byte[] { 4, 5, 6 }));
@@ -205,11 +213,13 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         assertTrue(buf.hasArray());
         assertNotNull(buf.array());
         assertEquals(0, buf.arrayOffset());
+
+        buf.release();
     }
 
     @Test
     public void testRangedConsolidation() {
-        CompositeByteBuf buf = releaseLater(compositeBuffer(Integer.MAX_VALUE));
+        CompositeByteBuf buf = compositeBuffer(Integer.MAX_VALUE);
         buf.addComponent(wrappedBuffer(new byte[] { 1 }));
         buf.addComponent(wrappedBuffer(new byte[] { 2, 3 }));
         buf.addComponent(wrappedBuffer(new byte[] { 4, 5, 6 }));
@@ -220,23 +230,27 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         assertEquals(wrappedBuffer(new byte[] { 1 }), buf.component(0));
         assertEquals(wrappedBuffer(new byte[] { 2, 3, 4, 5, 6 }), buf.component(1));
         assertEquals(wrappedBuffer(new byte[] { 7, 8, 9, 10 }), buf.component(2));
+
+        buf.release();
     }
 
     @Test
     public void testCompositeWrappedBuffer() {
-        ByteBuf header = releaseLater(buffer(12)).order(order);
-        ByteBuf payload = releaseLater(buffer(512)).order(order);
+        ByteBuf header = buffer(12).order(order);
+        ByteBuf payload = buffer(512).order(order);
 
         header.writeBytes(new byte[12]);
         payload.writeBytes(new byte[512]);
 
-        ByteBuf buffer = releaseLater(wrappedBuffer(header, payload));
+        ByteBuf buffer = wrappedBuffer(header, payload);
 
         assertEquals(12, header.readableBytes());
         assertEquals(512, payload.readableBytes());
 
         assertEquals(12 + 512, buffer.readableBytes());
         assertEquals(2, buffer.nioBufferCount());
+
+        buffer.release();
     }
 
     @Test
@@ -244,222 +258,323 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         ByteBuf a, b;
         // XXX Same tests with several buffers in wrappedCheckedBuffer
         // Different length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1 }).order(order));
-        b = releaseLater(wrappedBuffer(
+        a = wrappedBuffer(new byte[] { 1 }).order(order);
+        b = wrappedBuffer(
                 wrappedBuffer(new byte[] { 1 }).order(order),
-                wrappedBuffer(new byte[] { 2 }).order(order)));
+                wrappedBuffer(new byte[] { 2 }).order(order));
         assertFalse(ByteBufUtil.equals(a, b));
+
+        a.release();
+        b.release();
 
         // Same content, same firstIndex, short length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3 }).order(order));
-        b = releaseLater(wrappedBuffer(
+        a = wrappedBuffer(new byte[] { 1, 2, 3 }).order(order);
+        b = wrappedBuffer(
                 wrappedBuffer(new byte[]{1}).order(order),
                 wrappedBuffer(new byte[]{2}).order(order),
-                wrappedBuffer(new byte[]{3}).order(order)));
+                wrappedBuffer(new byte[]{3}).order(order));
         assertTrue(ByteBufUtil.equals(a, b));
+
+        a.release();
+        b.release();
 
         // Same content, different firstIndex, short length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3 }).order(order));
-        b = releaseLater(wrappedBuffer(
+        a = wrappedBuffer(new byte[] { 1, 2, 3 }).order(order);
+        b = wrappedBuffer(
                 wrappedBuffer(new byte[] { 0, 1, 2, 3, 4 }, 1, 2).order(order),
-                wrappedBuffer(new byte[] { 0, 1, 2, 3, 4 }, 3, 1).order(order)));
+                wrappedBuffer(new byte[] { 0, 1, 2, 3, 4 }, 3, 1).order(order));
         assertTrue(ByteBufUtil.equals(a, b));
+
+        a.release();
+        b.release();
 
         // Different content, same firstIndex, short length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3 }).order(order));
-        b = releaseLater(wrappedBuffer(
+        a = wrappedBuffer(new byte[] { 1, 2, 3 }).order(order);
+        b = wrappedBuffer(
                 wrappedBuffer(new byte[] { 1, 2 }).order(order),
-                wrappedBuffer(new byte[] { 4 }).order(order)));
+                wrappedBuffer(new byte[] { 4 }).order(order));
         assertFalse(ByteBufUtil.equals(a, b));
+
+        a.release();
+        b.release();
 
         // Different content, different firstIndex, short length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3 }).order(order));
-        b = releaseLater(wrappedBuffer(
+        a = wrappedBuffer(new byte[] { 1, 2, 3 }).order(order);
+        b = wrappedBuffer(
                 wrappedBuffer(new byte[] { 0, 1, 2, 4, 5 }, 1, 2).order(order),
-                wrappedBuffer(new byte[] { 0, 1, 2, 4, 5 }, 3, 1).order(order)));
+                wrappedBuffer(new byte[] { 0, 1, 2, 4, 5 }, 3, 1).order(order));
         assertFalse(ByteBufUtil.equals(a, b));
+
+        a.release();
+        b.release();
 
         // Same content, same firstIndex, long length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).order(order));
-        b = releaseLater(wrappedBuffer(
+        a = wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).order(order);
+        b = wrappedBuffer(
                 wrappedBuffer(new byte[] { 1, 2, 3 }).order(order),
                 wrappedBuffer(new byte[] { 4, 5, 6 }).order(order),
-                wrappedBuffer(new byte[] { 7, 8, 9, 10 }).order(order)));
+                wrappedBuffer(new byte[] { 7, 8, 9, 10 }).order(order));
         assertTrue(ByteBufUtil.equals(a, b));
+
+        a.release();
+        b.release();
 
         // Same content, different firstIndex, long length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).order(order));
-        b = releaseLater(wrappedBuffer(
+        a = wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).order(order);
+        b = wrappedBuffer(
                 wrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, 1, 5).order(order),
-                wrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, 6, 5).order(order)));
+                wrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, 6, 5).order(order));
         assertTrue(ByteBufUtil.equals(a, b));
 
+        a.release();
+        b.release();
+
         // Different content, same firstIndex, long length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).order(order));
-        b = releaseLater(wrappedBuffer(
+        a = wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).order(order);
+        b = wrappedBuffer(
                 wrappedBuffer(new byte[] { 1, 2, 3, 4, 6 }).order(order),
-                wrappedBuffer(new byte[] { 7, 8, 5, 9, 10 }).order(order)));
+                wrappedBuffer(new byte[] { 7, 8, 5, 9, 10 }).order(order));
         assertFalse(ByteBufUtil.equals(a, b));
 
+        a.release();
+        b.release();
+
         // Different content, different firstIndex, long length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).order(order));
-        b = releaseLater(wrappedBuffer(
+        a = wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).order(order);
+        b = wrappedBuffer(
                 wrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 6, 7, 8, 5, 9, 10, 11 }, 1, 5).order(order),
-                wrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 6, 7, 8, 5, 9, 10, 11 }, 6, 5).order(order)));
+                wrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 6, 7, 8, 5, 9, 10, 11 }, 6, 5).order(order));
         assertFalse(ByteBufUtil.equals(a, b));
+
+        a.release();
+        b.release();
     }
 
     @Test
     public void testWrappedBuffer() {
 
-        assertEquals(16, wrappedBuffer(wrappedBuffer(ByteBuffer.allocateDirect(16))).capacity());
+        ByteBuf a = wrappedBuffer(wrappedBuffer(ByteBuffer.allocateDirect(16)));
+        assertEquals(16, a.capacity());
+        a.release();
 
-        assertEquals(
-                wrappedBuffer(wrappedBuffer(new byte[] { 1, 2, 3 }).order(order)),
-                wrappedBuffer(wrappedBuffer(new byte[][] { new byte[] { 1, 2, 3 } }).order(order)));
+        a = wrappedBuffer(wrappedBuffer(new byte[] { 1, 2, 3 }).order(order));
+        ByteBuf b = wrappedBuffer(wrappedBuffer(new byte[][] { new byte[] { 1, 2, 3 } }).order(order));
+        assertEquals(a, b);
 
-        assertEquals(
-                wrappedBuffer(wrappedBuffer(new byte[] { 1, 2, 3 }).order(order)),
-                releaseLater(wrappedBuffer(wrappedBuffer(
-                        new byte[] { 1 },
-                        new byte[] { 2 },
-                        new byte[] { 3 }).order(order))));
+        a.release();
+        b.release();
 
-        assertEquals(
-                wrappedBuffer(wrappedBuffer(new byte[] { 1, 2, 3 }).order(order)),
-                wrappedBuffer(new ByteBuf[] {
-                        wrappedBuffer(new byte[] { 1, 2, 3 }).order(order)
-                }));
+        a = wrappedBuffer(wrappedBuffer(new byte[] { 1, 2, 3 }).order(order));
+        b = wrappedBuffer(wrappedBuffer(
+                new byte[] { 1 },
+                new byte[] { 2 },
+                new byte[] { 3 }).order(order));
+        assertEquals(a, b);
 
-        assertEquals(
-                wrappedBuffer(wrappedBuffer(new byte[] { 1, 2, 3 }).order(order)),
-                releaseLater(wrappedBuffer(
-                        wrappedBuffer(new byte[] { 1 }).order(order),
-                        wrappedBuffer(new byte[] { 2 }).order(order),
-                        wrappedBuffer(new byte[] { 3 }).order(order))));
+        a.release();
+        b.release();
 
-        assertEquals(
-                wrappedBuffer(wrappedBuffer(new byte[] { 1, 2, 3 }).order(order)),
-                wrappedBuffer(wrappedBuffer(new ByteBuffer[] {
-                        ByteBuffer.wrap(new byte[] { 1, 2, 3 })
-                })));
+        a = wrappedBuffer(wrappedBuffer(new byte[] { 1, 2, 3 }).order(order));
+        b = wrappedBuffer(new ByteBuf[] {
+                wrappedBuffer(new byte[] { 1, 2, 3 }).order(order)
+        });
+        assertEquals(a, b);
 
-        assertEquals(
-                wrappedBuffer(wrappedBuffer(new byte[] { 1, 2, 3 }).order(order)),
-                releaseLater(wrappedBuffer(wrappedBuffer(
-                        ByteBuffer.wrap(new byte[] { 1 }),
-                        ByteBuffer.wrap(new byte[] { 2 }),
-                        ByteBuffer.wrap(new byte[] { 3 })))));
+        a.release();
+        b.release();
+
+        a = wrappedBuffer(wrappedBuffer(new byte[] { 1, 2, 3 }).order(order));
+        b = wrappedBuffer(
+                wrappedBuffer(new byte[] { 1 }).order(order),
+                wrappedBuffer(new byte[] { 2 }).order(order),
+                wrappedBuffer(new byte[] { 3 }).order(order));
+        assertEquals(a, b);
+
+        a.release();
+        b.release();
+
+        a = wrappedBuffer(wrappedBuffer(new byte[] { 1, 2, 3 })).order(order);
+        b = wrappedBuffer(wrappedBuffer(new ByteBuffer[] {
+                ByteBuffer.wrap(new byte[] { 1, 2, 3 })
+        }));
+        assertEquals(a, b);
+
+        a.release();
+        b.release();
+
+        a = wrappedBuffer(wrappedBuffer(new byte[] { 1, 2, 3 }).order(order));
+        b = wrappedBuffer(wrappedBuffer(
+                ByteBuffer.wrap(new byte[] { 1 }),
+                ByteBuffer.wrap(new byte[] { 2 }),
+                ByteBuffer.wrap(new byte[] { 3 })));
+        assertEquals(a, b);
+
+        a.release();
+        b.release();
     }
 
     @Test
     public void testWrittenBuffersEquals() {
         //XXX Same tests than testEquals with written AggregateChannelBuffers
-        ByteBuf a, b;
+        ByteBuf a, b, c;
         // Different length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1  })).order(order);
-        b = releaseLater(wrappedBuffer(wrappedBuffer(new byte[] { 1 }, new byte[1])).order(order));
+        a = wrappedBuffer(new byte[] { 1  }).order(order);
+        b = wrappedBuffer(wrappedBuffer(new byte[] { 1 }, new byte[1])).order(order);
+        c = wrappedBuffer(new byte[] { 2 }).order(order);
+
         // to enable writeBytes
         b.writerIndex(b.writerIndex() - 1);
-        b.writeBytes(releaseLater(wrappedBuffer(new byte[] { 2 })).order(order));
+        b.writeBytes(c);
         assertFalse(ByteBufUtil.equals(a, b));
+
+        a.release();
+        b.release();
+        c.release();
 
         // Same content, same firstIndex, short length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3 })).order(order);
-        b = releaseLater(wrappedBuffer(releaseLater(wrappedBuffer(new byte[] { 1 }, new byte[2]))).order(order));
+        a = wrappedBuffer(new byte[] { 1, 2, 3 }).order(order);
+        b = wrappedBuffer(wrappedBuffer(new byte[] { 1 }, new byte[2])).order(order);
+        c = wrappedBuffer(new byte[] { 2 }).order(order);
+
         // to enable writeBytes
         b.writerIndex(b.writerIndex() - 2);
-        b.writeBytes(releaseLater(wrappedBuffer(new byte[] { 2 })).order(order));
-        b.writeBytes(releaseLater(wrappedBuffer(new byte[] { 3 })).order(order));
+        b.writeBytes(c);
+        c.release();
+        c = wrappedBuffer(new byte[] { 3 }).order(order);
+
+        b.writeBytes(c);
         assertTrue(ByteBufUtil.equals(a, b));
+
+        a.release();
+        b.release();
+        c.release();
 
         // Same content, different firstIndex, short length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3 })).order(order);
-        b = releaseLater(wrappedBuffer(releaseLater(wrappedBuffer(new byte[] { 0, 1, 2, 3, 4 }, 1, 3))).order(order));
+        a = wrappedBuffer(new byte[] { 1, 2, 3 }).order(order);
+        b = wrappedBuffer(wrappedBuffer(new byte[] { 0, 1, 2, 3, 4 }, 1, 3)).order(order);
+        c = wrappedBuffer(new byte[] { 0, 1, 2, 3, 4 }, 3, 1).order(order);
         // to enable writeBytes
         b.writerIndex(b.writerIndex() - 1);
-        b.writeBytes(releaseLater(wrappedBuffer(new byte[] { 0, 1, 2, 3, 4 }, 3, 1)).order(order));
+        b.writeBytes(c);
         assertTrue(ByteBufUtil.equals(a, b));
+
+        a.release();
+        b.release();
+        c.release();
 
         // Different content, same firstIndex, short length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3 })).order(order);
-        b = releaseLater(wrappedBuffer(releaseLater(wrappedBuffer(new byte[] { 1, 2 }, new byte[1])).order(order)));
+        a = wrappedBuffer(new byte[] { 1, 2, 3 }).order(order);
+        b = wrappedBuffer(wrappedBuffer(new byte[] { 1, 2 }, new byte[1])).order(order);
+        c = wrappedBuffer(new byte[] { 4 }).order(order);
         // to enable writeBytes
         b.writerIndex(b.writerIndex() - 1);
-        b.writeBytes(releaseLater(wrappedBuffer(new byte[] { 4 })).order(order));
+        b.writeBytes(c);
         assertFalse(ByteBufUtil.equals(a, b));
+
+        a.release();
+        b.release();
+        c.release();
 
         // Different content, different firstIndex, short length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3 })).order(order);
-        b = releaseLater(wrappedBuffer(releaseLater(wrappedBuffer(new byte[] { 0, 1, 2, 4, 5 }, 1, 3))).order(order));
+        a = wrappedBuffer(new byte[] { 1, 2, 3 }).order(order);
+        b = wrappedBuffer(wrappedBuffer(new byte[] { 0, 1, 2, 4, 5 }, 1, 3)).order(order);
+        c = wrappedBuffer(new byte[] { 0, 1, 2, 4, 5 }, 3, 1).order(order);
         // to enable writeBytes
         b.writerIndex(b.writerIndex() - 1);
-        b.writeBytes(releaseLater(wrappedBuffer(new byte[] { 0, 1, 2, 4, 5 }, 3, 1)).order(order));
+        b.writeBytes(c);
         assertFalse(ByteBufUtil.equals(a, b));
+
+        a.release();
+        b.release();
+        c.release();
 
         // Same content, same firstIndex, long length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })).order(order);
-        b = releaseLater(wrappedBuffer(releaseLater(wrappedBuffer(new byte[] { 1, 2, 3 }, new byte[7]))).order(order));
+        a = wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).order(order);
+        b = wrappedBuffer(wrappedBuffer(new byte[] { 1, 2, 3 }, new byte[7])).order(order);
+        c = wrappedBuffer(new byte[] { 4, 5, 6 }).order(order);
+
         // to enable writeBytes
         b.writerIndex(b.writerIndex() - 7);
-        b.writeBytes(releaseLater(wrappedBuffer(new byte[] { 4, 5, 6 })).order(order));
-        b.writeBytes(releaseLater(wrappedBuffer(new byte[] { 7, 8, 9, 10 })).order(order));
+        b.writeBytes(c);
+        c.release();
+        c = wrappedBuffer(new byte[] { 7, 8, 9, 10 }).order(order);
+        b.writeBytes(c);
         assertTrue(ByteBufUtil.equals(a, b));
+
+        a.release();
+        b.release();
+        c.release();
 
         // Same content, different firstIndex, long length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })).order(order);
-        b = releaseLater(wrappedBuffer(releaseLater(
-                wrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, 1, 10))).order(order));
+        a = wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).order(order);
+        b = wrappedBuffer(
+                wrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, 1, 10)).order(order);
+        c = wrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, 6, 5).order(order);
         // to enable writeBytes
         b.writerIndex(b.writerIndex() - 5);
-        b.writeBytes(releaseLater(
-                wrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, 6, 5)).order(order));
+        b.writeBytes(c);
         assertTrue(ByteBufUtil.equals(a, b));
 
+        a.release();
+        b.release();
+        c.release();
+
         // Different content, same firstIndex, long length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })).order(order);
-        b = releaseLater(wrappedBuffer(wrappedBuffer(new byte[] { 1, 2, 3, 4, 6 }, new byte[5])).order(order));
+        a = wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).order(order);
+        b = wrappedBuffer(wrappedBuffer(new byte[] { 1, 2, 3, 4, 6 }, new byte[5])).order(order);
+        c = wrappedBuffer(new byte[] { 7, 8, 5, 9, 10 }).order(order);
         // to enable writeBytes
         b.writerIndex(b.writerIndex() - 5);
-        b.writeBytes(releaseLater(wrappedBuffer(new byte[] { 7, 8, 5, 9, 10 })).order(order));
+        b.writeBytes(c);
         assertFalse(ByteBufUtil.equals(a, b));
 
+        a.release();
+        b.release();
+        c.release();
+
         // Different content, different firstIndex, long length.
-        a = releaseLater(wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })).order(order);
-        b = releaseLater(wrappedBuffer(releaseLater(
-                wrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 6, 7, 8, 5, 9, 10, 11 }, 1, 10))).order(order));
+        a = wrappedBuffer(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }).order(order);
+        b = wrappedBuffer(
+                wrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 6, 7, 8, 5, 9, 10, 11 }, 1, 10)).order(order);
+        c = wrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 6, 7, 8, 5, 9, 10, 11 }, 6, 5).order(order);
         // to enable writeBytes
         b.writerIndex(b.writerIndex() - 5);
-        b.writeBytes(releaseLater(
-                wrappedBuffer(new byte[] { 0, 1, 2, 3, 4, 6, 7, 8, 5, 9, 10, 11 }, 6, 5)).order(order));
+        b.writeBytes(c);
         assertFalse(ByteBufUtil.equals(a, b));
+
+        a.release();
+        b.release();
+        c.release();
     }
 
     @Test
     public void testEmptyBuffer() {
-        ByteBuf b = releaseLater(wrappedBuffer(new byte[]{1, 2}, new byte[]{3, 4}));
+        ByteBuf b = wrappedBuffer(new byte[]{1, 2}, new byte[]{3, 4});
         b.readBytes(new byte[4]);
         b.readBytes(EMPTY_BYTES);
+        b.release();
     }
 
     // Test for https://github.com/netty/netty/issues/1060
     @Test
     public void testReadWithEmptyCompositeBuffer() {
-        ByteBuf buf = releaseLater(compositeBuffer());
+        ByteBuf buf = compositeBuffer();
         int n = 65;
         for (int i = 0; i < n; i ++) {
             buf.writeByte(1);
             assertEquals(1, buf.readByte());
         }
+        buf.release();
     }
 
     @Test
     public void testComponentMustBeSlice() {
-        CompositeByteBuf buf = releaseLater(compositeBuffer());
+        CompositeByteBuf buf = compositeBuffer();
         buf.addComponent(buffer(4).setIndex(1, 3));
         assertThat(buf.component(0), is(instanceOf(AbstractUnpooledSlicedByteBuf.class)));
         assertThat(buf.component(0).capacity(), is(2));
         assertThat(buf.component(0).maxCapacity(), is(2));
+        buf.release();
     }
 
     @Test
@@ -468,7 +583,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         ByteBuf c2 = buffer().writeByte(2).retain();
         ByteBuf c3 = buffer().writeByte(3).retain(2);
 
-        CompositeByteBuf buf = releaseLater(compositeBuffer());
+        CompositeByteBuf buf = compositeBuffer();
         assertThat(buf.refCnt(), is(1));
         buf.addComponents(c1, c2, c3);
 
@@ -485,6 +600,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
 
         c3.release(2);
         c2.release();
+        buf.release();
     }
 
     @Test
@@ -529,7 +645,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         ByteBuf c2 = buffer().writeByte(2).retain();
         ByteBuf c3 = buffer().writeByte(3).retain(2);
 
-        CompositeByteBuf buf = releaseLater(compositeBuffer());
+        CompositeByteBuf buf = compositeBuffer();
         assertThat(buf.refCnt(), is(1));
 
         List<ByteBuf> components = new ArrayList<ByteBuf>();
@@ -547,11 +663,12 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
 
         c3.release(2);
         c2.release();
+        buf.release();
     }
 
     @Test
     public void testNestedLayout() {
-        CompositeByteBuf buf = releaseLater(compositeBuffer());
+        CompositeByteBuf buf = compositeBuffer();
         buf.addComponent(
                 compositeBuffer()
                         .addComponent(wrappedBuffer(new byte[]{1, 2}))
@@ -563,39 +680,50 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         assertThat(nioBuffers[0].get(), is((byte) 2));
         assertThat(nioBuffers[1].remaining(), is(1));
         assertThat(nioBuffers[1].get(), is((byte) 3));
+
+        buf.release();
     }
 
     @Test
     public void testRemoveLastComponent() {
-        CompositeByteBuf buf = releaseLater(compositeBuffer());
+        CompositeByteBuf buf = compositeBuffer();
         buf.addComponent(wrappedBuffer(new byte[]{1, 2}));
         assertEquals(1, buf.numComponents());
         buf.removeComponent(0);
         assertEquals(0, buf.numComponents());
+        buf.release();
     }
 
     @Test
     public void testCopyEmpty() {
-        CompositeByteBuf buf = releaseLater(compositeBuffer());
+        CompositeByteBuf buf = compositeBuffer();
         assertEquals(0, buf.numComponents());
-        assertEquals(0, releaseLater(buf.copy()).readableBytes());
+
+        ByteBuf copy = buf.copy();
+        assertEquals(0, copy.readableBytes());
+
+        buf.release();
+        copy.release();
     }
 
     @Test
     public void testDuplicateEmpty() {
-        CompositeByteBuf buf = releaseLater(compositeBuffer());
+        CompositeByteBuf buf = compositeBuffer();
         assertEquals(0, buf.numComponents());
-        assertEquals(0, releaseLater(buf.duplicate()).readableBytes());
+        assertEquals(0, buf.duplicate().readableBytes());
+
+        buf.release();
     }
 
     @Test
     public void testRemoveLastComponentWithOthersLeft() {
-        CompositeByteBuf buf = releaseLater(compositeBuffer());
+        CompositeByteBuf buf = compositeBuffer();
         buf.addComponent(wrappedBuffer(new byte[]{1, 2}));
         buf.addComponent(wrappedBuffer(new byte[]{1, 2}));
         assertEquals(2, buf.numComponents());
         buf.removeComponent(1);
         assertEquals(1, buf.numComponents());
+        buf.release();
     }
 
     @Test
@@ -632,7 +760,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
     }
 
     private static void testGatheringWrites(ByteBuf buf1, ByteBuf buf2) throws Exception {
-        CompositeByteBuf buf = releaseLater(compositeBuffer());
+        CompositeByteBuf buf = compositeBuffer();
         buf.addComponent(buf1.writeBytes(new byte[]{1, 2}));
         buf.addComponent(buf2.writeBytes(new byte[]{1, 2}));
         buf.writerIndex(3);
@@ -645,6 +773,8 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         byte[] data = new byte[2];
         buf.getBytes(1, data);
         assertArrayEquals(data, channel.writtenBytes());
+
+        buf.release();
     }
 
     @Test
@@ -714,7 +844,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
     }
 
     private static void testGatheringWritesPartial(ByteBuf buf1, ByteBuf buf2, boolean slice) throws Exception {
-        CompositeByteBuf buf = releaseLater(compositeBuffer());
+        CompositeByteBuf buf = compositeBuffer();
         buf1.writeBytes(new byte[]{1, 2, 3, 4});
         buf2.writeBytes(new byte[]{1, 2, 3, 4});
         if (slice) {
@@ -744,6 +874,8 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
             buf.getBytes(1, data);
         }
         assertArrayEquals(data, channel.writtenBytes());
+
+        buf.release();
     }
 
     @Test
@@ -757,7 +889,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
     }
 
     private static void testGatheringWritesSingleBuf(ByteBuf buf1) throws Exception {
-        CompositeByteBuf buf = releaseLater(compositeBuffer());
+        CompositeByteBuf buf = compositeBuffer();
         buf.addComponent(buf1.writeBytes(new byte[]{1, 2, 3, 4}));
         buf.writerIndex(3);
         buf.readerIndex(1);
@@ -768,6 +900,8 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         byte[] data = new byte[2];
         buf.getBytes(1, data);
         assertArrayEquals(data, channel.writtenBytes());
+
+        buf.release();
     }
 
     @Override
@@ -778,7 +912,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
 
     @Test
     public void testisDirectMultipleBufs() {
-        CompositeByteBuf buf = releaseLater(compositeBuffer());
+        CompositeByteBuf buf = compositeBuffer();
         assertFalse(buf.isDirect());
 
         buf.addComponent(directBuffer().writeByte(1));
@@ -789,12 +923,14 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
 
         buf.addComponent(buffer().writeByte(1));
         assertFalse(buf.isDirect());
+
+        buf.release();
     }
 
     // See https://github.com/netty/netty/issues/1976
     @Test
     public void testDiscardSomeReadBytes() {
-        CompositeByteBuf cbuf = releaseLater(compositeBuffer());
+        CompositeByteBuf cbuf = compositeBuffer();
         int len = 8 * 4;
         for (int i = 0; i < len; i += 4) {
             ByteBuf buf = buffer().writeInt(i);
@@ -807,6 +943,8 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         cbuf.readByte();
 
         cbuf.discardSomeReadBytes();
+
+        cbuf.release();
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -23,7 +23,6 @@ import java.nio.charset.Charset;
 import java.util.Random;
 
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
-import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -99,36 +98,45 @@ public class ByteBufUtilTest {
     @Test
     public void testWriteUsAscii() {
         String usAscii = "NettyRocks";
-        ByteBuf buf = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf = Unpooled.buffer(16);
         buf.writeBytes(usAscii.getBytes(CharsetUtil.US_ASCII));
-        ByteBuf buf2 = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf2 = Unpooled.buffer(16);
         ByteBufUtil.writeAscii(buf2, usAscii);
 
         assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
     }
 
     @Test
     public void testWriteUsAsciiWrapped() {
         String usAscii = "NettyRocks";
-        ByteBuf buf = unreleasableBuffer(releaseLater(Unpooled.buffer(16)));
+        ByteBuf buf = unreleasableBuffer(Unpooled.buffer(16));
         assertWrapped(buf);
         buf.writeBytes(usAscii.getBytes(CharsetUtil.US_ASCII));
-        ByteBuf buf2 = unreleasableBuffer(releaseLater(Unpooled.buffer(16)));
+        ByteBuf buf2 = unreleasableBuffer(Unpooled.buffer(16));
         assertWrapped(buf2);
         ByteBufUtil.writeAscii(buf2, usAscii);
 
         assertEquals(buf, buf2);
+
+        buf.unwrap().release();
+        buf2.unwrap().release();
     }
 
     @Test
     public void testWriteUtf8() {
         String usAscii = "Some UTF-8 like äÄ∏ŒŒ";
-        ByteBuf buf = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf = Unpooled.buffer(16);
         buf.writeBytes(usAscii.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf2 = Unpooled.buffer(16);
         ByteBufUtil.writeUtf8(buf2, usAscii);
 
         assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
     }
 
     @Test
@@ -140,12 +148,15 @@ public class ByteBufUtilTest {
                                 .append('\uDC00')
                                 .append('b')
                                 .toString();
-        ByteBuf buf = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf = Unpooled.buffer(16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf2 = Unpooled.buffer(16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
     }
 
     @Test
@@ -155,12 +166,15 @@ public class ByteBufUtilTest {
                                 .append('\uDC00')
                                 .append('b')
                                 .toString();
-        ByteBuf buf = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf = Unpooled.buffer(16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf2 = Unpooled.buffer(16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
     }
 
     @Test
@@ -170,12 +184,15 @@ public class ByteBufUtilTest {
                                 .append('\uD800')
                                 .append('b')
                                 .toString();
-        ByteBuf buf = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf = Unpooled.buffer(16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf2 = Unpooled.buffer(16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
     }
 
     @Test
@@ -186,12 +203,15 @@ public class ByteBufUtilTest {
                                 .append('\uD800')
                                 .append('b')
                                 .toString();
-        ByteBuf buf = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf = Unpooled.buffer(16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf2 = Unpooled.buffer(16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
     }
 
     @Test
@@ -202,12 +222,15 @@ public class ByteBufUtilTest {
                                 .append('\uD800')
                                 .append('b')
                                 .toString();
-        ByteBuf buf = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf = Unpooled.buffer(16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf2 = Unpooled.buffer(16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
     }
 
     @Test
@@ -218,12 +241,15 @@ public class ByteBufUtilTest {
                                 .append('\uDC00')
                                 .append('b')
                                 .toString();
-        ByteBuf buf = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf = Unpooled.buffer(16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf2 = Unpooled.buffer(16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
     }
 
     @Test
@@ -231,12 +257,15 @@ public class ByteBufUtilTest {
         String surrogateString = new StringBuilder(2)
                                 .append('\uD800')
                                 .toString();
-        ByteBuf buf = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf = Unpooled.buffer(16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf2 = Unpooled.buffer(16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
     }
 
     @Test
@@ -244,36 +273,45 @@ public class ByteBufUtilTest {
         String surrogateString = new StringBuilder(2)
                                 .append('\uDC00')
                                 .toString();
-        ByteBuf buf = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf = Unpooled.buffer(16);
         buf.writeBytes(surrogateString.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf2 = Unpooled.buffer(16);
         ByteBufUtil.writeUtf8(buf2, surrogateString);
 
         assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
     }
 
     @Test
     public void testWriteUsAsciiString() {
         AsciiString usAscii = new AsciiString("NettyRocks");
-        ByteBuf buf = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf = Unpooled.buffer(16);
         buf.writeBytes(usAscii.toString().getBytes(CharsetUtil.US_ASCII));
-        ByteBuf buf2 = releaseLater(Unpooled.buffer(16));
+        ByteBuf buf2 = Unpooled.buffer(16);
         ByteBufUtil.writeAscii(buf2, usAscii);
 
         assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
     }
 
     @Test
     public void testWriteUtf8Wrapped() {
         String usAscii = "Some UTF-8 like äÄ∏ŒŒ";
-        ByteBuf buf = unreleasableBuffer(releaseLater(Unpooled.buffer(16)));
+        ByteBuf buf = unreleasableBuffer(Unpooled.buffer(16));
         assertWrapped(buf);
         buf.writeBytes(usAscii.getBytes(CharsetUtil.UTF_8));
-        ByteBuf buf2 = unreleasableBuffer(releaseLater(Unpooled.buffer(16)));
+        ByteBuf buf2 = unreleasableBuffer(Unpooled.buffer(16));
         assertWrapped(buf2);
         ByteBufUtil.writeUtf8(buf2, usAscii);
 
         assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
     }
 
     private static void assertWrapped(ByteBuf buf) {

--- a/buffer/src/test/java/io/netty/buffer/ByteProcessorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteProcessorTest.java
@@ -16,7 +16,6 @@
 
 package io.netty.buffer;
 
-import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.junit.Assert.assertEquals;
 import io.netty.util.ByteProcessor;
 import io.netty.util.CharsetUtil;
@@ -26,8 +25,8 @@ import org.junit.Test;
 public class ByteProcessorTest {
     @Test
     public void testForward() {
-        final ByteBuf buf = releaseLater(
-                Unpooled.copiedBuffer("abc\r\n\ndef\r\rghi\n\njkl\0\0mno  \t\tx", CharsetUtil.ISO_8859_1));
+        final ByteBuf buf =
+                Unpooled.copiedBuffer("abc\r\n\ndef\r\rghi\n\njkl\0\0mno  \t\tx", CharsetUtil.ISO_8859_1);
         final int length = buf.readableBytes();
 
         assertEquals(3,  buf.forEachByte(0,  length, ByteProcessor.FIND_CRLF));
@@ -41,12 +40,14 @@ public class ByteProcessorTest {
         assertEquals(24, buf.forEachByte(21, length - 21, ByteProcessor.FIND_LINEAR_WHITESPACE));
         assertEquals(28, buf.forEachByte(24, length - 24, ByteProcessor.FIND_NON_LINEAR_WHITESPACE));
         assertEquals(-1, buf.forEachByte(28, length - 28, ByteProcessor.FIND_LINEAR_WHITESPACE));
+
+        buf.release();
     }
 
     @Test
     public void testBackward() {
-        final ByteBuf buf = releaseLater(
-                Unpooled.copiedBuffer("abc\r\n\ndef\r\rghi\n\njkl\0\0mno  \t\tx", CharsetUtil.ISO_8859_1));
+        final ByteBuf buf =
+                Unpooled.copiedBuffer("abc\r\n\ndef\r\rghi\n\njkl\0\0mno  \t\tx", CharsetUtil.ISO_8859_1);
         final int length = buf.readableBytes();
 
         assertEquals(27, buf.forEachByteDesc(0, length, ByteProcessor.FIND_LINEAR_WHITESPACE));
@@ -60,5 +61,7 @@ public class ByteProcessorTest {
         assertEquals(5,  buf.forEachByteDesc(0, 9, ByteProcessor.FIND_CRLF));
         assertEquals(2,  buf.forEachByteDesc(0, 6, ByteProcessor.FIND_NON_CRLF));
         assertEquals(-1, buf.forEachByteDesc(0, 3, ByteProcessor.FIND_CRLF));
+
+        buf.release();
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/FixedCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/FixedCompositeByteBufTest.java
@@ -32,103 +32,153 @@ import static org.junit.Assert.*;
 public class FixedCompositeByteBufTest {
 
     private static ByteBuf newBuffer(ByteBuf... buffers) {
-        return releaseLater(new FixedCompositeByteBuf(UnpooledByteBufAllocator.DEFAULT, buffers));
+        return new FixedCompositeByteBuf(UnpooledByteBufAllocator.DEFAULT, buffers);
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetBoolean() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
-        buf.setBoolean(0, true);
+        try {
+            buf.setBoolean(0, true);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetByte() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
-        buf.setByte(0, 1);
+        try {
+            buf.setByte(0, 1);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetBytesWithByteBuf() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
-        buf.setBytes(0, wrappedBuffer(new byte[4]));
+        ByteBuf src = wrappedBuffer(new byte[4]);
+        try {
+            buf.setBytes(0, src);
+        } finally {
+            buf.release();
+            src.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetBytesWithByteBuffer() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
-        buf.setBytes(0, ByteBuffer.wrap(new byte[4]));
+        try {
+            buf.setBytes(0, ByteBuffer.wrap(new byte[4]));
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetBytesWithInputStream() throws IOException {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
-        buf.setBytes(0, new ByteArrayInputStream(new byte[4]), 4);
+        try {
+            buf.setBytes(0, new ByteArrayInputStream(new byte[4]), 4);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetBytesWithChannel() throws IOException {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
-        buf.setBytes(0, new ScatteringByteChannel() {
-            @Override
-            public long read(ByteBuffer[] dsts, int offset, int length) {
-                return 0;
-            }
+        try {
+            buf.setBytes(0, new ScatteringByteChannel() {
+                @Override
+                public long read(ByteBuffer[] dsts, int offset, int length) {
+                    return 0;
+                }
 
-            @Override
-            public long read(ByteBuffer[] dsts) {
-                return 0;
-            }
+                @Override
+                public long read(ByteBuffer[] dsts) {
+                    return 0;
+                }
 
-            @Override
-            public int read(ByteBuffer dst) {
-                return 0;
-            }
+                @Override
+                public int read(ByteBuffer dst) {
+                    return 0;
+                }
 
-            @Override
-            public boolean isOpen() {
-                return true;
-            }
+                @Override
+                public boolean isOpen() {
+                    return true;
+                }
 
-            @Override
-            public void close() {
-            }
-        }, 4);
+                @Override
+                public void close() {
+                }
+            }, 4);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetChar() throws IOException {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
-        buf.setChar(0, 'b');
+        try {
+            buf.setChar(0, 'b');
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetDouble() throws IOException {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
-        buf.setDouble(0, 1);
+        try {
+            buf.setDouble(0, 1);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetFloat() throws IOException {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
-        buf.setFloat(0, 1);
+        try {
+            buf.setFloat(0, 1);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetInt() throws IOException {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
-        buf.setInt(0, 1);
+        try {
+            buf.setInt(0, 1);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetLong() {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
-        buf.setLong(0, 1);
+        try {
+            buf.setLong(0, 1);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetMedium() throws IOException {
         ByteBuf buf = newBuffer(wrappedBuffer(new byte[8]));
-        buf.setMedium(0, 1);
+        try {
+            buf.setMedium(0, 1);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 
-import static io.netty.util.ReferenceCountUtil.releaseLater;
-
 public class ReadOnlyDirectByteBufferBufTest {
 
     protected ByteBuf buffer(ByteBuffer buffer) {
@@ -37,62 +35,95 @@ public class ReadOnlyDirectByteBufferBufTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructWithWritable() {
-        releaseLater(buffer(allocate(1)));
+        buffer(allocate(1));
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetByte() {
-        ByteBuf buf = releaseLater(buffer(allocate(8).asReadOnlyBuffer()));
-        buf.setByte(0, 1);
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        try {
+            buf.setByte(0, 1);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetInt() {
-        ByteBuf buf = releaseLater(buffer(allocate(8).asReadOnlyBuffer()));
-        buf.setInt(0, 1);
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        try {
+            buf.setInt(0, 1);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetShort() {
-        ByteBuf buf = releaseLater(buffer(allocate(8).asReadOnlyBuffer()));
-        buf.setShort(0, 1);
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        try {
+            buf.setShort(0, 1);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetMedium() {
-        ByteBuf buf = releaseLater(buffer(allocate(8).asReadOnlyBuffer()));
-        buf.setMedium(0, 1);
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        try {
+            buf.setMedium(0, 1);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetLong() {
-        ByteBuf buf = releaseLater(buffer(allocate(8).asReadOnlyBuffer()));
-        buf.setLong(0, 1);
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        try {
+            buf.setLong(0, 1);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetBytesViaArray() {
-        ByteBuf buf = releaseLater(buffer(allocate(8).asReadOnlyBuffer()));
-        buf.setBytes(0, "test".getBytes());
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        try {
+            buf.setBytes(0, "test".getBytes());
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetBytesViaBuffer() {
-        ByteBuf buf = releaseLater(buffer(allocate(8).asReadOnlyBuffer()));
-        buf.setBytes(0, Unpooled.copyInt(1));
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        ByteBuf copy = Unpooled.copyInt(1);
+        try {
+            buf.setBytes(0, copy);
+        } finally {
+            buf.release();
+            copy.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetBytesViaStream() throws IOException {
-        ByteBuf buf = releaseLater(buffer(ByteBuffer.allocateDirect(8).asReadOnlyBuffer()));
-        buf.setBytes(0, new ByteArrayInputStream("test".getBytes()), 2);
-        buf.release();
+        ByteBuf buf = buffer(ByteBuffer.allocateDirect(8).asReadOnlyBuffer());
+        try {
+            buf.setBytes(0, new ByteArrayInputStream("test".getBytes()), 2);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test
     public void testGetReadByte() {
-        ByteBuf buf = releaseLater(buffer(
-                ((ByteBuffer) allocate(2).put(new byte[] { (byte) 1, (byte) 2 }).flip()).asReadOnlyBuffer()));
+        ByteBuf buf = buffer(
+                ((ByteBuffer) allocate(2).put(new byte[] { (byte) 1, (byte) 2 }).flip()).asReadOnlyBuffer());
 
         Assert.assertEquals(1, buf.getByte(0));
         Assert.assertEquals(2, buf.getByte(1));
@@ -100,11 +131,13 @@ public class ReadOnlyDirectByteBufferBufTest {
         Assert.assertEquals(1, buf.readByte());
         Assert.assertEquals(2, buf.readByte());
         Assert.assertFalse(buf.isReadable());
+
+        buf.release();
     }
 
     @Test
     public void testGetReadInt() {
-        ByteBuf buf = releaseLater(buffer(((ByteBuffer) allocate(8).putInt(1).putInt(2).flip()).asReadOnlyBuffer()));
+        ByteBuf buf = buffer(((ByteBuffer) allocate(8).putInt(1).putInt(2).flip()).asReadOnlyBuffer());
 
         Assert.assertEquals(1, buf.getInt(0));
         Assert.assertEquals(2, buf.getInt(4));
@@ -112,12 +145,14 @@ public class ReadOnlyDirectByteBufferBufTest {
         Assert.assertEquals(1, buf.readInt());
         Assert.assertEquals(2, buf.readInt());
         Assert.assertFalse(buf.isReadable());
+
+        buf.release();
     }
 
     @Test
     public void testGetReadShort() {
-        ByteBuf buf = releaseLater(buffer(((ByteBuffer) allocate(8)
-                .putShort((short) 1).putShort((short) 2).flip()).asReadOnlyBuffer()));
+        ByteBuf buf = buffer(((ByteBuffer) allocate(8)
+                .putShort((short) 1).putShort((short) 2).flip()).asReadOnlyBuffer());
 
         Assert.assertEquals(1, buf.getShort(0));
         Assert.assertEquals(2, buf.getShort(2));
@@ -125,12 +160,14 @@ public class ReadOnlyDirectByteBufferBufTest {
         Assert.assertEquals(1, buf.readShort());
         Assert.assertEquals(2, buf.readShort());
         Assert.assertFalse(buf.isReadable());
+
+        buf.release();
     }
 
     @Test
     public void testGetReadLong() {
-        ByteBuf buf = releaseLater(buffer(((ByteBuffer) allocate(16)
-                .putLong(1).putLong(2).flip()).asReadOnlyBuffer()));
+        ByteBuf buf = buffer(((ByteBuffer) allocate(16)
+                .putLong(1).putLong(2).flip()).asReadOnlyBuffer());
 
         Assert.assertEquals(1, buf.getLong(0));
         Assert.assertEquals(2, buf.getLong(8));
@@ -138,37 +175,47 @@ public class ReadOnlyDirectByteBufferBufTest {
         Assert.assertEquals(1, buf.readLong());
         Assert.assertEquals(2, buf.readLong());
         Assert.assertFalse(buf.isReadable());
+
+        buf.release();
     }
 
     @Test
     public void testCopy() {
-        ByteBuf buf = releaseLater(buffer(((ByteBuffer) allocate(16).putLong(1).putLong(2).flip()).asReadOnlyBuffer()));
-        ByteBuf copy = releaseLater(buf.copy());
+        ByteBuf buf = buffer(((ByteBuffer) allocate(16).putLong(1).putLong(2).flip()).asReadOnlyBuffer());
+        ByteBuf copy = buf.copy();
 
         Assert.assertEquals(buf, copy);
+
+        buf.release();
+        copy.release();
     }
 
     @Test
     public void testCopyWithOffset() {
-        ByteBuf buf = releaseLater(buffer(((ByteBuffer) allocate(16).putLong(1).putLong(2).flip()).asReadOnlyBuffer()));
-        ByteBuf copy = releaseLater(buf.copy(1, 9));
+        ByteBuf buf = buffer(((ByteBuffer) allocate(16).putLong(1).putLong(2).flip()).asReadOnlyBuffer());
+        ByteBuf copy = buf.copy(1, 9);
 
         Assert.assertEquals(buf.slice(1, 9), copy);
+
+        buf.release();
+        copy.release();
     }
 
     // Test for https://github.com/netty/netty/issues/1708
     @Test
     public void testWrapBufferWithNonZeroPosition() {
-        ByteBuf buf = releaseLater(buffer(((ByteBuffer) allocate(16)
-                .putLong(1).flip().position(1)).asReadOnlyBuffer()));
+        ByteBuf buf = buffer(((ByteBuffer) allocate(16)
+                .putLong(1).flip().position(1)).asReadOnlyBuffer());
 
         ByteBuf slice = buf.slice();
         Assert.assertEquals(buf, slice);
+
+        buf.release();
     }
 
     @Test
     public void testWrapBufferRoundTrip() {
-        ByteBuf buf = releaseLater(buffer(((ByteBuffer) allocate(16).putInt(1).putInt(2).flip()).asReadOnlyBuffer()));
+        ByteBuf buf = buffer(((ByteBuffer) allocate(16).putInt(1).putInt(2).flip()).asReadOnlyBuffer());
 
         Assert.assertEquals(1, buf.readInt());
 
@@ -176,5 +223,7 @@ public class ReadOnlyDirectByteBufferBufTest {
 
         // Ensure this can be accessed without throwing a BufferUnderflowException
         Assert.assertEquals(2, nioBuffer.getInt());
+
+        buf.release();
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
@@ -30,7 +30,6 @@ import java.nio.channels.ClosedChannelException;
 import java.util.List;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
-import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -282,15 +281,15 @@ public class HttpObjectAggregatorTest {
         HttpUtil.set100ContinueExpected(message, true);
         HttpUtil.setContentLength(message, 16);
 
-        HttpContent chunk1 = releaseLater(new DefaultHttpContent(Unpooled.copiedBuffer("some", CharsetUtil.US_ASCII)));
-        HttpContent chunk2 = releaseLater(new DefaultHttpContent(Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII)));
+        HttpContent chunk1 = new DefaultHttpContent(Unpooled.copiedBuffer("some", CharsetUtil.US_ASCII));
+        HttpContent chunk2 = new DefaultHttpContent(Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII));
         HttpContent chunk3 = LastHttpContent.EMPTY_LAST_CONTENT;
 
         // Send a request with 100-continue + large Content-Length header value.
         assertFalse(embedder.writeInbound(message));
 
         // The aggregator should respond with '417.'
-        FullHttpResponse response = (FullHttpResponse) embedder.readOutbound();
+        FullHttpResponse response = embedder.readOutbound();
         assertEquals(HttpResponseStatus.EXPECTATION_FAILED, response.status());
         assertEquals("0", response.headers().get(HttpHeaderNames.CONTENT_LENGTH));
 
@@ -377,15 +376,15 @@ public class HttpObjectAggregatorTest {
         HttpUtil.set100ContinueExpected(message, true);
         HttpUtil.setContentLength(message, 16);
 
-        HttpContent chunk1 = releaseLater(new DefaultHttpContent(Unpooled.copiedBuffer("some", CharsetUtil.US_ASCII)));
-        HttpContent chunk2 = releaseLater(new DefaultHttpContent(Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII)));
+        HttpContent chunk1 = new DefaultHttpContent(Unpooled.copiedBuffer("some", CharsetUtil.US_ASCII));
+        HttpContent chunk2 = new DefaultHttpContent(Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII));
         HttpContent chunk3 = LastHttpContent.EMPTY_LAST_CONTENT;
 
         // Send a request with 100-continue + large Content-Length header value.
         assertFalse(embedder.writeInbound(message));
 
         // The aggregator should respond with '417'.
-        FullHttpResponse response = (FullHttpResponse) embedder.readOutbound();
+        FullHttpResponse response = embedder.readOutbound();
         assertEquals(HttpResponseStatus.EXPECTATION_FAILED, response.status());
         assertEquals("0", response.headers().get(HttpHeaderNames.CONTENT_LENGTH));
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoderTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
 
-import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -87,8 +86,8 @@ public class HttpPostRequestDecoderTest {
             // Create decoder instance to test.
             final HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(inMemoryFactory, req);
 
-            decoder.offer(releaseLater(new DefaultHttpContent(Unpooled.copiedBuffer(body, CharsetUtil.UTF_8))));
-            decoder.offer(releaseLater(new DefaultHttpContent(Unpooled.EMPTY_BUFFER)));
+            decoder.offer(new DefaultHttpContent(Unpooled.copiedBuffer(body, CharsetUtil.UTF_8)));
+            decoder.offer(new DefaultHttpContent(Unpooled.EMPTY_BUFFER));
 
             // Validate it's enough chunks to decode upload.
             assertTrue(decoder.hasNext());
@@ -257,8 +256,8 @@ public class HttpPostRequestDecoderTest {
         aSmallBuf.writeBytes(aBytes, 0, split);
         aLargeBuf.writeBytes(aBytes, split, aBytes.length - split);
 
-        aDecoder.offer(releaseLater(new DefaultHttpContent(aSmallBuf)));
-        aDecoder.offer(releaseLater(new DefaultHttpContent(aLargeBuf)));
+        aDecoder.offer(new DefaultHttpContent(aSmallBuf));
+        aDecoder.offer(new DefaultHttpContent(aLargeBuf));
 
         aDecoder.offer(LastHttpContent.EMPTY_LAST_CONTENT);
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker00Test.java
@@ -29,7 +29,6 @@ import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.codec.http.HttpResponseEncoder;
 import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.CharsetUtil;
-import io.netty.util.ReferenceCountUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -51,8 +50,8 @@ public class WebSocketServerHandshaker00Test {
         EmbeddedChannel ch = new EmbeddedChannel(
                 new HttpObjectAggregator(42), new HttpRequestDecoder(), new HttpResponseEncoder());
 
-        FullHttpRequest req = ReferenceCountUtil.releaseLater(new DefaultFullHttpRequest(
-                HTTP_1_1, HttpMethod.GET, "/chat", Unpooled.copiedBuffer("^n:ds[4U", CharsetUtil.US_ASCII)));
+        FullHttpRequest req = new DefaultFullHttpRequest(
+                HTTP_1_1, HttpMethod.GET, "/chat", Unpooled.copiedBuffer("^n:ds[4U", CharsetUtil.US_ASCII));
 
         req.headers().set(HttpHeaderNames.HOST, "server.example.com");
         req.headers().set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET);
@@ -85,5 +84,6 @@ public class WebSocketServerHandshaker00Test {
 
         Assert.assertEquals("8jKS'y:G*Co,Wxa-", content.content().toString(CharsetUtil.US_ASCII));
         content.release();
+        req.release();
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker08Test.java
@@ -49,8 +49,7 @@ public class WebSocketServerHandshaker08Test {
         EmbeddedChannel ch = new EmbeddedChannel(
                 new HttpObjectAggregator(42), new HttpRequestDecoder(), new HttpResponseEncoder());
 
-        FullHttpRequest req = ReferenceCountUtil.releaseLater(
-                new DefaultFullHttpRequest(HTTP_1_1, HttpMethod.GET, "/chat"));
+        FullHttpRequest req = new DefaultFullHttpRequest(HTTP_1_1, HttpMethod.GET, "/chat");
         req.headers().set(HttpHeaderNames.HOST, "server.example.com");
         req.headers().set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET);
         req.headers().set(HttpHeaderNames.CONNECTION, "Upgrade");
@@ -81,5 +80,6 @@ public class WebSocketServerHandshaker08Test {
             Assert.assertNull(res.headers().get(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL));
         }
         ReferenceCountUtil.release(res);
+        req.release();
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerHandshaker13Test.java
@@ -49,8 +49,7 @@ public class WebSocketServerHandshaker13Test {
         EmbeddedChannel ch = new EmbeddedChannel(
                 new HttpObjectAggregator(42), new HttpRequestDecoder(), new HttpResponseEncoder());
 
-        FullHttpRequest req = ReferenceCountUtil.releaseLater(
-                new DefaultFullHttpRequest(HTTP_1_1, HttpMethod.GET, "/chat"));
+        FullHttpRequest req = new DefaultFullHttpRequest(HTTP_1_1, HttpMethod.GET, "/chat");
         req.headers().set(HttpHeaderNames.HOST, "server.example.com");
         req.headers().set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET);
         req.headers().set(HttpHeaderNames.CONNECTION, "Upgrade");
@@ -81,5 +80,6 @@ public class WebSocketServerHandshaker13Test {
             Assert.assertNull(res.headers().get(HttpHeaderNames.SEC_WEBSOCKET_PROTOCOL));
         }
         ReferenceCountUtil.release(res);
+        req.release();
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandlerTest.java
@@ -54,7 +54,10 @@ public class WebSocketServerProtocolHandlerTest {
         EmbeddedChannel ch = createChannel(new MockOutboundHandler());
         ChannelHandlerContext handshakerCtx = ch.pipeline().context(WebSocketServerProtocolHandshakeHandler.class);
         writeUpgradeRequest(ch);
-        assertEquals(SWITCHING_PROTOCOLS, ReferenceCountUtil.releaseLater(responses.remove()).status());
+
+        FullHttpResponse response = responses.remove();
+        assertEquals(SWITCHING_PROTOCOLS, response.status());
+        response.release();
         assertNotNull(WebSocketServerProtocolHandler.getHandshaker(handshakerCtx.channel()));
     }
 
@@ -63,10 +66,15 @@ public class WebSocketServerProtocolHandlerTest {
         EmbeddedChannel ch = createChannel();
 
         writeUpgradeRequest(ch);
-        assertEquals(SWITCHING_PROTOCOLS, ReferenceCountUtil.releaseLater(responses.remove()).status());
+
+        FullHttpResponse response = responses.remove();
+        assertEquals(SWITCHING_PROTOCOLS, response.status());
+        response.release();
 
         ch.writeInbound(new DefaultFullHttpRequest(HTTP_1_1, HttpMethod.GET, "/test"));
-        assertEquals(FORBIDDEN, ReferenceCountUtil.releaseLater(responses.remove()).status());
+        response = responses.remove();
+        assertEquals(FORBIDDEN, response.status());
+        response.release();
     }
 
     @Test
@@ -82,9 +90,10 @@ public class WebSocketServerProtocolHandlerTest {
 
         ch.writeInbound(httpRequestWithEntity);
 
-        FullHttpResponse response = ReferenceCountUtil.releaseLater(responses.remove());
+        FullHttpResponse response = responses.remove();
         assertEquals(BAD_REQUEST, response.status());
         assertEquals("not a WebSocket handshake request: missing upgrade", getResponseMessage(response));
+        response.release();
     }
 
     @Test
@@ -101,9 +110,10 @@ public class WebSocketServerProtocolHandlerTest {
 
         ch.writeInbound(httpRequest);
 
-        FullHttpResponse response = ReferenceCountUtil.releaseLater(responses.remove());
+        FullHttpResponse response = responses.remove();
         assertEquals(BAD_REQUEST, response.status());
         assertEquals("not a WebSocket request: missing key", getResponseMessage(response));
+        response.release();
     }
 
     @Test

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionTestUtil.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionTestUtil.java
@@ -31,13 +31,12 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
-import io.netty.util.ReferenceCountUtil;
 
 public final class WebSocketExtensionTestUtil {
 
     public static HttpRequest newUpgradeRequest(String ext) {
-        HttpRequest req = ReferenceCountUtil.releaseLater(new DefaultHttpRequest(
-                HttpVersion.HTTP_1_1, HttpMethod.GET, "/chat"));
+        HttpRequest req = new DefaultHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.GET, "/chat");
 
         req.headers().set(HttpHeaderNames.HOST, "server.example.com");
         req.headers().set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET.toString().toLowerCase());
@@ -51,8 +50,8 @@ public final class WebSocketExtensionTestUtil {
     }
 
     public static HttpResponse newUpgradeResponse(String ext) {
-        HttpResponse res = ReferenceCountUtil.releaseLater(new DefaultHttpResponse(
-                HttpVersion.HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS));
+        HttpResponse res = new DefaultHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS);
 
         res.headers().set(HttpHeaderNames.HOST, "server.example.com");
         res.headers().set(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET.toString().toLowerCase());

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameDecoderTest.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.spdy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.util.ReferenceCountUtil;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -143,7 +142,7 @@ public class SpdyFrameDecoderTest {
         byte flags = 0;
         int length = 1024;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeDataFrameHeader(buf, streamId, flags, length);
         for (int i = 0; i < 256; i ++) {
             buf.writeInt(RANDOM.nextInt());
@@ -153,6 +152,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -161,7 +161,7 @@ public class SpdyFrameDecoderTest {
         byte flags = 0;
         int length = 0;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeDataFrameHeader(buf, streamId, flags, length);
 
         delegate.readDataFrame(streamId, false, Unpooled.EMPTY_BUFFER);
@@ -169,6 +169,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -177,7 +178,7 @@ public class SpdyFrameDecoderTest {
         byte flags = 0x01; // FLAG_FIN
         int length = 0;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeDataFrameHeader(buf, streamId, flags, length);
 
         delegate.readDataFrame(streamId, true, Unpooled.EMPTY_BUFFER);
@@ -185,6 +186,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -193,7 +195,7 @@ public class SpdyFrameDecoderTest {
         byte flags = (byte) 0xFE; // should ignore any unknown flags
         int length = 0;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeDataFrameHeader(buf, streamId, flags, length);
 
         delegate.readDataFrame(streamId, false, Unpooled.EMPTY_BUFFER);
@@ -201,6 +203,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -209,7 +212,7 @@ public class SpdyFrameDecoderTest {
         byte flags = 0;
         int length = 0;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeDataFrameHeader(buf, streamId, flags, length);
 
         delegate.readFrameError((String) anyObject());
@@ -217,6 +220,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -226,7 +230,7 @@ public class SpdyFrameDecoderTest {
         byte flags = 0;
         int length = 0;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(2 * (SPDY_HEADER_SIZE + length)));
+        ByteBuf buf = Unpooled.buffer(2 * (SPDY_HEADER_SIZE + length));
         encodeDataFrameHeader(buf, streamId1, flags, length);
         encodeDataFrameHeader(buf, streamId2, flags, length);
 
@@ -236,6 +240,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -247,7 +252,7 @@ public class SpdyFrameDecoderTest {
         int associatedToStreamId = RANDOM.nextInt() & 0x7FFFFFFF;
         byte priority = (byte) (RANDOM.nextInt() & 0x07);
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
         buf.writeInt(associatedToStreamId);
@@ -260,6 +265,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -271,7 +277,7 @@ public class SpdyFrameDecoderTest {
         int associatedToStreamId = RANDOM.nextInt() & 0x7FFFFFFF;
         byte priority = (byte) (RANDOM.nextInt() & 0x07);
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
         buf.writeInt(associatedToStreamId);
@@ -284,6 +290,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -295,7 +302,7 @@ public class SpdyFrameDecoderTest {
         int associatedToStreamId = RANDOM.nextInt() & 0x7FFFFFFF;
         byte priority = (byte) (RANDOM.nextInt() & 0x07);
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
         buf.writeInt(associatedToStreamId);
@@ -308,6 +315,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -319,7 +327,7 @@ public class SpdyFrameDecoderTest {
         int associatedToStreamId = 0; // independent of all other streams
         byte priority = (byte) (RANDOM.nextInt() & 0x07);
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
         buf.writeInt(associatedToStreamId);
@@ -332,6 +340,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -343,7 +352,7 @@ public class SpdyFrameDecoderTest {
         int associatedToStreamId = RANDOM.nextInt() & 0x7FFFFFFF;
         byte priority = (byte) (RANDOM.nextInt() & 0x07);
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
         buf.writeInt(associatedToStreamId);
@@ -356,6 +365,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -367,7 +377,7 @@ public class SpdyFrameDecoderTest {
         int associatedToStreamId = RANDOM.nextInt() & 0x7FFFFFFF;
         byte priority = (byte) (RANDOM.nextInt() & 0x07);
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId | 0x80000000); // should ignore reserved bit
         buf.writeInt(associatedToStreamId | 0x80000000); // should ignore reserved bit
@@ -380,6 +390,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -390,7 +401,7 @@ public class SpdyFrameDecoderTest {
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
         int associatedToStreamId = RANDOM.nextInt() & 0x7FFFFFFF;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
         buf.writeInt(associatedToStreamId);
@@ -400,6 +411,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -411,7 +423,7 @@ public class SpdyFrameDecoderTest {
         int associatedToStreamId = RANDOM.nextInt() & 0x7FFFFFFF;
         byte priority = (byte) (RANDOM.nextInt() & 0x07);
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
         buf.writeInt(associatedToStreamId);
@@ -423,6 +435,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -435,14 +448,14 @@ public class SpdyFrameDecoderTest {
         int associatedToStreamId = RANDOM.nextInt() & 0x7FFFFFFF;
         byte priority = (byte) (RANDOM.nextInt() & 0x07);
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length + headerBlockLength));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length + headerBlockLength);
         encodeControlFrameHeader(buf, type, flags, length + headerBlockLength);
         buf.writeInt(streamId);
         buf.writeInt(associatedToStreamId);
         buf.writeByte(priority << 5);
         buf.writeByte(0);
 
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(headerBlockLength));
+        ByteBuf headerBlock = Unpooled.buffer(headerBlockLength);
         for (int i = 0; i < 256; i ++) {
             headerBlock.writeInt(RANDOM.nextInt());
         }
@@ -456,6 +469,8 @@ public class SpdyFrameDecoderTest {
         verify(delegate);
         assertFalse(buf.isReadable());
         assertFalse(headerBlock.isReadable());
+        buf.release();
+        headerBlock.release();
     }
 
     @Test
@@ -465,7 +480,7 @@ public class SpdyFrameDecoderTest {
         int length = 4;
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
@@ -475,6 +490,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -484,7 +500,7 @@ public class SpdyFrameDecoderTest {
         int length = 4;
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
@@ -494,6 +510,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -503,7 +520,7 @@ public class SpdyFrameDecoderTest {
         int length = 4;
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
@@ -513,6 +530,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -522,7 +540,7 @@ public class SpdyFrameDecoderTest {
         int length = 4;
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId | 0x80000000); // should ignore reserved bit
 
@@ -532,6 +550,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -540,7 +559,7 @@ public class SpdyFrameDecoderTest {
         byte flags = 0;
         int length = 0; // invalid length
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
 
         delegate.readFrameError((String) anyObject());
@@ -548,6 +567,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -557,7 +577,7 @@ public class SpdyFrameDecoderTest {
         int length = 4;
         int streamId = 0; // invalid stream identifier
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
@@ -566,6 +586,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -576,7 +597,7 @@ public class SpdyFrameDecoderTest {
         int headerBlockLength = 1024;
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length + headerBlockLength));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length + headerBlockLength);
         encodeControlFrameHeader(buf, type, flags, length + headerBlockLength);
         buf.writeInt(streamId);
 
@@ -594,6 +615,8 @@ public class SpdyFrameDecoderTest {
         verify(delegate);
         assertFalse(buf.isReadable());
         assertFalse(headerBlock.isReadable());
+        buf.release();
+        headerBlock.release();
     }
 
     @Test
@@ -604,7 +627,7 @@ public class SpdyFrameDecoderTest {
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
         int statusCode = RANDOM.nextInt() | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
         buf.writeInt(statusCode);
@@ -614,6 +637,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -624,7 +648,7 @@ public class SpdyFrameDecoderTest {
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
         int statusCode = RANDOM.nextInt() | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId | 0x80000000); // should ignore reserved bit
         buf.writeInt(statusCode);
@@ -634,6 +658,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -644,7 +669,7 @@ public class SpdyFrameDecoderTest {
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
         int statusCode = RANDOM.nextInt() | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
         buf.writeInt(statusCode);
@@ -654,6 +679,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -664,7 +690,7 @@ public class SpdyFrameDecoderTest {
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
         int statusCode = RANDOM.nextInt() | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
         buf.writeInt(statusCode);
@@ -674,6 +700,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -684,7 +711,7 @@ public class SpdyFrameDecoderTest {
         int streamId = 0; // invalid stream identifier
         int statusCode = RANDOM.nextInt() | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
         buf.writeInt(statusCode);
@@ -694,6 +721,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -704,7 +732,7 @@ public class SpdyFrameDecoderTest {
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
         int statusCode = 0; // invalid status code
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
         buf.writeInt(statusCode);
@@ -714,6 +742,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -726,7 +755,7 @@ public class SpdyFrameDecoderTest {
         int id = RANDOM.nextInt() & 0x00FFFFFF;
         int value = RANDOM.nextInt();
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(numSettings);
         for (int i = 0; i < numSettings; i++) {
@@ -743,6 +772,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -752,7 +782,7 @@ public class SpdyFrameDecoderTest {
         int numSettings = 0;
         int length = 8 * numSettings + 4;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(numSettings);
 
@@ -762,6 +792,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -771,7 +802,7 @@ public class SpdyFrameDecoderTest {
         int numSettings = 0;
         int length = 8 * numSettings + 4;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(numSettings);
 
@@ -781,6 +812,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -793,7 +825,7 @@ public class SpdyFrameDecoderTest {
         int id = RANDOM.nextInt() & 0x00FFFFFF;
         int value = RANDOM.nextInt();
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(numSettings);
         for (int i = 0; i < numSettings; i++) {
@@ -810,6 +842,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -822,7 +855,7 @@ public class SpdyFrameDecoderTest {
         int id = RANDOM.nextInt() & 0x00FFFFFF;
         int value = RANDOM.nextInt();
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(numSettings);
         for (int i = 0; i < numSettings; i++) {
@@ -839,6 +872,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -848,7 +882,7 @@ public class SpdyFrameDecoderTest {
         int numSettings = 0;
         int length = 8 * numSettings + 4;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(numSettings);
 
@@ -858,6 +892,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -870,7 +905,7 @@ public class SpdyFrameDecoderTest {
         int id = RANDOM.nextInt() & 0x00FFFFFF;
         int value = RANDOM.nextInt();
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(numSettings);
         for (int i = 0; i < numSettings; i++) {
@@ -887,6 +922,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -899,7 +935,7 @@ public class SpdyFrameDecoderTest {
         int id = RANDOM.nextInt() & 0x00FFFFFF;
         int value = RANDOM.nextInt();
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(numSettings);
         for (int i = 0; i < numSettings; i++) {
@@ -913,6 +949,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -925,7 +962,7 @@ public class SpdyFrameDecoderTest {
         int id = RANDOM.nextInt() & 0x00FFFFFF;
         int value = RANDOM.nextInt();
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(0); // invalid num_settings
         for (int i = 0; i < numSettings; i++) {
@@ -939,6 +976,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -947,7 +985,7 @@ public class SpdyFrameDecoderTest {
         byte flags = (byte) 0xFF;
         int length = 8;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeLong(RANDOM.nextLong());
 
@@ -955,6 +993,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -963,13 +1002,14 @@ public class SpdyFrameDecoderTest {
         byte flags = (byte) 0xFF;
         int length = 0;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
 
         replay(delegate);
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -979,7 +1019,7 @@ public class SpdyFrameDecoderTest {
         int segment = 4;
         int length = 2 * segment;
 
-        ByteBuf header = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE));
+        ByteBuf header = Unpooled.buffer(SPDY_HEADER_SIZE);
         ByteBuf segment1 = Unpooled.buffer(segment);
         ByteBuf segment2 = Unpooled.buffer(segment);
         encodeControlFrameHeader(header, type, flags, length);
@@ -994,6 +1034,9 @@ public class SpdyFrameDecoderTest {
         assertFalse(header.isReadable());
         assertFalse(segment1.isReadable());
         assertFalse(segment2.isReadable());
+        header.release();
+        segment1.release();
+        segment2.release();
     }
 
     @Test
@@ -1003,7 +1046,7 @@ public class SpdyFrameDecoderTest {
         int length = 4;
         int id = RANDOM.nextInt();
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(id);
 
@@ -1012,6 +1055,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1021,7 +1065,7 @@ public class SpdyFrameDecoderTest {
         int length = 4;
         int id = RANDOM.nextInt();
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(id);
 
@@ -1030,6 +1074,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1039,7 +1084,7 @@ public class SpdyFrameDecoderTest {
         int length = 8; // invalid length
         int id = RANDOM.nextInt();
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(id);
 
@@ -1048,6 +1093,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1058,7 +1104,7 @@ public class SpdyFrameDecoderTest {
         int lastGoodStreamId = RANDOM.nextInt() & 0x7FFFFFFF;
         int statusCode = RANDOM.nextInt() | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(lastGoodStreamId);
         buf.writeInt(statusCode);
@@ -1068,6 +1114,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1078,7 +1125,7 @@ public class SpdyFrameDecoderTest {
         int lastGoodStreamId = RANDOM.nextInt() & 0x7FFFFFFF;
         int statusCode = RANDOM.nextInt() | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(lastGoodStreamId);
         buf.writeInt(statusCode);
@@ -1088,6 +1135,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1098,7 +1146,7 @@ public class SpdyFrameDecoderTest {
         int lastGoodStreamId = RANDOM.nextInt() & 0x7FFFFFFF;
         int statusCode = RANDOM.nextInt() | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(lastGoodStreamId | 0x80000000); // should ignore reserved bit
         buf.writeInt(statusCode);
@@ -1108,6 +1156,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1118,7 +1167,7 @@ public class SpdyFrameDecoderTest {
         int lastGoodStreamId = RANDOM.nextInt() & 0x7FFFFFFF;
         int statusCode = RANDOM.nextInt() | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(lastGoodStreamId);
         buf.writeInt(statusCode);
@@ -1128,6 +1177,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1137,7 +1187,7 @@ public class SpdyFrameDecoderTest {
         int length = 4;
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
@@ -1147,6 +1197,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1156,7 +1207,7 @@ public class SpdyFrameDecoderTest {
         int length = 4;
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
@@ -1166,6 +1217,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1175,7 +1227,7 @@ public class SpdyFrameDecoderTest {
         int length = 4;
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
@@ -1185,6 +1237,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1194,7 +1247,7 @@ public class SpdyFrameDecoderTest {
         int length = 4;
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId | 0x80000000); // should ignore reserved bit
 
@@ -1204,6 +1257,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1212,7 +1266,7 @@ public class SpdyFrameDecoderTest {
         byte flags = 0;
         int length = 0; // invalid length
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
 
         delegate.readFrameError((String) anyObject());
@@ -1220,6 +1274,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1229,7 +1284,7 @@ public class SpdyFrameDecoderTest {
         int length = 4;
         int streamId = 0; // invalid stream identifier
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
@@ -1238,6 +1293,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1248,11 +1304,11 @@ public class SpdyFrameDecoderTest {
         int headerBlockLength = 1024;
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length + headerBlockLength);
         buf.writeInt(streamId);
 
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(headerBlockLength));
+        ByteBuf headerBlock = Unpooled.buffer(headerBlockLength);
         for (int i = 0; i < 256; i ++) {
             headerBlock.writeInt(RANDOM.nextInt());
         }
@@ -1266,6 +1322,8 @@ public class SpdyFrameDecoderTest {
         verify(delegate);
         assertFalse(buf.isReadable());
         assertFalse(headerBlock.isReadable());
+        buf.release();
+        headerBlock.release();
     }
 
     @Test
@@ -1296,7 +1354,7 @@ public class SpdyFrameDecoderTest {
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF;
         int deltaWindowSize = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
         buf.writeInt(deltaWindowSize);
@@ -1306,6 +1364,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1316,7 +1375,7 @@ public class SpdyFrameDecoderTest {
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF;
         int deltaWindowSize = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId | 0x80000000); // should ignore reserved bit
         buf.writeInt(deltaWindowSize | 0x80000000); // should ignore reserved bit
@@ -1326,6 +1385,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1336,7 +1396,7 @@ public class SpdyFrameDecoderTest {
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF;
         int deltaWindowSize = RANDOM.nextInt() & 0x7FFFFFFF | 0x01;
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
         buf.writeInt(deltaWindowSize);
@@ -1346,6 +1406,7 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 
     @Test
@@ -1356,7 +1417,7 @@ public class SpdyFrameDecoderTest {
         int streamId = RANDOM.nextInt() & 0x7FFFFFFF;
         int deltaWindowSize = 0; // invalid delta window size
 
-        ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer(SPDY_HEADER_SIZE + length));
+        ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
         buf.writeInt(deltaWindowSize);
@@ -1366,5 +1427,6 @@ public class SpdyFrameDecoderTest {
         decoder.decode(buf);
         verify(delegate);
         assertFalse(buf.isReadable());
+        buf.release();
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyHeaderBlockRawDecoderTest.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.spdy;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
-import io.netty.util.ReferenceCountUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,18 +51,19 @@ public class SpdyHeaderBlockRawDecoderTest {
 
     @Test
     public void testEmptyHeaderBlock() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.EMPTY_BUFFER);
+        ByteBuf headerBlock = Unpooled.EMPTY_BUFFER;
         decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
         decoder.endHeaderBlock(frame);
 
         assertFalse(headerBlock.isReadable());
         assertTrue(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testZeroNameValuePairs() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(4));
+        ByteBuf headerBlock = Unpooled.buffer(4);
         headerBlock.writeInt(0);
         decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
         decoder.endHeaderBlock(frame);
@@ -71,22 +71,24 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertFalse(headerBlock.isReadable());
         assertFalse(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testNegativeNameValuePairs() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(4));
+        ByteBuf headerBlock = Unpooled.buffer(4);
         headerBlock.writeInt(-1);
         decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
 
         assertFalse(headerBlock.isReadable());
         assertTrue(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testOneNameValuePair() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(21));
+        ByteBuf headerBlock = Unpooled.buffer(21);
         headerBlock.writeInt(1);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -101,11 +103,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertTrue(frame.headers().contains(name));
         assertEquals(1, frame.headers().getAll(name).size());
         assertEquals(value, frame.headers().get(name));
+        headerBlock.release();
     }
 
     @Test
     public void testMissingNameLength() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(4));
+        ByteBuf headerBlock = Unpooled.buffer(4);
         headerBlock.writeInt(1);
         decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
         decoder.endHeaderBlock(frame);
@@ -113,11 +116,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertFalse(headerBlock.isReadable());
         assertTrue(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testZeroNameLength() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(8));
+        ByteBuf headerBlock = Unpooled.buffer(8);
         headerBlock.writeInt(1);
         headerBlock.writeInt(0);
         decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
@@ -125,11 +129,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertFalse(headerBlock.isReadable());
         assertTrue(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testNegativeNameLength() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(8));
+        ByteBuf headerBlock = Unpooled.buffer(8);
         headerBlock.writeInt(1);
         headerBlock.writeInt(-1);
         decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
@@ -137,11 +142,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertFalse(headerBlock.isReadable());
         assertTrue(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testMissingName() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(8));
+        ByteBuf headerBlock = Unpooled.buffer(8);
         headerBlock.writeInt(1);
         headerBlock.writeInt(4);
         decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
@@ -150,11 +156,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertFalse(headerBlock.isReadable());
         assertTrue(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testIllegalNameOnlyNull() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(18));
+        ByteBuf headerBlock = Unpooled.buffer(18);
         headerBlock.writeInt(1);
         headerBlock.writeInt(1);
         headerBlock.writeByte(0);
@@ -165,11 +172,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertFalse(headerBlock.isReadable());
         assertTrue(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testMissingValueLength() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(12));
+        ByteBuf headerBlock =  Unpooled.buffer(12);
         headerBlock.writeInt(1);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -179,11 +187,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertFalse(headerBlock.isReadable());
         assertTrue(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testZeroValueLength() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(16));
+        ByteBuf headerBlock = Unpooled.buffer(16);
         headerBlock.writeInt(1);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -197,11 +206,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertTrue(frame.headers().contains(name));
         assertEquals(1, frame.headers().getAll(name).size());
         assertEquals("", frame.headers().get(name));
+        headerBlock.release();
     }
 
     @Test
     public void testNegativeValueLength() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(16));
+        ByteBuf headerBlock = Unpooled.buffer(16);
         headerBlock.writeInt(1);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -211,11 +221,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertFalse(headerBlock.isReadable());
         assertTrue(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testMissingValue() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(16));
+        ByteBuf headerBlock = Unpooled.buffer(16);
         headerBlock.writeInt(1);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -226,11 +237,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertFalse(headerBlock.isReadable());
         assertTrue(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testIllegalValueOnlyNull() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(17));
+        ByteBuf headerBlock = Unpooled.buffer(17);
         headerBlock.writeInt(1);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -241,11 +253,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertFalse(headerBlock.isReadable());
         assertTrue(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testIllegalValueStartsWithNull() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(22));
+        ByteBuf headerBlock = Unpooled.buffer(22);
         headerBlock.writeInt(1);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -257,11 +270,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertFalse(headerBlock.isReadable());
         assertTrue(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testIllegalValueEndsWithNull() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(22));
+        ByteBuf headerBlock = Unpooled.buffer(22);
         headerBlock.writeInt(1);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -273,11 +287,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertFalse(headerBlock.isReadable());
         assertTrue(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testMultipleValues() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(27));
+        ByteBuf headerBlock = Unpooled.buffer(27);
         headerBlock.writeInt(1);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -295,11 +310,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertEquals(2, frame.headers().getAll(name).size());
         assertEquals(value, frame.headers().getAll(name).get(0));
         assertEquals(value, frame.headers().getAll(name).get(1));
+        headerBlock.release();
     }
 
     @Test
     public void testMultipleValuesEndsWithNull() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(28));
+        ByteBuf headerBlock = Unpooled.buffer(28);
         headerBlock.writeInt(1);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -316,11 +332,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertTrue(frame.headers().contains(name));
         assertEquals(1, frame.headers().getAll(name).size());
         assertEquals(value, frame.headers().get(name));
+        headerBlock.release();
     }
 
     @Test
     public void testIllegalValueMultipleNulls() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(28));
+        ByteBuf headerBlock = Unpooled.buffer(28);
         headerBlock.writeInt(1);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -335,11 +352,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertFalse(headerBlock.isReadable());
         assertTrue(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testMissingNextNameValuePair() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(21));
+        ByteBuf headerBlock = Unpooled.buffer(21);
         headerBlock.writeInt(2);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -354,11 +372,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertTrue(frame.headers().contains(name));
         assertEquals(1, frame.headers().getAll(name).size());
         assertEquals(value, frame.headers().get(name));
+        headerBlock.release();
     }
 
     @Test
     public void testMultipleNames() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(38));
+        ByteBuf headerBlock = Unpooled.buffer(38);
         headerBlock.writeInt(2);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -376,11 +395,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertTrue(frame.headers().contains(name));
         assertEquals(1, frame.headers().getAll(name).size());
         assertEquals(value, frame.headers().get(name));
+        headerBlock.release();
     }
 
     @Test
     public void testExtraData() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(22));
+        ByteBuf headerBlock = Unpooled.buffer(22);
         headerBlock.writeInt(1);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -395,11 +415,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertTrue(frame.headers().contains(name));
         assertEquals(1, frame.headers().getAll(name).size());
         assertEquals(value, frame.headers().get(name));
+        headerBlock.release();
     }
 
     @Test
     public void testMultipleDecodes() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(21));
+        ByteBuf headerBlock = Unpooled.buffer(21);
         headerBlock.writeInt(1);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -419,18 +440,19 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertTrue(frame.headers().contains(name));
         assertEquals(1, frame.headers().getAll(name).size());
         assertEquals(value, frame.headers().get(name));
+        headerBlock.release();
     }
 
     @Test
     public void testContinueAfterInvalidHeaders() throws Exception {
-        ByteBuf numHeaders = ReferenceCountUtil.releaseLater(Unpooled.buffer(4));
+        ByteBuf numHeaders = Unpooled.buffer(4);
         numHeaders.writeInt(1);
 
-        ByteBuf nameBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(8));
+        ByteBuf nameBlock = Unpooled.buffer(8);
         nameBlock.writeInt(4);
         nameBlock.writeBytes(nameBytes);
 
-        ByteBuf valueBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(9));
+        ByteBuf valueBlock = Unpooled.buffer(9);
         valueBlock.writeInt(5);
         valueBlock.writeBytes(valueBytes);
 
@@ -447,11 +469,14 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertTrue(frame.headers().contains(name));
         assertEquals(1, frame.headers().getAll(name).size());
         assertEquals(value, frame.headers().get(name));
+        numHeaders.release();
+        nameBlock.release();
+        valueBlock.release();
     }
 
     @Test
     public void testTruncatedHeaderName() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(maxHeaderSize + 18));
+        ByteBuf headerBlock = Unpooled.buffer(maxHeaderSize + 18);
         headerBlock.writeInt(1);
         headerBlock.writeInt(maxHeaderSize + 1);
         for (int i = 0; i < maxHeaderSize + 1; i++) {
@@ -466,11 +491,12 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertTrue(frame.isTruncated());
         assertFalse(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 
     @Test
     public void testTruncatedHeaderValue() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(maxHeaderSize + 13));
+        ByteBuf headerBlock = Unpooled.buffer(maxHeaderSize + 13);
         headerBlock.writeInt(1);
         headerBlock.writeInt(4);
         headerBlock.writeBytes(nameBytes);
@@ -485,5 +511,6 @@ public class SpdyHeaderBlockRawDecoderTest {
         assertTrue(frame.isTruncated());
         assertFalse(frame.isInvalid());
         assertEquals(0, frame.headers().names().size());
+        headerBlock.release();
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyHeaderBlockZlibDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyHeaderBlockZlibDecoderTest.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.spdy;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
-import io.netty.util.ReferenceCountUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +55,7 @@ public class SpdyHeaderBlockZlibDecoderTest {
 
     @Test
     public void testHeaderBlock() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(37));
+        ByteBuf headerBlock = Unpooled.buffer(37);
         headerBlock.writeBytes(zlibHeader);
         headerBlock.writeByte(0); // Non-compressed block
         headerBlock.writeByte(0x15); // little-endian length (21)
@@ -78,11 +77,13 @@ public class SpdyHeaderBlockZlibDecoderTest {
         assertTrue(frame.headers().contains(name));
         assertEquals(1, frame.headers().getAll(name).size());
         assertEquals(value, frame.headers().get(name));
+
+        headerBlock.release();
     }
 
     @Test
     public void testHeaderBlockMultipleDecodes() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(37));
+        ByteBuf headerBlock = Unpooled.buffer(37);
         headerBlock.writeBytes(zlibHeader);
         headerBlock.writeByte(0); // Non-compressed block
         headerBlock.writeByte(0x15); // little-endian length (21)
@@ -109,11 +110,13 @@ public class SpdyHeaderBlockZlibDecoderTest {
         assertTrue(frame.headers().contains(name));
         assertEquals(1, frame.headers().getAll(name).size());
         assertEquals(value, frame.headers().get(name));
+
+        headerBlock.release();
     }
 
     @Test
     public void testLargeHeaderName() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(8220));
+        ByteBuf headerBlock = Unpooled.buffer(8220);
         headerBlock.writeBytes(zlibHeader);
         headerBlock.writeByte(0); // Non-compressed block
         headerBlock.writeByte(0x0c); // little-endian length (8204)
@@ -134,11 +137,13 @@ public class SpdyHeaderBlockZlibDecoderTest {
         assertFalse(frame.isInvalid());
         assertFalse(frame.isTruncated());
         assertEquals(1, frame.headers().names().size());
+
+        headerBlock.release();
     }
 
     @Test
     public void testLargeHeaderValue() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(8220));
+        ByteBuf headerBlock = Unpooled.buffer(8220);
         headerBlock.writeBytes(zlibHeader);
         headerBlock.writeByte(0); // Non-compressed block
         headerBlock.writeByte(0x0c); // little-endian length (8204)
@@ -161,11 +166,13 @@ public class SpdyHeaderBlockZlibDecoderTest {
         assertFalse(frame.isTruncated());
         assertEquals(1, frame.headers().names().size());
         assertEquals(8191, frame.headers().get("n").length());
+
+        headerBlock.release();
     }
 
     @Test(expected = SpdyProtocolException.class)
     public void testHeaderBlockExtraData() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(37));
+        ByteBuf headerBlock = Unpooled.buffer(37);
         headerBlock.writeBytes(zlibHeader);
         headerBlock.writeByte(0); // Non-compressed block
         headerBlock.writeByte(0x15); // little-endian length (21)
@@ -183,11 +190,13 @@ public class SpdyHeaderBlockZlibDecoderTest {
         headerBlock.writeByte(0xc9); // adler-32 checksum
         headerBlock.writeByte(0); // Data following zlib stream
         decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
+
+        headerBlock.release();
     }
 
     @Test(expected = SpdyProtocolException.class)
     public void testHeaderBlockInvalidDictionary() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(7));
+        ByteBuf headerBlock = Unpooled.buffer(7);
         headerBlock.writeByte(0x78);
         headerBlock.writeByte(0x3f);
         headerBlock.writeByte(0x01); // Unknown dictionary
@@ -196,11 +205,13 @@ public class SpdyHeaderBlockZlibDecoderTest {
         headerBlock.writeByte(0x04); // Unknown dictionary
         headerBlock.writeByte(0); // Non-compressed block
         decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
+
+        headerBlock.release();
     }
 
     @Test(expected = SpdyProtocolException.class)
     public void testHeaderBlockInvalidDeflateBlock() throws Exception {
-        ByteBuf headerBlock = ReferenceCountUtil.releaseLater(Unpooled.buffer(11));
+        ByteBuf headerBlock = Unpooled.buffer(11);
         headerBlock.writeBytes(zlibHeader);
         headerBlock.writeByte(0); // Non-compressed block
         headerBlock.writeByte(0x00); // little-endian length (0)
@@ -208,5 +219,7 @@ public class SpdyHeaderBlockZlibDecoderTest {
         headerBlock.writeByte(0x00); // invalid one's compliment
         headerBlock.writeByte(0x00); // invalid one's compliment
         decoder.decode(ByteBufAllocator.DEFAULT, headerBlock, frame);
+
+        headerBlock.release();
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2CodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2CodecTest.java
@@ -28,7 +28,6 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
 import io.netty.channel.local.LocalServerChannel;
-import io.netty.util.ReferenceCountUtil;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -129,7 +128,7 @@ public class Http2CodecTest {
         Http2Headers headers = new DefaultHttp2Headers();
         childChannel.write(new DefaultHttp2HeadersFrame(headers));
         ByteBuf data = Unpooled.buffer(100).writeZero(100);
-        childChannel.writeAndFlush(ReferenceCountUtil.releaseLater(new DefaultHttp2DataFrame(data, true)));
+        childChannel.writeAndFlush(new DefaultHttp2DataFrame(data, true));
 
         Http2HeadersFrame headersFrame = serverLastInboundHandler.blockingReadInbound();
         assertNotNull(headersFrame);
@@ -138,10 +137,10 @@ public class Http2CodecTest {
 
         Http2DataFrame dataFrame = serverLastInboundHandler.blockingReadInbound();
         assertNotNull(dataFrame);
-        ReferenceCountUtil.releaseLater(dataFrame);
         assertEquals(3, dataFrame.streamId());
         assertEquals(data.resetReaderIndex(), dataFrame.content());
         assertTrue(dataFrame.isEndStream());
+        dataFrame.release();
 
         childChannel.close();
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -42,7 +42,6 @@ import java.net.InetSocketAddress;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
-import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -150,22 +149,26 @@ public class Http2FrameCodecTest {
         // Release hello to emulate ByteToMessageDecoder
         hello.release();
         Http2DataFrame inboundData = inboundHandler.readInbound();
-        assertEquals(releaseLater(new DefaultHttp2DataFrame(bb("hello"), true, 31).streamId(stream.id())),
-                     releaseLater(inboundData));
+        Http2DataFrame expected = new DefaultHttp2DataFrame(bb("hello"), true, 31).streamId(stream.id());
+        assertEquals(expected, inboundData);
         assertEquals(1, inboundData.refCnt());
+        expected.release();
         assertNull(inboundHandler.readInbound());
 
         inboundHandler.writeOutbound(new DefaultHttp2HeadersFrame(response, false).streamId(stream.id()));
         verify(frameWriter).writeHeaders(eq(http2HandlerCtx), eq(1), eq(response), anyInt(),
                                          anyShort(), anyBoolean(), eq(0), eq(false), anyChannelPromise());
 
-        inboundHandler.writeOutbound(releaseLater(new DefaultHttp2DataFrame(bb("world"), true, 27)
-                                                          .streamId(stream.id())));
+        inboundHandler.writeOutbound(new DefaultHttp2DataFrame(bb("world"), true, 27)
+                                                          .streamId(stream.id()));
         ArgumentCaptor<ByteBuf> outboundData = ArgumentCaptor.forClass(ByteBuf.class);
         verify(frameWriter).writeData(eq(http2HandlerCtx), eq(1), outboundData.capture(), eq(27),
                                       eq(true), anyChannelPromise());
-        assertEquals(releaseLater(bb("world")), outboundData.getValue());
+
+        ByteBuf bb = bb("world");
+        assertEquals(bb, outboundData.getValue());
         assertEquals(1, outboundData.getValue().refCnt());
+        bb.release();
         verify(frameWriter, never()).writeRstStream(
                 any(ChannelHandlerContext.class), anyInt(), anyLong(), anyChannelPromise());
         assertTrue(channel.isActive());
@@ -224,15 +227,18 @@ public class Http2FrameCodecTest {
         assertEquals(State.OPEN, stream.state());
 
         ByteBuf debugData = bb("debug");
+        ByteBuf expected = debugData.copy();
+
         Http2GoAwayFrame goAwayFrame = new DefaultHttp2GoAwayFrame(Http2Error.NO_ERROR.code(), debugData.slice());
         goAwayFrame.setExtraStreamIds(2);
 
-        inboundHandler.writeOutbound(releaseLater(goAwayFrame));
+        inboundHandler.writeOutbound(goAwayFrame);
         verify(frameWriter).writeGoAway(
-                eq(http2HandlerCtx), eq(7), eq(Http2Error.NO_ERROR.code()), eq(debugData), anyChannelPromise());
+                eq(http2HandlerCtx), eq(7), eq(Http2Error.NO_ERROR.code()), eq(expected), anyChannelPromise());
         assertEquals(1, debugData.refCnt());
         assertEquals(State.OPEN, stream.state());
         assertTrue(channel.isActive());
+        expected.release();
     }
 
     @Test
@@ -244,8 +250,11 @@ public class Http2FrameCodecTest {
         Http2GoAwayFrame expectedFrame = new DefaultHttp2GoAwayFrame(2, Http2Error.NO_ERROR.code(), bb("foo"));
         Http2GoAwayFrame actualFrame = inboundHandler.readInbound();
 
-        assertEquals(releaseLater(expectedFrame), releaseLater(actualFrame));
+        assertEquals(expectedFrame, actualFrame);
         assertNull(inboundHandler.readInbound());
+
+        expectedFrame.release();
+        actualFrame.release();
     }
 
     @Test
@@ -306,7 +315,7 @@ public class Http2FrameCodecTest {
         Http2GoAwayFrame goAwayFrame = new DefaultHttp2GoAwayFrame(Http2Error.NO_ERROR.code(), debugData.slice());
         goAwayFrame.setExtraStreamIds(Integer.MAX_VALUE);
 
-        inboundHandler.writeOutbound(releaseLater(goAwayFrame));
+        inboundHandler.writeOutbound(goAwayFrame);
         // When the last stream id computation overflows, the last stream id should just be set to 2^31 - 1.
         verify(frameWriter).writeGoAway(eq(http2HandlerCtx), eq(Integer.MAX_VALUE), eq(Http2Error.NO_ERROR.code()),
                                         eq(debugData), anyChannelPromise());
@@ -393,13 +402,14 @@ public class Http2FrameCodecTest {
         assertNotNull(stream);
 
         ByteBuf data = Unpooled.buffer(100).writeZero(100);
-        frameListener.onDataRead(http2HandlerCtx, 3, releaseLater(data), 0, true);
+        frameListener.onDataRead(http2HandlerCtx, 3, data, 0, true);
 
         int before = connection.local().flowController().unconsumedBytes(stream);
         ChannelFuture f = channel.write(new DefaultHttp2WindowUpdateFrame(100).streamId(stream.id()));
         int after = connection.local().flowController().unconsumedBytes(stream);
         assertEquals(100, before - after);
         assertTrue(f.isSuccess());
+        data.release();
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
@@ -39,7 +39,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static io.netty.util.ReferenceCountUtil.release;
-import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -93,8 +92,8 @@ public class Http2MultiplexCodecTest {
 
         Http2StreamActiveEvent streamActive = new Http2StreamActiveEvent(streamId);
         Http2HeadersFrame headersFrame = new DefaultHttp2HeadersFrame(request).streamId(streamId);
-        Http2DataFrame dataFrame1 = releaseLater(new DefaultHttp2DataFrame(bb("hello")).streamId(streamId));
-        Http2DataFrame dataFrame2 = releaseLater(new DefaultHttp2DataFrame(bb("world")).streamId(streamId));
+        Http2DataFrame dataFrame1 = new DefaultHttp2DataFrame(bb("hello")).streamId(streamId);
+        Http2DataFrame dataFrame2 = new DefaultHttp2DataFrame(bb("world")).streamId(streamId);
 
         assertFalse(inboundHandler.isChannelActive());
         parentChannel.pipeline().fireUserEventTriggered(streamActive);
@@ -109,6 +108,9 @@ public class Http2MultiplexCodecTest {
         assertEquals(dataFrame1, inboundHandler.readInbound());
         assertEquals(dataFrame2, inboundHandler.readInbound());
         assertNull(inboundHandler.readInbound());
+
+        dataFrame1.release();
+        dataFrame2.release();
     }
 
     @Test

--- a/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ByteToMessageDecoderTest.java
@@ -87,7 +87,7 @@ public class ByteToMessageDecoderTest {
      */
     @Test
     public void testInternalBufferClearReadAll() {
-        final ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer().writeBytes(new byte[] {'a'}));
+        final ByteBuf buf = Unpooled.buffer().writeBytes(new byte[] {'a'});
         EmbeddedChannel channel = new EmbeddedChannel(new ByteToMessageDecoder() {
             @Override
             protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
@@ -109,7 +109,7 @@ public class ByteToMessageDecoderTest {
      */
     @Test
     public void testInternalBufferClearReadPartly() {
-        final ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer().writeBytes(new byte[] {'a', 'b'}));
+        final ByteBuf buf = Unpooled.buffer().writeBytes(new byte[] {'a', 'b'});
         EmbeddedChannel channel = new EmbeddedChannel(new ByteToMessageDecoder() {
             @Override
             protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
@@ -134,7 +134,7 @@ public class ByteToMessageDecoderTest {
     @Test
     public void testFireChannelReadCompleteOnInactive() throws InterruptedException {
         final BlockingQueue<Integer> queue = new LinkedBlockingDeque<Integer>();
-        final ByteBuf buf = ReferenceCountUtil.releaseLater(Unpooled.buffer().writeBytes(new byte[] {'a', 'b'}));
+        final ByteBuf buf = Unpooled.buffer().writeBytes(new byte[] {'a', 'b'});
         EmbeddedChannel channel = new EmbeddedChannel(new ByteToMessageDecoder() {
             @Override
             protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {

--- a/codec/src/test/java/io/netty/handler/codec/DelimiterBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DelimiterBasedFrameDecoderTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 
 import java.nio.charset.Charset;
 
-import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.junit.Assert.*;
 
 public class DelimiterBasedFrameDecoderTest {
@@ -34,10 +33,17 @@ public class DelimiterBasedFrameDecoderTest {
         EmbeddedChannel ch = new EmbeddedChannel(new DelimiterBasedFrameDecoder(8192, true,
                 Delimiters.lineDelimiter()));
         ch.writeInbound(Unpooled.copiedBuffer("TestLine\r\ng\r\n", Charset.defaultCharset()));
-        assertEquals("TestLine", releaseLater((ByteBuf) ch.readInbound()).toString(Charset.defaultCharset()));
-        assertEquals("g", releaseLater((ByteBuf) ch.readInbound()).toString(Charset.defaultCharset()));
+
+        ByteBuf buf = ch.readInbound();
+        assertEquals("TestLine", buf.toString(Charset.defaultCharset()));
+
+        ByteBuf buf2 = ch.readInbound();
+        assertEquals("g", buf2.toString(Charset.defaultCharset()));
         assertNull(ch.readInbound());
         ch.finish();
+
+        buf.release();
+        buf2.release();
     }
 
     @Test
@@ -47,10 +53,17 @@ public class DelimiterBasedFrameDecoderTest {
         ch.writeInbound(Unpooled.copiedBuffer("Test", Charset.defaultCharset()));
         assertNull(ch.readInbound());
         ch.writeInbound(Unpooled.copiedBuffer("Line\r\ng\r\n", Charset.defaultCharset()));
-        assertEquals("TestLine", releaseLater((ByteBuf) ch.readInbound()).toString(Charset.defaultCharset()));
-        assertEquals("g", releaseLater((ByteBuf) ch.readInbound()).toString(Charset.defaultCharset()));
+
+        ByteBuf buf = ch.readInbound();
+        assertEquals("TestLine", buf.toString(Charset.defaultCharset()));
+
+        ByteBuf buf2 = ch.readInbound();
+        assertEquals("g", buf2.toString(Charset.defaultCharset()));
         assertNull(ch.readInbound());
         ch.finish();
+
+        buf.release();
+        buf2.release();
     }
 
     @Test
@@ -58,10 +71,17 @@ public class DelimiterBasedFrameDecoderTest {
         EmbeddedChannel ch = new EmbeddedChannel(new DelimiterBasedFrameDecoder(8192, false,
                 Delimiters.lineDelimiter()));
         ch.writeInbound(Unpooled.copiedBuffer("TestLine\r\ng\r\n", Charset.defaultCharset()));
-        assertEquals("TestLine\r\n", releaseLater((ByteBuf) ch.readInbound()).toString(Charset.defaultCharset()));
-        assertEquals("g\r\n", releaseLater((ByteBuf) ch.readInbound()).toString(Charset.defaultCharset()));
+
+        ByteBuf buf = ch.readInbound();
+        assertEquals("TestLine\r\n", buf.toString(Charset.defaultCharset()));
+
+        ByteBuf buf2 = ch.readInbound();
+        assertEquals("g\r\n", buf2.toString(Charset.defaultCharset()));
         assertNull(ch.readInbound());
         ch.finish();
+
+        buf.release();
+        buf2.release();
     }
 
     @Test
@@ -71,10 +91,17 @@ public class DelimiterBasedFrameDecoderTest {
         ch.writeInbound(Unpooled.copiedBuffer("Test", Charset.defaultCharset()));
         assertNull(ch.readInbound());
         ch.writeInbound(Unpooled.copiedBuffer("Line\r\ng\r\n", Charset.defaultCharset()));
-        assertEquals("TestLine\r\n", releaseLater((ByteBuf) ch.readInbound()).toString(Charset.defaultCharset()));
-        assertEquals("g\r\n", releaseLater((ByteBuf) ch.readInbound()).toString(Charset.defaultCharset()));
+
+        ByteBuf buf = ch.readInbound();
+        assertEquals("TestLine\r\n", buf.toString(Charset.defaultCharset()));
+
+        ByteBuf buf2 = ch.readInbound();
+        assertEquals("g\r\n", buf2.toString(Charset.defaultCharset()));
         assertNull(ch.readInbound());
         ch.finish();
+
+        buf.release();
+        buf2.release();
     }
 
     @Test
@@ -83,11 +110,18 @@ public class DelimiterBasedFrameDecoderTest {
                 new DelimiterBasedFrameDecoder(8192, true, Delimiters.lineDelimiter()));
 
         ch.writeInbound(Unpooled.copiedBuffer("first\r\nsecond\nthird", CharsetUtil.US_ASCII));
-        assertEquals("first", releaseLater((ByteBuf) ch.readInbound()).toString(CharsetUtil.US_ASCII));
-        assertEquals("second", releaseLater((ByteBuf) ch.readInbound()).toString(CharsetUtil.US_ASCII));
+
+        ByteBuf buf = ch.readInbound();
+        assertEquals("first", buf.toString(CharsetUtil.US_ASCII));
+
+        ByteBuf buf2 = ch.readInbound();
+        assertEquals("second", buf2.toString(CharsetUtil.US_ASCII));
         assertNull(ch.readInbound());
         ch.finish();
 
         ReferenceCountUtil.release(ch.readInbound());
+
+        buf.release();
+        buf2.release();
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/LengthFieldBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/LengthFieldBasedFrameDecoderTest.java
@@ -21,7 +21,6 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static io.netty.util.ReferenceCountUtil.releaseLater;
 
 public class LengthFieldBasedFrameDecoderTest {
 
@@ -55,7 +54,7 @@ public class LengthFieldBasedFrameDecoderTest {
 
     @Test
     public void testDiscardTooLongFrame2() {
-        ByteBuf buf = releaseLater(Unpooled.buffer());
+        ByteBuf buf = Unpooled.buffer();
         buf.writeInt(32);
         for (int i = 0; i < 32; i++) {
             buf.writeByte(i);
@@ -81,5 +80,7 @@ public class LengthFieldBasedFrameDecoderTest {
 
         Assert.assertNull(channel.readInbound());
         channel.finish();
+
+        buf.release();
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderByteBufTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderByteBufTest.java
@@ -21,7 +21,6 @@ import io.netty.util.CharsetUtil;
 import io.netty.util.Signal;
 import org.junit.Test;
 
-import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.junit.Assert.*;
 
 public class ReplayingDecoderByteBufTest {
@@ -31,8 +30,8 @@ public class ReplayingDecoderByteBufTest {
      */
     @Test
     public void testGetUnsignedByte() {
-        ReplayingDecoderByteBuf buffer = new ReplayingDecoderByteBuf(releaseLater(Unpooled.copiedBuffer("TestBuffer",
-                CharsetUtil.ISO_8859_1)));
+        ByteBuf buf = Unpooled.copiedBuffer("TestBuffer", CharsetUtil.ISO_8859_1);
+        ReplayingDecoderByteBuf buffer = new ReplayingDecoderByteBuf(buf);
 
         boolean error;
         int i = 0;
@@ -47,6 +46,8 @@ public class ReplayingDecoderByteBufTest {
 
         assertTrue(error);
         assertEquals(10, i);
+
+        buf.release();
     }
 
     /**
@@ -54,8 +55,8 @@ public class ReplayingDecoderByteBufTest {
      */
     @Test
     public void testGetByte() {
-        ReplayingDecoderByteBuf buffer = new ReplayingDecoderByteBuf(releaseLater(Unpooled.copiedBuffer("TestBuffer",
-                CharsetUtil.ISO_8859_1)));
+        ByteBuf buf = Unpooled.copiedBuffer("TestBuffer", CharsetUtil.ISO_8859_1);
+        ReplayingDecoderByteBuf buffer = new ReplayingDecoderByteBuf(buf);
 
         boolean error;
         int i = 0;
@@ -70,6 +71,8 @@ public class ReplayingDecoderByteBufTest {
 
         assertTrue(error);
         assertEquals(10, i);
+
+        buf.release();
     }
 
     /**
@@ -77,7 +80,7 @@ public class ReplayingDecoderByteBufTest {
      */
     @Test
     public void testGetBoolean() {
-        ByteBuf buf = releaseLater(Unpooled.buffer(10));
+        ByteBuf buf = Unpooled.buffer(10);
         while (buf.isWritable()) {
             buf.writeBoolean(true);
         }
@@ -96,6 +99,8 @@ public class ReplayingDecoderByteBufTest {
 
         assertTrue(error);
         assertEquals(10, i);
+
+        buf.release();
     }
 
 }

--- a/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/ReplayingDecoderTest.java
@@ -28,7 +28,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static io.netty.util.ReferenceCountUtil.*;
 import static org.junit.Assert.*;
 
 public class ReplayingDecoderTest {
@@ -45,7 +44,13 @@ public class ReplayingDecoderTest {
         ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 'C' }));
         assertNull(ch.readInbound());
         ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { '\n' }));
-        assertEquals(Unpooled.wrappedBuffer(new byte[] { 'A', 'B', 'C' }), releaseLater(ch.readInbound()));
+
+        ByteBuf buf = Unpooled.wrappedBuffer(new byte[] { 'A', 'B', 'C' });
+        ByteBuf buf2 = ch.readInbound();
+        assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
 
         // Truncated input
         ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 'A' }));
@@ -78,8 +83,13 @@ public class ReplayingDecoderTest {
 
         // "C\n" should be appended to "AB" so that LineDecoder decodes it correctly.
         ch.writeInbound(Unpooled.wrappedBuffer(new byte[]{'C', '\n'}));
-        assertEquals(releaseLater(Unpooled.wrappedBuffer(new byte[] { 'A', 'B', 'C' })),
-                releaseLater(ch.readInbound()));
+
+        ByteBuf buf = Unpooled.wrappedBuffer(new byte[] { 'A', 'B', 'C' });
+        ByteBuf buf2 = ch.readInbound();
+        assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
 
         ch.finish();
         assertNull(ch.readInbound());
@@ -101,12 +111,26 @@ public class ReplayingDecoderTest {
 
         // "C\n" should be appended to "AB" so that LineDecoder decodes it correctly.
         ch.writeInbound(Unpooled.wrappedBuffer(new byte[]{'C', '\n' , 'B', '\n'}));
-        assertEquals(releaseLater(Unpooled.wrappedBuffer(new byte[] {'C' })), releaseLater(ch.readInbound()));
+
+        ByteBuf buf  = Unpooled.wrappedBuffer(new byte[] {'C'});
+        ByteBuf buf2 = ch.readInbound();
+        assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
+
         assertNull("Must be null as it must only decode one frame", ch.readInbound());
 
         ch.read();
         ch.finish();
-        assertEquals(releaseLater(Unpooled.wrappedBuffer(new byte[] {'B' })), releaseLater(ch.readInbound()));
+
+        buf  = Unpooled.wrappedBuffer(new byte[] {'B'});
+        buf2 = ch.readInbound();
+        assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
+
         assertNull(ch.readInbound());
     }
 
@@ -185,7 +209,7 @@ public class ReplayingDecoderTest {
     @Test
     public void testFireChannelReadCompleteOnInactive() throws InterruptedException {
         final BlockingQueue<Integer> queue = new LinkedBlockingDeque<Integer>();
-        final ByteBuf buf = releaseLater(Unpooled.buffer().writeBytes(new byte[]{'a', 'b'}));
+        final ByteBuf buf = Unpooled.buffer().writeBytes(new byte[]{'a', 'b'});
         EmbeddedChannel channel = new EmbeddedChannel(new ReplayingDecoder<Integer>() {
 
             @Override

--- a/codec/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/SnappyFrameDecoderTest.java
@@ -21,7 +21,6 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.Before;
 import org.junit.Test;
 
-import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.junit.Assert.*;
 
 public class SnappyFrameDecoderTest {
@@ -109,7 +108,11 @@ public class SnappyFrameDecoderTest {
         channel.writeInbound(in);
 
         ByteBuf expected = Unpooled.wrappedBuffer(new byte[] { 'n', 'e', 't', 't', 'y' });
-        assertEquals(releaseLater(expected), releaseLater(channel.readInbound()));
+        ByteBuf actual = channel.readInbound();
+        assertEquals(expected, actual);
+
+        expected.release();
+        actual.release();
     }
 
     @Test
@@ -125,7 +128,12 @@ public class SnappyFrameDecoderTest {
         channel.writeInbound(in);
 
         ByteBuf expected = Unpooled.wrappedBuffer(new byte[] { 'n', 'e', 't', 't', 'y' });
-        assertEquals(releaseLater(expected), releaseLater(channel.readInbound()));
+        ByteBuf actual = channel.readInbound();
+
+        assertEquals(expected, actual);
+
+        expected.release();
+        actual.release();
     }
 
     // The following two tests differ in only the checksum provided for the literal

--- a/codec/src/test/java/io/netty/handler/codec/compression/SnappyFrameEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/SnappyFrameEncoderTest.java
@@ -22,7 +22,6 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.Before;
 import org.junit.Test;
 
-import static io.netty.util.ReferenceCountUtil.*;
 import static org.junit.Assert.*;
 
 public class SnappyFrameEncoderTest {
@@ -46,8 +45,11 @@ public class SnappyFrameEncoderTest {
             (byte) 0xff, 0x06, 0x00, 0x00, 0x73, 0x4e, 0x61, 0x50, 0x70, 0x59,
              0x01, 0x09, 0x00, 0x00, 0x6f, -0x68, -0x7e, -0x5e, 'n', 'e', 't', 't', 'y'
         });
+        ByteBuf actual = channel.readOutbound();
+        assertEquals(expected, actual);
 
-        assertEquals(releaseLater(expected), releaseLater(channel.readOutbound()));
+        expected.release();
+        actual.release();
     }
 
     @Test
@@ -67,8 +69,11 @@ public class SnappyFrameEncoderTest {
                    'n', 'e', 't', 't', 'y',
                    0x3a, 0x05, 0x00
         });
+        ByteBuf actual = channel.readOutbound();
+        assertEquals(expected, actual);
 
-        assertEquals(releaseLater(expected), releaseLater(channel.readOutbound()));
+        expected.release();
+        actual.release();
     }
 
     @Test
@@ -96,7 +101,10 @@ public class SnappyFrameEncoderTest {
             }
             actual.addComponent(true, m);
         }
-        assertEquals(releaseLater(expected), releaseLater(actual));
+        assertEquals(expected, actual);
+
+        expected.release();
+        actual.release();
     }
 
     /**

--- a/codec/src/test/java/io/netty/handler/codec/frame/DelimiterBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/frame/DelimiterBasedFrameDecoderTest.java
@@ -25,7 +25,6 @@ import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
 import org.junit.Test;
 
-import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.junit.Assert.*;
 
 public class DelimiterBasedFrameDecoderTest {
@@ -45,8 +44,10 @@ public class DelimiterBasedFrameDecoderTest {
             }
 
             ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 'A', 0 }));
-            ByteBuf buf = releaseLater((ByteBuf) ch.readInbound());
+            ByteBuf buf = ch.readInbound();
             assertEquals("A", buf.toString(CharsetUtil.ISO_8859_1));
+
+            buf.release();
         }
     }
 
@@ -64,8 +65,10 @@ public class DelimiterBasedFrameDecoderTest {
             }
 
             ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 'A', 0 }));
-            ByteBuf buf = releaseLater((ByteBuf) ch.readInbound());
+            ByteBuf buf = ch.readInbound();
             assertEquals("A", buf.toString(CharsetUtil.ISO_8859_1));
+
+            buf.release();
         }
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/frame/LengthFieldBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/frame/LengthFieldBasedFrameDecoderTest.java
@@ -24,7 +24,6 @@ import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
 import org.junit.Test;
 
-import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.junit.Assert.*;
 
 public class LengthFieldBasedFrameDecoderTest {
@@ -43,7 +42,7 @@ public class LengthFieldBasedFrameDecoderTest {
             }
 
             ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 0, 0, 1, 'A' }));
-            ByteBuf buf = releaseLater((ByteBuf) ch.readInbound());
+            ByteBuf buf = ch.readInbound();
             assertEquals("A", buf.toString(CharsetUtil.ISO_8859_1));
             buf.release();
         }
@@ -63,7 +62,7 @@ public class LengthFieldBasedFrameDecoderTest {
             }
 
             ch.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0, 0, 0, 0, 0, 1, 'A' }));
-            ByteBuf buf = releaseLater((ByteBuf) ch.readInbound());
+            ByteBuf buf = ch.readInbound();
             assertEquals("A", buf.toString(CharsetUtil.ISO_8859_1));
             buf.release();
         }

--- a/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoderTest.java
@@ -21,7 +21,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static io.netty.buffer.Unpooled.*;
-import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.hamcrest.core.Is.*;
 import static org.hamcrest.core.IsNull.*;
 import static org.junit.Assert.*;
@@ -43,10 +42,15 @@ public class ProtobufVarint32FrameDecoderTest {
         assertFalse(ch.writeInbound(wrappedBuffer(b, 1, 2)));
         assertThat(ch.readInbound(), is(nullValue()));
         assertTrue(ch.writeInbound(wrappedBuffer(b, 3, b.length - 3)));
-        assertThat(
-                releaseLater((ByteBuf) ch.readInbound()),
-                is(releaseLater(wrappedBuffer(new byte[] { 1, 1, 1, 1 }))));
+
+        ByteBuf expected = wrappedBuffer(new byte[] { 1, 1, 1, 1 });
+        ByteBuf actual = ch.readInbound();
+
+        assertThat(expected, is(actual));
         assertFalse(ch.finish());
+
+        expected.release();
+        actual.release();
     }
 
     @Test
@@ -64,7 +68,13 @@ public class ProtobufVarint32FrameDecoderTest {
         assertFalse(ch.writeInbound(wrappedBuffer(b, 127, 600)));
         assertThat(ch.readInbound(), is(nullValue()));
         assertTrue(ch.writeInbound(wrappedBuffer(b, 727, b.length - 727)));
-        assertThat(releaseLater((ByteBuf) ch.readInbound()), is(releaseLater(wrappedBuffer(b, 2, b.length - 2))));
+
+        ByteBuf expected = wrappedBuffer(b, 2, b.length - 2);
+        ByteBuf actual = ch.readInbound();
+        assertThat(expected, is(actual));
         assertFalse(ch.finish());
+
+        expected.release();
+        actual.release();
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/protobuf/ProtobufVarint32LengthFieldPrependerTest.java
@@ -21,7 +21,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static io.netty.buffer.Unpooled.*;
-import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.hamcrest.core.Is.*;
 import static org.junit.Assert.*;
 
@@ -46,8 +45,15 @@ public class ProtobufVarint32LengthFieldPrependerTest {
             buf[i] = 1;
         }
         assertTrue(ch.writeOutbound(wrappedBuffer(buf, size, buf.length - size)));
-        assertThat(releaseLater((ByteBuf) ch.readOutbound()), is(releaseLater(wrappedBuffer(buf))));
+
+        ByteBuf expected = wrappedBuffer(buf);
+        ByteBuf actual = ch.readOutbound();
+
+        assertThat(expected, is(actual));
         assertFalse(ch.finish());
+
+        expected.release();
+        actual.release();
     }
 
     @Test
@@ -74,8 +80,15 @@ public class ProtobufVarint32LengthFieldPrependerTest {
             buf[i] = 1;
         }
         assertTrue(ch.writeOutbound(wrappedBuffer(buf, size, buf.length - size)));
-        assertThat(releaseLater((ByteBuf) ch.readOutbound()), is(releaseLater(wrappedBuffer(buf))));
+
+        ByteBuf expected = wrappedBuffer(buf);
+        ByteBuf actual = ch.readOutbound();
+
+        assertThat(actual, is(expected));
         assertFalse(ch.finish());
+
+        expected.release();
+        actual.release();
     }
 
     @Test
@@ -103,8 +116,15 @@ public class ProtobufVarint32LengthFieldPrependerTest {
             buf[i] = 1;
         }
         assertTrue(ch.writeOutbound(wrappedBuffer(buf, size, buf.length - size)));
-        assertThat(releaseLater((ByteBuf) ch.readOutbound()), is(releaseLater(wrappedBuffer(buf))));
+
+        ByteBuf expected = wrappedBuffer(buf);
+        ByteBuf actual = ch.readOutbound();
+
+        assertThat(expected, is(actual));
         assertFalse(ch.finish());
+
+        expected.release();
+        actual.release();
     }
 
     @Test
@@ -133,16 +153,30 @@ public class ProtobufVarint32LengthFieldPrependerTest {
             buf[i] = 1;
         }
         assertTrue(ch.writeOutbound(wrappedBuffer(buf, size, buf.length - size)));
-        assertThat(releaseLater((ByteBuf) ch.readOutbound()), is(releaseLater(wrappedBuffer(buf))));
+
+        ByteBuf expected = wrappedBuffer(buf);
+        ByteBuf actual = ch.readOutbound();
+
+        assertThat(actual, is(expected));
         assertFalse(ch.finish());
+
+        expected.release();
+        actual.release();
     }
 
     @Test
     public void testTinyEncode() {
         byte[] b = { 4, 1, 1, 1, 1 };
         assertTrue(ch.writeOutbound(wrappedBuffer(b, 1, b.length - 1)));
-        assertThat(releaseLater((ByteBuf) ch.readOutbound()), is(releaseLater(wrappedBuffer(b))));
+
+        ByteBuf expected = wrappedBuffer(b);
+        ByteBuf actual = ch.readOutbound();
+
+        assertThat(actual, is(expected));
         assertFalse(ch.finish());
+
+        expected.release();
+        actual.release();
     }
 
     @Test
@@ -154,7 +188,14 @@ public class ProtobufVarint32LengthFieldPrependerTest {
         b[0] = -2;
         b[1] = 15;
         assertTrue(ch.writeOutbound(wrappedBuffer(b, 2, b.length - 2)));
-        assertThat(releaseLater((ByteBuf) ch.readOutbound()), is(releaseLater(wrappedBuffer(b))));
+
+        ByteBuf expected = wrappedBuffer(b);
+        ByteBuf actual = ch.readOutbound();
+
+        assertThat(actual, is(expected));
         assertFalse(ch.finish());
+
+        expected.release();
+        actual.release();
     }
 }

--- a/common/src/main/java/io/netty/util/ReferenceCountUtil.java
+++ b/common/src/main/java/io/netty/util/ReferenceCountUtil.java
@@ -133,7 +133,10 @@ public final class ReferenceCountUtil {
      * Schedules the specified object to be released when the caller thread terminates. Note that this operation is
      * intended to simplify reference counting of ephemeral objects during unit tests. Do not use it beyond the
      * intended use case.
+     *
+     * @deprecated this may introduce a lot of memory usage so it is generally preferable to manually release objects.
      */
+    @Deprecated
     public static <T> T releaseLater(T msg) {
         return releaseLater(msg, 1);
     }
@@ -142,7 +145,10 @@ public final class ReferenceCountUtil {
      * Schedules the specified object to be released when the caller thread terminates. Note that this operation is
      * intended to simplify reference counting of ephemeral objects during unit tests. Do not use it beyond the
      * intended use case.
+     *
+     * @deprecated this may introduce a lot of memory usage so it is generally preferable to manually release objects.
      */
+    @Deprecated
     public static <T> T releaseLater(T msg, int decrement) {
         if (msg instanceof ReferenceCounted) {
             ThreadDeathWatcher.watch(Thread.currentThread(), new ReleasingTask((ReferenceCounted) msg, decrement));

--- a/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/stream/ChunkedWriteHandlerTest.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.nio.channels.Channels;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -107,7 +106,7 @@ public class ChunkedWriteHandlerTest {
 
         ChunkedInput<ByteBuf> input = new ChunkedInput<ByteBuf>() {
             private boolean done;
-            private final ByteBuf buffer = releaseLater(Unpooled.copiedBuffer("Test", CharsetUtil.ISO_8859_1));
+            private final ByteBuf buffer = Unpooled.copiedBuffer("Test", CharsetUtil.ISO_8859_1);
 
             @Override
             public boolean isEndOfInput() throws Exception {
@@ -116,7 +115,7 @@ public class ChunkedWriteHandlerTest {
 
             @Override
             public void close() throws Exception {
-                // NOOP
+                buffer.release();
             }
 
             @Deprecated
@@ -162,8 +161,12 @@ public class ChunkedWriteHandlerTest {
         // the listener should have been notified
         assertTrue(listenerNotified.get());
 
-        assertEquals(releaseLater(buffer), releaseLater(ch.readOutbound()));
+        ByteBuf buffer2 = ch.readOutbound();
+        assertEquals(buffer, buffer2);
         assertNull(ch.readOutbound());
+
+        buffer.release();
+        buffer2.release();
     }
 
     @Test


### PR DESCRIPTION
Motiviation:

We used ReferenceCountUtil.releaseLater(...) in our tests which simplifies a bit the releasing of ReferenceCounted objects. The problem with this is that while it simplifies stuff it increase memory usage a lot as memory may not be freed up in a timely manner.

Modifications:

- Deprecate releaseLater(...)
- Remove usage of releaseLater(...) in tests.

Result:

Less memory needed to build netty while running the tests.