### PR TITLE
Fix frame-pointer to improve epoll flamegraph tracing

### DIFF
--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -199,7 +199,7 @@
               <value>${linux.sendmmsg.support}${glibc.sendmmsg.support}</value>
               <!-- If glibc and linux kernel are both not sufficient...then define the CFLAGS -->
               <regex>.*IO_NETTY_SENDMSSG_NOT_FOUND.*</regex>
-              <replacement>CFLAGS=-O3 -DIO_NETTY_SENDMMSG_NOT_FOUND -Werror</replacement>
+              <replacement>CFLAGS=-O3 -DIO_NETTY_SENDMMSG_NOT_FOUND -Werror -fno-omit-frame-pointer</replacement>
               <failIfNoMatch>false</failIfNoMatch>
             </configuration>
           </execution>
@@ -215,7 +215,7 @@
               <value>${jni.compiler.args.cflags}</value>
               <!-- If glibc and linux kernel are both not sufficient...then define the CFLAGS -->
               <regex>^((?!CFLAGS=).)*$</regex>
-              <replacement>CFLAGS=-O3 -Werror</replacement>
+              <replacement>CFLAGS=-O3 -Werror -fno-omit-frame-pointer</replacement>
               <failIfNoMatch>false</failIfNoMatch>
             </configuration>
           </execution>


### PR DESCRIPTION
This patch allows linux perf to track the frame pointer from java to epoll native lib.  This cleans up flamegraphs which use epoll.

There is also an issue with the extracted native lib being deleted by the netty library loader util.  I'm not sure how you want to deal with that, perhaps a property to keep it around for perf testing? 