### PR TITLE
Misc clean up

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1308,13 +1308,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o instanceof ByteBuf) {
-            return ByteBufUtil.equals(this, (ByteBuf) o);
-        }
-        return false;
+        return this == o || (o instanceof ByteBuf && ByteBufUtil.equals(this, (ByteBuf) o));
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -313,10 +313,8 @@ public class DefaultHttpHeaders extends HttpHeaders {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof DefaultHttpHeaders)) {
-            return false;
-        }
-        return headers.equals(((DefaultHttpHeaders) o).headers, CASE_SENSITIVE_HASHER);
+        return o instanceof DefaultHttpHeaders
+                && headers.equals(((DefaultHttpHeaders) o).headers, CASE_SENSITIVE_HASHER);
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieEncoder.java
@@ -34,9 +34,6 @@ import java.util.List;
  * A <a href="http://tools.ietf.org/html/rfc6265">RFC6265</a> compliant cookie encoder to be used client side, so
  * only name=value pairs are sent.
  *
- * User-Agents are not supposed to interpret cookies, so, if present, {@link Cookie#rawValue()} will be used.
- * Otherwise, {@link Cookie#value()} will be used unquoted.
- *
  * Note that multiple cookies are supposed to be sent at once in a single "Cookie" header.
  *
  * <pre>

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/DefaultCookie.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/DefaultCookie.java
@@ -153,8 +153,6 @@ public class DefaultCookie implements Cookie {
             if (that.domain() != null) {
                 return false;
             }
-        } else if (that.domain() == null) {
-            return false;
         } else {
             return domain().equalsIgnoreCase(that.domain());
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieDecoder.java
@@ -96,45 +96,43 @@ public final class ServerCookieDecoder extends CookieDecoder {
             }
 
             int nameBegin = i;
-            int nameEnd = i;
-            int valueBegin = -1;
-            int valueEnd = -1;
+            int nameEnd;
+            int valueBegin;
+            int valueEnd;
 
-            if (i != headerLen) {
-                keyValLoop: for (;;) {
+            for (;;) {
 
-                    char curChar = header.charAt(i);
-                    if (curChar == ';') {
-                        // NAME; (no value till ';')
-                        nameEnd = i;
-                        valueBegin = valueEnd = -1;
-                        break keyValLoop;
+                char curChar = header.charAt(i);
+                if (curChar == ';') {
+                    // NAME; (no value till ';')
+                    nameEnd = i;
+                    valueBegin = valueEnd = -1;
+                    break;
 
-                    } else if (curChar == '=') {
-                        // NAME=VALUE
-                        nameEnd = i;
-                        i++;
-                        if (i == headerLen) {
-                            // NAME= (empty value, i.e. nothing after '=')
-                            valueBegin = valueEnd = 0;
-                            break keyValLoop;
-                        }
-
-                        valueBegin = i;
-                        // NAME=VALUE;
-                        int semiPos = header.indexOf(';', i);
-                        valueEnd = i = semiPos > 0 ? semiPos : headerLen;
-                        break keyValLoop;
-                    } else {
-                        i++;
-                    }
-
+                } else if (curChar == '=') {
+                    // NAME=VALUE
+                    nameEnd = i;
+                    i++;
                     if (i == headerLen) {
-                        // NAME (no value till the end of string)
-                        nameEnd = headerLen;
-                        valueBegin = valueEnd = -1;
+                        // NAME= (empty value, i.e. nothing after '=')
+                        valueBegin = valueEnd = 0;
                         break;
                     }
+
+                    valueBegin = i;
+                    // NAME=VALUE;
+                    int semiPos = header.indexOf(';', i);
+                    valueEnd = i = semiPos > 0 ? semiPos : headerLen;
+                    break;
+                } else {
+                    i++;
+                }
+
+                if (i == headerLen) {
+                    // NAME (no value till the end of string)
+                    nameEnd = headerLen;
+                    valueBegin = valueEnd = -1;
+                    break;
                 }
             }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
@@ -213,7 +213,7 @@ public final class ServerCookieEncoder extends CookieEncoder {
         Map<String, Integer> nameToIndex = strict && cookiesIt.hasNext() ? new HashMap<String, Integer>() : null;
         int i = 0;
         encoded.add(encode(firstCookie));
-        boolean hasDupdName = nameToIndex != null ? nameToIndex.put(firstCookie.name(), i++) != null : false;
+        boolean hasDupdName = nameToIndex != null && nameToIndex.put(firstCookie.name(), i++) != null;
         while (cookiesIt.hasNext()) {
             Cookie c = cookiesIt.next();
             encoded.add(encode(c));

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -120,11 +120,7 @@ public class DefaultHttp2Headers
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Http2Headers)) {
-            return false;
-        }
-
-        return equals((Http2Headers) o, CASE_SENSITIVE_HASHER);
+        return o instanceof Http2Headers && equals((Http2Headers) o, CASE_SENSITIVE_HASHER);
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -328,8 +328,8 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
 
     @Override
     public T addObject(K name, Object... values) {
-        for (int i = 0; i < values.length; i++) {
-            addObject(name, values[i]);
+        for (Object value: values) {
+            addObject(name, value);
         }
         return thisT();
     }


### PR DESCRIPTION
Motivation:
IntelliJ issues several warnings.

Modifications:

* `ClientCookieDecoder` and `ServerCookieDecoder`:
  * `nameEnd`, `valueBegin` and `valueEnd` don't need to be initialized
  * `keyValLoop` loop doesn't been to be labelled, as it's the most inner one (same thing for labelled breaks)
  * Remove `if (i != headerLen)` as condition is always true
* `ClientCookieEncoder` javadoc still mention old logic
* `DefaultCookie`, `ServerCookieEncoder` and `DefaultHttpHeaders` use ternary ops that can be turned into simple boolean ones
* `DefaultHeaders` uses a for(int) loop over an array. It can be turned into a foreach one as javac doesn't allocate an iterator to iterate over arrays

Result:

Cleaner code