### PR TITLE
Now that LocalChannel#releaseInboundBuffers is only called from the E…

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -422,9 +422,8 @@ public class LocalChannel extends AbstractChannel {
     }
 
     private void releaseInboundBuffers() {
-        if (readInProgress) {
-            return;
-        }
+        assert eventLoop() == null || eventLoop().inEventLoop();
+        readInProgress = false;
         Queue<Object> inboundBuffer = this.inboundBuffer;
         Object msg;
         while ((msg = inboundBuffer.poll()) != null) {


### PR DESCRIPTION
…ventLoop (eb4d317b9d64f3945a209804fec4c3fe695f4f9f) it should clear readInProgress and drain/release the queue. Otherwise if a read event is pending (doBeginRead) was called we may later call channelRead or channelReadComplete after we have closed the channel.

Modifications:
LocalChannel#releaseInboundBuffers should always clear/release the queue and set readInProgress to false

Result:
LocalChannel queue is more reliably cleaned up.