### PR TITLE
Support compiling netty with Java9

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -29,7 +29,6 @@
   <name>Netty/All-in-One</name>
 
   <properties>
-    <quickbuild>true</quickbuild>
     <generatedSourceDir>${project.build.directory}/src</generatedSourceDir>
     <dependencyVersionsDir>${project.build.directory}/versions</dependencyVersionsDir>
   </properties>
@@ -37,9 +36,91 @@
   <profiles>
     <profile>
       <id>full</id>
-      <properties>
-        <quickbuild>false</quickbuild>
-      </properties>
+
+      <!-- Only include in full profile as this will not work on Java9 yet -->
+      <!-- https://issues.apache.org/jira/browse/JXR-133 -->
+      <build>
+        <plugins>
+          <!-- Generate Xref -->
+          <plugin>
+            <artifactId>maven-jxr-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-xref</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jxr</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <linkJavadoc>true</linkJavadoc>
+              <destDir>${project.build.directory}/xref</destDir>
+              <javadocDir>${project.build.directory}/api</javadocDir>
+              <docTitle>Netty Source Xref (${project.version})</docTitle>
+              <windowTitle>Netty Source Xref (${project.version})</windowTitle>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>netty-build</artifactId>
+                <version>19</version>
+                <exclusions>
+                  <!-- Use version 7.3 until a new netty-build release is out -->
+                  <!-- See https://issues.apache.org/jira/browse/JXR-133 -->
+                  <exclusion>
+                    <groupId>com.puppycrawl.tools</groupId>
+                    <artifactId>checkstyle</artifactId>
+                  </exclusion>
+                </exclusions> 
+              </dependency>
+              <dependency>
+                <groupId>com.puppycrawl.tools</groupId>
+                <artifactId>checkstyle</artifactId>
+                <version>7.3</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+
+          <!-- Generate Javadoc -->
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <skip>${quickbuild}</skip>
+              <excludePackageNames>*.internal,*.example</excludePackageNames>
+              <docfilessubdirs>true</docfilessubdirs>
+              <outputDirectory>${project.build.directory}/api</outputDirectory>
+              <overview>${project.basedir}/src/javadoc/overview.html</overview>
+              <doctitle>Netty API Reference (${project.version})</doctitle>
+              <windowtitle>Netty API Reference (${project.version})</windowtitle>
+              <detectJavaApiLink>false</detectJavaApiLink>
+              <additionalparam>
+                -link http://docs.oracle.com/javase/7/docs/api/
+                -link http://code.google.com/apis/protocolbuffers/docs/reference/java/
+                -link http://docs.oracle.com/javaee/6/api/
+                -link http://www.slf4j.org/apidocs/
+                -link https://commons.apache.org/proper/commons-logging/apidocs/
+                -link http://logging.apache.org/log4j/1.2/apidocs/
+
+                -group "Low-level data representation" io.netty.buffer*
+                -group "Central interface for all I/O operations" io.netty.channel*
+                -group "Client &amp; Server bootstrapping utilities" io.netty.bootstrap*
+                -group "Reusable I/O event interceptors" io.netty.handler*
+                -group "Miscellaneous" io.netty.util*
+              </additionalparam>
+              <locale>en_US</locale>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>coverage</id>
@@ -505,73 +586,6 @@
             <phase>none</phase>
           </execution>
         </executions>
-      </plugin>
-
-      <!-- Generate Xref -->
-      <plugin>
-        <artifactId>maven-jxr-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>generate-xref</id>
-            <phase>package</phase>
-            <goals>
-              <goal>jxr</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <skip>${quickbuild}</skip>
-          <linkJavadoc>true</linkJavadoc>
-          <destDir>${project.build.directory}/xref</destDir>
-          <javadocDir>${project.build.directory}/api</javadocDir>
-          <docTitle>Netty Source Xref (${project.version})</docTitle>
-          <windowTitle>Netty Source Xref (${project.version})</windowTitle>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>netty-build</artifactId>
-            <version>19</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-
-      <!-- Generate Javadoc -->
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <skip>${quickbuild}</skip>
-          <excludePackageNames>*.internal,*.example</excludePackageNames>
-          <docfilessubdirs>true</docfilessubdirs>
-          <outputDirectory>${project.build.directory}/api</outputDirectory>
-          <overview>${project.basedir}/src/javadoc/overview.html</overview>
-          <doctitle>Netty API Reference (${project.version})</doctitle>
-          <windowtitle>Netty API Reference (${project.version})</windowtitle>
-          <detectJavaApiLink>false</detectJavaApiLink>
-          <additionalparam>
-            -link http://docs.oracle.com/javase/7/docs/api/
-            -link http://code.google.com/apis/protocolbuffers/docs/reference/java/
-            -link http://docs.oracle.com/javaee/6/api/
-            -link http://www.slf4j.org/apidocs/
-            -link https://commons.apache.org/proper/commons-logging/apidocs/
-            -link http://logging.apache.org/log4j/1.2/apidocs/
-
-            -group "Low-level data representation" io.netty.buffer*
-            -group "Central interface for all I/O operations" io.netty.channel*
-            -group "Client &amp; Server bootstrapping utilities" io.netty.bootstrap*
-            -group "Reusable I/O event interceptors" io.netty.handler*
-            -group "Miscellaneous" io.netty.util*
-          </additionalparam>
-          <locale>en_US</locale>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -105,6 +105,30 @@
             </configuration>
           </execution>
         </executions>
