### PR TITLE
EPOLL RDHUP processing

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollRecvByteAllocatorStreamingHandle.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollRecvByteAllocatorStreamingHandle.java
@@ -28,7 +28,9 @@ final class EpollRecvByteAllocatorStreamingHandle extends EpollRecvByteAllocator
         /**
          * For stream oriented descriptors we can assume we are done reading if the last read attempt didn't produce
          * a full buffer (see Q9 in <a href="http://man7.org/linux/man-pages/man7/epoll.7.html">epoll man</a>).
+         *
+         * If EPOLLRDHUP has been received we must read until we get a read error.
          */
-        return isEdgeTriggered() && lastBytesRead() == attemptedBytesRead();
+        return isEdgeTriggered() && (lastBytesRead() == attemptedBytesRead() || isReceivedRdHup());
     }
 }


### PR DESCRIPTION
Motivation:
EpollRecvByteAllocatorHandle will read unconditionally if EPOLLRDHUP has been received. However we can just treat this the same was we do as data maybe pending in ET mode, and let LT mode notify us if we haven't read all data.

Modifications:
- EpollRecvByteAllocatorHandle should not always force a read just because EPOLLRDHUP has been received, but just treated as an indicator that there maybe more data to read in ET mode

Result:
Fixes https://github.com/netty/netty/issues/6173.
