### PR TITLE
Disallow setting logger factory twice

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -16,24 +16,64 @@
 
 package io.netty.util.internal.logging;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
- * Creates an {@link InternalLogger} or changes the default factory
- * implementation.  This factory allows you to choose what logging framework
- * Netty should use.  The default factory is {@link Slf4JLoggerFactory}.  If SLF4J
- * is not available, {@link Log4JLoggerFactory} is used.  If Log4J is not available,
- * {@link JdkLoggerFactory} is used.  You can change it to your preferred
- * logging framework before other Netty classes are loaded:
- * <pre>
- * {@link InternalLoggerFactory}.setDefaultFactory({@link Log4JLoggerFactory}.INSTANCE);
- * </pre>
- * Please note that the new default factory is effective only for the classes
- * which were loaded after the default factory is changed.  Therefore,
- * {@link #setDefaultFactory(InternalLoggerFactory)} should be called as early
- * as possible and shouldn't be called more than once.
+ * Creates {@link InternalLogger}s. This factory allows you to choose what logging framework Netty should use. The
+ * default factory is {@link Slf4JLoggerFactory}. If SLF4J is not available, {@link Log4JLoggerFactory} is used. If
+ * Log4J is not available, {@link JdkLoggerFactory} is used. You can change it to your preferred logging framework
+ * before other Netty classes are loaded via {@link #setDefaultFactory(InternalLoggerFactory)}. If you want to change
+ * the logger factory, {@link #setDefaultFactory(InternalLoggerFactory)} must be invoked before any other Netty classes
+ * are loaded. Note that {@link #setDefaultFactory(InternalLoggerFactory)}} can not be invoked more than once.
  */
 public abstract class InternalLoggerFactory {
 
-    private static volatile InternalLoggerFactory defaultFactory;
+    private static final InternalLoggerFactoryHolder HOLDER = new InternalLoggerFactoryHolder();
+
+    /**
+     * This class holds a reference to the {@link InternalLoggerFactory}. The raison d'être for this class is primarily
+     * to aid in testing.
+     */
+    static final class InternalLoggerFactoryHolder {
+        private final AtomicReference<InternalLoggerFactory> reference;
+
+        InternalLoggerFactoryHolder() {
+            this(null);
+        }
+
+        InternalLoggerFactoryHolder(final InternalLoggerFactory holder) {
+            this.reference = new AtomicReference<InternalLoggerFactory>(holder);
+        }
+
+        InternalLoggerFactory getFactory() {
+            if (reference.get() == null) {
+                reference.compareAndSet(null, newDefaultFactory(InternalLoggerFactory.class.getName()));
+            }
+            return reference.get();
+        }
+
+        void setFactory(final InternalLoggerFactory factory) {
+            if (factory == null) {
+                throw new NullPointerException("factory");
+            }
+            if (!reference.compareAndSet(null, factory)) {
+                throw new IllegalStateException(
+                        "factory is already set to [" + reference.get() + "], rejecting [" + factory + "]");
+            }
+        }
+
+        InternalLogger getInstance(final Class<?> clazz) {
+            return getInstance(clazz.getName());
+        }
+
+        InternalLogger getInstance(final String name) {
+            return newInstance(name);
+        }
+
+        InternalLogger newInstance(String name) {
+            return getFactory().newInstance(name);
+        }
+    }
 
     @SuppressWarnings("UnusedCatchParameter")
     private static InternalLoggerFactory newDefaultFactory(String name) {
@@ -54,38 +94,35 @@ public abstract class InternalLoggerFactory {
     }
 
     /**
-     * Returns the default factory.  The initial default factory is
-     * {@link JdkLoggerFactory}.
+     * Get the default factory that was either initialized automatically based on logging implementations on the
+     * classpath, or set explicitly via {@link #setDefaultFactory(InternalLoggerFactory)}.
      */
     public static InternalLoggerFactory getDefaultFactory() {
-        if (defaultFactory == null) {
-            defaultFactory = newDefaultFactory(InternalLoggerFactory.class.getName());
-        }
-        return defaultFactory;
+        return HOLDER.getFactory();
     }
 
     /**
-     * Changes the default factory.
+     * Set the default factory. This method must be invoked before the default factory is initialized via
+     * {@link #getDefaultFactory()}, and can not be invoked multiple times.
+     *
+     * @param defaultFactory a non-null implementation of {@link InternalLoggerFactory}
      */
     public static void setDefaultFactory(InternalLoggerFactory defaultFactory) {
-        if (defaultFactory == null) {
-            throw new NullPointerException("defaultFactory");
-        }
-        InternalLoggerFactory.defaultFactory = defaultFactory;
+        HOLDER.setFactory(defaultFactory);
     }
 
     /**
      * Creates a new logger instance with the name of the specified class.
      */
     public static InternalLogger getInstance(Class<?> clazz) {
-        return getInstance(clazz.getName());
+        return HOLDER.getInstance(clazz);
     }
 
     /**
      * Creates a new logger instance with the specified name.
      */
     public static InternalLogger getInstance(String name) {
-        return getDefaultFactory().newInstance(name);
+        return HOLDER.getInstance(name);
     }
 
     /**


### PR DESCRIPTION
Motivation:

InternalLoggerFactory either sets a default logger factory
implementation based on the logging implementations on the classpath, or
applications can set a logger factory explicitly. If applications wait
too long to set the logger factory, Netty will have already set a logger
factory leading to some objects using one logging implementation and
other objets using another logging implementation. This can happen too
if the application tries to set the logger factory twice, which is
likely a bug in the application. Yet, the Javadocs for
InternalLoggerFactory warn against this saying that
InternalLoggerFactory#setLoggerFactory "should be called as early as
possible and shouldn't be called more than once". Instead, Netty should
guard against this.

Modications:

We replace the logger factory field with an atomic reference on which we
can do CAS operations to safely guard against it being set twice. We
also add an internal holder class that captures the static interface of
InternalLoggerFactory that can aid in testing.

Result:

The logging factory can not be set twice, and applications that want to
set the logging factory must do it before any Netty classes are
initialized (or the default logger factory will be set).