### PR TITLE
Use a single array in SelectedSelectionKeySet

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioChannel.java
@@ -384,7 +384,7 @@ public abstract class AbstractNioChannel extends AbstractChannel {
         boolean selected = false;
         for (;;) {
             try {
-                selectionKey = javaChannel().register(eventLoop().selector, 0, this);
+                selectionKey = javaChannel().register(eventLoop().unwrappedSelector(), 0, this);
                 return;
             } catch (CancelledKeyException e) {
                 if (!selected) {

--- a/transport/src/main/java/io/netty/channel/nio/SelectedSelectionKeySetSelector.java
+++ b/transport/src/main/java/io/netty/channel/nio/SelectedSelectionKeySetSelector.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.nio;
+
+import java.io.IOException;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.spi.SelectorProvider;
+import java.util.Set;
+
+final class SelectedSelectionKeySetSelector extends Selector {
+    private final SelectedSelectionKeySet selectionKeys;
+    private final Selector delegate;
+
+    SelectedSelectionKeySetSelector(Selector delegate, SelectedSelectionKeySet selectionKeys) {
+        this.delegate = delegate;
+        this.selectionKeys = selectionKeys;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return delegate.isOpen();
+    }
+
+    @Override
+    public SelectorProvider provider() {
+        return delegate.provider();
+    }
+
+    @Override
+    public Set<SelectionKey> keys() {
+        return delegate.keys();
+    }
+
+    @Override
+    public Set<SelectionKey> selectedKeys() {
+        return delegate.selectedKeys();
+    }
+
+    @Override
+    public int selectNow() throws IOException {
+        selectionKeys.reset();
+        return delegate.selectNow();
+    }
+
+    @Override
+    public int select(long timeout) throws IOException {
+        selectionKeys.reset();
+        return delegate.select(timeout);
+    }
+
+    @Override
+    public int select() throws IOException {
+        selectionKeys.reset();
+        return delegate.select();
+    }
+
+    @Override
+    public Selector wakeup() {
+        return delegate.wakeup();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+}

--- a/transport/src/test/java/io/netty/channel/nio/SelectedSelectionKeySetTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/SelectedSelectionKeySetTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.nio;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.nio.channels.SelectionKey;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class SelectedSelectionKeySetTest {
+    @Mock
+    private SelectionKey mockKey;
+    @Mock
+    private SelectionKey mockKey2;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void addElements() {
+        SelectedSelectionKeySet set = new SelectedSelectionKeySet();
+        final int expectedSize = 1000000;
+        for (int i = 0; i < expectedSize; ++i) {
+            assertTrue(set.add(mockKey));
+        }
+
+        assertEquals(expectedSize, set.size());
+        assertFalse(set.isEmpty());
+    }
+
+    @Test
+    public void resetSet() {
+        SelectedSelectionKeySet set = new SelectedSelectionKeySet();
+        assertTrue(set.add(mockKey));
+        assertTrue(set.add(mockKey2));
+        set.reset(1);
+
+        assertSame(mockKey, set.keys[0]);
+        assertNull(set.keys[1]);
+        assertEquals(0, set.size());
+        assertTrue(set.isEmpty());
+    }
+}


### PR DESCRIPTION
Motivation:
SelectedSelectionKeySet currently uses 2 arrays internally and users are expected to call flip() to access the underlying array and switch the active array. However we do not concurrently use 2 arrays at the same time and we can get away with using a single array if we are careful about when we reset the elements of the array.

Modifications:
- Introduce SelectedSelectionKeySetSelector which wraps a Selector and ensures we reset the underlying SelectedSelectionKeySet data structures before we select
- The loop bounds in NioEventLoop#processSelectedKeysOptimized can be defined more precisely because we know the real size of the underlying array

Result:
Fixes https://github.com/netty/netty/issues/6058