### PR TITLE
HTTP/2 limit reserved streams

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -166,12 +166,6 @@ public interface Http2Connection {
         boolean created(Http2Stream stream);
 
         /**
-         * Indicates whether or a stream created by this endpoint can be opened without violating
-         * {@link #maxActiveStreams()}.
-         */
-        boolean canOpenStream();
-
-        /**
          * Creates a stream initiated by this endpoint. This could fail for the following reasons:
          * <ul>
          * <li>The requested stream ID is not the next sequential ID for this endpoint.</li>

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -374,7 +374,9 @@ public class DefaultHttp2ConnectionTest {
         Http2Stream pushStream = server.local().reservePushStream(2, stream);
         assertEquals(2, pushStream.id());
         assertEquals(State.RESERVED_LOCAL, pushStream.state());
-        assertEquals(1, server.numActiveStreams());
+        assertEquals(2, server.numActiveStreams());
+        assertEquals(1, server.local().numActiveStreams());
+        assertEquals(server.local().numActiveStreams(), server.remote().numActiveStreams());
         assertEquals(2, server.local().lastStreamCreated());
     }
 
@@ -384,7 +386,9 @@ public class DefaultHttp2ConnectionTest {
         Http2Stream pushStream = server.local().reservePushStream(4, stream);
         assertEquals(4, pushStream.id());
         assertEquals(State.RESERVED_LOCAL, pushStream.state());
-        assertEquals(1, server.numActiveStreams());
+        assertEquals(2, server.numActiveStreams());
+        assertEquals(1, server.local().numActiveStreams());
+        assertEquals(server.local().numActiveStreams(), server.remote().numActiveStreams());
         assertEquals(4, server.local().lastStreamCreated());
     }
 


### PR DESCRIPTION
Motivation:
The HTTP/2 RFC provides conflicting direction on how reserved streams should be limited. [Seciton 5.1.2](https://tools.ietf.org/html/rfc7540#section-5.1.2) states `Streams in either of the "reserved" states do not count toward the stream limit.` and [Section 8.2.2](https://tools.ietf.org/html/rfc7540#section-8.2.2) states `A client can use the SETTINGS_MAX_CONCURRENT_STREAMS setting to limit the number of responses that can be concurrently pushed by a server.`. We currently honor section 5.1.2 but this means we have have an implementation specific heuristic to limit on the number of reserved streams.

Modifications:
- Follow section 8.2.2 and include reserved streams toward the SETTINGS_MAX_CONCURRENT_STREAMS count.

Result:
The number of streams in the reserved states are limited according to the RFC instead of an implementation specific heuristic.