### PR TITLE
Allow to set max BIO memory size

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -737,7 +737,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                     // As this is called for the handshake we have no real idea how big the buffer needs to be.
                     // That said 2048 should give us enough room to include everything like ALPN / NPN data.
                     // If this is not enough we will increase the buffer in wrap(...).
-                    out = allocateOutNetBuf(ctx, 2048);
+                    out = allocateOutNetBuf(ctx, SslUtils.MIN_HANDSHAKE_BUFFER_SIZE);
                 }
                 SSLEngineResult result = wrap(alloc, engine, Unpooled.EMPTY_BUFFER, out);
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -63,6 +63,8 @@ final class SslUtils {
      */
     static final int NOT_ENCRYPTED = -2;
 
+    static final int MIN_HANDSHAKE_BUFFER_SIZE = 2048;
+
     /**
      * Return how much bytes can be read out of the encrypted data. Be aware that this method will not increase
      * the readerIndex of the given {@link ByteBuf}.


### PR DESCRIPTION

Motivation:

By default openssl uses 17k bytes as memory size for its BIO. This can become very wasteful if you need to handle a lot of concurrent connections. We should allow to adjust the used memory and so trade memory usage with cpu usage.

Modification:

- Allow to adjust the max memory used by the BIO
- Adjust SSLEngine implementation to not assume 17k buffers.

Result:

Its now possible to use smaller buffers when using openssl based SSLEngine.