### PR TITLE
Deprecate HttpUtil.getCharsetAsString(...) and introduce HttpUtil.get…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -352,7 +352,7 @@ public final class HttpUtil {
      * if charset is not presented or unparsable
      */
     public static Charset getCharset(HttpMessage message, Charset defaultCharset) {
-        CharSequence charsetCharSequence = getCharsetAsString(message);
+        CharSequence charsetCharSequence = getCharsetAsSequence(message);
         if (charsetCharSequence != null) {
             try {
                 return Charset.forName(charsetCharSequence.toString());
@@ -372,8 +372,23 @@ public final class HttpUtil {
      *
      * @return the {@code CharSequence} with charset from message's Content-Type header
      * or {@code null} if charset is not presented
+     * @deprecated use {@link #getCharsetAsSequence(HttpMessage)}
      */
+    @Deprecated
     public static CharSequence getCharsetAsString(HttpMessage message) {
+        return getCharsetAsSequence(message);
+    }
+
+    /**
+     * Fetch charset from message's Content-Type header as a char sequence.
+     *
+     * A lot of sites/possibly clients have charset="CHARSET", for example charset="utf-8". Or "utf8" instead of "utf-8"
+     * This is not according to standard, but this method provide an ability to catch desired mistakes manually in code
+     *
+     * @return the {@code CharSequence} with charset from message's Content-Type header
+     * or {@code null} if charset is not presented
+     */
+    public static CharSequence getCharsetAsSequence(HttpMessage message) {
         CharSequence contentTypeValue = message.headers().get(HttpHeaderNames.CONTENT_TYPE);
         if (contentTypeValue != null) {
             int indexOfCharset = AsciiString.indexOfIgnoreCaseAscii(contentTypeValue, CHARSET_EQUALS, 0);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -18,7 +18,6 @@ package io.netty.handler.codec.http;
 import io.netty.util.CharsetUtil;
 import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
@@ -57,10 +56,10 @@ public class HttpUtilTest {
     public void testGetCharsetAsRawString() {
         HttpMessage message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
         message.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=\"utf8\"");
-        assertEquals("\"utf8\"", HttpUtil.getCharsetAsString(message));
+        assertEquals("\"utf8\"", HttpUtil.getCharsetAsSequence(message));
 
         message.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html");
-        assertNull(HttpUtil.getCharsetAsString(message));
+        assertNull(HttpUtil.getCharsetAsSequence(message));
     }
 
     @Test
@@ -80,13 +79,13 @@ public class HttpUtilTest {
         assertEquals(CharsetUtil.ISO_8859_1, HttpUtil.getCharset(message));
 
         message.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html");
-        assertEquals(CharsetUtil.UTF_8, HttpUtil.getCharset(message, StandardCharsets.UTF_8));
+        assertEquals(CharsetUtil.UTF_8, HttpUtil.getCharset(message, CharsetUtil.UTF_8));
 
         message.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTFFF");
         assertEquals(CharsetUtil.ISO_8859_1, HttpUtil.getCharset(message));
 
         message.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTFFF");
-        assertEquals(CharsetUtil.UTF_8, HttpUtil.getCharset(message, StandardCharsets.UTF_8));
+        assertEquals(CharsetUtil.UTF_8, HttpUtil.getCharset(message, CharsetUtil.UTF_8));
     }
 
     @Test


### PR DESCRIPTION
…CharsetAsSequence(...).

Motivation:

The method HttpUtil.getCharsetAsString(...) is missleading as its return type is CharSequence and not String.

Modifications:

Deprecate HttpUtil.getCharsetAsString(...) and introduce HttpUtil.getCharsetAsSe
quence(...).

Result:

Less confusing method name.