### PR TITLE
Catch exceptions from PlatformDependent#getSystemClassLoader

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -1163,9 +1163,11 @@ public final class PlatformDependent {
 
     private static long maxDirectMemory0() {
         long maxDirectMemory = 0;
+        ClassLoader systemClassLoader = null;
         try {
             // Try to get from sun.misc.VM.maxDirectMemory() which should be most accurate.
-            Class<?> vmClass = Class.forName("sun.misc.VM", true, getSystemClassLoader());
+            systemClassLoader = getSystemClassLoader();
+            Class<?> vmClass = Class.forName("sun.misc.VM", true, systemClassLoader);
             Method m = vmClass.getDeclaredMethod("maxDirectMemory");
             maxDirectMemory = ((Number) m.invoke(null)).longValue();
         } catch (Throwable ignored) {
@@ -1180,9 +1182,9 @@ public final class PlatformDependent {
             // Now try to get the JVM option (-XX:MaxDirectMemorySize) and parse it.
             // Note that we are using reflection because Android doesn't have these classes.
             Class<?> mgmtFactoryClass = Class.forName(
-                    "java.lang.management.ManagementFactory", true, getSystemClassLoader());
+                    "java.lang.management.ManagementFactory", true, systemClassLoader);
             Class<?> runtimeClass = Class.forName(
-                    "java.lang.management.RuntimeMXBean", true, getSystemClassLoader());
+                    "java.lang.management.RuntimeMXBean", true, systemClassLoader);
 
             Object runtime = mgmtFactoryClass.getDeclaredMethod("getRuntimeMXBean").invoke(null);
 

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -224,16 +224,8 @@ final class PlatformDependent0 {
                         Method unalignedMethod = bitsClass.getDeclaredMethod("unaligned");
                         unalignedMethod.setAccessible(true);
                         return unalignedMethod.invoke(null);
-                    } catch (ClassNotFoundException e) {
-                        return e;
-                    } catch (NoSuchMethodException e) {
-                        return e;
-                    } catch (InvocationTargetException e) {
-                        return e;
-                    } catch (IllegalAccessException e) {
-                        return e;
-                    } catch (SecurityException e) {
-                        return e;
+                    } catch (Throwable cause) {
+                        return cause;
                     }
                 }
             });
@@ -245,8 +237,8 @@ final class PlatformDependent0 {
                 String arch = SystemPropertyUtil.get("os.arch", "");
                 //noinspection DynamicRegexReplaceableByCompiledPattern
                 unaligned = arch.matches("^(i[3-6]86|x86(_64)?|x64|amd64)$");
-                Exception e = (Exception) maybeUnaligned;
-                logger.debug("java.nio.Bits.unaligned: unavailable, " + unaligned, e);
+                Throwable t = (Throwable) maybeUnaligned;
+                logger.debug("java.nio.Bits.unaligned: unavailable {}", unaligned, t);
             }
 
             UNALIGNED = unaligned;

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -171,10 +171,8 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                             "sun.nio.ch.SelectorImpl",
                             false,
                             PlatformDependent.getSystemClassLoader());
-                } catch (ClassNotFoundException e) {
-                    return e;
-                } catch (SecurityException e) {
-                    return e;
+                } catch (Throwable cause) {
+                    return cause;
                 }
             }
         });
@@ -182,9 +180,9 @@ public final class NioEventLoop extends SingleThreadEventLoop {
         if (!(maybeSelectorImplClass instanceof Class) ||
                 // ensure the current selector implementation is what we can instrument.
                 !((Class<?>) maybeSelectorImplClass).isAssignableFrom(selector.getClass())) {
-            if (maybeSelectorImplClass instanceof Exception) {
-                Exception e = (Exception) maybeSelectorImplClass;
-                logger.trace("failed to instrument a special java.util.Set into: {}", selector, e);
+            if (maybeSelectorImplClass instanceof Throwable) {
+                Throwable t = (Throwable) maybeSelectorImplClass;
+                logger.trace("failed to instrument a special java.util.Set into: {}", selector, t);
             }
             return selector;
         }


### PR DESCRIPTION
Motivation:
PlatformDependent#getSystemClassLoader may throw a wide variety of exceptions based upon the environment. We should handle all exceptions and continue initializing the slow path if an exception occurs.

Modifications:
- Catch Throwable in cases where PlatformDependent#getSystemClassLoader is used

Result:
Fixes https://github.com/netty/netty/issues/6038