### PR TITLE
Correct fail write with NotYetConnectedException when OioDatagramChan…

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -194,10 +194,7 @@ public class DatagramUnicastTest extends AbstractDatagramTest {
 
             ChannelFuture future = cc.writeAndFlush(
                     buf.retain().duplicate()).awaitUninterruptibly();
-            if (!(cc instanceof OioDatagramChannel)) {
-                // TODO: Also handle OIO
-                assertTrue(future.cause() instanceof NotYetConnectedException);
-            }
+            assertTrue(future.cause() instanceof NotYetConnectedException);
         } finally {
             // release as we used buf.retain() before
             buf.release();


### PR DESCRIPTION
…nel is not connected yet.

Motivation:

NioDatagramChannel fails a write with NotYetConnectedException when the DatagramChannel was not yet connected and a ByteBuf is written. The same should be done for OioDatagramChannel as well.

Modifications:

Make OioDatagramChannel consistent with NioDatagramChannel

Result:

Correct and consistent implementations of DatagramChannel