### PR TITLE
LzmaFrameEncoderTest leak due to LzmaInputStream close behavior

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/compression/LzmaFrameEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/compression/LzmaFrameEncoderTest.java
@@ -98,7 +98,11 @@ public class LzmaFrameEncoderTest extends AbstractEncoderTest {
         } finally {
             if (lzmaIs != null) {
                 lzmaIs.close();
-            } else {
+            }
+            // LzmaInputStream does not close the stream it wraps, so we should always close.
+            // The close operation should be safe to call multiple times anyways so lets just call it and be safe.
+            // https://github.com/jponge/lzma-java/issues/14
+            if (is != null) {
                 is.close();
             }
         }


### PR DESCRIPTION
Motivation:
c1932a8537b742aaf15a7cfacf9f76ad8239f3c7 made an assumption that the LzmaInputStream which wraps a ByteBufInputStream would delegate the close operation to the wrapped stream. This assumption is not true and thus we still had a leak. An issue has been logged with our LZMA dependency https://github.com/jponge/lzma-java/issues/14.

Modifications:
- Force a close on the wrapped stream

Result:
No more leak.