### PR TITLE
[#6114] Increase test timeout for test introduced in c2f4daa7398a9363…

### DIFF
--- a/common/src/test/java/io/netty/util/ResourceLeakDetectorTest.java
+++ b/common/src/test/java/io/netty/util/ResourceLeakDetectorTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class ResourceLeakDetectorTest {
 
-    @Test(timeout = 30000)
+    @Test(timeout = 60000)
     public void testConcurentUsage() throws Throwable {
         final AtomicBoolean finished = new AtomicBoolean();
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();


### PR DESCRIPTION
…fde8e51bf52c0d0323f870a5

Motivation:

c2f4daa7398a9363fde8e51bf52c0d0323f870a5 added a unit test but used a too small test timeout.

Modifications:

Increase timeout.

Result:

Test should have enough time to complete on the CI.