### PR TITLE
Allow to build netty when sun.misc.Unsafe is not avaible or -Dio.nett…

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeDirectByteBufTest.java
@@ -23,8 +23,10 @@ import org.junit.Before;
 public class BigEndianUnsafeDirectByteBufTest extends BigEndianDirectByteBufTest {
 
     @Before
-    public void checkHasUnsafe() {
+    @Override
+    public void init() {
         Assume.assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
+        super.init();
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeNoCleanerDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/BigEndianUnsafeNoCleanerDirectByteBufTest.java
@@ -23,9 +23,11 @@ import org.junit.Before;
 public class BigEndianUnsafeNoCleanerDirectByteBufTest extends BigEndianDirectByteBufTest {
 
     @Before
-    public void checkHasUnsafe() {
+    @Override
+    public void init() {
         Assume.assumeTrue("java.nio.DirectByteBuffer.<init>(long, int) not found, skip tests",
                 PlatformDependent.useDirectBufferNoCleaner());
+        super.init();
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeDirectByteBufTest.java
@@ -22,8 +22,10 @@ import org.junit.Before;
 public class LittleEndianUnsafeDirectByteBufTest extends LittleEndianDirectByteBufTest {
 
     @Before
-    public void checkHasUnsafe() {
+    @Override
+    public void init() {
         Assume.assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
+        super.init();
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeNoCleanerDirectByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/LittleEndianUnsafeNoCleanerDirectByteBufTest.java
@@ -22,9 +22,11 @@ import org.junit.Before;
 public class LittleEndianUnsafeNoCleanerDirectByteBufTest extends LittleEndianDirectByteBufTest {
 
     @Before
-    public void checkHasUnsafe() {
+    @Override
+    public void init() {
         Assume.assumeTrue("java.nio.DirectByteBuffer.<init>(long, int) not found, skip tests",
                 PlatformDependent.useDirectBufferNoCleaner());
+        super.init();
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBufferBufTest.java
@@ -16,6 +16,7 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 
 import java.nio.ByteBuffer;
@@ -29,7 +30,7 @@ public class ReadOnlyUnsafeDirectByteBufferBufTest extends ReadOnlyDirectByteBuf
      */
     @BeforeClass
     public static void assumeConditions() {
-        assumeTrue(PlatformDependent.hasUnsafe());
+        assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/UnsafeByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnsafeByteBufUtilTest.java
@@ -15,6 +15,9 @@
  */
 package io.netty.buffer;
 
+import io.netty.util.internal.PlatformDependent;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -25,6 +28,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 public class UnsafeByteBufUtilTest {
+    @Before
+    public void checkHasUnsafe() {
+        Assume.assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
+    }
 
     @Test
     public void testSetBytesOnReadOnlyByteBuffer() throws Exception {

--- a/buffer/src/test/java/io/netty/buffer/WrappedUnpooledUnsafeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/WrappedUnpooledUnsafeByteBufTest.java
@@ -16,11 +16,20 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 
 public class WrappedUnpooledUnsafeByteBufTest extends BigEndianUnsafeDirectByteBufTest {
+
+    @Before
+    @Override
+    public void init() {
+        Assume.assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
+        super.init();
+    }
 
     @Override
     protected ByteBuf newBuffer(int length) {


### PR DESCRIPTION
…y.noUnsafe=true is used.

Motivation:

We support using Netty without sun.misc.Unsafe, so we should also support building it without it. This way we can also run all tests without sun.misc.Unsafe and so see if it works as expected.

Modifications:

Correctly skip tests that depend on sun.misc.Unsafe if its not present or -Dio.netty.noUnsafe=true is used.

Result:

Be able to build netty without sun.misc.Unsafe