### PR TITLE
NIO ServerChannel shouldn't close because of Exception

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
@@ -176,7 +176,7 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
         // accepting incoming connections. (e.g. too many open files)
         return cause instanceof IOException &&
                 !(cause instanceof PortUnreachableException) &&
-                this instanceof ServerChannel;
+                !(this instanceof ServerChannel);
     }
 
     /**


### PR DESCRIPTION
Motivation:
e102a008b63d0063581ba242539f0a8d473cae00 changed a conditional where previously the NIO ServerChannel would not be closed in the event of an exception.

Modifications:
- Restore the logic prior to e102a008b63d0063581ba242539f0a8d473cae00 which does not automatically close ServerChannels for IOExceptions

Result:
NIO ServerChannel doesn't close automatically for an IOException.