### PR TITLE
 Implemented batching versions of LengthFieldBasedFrameDecoder and Fixed…

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/BatchedByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/BatchedByteToMessageDecoder.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+
+import java.util.List;
+
+public abstract class BatchedByteToMessageDecoder extends ByteToMessageDecoder {
+
+    private boolean readInProgress;
+
+    protected BatchedByteToMessageDecoder() {
+        setDiscardAfterReads(1);
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        readInProgress = true;
+        super.channelRead(ctx, msg);
+    }
+
+    @Override
+    protected final void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
+        if (!readInProgress) {
+            decodeBatched(ctx, in, out);
+        }
+    }
+
+    /**
+     * Decodes from one {@link ByteBuf} to another. This method will be called till either the input
+     * {@link ByteBuf} has nothing to read when return from this method or till nothing was read from the input
+     * {@link ByteBuf}. Compared to {@link ByteToMessageDecoder#decode(ChannelHandlerContext, ByteBuf, List)}, this
+     * method decodes messages by applying the batching strategy. Instead of having one {@link ByteBuf} which
+     * would always contain only one message, this method decodes a {@link ByteBuf} so that the resulting
+     * {@link ByteBuf} will contain N messages at once (where N can be greater or equal to 1).
+     *
+     * @param ctx the {@link ChannelHandlerContext} which this {@link BatchedByteToMessageDecoder} belongs to
+     * @param in the {@link ByteBuf} from which to read data
+     * @param out the {@link List} to which decoded messages should be added
+     */
+    protected abstract void decodeBatched(ChannelHandlerContext ctx, ByteBuf in, List<Object> out);
+
+    @Override
+    public final void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        resetReadAndFlushIfNeeded(ctx);
+        super.channelReadComplete(ctx);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        resetReadAndFlushIfNeeded(ctx);
+        super.exceptionCaught(ctx, cause);
+    }
+
+    private void resetReadAndFlushIfNeeded(ChannelHandlerContext ctx) {
+        readInProgress = false;
+        CodecOutputList out = CodecOutputList.newInstance();
+        try {
+            decodeBatched(ctx, internalBuffer(), out);
+        } finally {
+            afterDecode(ctx, out);
+        }
+    }
+}

--- a/codec/src/main/java/io/netty/handler/codec/BatchedFixedLengthFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/BatchedFixedLengthFrameDecoder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.internal.ObjectUtil;
+
+import java.util.List;
+
+/**
+ * A decoder that mostly mimics {@link FixedLengthFrameDecoder} semantics. The only difference is this decoder batches
+ * incoming {@link ByteBuf} messages and then decodes them at once, passing a big {@link ByteBuf} which can possibly
+ * contain N messages (where N >= 1) through the pipeline at once.
+ */
+public class BatchedFixedLengthFrameDecoder extends BatchedByteToMessageDecoder {
+
+    final int frameLength;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param frameLength the length of the frame
+     */
+    public BatchedFixedLengthFrameDecoder(int frameLength) {
+        this.frameLength = ObjectUtil.checkPositive(frameLength, "frameLength");
+    }
+
+    @Override
+    protected void decodeBatched(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
+        final int readableBytes = in.readableBytes();
+
+        if (readableBytes < frameLength) {
+            return;
+        }
+
+        final int numberOfMessages = readableBytes / frameLength;
+        final int bytesToCopy = numberOfMessages * frameLength;
+        final ByteBuf chunk = in.readRetainedSlice(bytesToCopy);
+
+        out.add(chunk);
+    }
+}

