### PR TITLE
HTTP/2 WeightedFairQueueByteDistributor Bug

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PriorityQueue.java
+++ b/common/src/main/java/io/netty/util/internal/PriorityQueue.java
@@ -78,10 +78,9 @@ public final class PriorityQueue<T extends PriorityQueueNode<T>> extends Abstrac
 
     @Override
     public boolean offer(T e) {
-        checkNotNull(e, "e");
         if (e.priorityQueueIndex() != INDEX_NOT_IN_QUEUE) {
             throw new IllegalArgumentException("e.priorityQueueIndex(): " + e.priorityQueueIndex() +
-                    " (expected: " + INDEX_NOT_IN_QUEUE + ")");
+                    " (expected: " + INDEX_NOT_IN_QUEUE + ") + e: " + e);
         }
 
         // Check that the array capacity is enough to hold values by doubling capacity.


### PR DESCRIPTION
Motivation:
If a stream is not able to send any data (flow control window for the stream is exhausted) but has descendants who can send data then WeightedFairQueueByteDistributor may incorrectly modify the pseudo time and also double add the associated state to the parent's priority queue. The pseudo time should only be modified if a node is moved in the priority tree, and not if there happens to be no active streams in its descendent tree and a descendent is moved (e.g. removed from the tree because it wrote all data and the last data frame was EOS). Also the state objects for WeightedFairQueueByteDistributor should only appear once in any queue. If this condition is violated the pseudo time accounting would be biased at and assumptions in WeightedFairQueueByteDistributor would be invalidated.

Modifications:
- WeightedFairQueueByteDistributor#isActiveCountChangeForTree should not allow re-adding to the priority queue if we are currently processing a node in the distribution algorithm. The distribution algorithm will re-evaluate if the node should be re-added on the tail end of the recursion.

Result:
Fixes https://github.com/netty/netty/issues/5980