### PR TITLE
Add SslCloseCompletionEvent that is fired once a close_notify was rec…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslCloseCompletionEvent.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslCloseCompletionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 The Netty Project
+ * Copyright 2017 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,25 +15,23 @@
  */
 package io.netty.handler.ssl;
 
-
 /**
- * Event that is fired once the SSL handshake is complete, which may be because it was successful or there
- * was an error.
+ * Event that is fired once the close_notify was received or if an failure happens before it was received.
  */
-public final class SslHandshakeCompletionEvent extends SslCompletionEvent {
+public final class SslCloseCompletionEvent extends SslCompletionEvent {
 
-    public static final SslHandshakeCompletionEvent SUCCESS = new SslHandshakeCompletionEvent();
-
-    /**
-     * Creates a new event that indicates a successful handshake.
-     */
-    private SslHandshakeCompletionEvent() { }
+    public static final SslCloseCompletionEvent SUCCESS = new SslCloseCompletionEvent();
 
     /**
-     * Creates a new event that indicates an unsuccessful handshake.
-     * Use {@link #SUCCESS} to indicate a successful handshake.
+     * Creates a new event that indicates a successful receiving of close_notify.
      */
-    public SslHandshakeCompletionEvent(Throwable cause) {
+    private SslCloseCompletionEvent() { }
+
+    /**
+     * Creates a new event that indicates an close_notify was not received because of an previous error.
+     * Use {@link #SUCCESS} to indicate a success.
+     */
+    public SslCloseCompletionEvent(Throwable cause) {
         super(cause);
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/SslCompletionEvent.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslCompletionEvent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import io.netty.util.internal.ObjectUtil;
+
+public abstract class SslCompletionEvent {
+
+    private final Throwable cause;
+
+    SslCompletionEvent() {
+        cause = null;
+    }
+
+    SslCompletionEvent(Throwable cause) {
+        this.cause = ObjectUtil.checkNotNull(cause, "cause");
+    }
+
+    /**
+     * Return {@code true} if the completion was successful
+     */
+    public final boolean isSuccess() {
+        return cause == null;
+    }
+
+    /**
+     * Return the {@link Throwable} if {@link #isSuccess()} returns {@code false}
+     * and so the completion failed.
+     */
+    public final Throwable cause() {
+        return cause;
+    }
+
+    @Override
+    public final String toString() {
+        final Throwable cause = cause();
+        return cause == null? getClass().getSimpleName() + "(SUCCESS)" :
+                getClass().getSimpleName() +  '(' + cause + ')';
+    }
+}

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -772,7 +772,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         setHandshakeFailure(ctx, CHANNEL_CLOSED, !outboundClosed);
 
         // Ensure we always notify the sslClosePromise as well
-        sslClosePromise.tryFailure(CHANNEL_CLOSED);
+        notifyClosePromise(CHANNEL_CLOSED);
         super.channelInactive(ctx);
     }
 
@@ -1132,7 +1132,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             }
 
             if (notifyClosure) {
-                sslClosePromise.trySuccess(ctx.channel());
+                notifyClosePromise(null);
             }
         } finally {
             if (decodeOut != null) {
@@ -1288,6 +1288,18 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     private void notifyHandshakeFailure(Throwable cause) {
         if (handshakePromise.tryFailure(cause)) {
             SslUtils.notifyHandshakeFailure(ctx, cause);
+        }
+    }
+
+    private void notifyClosePromise(Throwable cause) {
+        if (cause == null) {
+            if (sslClosePromise.trySuccess(ctx.channel())) {
+                ctx.fireUserEventTriggered(SslCloseCompletionEvent.SUCCESS);
+            }
+        } else {
+            if (sslClosePromise.tryFailure(cause)) {
+                ctx.fireUserEventTriggered(new SslCloseCompletionEvent(cause));
+            }
         }
     }
 


### PR DESCRIPTION
…eived

Motivation:

For the completion of a handshake we already fire a SslHandshakeCompletionEvent which the user can intercept. We should do the same for the receiving of close_notify.

Modifications:

Add SslCloseCompletionEvent and test-case.

Result:

More consistent API.