### PR TITLE
Fix buffer leaks in tests

### DIFF
--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheEncoderTest.java
@@ -46,7 +46,7 @@ public class BinaryMemcacheEncoderTest {
 
     @After
     public void teardown() throws Exception {
-        channel.finish();
+        channel.finishAndReleaseAll();
     }
 
     @Test
@@ -92,8 +92,8 @@ public class BinaryMemcacheEncoderTest {
 
         ByteBuf written = channel.readOutbound();
         assertThat(written.readableBytes(), is(DEFAULT_HEADER_SIZE + extrasLength));
-        written.readBytes(DEFAULT_HEADER_SIZE);
-        assertThat(written.readBytes(extrasLength).toString(CharsetUtil.UTF_8), equalTo(extrasContent));
+        written.skipBytes(DEFAULT_HEADER_SIZE);
+        assertThat(written.readSlice(extrasLength).toString(CharsetUtil.UTF_8), equalTo(extrasContent));
         written.release();
     }
 
@@ -109,8 +109,8 @@ public class BinaryMemcacheEncoderTest {
 
         ByteBuf written = channel.readOutbound();
         assertThat(written.readableBytes(), is(DEFAULT_HEADER_SIZE + keyLength));
-        written.readBytes(DEFAULT_HEADER_SIZE);
-        assertThat(written.readBytes(keyLength).toString(CharsetUtil.UTF_8), equalTo("netty"));
+        written.skipBytes(DEFAULT_HEADER_SIZE);
+        assertThat(written.readSlice(keyLength).toString(CharsetUtil.UTF_8), equalTo("netty"));
         written.release();
     }
 
@@ -139,7 +139,7 @@ public class BinaryMemcacheEncoderTest {
         written = channel.readOutbound();
         assertThat(written.readableBytes(), is(content1.content().readableBytes()));
         assertThat(
-                written.readBytes(content1.content().readableBytes()).toString(CharsetUtil.UTF_8),
+                written.readSlice(content1.content().readableBytes()).toString(CharsetUtil.UTF_8),
                 is("Netty")
         );
         written.release();
@@ -147,7 +147,7 @@ public class BinaryMemcacheEncoderTest {
         written = channel.readOutbound();
         assertThat(written.readableBytes(), is(content2.content().readableBytes()));
         assertThat(
-                written.readBytes(content2.content().readableBytes()).toString(CharsetUtil.UTF_8),
+                written.readSlice(content2.content().readableBytes()).toString(CharsetUtil.UTF_8),
                 is(" Rocks!")
         );
         written.release();

--- a/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregatorTest.java
+++ b/codec-memcache/src/test/java/io/netty/handler/codec/memcache/binary/BinaryMemcacheObjectAggregatorTest.java
@@ -76,7 +76,7 @@ public class BinaryMemcacheObjectAggregatorTest {
 
         assertThat(channel.readInbound(), nullValue());
 
-        channel.finish();
+        assertFalse(channel.finish());
     }
 
     @Test

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeEncoderTest.java
@@ -51,12 +51,16 @@ public class StompSubframeEncoderTest {
         ByteBuf byteBuf = channel.readOutbound();
         assertNotNull(byteBuf);
         aggregatedBuffer.writeBytes(byteBuf);
+        byteBuf.release();
 
         byteBuf = channel.readOutbound();
         assertNotNull(byteBuf);
         aggregatedBuffer.writeBytes(byteBuf);
+        byteBuf.release();
+
         aggregatedBuffer.resetReaderIndex();
         String content = aggregatedBuffer.toString(CharsetUtil.UTF_8);
         assertEquals(StompTestConstants.CONNECT_FRAME, content);
+        aggregatedBuffer.release();
     }
 }


### PR DESCRIPTION
Motivation:

While working on #6087 some buffer leaks showed up.

Modifications:

Correctly release buffers.

Result:

No more buffer leaks in memcache and stomp codec tests.