### PR TITLE
Correct guard against non SSL data in ReferenceCountedOpenSslEngine

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -796,6 +796,11 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             }
 
             int packetLength = SslUtils.getEncryptedPacketLength(srcs, srcsOffset);
+
+            if (packetLength == SslUtils.NOT_ENCRYPTED) {
+                throw new NotSslRecordException("not an SSL/TLS record");
+            }
+
             if (packetLength - SslUtils.SSL_RECORD_HEADER_LENGTH > capacity) {
                 // No enough space in the destination buffer so signal the caller
                 // that the buffer needs to be increased.

--- a/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
@@ -130,7 +130,7 @@ public class SniHandler extends ByteToMessageDecoder implements ChannelOutboundH
                             final int len = SslUtils.getEncryptedPacketLength(in, readerIndex);
 
                             // Not an SSL/TLS packet
-                            if (len == -1) {
+                            if (len == SslUtils.NOT_ENCRYPTED) {
                                 handshakeFailed = true;
                                 NotSslRecordException e = new NotSslRecordException(
                                         "not an SSL/TLS record: " + ByteBufUtil.hexDump(in));
@@ -140,7 +140,8 @@ public class SniHandler extends ByteToMessageDecoder implements ChannelOutboundH
                                 SslUtils.notifyHandshakeFailure(ctx, e);
                                 return;
                             }
-                            if (writerIndex - readerIndex - SslUtils.SSL_RECORD_HEADER_LENGTH < len) {
+                            if (len == SslUtils.NOT_ENOUGH_DATA ||
+                                    writerIndex - readerIndex - SslUtils.SSL_RECORD_HEADER_LENGTH < len) {
                                 // Not enough data
                                 return;
                             }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -877,7 +877,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             throw new IllegalArgumentException(
                     "buffer must have at least " + SslUtils.SSL_RECORD_HEADER_LENGTH + " readable bytes");
         }
-        return getEncryptedPacketLength(buffer, buffer.readerIndex()) != -1;
+        return getEncryptedPacketLength(buffer, buffer.readerIndex()) != SslUtils.NOT_ENCRYPTED;
     }
 
     @Override
@@ -907,7 +907,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             }
 
             final int packetLength = getEncryptedPacketLength(in, offset);
-            if (packetLength == -1) {
+            if (packetLength == SslUtils.NOT_ENCRYPTED) {
                 nonSslRecord = true;
                 break;
             }


### PR DESCRIPTION
Motivation:

When non SSL data is passed into SSLEngine.unwrap(...) we need to throw an SSLException. This was not done at the moment. Even worse we threw an IllegalArgumentException as we tried to allocate a direct buffer with capacity of -1.

Modifications:

- Guard against non SSL data and added an unit test.
- Make code more consistent

Result:

Correct behaving SSLEngine implementation.