### PR TITLE
Do not replace System.err during Slf4LoggerFactory construction

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
@@ -19,16 +19,13 @@ package io.netty.util.internal.logging;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.NOPLoggerFactory;
 
-import java.io.OutputStream;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
-
 /**
  * Logger factory which creates a <a href="http://www.slf4j.org/">SLF4J</a>
  * logger.
  */
 public class Slf4JLoggerFactory extends InternalLoggerFactory {
 
+    @SuppressWarnings("deprecation")
     public static final InternalLoggerFactory INSTANCE = new Slf4JLoggerFactory();
 
     /**
@@ -40,31 +37,8 @@ public class Slf4JLoggerFactory extends InternalLoggerFactory {
 
     Slf4JLoggerFactory(boolean failIfNOP) {
         assert failIfNOP; // Should be always called with true.
-
-        // SFL4J writes it error messages to System.err. Capture them so that the user does not see such a message on
-        // the console during automatic detection.
-        final StringBuffer buf = new StringBuffer();
-        final PrintStream err = System.err;
-        try {
-            System.setErr(new PrintStream(new OutputStream() {
-                @Override
-                public void write(int b) {
-                    buf.append((char) b);
-                }
-            }, true, "US-ASCII"));
-        } catch (UnsupportedEncodingException e) {
-            throw new Error(e);
-        }
-
-        try {
-            if (LoggerFactory.getILoggerFactory() instanceof NOPLoggerFactory) {
-                throw new NoClassDefFoundError(buf.toString());
-            } else {
-                err.print(buf);
-                err.flush();
-            }
-        } finally {
-            System.setErr(err);
+        if (LoggerFactory.getILoggerFactory() instanceof NOPLoggerFactory) {
+            throw new NoClassDefFoundError("NOPLoggerFactory not supported");
         }
     }
 


### PR DESCRIPTION
Motivation:

Replacing System.err during Slf4LoggerFactory construction is problematic as another class may optain the System.err reference before we set it back to the original value.

Modifications:

Remove code that temporary replaced System.err.

Result:

Fixes [#6212].