### PR TITLE
Allow to run tests with extra commandline arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,7 @@
     <argLine.noUnsafe>-D_</argLine.noUnsafe> <!-- Overridden when 'noUnsafe' profile is active -->
     <argLine.coverage>-D_</argLine.coverage> <!-- Overridden when 'coverage' profile is active -->
     <argLine.java9></argLine.java9> <!-- Overridden when 'java9' profile is active -->
+    <argLine.javaProperties>-D_</argLine.javaProperties>
     <!-- Configure the os-maven-plugin extension to expand the classifier on                  -->
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
@@ -854,7 +855,7 @@
             <logback.configurationFile>${logging.config}</logback.configurationFile>
             <logLevel>${logging.logLevel}</logLevel>
           </systemPropertyVariables>
-          <argLine>${argLine.common} ${argLine.alpnAgent} ${argLine.leak} ${argLine.coverage} ${argLine.noUnsafe} ${argLine.java9}</argLine>
+          <argLine>${argLine.common} ${argLine.alpnAgent} ${argLine.leak} ${argLine.coverage} ${argLine.noUnsafe} ${argLine.java9} ${argLine.javaProperties}</argLine>
           <properties>
             <property>
               <name>listener</name>


### PR DESCRIPTION
Motivation:

Often its useful to run the tests with different commandline arguments (like different system properties).

Modifications:

Introduce argLine.javaProperties which can be set from the commandline as well to add arguments that should be append when run the unit tests.

Result:

More flexible way to run the tests.