### PR TITLE
Return status 431 on header size errors

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -374,6 +374,7 @@ public class DefaultHttp2Connection implements Http2Connection {
         private DefaultStream parent;
         private IntObjectMap<DefaultStream> children = IntCollections.emptyMap();
         private boolean resetSent;
+        private boolean headersSent;
 
         DefaultStream(int id, State state) {
             this.id = id;
@@ -399,6 +400,17 @@ public class DefaultHttp2Connection implements Http2Connection {
         public Http2Stream resetSent() {
             resetSent = true;
             return this;
+        }
+
+        @Override
+        public Http2Stream headersSent() {
+            headersSent = true;
+            return this;
+        }
+
+        @Override
+        public boolean isHeadersSent() {
+            return headersSent;
         }
 
         @Override
@@ -802,6 +814,16 @@ public class DefaultHttp2Connection implements Http2Connection {
 
         @Override
         public Http2Stream closeRemoteSide() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Http2Stream headersSent() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isHeadersSent() {
             throw new UnsupportedOperationException();
         }
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2FrameReader.java
@@ -673,7 +673,7 @@ public class DefaultHttp2FrameReader implements Http2FrameReader, Http2FrameSize
          */
         private void headerSizeExceeded() throws Http2Exception {
             close();
-            headerListSizeExceeded(streamId, headersDecoder.configuration().headerTable().maxHeaderListSize());
+            headerListSizeExceeded(streamId, headersDecoder.configuration().headerTable().maxHeaderListSize(), true);
         }
 
         /**

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -30,7 +30,7 @@ import io.netty.util.internal.UnstableApi;
 import static io.netty.buffer.Unpooled.directBuffer;
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
-import static io.netty.handler.codec.http2.Http2Exception.streamError;
+import static io.netty.handler.codec.http2.Http2Exception.headerListSizeError;
 import static io.netty.util.CharsetUtil.UTF_8;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -223,8 +223,10 @@ public final class Http2CodecUtil {
         return max(0, min(state.pendingBytes(), state.windowSize()));
     }
 
-    public static void headerListSizeExceeded(int streamId, long maxHeaderListSize) throws Http2Exception {
-        throw streamError(streamId, PROTOCOL_ERROR, "Header size exceeded max allowed size (%d)", maxHeaderListSize);
+    public static void headerListSizeExceeded(int streamId, long maxHeaderListSize,
+                                              boolean onDecode) throws Http2Exception {
+        throw headerListSizeError(streamId, PROTOCOL_ERROR, onDecode, "Header size exceeded max " +
+                                  "allowed size (%d)", maxHeaderListSize);
     }
 
     static void writeFrameHeaderInternal(ByteBuf out, int payloadLength, byte type,

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -183,4 +183,14 @@ public interface Http2Stream {
      * @return The stream before iteration stopped or {@code null} if iteration went past the end.
      */
     Http2Stream forEachChild(Http2StreamVisitor visitor) throws Http2Exception;
+
+    /**
+     * Indicates that headers has been sent to the remote on this stream.
+     */
+    Http2Stream headersSent();
+
+    /**
+     * Indicates whether or not headers was sent to the remote endpoint.
+     */
+    boolean isHeadersSent();
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/Decoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/Decoder.java
@@ -207,7 +207,7 @@ public final class Decoder {
                         state = READ_LITERAL_HEADER_NAME_LENGTH;
                     } else {
                         if (index > maxHeaderListSize - headersLength) {
-                            headerListSizeExceeded(streamId, maxHeaderListSize);
+                            headerListSizeExceeded(streamId, maxHeaderListSize, true);
                         }
                         nameLength = index;
                         state = READ_LITERAL_HEADER_NAME;
@@ -219,7 +219,7 @@ public final class Decoder {
                     nameLength = decodeULE128(in, index);
 
                     if (nameLength > maxHeaderListSize - headersLength) {
-                        headerListSizeExceeded(streamId, maxHeaderListSize);
+                        headerListSizeExceeded(streamId, maxHeaderListSize, true);
                     }
                     state = READ_LITERAL_HEADER_NAME;
                     break;
@@ -251,7 +251,7 @@ public final class Decoder {
                         default:
                             // Check new header size against max header size
                             if ((long) index + nameLength > maxHeaderListSize - headersLength) {
-                                headerListSizeExceeded(streamId, maxHeaderListSize);
+                                headerListSizeExceeded(streamId, maxHeaderListSize, true);
                             }
                             valueLength = index;
                             state = READ_LITERAL_HEADER_VALUE;
@@ -265,7 +265,7 @@ public final class Decoder {
 
                     // Check new header size against max header size
                     if ((long) valueLength + nameLength > maxHeaderListSize - headersLength) {
-                        headerListSizeExceeded(streamId, maxHeaderListSize);
+                        headerListSizeExceeded(streamId, maxHeaderListSize, true);
                     }
                     state = READ_LITERAL_HEADER_VALUE;
                     break;
@@ -403,7 +403,7 @@ public final class Decoder {
                            long headersLength) throws Http2Exception {
         headersLength += name.length() + value.length();
         if (headersLength > maxHeaderListSize) {
-            headerListSizeExceeded(streamId, maxHeaderListSize);
+            headerListSizeExceeded(streamId, maxHeaderListSize, true);
         }
         headers.add(name, value);
         return headersLength;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/Encoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/Encoder.java
@@ -124,7 +124,7 @@ public final class Encoder {
             // overflow.
             headerSize += currHeaderSize;
             if (headerSize > maxHeaderListSize) {
-                headerListSizeExceeded(streamId, maxHeaderListSize);
+                headerListSizeExceeded(streamId, maxHeaderListSize, false);
             }
             encodeHeader(out, name, value, sensitivityDetector.isSensitive(name, value), currHeaderSize);
         }


### PR DESCRIPTION
Motivation:

Currently clients attempting to send headers that are too large recieve
a RST frame. This makes it harder than needed for implementations on top
of netty to handle this in a graceful way.

Modifications:

When the Decoder throws a StreamError of type FRAME_SIZE_ERROR, the
Http2ConnectionHandler will now attempt to send an Http2Header with
status 431 and endOfStream=true

Result:

Implementations now do not have to subclass parts of netty to handle
431s