### PR TITLE
ByteBuf Input Stream Reference Count Ownership

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
@@ -15,6 +15,8 @@
  */
 package io.netty.buffer;
 
+import io.netty.util.ReferenceCounted;
+
 import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.EOFException;
@@ -38,15 +40,23 @@ import java.io.InputStream;
  * @see ByteBufOutputStream
  */
 public class ByteBufInputStream extends InputStream implements DataInput {
-
     private final ByteBuf buffer;
     private final int startIndex;
     private final int endIndex;
+    private boolean closed;
+    /**
+     * To preserve backwards compatibility (which didn't transfer ownership) we support a conditional flag which
+     * indicates if {@link #buffer} should be released when this {@link InputStream} is closed.
+     * However in future releases ownership should always be transferred and callers of this class should call
+     * {@link ReferenceCounted#retain()} if necessary.
+     */
+    private boolean releaseOnClose;
 
     /**
      * Creates a new stream which reads data from the specified {@code buffer}
      * starting at the current {@code readerIndex} and ending at the current
      * {@code writerIndex}.
+     * @param buffer The buffer which provides the content for this {@link InputStream}.
      */
     public ByteBufInputStream(ByteBuf buffer) {
         this(buffer, buffer.readableBytes());
@@ -56,23 +66,59 @@ public class ByteBufInputStream extends InputStream implements DataInput {
      * Creates a new stream which reads data from the specified {@code buffer}
      * starting at the current {@code readerIndex} and ending at
      * {@code readerIndex + length}.
-     *
+     * @param buffer The buffer which provides the content for this {@link InputStream}.
+     * @param length The length of the buffer to use for this {@link InputStream}.
      * @throws IndexOutOfBoundsException
      *         if {@code readerIndex + length} is greater than
      *            {@code writerIndex}
      */
     public ByteBufInputStream(ByteBuf buffer, int length) {
+        this(buffer, length, false);
+    }
+
+    /**
+     * Creates a new stream which reads data from the specified {@code buffer}
+     * starting at the current {@code readerIndex} and ending at the current
+     * {@code writerIndex}.
+     * @param buffer The buffer which provides the content for this {@link InputStream}.
+     * @param releaseOnClose {@code true} means that when {@link #close()} is called then {@link ByteBuf#release()} will
+     *                       be called on {@code buffer}.
+     */
+    public ByteBufInputStream(ByteBuf buffer, boolean releaseOnClose) {
+        this(buffer, buffer.readableBytes(), releaseOnClose);
+    }
+
+    /**
+     * Creates a new stream which reads data from the specified {@code buffer}
+     * starting at the current {@code readerIndex} and ending at
+     * {@code readerIndex + length}.
+     * @param buffer The buffer which provides the content for this {@Link InputStream}.
+     * @param length The length of the buffer to use for this {@link InputStream}.
+     * @param releaseOnClose {@code true} means that when {@link #close()} is called then {@link ByteBuf#release()} will
+     *                       be called on {@code buffer}.
+     * @throws IndexOutOfBoundsException
+     *         if {@code readerIndex + length} is greater than
+     *            {@code writerIndex}
+     */
+    public ByteBufInputStream(ByteBuf buffer, int length, boolean releaseOnClose) {
         if (buffer == null) {
             throw new NullPointerException("buffer");
         }
         if (length < 0) {
+            if (releaseOnClose) {
+                buffer.release();
+            }
             throw new IllegalArgumentException("length: " + length);
         }
         if (length > buffer.readableBytes()) {
+            if (releaseOnClose) {
+                buffer.release();
+            }
             throw new IndexOutOfBoundsException("Too many bytes to be read - Needs "
                     + length + ", maximum is " + buffer.readableBytes());
         }
 
+        this.releaseOnClose = releaseOnClose;
         this.buffer = buffer;
         startIndex = buffer.readerIndex();
         endIndex = startIndex + length;
@@ -84,6 +130,19 @@ public class ByteBufInputStream extends InputStream implements DataInput {
      */
     public int readBytes() {
         return buffer.readerIndex() - startIndex;
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            super.close();
+        } finally {
+            // The Closable interface says "If the stream is already closed then invoking this method has no effect."
+            if (releaseOnClose && !closed) {
+                closed = true;
+                buffer.release();
+            }
+        }
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/compression/LzmaFrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/LzmaFrameEncoder.java
@@ -175,16 +175,23 @@ public class LzmaFrameEncoder extends MessageToByteEncoder<ByteBuf> {
     @Override
     protected void encode(ChannelHandlerContext ctx, ByteBuf in, ByteBuf out) throws Exception {
         final int length = in.readableBytes();
-        final InputStream bbIn = new ByteBufInputStream(in);
-
-        final ByteBufOutputStream bbOut = new ByteBufOutputStream(out);
-        bbOut.writeByte(properties);
-        bbOut.writeInt(littleEndianDictionarySize);
-        bbOut.writeLong(Long.reverseBytes(length));
-        encoder.code(bbIn, bbOut, -1, -1, null);
-
-        bbIn.close();
-        bbOut.close();
+        InputStream bbIn = null;
+        ByteBufOutputStream bbOut = null;
+        try {
+            bbIn = new ByteBufInputStream(in);
+            bbOut = new ByteBufOutputStream(out);
+            bbOut.writeByte(properties);
+            bbOut.writeInt(littleEndianDictionarySize);
+            bbOut.writeLong(Long.reverseBytes(length));
+            encoder.code(bbIn, bbOut, -1, -1, null);
+        } finally {
+            if (bbIn != null) {
+                bbIn.close();
+            }
+            if (bbOut != null) {
+                bbOut.close();
+            }
+        }
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/serialization/ObjectDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ObjectDecoder.java
@@ -71,14 +71,11 @@ public class ObjectDecoder extends LengthFieldBasedFrameDecoder {
             return null;
         }
 
-        ObjectInputStream is = new CompactObjectInputStream(new ByteBufInputStream(frame), classResolver);
-        Object result = is.readObject();
-        is.close();
-        return result;
-    }
-
-    @Override
-    protected ByteBuf extractFrame(ChannelHandlerContext ctx, ByteBuf buffer, int index, int length) {
-        return buffer.slice(index, length);
+        ObjectInputStream ois = new CompactObjectInputStream(new ByteBufInputStream(frame, true), classResolver);
+        try {
+            return ois.readObject();
+        } finally {
+            ois.close();
+        }
     }
 }

--- a/codec/src/main/java/io/netty/handler/codec/serialization/ObjectEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ObjectEncoder.java
@@ -42,11 +42,19 @@ public class ObjectEncoder extends MessageToByteEncoder<Serializable> {
         int startIdx = out.writerIndex();
 
         ByteBufOutputStream bout = new ByteBufOutputStream(out);
-        bout.write(LENGTH_PLACEHOLDER);
-        ObjectOutputStream oout = new CompactObjectOutputStream(bout);
-        oout.writeObject(msg);
-        oout.flush();
-        oout.close();
+        ObjectOutputStream oout = null;
+        try {
+            bout.write(LENGTH_PLACEHOLDER);
+            oout = new CompactObjectOutputStream(bout);
+            oout.writeObject(msg);
+            oout.flush();
+        } finally {
+            if (oout != null) {
+                oout.close();
+            } else {
+                bout.close();
+            }
+        }
 
         int endIdx = out.writerIndex();
 

--- a/codec/src/main/java/io/netty/handler/codec/serialization/ObjectEncoderOutputStream.java
+++ b/codec/src/main/java/io/netty/handler/codec/serialization/ObjectEncoderOutputStream.java
@@ -80,16 +80,22 @@ public class ObjectEncoderOutputStream extends OutputStream implements
 
     @Override
     public void writeObject(Object obj) throws IOException {
-        ByteBufOutputStream bout = new ByteBufOutputStream(Unpooled.buffer(estimatedLength));
-        ObjectOutputStream oout = new CompactObjectOutputStream(bout);
-        oout.writeObject(obj);
-        oout.flush();
-        oout.close();
+        ByteBuf buf = Unpooled.buffer(estimatedLength);
+        try {
+            ObjectOutputStream oout = new CompactObjectOutputStream(new ByteBufOutputStream(buf));
+            try {
+                oout.writeObject(obj);
+                oout.flush();
+            } finally {
+                oout.close();
+            }
 
-        ByteBuf buffer = bout.buffer();
-        int objectSize = buffer.readableBytes();
-        writeInt(objectSize);
-        buffer.getBytes(0, this, objectSize);
+            int objectSize = buf.readableBytes();
+            writeInt(objectSize);
+            buf.getBytes(0, this, objectSize);
+        } finally {
+            buf.release();
+        }
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
@@ -111,8 +111,6 @@ public abstract class AbstractEncoderTest extends AbstractCompressionTest {
         while ((msg = channel.readOutbound()) != null) {
             compressed.addComponent(true, msg);
         }
-        ByteBuf decompressed =  decompress(compressed, dataLength);
-        compressed.release();
-        return decompressed;
+        return decompress(compressed, dataLength);
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/compression/Bzip2EncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Bzip2EncoderTest.java
@@ -35,21 +35,28 @@ public class Bzip2EncoderTest extends AbstractEncoderTest {
 
     @Override
     protected ByteBuf decompress(ByteBuf compressed, int originalLength) throws Exception {
-        InputStream is = new ByteBufInputStream(compressed);
-        BZip2CompressorInputStream bzip2Is = new BZip2CompressorInputStream(is);
-
+        InputStream is = new ByteBufInputStream(compressed, true);
+        BZip2CompressorInputStream bzip2Is = null;
         byte[] decompressed = new byte[originalLength];
-        int remaining = originalLength;
-        while (remaining > 0) {
-            int read = bzip2Is.read(decompressed, originalLength - remaining, remaining);
-            if (read > 0) {
-                remaining -= read;
+        try {
+            bzip2Is = new BZip2CompressorInputStream(is);
+            int remaining = originalLength;
+            while (remaining > 0) {
+                int read = bzip2Is.read(decompressed, originalLength - remaining, remaining);
+                if (read > 0) {
+                    remaining -= read;
+                } else {
+                    break;
+                }
+            }
+            assertEquals(-1, bzip2Is.read());
+        } finally {
+            if (bzip2Is != null) {
+                bzip2Is.close();
             } else {
-                break;
+                is.close();
             }
         }
-        assertEquals(-1, bzip2Is.read());
-        bzip2Is.close();
 
         return Unpooled.wrappedBuffer(decompressed);
     }

--- a/codec/src/test/java/io/netty/handler/codec/compression/LzfEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/LzfEncoderTest.java
@@ -31,6 +31,7 @@ public class LzfEncoderTest extends AbstractEncoderTest {
     protected ByteBuf decompress(ByteBuf compressed, int originalLength) throws Exception {
         byte[] compressedArray = new byte[compressed.readableBytes()];
         compressed.readBytes(compressedArray);
+        compressed.release();
 
         byte[] decompressed = LZFDecoder.decode(compressedArray);
         return Unpooled.wrappedBuffer(decompressed);

--- a/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/ZlibTest.java
@@ -300,16 +300,19 @@ public abstract class ZlibTest {
         }
 
         ByteBuf decoded = Unpooled.buffer();
-        GZIPInputStream stream = new GZIPInputStream(new ByteBufInputStream(encoded));
-        byte[] buf = new byte[8192];
-        for (;;) {
-            int readBytes = stream.read(buf);
-            if (readBytes < 0) {
-                break;
+        GZIPInputStream stream = new GZIPInputStream(new ByteBufInputStream(encoded, true));
+        try {
+            byte[] buf = new byte[8192];
+            for (;;) {
+                int readBytes = stream.read(buf);
+                if (readBytes < 0) {
+                    break;
+                }
+                decoded.writeBytes(buf, 0, readBytes);
             }
-            decoded.writeBytes(buf, 0, readBytes);
+        } finally {
+            stream.close();
         }
-        stream.close();
 
         if (data != null) {
             assertEquals(Unpooled.wrappedBuffer(data), decoded);
@@ -317,7 +320,6 @@ public abstract class ZlibTest {
             assertFalse(decoded.isReadable());
         }
 
-        encoded.release();
         decoded.release();
     }
 

--- a/transport/src/test/java/io/netty/channel/DefaultChannelIdTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelIdTest.java
@@ -25,8 +25,11 @@ import org.junit.Test;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("DynamicRegexReplaceableByCompiledPattern")
 public class DefaultChannelIdTest {
@@ -63,11 +66,19 @@ public class DefaultChannelIdTest {
 
         ByteBuf buf = Unpooled.buffer();
         ObjectOutputStream out = new ObjectOutputStream(new ByteBufOutputStream(buf));
-        out.writeObject(a);
-        out.flush();
+        try {
+            out.writeObject(a);
+            out.flush();
+        } finally {
+            out.close();
+        }
 
-        ObjectInputStream in = new ObjectInputStream(new ByteBufInputStream(buf));
-        b = (ChannelId) in.readObject();
+        ObjectInputStream in = new ObjectInputStream(new ByteBufInputStream(buf, true));
+        try {
+            b = (ChannelId) in.readObject();
+        } finally {
+            in.close();
+        }
 
         assertThat(a, is(b));
         assertThat(a, is(not(sameInstance(b))));


### PR DESCRIPTION
Motivation:
Netty provides a adaptor from ByteBuf to Java's InputStream interface. The JDK Stream interfaces have an explicit lifetime because they implement the Closable interface. This lifetime may be differnt than the ByteBuf which is wrapped, and controlled by the interface which accepts the JDK Stream. However Netty's ByteBufInputStream currently does not take reference count ownership of the underlying ByteBuf. There may be no way for existing classes which only accept the InputStream interface to communicate when they are done with the stream, other than calling close(). This means that when the stream is closed it may be appropriate to release the underlying ByteBuf, as the ownership of the underlying ByteBuf resource may be transferred to the Java Stream.

Motivation:
- ByteBufInputStream.close() supports taking reference count ownership of the underyling ByteBuf

Result:
ByteBufInputStream can assume reference count ownership so the underlying ByteBuf can be cleaned up when the stream is closed.