### PR TITLE
Not use InternalThreadLocalMap where access may be done from outside …

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/IdentityCipherSuiteFilter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/IdentityCipherSuiteFilter.java
@@ -15,8 +15,7 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.util.internal.InternalThreadLocalMap;
-
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -34,7 +33,7 @@ public final class IdentityCipherSuiteFilter implements CipherSuiteFilter {
         if (ciphers == null) {
             return defaultCiphers.toArray(new String[defaultCiphers.size()]);
         } else {
-            List<String> newCiphers = InternalThreadLocalMap.get().arrayList(supportedCiphers.size());
+            List<String> newCiphers = new ArrayList<String>(supportedCiphers.size());
             for (String c : ciphers) {
                 if (c == null) {
                     break;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -24,7 +24,6 @@ import io.netty.util.ResourceLeak;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetectorFactory;
 import io.netty.util.internal.EmptyArrays;
-import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.ThrowableUtil;
@@ -39,6 +38,7 @@ import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.security.Principal;
 import java.security.cert.Certificate;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1147,7 +1147,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
 
     @Override
     public final String[] getEnabledProtocols() {
-        List<String> enabled = InternalThreadLocalMap.get().arrayList();
+        List<String> enabled = new ArrayList<String>(6);
         // Seems like there is no way to explict disable SSLv2Hello in openssl so it is always enabled
         enabled.add(OpenSsl.PROTOCOL_SSL_V2_HELLO);
 

--- a/handler/src/main/java/io/netty/handler/ssl/SupportedCipherSuiteFilter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SupportedCipherSuiteFilter.java
@@ -15,9 +15,8 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.util.internal.InternalThreadLocalMap;
-
 import javax.net.ssl.SSLEngine;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -41,10 +40,10 @@ public final class SupportedCipherSuiteFilter implements CipherSuiteFilter {
 
         final List<String> newCiphers;
         if (ciphers == null) {
-            newCiphers = InternalThreadLocalMap.get().arrayList(defaultCiphers.size());
+            newCiphers = new ArrayList<String>(defaultCiphers.size());
             ciphers = defaultCiphers;
         } else {
-            newCiphers = InternalThreadLocalMap.get().arrayList(supportedCiphers.size());
+            newCiphers = new ArrayList<String>(supportedCiphers.size());
         }
         for (String c : ciphers) {
             if (c == null) {

--- a/handler/src/main/java/io/netty/handler/ssl/util/FingerprintTrustManagerFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/util/FingerprintTrustManagerFactory.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.concurrent.FastThreadLocal;
-import io.netty.util.internal.InternalThreadLocalMap;
 
 import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.TrustManager;
@@ -32,6 +31,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -159,7 +159,7 @@ public final class FingerprintTrustManagerFactory extends SimpleTrustManagerFact
             throw new NullPointerException("fingerprints");
         }
 
-        List<byte[]> list = InternalThreadLocalMap.get().arrayList();
+        List<byte[]> list = new ArrayList<byte[]>(fingerprints.length);
         for (byte[] f: fingerprints) {
             if (f == null) {
                 break;
@@ -179,7 +179,7 @@ public final class FingerprintTrustManagerFactory extends SimpleTrustManagerFact
             throw new NullPointerException("fingerprints");
         }
 
-        List<byte[]> list = InternalThreadLocalMap.get().arrayList();
+        List<byte[]> list = new ArrayList<byte[]>();
         for (String f: fingerprints) {
             if (f == null) {
                 break;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -23,9 +23,9 @@ import io.netty.channel.ReflectiveChannelFactory;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.resolver.HostsFileEntriesResolver;
-import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.UnstableApi;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
@@ -160,8 +160,8 @@ public final class DnsNameResolverBuilder {
     public DnsNameResolverBuilder resolvedAddressTypes(InternetProtocolFamily... resolvedAddressTypes) {
         checkNotNull(resolvedAddressTypes, "resolvedAddressTypes");
 
-        final List<InternetProtocolFamily> list =
-                InternalThreadLocalMap.get().arrayList(InternetProtocolFamily.values().length);
+        final List<InternetProtocolFamily> list = new ArrayList<InternetProtocolFamily>(
+                InternetProtocolFamily.values().length);
 
         for (InternetProtocolFamily f : resolvedAddressTypes) {
             if (f == null) {
@@ -197,8 +197,8 @@ public final class DnsNameResolverBuilder {
     public DnsNameResolverBuilder resolvedAddressTypes(Iterable<InternetProtocolFamily> resolvedAddressTypes) {
         checkNotNull(resolvedAddressTypes, "resolveAddressTypes");
 
-        final List<InternetProtocolFamily> list =
-                InternalThreadLocalMap.get().arrayList(InternetProtocolFamily.values().length);
+        final List<InternetProtocolFamily> list = new ArrayList<InternetProtocolFamily>(
+                InternetProtocolFamily.values().length);
 
         for (InternetProtocolFamily f : resolvedAddressTypes) {
             if (f == null) {
@@ -299,8 +299,7 @@ public final class DnsNameResolverBuilder {
     public DnsNameResolverBuilder searchDomains(Iterable<String> searchDomains) {
         checkNotNull(searchDomains, "searchDomains");
 
-        final List<String> list =
-            InternalThreadLocalMap.get().arrayList(4);
+        final List<String> list = new ArrayList<String>(4);
 
         for (String f : searchDomains) {
             if (f == null) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddresses.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddresses.java
@@ -16,7 +16,6 @@
 
 package io.netty.resolver.dns;
 
-import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -243,7 +242,7 @@ public abstract class DnsServerAddresses {
             throw new NullPointerException("addresses");
         }
 
-        List<InetSocketAddress> list = InternalThreadLocalMap.get().arrayList(addresses.length);
+        List<InetSocketAddress> list = new ArrayList<InetSocketAddress>(addresses.length);
         for (InetSocketAddress a: addresses) {
             if (a == null) {
                 break;


### PR DESCRIPTION
…the EventLoop.

Motivation:

We should not use the InternalThreadLocalMap where access may be done from outside the EventLoop as this may create a lot of memory usage while not be reused anyway.

Modifications:

Not use InternalThreadLocalMap in places where the code-path will likely be executed from outside the EventLoop.

Result:

Less memory bloat.