### PR TITLE
Fix possible IOOBE when calling ReferenceCountedSslEngine.unwrap(...)…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -422,12 +422,14 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             final ByteBuf buf = alloc.directBuffer(len);
             try {
                 final long addr = memoryAddress(buf);
+
+                // Set the limit depending on the length of the allocated buffer and restore the original
+                // after we copied bytes.
+                int limit = src.limit();
                 int newLimit = pos + len;
-                if (newLimit != src.remaining()) {
-                    buf.setBytes(0, (ByteBuffer) src.duplicate().position(pos).limit(newLimit));
-                } else {
-                    buf.setBytes(0, src);
-                }
+                src.limit(newLimit);
+                buf.setBytes(0, src);
+                src.limit(limit);
 
                 netWrote = SSL.writeToBIO(networkBIO, addr, len);
                 if (netWrote >= 0) {


### PR DESCRIPTION
… with heap buffers.

Motivation:

fc3c9c9523150190760801dd0fbf014909519942 introduced a bug which will have ReferenceCountedSslEngine.unwrap(...) produce an IOOBE when be called with an BŷteBuffer as src that contains multiple SSLRecords and has a position != 0.

Modification:

- Correctly set the limit on the ByteBuffer and so fix the IOOBE.
- Add test-case to verify the fix

Result:

Correctly handle heap buffers as well.