### PR TITLE
Compile with java8 and so remove reflection hacks.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/Java7SslParametersUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Java7SslParametersUtils.java
@@ -18,9 +18,9 @@ package io.netty.handler.ssl;
 import javax.net.ssl.SSLParameters;
 import java.security.AlgorithmConstraints;
 
-final class SslParametersUtils {
+final class Java7SslParametersUtils {
 
-    private SslParametersUtils() {
+    private Java7SslParametersUtils() {
         // Utility
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/Java8SslParametersUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Java8SslParametersUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLParameters;
+import java.util.ArrayList;
+import java.util.List;
+
+final class Java8SslParametersUtils {
+
+    private Java8SslParametersUtils() { }
+
+    static List<String> getSniHostNames(SSLParameters sslParameters) {
+        List<SNIServerName> names = sslParameters.getServerNames();
+        List<String> strings = new ArrayList<String>(names.size());
+
+        for (SNIServerName serverName : names) {
+            if (serverName instanceof SNIHostName) {
+                strings.add(((SNIHostName) serverName).getAsciiName());
+            } else {
+                throw new IllegalArgumentException("Only " + SNIHostName.class.getName()
+                        + " instances are supported, but found: " + serverName);
+            }
+        }
+        return strings;
+    }
+
+    static void setSniHostNames(SSLParameters sslParameters, List<String> names) {
+        List<SNIServerName> sniServerNames = new ArrayList<SNIServerName>(names.size());
+        for (String name: names) {
+            sniServerNames.add(new SNIHostName(name));
+        }
+        sslParameters.setServerNames(sniServerNames);
+    }
+
+    static boolean getUseCipherSuitesOrder(SSLParameters sslParameters) {
+        return sslParameters.getUseCipherSuitesOrder();
+    }
+
+    static void setUseCipherSuitesOrder(SSLParameters sslParameters, boolean useOrder) {
+        sslParameters.setUseCipherSuitesOrder(useOrder);
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -32,15 +32,12 @@ import io.netty.util.internal.ThrowableUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.security.Principal;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,63 +89,8 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             new SSLException("renegotiation unsupported"), ReferenceCountedOpenSslEngine.class, "beginHandshake()");
     private static final SSLException ENCRYPTED_PACKET_OVERSIZED = ThrowableUtil.unknownStackTrace(
             new SSLException("encrypted packet oversized"), ReferenceCountedOpenSslEngine.class, "unwrap(...)");
-    private static final Class<?> SNI_HOSTNAME_CLASS;
-    private static final Method GET_SERVER_NAMES_METHOD;
-    private static final Method SET_SERVER_NAMES_METHOD;
-    private static final Method GET_ASCII_NAME_METHOD;
-    private static final Method GET_USE_CIPHER_SUITES_ORDER_METHOD;
-    private static final Method SET_USE_CIPHER_SUITES_ORDER_METHOD;
     private static final ResourceLeakDetector<ReferenceCountedOpenSslEngine> leakDetector =
             ResourceLeakDetectorFactory.instance().newResourceLeakDetector(ReferenceCountedOpenSslEngine.class);
-
-    static {
-        Method getUseCipherSuitesOrderMethod = null;
-        Method setUseCipherSuitesOrderMethod = null;
-        Class<?> sniHostNameClass = null;
-        Method getAsciiNameMethod = null;
-        Method getServerNamesMethod = null;
-        Method setServerNamesMethod = null;
-        if (PlatformDependent.javaVersion() >= 8) {
-            try {
-                getUseCipherSuitesOrderMethod = SSLParameters.class.getDeclaredMethod("getUseCipherSuitesOrder");
-                SSLParameters parameters = new SSLParameters();
-                @SuppressWarnings("unused")
-                Boolean order = (Boolean) getUseCipherSuitesOrderMethod.invoke(parameters);
-                setUseCipherSuitesOrderMethod = SSLParameters.class.getDeclaredMethod("setUseCipherSuitesOrder",
-                        boolean.class);
-                setUseCipherSuitesOrderMethod.invoke(parameters, true);
-            } catch (Throwable ignore) {
-                getUseCipherSuitesOrderMethod = null;
-                setUseCipherSuitesOrderMethod = null;
-            }
-            try {
-                sniHostNameClass = Class.forName("javax.net.ssl.SNIHostName", false,
-                        PlatformDependent.getClassLoader(ReferenceCountedOpenSslEngine.class));
-                Object sniHostName = sniHostNameClass.getConstructor(String.class).newInstance("netty.io");
-                getAsciiNameMethod = sniHostNameClass.getDeclaredMethod("getAsciiName");
-                @SuppressWarnings("unused")
-                String name = (String) getAsciiNameMethod.invoke(sniHostName);
-
-                getServerNamesMethod = SSLParameters.class.getDeclaredMethod("getServerNames");
-                setServerNamesMethod = SSLParameters.class.getDeclaredMethod("setServerNames", List.class);
-                SSLParameters parameters = new SSLParameters();
-                @SuppressWarnings({ "rawtypes", "unused" })
-                List serverNames = (List) getServerNamesMethod.invoke(parameters);
-                setServerNamesMethod.invoke(parameters, Collections.emptyList());
-            } catch (Throwable ignore) {
-                sniHostNameClass = null;
-                getAsciiNameMethod = null;
-                getServerNamesMethod = null;
-                setServerNamesMethod = null;
-            }
-        }
-        GET_USE_CIPHER_SUITES_ORDER_METHOD = getUseCipherSuitesOrderMethod;
-        SET_USE_CIPHER_SUITES_ORDER_METHOD = setUseCipherSuitesOrderMethod;
-        SNI_HOSTNAME_CLASS = sniHostNameClass;
-        GET_ASCII_NAME_METHOD = getAsciiNameMethod;
-        GET_SERVER_NAMES_METHOD = getServerNamesMethod;
-        SET_SERVER_NAMES_METHOD = setServerNamesMethod;
-    }
 
     static final int MAX_PLAINTEXT_LENGTH = 16 * 1024; // 2^14
 
@@ -244,7 +186,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     private String endPointIdentificationAlgorithm;
     // Store as object as AlgorithmConstraints only exists since java 7.
     private Object algorithmConstraints;
-    private List<?> sniHostNames;
+    private List<String> sniHostNames;
 
     // SSL Engine status variables
     private boolean isInboundDone;
@@ -1601,26 +1543,14 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         int version = PlatformDependent.javaVersion();
         if (version >= 7) {
             sslParameters.setEndpointIdentificationAlgorithm(endPointIdentificationAlgorithm);
-            SslParametersUtils.setAlgorithmConstraints(sslParameters, algorithmConstraints);
+            Java7SslParametersUtils.setAlgorithmConstraints(sslParameters, algorithmConstraints);
             if (version >= 8) {
-                if (SET_SERVER_NAMES_METHOD != null && sniHostNames != null) {
-                    try {
-                        SET_SERVER_NAMES_METHOD.invoke(sslParameters, sniHostNames);
-                    } catch (IllegalAccessException e) {
-                        throw new Error(e);
-                    } catch (InvocationTargetException e) {
-                        throw new Error(e);
-                    }
+                if (sniHostNames != null) {
+                    Java8SslParametersUtils.setSniHostNames(sslParameters, sniHostNames);
                 }
-                if (SET_USE_CIPHER_SUITES_ORDER_METHOD != null && !isDestroyed()) {
-                    try {
-                        SET_USE_CIPHER_SUITES_ORDER_METHOD.invoke(sslParameters,
-                                (SSL.getOptions(ssl) & SSL.SSL_OP_CIPHER_SERVER_PREFERENCE) != 0);
-                    } catch (IllegalAccessException e) {
-                        throw new Error(e);
-                    } catch (InvocationTargetException e) {
-                        throw new Error(e);
-                    }
+                if (!isDestroyed()) {
+                    Java8SslParametersUtils.setUseCipherSuitesOrder(
+                            sslParameters, (SSL.getOptions(ssl) & SSL.SSL_OP_CIPHER_SERVER_PREFERENCE) != 0);
                 }
             }
         }
@@ -1635,42 +1565,17 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         if (version >= 7) {
             endPointIdentificationAlgorithm = sslParameters.getEndpointIdentificationAlgorithm();
             algorithmConstraints = sslParameters.getAlgorithmConstraints();
-            if (version >= 8) {
-                if (SNI_HOSTNAME_CLASS != null && clientMode && !isDestroyed()) {
-                    assert GET_SERVER_NAMES_METHOD != null;
-                    assert GET_ASCII_NAME_METHOD != null;
-                    try {
-                        List<?> servernames = (List<?>) GET_SERVER_NAMES_METHOD.invoke(sslParameters);
-                        if (servernames != null) {
-                            for (Object serverName : servernames) {
-                                if (SNI_HOSTNAME_CLASS.isInstance(serverName)) {
-                                    SSL.setTlsExtHostName(ssl, (String) GET_ASCII_NAME_METHOD.invoke(serverName));
-                                } else {
-                                    throw new IllegalArgumentException("Only " + SNI_HOSTNAME_CLASS.getName()
-                                            + " instances are supported, but found: " +
-                                            serverName);
-                                }
-                            }
-                        }
-                        sniHostNames = servernames;
-                    } catch (IllegalAccessException e) {
-                        throw new Error(e);
-                    } catch (InvocationTargetException e) {
-                        throw new Error(e);
+            if (version >= 8 && !isDestroyed()) {
+                if (clientMode) {
+                    sniHostNames = Java8SslParametersUtils.getSniHostNames(sslParameters);
+                    for (String name: sniHostNames) {
+                        SSL.setTlsExtHostName(ssl, name);
                     }
                 }
-                if (GET_USE_CIPHER_SUITES_ORDER_METHOD != null && !isDestroyed()) {
-                    try {
-                        if ((Boolean) GET_USE_CIPHER_SUITES_ORDER_METHOD.invoke(sslParameters)) {
-                            SSL.setOptions(ssl, SSL.SSL_OP_CIPHER_SERVER_PREFERENCE);
-                        } else {
-                            SSL.clearOptions(ssl, SSL.SSL_OP_CIPHER_SERVER_PREFERENCE);
-                        }
-                    } catch (IllegalAccessException e) {
-                        throw new Error(e);
-                    } catch (InvocationTargetException e) {
-                        throw new Error(e);
-                    }
+                if (Java8SslParametersUtils.getUseCipherSuitesOrder(sslParameters)) {
+                    SSL.setOptions(ssl, SSL.SSL_OP_CIPHER_SERVER_PREFERENCE);
+                } else {
+                    SSL.clearOptions(ssl, SSL.SSL_OP_CIPHER_SERVER_PREFERENCE);
                 }
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -168,11 +168,6 @@
                 </goals>
                 <configuration>
                   <rules>
-                    <requireJavaVersion>
-                      <!-- Enforce JDK 1.7 (and not 1.8+) for compilation. -->
-                      <!-- See: https://github.com/netty/netty/issues/3548 -->
-                      <version>[1.7.0, 1.8.0)</version>
-                    </requireJavaVersion>
                     <requireProperty>
                       <regexMessage>
                         Release process must be performed on linux-x86_64.
@@ -620,9 +615,9 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.6.0</version>
         <configuration>
-          <compilerVersion>1.7</compilerVersion>
+          <compilerVersion>1.8</compilerVersion>
           <fork>true</fork>
           <source>1.6</source>
           <target>1.6</target>
@@ -698,6 +693,8 @@
             <ignore>javax.net.ssl.SSLEngine</ignore>
             <ignore>javax.net.ssl.X509ExtendedTrustManager</ignore>
             <ignore>javax.net.ssl.SSLParameters</ignore>
+            <ignore>javax.net.ssl.SNIServerName</ignore>
+            <ignore>javax.net.ssl.SNIHostName</ignore>
             <ignore>java.security.AlgorithmConstraints</ignore>
             <ignore>java.security.cert.CertificateRevokedException</ignore>
             <ignore>java.security.cert.CertPathValidatorException</ignore>


### PR DESCRIPTION
Motivation:

We previously changed netty to always compile with java7 as otherwise source compatibility was broken.

This was reported in [#3548] but was fixed in the meantime:
- https://bugs.openjdk.java.net/browse/JDK-8029240
- https://bugs.openjdk.java.net/browse/JDK-8030855

Modifications:

Use again java8 and so remove all the reflection hacks.

Result:

Easier to maintain code.