### PR TITLE
Buffer Leaks in Compression Tests

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractDecoderTest.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.experimental.theories.DataPoints;
@@ -62,6 +63,14 @@ public abstract class AbstractDecoderTest extends AbstractCompressionTest {
 
     @Before
     public abstract void initChannel();
+
+    @After
+    public void destroyChannel() {
+        if (channel != null) {
+            channel.finishAndReleaseAll();
+            channel = null;
+        }
+    }
 
     @DataPoints("smallData")
     public static ByteBuf[] smallData() {

--- a/codec/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/AbstractEncoderTest.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.FromDataPoints;
@@ -41,6 +42,14 @@ public abstract class AbstractEncoderTest extends AbstractCompressionTest {
 
     @Before
     public abstract void initChannel();
+
+    @After
+    public void destroyChannel() {
+        if (channel != null) {
+            channel.finishAndReleaseAll();
+            channel = null;
+        }
+    }
 
     @DataPoints("smallData")
     public static ByteBuf[] smallData() {

--- a/codec/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/Bzip2DecoderTest.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
 
 import static io.netty.handler.codec.compression.Bzip2Constants.*;
+import static org.junit.Assert.fail;
 
 public class Bzip2DecoderTest extends AbstractDecoderTest {
 
@@ -43,6 +44,19 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         channel = new EmbeddedChannel(new Bzip2Decoder());
     }
 
+    private void writeInboundDestroyAndExpectDecompressionException(ByteBuf in) {
+        try {
+            channel.writeInbound(in);
+        } finally {
+            try {
+                destroyChannel();
+                fail();
+            } catch (DecompressionException ignored) {
+                // expected
+            }
+        }
+    }
+
     @Test
     public void testUnexpectedStreamIdentifier() throws Exception {
         expected.expect(DecompressionException.class);
@@ -50,8 +64,7 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
 
         ByteBuf in = Unpooled.buffer();
         in.writeLong(1823080128301928729L); //random value
-
-        channel.writeInbound(in);
+        writeInboundDestroyAndExpectDecompressionException(in);
     }
 
     @Test
@@ -140,7 +153,7 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         data[11] = 0x77;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
-        channel.writeInbound(in);
+        writeInboundDestroyAndExpectDecompressionException(in);
     }
 
     @Test
@@ -152,7 +165,7 @@ public class Bzip2DecoderTest extends AbstractDecoderTest {
         data[14] = (byte) 0xFF;
 
         ByteBuf in = Unpooled.wrappedBuffer(data);
-        channel.writeInbound(in);
+        writeInboundDestroyAndExpectDecompressionException(in);
     }
 
     @Override


### PR DESCRIPTION
Motivation:
The unit tests for the compression encoders/decoders may write buffers to an EmbeddedChannel but then may not release buffer or close the channel after the test. This may result in buffer leaks.

Modifications:
- Call channel.finishAndReleaseAll() after each test

Result:
Fixes https://github.com/netty/netty/issues/6007