### PR TITLE
Fail build when unused c code is detected

### DIFF
--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -199,7 +199,7 @@
               <value>${linux.sendmmsg.support}${glibc.sendmmsg.support}</value>
               <!-- If glibc and linux kernel are both not sufficient...then define the CFLAGS -->
               <regex>.*IO_NETTY_SENDMSSG_NOT_FOUND.*</regex>
-              <replacement>CFLAGS=-O3 -DIO_NETTY_SENDMMSG_NOT_FOUND -Werror -fno-omit-frame-pointer</replacement>
+              <replacement>CFLAGS=-O3 -DIO_NETTY_SENDMMSG_NOT_FOUND -Werror -fno-omit-frame-pointer -Wunused-variable</replacement>
               <failIfNoMatch>false</failIfNoMatch>
             </configuration>
           </execution>
@@ -215,7 +215,7 @@
               <value>${jni.compiler.args.cflags}</value>
               <!-- If glibc and linux kernel are both not sufficient...then define the CFLAGS -->
               <regex>^((?!CFLAGS=).)*$</regex>
-              <replacement>CFLAGS=-O3 -Werror -fno-omit-frame-pointer</replacement>
+              <replacement>CFLAGS=-O3 -Werror -fno-omit-frame-pointer -Wunused-variable</replacement>
               <failIfNoMatch>false</failIfNoMatch>
             </configuration>
           </execution>


### PR DESCRIPTION
Motivation:

To keep our code clean we should fail the build when unused c code is detected.

Modifications:

- Add '-Wunused-variable' to build flags

Result:

Cleaner code.