### PR TITLE
HTTP/2 relax test timeouts

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -222,7 +222,7 @@ public class DefaultHttp2ConnectionTest {
                 return true;
             }
         });
-        assertTrue(latch.await(2, TimeUnit.SECONDS));
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
     }
 
     @Test
@@ -256,7 +256,7 @@ public class DefaultHttp2ConnectionTest {
                 }
             });
         }
-        assertTrue(latch.await(2, TimeUnit.SECONDS));
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
     }
 
     @Test
@@ -1183,7 +1183,7 @@ public class DefaultHttp2ConnectionTest {
                 latch.countDown();
             }
         });
-        assertTrue(latch.await(2, TimeUnit.SECONDS));
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
     }
 
     private void incrementAndGetStreamShouldRespectOverflow(Endpoint<?> endpoint, int streamId) throws Http2Exception {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2CodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2CodecTest.java
@@ -83,7 +83,7 @@ public class Http2CodecTest {
                 .group(group)
                 .handler(new Http2Codec(false, new TestChannelInitializer()));
         clientChannel = cb.connect(serverAddress).sync().channel();
-        assertTrue(serverChannelLatch.await(2, TimeUnit.SECONDS));
+        assertTrue(serverChannelLatch.await(5, TimeUnit.SECONDS));
     }
 
     @AfterClass

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -195,7 +195,7 @@ public class Http2ConnectionRoundtripTest {
             }
         });
 
-        assertTrue(requestLatch.await(2, SECONDS));
+        assertTrue(requestLatch.await(5, SECONDS));
         verify(serverListener).onHeadersRead(any(ChannelHandlerContext.class), eq(3), eq(headers),
                 eq(0), eq(weight), eq(false), eq(0), eq(true));
         // Wait for some time to see if a go_away or reset frame will be received.
@@ -578,7 +578,7 @@ public class Http2ConnectionRoundtripTest {
         assertTrue(ccf.awaitUninterruptibly().isSuccess());
         clientChannel = ccf.channel();
         http2Client = clientChannel.pipeline().get(Http2ConnectionHandler.class);
-        assertTrue(serverInitLatch.await(2, TimeUnit.SECONDS));
+        assertTrue(serverInitLatch.await(5, TimeUnit.SECONDS));
         http2Server = serverHandlerRef.get();
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -732,7 +732,7 @@ public class InboundHttp2ToHttpAdapterTest {
                 clientChannel.flush();
             }
         });
-        assertTrue(settingsLatch.await(3, SECONDS));
+        assertTrue(settingsLatch.await(5, SECONDS));
         ArgumentCaptor<Http2Settings> settingsCaptor = ArgumentCaptor.forClass(Http2Settings.class);
         verify(settingsListener, times(2)).messageReceived(settingsCaptor.capture());
         assertEquals(settings, settingsCaptor.getValue());
@@ -826,7 +826,7 @@ public class InboundHttp2ToHttpAdapterTest {
         ChannelFuture ccf = cb.connect(serverChannel.localAddress());
         assertTrue(ccf.awaitUninterruptibly().isSuccess());
         clientChannel = ccf.channel();
-        assertTrue(serverChannelLatch.await(2, SECONDS));
+        assertTrue(serverChannelLatch.await(5, SECONDS));
     }
 
     private void cleanupCapturedRequests() {
@@ -848,19 +848,19 @@ public class InboundHttp2ToHttpAdapterTest {
     }
 
     private void awaitRequests() throws Exception {
-        assertTrue(serverLatch.await(3, SECONDS));
+        assertTrue(serverLatch.await(5, SECONDS));
     }
 
     private void awaitResponses() throws Exception {
-        assertTrue(clientLatch.await(3, SECONDS));
+        assertTrue(clientLatch.await(5, SECONDS));
     }
 
     private void awaitRequests2() throws Exception {
-        assertTrue(serverLatch2.await(3, SECONDS));
+        assertTrue(serverLatch2.await(5, SECONDS));
     }
 
     private void awaitResponses2() throws Exception {
-        assertTrue(clientLatch2.await(3, SECONDS));
+        assertTrue(clientLatch2.await(5, SECONDS));
     }
 
     private ChannelHandlerContext ctxClient() {


### PR DESCRIPTION
Motivation:
Build failures have been observed with 2 second timeouts on the CI servers. We should make the timeouts longer to reduce false positive test failures due to tests timing out prematurely.

Modifications:
- Increase timeouts from 2 and 3 seconds to 5 seconds.

Result:
Less false positive test failures.
