### PR TITLE
Fix false-positives when using ResourceLeakDetector.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBufAllocator.java
@@ -16,8 +16,8 @@
 
 package io.netty.buffer;
 
-import io.netty.util.ResourceLeak;
 import io.netty.util.ResourceLeakDetector;
+import io.netty.util.ResourceLeakTracker;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 
@@ -29,17 +29,17 @@ public abstract class AbstractByteBufAllocator implements ByteBufAllocator {
     static final int DEFAULT_MAX_COMPONENTS = 16;
 
     protected static ByteBuf toLeakAwareBuffer(ByteBuf buf) {
-        ResourceLeak leak;
+        ResourceLeakTracker<ByteBuf> leak;
         switch (ResourceLeakDetector.getLevel()) {
             case SIMPLE:
-                leak = AbstractByteBuf.leakDetector.open(buf);
+                leak = AbstractByteBuf.leakDetector.track(buf);
                 if (leak != null) {
                     buf = new SimpleLeakAwareByteBuf(buf, leak);
                 }
                 break;
             case ADVANCED:
             case PARANOID:
-                leak = AbstractByteBuf.leakDetector.open(buf);
+                leak = AbstractByteBuf.leakDetector.track(buf);
                 if (leak != null) {
                     buf = new AdvancedLeakAwareByteBuf(buf, leak);
                 }
@@ -51,17 +51,17 @@ public abstract class AbstractByteBufAllocator implements ByteBufAllocator {
     }
 
     protected static CompositeByteBuf toLeakAwareBuffer(CompositeByteBuf buf) {
-        ResourceLeak leak;
+        ResourceLeakTracker<ByteBuf> leak;
         switch (ResourceLeakDetector.getLevel()) {
             case SIMPLE:
-                leak = AbstractByteBuf.leakDetector.open(buf);
+                leak = AbstractByteBuf.leakDetector.track(buf);
                 if (leak != null) {
                     buf = new SimpleLeakAwareCompositeByteBuf(buf, leak);
                 }
                 break;
             case ADVANCED:
             case PARANOID:
-                leak = AbstractByteBuf.leakDetector.open(buf);
+                leak = AbstractByteBuf.leakDetector.track(buf);
                 if (leak != null) {
                     buf = new AdvancedLeakAwareCompositeByteBuf(buf, leak);
                 }

--- a/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractPooledDerivedByteBuf.java
@@ -43,6 +43,12 @@ abstract class AbstractPooledDerivedByteBuf extends AbstractReferenceCountedByte
         this.recyclerHandle = (Handle<AbstractPooledDerivedByteBuf>) recyclerHandle;
     }
 
+    // Called from within SimpleLeakAwareByteBuf and AdvancedLeakAwareByteBuf.
+    final void parent(ByteBuf newParent) {
+        assert newParent instanceof SimpleLeakAwareByteBuf;
+        parent = newParent;
+    }
+
     @Override
     public final AbstractByteBuf unwrap() {
         return rootParent;

--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
@@ -17,7 +17,7 @@ package io.netty.buffer;
 
 
 import io.netty.util.ByteProcessor;
-import io.netty.util.ResourceLeak;
+import io.netty.util.ResourceLeakTracker;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,77 +33,70 @@ import java.util.List;
 
 import static io.netty.buffer.AdvancedLeakAwareByteBuf.recordLeakNonRefCountingOperation;
 
-final class AdvancedLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
+final class AdvancedLeakAwareCompositeByteBuf extends SimpleLeakAwareCompositeByteBuf {
 
-    private final ResourceLeak leak;
-
-    AdvancedLeakAwareCompositeByteBuf(CompositeByteBuf wrapped, ResourceLeak leak) {
-        super(wrapped);
-        this.leak = leak;
+    AdvancedLeakAwareCompositeByteBuf(CompositeByteBuf wrapped, ResourceLeakTracker<ByteBuf> leak) {
+        super(wrapped, leak);
     }
 
     @Override
     public ByteBuf order(ByteOrder endianness) {
         recordLeakNonRefCountingOperation(leak);
-        if (order() == endianness) {
-            return this;
-        } else {
-            return new AdvancedLeakAwareByteBuf(super.order(endianness), leak);
-        }
+        return super.order(endianness);
     }
 
     @Override
     public ByteBuf slice() {
         recordLeakNonRefCountingOperation(leak);
-        return new AdvancedLeakAwareByteBuf(super.slice(), leak);
+        return super.slice();
     }
 
     @Override
     public ByteBuf retainedSlice() {
         recordLeakNonRefCountingOperation(leak);
-        return new AdvancedLeakAwareByteBuf(super.retainedSlice(), leak);
+        return super.retainedSlice();
     }
 
     @Override
     public ByteBuf slice(int index, int length) {
         recordLeakNonRefCountingOperation(leak);
-        return new AdvancedLeakAwareByteBuf(super.slice(index, length), leak);
+        return super.slice(index, length);
     }
 
     @Override
     public ByteBuf retainedSlice(int index, int length) {
         recordLeakNonRefCountingOperation(leak);
-        return new AdvancedLeakAwareByteBuf(super.retainedSlice(index, length), leak);
+        return super.retainedSlice(index, length);
     }
 
     @Override
     public ByteBuf duplicate() {
         recordLeakNonRefCountingOperation(leak);
-        return new AdvancedLeakAwareByteBuf(super.duplicate(), leak);
+        return super.duplicate();
     }
 
     @Override
     public ByteBuf retainedDuplicate() {
         recordLeakNonRefCountingOperation(leak);
-        return new AdvancedLeakAwareByteBuf(super.retainedDuplicate(), leak);
+        return super.retainedDuplicate();
     }
 
     @Override
     public ByteBuf readSlice(int length) {
         recordLeakNonRefCountingOperation(leak);
-        return new AdvancedLeakAwareByteBuf(super.readSlice(length), leak);
+        return super.readSlice(length);
     }
 
     @Override
     public ByteBuf readRetainedSlice(int length) {
         recordLeakNonRefCountingOperation(leak);
-        return new AdvancedLeakAwareByteBuf(super.readRetainedSlice(length), leak);
+        return super.readRetainedSlice(length);
     }
 
     @Override
     public ByteBuf asReadOnly() {
         recordLeakNonRefCountingOperation(leak);
-        return new AdvancedLeakAwareByteBuf(super.asReadOnly(), leak);
+        return super.asReadOnly();
     }
 
     @Override
@@ -1037,24 +1030,8 @@ final class AdvancedLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     }
 
     @Override
-    public boolean release() {
-        boolean deallocated = super.release();
-        if (deallocated) {
-            leak.close();
-        } else {
-            leak.record();
-        }
-        return deallocated;
-    }
-
-    @Override
-    public boolean release(int decrement) {
-        boolean deallocated = super.release(decrement);
-        if (deallocated) {
-            leak.close();
-        } else {
-            leak.record();
-        }
-        return deallocated;
+    protected AdvancedLeakAwareByteBuf newLeakAwareByteBuf(
+            ByteBuf wrapped, ByteBuf trackedByteBuf, ResourceLeakTracker<ByteBuf> leakTracker) {
+        return new AdvancedLeakAwareByteBuf(wrapped, trackedByteBuf, leakTracker);
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -1762,18 +1762,37 @@ public abstract class AbstractByteBufTest {
 
     @Test
     public void testRetainedSliceIndex() throws Exception {
-        assertEqualsAndRelease(buffer, 0, buffer.retainedSlice(0, buffer.capacity()).readerIndex());
-        assertEqualsAndRelease(buffer, 0, buffer.retainedSlice(0, buffer.capacity() - 1).readerIndex());
-        assertEqualsAndRelease(buffer, 0, buffer.retainedSlice(1, buffer.capacity() - 1).readerIndex());
-        assertEqualsAndRelease(buffer, 0, buffer.retainedSlice(1, buffer.capacity() - 2).readerIndex());
+        ByteBuf retainedSlice = buffer.retainedSlice(0, buffer.capacity());
+        assertEquals(0, retainedSlice.readerIndex());
+        retainedSlice.release();
 
-        assertEqualsAndRelease(buffer, buffer.capacity(), buffer.retainedSlice(0, buffer.capacity()).writerIndex());
-        assertEqualsAndRelease(buffer,
-                buffer.capacity() - 1, buffer.retainedSlice(0, buffer.capacity() - 1).writerIndex());
-        assertEqualsAndRelease(buffer,
-                buffer.capacity() - 1, buffer.retainedSlice(1, buffer.capacity() - 1).writerIndex());
-        assertEqualsAndRelease(buffer,
-                buffer.capacity() - 2, buffer.retainedSlice(1, buffer.capacity() - 2).writerIndex());
+        retainedSlice = buffer.retainedSlice(0, buffer.capacity() - 1);
+        assertEquals(0, retainedSlice.readerIndex());
+        retainedSlice.release();
+
+        retainedSlice = buffer.retainedSlice(1, buffer.capacity() - 1);
+        assertEquals(0, retainedSlice.readerIndex());
+        retainedSlice.release();
+
+        retainedSlice = buffer.retainedSlice(1, buffer.capacity() - 2);
+        assertEquals(0, retainedSlice.readerIndex());
+        retainedSlice.release();
+
+        retainedSlice = buffer.retainedSlice(0, buffer.capacity());
+        assertEquals(buffer.capacity(), retainedSlice.writerIndex());
+        retainedSlice.release();
+
+        retainedSlice = buffer.retainedSlice(0, buffer.capacity() - 1);
+        assertEquals(buffer.capacity() - 1, retainedSlice.writerIndex());
+        retainedSlice.release();
+
+        retainedSlice = buffer.retainedSlice(1, buffer.capacity() - 1);
+        assertEquals(buffer.capacity() - 1, retainedSlice.writerIndex());
+        retainedSlice.release();
+
+        retainedSlice = buffer.retainedSlice(1, buffer.capacity() - 2);
+        assertEquals(buffer.capacity() - 2, retainedSlice.writerIndex());
+        retainedSlice.release();
     }
 
     @Test
@@ -1832,9 +1851,14 @@ public abstract class AbstractByteBufTest {
         assertTrue(buffer.compareTo(wrappedBuffer(value, 0, 31).order(LITTLE_ENDIAN)) > 0);
         assertTrue(buffer.slice(0, 31).compareTo(wrappedBuffer(value)) < 0);
         assertTrue(buffer.slice(0, 31).compareTo(wrappedBuffer(value).order(LITTLE_ENDIAN)) < 0);
-        assertTrueAndRelease(buffer, buffer.retainedSlice(0, 31).compareTo(wrappedBuffer(value)) < 0);
-        assertTrueAndRelease(buffer,
-                buffer.retainedSlice(0, 31).compareTo(wrappedBuffer(value).order(LITTLE_ENDIAN)) < 0);
+
+        ByteBuf retainedSlice = buffer.retainedSlice(0, 31);
+        assertTrue(retainedSlice.compareTo(wrappedBuffer(value)) < 0);
+        retainedSlice.release();
+
+        retainedSlice = buffer.retainedSlice(0, 31);
+        assertTrue(retainedSlice.compareTo(wrappedBuffer(value).order(LITTLE_ENDIAN)) < 0);
+        retainedSlice.release();
     }
 
     @Test
@@ -3817,22 +3841,6 @@ public abstract class AbstractByteBufTest {
             buffer.getBytes(buffer.readerIndex(), nioBuffer);
         } finally {
             buffer.release();
-        }
-    }
-
-    private static void assertTrueAndRelease(ByteBuf buf, boolean actual) {
-        try {
-            assertTrue(actual);
-        } finally {
-            buf.release();
-        }
-    }
-
-    private static void assertEqualsAndRelease(ByteBuf buf, int expected, int actual) {
-        try {
-            assertEquals(expected, actual);
-        } finally {
-            buf.release();
         }
     }
 

--- a/buffer/src/test/java/io/netty/buffer/AdvancedLeakAwareByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdvancedLeakAwareByteBufTest.java
@@ -24,6 +24,6 @@ public class AdvancedLeakAwareByteBufTest extends SimpleLeakAwareByteBufTest {
 
     @Override
     protected ByteBuf wrap(ByteBuf buffer) {
-        return new AdvancedLeakAwareByteBuf(buffer, NoopResourceLeak.INSTANCE);
+        return new AdvancedLeakAwareByteBuf(buffer, new NoopResourceLeakTracker<ByteBuf>());
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBufTest.java
@@ -19,7 +19,7 @@ public class AdvancedLeakAwareCompositeByteBufTest extends SimpleLeakAwareCompos
 
     @Override
     protected WrappedCompositeByteBuf wrap(CompositeByteBuf buffer) {
-        return new AdvancedLeakAwareCompositeByteBuf(buffer, NoopResourceLeak.INSTANCE);
+        return new AdvancedLeakAwareCompositeByteBuf(buffer, new NoopResourceLeakTracker<ByteBuf>());
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/NoopResourceLeakTracker.java
+++ b/buffer/src/test/java/io/netty/buffer/NoopResourceLeakTracker.java
@@ -15,22 +15,27 @@
  */
 package io.netty.buffer;
 
-import io.netty.util.ResourceLeak;
+import io.netty.util.ResourceLeakTracker;
 
-final class NoopResourceLeak implements ResourceLeak {
+import java.util.concurrent.atomic.AtomicBoolean;
 
-    static final NoopResourceLeak INSTANCE = new NoopResourceLeak();
 
-    private NoopResourceLeak() { }
+final class NoopResourceLeakTracker<T> extends AtomicBoolean implements ResourceLeakTracker<T> {
 
-    @Override
-    public void record() { }
+    private static final long serialVersionUID = 7874092436796083851L;
 
     @Override
-    public void record(Object hint) { }
+    public void record() {
+        // NOOP
+    }
 
     @Override
-    public boolean close() {
-        return false;
+    public void record(Object hint) {
+        // NOOP
+    }
+
+    @Override
+    public boolean close(T trackedObject) {
+        return compareAndSet(false, true);
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareByteBufTest.java
@@ -27,7 +27,7 @@ public class SimpleLeakAwareByteBufTest extends BigEndianHeapByteBufTest {
     }
 
     protected ByteBuf wrap(ByteBuf buffer) {
-        return new SimpleLeakAwareByteBuf(buffer, NoopResourceLeak.INSTANCE);
+        return new SimpleLeakAwareByteBuf(buffer, new NoopResourceLeakTracker<ByteBuf>());
     }
 
     protected Class<? extends ByteBuf> leakClass() {

--- a/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SimpleLeakAwareCompositeByteBufTest.java
@@ -24,7 +24,7 @@ public class SimpleLeakAwareCompositeByteBufTest extends WrappedCompositeByteBuf
 
     @Override
     protected WrappedCompositeByteBuf wrap(CompositeByteBuf buffer) {
-        return new SimpleLeakAwareCompositeByteBuf(buffer, NoopResourceLeak.INSTANCE);
+        return new SimpleLeakAwareCompositeByteBuf(buffer, new NoopResourceLeakTracker<ByteBuf>());
     }
 
     protected Class<? extends ByteBuf> leakClass() {

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsMessage.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsMessage.java
@@ -18,9 +18,9 @@ package io.netty.handler.codec.dns;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
-import io.netty.util.ResourceLeak;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetectorFactory;
+import io.netty.util.ResourceLeakTracker;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.UnstableApi;
 
@@ -41,7 +41,7 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
     private static final int SECTION_QUESTION = DnsSection.QUESTION.ordinal();
     private static final int SECTION_COUNT = 4;
 
-    private final ResourceLeak leak = leakDetector.open(this);
+    private final ResourceLeakTracker<DnsMessage> leak = leakDetector.track(this);
     private short id;
     private DnsOpCode opCode;
     private boolean recursionDesired;
@@ -379,9 +379,10 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
     protected void deallocate() {
         clear();
 
-        final ResourceLeak leak = this.leak;
+        final ResourceLeakTracker<DnsMessage> leak = this.leak;
         if (leak != null) {
-            leak.close();
+            boolean closed = leak.close(this);
+            assert closed;
         }
     }
 

--- a/common/src/main/java/io/netty/util/ResourceLeakTracker.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2016 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,14 +13,10 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty.util;
 
-/**
- * @deprecated please use {@link ResourceLeakTracker} as it may lead to false-positives.
- */
-@Deprecated
-public interface ResourceLeak {
+public interface ResourceLeakTracker<T>  {
+
     /**
      * Records the caller's current stack trace so that the {@link ResourceLeakDetector} can tell where the leaked
      * resource was accessed lastly. This method is a shortcut to {@link #record(Object) record(null)}.
@@ -34,9 +30,10 @@ public interface ResourceLeak {
     void record(Object hint);
 
     /**
-     * Close the leak so that {@link ResourceLeakDetector} does not warn about leaked resources.
+     * Close the leak so that {@link ResourceLeakTracker} does not warn about leaked resources.
+     * After this method is called a leak associated with this ResourceLeakTracker should not be reported.
      *
      * @return {@code true} if called first time, {@code false} if called already
      */
-    boolean close();
+    boolean close(T trackedObject);
 }

--- a/common/src/test/java/io/netty/util/ResourceLeakDetectorTest.java
+++ b/common/src/test/java/io/netty/util/ResourceLeakDetectorTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util;
+
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ResourceLeakDetectorTest {
+
+    @Test(timeout = 30000)
+    public void testConcurentUsage() throws Throwable {
+        final AtomicBoolean finished = new AtomicBoolean();
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        // With 50 threads issue #6087 is reproducible on every run.
+        Thread[] threads = new Thread[50];
+        final CyclicBarrier barrier = new CyclicBarrier(threads.length);
+        for (int i = 0; i < threads.length; i++) {
+            Thread t = new Thread(new Runnable() {
+                Queue<LeakAwareResource> resources = new ArrayDeque<LeakAwareResource>(100);
+
+                @Override
+                public void run() {
+                    try {
+                        barrier.await();
+
+                        // Run 10000 times or until the test is marked as finished.
+                        for (int b = 0; b < 1000 && !finished.get(); b++) {
+
+                            // Allocate 100 LeakAwareResource per run and close them after it.
+                            for (int a = 0; a < 100; a++) {
+                                DefaultResource resource = new DefaultResource();
+                                ResourceLeakTracker<Resource> leak = DefaultResource.detector.track(resource);
+                                LeakAwareResource leakAwareResource = new LeakAwareResource(resource, leak);
+                                resources.add(leakAwareResource);
+                            }
+                            if (closeResources(true)) {
+                                finished.set(true);
+                            }
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } catch (Throwable e) {
+                        error.compareAndSet(null, e);
+                    } finally {
+                        // Just close all resource now without assert it to eliminate more reports.
+                        closeResources(false);
+                    }
+                }
+
+                private boolean closeResources(boolean checkClosed) {
+                    for (;;) {
+                        LeakAwareResource r = resources.poll();
+                        if (r == null) {
+                            return false;
+                        }
+                        boolean closed = r.close();
+                        if (checkClosed && !closed) {
+                            error.compareAndSet(null,
+                                    new AssertionError("ResourceLeak.close() returned 'false' but expected 'true'"));
+                            return true;
+                        }
+                    }
+                }
+            });
+            threads[i] = t;
+            t.start();
+        }
+
+        // Just wait until all threads are done.
+        for (Thread t: threads) {
+            t.join();
+        }
+
+        // Check if we had any leak reports in the ResourceLeakDetector itself
+        DefaultResource.detector.assertNoErrors();
+
+        assertNoErrors(error);
+    }
+
+    // Mimic the way how we implement our classes that should help with leak detection
+    private static final  class LeakAwareResource implements Resource {
+        private final Resource resource;
+        private final ResourceLeakTracker<Resource> leak;
+
+        LeakAwareResource(Resource resource, ResourceLeakTracker<Resource> leak) {
+            this.resource = resource;
+            this.leak = leak;
+        }
+
+        @Override
+        public boolean close() {
+            // Using ResourceLeakDetector.close(...) to prove this fixes the leak problem reported
+            // in https://github.com/netty/netty/issues/6034 .
+            //
+            // The following implementation would produce a leak:
+            //     return leak.close();
+            return leak.close(resource);
+        }
+    }
+
+    private static final class DefaultResource implements Resource {
+        // Sample every allocation
+        static final TestResourceLeakDetector<Resource> detector = new TestResourceLeakDetector<Resource>(
+                Resource.class, 1, Integer.MAX_VALUE);
+
+        @Override
+        public boolean close() {
+            return true;
+        }
+    }
+
+    private interface Resource {
+        boolean close();
+    }
+
+    private static void assertNoErrors(AtomicReference<Throwable> ref) throws Throwable {
+        Throwable error = ref.get();
+        if (error != null) {
+            throw error;
+        }
+    }
+
+    private static final class TestResourceLeakDetector<T> extends ResourceLeakDetector<T> {
+
+        private final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+
+        TestResourceLeakDetector(Class<?> resourceType, int samplingInterval, long maxActive) {
+            super(resourceType, samplingInterval, maxActive);
+        }
+
+        @Override
+        protected void reportTracedLeak(String resourceType, String records) {
+            reportError(new AssertionError("Leak reported for '" + resourceType + "':\n" + records));
+        }
+
+        @Override
+        protected void reportUntracedLeak(String resourceType) {
+            reportError(new AssertionError("Leak reported for '" + resourceType + '\''));
+        }
+
+        @Override
+        protected void reportInstancesLeak(String resourceType) {
+            reportError(new AssertionError("Leak reported for '" + resourceType + '\''));
+        }
+
+        private void reportError(AssertionError cause) {
+            error.compareAndSet(null, cause);
+        }
+
+        void assertNoErrors() throws Throwable {
+            ResourceLeakDetectorTest.assertNoErrors(error);
+        }
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -19,9 +19,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ReferenceCounted;
-import io.netty.util.ResourceLeak;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetectorFactory;
+import io.netty.util.ResourceLeakTracker;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.SystemPropertyUtil;
@@ -108,7 +108,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     private final int mode;
 
     // Reference Counting
-    private final ResourceLeak leak;
+    private final ResourceLeakTracker<ReferenceCountedOpenSslContext> leak;
     private final AbstractReferenceCounted refCnt = new AbstractReferenceCounted() {
         @Override
         public ReferenceCounted touch(Object hint) {
@@ -123,7 +123,8 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         protected void deallocate() {
             destroy();
             if (leak != null) {
-                leak.close();
+                boolean closed = leak.close(ReferenceCountedOpenSslContext.this);
+                assert closed;
             }
         }
     };
@@ -217,7 +218,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         if (mode != SSL.SSL_MODE_SERVER && mode != SSL.SSL_MODE_CLIENT) {
             throw new IllegalArgumentException("mode most be either SSL.SSL_MODE_SERVER or SSL.SSL_MODE_CLIENT");
         }
-        leak = leakDetection ? leakDetector.open(this) : null;
+        leak = leakDetection ? leakDetector.track(this) : null;
         this.mode = mode;
         this.clientAuth = isServer() ? checkNotNull(clientAuth, "clientAuth") : ClientAuth.NONE;
 

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -20,9 +20,9 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ReferenceCounted;
-import io.netty.util.ResourceLeak;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.ResourceLeakDetectorFactory;
+import io.netty.util.ResourceLeakTracker;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
@@ -208,7 +208,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     private volatile int destroyed;
 
     // Reference Counting
-    private final ResourceLeak leak;
+    private final ResourceLeakTracker<ReferenceCountedOpenSslEngine> leak;
     private final AbstractReferenceCounted refCnt = new AbstractReferenceCounted() {
         @Override
         public ReferenceCounted touch(Object hint) {
@@ -223,7 +223,8 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         protected void deallocate() {
             shutdown();
             if (leak != null) {
-                leak.close();
+                boolean closed = leak.close(ReferenceCountedOpenSslEngine.this);
+                assert closed;
             }
         }
     };
@@ -270,7 +271,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                                   int peerPort, boolean leakDetection) {
         super(peerHost, peerPort);
         OpenSsl.ensureAvailability();
-        leak = leakDetection ? leakDetector.open(this) : null;
+        leak = leakDetection ? leakDetector.track(this) : null;
         this.alloc = checkNotNull(alloc, "alloc");
         apn = (OpenSslApplicationProtocolNegotiator) context.applicationProtocolNegotiator();
         ssl = SSL.newSSL(context.ctx, !context.isClient());


### PR DESCRIPTION
Motivation:

We need to ensure the tracked object can not be GC'ed before ResourceLeak.close() is called as otherwise we may get false-positives reported by the ResourceLeakDetector. This can happen as the JIT / GC may be able to figure out that we do not need the tracked object anymore and so already enqueue it for collection before we actually get a chance to close the enclosing ResourceLeak.

Modifications:

- Add ResourceLeakTracker and deprecate the old ResourceLeak
- Fix some javadocs to correctly release buffers.
- Add a unit test for ResourceLeakDetector that shows that ResourceLeakTracker has not the problems.

Result:

No more false-positives reported by ResourceLeakDetector when ResourceLeakDetector.track(...) is used.