### PR TITLE
[#6061] Correctly mark EpollServerDomainSocketChannel.isActive() as t…

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerDomainSocketChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollServerDomainSocketChannel.java
@@ -75,6 +75,7 @@ public final class EpollServerDomainSocketChannel extends AbstractEpollServerCha
         fd().bind(localAddress);
         fd().listen(config.getBacklog());
         local = (DomainSocketAddress) localAddress;
+        active = true;
     }
 
     @Override


### PR DESCRIPTION
…rue after bind is complete.]

Motivation:

We missed to set active = true in EpollServerDomainSocketChannel.doBind(...) which also means that channelActive(...) was never triggered.

Modifications:

Correct set active = true in doBind(...)

Result:

EpollServerDomainSocketChannel is correctly set to active when bound.