+        <!-- Needed to support JDK9 -->
+        <!-- See https://github.com/netty/netty/issues/6100 -->
+        <dependencies>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>${asm.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+            <version>${asm.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-analysis</artifactId>
+            <version>${asm.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-util</artifactId>
+            <version>${asm.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <!-- Add generated collection sources. -->
       <plugin>

--- a/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkAlpnSslEngine.java
@@ -26,6 +26,7 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 
+import io.netty.util.internal.PlatformDependent;
 import org.eclipse.jetty.alpn.ALPN;
 import org.eclipse.jetty.alpn.ALPN.ClientProvider;
 import org.eclipse.jetty.alpn.ALPN.ServerProvider;
@@ -39,7 +40,8 @@ final class JdkAlpnSslEngine extends JdkSslEngine {
     }
 
     private static void updateAvailability() {
-        if (available) {
+        // TODO: Add support for ALPN when using Java9 and still be able to configure it the Netty way.
+        if (available || PlatformDependent.javaVersion() > 8) {
             return;
         }
 

--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -37,7 +37,6 @@ import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import sun.security.validator.ValidatorException;
 
 import javax.net.ssl.ManagerFactoryParameters;
 import javax.net.ssl.SSLException;
@@ -103,7 +102,7 @@ public class SslErrorTest {
     }
 
     private static CertificateException newCertificateException(CertPathValidatorException.Reason reason) {
-        return new ValidatorException("Test exception",
+        return new TestCertificateException(
                 new CertPathValidatorException("x", null, null, -1, reason));
     }
 
@@ -197,7 +196,7 @@ public class SslErrorTest {
                                     // Unwrap as its wrapped by a DecoderException
                                     Throwable unwrappedCause = cause.getCause();
                                     if (unwrappedCause instanceof SSLException) {
-                                        if (exception instanceof ValidatorException) {
+                                        if (exception instanceof TestCertificateException) {
                                             CertPathValidatorException.Reason reason =
                                                     ((CertPathValidatorException) exception.getCause()).getReason();
                                             if (reason == CertPathValidatorException.BasicReason.EXPIRED) {
@@ -243,6 +242,13 @@ public class SslErrorTest {
             promise.setSuccess(null);
         } else {
             promise.setFailure(new AssertionError("message not contains '" + messagePart + "': " + message));
+        }
+    }
+
+    private static final class TestCertificateException extends CertificateException {
+
+        public TestCertificateException(Throwable cause) {
+            super(cause);
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,24 @@
   </developers>
 
   <profiles>
+    <!-- JDK9 -->
+    <profile>
+      <id>java9</id>
+      <properties>
+        <!-- Export some stuff which is used during our tests -->
+        <argLine.java9>--add-modules java.xml.bind --add-exports java.base/sun.security.x509=ALL-UNNAMED</argLine.java9>
+        <!-- Not use alpn agent as Java9 supports alpn out of the box -->
+        <argLine.alpnAgent></argLine.alpnAgent>
+        <!-- This is needed as earlier ASM versions not support java9 -->
+        <!-- https://issues.apache.org/jira/browse/MSHADE-242 -->
+        <!-- https://github.com/netty/netty/issues/6100 -->
+        <asm.version>6.0_ALPHA</asm.version>
+      </properties>
+      <activation>
+        <jdk>9</jdk>
+      </activation>
+    </profile>
+
     <profile>
       <id>leak</id>
       <properties>
@@ -220,6 +238,7 @@
     <argLine.leak>-D_</argLine.leak> <!-- Overridden when 'leak' profile is active -->
     <argLine.noUnsafe>-D_</argLine.noUnsafe> <!-- Overridden when 'noUnsafe' profile is active -->
     <argLine.coverage>-D_</argLine.coverage> <!-- Overridden when 'coverage' profile is active -->
+    <argLine.java9></argLine.java9> <!-- Overridden when 'java9' profile is active -->
     <!-- Configure the os-maven-plugin extension to expand the classifier on                  -->
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
@@ -230,6 +249,7 @@
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>
     <logging.logLevel>debug</logging.logLevel>
     <log4j2.version>2.6.2</log4j2.version>
+    <asm.version>5.1</asm.version>
   </properties>
 
   <modules>
@@ -680,7 +700,7 @@
           <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-all</artifactId>
-            <version>5.1</version>
+            <version>${asm.version}</version>
           </dependency>
         </dependencies>
         <configuration>
@@ -732,6 +752,10 @@
             <!-- Compression -->
             <ignore>java.util.zip.CRC32</ignore>
             <ignore>java.util.zip.Adler32</ignore>
+
+            <!-- JDK 9 -->
+            <ignore>java.nio.ByteBuffer</ignore>
+            <ignore>java.nio.CharBuffer</ignore>
           </ignores>
         </configuration>
         <executions>
@@ -830,7 +854,7 @@
             <logback.configurationFile>${logging.config}</logback.configurationFile>
             <logLevel>${logging.logLevel}</logLevel>
           </systemPropertyVariables>
-          <argLine>${argLine.common} ${argLine.alpnAgent} ${argLine.leak} ${argLine.coverage} ${argLine.noUnsafe}</argLine>
+          <argLine>${argLine.common} ${argLine.alpnAgent} ${argLine.leak} ${argLine.coverage} ${argLine.noUnsafe} ${argLine.java9}</argLine>
           <properties>
             <property>
               <name>listener</name>


### PR DESCRIPTION
Motivation:

Java9 will be released soon so we should ensure we can compile netty with Java9 and run all our tests. This will help to make sure Netty will be usable with Java9.

Modification:

- Add some workarounds to be able to compile with Java9, note that the full profile is not supported with Java9 atm.
- Remove some usage of internal APIs to be able to compile on java9
- Not support Alpn / Npn and so not run the tests when using Java9 for now. We will do a follow up PR to add support.

Result:

Its possible to build netty and run its testsuite with Java9.