--- a/codec/src/main/java/io/netty/handler/codec/BatchedLengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/BatchedLengthFieldBasedFrameDecoder.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.internal.ObjectUtil;
+
+import java.util.List;
+
+/**
+ * A decoder that mostly mimics {@link LengthFieldBasedFrameDecoder} semantics. The only difference is this decoder
+ * batches incoming {@link ByteBuf} messages and then decodes them at once, passing a big {@link ByteBuf} which can
+ * possibly contain N messages (where N >= 1) through the pipeline at once.
+ */
+public class BatchedLengthFieldBasedFrameDecoder extends BatchedByteToMessageDecoder {
+
+    private final int maxFrameLength;
+    private final int lengthFieldOffset;
+    private final int lengthFieldLength;
+    private final int lengthFieldEndOffset;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param maxFrameLength the maximum length of the frame.  If the length of the frame is greater than this value,
+     * {@link TooLongFrameException} will be thrown.
+     * @param lengthFieldOffset the offset of the length field
+     * @param lengthFieldLength the length of the length field
+     */
+    public BatchedLengthFieldBasedFrameDecoder(int maxFrameLength, int lengthFieldOffset, int lengthFieldLength) {
+        this.maxFrameLength = ObjectUtil.checkPositive(maxFrameLength, "maxFrameLength");
+        this.lengthFieldOffset = ObjectUtil.checkPositiveOrZero(lengthFieldOffset, "lengthFieldEndOffset");
+
+        if (lengthFieldOffset > maxFrameLength - lengthFieldLength) {
+            throw new IllegalArgumentException(
+                    "maxFrameLength (" + maxFrameLength + ") " +
+                    "must be equal to or greater than " +
+                    "lengthFieldOffset (" + lengthFieldOffset + ") + " +
+                    "lengthFieldLength (" + lengthFieldLength + ").");
+        }
+
+        this.lengthFieldLength = lengthFieldLength;
+        lengthFieldEndOffset = lengthFieldOffset + lengthFieldLength;
+    }
+
+    @Override
+    protected void decodeBatched(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
+        final int previousRdIdx = in.readerIndex();
+        int rdIdx = previousRdIdx;
+        int readableBytes = in.readableBytes();
+
+        while (readableBytes >= lengthFieldEndOffset) {
+            int actualLengthFieldOffset = rdIdx + lengthFieldOffset;
+            long frameLength =
+                    UnadjustedFrameLengthDecoderUtil.decode(in, actualLengthFieldOffset, lengthFieldLength);
+
+            if (frameLength < 0) {
+                throw new CorruptedFrameException(
+                        "negative pre-adjustment length field: " + frameLength);
+            }
+
+            frameLength += lengthFieldEndOffset;
+
+            if (frameLength > maxFrameLength) {
+                throw new TooLongFrameException(
+                        "Adjusted frame length exceeds " + maxFrameLength +
+                        ": " + frameLength + " - discarded");
+            }
+
+            int frameLengthInt = (int) frameLength;
+
+            if (readableBytes < frameLengthInt) {
+                break;
+            }
+
+            readableBytes -= frameLengthInt;
+            rdIdx += frameLengthInt;
+        }
+
+        if (rdIdx == previousRdIdx) {
+            return;
+        }
+
+        final int bytesToCopy = rdIdx - previousRdIdx;
+        final ByteBuf chunk = in.readRetainedSlice(bytesToCopy);
+
+        out.add(chunk);
+    }
+}

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -251,25 +251,29 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
             } catch (Throwable t) {
                 throw new DecoderException(t);
             } finally {
-                if (cumulation != null && !cumulation.isReadable()) {
-                    numReads = 0;
-                    cumulation.release();
-                    cumulation = null;
-                } else if (++ numReads >= discardAfterReads) {
-                    // We did enough reads already try to discard some bytes so we not risk to see a OOME.
-                    // See https://github.com/netty/netty/issues/4275
-                    numReads = 0;
-                    discardSomeReadBytes();
-                }
-
-                int size = out.size();
-                decodeWasNull = !out.insertSinceRecycled();
-                fireChannelRead(ctx, out, size);
-                out.recycle();
+                afterDecode(ctx, out);
             }
         } else {
             ctx.fireChannelRead(msg);
         }
