### PR TITLE
Dns codec cleanup

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsMessage.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/AbstractDnsMessage.java
@@ -30,7 +30,8 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 /**
  * A skeletal implementation of {@link DnsMessage}.
  */
-public abstract class AbstractDnsMessage extends AbstractReferenceCounted implements DnsMessage {
+public abstract class AbstractDnsMessage<M extends ReferenceCounted & DnsMessage<M>>
+        extends AbstractReferenceCounted implements DnsMessage<M> {
 
     private static final ResourceLeakDetector<DnsMessage> leakDetector =
             new ResourceLeakDetector<DnsMessage>(DnsMessage.class);
@@ -66,15 +67,19 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
         setOpCode(opCode);
     }
 
+    protected final M cast(AbstractDnsMessage msg) {
+        return (M) msg;
+    }
+
     @Override
     public int id() {
         return id & 0xFFFF;
     }
 
     @Override
-    public DnsMessage setId(int id) {
+    public M setId(int id) {
         this.id = (short) id;
-        return this;
+        return (M) this;
     }
 
     @Override
@@ -83,9 +88,9 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
     }
 
     @Override
-    public DnsMessage setOpCode(DnsOpCode opCode) {
+    public M setOpCode(DnsOpCode opCode) {
         this.opCode = checkNotNull(opCode, "opCode");
-        return this;
+        return cast(this);
     }
 
     @Override
@@ -94,9 +99,9 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
     }
 
     @Override
-    public DnsMessage setRecursionDesired(boolean recursionDesired) {
+    public M setRecursionDesired(boolean recursionDesired) {
         this.recursionDesired = recursionDesired;
-        return this;
+        return cast(this);
     }
 
     @Override
@@ -105,9 +110,9 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
     }
 
     @Override
-    public DnsMessage setZ(int z) {
+    public M setZ(int z) {
         this.z = (byte) (z & 7);
-        return this;
+        return cast(this);
     }
 
     @Override
@@ -187,9 +192,9 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
     }
 
     @Override
-    public DnsMessage setRecord(DnsSection section, DnsRecord record) {
+    public M setRecord(DnsSection section, DnsRecord record) {
         setRecord(sectionOrdinal(section), record);
-        return this;
+        return (M) this;
     }
 
     private void setRecord(int section, DnsRecord record) {
@@ -225,9 +230,9 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
     }
 
     @Override
-    public DnsMessage addRecord(DnsSection section, DnsRecord record) {
+    public M addRecord(DnsSection section, DnsRecord record) {
         addRecord(sectionOrdinal(section), record);
-        return this;
+        return cast(this);
     }
 
     private void addRecord(int section, DnsRecord record) {
@@ -253,9 +258,9 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
     }
 
     @Override
-    public DnsMessage addRecord(DnsSection section, int index, DnsRecord record) {
+    public M addRecord(DnsSection section, int index, DnsRecord record) {
         addRecord(sectionOrdinal(section), index, record);
-        return this;
+        return cast(this);
     }
 
     private void addRecord(int section, int index, DnsRecord record) {
@@ -320,17 +325,17 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
     }
 
     @Override
-    public DnsMessage clear(DnsSection section) {
+    public M clear(DnsSection section) {
         clear(sectionOrdinal(section));
-        return this;
+        return cast(this);
     }
 
     @Override
-    public DnsMessage clear() {
+    public M clear() {
         for (int i = 0; i < SECTION_COUNT; i ++) {
             clear(i);
         }
-        return this;
+        return cast(this);
     }
 
     private void clear(int section) {
@@ -350,26 +355,26 @@ public abstract class AbstractDnsMessage extends AbstractReferenceCounted implem
     }
 
     @Override
-    public DnsMessage touch() {
-        return (DnsMessage) super.touch();
+    public M touch() {
+        return cast((AbstractDnsMessage) super.touch());
     }
 
     @Override
-    public DnsMessage touch(Object hint) {
+    public M touch(Object hint) {
         if (leak != null) {
             leak.record(hint);
         }
-        return this;
+        return cast(this);
     }
 
     @Override
-    public DnsMessage retain() {
-        return (DnsMessage) super.retain();
+    public M retain() {
+        return cast((AbstractDnsMessage) super.retain());
     }
 
     @Override
-    public DnsMessage retain(int increment) {
-        return (DnsMessage) super.retain(increment);
+    public M retain(int increment) {
+        return cast((AbstractDnsMessage) super.retain(increment));
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQuery.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQuery.java
@@ -23,7 +23,7 @@ import java.net.SocketAddress;
 /**
  * A {@link DnsQuery} implementation for UDP/IP.
  */
-public class DatagramDnsQuery extends DefaultDnsQuery
+public class DatagramDnsQuery extends DefaultDnsQuery<DatagramDnsQuery>
         implements AddressedEnvelope<DatagramDnsQuery, InetSocketAddress> {
 
     private final InetSocketAddress sender;
@@ -74,71 +74,6 @@ public class DatagramDnsQuery extends DefaultDnsQuery
     @Override
     public InetSocketAddress recipient() {
         return recipient;
-    }
-
-    @Override
-    public DatagramDnsQuery setId(int id) {
-        return (DatagramDnsQuery) super.setId(id);
-    }
-
-    @Override
-    public DatagramDnsQuery setOpCode(DnsOpCode opCode) {
-        return (DatagramDnsQuery) super.setOpCode(opCode);
-    }
-
-    @Override
-    public DatagramDnsQuery setRecursionDesired(boolean recursionDesired) {
-        return (DatagramDnsQuery) super.setRecursionDesired(recursionDesired);
-    }
-
-    @Override
-    public DatagramDnsQuery setZ(int z) {
-        return (DatagramDnsQuery) super.setZ(z);
-    }
-
-    @Override
-    public DatagramDnsQuery setRecord(DnsSection section, DnsRecord record) {
-        return (DatagramDnsQuery) super.setRecord(section, record);
-    }
-
-    @Override
-    public DatagramDnsQuery addRecord(DnsSection section, DnsRecord record) {
-        return (DatagramDnsQuery) super.addRecord(section, record);
-    }
-
-    @Override
-    public DatagramDnsQuery addRecord(DnsSection section, int index, DnsRecord record) {
-        return (DatagramDnsQuery) super.addRecord(section, index, record);
-    }
-
-    @Override
-    public DatagramDnsQuery clear(DnsSection section) {
-        return (DatagramDnsQuery) super.clear(section);
-    }
-
-    @Override
-    public DatagramDnsQuery clear() {
-        return (DatagramDnsQuery) super.clear();
-    }
-
-    @Override
-    public DatagramDnsQuery touch() {
-        return (DatagramDnsQuery) super.touch();
-    }
-
-    @Override
-    public DatagramDnsQuery touch(Object hint) {
-        return (DatagramDnsQuery) super.touch(hint);
-    }
-
-    @Override
-    public DatagramDnsQuery retain() {
-        return (DatagramDnsQuery) super.retain();
-    }
-
-    @Override
-    public DatagramDnsQuery retain(int increment) {
-        return (DatagramDnsQuery) super.retain(increment);
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsQueryEncoder.java
@@ -32,7 +32,8 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * {@link DatagramPacket}.
  */
 @ChannelHandler.Sharable
-public class DatagramDnsQueryEncoder extends MessageToMessageEncoder<AddressedEnvelope<DnsQuery, InetSocketAddress>> {
+public class DatagramDnsQueryEncoder
+        extends MessageToMessageEncoder<AddressedEnvelope<DnsQuery<?>, InetSocketAddress>> {
 
     private final DnsRecordEncoder recordEncoder;
 
@@ -53,7 +54,7 @@ public class DatagramDnsQueryEncoder extends MessageToMessageEncoder<AddressedEn
     @Override
     protected void encode(
             ChannelHandlerContext ctx,
-            AddressedEnvelope<DnsQuery, InetSocketAddress> in, List<Object> out) throws Exception {
+            AddressedEnvelope<DnsQuery<?>, InetSocketAddress> in, List<Object> out) throws Exception {
 
         final InetSocketAddress recipient = in.recipient();
         final DnsQuery query = in.content();
@@ -80,7 +81,7 @@ public class DatagramDnsQueryEncoder extends MessageToMessageEncoder<AddressedEn
      */
     protected ByteBuf allocateBuffer(
             ChannelHandlerContext ctx,
-            @SuppressWarnings("unused") AddressedEnvelope<DnsQuery, InetSocketAddress> msg) throws Exception {
+            @SuppressWarnings("unused") AddressedEnvelope<DnsQuery<?>, InetSocketAddress> msg) throws Exception {
         return ctx.alloc().ioBuffer(1024);
     }
 
@@ -92,7 +93,7 @@ public class DatagramDnsQueryEncoder extends MessageToMessageEncoder<AddressedEn
      * @param buf
      *            the buffer the encoded data should be written to
      */
-    private static void encodeHeader(DnsQuery query, ByteBuf buf) {
+    private static void encodeHeader(DnsQuery<?> query, ByteBuf buf) {
         buf.writeShort(query.id());
         int flags = 0;
         flags |= (query.opCode().byteValue() & 0xFF) << 14;
@@ -104,14 +105,14 @@ public class DatagramDnsQueryEncoder extends MessageToMessageEncoder<AddressedEn
         buf.writeShort(query.count(DnsSection.ADDITIONAL));
     }
 
-    private void encodeQuestions(DnsQuery query, ByteBuf buf) throws Exception {
+    private void encodeQuestions(DnsQuery<?> query, ByteBuf buf) throws Exception {
         final int count = query.count(DnsSection.QUESTION);
         for (int i = 0; i < count; i ++) {
             recordEncoder.encodeQuestion((DnsQuestion) query.recordAt(DnsSection.QUESTION, i), buf);
         }
     }
 
-    private void encodeRecords(DnsQuery query, DnsSection section, ByteBuf buf) throws Exception {
+    private void encodeRecords(DnsQuery<?> query, DnsSection section, ByteBuf buf) throws Exception {
         final int count = query.count(section);
         for (int i = 0; i < count; i ++) {
             recordEncoder.encodeRecord(query.recordAt(section, i), buf);

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponse.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponse.java
@@ -23,7 +23,7 @@ import java.net.SocketAddress;
 /**
  * A {@link DnsResponse} implementation for UDP/IP.
  */
-public class DatagramDnsResponse extends DefaultDnsResponse
+public class DatagramDnsResponse extends DefaultDnsResponse<DatagramDnsResponse>
         implements AddressedEnvelope<DatagramDnsResponse, InetSocketAddress> {
 
     private final InetSocketAddress sender;
@@ -88,91 +88,6 @@ public class DatagramDnsResponse extends DefaultDnsResponse
     @Override
     public InetSocketAddress recipient() {
         return recipient;
-    }
-
-    @Override
-    public DatagramDnsResponse setAuthoritativeAnswer(boolean authoritativeAnswer) {
-        return (DatagramDnsResponse) super.setAuthoritativeAnswer(authoritativeAnswer);
-    }
-
-    @Override
-    public DatagramDnsResponse setTruncated(boolean truncated) {
-        return (DatagramDnsResponse) super.setTruncated(truncated);
-    }
-
-    @Override
-    public DatagramDnsResponse setRecursionAvailable(boolean recursionAvailable) {
-        return (DatagramDnsResponse) super.setRecursionAvailable(recursionAvailable);
-    }
-
-    @Override
-    public DatagramDnsResponse setCode(DnsResponseCode code) {
-        return (DatagramDnsResponse) super.setCode(code);
-    }
-
-    @Override
-    public DatagramDnsResponse setId(int id) {
-        return (DatagramDnsResponse) super.setId(id);
-    }
-
-    @Override
-    public DatagramDnsResponse setOpCode(DnsOpCode opCode) {
-        return (DatagramDnsResponse) super.setOpCode(opCode);
-    }
-
-    @Override
-    public DatagramDnsResponse setRecursionDesired(boolean recursionDesired) {
-        return (DatagramDnsResponse) super.setRecursionDesired(recursionDesired);
-    }
-
-    @Override
-    public DatagramDnsResponse setZ(int z) {
-        return (DatagramDnsResponse) super.setZ(z);
-    }
-
-    @Override
-    public DatagramDnsResponse setRecord(DnsSection section, DnsRecord record) {
-        return (DatagramDnsResponse) super.setRecord(section, record);
-    }
-
-    @Override
-    public DatagramDnsResponse addRecord(DnsSection section, DnsRecord record) {
-        return (DatagramDnsResponse) super.addRecord(section, record);
-    }
-
-    @Override
-    public DatagramDnsResponse addRecord(DnsSection section, int index, DnsRecord record) {
-        return (DatagramDnsResponse) super.addRecord(section, index, record);
-    }
-
-    @Override
-    public DatagramDnsResponse clear(DnsSection section) {
-        return (DatagramDnsResponse) super.clear(section);
-    }
-
-    @Override
-    public DatagramDnsResponse clear() {
-        return (DatagramDnsResponse) super.clear();
-    }
-
-    @Override
-    public DatagramDnsResponse touch() {
-        return (DatagramDnsResponse) super.touch();
-    }
-
-    @Override
-    public DatagramDnsResponse touch(Object hint) {
-        return (DatagramDnsResponse) super.touch(hint);
-    }
-
-    @Override
-    public DatagramDnsResponse retain() {
-        return (DatagramDnsResponse) super.retain();
-    }
-
-    @Override
-    public DatagramDnsResponse retain(int increment) {
-        return (DatagramDnsResponse) super.retain(increment);
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponseDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DatagramDnsResponseDecoder.java
@@ -76,7 +76,7 @@ public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<Datagram
         }
     }
 
-    private static DnsResponse newResponse(InetSocketAddress sender, ByteBuf buf) {
+    private static DnsResponse<?> newResponse(InetSocketAddress sender, ByteBuf buf) {
         final int id = buf.readUnsignedShort();
 
         final int flags = buf.readUnsignedShort();
@@ -96,14 +96,14 @@ public class DatagramDnsResponseDecoder extends MessageToMessageDecoder<Datagram
         return response;
     }
 
-    private void decodeQuestions(DnsResponse response, ByteBuf buf, int questionCount) throws Exception {
+    private void decodeQuestions(DnsResponse<?> response, ByteBuf buf, int questionCount) throws Exception {
         for (int i = questionCount; i > 0; i --) {
             response.addRecord(DnsSection.QUESTION, recordDecoder.decodeQuestion(buf));
         }
     }
 
     private void decodeRecords(
-            DnsResponse response, DnsSection section, ByteBuf buf, int count) throws Exception {
+            DnsResponse<?> response, DnsSection section, ByteBuf buf, int count) throws Exception {
         for (int i = count; i > 0; i --) {
             final DnsRecord r = recordDecoder.decodeRecord(buf);
             if (r == null) {

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsQuery.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsQuery.java
@@ -15,10 +15,13 @@
  */
 package io.netty.handler.codec.dns;
 
+import io.netty.util.ReferenceCounted;
+
 /**
  * The default {@link DnsQuery} implementation.
  */
-public class DefaultDnsQuery extends AbstractDnsMessage implements DnsQuery {
+public class DefaultDnsQuery<M extends ReferenceCounted & DnsQuery<M>>
+        extends AbstractDnsMessage<M> implements DnsQuery<M> {
 
     /**
      * Creates a new instance with the {@link DnsOpCode#QUERY} {@code opCode}.
@@ -37,71 +40,6 @@ public class DefaultDnsQuery extends AbstractDnsMessage implements DnsQuery {
      */
     public DefaultDnsQuery(int id, DnsOpCode opCode) {
         super(id, opCode);
-    }
-
-    @Override
-    public DnsQuery setId(int id) {
-        return (DnsQuery) super.setId(id);
-    }
-
-    @Override
-    public DnsQuery setOpCode(DnsOpCode opCode) {
-        return (DnsQuery) super.setOpCode(opCode);
-    }
-
-    @Override
-    public DnsQuery setRecursionDesired(boolean recursionDesired) {
-        return (DnsQuery) super.setRecursionDesired(recursionDesired);
-    }
-
-    @Override
-    public DnsQuery setZ(int z) {
-        return (DnsQuery) super.setZ(z);
-    }
-
-    @Override
-    public DnsQuery setRecord(DnsSection section, DnsRecord record) {
-        return (DnsQuery) super.setRecord(section, record);
-    }
-
-    @Override
-    public DnsQuery addRecord(DnsSection section, DnsRecord record) {
-        return (DnsQuery) super.addRecord(section, record);
-    }
-
-    @Override
-    public DnsQuery addRecord(DnsSection section, int index, DnsRecord record) {
-        return (DnsQuery) super.addRecord(section, index, record);
-    }
-
-    @Override
-    public DnsQuery clear(DnsSection section) {
-        return (DnsQuery) super.clear(section);
-    }
-
-    @Override
-    public DnsQuery clear() {
-        return (DnsQuery) super.clear();
-    }
-
-    @Override
-    public DnsQuery touch() {
-        return (DnsQuery) super.touch();
-    }
-
-    @Override
-    public DnsQuery touch(Object hint) {
-        return (DnsQuery) super.touch(hint);
-    }
-
-    @Override
-    public DnsQuery retain() {
-        return (DnsQuery) super.retain();
-    }
-
-    @Override
-    public DnsQuery retain(int increment) {
-        return (DnsQuery) super.retain(increment);
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsResponse.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsResponse.java
@@ -15,12 +15,14 @@
  */
 package io.netty.handler.codec.dns;
 
+import io.netty.util.ReferenceCounted;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * The default {@link DnsResponse} implementation.
  */
-public class DefaultDnsResponse extends AbstractDnsMessage implements DnsResponse {
+public class DefaultDnsResponse<M extends ReferenceCounted & DnsResponse<M>>
+        extends AbstractDnsMessage<M> implements DnsResponse<M> {
 
     private boolean authoritativeAnswer;
     private boolean truncated;
@@ -50,7 +52,7 @@ public class DefaultDnsResponse extends AbstractDnsMessage implements DnsRespons
     /**
      * Creates a new instance.
      *
-     * @param id the {@code ID} of the DNS response
+     * @param id the {@code ID} ofDefaultDnsResponse the DNS response
      * @param opCode the {@code opCode} of the DNS response
      * @param code the {@code RCODE} of the DNS response
      */
@@ -65,9 +67,9 @@ public class DefaultDnsResponse extends AbstractDnsMessage implements DnsRespons
     }
 
     @Override
-    public DnsResponse setAuthoritativeAnswer(boolean authoritativeAnswer) {
+    public M setAuthoritativeAnswer(boolean authoritativeAnswer) {
         this.authoritativeAnswer = authoritativeAnswer;
-        return this;
+        return cast(this);
     }
 
     @Override
@@ -76,9 +78,9 @@ public class DefaultDnsResponse extends AbstractDnsMessage implements DnsRespons
     }
 
     @Override
-    public DnsResponse setTruncated(boolean truncated) {
+    public M setTruncated(boolean truncated) {
         this.truncated = truncated;
-        return this;
+        return cast(this);
     }
 
     @Override
@@ -87,9 +89,9 @@ public class DefaultDnsResponse extends AbstractDnsMessage implements DnsRespons
     }
 
     @Override
-    public DnsResponse setRecursionAvailable(boolean recursionAvailable) {
+    public M setRecursionAvailable(boolean recursionAvailable) {
         this.recursionAvailable = recursionAvailable;
-        return this;
+        return cast(this);
     }
 
     @Override
@@ -98,74 +100,9 @@ public class DefaultDnsResponse extends AbstractDnsMessage implements DnsRespons
     }
 
     @Override
-    public DnsResponse setCode(DnsResponseCode code) {
+    public M setCode(DnsResponseCode code) {
         this.code = checkNotNull(code, "code");
-        return this;
-    }
-
-    @Override
-    public DnsResponse setId(int id) {
-        return (DnsResponse) super.setId(id);
-    }
-
-    @Override
-    public DnsResponse setOpCode(DnsOpCode opCode) {
-        return (DnsResponse) super.setOpCode(opCode);
-    }
-
-    @Override
-    public DnsResponse setRecursionDesired(boolean recursionDesired) {
-        return (DnsResponse) super.setRecursionDesired(recursionDesired);
-    }
-
-    @Override
-    public DnsResponse setZ(int z) {
-        return (DnsResponse) super.setZ(z);
-    }
-
-    @Override
-    public DnsResponse setRecord(DnsSection section, DnsRecord record) {
-        return (DnsResponse) super.setRecord(section, record);
-    }
-
-    @Override
-    public DnsResponse addRecord(DnsSection section, DnsRecord record) {
-        return (DnsResponse) super.addRecord(section, record);
-    }
-
-    @Override
-    public DnsResponse addRecord(DnsSection section, int index, DnsRecord record) {
-        return (DnsResponse) super.addRecord(section, index, record);
-    }
-
-    @Override
-    public DnsResponse clear(DnsSection section) {
-        return (DnsResponse) super.clear(section);
-    }
-
-    @Override
-    public DnsResponse clear() {
-        return (DnsResponse) super.clear();
-    }
-
-    @Override
-    public DnsResponse touch() {
-        return (DnsResponse) super.touch();
-    }
-
-    @Override
-    public DnsResponse touch(Object hint) {
-        return (DnsResponse) super.touch(hint);
-    }
-
-    @Override
-    public DnsResponse retain() {
-        return (DnsResponse) super.retain();
-    }
-
-    @Override
-    public DnsResponse retain(int increment) {
-        return (DnsResponse) super.retain(increment);
+        return cast(this);
     }
 
     @Override

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessage.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMessage.java
@@ -20,7 +20,7 @@ import io.netty.util.ReferenceCounted;
 /**
  * The superclass which contains core information concerning a {@link DnsQuery} and a {@link DnsResponse}.
  */
-public interface DnsMessage extends ReferenceCounted {
+public interface DnsMessage<M extends ReferenceCounted & DnsMessage> extends ReferenceCounted {
 
     /**
      * Returns the {@code ID} of this DNS message.
@@ -30,7 +30,7 @@ public interface DnsMessage extends ReferenceCounted {
     /**
      * Sets the {@code ID} of this DNS message.
      */
-    DnsMessage setId(int id);
+    M setId(int id);
 
     /**
      * Returns the {@code opCode} of this DNS message.
@@ -40,7 +40,7 @@ public interface DnsMessage extends ReferenceCounted {
     /**
      * Sets the {@code opCode} of this DNS message.
      */
-    DnsMessage setOpCode(DnsOpCode opCode);
+    M setOpCode(DnsOpCode opCode);
 
     /**
      * Returns the {@code RD} (recursion desired} field of this DNS message.
@@ -50,7 +50,7 @@ public interface DnsMessage extends ReferenceCounted {
     /**
      * Sets the {@code RD} (recursion desired} field of this DNS message.
      */
-    DnsMessage setRecursionDesired(boolean recursionDesired);
+    M setRecursionDesired(boolean recursionDesired);
 
     /**
      * Returns the {@code Z} (reserved for future use) field of this DNS message.
@@ -60,7 +60,7 @@ public interface DnsMessage extends ReferenceCounted {
     /**
      * Sets the {@code Z} (reserved for future use) field of this DNS message.
      */
-    DnsMessage setZ(int z);
+    M setZ(int z);
 
     /**
      * Returns the number of records in the specified {@code section} of this DNS message.
@@ -95,7 +95,7 @@ public interface DnsMessage extends ReferenceCounted {
      * making it a single-record section. When the specified {@code section} is {@link DnsSection#QUESTION},
      * the specified {@code record} must be a {@link DnsQuestion}.
      */
-    DnsMessage setRecord(DnsSection section, DnsRecord record);
+    M setRecord(DnsSection section, DnsRecord record);
 
     /**
      * Sets the specified {@code record} at the specified {@code index} of the specified {@code section}
@@ -112,7 +112,7 @@ public interface DnsMessage extends ReferenceCounted {
      * When the specified {@code section} is {@link DnsSection#QUESTION}, the specified {@code record}
      * must be a {@link DnsQuestion}.
      */
-    DnsMessage addRecord(DnsSection section, DnsRecord record);
+    M addRecord(DnsSection section, DnsRecord record);
 
     /**
      * Adds the specified {@code record} at the specified {@code index} of the specified {@code section}
@@ -121,7 +121,7 @@ public interface DnsMessage extends ReferenceCounted {
      *
      * @throws IndexOutOfBoundsException if the specified {@code index} is out of bounds
      */
-    DnsMessage addRecord(DnsSection section, int index, DnsRecord record);
+    M addRecord(DnsSection section, int index, DnsRecord record);
 
     /**
      * Removes the record at the specified {@code index} of the specified {@code section} from this DNS message.
@@ -135,22 +135,22 @@ public interface DnsMessage extends ReferenceCounted {
     /**
      * Removes all the records in the specified {@code section} of this DNS message.
      */
-    DnsMessage clear(DnsSection section);
+    M clear(DnsSection section);
 
     /**
      * Removes all the records in this DNS message.
      */
-    DnsMessage clear();
+    M clear();
 
     @Override
-    DnsMessage touch();
+    M touch();
 
     @Override
-    DnsMessage touch(Object hint);
+    M touch(Object hint);
 
     @Override
-    DnsMessage retain();
+    M retain();
 
     @Override
-    DnsMessage retain(int increment);
+    M retain(int increment);
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuery.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsQuery.java
@@ -15,46 +15,10 @@
  */
 package io.netty.handler.codec.dns;
 
+import io.netty.util.ReferenceCounted;
+
 /**
  * A DNS query message.
  */
-public interface DnsQuery extends DnsMessage {
-    @Override
-    DnsQuery setId(int id);
-
-    @Override
-    DnsQuery setOpCode(DnsOpCode opCode);
-
-    @Override
-    DnsQuery setRecursionDesired(boolean recursionDesired);
-
-    @Override
-    DnsQuery setZ(int z);
-
-    @Override
-    DnsQuery setRecord(DnsSection section, DnsRecord record);
-
-    @Override
-    DnsQuery addRecord(DnsSection section, DnsRecord record);
-
-    @Override
-    DnsQuery addRecord(DnsSection section, int index, DnsRecord record);
-
-    @Override
-    DnsQuery clear(DnsSection section);
-
-    @Override
-    DnsQuery clear();
-
-    @Override
-    DnsQuery touch();
-
-    @Override
-    DnsQuery touch(Object hint);
-
-    @Override
-    DnsQuery retain();
-
-    @Override
-    DnsQuery retain(int increment);
+public interface DnsQuery<M extends ReferenceCounted & DnsQuery> extends DnsMessage<M> {
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponse.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsResponse.java
@@ -15,10 +15,12 @@
  */
 package io.netty.handler.codec.dns;
 
+import io.netty.util.ReferenceCounted;
+
 /**
  * A DNS response message.
  */
-public interface DnsResponse extends DnsMessage {
+public interface DnsResponse<M extends ReferenceCounted & DnsResponse> extends DnsMessage<M> {
 
     /**
      * Returns {@code true} if responding server is authoritative for the domain
@@ -32,7 +34,7 @@ public interface DnsResponse extends DnsMessage {
      *
      * @param authoritativeAnswer flag for authoritative answer
      */
-    DnsResponse setAuthoritativeAnswer(boolean authoritativeAnswer);
+    M setAuthoritativeAnswer(boolean authoritativeAnswer);
 
     /**
      * Returns {@code true} if response has been truncated, usually if it is
@@ -46,7 +48,7 @@ public interface DnsResponse extends DnsMessage {
      *
      * @param truncated flag for truncation
      */
-    DnsResponse setTruncated(boolean truncated);
+    M setTruncated(boolean truncated);
 
     /**
      * Returns {@code true} if DNS server can handle recursive queries.
@@ -58,7 +60,7 @@ public interface DnsResponse extends DnsMessage {
      *
      * @param recursionAvailable flag for recursion availability
      */
-    DnsResponse setRecursionAvailable(boolean recursionAvailable);
+    M setRecursionAvailable(boolean recursionAvailable);
 
     /**
      * Returns the 4 bit return code.
@@ -70,44 +72,5 @@ public interface DnsResponse extends DnsMessage {
      *
      * @param code the response code
      */
-    DnsResponse setCode(DnsResponseCode code);
-
-    @Override
-    DnsResponse setId(int id);
-
-    @Override
-    DnsResponse setOpCode(DnsOpCode opCode);
-
-    @Override
-    DnsResponse setRecursionDesired(boolean recursionDesired);
-
-    @Override
-    DnsResponse setZ(int z);
-
-    @Override
-    DnsResponse setRecord(DnsSection section, DnsRecord record);
-
-    @Override
-    DnsResponse addRecord(DnsSection section, DnsRecord record);
-
-    @Override
-    DnsResponse addRecord(DnsSection section, int index, DnsRecord record);
-
-    @Override
-    DnsResponse clear(DnsSection section);
-
-    @Override
-    DnsResponse clear();
-
-    @Override
-    DnsResponse touch();
-
-    @Override
-    DnsResponse touch(Object hint);
-
-    @Override
-    DnsResponse retain();
-
-    @Override
-    DnsResponse retain(int increment);
+    M setCode(DnsResponseCode code);
 }


### PR DESCRIPTION
Motivation:

On the way to trying to reconcile my dns-server patches from last year with the current code, I noticed the current structure of DnsMessage and its subclasses requires boilerplate overloads and casts in implementation classes, which can be solved more cleanly with generics.

Modification:

Replaced overloads in DnsMessage subtypes, which were needed to alter the return type in overloaded methods, to instead parameterize the type on itself and return the type parameter - i.e. DnsMessage<M extends ReferenceCounted & DnsMessage>.

Result:

Implementations don't need casts, and supertype implementations of self-type returning methods do the right thing without needing overloads that just call the super method.
