### PR TITLE
Use GitHub Issue/PR Template Feature

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please review the [guidelines for contributing](http://netty.io/wiki/developer-guide.html) for this repository.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+### Expected behavior
+
+### Actual behavior
+
+### Steps to reproduce
+
+### Minimal yet complete reproducer code (or URL to code)
+
+### Netty version
+
+### JVM version (e.g. `java -version`)
+
+### OS version (e.g. `uname -a`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+Motivation:
+
+Explain here the context, and why you're making that change.
+What is the problem you're trying to solve.
+
+Modification:
+
+Describe the modifications you've done.
+
+Result:
+
+Fixes #<GitHub issue number>. 
+
+If there is no issue then describe the changes introduced by this PR.


### PR DESCRIPTION
Motivation:
GitHub recently added the ability to setup PR and Issue templates https://github.com/blog/2111-issue-and-pull-request-templates. We should take advantage of this feature to ensure Issues / PRs are properly formed.

Modifications:
- add a .github directory with a CONTRIBUTING.md, ISSUE_TEMPLATE.md, and PULL_REQUEST_TEMPLATE.md file

Result:
Fixes https://github.com/netty/netty/issues/6074.