### PR TITLE
InternalThreadLocalMap.arrayList should create a reusable ArrayList only if arrayList field is NULL.

### DIFF
--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -192,14 +192,15 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
         return arrayList(DEFAULT_ARRAY_LIST_INITIAL_CAPACITY);
     }
 
+    @SuppressWarnings("unchecked")
     public <E> ArrayList<E> arrayList(int minCapacity) {
         ArrayList<E> list = (ArrayList<E>) arrayList;
         if (list == null) {
-            list = (ArrayList<E>) new ArrayList<Object>(minCapacity);
-        } else {
-            list.clear();
-            list.ensureCapacity(minCapacity);
+            arrayList = new ArrayList<Object>(minCapacity);
+            return (ArrayList<E>) arrayList;
         }
+        list.clear();
+        list.ensureCapacity(minCapacity);
         return list;
     }
 


### PR DESCRIPTION
Motivation:

InternalThreadLocalMap.arrayList returns a new ArrayList every time it's called that defeats the purpose of having a reusable ArrayList.

Modification:

Modified InternalThreadLocalMap.arrayList to create an ArrayList only if arrayList field is NULL.

Result:

InternalThreadLocalMap.arrayList now creates a reusable ArrayList only if arrayList field is NULL.

