### PR TITLE
Ensure SSLErrorTest also works with boringssl

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -58,6 +58,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 
 @RunWith(Parameterized.class)
@@ -238,7 +239,7 @@ public class SslErrorTest {
     // at the moment as there are no different exceptions for the different alerts.
     private static void verifyException(Throwable cause, String messagePart, Promise<Void> promise) {
         String message = cause.getMessage();
-        if (message.contains(messagePart)) {
+        if (message.toLowerCase(Locale.UK).contains(messagePart.toLowerCase(Locale.UK))) {
             promise.setSuccess(null);
         } else {
             promise.setFailure(new AssertionError("message not contains '" + messagePart + "': " + message));


### PR DESCRIPTION
Motivation:

boringssl uses different messages for the ssl alerts which are all uppercase. As we try to match case as well this fails in SSLErrorTest as we expect lower-case.

This test was introduced by 9b7fb2f3620449c8cfafa62fd294cb82600f043a.

Modifications:

Ensure we first translate everything to lower-case before doing the assert.

Result:

SSLErrorTest also pass when boringssl is used.