### PR TITLE
[#6141] OpenSSLContext Mutual Auth does not announce acceptable CAs

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
@@ -153,6 +153,21 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
                 } else {
                     SSLContext.setCertVerifyCallback(ctx, new TrustManagerVerifyCallback(engineMap, manager));
                 }
+
+                X509Certificate[] issuers = manager.getAcceptedIssuers();
+                if (issuers != null && issuers.length > 0) {
+                    long bio = 0;
+                    try {
+                        bio = toBIO(issuers);
+                        if (!SSLContext.setCACertificateBio(ctx, bio)) {
+                            throw new SSLException("unable to setup accepted issuers for trustmanager " + manager);
+                        }
+                    } finally {
+                        freeBio(bio);
+                    }
+                }
+            } catch (SSLException e) {
+                throw e;
             } catch (Exception e) {
                 throw new SSLException("unable to setup trustmanager", e);
             }

--- a/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public abstract class RenegotiateTest {
 
-    @Test(timeout = 5000)
+    @Test(timeout = 30000)
     public void testRenegotiateServer() throws Throwable {
         final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
         final CountDownLatch latch = new CountDownLatch(2);

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -538,7 +538,7 @@ public abstract class SSLEngineTest {
         }
     }
 
-    @Test(timeout = 3000)
+    @Test(timeout = 30000)
     public void clientInitiatedRenegotiationWithFatalAlertDoesNotInfiniteLoopServer()
             throws CertificateException, SSLException, InterruptedException, ExecutionException {
         final SelfSignedCertificate ssc = new SelfSignedCertificate();
@@ -891,7 +891,7 @@ public abstract class SSLEngineTest {
         clientChannel = ccf.channel();
     }
 
-    @Test(timeout = 5000)
+    @Test(timeout = 30000)
     public void testMutualAuthSameCertChain() throws Exception {
         serverSslCtx = SslContextBuilder.forServer(
                 new ByteArrayInputStream(X509_CERT_PEM.getBytes(CharsetUtil.UTF_8)),

--- a/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniClientTest.java
@@ -35,24 +35,24 @@ import org.junit.Test;
 
 public class SniClientTest {
 
-    @Test(timeout = 5000)
+    @Test(timeout = 30000)
     public void testSniClientJdkSslServerJdkSsl() throws Exception {
         testSniClient(SslProvider.JDK, SslProvider.JDK);
     }
 
-    @Test(timeout = 5000)
+    @Test(timeout = 30000)
     public void testSniClientOpenSslServerOpenSsl() throws Exception {
         Assume.assumeTrue(OpenSsl.isAvailable());
         testSniClient(SslProvider.OPENSSL, SslProvider.OPENSSL);
     }
 
-    @Test(timeout = 5000)
+    @Test(timeout = 30000)
     public void testSniClientJdkSslServerOpenSsl() throws Exception {
         Assume.assumeTrue(OpenSsl.isAvailable());
         testSniClient(SslProvider.JDK, SslProvider.OPENSSL);
     }
 
-    @Test(timeout = 5000)
+    @Test(timeout = 30000)
     public void testSniClientOpenSslServerJdkSsl() throws Exception {
         Assume.assumeTrue(OpenSsl.isAvailable());
         testSniClient(SslProvider.OPENSSL, SslProvider.JDK);

--- a/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SniHandlerTest.java
@@ -313,7 +313,7 @@ public class SniHandlerTest {
         }
     }
 
-    @Test(timeout = 10L * 1000L)
+    @Test(timeout = 30000)
     public void testReplaceHandler() throws Exception {
         switch (provider) {
             case OPENSSL:

--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -117,7 +117,7 @@ public class SslErrorTest {
         this.exception = exception;
     }
 
-    @Test(timeout = 10000L)
+    @Test(timeout = 30000)
     public void testCorrectAlert() throws Exception {
         // As this only works correctly at the moment when OpenSslEngine is used on the server-side there is
         // no need to run it if there is no openssl is available at all.

--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -46,7 +46,6 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.EmptyArrays;
-import org.junit.Assume;
 import org.junit.Test;
 
 import io.netty.buffer.ByteBufAllocator;
@@ -186,7 +185,7 @@ public class SslHandlerTest {
         new TlsReadTest().test(true);
     }
 
-    @Test(timeout = 5000)
+    @Test(timeout = 30000)
     public void testRemoval() throws Exception {
         NioEventLoopGroup group = new NioEventLoopGroup();
         Channel sc = null;
@@ -264,12 +263,12 @@ public class SslHandlerTest {
         };
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 30000)
     public void testAlertProducedAndSendJdk() throws Exception {
         testAlertProducedAndSend(SslProvider.JDK);
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 30000)
     public void testAlertProducedAndSendOpenSsl() throws Exception {
         assumeTrue(OpenSsl.isAvailable());
         testAlertProducedAndSend(SslProvider.OPENSSL);

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
-    <tcnative.version>1.1.33.Fork23</tcnative.version>
+    <tcnative.version>1.1.33.Fork25</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <epoll.classifier>${os.detected.name}-${os.detected.arch}</epoll.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>


### PR DESCRIPTION
Motivation:

Openssl provider should behave same as JDK provider when mutual authentication is required and a specific set of trusted Certificate Authorities are specified. The SSL handshake should return back to the connected peer the same list of configured Certificate Authorities.

Modifications:

Correctly set the CA list.

Result:

Correct and same behaviour as the JDK implementation.
