### PR TITLE
Fix HTTP/2 test cleanup with LocalChannel

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -88,6 +88,7 @@ public class Http2ConnectionRoundtripTest {
     private ServerBootstrap sb;
     private Bootstrap cb;
     private Channel serverChannel;
+    private volatile Channel serverConnectedChannel;
     private Channel clientChannel;
     private FrameCountDown serverFrameCountDown;
     private CountDownLatch requestLatch;
@@ -112,6 +113,10 @@ public class Http2ConnectionRoundtripTest {
         if (serverChannel != null) {
             serverChannel.close().sync();
             serverChannel = null;
+        }
+        if (serverConnectedChannel != null) {
+            serverConnectedChannel.close().sync();
+            serverConnectedChannel = null;
         }
         Future<?> serverGroup = sb.config().group().shutdownGracefully(0, 0, MILLISECONDS);
         Future<?> serverChildGroup = sb.config().childGroup().shutdownGracefully(0, 0, MILLISECONDS);
@@ -537,6 +542,7 @@ public class Http2ConnectionRoundtripTest {
         sb.childHandler(new ChannelInitializer<Channel>() {
             @Override
             protected void initChannel(Channel ch) throws Exception {
+                serverConnectedChannel = ch;
                 ChannelPipeline p = ch.pipeline();
                 serverFrameCountDown =
                         new FrameCountDown(serverListener, serverSettingsAckLatch,


### PR DESCRIPTION
Motivation:
When a LocalChannel is closed it is responsible to ensure all queued objects are released. When a LocalChannel is closed it will also close its peer channel. However in HTTP/2 unit tests we may not wait until all channels have completed the shutdown process before destroying the threads and exiting the test. This may mean buffers are GCed before they are released and be reported as a leak.

Modifications:
- In HTTP/2 tests when we use LocalChannel we should wait for all channels to close before exiting the test and cleaning up the associated EventLoopGroups.

Result:
More correct usage of LocalChannel in HTTP/2 tests.