### PR TITLE
WebSocketClientHandshaker.rawPath(URI) should use the raw query

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
@@ -434,7 +434,7 @@ public abstract class WebSocketClientHandshaker {
      */
     static String rawPath(URI wsURL) {
         String path = wsURL.getRawPath();
-        String query = wsURL.getQuery();
+        String query = wsURL.getRawQuery();
         if (query != null && !query.isEmpty()) {
             path = path + '?' + query;
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
@@ -52,6 +52,18 @@ public abstract class WebSocketClientHandshakerTest {
         }
     }
 
+    @Test
+    public void testRawPathWithQuery() {
+        URI uri = URI.create("ws://localhost:9999/path%20with%20ws?a=b%20c");
+        WebSocketClientHandshaker handshaker = newHandshaker(uri);
+        FullHttpRequest request = handshaker.newHandshakeRequest();
+        try {
+            assertEquals("/path%20with%20ws?a=b%20c", request.uri());
+        } finally {
+            request.release();
+        }
+    }
+
     @Test(timeout = 3000)
     public void testHttpResponseAndFrameInSameBuffer() {
         testHttpResponseAndFrameInSameBuffer(false);


### PR DESCRIPTION
Motivation:

If the wsURL contains an encoded query, it will be decoded when generating the raw path.  For example if the wsURL is http://test.org/path?a=1%3A5, the returned raw path would be /path?a=1:5

Modifications:

Use wsURL.getRawQuery() rather than wsURL.getQuery()

Result:

rawPath will now return /path?a=1%3A5