### PR TITLE
Add codec-smtp to all jar.

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -163,6 +163,13 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-smtp</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-socks</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>


### PR DESCRIPTION
Motivation:

562d8d220028fbb3d62028bc5879a121dff2fdbd added codec-smtp but we missed to add it to the all jar.

Modifications:

Include codec-smtp in the all jar.

Result:

Include all codecs in the all jar.