### PR TITLE
Check startsWith instead of exact match to websocketPath in WebSocket…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -102,9 +102,14 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     private final boolean allowExtensions;
     private final int maxFramePayloadLength;
     private final boolean allowMaskMismatch;
+    private final boolean checkStartsWith;
 
     public WebSocketServerProtocolHandler(String websocketPath) {
         this(websocketPath, null, false);
+    }
+
+    public WebSocketServerProtocolHandler(String websocketPath, boolean checkStartsWith) {
+        this(websocketPath, null, false, 65536, false, checkStartsWith);
     }
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols) {
@@ -122,11 +127,17 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
             boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch) {
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, false);
+    }
+
+    public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
+            boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch, boolean checkStartsWith) {
         this.websocketPath = websocketPath;
         this.subprotocols = subprotocols;
         this.allowExtensions = allowExtensions;
         maxFramePayloadLength = maxFrameSize;
         this.allowMaskMismatch = allowMaskMismatch;
+        this.checkStartsWith = checkStartsWith;
     }
 
     @Override
@@ -136,7 +147,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
             // Add the WebSocketHandshakeHandler before this one.
             ctx.pipeline().addBefore(ctx.name(), WebSocketServerProtocolHandshakeHandler.class.getName(),
                     new WebSocketServerProtocolHandshakeHandler(websocketPath, subprotocols,
-                            allowExtensions, maxFramePayloadLength, allowMaskMismatch));
+                            allowExtensions, maxFramePayloadLength, allowMaskMismatch, checkStartsWith));
         }
         if (cp.get(Utf8FrameValidator.class) == null) {
             // Add the UFT8 checking before this one.

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandshakeHandler.java
@@ -42,20 +42,32 @@ class WebSocketServerProtocolHandshakeHandler extends ChannelInboundHandlerAdapt
     private final boolean allowExtensions;
     private final int maxFramePayloadSize;
     private final boolean allowMaskMismatch;
+    private final boolean checkStartsWith;
 
     WebSocketServerProtocolHandshakeHandler(String websocketPath, String subprotocols,
             boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch) {
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, false);
+    }
+
+    WebSocketServerProtocolHandshakeHandler(String websocketPath, String subprotocols,
+            boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch, boolean checkStartsWith) {
         this.websocketPath = websocketPath;
         this.subprotocols = subprotocols;
         this.allowExtensions = allowExtensions;
         maxFramePayloadSize = maxFrameSize;
         this.allowMaskMismatch = allowMaskMismatch;
+        this.checkStartsWith = checkStartsWith;
     }
 
     @Override
     public void channelRead(final ChannelHandlerContext ctx, Object msg) throws Exception {
         final FullHttpRequest req = (FullHttpRequest) msg;
-        if (!websocketPath.equals(req.uri())) {
+        if (checkStartsWith) {
+            if (!req.uri().startsWith(websocketPath)) {
+                ctx.fireChannelRead(msg);
+                return;
+            }
+        } else if (!req.uri().equals(websocketPath)) {
             ctx.fireChannelRead(msg);
             return;
         }


### PR DESCRIPTION
This small change enables flexible routing based on request URI. E.g.

```scala
pipeline.addLast(new WebSocketServerProtocolHandler("/subscribe", null, true))
pipeline.addLast(new WSFrameHandler() {
  override def userEventTriggered(ctx: ChannelHandlerContext, evt: Any) {
    super.userEventTriggered(ctx, evt)
    evt match {
      case complete: WebSocketServerProtocolHandler.HandshakeComplete =>
        complete.requestUri // <- do something with requestUri
      case _ =>
    }
  }
})
```
Allows connecting on client-side in that way:

```js
new WebSocket("ws://::1:3000/subscribe/topic-1?token=....")
new WebSocket("ws://::1:3000/subscribe/topic-2?token=....")
```