### PR TITLE
Do not eagerly initialize the logger factory

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -13,9 +13,8 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.util.internal.logging;
 
-import io.netty.util.internal.ThreadLocalRandom;
+package io.netty.util.internal.logging;
 
 /**
  * Creates an {@link InternalLogger} or changes the default factory
@@ -34,18 +33,7 @@ import io.netty.util.internal.ThreadLocalRandom;
  */
 public abstract class InternalLoggerFactory {
 
-    private static volatile InternalLoggerFactory defaultFactory =
-            newDefaultFactory(InternalLoggerFactory.class.getName());
-
-    static {
-        // Initiate some time-consuming background jobs here,
-        // because this class is often initialized at the earliest time.
-        try {
-            Class.forName(ThreadLocalRandom.class.getName(), true, InternalLoggerFactory.class.getClassLoader());
-        } catch (Exception ignored) {
-            // Should not fail, but it does not harm to fail.
-        }
-    }
+    private static volatile InternalLoggerFactory defaultFactory;
 
     @SuppressWarnings("UnusedCatchParameter")
     private static InternalLoggerFactory newDefaultFactory(String name) {
@@ -70,6 +58,9 @@ public abstract class InternalLoggerFactory {
      * {@link JdkLoggerFactory}.
      */
     public static InternalLoggerFactory getDefaultFactory() {
+        if (defaultFactory == null) {
+            defaultFactory = newDefaultFactory(InternalLoggerFactory.class.getName());
+        }
         return defaultFactory;
     }
 
@@ -101,4 +92,5 @@ public abstract class InternalLoggerFactory {
      * Creates a new logger instance with the specified name.
      */
     protected abstract InternalLogger newInstance(String name);
+
 }


### PR DESCRIPTION
Motivation:

For applications that set their own logger factory, they want that
logger factory to be the one logger factory. Yet, Netty eagerly
initializes this and then triggers initialization of other classes
before the application has had a chance to set its preferred logger
factory.

Modifications:

With this commit there are two key changes:
 - Netty does not attempt to eagerly initialize the default logger
   factory, only doing so if the application layer above Netty has not
   already set a logger factory
 - do not eagerly initialize unrelated classes from the logger factory;
   while the motivation behind this was to initialize ThreadLocalRandom
   as soon as possible in case it has to block reading from /dev/random,
   this can be worked around for applications where it is problematic by
   setting securerandom.source=file:/dev/urandom in their Java system
   security policy (no, it is not less secure; do not even get me
   started on myths about /dev/random)

Result:

Netty uses the logger factory that the application prefers, and does not
initialize unrelated classes.