### PR TITLE
Correct release buffers in RedisEncoderTest

### DIFF
--- a/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisEncoderTest.java
+++ b/codec-redis/src/test/java/io/netty/handler/codec/redis/RedisEncoderTest.java
@@ -175,6 +175,7 @@ public class RedisEncoderTest {
         ByteBuf read;
         while ((read = channel.readOutbound()) != null) {
             buf.writeBytes(read);
+            read.release();
         }
         return buf;
     }


### PR DESCRIPTION
Motivation:

RedisEncoderTest did not release all buffers correctly which could lead to leaks.

Modifications:

Call ByteBuf.release() after buffer is read.

Result:

No more leaks in RedisEncoderTest.