### PR TITLE
SwappedByteBuf.unwrap() should return wrapped buffer.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SwappedByteBuf.java
@@ -69,7 +69,7 @@ public class SwappedByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf unwrap() {
-        return buf.unwrap();
+        return buf;
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/ByteBufDerivationTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufDerivationTest.java
@@ -22,6 +22,7 @@ import java.nio.ByteOrder;
 import java.util.Random;
 
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.*;
 
 /**
@@ -156,7 +157,7 @@ public class ByteBufDerivationTest {
         ByteBuf swapped = buf.order(ByteOrder.LITTLE_ENDIAN);
 
         assertThat(swapped, instanceOf(SwappedByteBuf.class));
-        assertThat(swapped.unwrap(), is((ByteBuf) null));
+        assertThat(swapped.unwrap(), sameInstance(buf));
         assertThat(swapped.order(ByteOrder.LITTLE_ENDIAN), sameInstance(swapped));
         assertThat(swapped.order(ByteOrder.BIG_ENDIAN), sameInstance(buf));
 


### PR DESCRIPTION
Motivation:

SwappedByteBuf.unwrap() not returned the wrapped buffer but the buffer that was wrapped by the original buffer. This is not correct.

Modifications:

Correctly return wrapped buffer and fix test.

Result:

SwappedByteBuf.unwrap() works as expected.