+    }
+
+    final void afterDecode(ChannelHandlerContext ctx, CodecOutputList out) {
+        if (cumulation != null && !cumulation.isReadable()) {
+            numReads = 0;
+            cumulation.release();
+            cumulation = null;
+        } else if (++ numReads >= discardAfterReads) {
+            // We did enough reads already try to discard some bytes so we not risk to see a OOME.
+            // See https://github.com/netty/netty/issues/4275
+            numReads = 0;
+            discardSomeReadBytes();
+        }
+
+        int size = out.size();
+        decodeWasNull = !out.insertSinceRecycled();
+        fireChannelRead(ctx, out, size);
+        out.recycle();
     }
 
     /**

--- a/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/LengthFieldBasedFrameDecoder.java
@@ -435,29 +435,7 @@ public class LengthFieldBasedFrameDecoder extends ByteToMessageDecoder {
      * @throws DecoderException if failed to decode the specified region
      */
     protected long getUnadjustedFrameLength(ByteBuf buf, int offset, int length, ByteOrder order) {
-        buf = buf.order(order);
-        long frameLength;
-        switch (length) {
-        case 1:
-            frameLength = buf.getUnsignedByte(offset);
-            break;
-        case 2:
-            frameLength = buf.getUnsignedShort(offset);
-            break;
-        case 3:
-            frameLength = buf.getUnsignedMedium(offset);
-            break;
-        case 4:
-            frameLength = buf.getUnsignedInt(offset);
-            break;
-        case 8:
-            frameLength = buf.getLong(offset);
-            break;
-        default:
-            throw new DecoderException(
-                    "unsupported lengthFieldLength: " + lengthFieldLength + " (expected: 1, 2, 3, 4, or 8)");
-        }
-        return frameLength;
+        return UnadjustedFrameLengthDecoderUtil.decode(buf.order(order), offset, length);
     }
 
     private void failIfNecessary(boolean firstDetectionOfTooLongFrame) {

--- a/codec/src/main/java/io/netty/handler/codec/UnadjustedFrameLengthDecoderUtil.java
+++ b/codec/src/main/java/io/netty/handler/codec/UnadjustedFrameLengthDecoderUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec;
+
+import io.netty.buffer.ByteBuf;
+
+final class UnadjustedFrameLengthDecoderUtil {
+
+    private UnadjustedFrameLengthDecoderUtil() {
+    }
+
+    /**
+     * Decodes the specified region of the buffer into an unadjusted frame length. The default implementation is
+     * capable of decoding the specified region into an unsigned 8/16/24/32/64 bit integer. Override this method to
+     * decode the length field encoded differently. Note that this method must not modify the state of the specified
+     * buffer (e.g. {@code readerIndex}, {@code writerIndex}, and the content of the buffer.)
+     *
+     * @throws DecoderException if failed to decode the specified region
+     */
+    static long decode(ByteBuf buf, int offset, int length) {
+        switch (length) {
+        case 1:
+            return buf.getUnsignedByte(offset);
+        case 2:
+            return buf.getUnsignedShort(offset);
+        case 3:
+            return buf.getUnsignedMedium(offset);
+        case 4:
+            return buf.getUnsignedInt(offset);
+        case 8:
+            return buf.getLong(offset);
+        default:
+            throw new DecoderException(
+                    "unsupported lengthFieldLength: " + length + " (expected: 1, 2, 3, 4, or 8)");
+        }
+    }
+}

--- a/codec/src/test/java/io/netty/handler/codec/BatchedFixedLengthFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/BatchedFixedLengthFrameDecoderTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+public class BatchedFixedLengthFrameDecoderTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void decoderWithZeroFrameLengthShouldThrowException() {
+        new BatchedFixedLengthFrameDecoder(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void decoderWithNegativeFrameLengthShouldThrowException() {
+        new BatchedFixedLengthFrameDecoder(-1);
+    }
+
+    @Test
+    public void writingNotAByteBufShouldPassThePipeline() {
+        final int frameLength = 10;
+        final EmbeddedChannel channel = new EmbeddedChannel(new BatchedFixedLengthFrameDecoder(frameLength));
+        final Object marker = new Object();
+
+        final boolean inboundBufferChanged = channel.writeInbound(marker);
+        final Object receivedObject = channel.readInbound();
+
+        assertThat(inboundBufferChanged, is(true));
+        assertThat(receivedObject, is(equalTo(marker)));
+
+        final boolean bufferReadable = channel.finishAndReleaseAll();
+
+        assertThat(bufferReadable, is(false));
+    }
+
+    @Test
+    public void writingNotEnoughBytesReadsNothing() {
+        final int frameLength = 10;
+        final EmbeddedChannel channel = new EmbeddedChannel(new BatchedFixedLengthFrameDecoder(frameLength));
+        final ByteBuf chunk = Unpooled.copiedBuffer(new byte[5]);
+
+        final boolean inboundBufferChanged = channel.writeInbound(chunk);
+        final Object receivedObject = channel.readInbound();
+
+        assertThat(inboundBufferChanged, is(false));
+        assertThat(receivedObject, is(equalTo(null)));
+
+        final boolean bufferReadable = channel.finishAndReleaseAll();
+
+        assertThat(bufferReadable, is(false));
+    }
+
+    @Test
+    public void writingOneAndAHalfMessageShouldRetrieveOnlyOneMessage() {
+        final int frameLength = 10;
+        final int oneAndAHalfMessageLength = frameLength + frameLength / 2;
+        final EmbeddedChannel channel =
+                new EmbeddedChannel(new BatchedFixedLengthFrameDecoder(frameLength));
+        final ByteBuf chunk = Unpooled.copiedBuffer(new byte[oneAndAHalfMessageLength]);
+
+        final boolean inboundBufferChanged = channel.writeInbound(chunk);
+        final ByteBuf receivedChunk = channel.readInbound();
+
+        assertThat(inboundBufferChanged, is(true));
+        assertThat(receivedChunk.readableBytes(), is(equalTo(frameLength)));
+        receivedChunk.release();
+
+        final boolean bufferReadable = channel.finishAndReleaseAll();
+
+        assertThat(bufferReadable, is(false));
+    }
+
+    @Test
+    public void leftBytesShouldAccumulate() {
+        final int frameLength = 10;
+        final EmbeddedChannel channel =
+                new EmbeddedChannel(new BatchedFixedLengthFrameDecoder(frameLength));
+
+        boolean inboundBufferChanged = channel.writeInbound(Unpooled.copiedBuffer(new byte[15]));
+        ByteBuf receivedChunk = channel.readInbound();
+
+        assertThat(inboundBufferChanged, is(true));
+        assertThat(receivedChunk.readableBytes(), is(equalTo(frameLength)));
+        receivedChunk.release();
+
+        inboundBufferChanged = channel.writeInbound(Unpooled.copiedBuffer(new byte[10]));
+        receivedChunk = channel.readInbound();
+
+        assertThat(inboundBufferChanged, is(true));
+        assertThat(receivedChunk.readableBytes(), is(equalTo(frameLength)));
+        receivedChunk.release();
+
+        receivedChunk = channel.readInbound();
+        assertThat(receivedChunk, is(equalTo(null)));
+
+        final boolean bufferReadable = channel.finishAndReleaseAll();
+
+        assertThat(bufferReadable, is(false));
+    }
+}

--- a/codec/src/test/java/io/netty/handler/codec/BatchedLengthFieldBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/BatchedLengthFieldBasedFrameDecoderTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+public class BatchedLengthFieldBasedFrameDecoderTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void decoderWithZeroMaxFrameLengthShouldThrowException() {
+        new BatchedLengthFieldBasedFrameDecoder(0, 1, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void decoderWithNegativeMaxFrameLengthShouldThrowException() {
+        new BatchedLengthFieldBasedFrameDecoder(-1, 1, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void decoderWithNegativeLengthFieldOffsetShouldThrowException() {
+        new BatchedLengthFieldBasedFrameDecoder(1, -1, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void decoderWithTooBigLengthFieldOffsetShouldThrowException() {
+        new BatchedLengthFieldBasedFrameDecoder(10, 8, 8);
+    }
+
+    @Test
+    public void writingNotAByteBufShouldPassThePipeline() {
+        final EmbeddedChannel channel = new EmbeddedChannel(new BatchedLengthFieldBasedFrameDecoder(2, 0, 1));
+        final Object marker = new Object();
+
+        final boolean inboundBufferChanged = channel.writeInbound(marker);
+        final Object receivedObject = channel.readInbound();
+
+        assertThat(inboundBufferChanged, is(true));
+        assertThat(receivedObject, is(equalTo(marker)));
+
+        final boolean bufferReadable = channel.finishAndReleaseAll();
+
+        assertThat(bufferReadable, is(false));
+    }
+
+    @Test
+    public void writingNotEnoughBytesReadsNothing() {
+        final EmbeddedChannel channel = new EmbeddedChannel(new BatchedLengthFieldBasedFrameDecoder(6, 2, 1));
+        final ByteBuf chunk = Unpooled.copiedBuffer(new byte[] { 1, 1, 3, 0, 0 });
+
+        final boolean inboundBufferChanged = channel.writeInbound(chunk);
+        final Object receivedObject = channel.readInbound();
+
+        assertThat(inboundBufferChanged, is(false));
+        assertThat(receivedObject, is(equalTo(null)));
+
+        final boolean bufferReadable = channel.finishAndReleaseAll();
+
+        assertThat(bufferReadable, is(false));
+    }
+
+    @Test
+    public void writingOneAndAHalfMessageShouldRetrieveOnlyOneMessage() {
+        final EmbeddedChannel channel =
+                new EmbeddedChannel(new BatchedLengthFieldBasedFrameDecoder(10, 2, 1));
+        final byte[] completeFrame = { 1, 1, 3, 0, 0, 0 };
+        final byte[] halfFrame = { 1, 1, 2, 0 };
+        final ByteBuf chunk = Unpooled.copiedBuffer(completeFrame, halfFrame);
+
+        final boolean inboundBufferChanged = channel.writeInbound(chunk);
+        final ByteBuf receivedChunk = channel.readInbound();
+
+        assertThat(inboundBufferChanged, is(true));
+        assertThat(receivedChunk.readableBytes(), is(equalTo(completeFrame.length)));
+        receivedChunk.release();
+
+        final boolean bufferReadable = channel.finishAndReleaseAll();
+
+        assertThat(bufferReadable, is(false));
+    }
+
+    @Test
+    public void leftBytesShouldAccumulate() {
+        final EmbeddedChannel channel =
+                new EmbeddedChannel(new BatchedLengthFieldBasedFrameDecoder(10, 2, 1));
+        final byte[] completeFrame = { 1, 1, 3, 0, 0, 0 };
+        final byte[] halfFrame = { 1, 1, 4, 0 };
+        final byte[] anotherHalfFrame = { 0, 0, 0 };
+        ByteBuf chunk = Unpooled.copiedBuffer(completeFrame, halfFrame);
+
+        boolean inboundBufferChanged = channel.writeInbound(chunk);
+        ByteBuf receivedChunk = channel.readInbound();
+
+        assertThat(inboundBufferChanged, is(true));
+        assertThat(receivedChunk.readableBytes(), is(equalTo(completeFrame.length)));
+        receivedChunk.release();
+
+        chunk = Unpooled.copiedBuffer(anotherHalfFrame);
+        inboundBufferChanged = channel.writeInbound(chunk);
+        receivedChunk = channel.readInbound();
+
+        assertThat(inboundBufferChanged, is(true));
+        assertThat(receivedChunk.readableBytes(), is(equalTo(halfFrame.length + anotherHalfFrame.length)));
+        receivedChunk.release();
+
+        final boolean bufferReadable = channel.finishAndReleaseAll();
+
+        assertThat(bufferReadable, is(false));
+    }
+}


### PR DESCRIPTION
…LengthFrameDecoder

Motivation:

According to performance tests, LengthFieldBasedFrameDecoder and FixedLengthFrameDecoder generate a lot of garbage as well as perform quite poorly in cases where clients send data at a very high-speed rate.

Modifications:

- Introduce a base class which implements batching of all incoming ByteBuf messages as well as provides a convenient API for decoding the resulting chunk of data
- Introduce an optimised version of LengthFieldBasedFrameDecoder - BatchLengthFieldBasedFrameDecoder
- Introduce an optimised version of FixedLengthFrameDecoder - BatchFixedLengthFrameDecoder

Result:

BatchLengthFieldBasedFrameDecoder and BatchFixedLengthFrameDecoder will provide much better throughput as compared to LengthFieldBasedFrameDecoder and FixedLengthFrameDecoder

P.S I [created](https://github.com/maseev/echo) a simple echo application which tests three batching strategies. Here are some throughput as well as GC diagrams:

[Dummy Handler](https://github.com/maseev/echo/blob/master/server/src/main/java/io/github/maseev/echo/handler/DummyEchoServerHandler.java)
![Dummy Handler Throughput](https://maseev.github.io/2016/09/16/gotta-go-fast-with-netty/DUMMY_THROUGHPUT.png)
![Dummy Handler GC](https://maseev.github.io/2016/09/16/gotta-go-fast-with-netty/DUMMY_GC.png)

[Batching Handler](https://github.com/maseev/echo/blob/master/server/src/main/java/io/github/maseev/echo/handler/BatchingEchoServerHandler.java)
![Batching Handler Throughput](https://maseev.github.io/2016/09/16/gotta-go-fast-with-netty/BATCHING_THROUGHPUT.png)
![Batching Handler GC](https://maseev.github.io/2016/09/16/gotta-go-fast-with-netty/BATCHING_GC.png)

[Optimised Handler](https://github.com/maseev/echo/blob/master/server/src/main/java/io/github/maseev/echo/handler/HighPerformanceEchoServerHandler.java)
![Optimised Throughput](https://maseev.github.io/2016/09/16/gotta-go-fast-with-netty/OPTIMISED_THROUGHPUT.png)
![Optimised GC](https://maseev.github.io/2016/09/16/gotta-go-fast-with-netty/OPTIMISED_GC.png)

This particular handler mimics the semantic of the one in the [PR](https://github.com/maseev/netty/commit/e67ac28504952f989f7a926359a24fdeac03ad0d#diff-424f83af20faabeda9dd287cb533fbc8). As you can see, throughput in the last case is much higher.

This PR is probably related to the following issues: #1759, #5152