### PR TITLE
Proxy protocol tlv

### DIFF
--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxySSLTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxySSLTLV.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.haproxy;
+
+import io.netty.buffer.ByteBuf;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents a {@link HAProxyTLV} of the type {@link HAProxyTLV.Type#PP2_TYPE_SSL}.
+ * This TLV encapsulates other TLVs and has additional information like verification information and a client bitfield.
+ */
+public final class HAProxySSLTLV extends HAProxyTLV {
+
+    private final int verify;
+    private final List<HAProxyTLV> tlvs;
+    private final byte clientBitField;
+
+    /**
+     * Creates a new HAProxySSLTLV
+     *
+     * @param verify the verification result as defined in the specification for the pp2_tlv_ssl struct (see
+     * http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt)
+     * @param clientBitField the bitfield with client information
+     * @param tlvs the encapsulated {@link HAProxyTLV}s
+     * @param rawContent the raw TLV content
+     */
+    HAProxySSLTLV(final int verify, final byte clientBitField, final List<HAProxyTLV> tlvs, final ByteBuf rawContent) {
+        super(Type.PP2_TYPE_SSL, (byte) 0x20, rawContent);
+
+        this.verify = verify;
+        this.tlvs = Collections.unmodifiableList(tlvs);
+        this.clientBitField = clientBitField;
+    }
+
+    /**
+     * Returns {@code true} if the bit field for PP2_CLIENT_CERT_CONN was set
+     */
+    public boolean isPP2ClientCertConn() {
+        return (clientBitField & 0x2) != 0;
+    }
+
+    /**
+     * Returns {@code true} if the bit field for PP2_CLIENT_SSL was set
+     */
+    public boolean isPP2ClientSSL() {
+        return (clientBitField & 0x1) != 0;
+    }
+
+    /**
+     * Returns {@code true} if the bit field for PP2_CLIENT_CERT_SESS was set
+     */
+    public boolean isPP2ClientCertSess() {
+        return (clientBitField & 0x4) != 0;
+    }
+
+    /**
+     * Returns the verification result
+     */
+    public int verify() {
+        return verify;
+    }
+
+    /**
+     * Returns an unmodifiable Set of encapsulated {@link HAProxyTLV}s.
+     */
+    public List<HAProxyTLV> encapsulatedTLVs() {
+        return tlvs;
+    }
+
+}

--- a/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyTLV.java
+++ b/codec-haproxy/src/main/java/io/netty/handler/codec/haproxy/HAProxyTLV.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.haproxy;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.DefaultByteBufHolder;
+
+import static io.netty.util.internal.ObjectUtil.*;
+
+/**
+ * A Type-Length Value (TLV vector) that can be added to the PROXY protocol
+ * to include additional information like SSL information.
+ *
+ * @see HAProxySSLTLV
+ */
+public class HAProxyTLV extends DefaultByteBufHolder {
+
+    private final Type type;
+    private final byte typeByteValue;
+
+    /**
+     * The registered types a TLV can have regarding the PROXY protocol 1.5 spec
+     */
+    public enum Type {
+        PP2_TYPE_ALPN,
+        PP2_TYPE_AUTHORITY,
+        PP2_TYPE_SSL,
+        PP2_TYPE_SSL_VERSION,
+        PP2_TYPE_SSL_CN,
+        PP2_TYPE_NETNS,
+        /**
+         * A TLV type that is not officially defined in the spec. May be used for nonstandard TLVs
+         */
+        OTHER;
+
+        /**
+         * Returns the the {@link Type} for a specific byte value as defined in the PROXY protocol 1.5 spec
+         * <p>
+         * If the byte value is not an official one, it will return {@link Type#OTHER}.
+         *
+         * @param byteValue the byte for a type
+         *
+         * @return the {@link Type} of a TLV
+         */
+        public static Type typeForByteValue(final byte byteValue) {
+            switch (byteValue) {
+            case 0x01:
+                return PP2_TYPE_ALPN;
+            case 0x02:
+                return PP2_TYPE_AUTHORITY;
+            case 0x20:
+                return PP2_TYPE_SSL;
+            case 0x21:
+                return PP2_TYPE_SSL_VERSION;
+            case 0x22:
+                return PP2_TYPE_SSL_CN;
+            case 0x30:
+                return PP2_TYPE_NETNS;
+            default:
+                return OTHER;
+            }
+        }
+    }
+
+    /**
+     * Creates a new HAProxyTLV
+     *
+     * @param type the {@link Type} of the TLV
+     * @param typeByteValue the byteValue of the TLV. This is especially important if non-standard TLVs are used
+     * @param content the raw content of the TLV
+     */
+    HAProxyTLV(final Type type, final byte typeByteValue, final ByteBuf content) {
+        super(content);
+        checkNotNull(type, "type");
+
+        this.type = type;
+        this.typeByteValue = typeByteValue;
+    }
+
+    /**
+     * Returns the {@link Type} of this TLV
+     */
+    public Type type() {
+        return type;
+    }
+
+    /**
+     * Returns the type of the TLV as byte
+     */
+    public byte typeByteValue() {
+        return typeByteValue;
+    }
+
+    @Override
+    public HAProxyTLV copy() {
+        return replace(content().copy());
+    }
+
+    @Override
+    public HAProxyTLV duplicate() {
+        return replace(content().duplicate());
+    }
+
+    @Override
+    public HAProxyTLV retainedDuplicate() {
+        return replace(content().retainedDuplicate());
+    }
+
+    @Override
+    public HAProxyTLV replace(ByteBuf content) {
+        return new HAProxyTLV(type, typeByteValue, content);
+    }
+
+    @Override
+    public HAProxyTLV retain() {
+        super.retain();
+        return this;
+    }
+
+    @Override
+    public HAProxyTLV retain(int increment) {
+        super.retain(increment);
+        return this;
+    }
+
+    @Override
+    public HAProxyTLV touch() {
+        super.touch();
+        return this;
+    }
+
+    @Override
+    public HAProxyTLV touch(Object hint) {
+        super.touch(hint);
+        return this;
+    }
+}

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxyMessageDecoderTest.java
@@ -26,6 +26,8 @@ import io.netty.util.CharsetUtil;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
+
 import static io.netty.buffer.Unpooled.*;
 import static org.junit.Assert.*;
 
@@ -155,7 +157,7 @@ public class HAProxyMessageDecoderTest {
     @Test(expected = HAProxyProtocolException.class)
     public void testHeaderTooLong() {
         String header = "PROXY TCP4 192.168.0.1 192.168.0.11 56324 " +
-                "00000000000000000000000000000000000000000000000000000000000000000443\r\n";
+                        "00000000000000000000000000000000000000000000000000000000000000000443\r\n";
         ch.writeInbound(copiedBuffer(header, CharsetUtil.US_ASCII));
     }
 
@@ -212,16 +214,16 @@ public class HAProxyMessageDecoderTest {
     @Test
     public void testV2IPV4Decode() {
         byte[] header = new byte[28];
-        header[0]  = 0x0D; // Binary Prefix
-        header[1]  = 0x0A; // -----
-        header[2]  = 0x0D; // -----
-        header[3]  = 0x0A; // -----
-        header[4]  = 0x00; // -----
-        header[5]  = 0x0D; // -----
-        header[6]  = 0x0A; // -----
-        header[7]  = 0x51; // -----
-        header[8]  = 0x55; // -----
-        header[9]  = 0x49; // -----
+        header[0] = 0x0D; // Binary Prefix
+        header[1] = 0x0A; // -----
+        header[2] = 0x0D; // -----
+        header[3] = 0x0A; // -----
+        header[4] = 0x00; // -----
+        header[5] = 0x0D; // -----
+        header[6] = 0x0A; // -----
+        header[7] = 0x51; // -----
+        header[8] = 0x55; // -----
+        header[9] = 0x49; // -----
         header[10] = 0x54; // -----
         header[11] = 0x0A; // -----
 
@@ -267,16 +269,16 @@ public class HAProxyMessageDecoderTest {
     @Test
     public void testV2UDPDecode() {
         byte[] header = new byte[28];
-        header[0]  = 0x0D; // Binary Prefix
-        header[1]  = 0x0A; // -----
-        header[2]  = 0x0D; // -----
-        header[3]  = 0x0A; // -----
-        header[4]  = 0x00; // -----
-        header[5]  = 0x0D; // -----
-        header[6]  = 0x0A; // -----
-        header[7]  = 0x51; // -----
-        header[8]  = 0x55; // -----
-        header[9]  = 0x49; // -----
+        header[0] = 0x0D; // Binary Prefix
+        header[1] = 0x0A; // -----
+        header[2] = 0x0D; // -----
+        header[3] = 0x0A; // -----
+        header[4] = 0x00; // -----
+        header[5] = 0x0D; // -----
+        header[6] = 0x0A; // -----
+        header[7] = 0x51; // -----
+        header[8] = 0x55; // -----
+        header[9] = 0x49; // -----
         header[10] = 0x54; // -----
         header[11] = 0x0A; // -----
 
@@ -322,16 +324,16 @@ public class HAProxyMessageDecoderTest {
     @Test
     public void testv2IPV6Decode() {
         byte[] header = new byte[52];
-        header[0]  = 0x0D; // Binary Prefix
-        header[1]  = 0x0A; // -----
-        header[2]  = 0x0D; // -----
-        header[3]  = 0x0A; // -----
-        header[4]  = 0x00; // -----
-        header[5]  = 0x0D; // -----
-        header[6]  = 0x0A; // -----
-        header[7]  = 0x51; // -----
-        header[8]  = 0x55; // -----
-        header[9]  = 0x49; // -----
+        header[0] = 0x0D; // Binary Prefix
+        header[1] = 0x0A; // -----
+        header[2] = 0x0D; // -----
+        header[3] = 0x0A; // -----
+        header[4] = 0x00; // -----
+        header[5] = 0x0D; // -----
+        header[6] = 0x0A; // -----
+        header[7] = 0x51; // -----
+        header[8] = 0x55; // -----
+        header[9] = 0x49; // -----
         header[10] = 0x54; // -----
         header[11] = 0x0A; // -----
 
@@ -401,16 +403,16 @@ public class HAProxyMessageDecoderTest {
     @Test
     public void testv2UnixDecode() {
         byte[] header = new byte[232];
-        header[0]  = 0x0D; // Binary Prefix
-        header[1]  = 0x0A; // -----
-        header[2]  = 0x0D; // -----
-        header[3]  = 0x0A; // -----
-        header[4]  = 0x00; // -----
-        header[5]  = 0x0D; // -----
-        header[6]  = 0x0A; // -----
-        header[7]  = 0x51; // -----
-        header[8]  = 0x55; // -----
-        header[9]  = 0x49; // -----
+        header[0] = 0x0D; // Binary Prefix
+        header[1] = 0x0A; // -----
+        header[2] = 0x0D; // -----
+        header[3] = 0x0A; // -----
+        header[4] = 0x00; // -----
+        header[5] = 0x0D; // -----
+        header[6] = 0x0A; // -----
+        header[7] = 0x51; // -----
+        header[8] = 0x55; // -----
+        header[9] = 0x49; // -----
         header[10] = 0x54; // -----
         header[11] = 0x0A; // -----
 
@@ -479,16 +481,16 @@ public class HAProxyMessageDecoderTest {
     @Test
     public void testV2LocalProtocolDecode() {
         byte[] header = new byte[28];
-        header[0]  = 0x0D; // Binary Prefix
-        header[1]  = 0x0A; // -----
-        header[2]  = 0x0D; // -----
-        header[3]  = 0x0A; // -----
-        header[4]  = 0x00; // -----
-        header[5]  = 0x0D; // -----
-        header[6]  = 0x0A; // -----
-        header[7]  = 0x51; // -----
-        header[8]  = 0x55; // -----
-        header[9]  = 0x49; // -----
+        header[0] = 0x0D; // Binary Prefix
+        header[1] = 0x0A; // -----
+        header[2] = 0x0D; // -----
+        header[3] = 0x0A; // -----
+        header[4] = 0x00; // -----
+        header[5] = 0x0D; // -----
+        header[6] = 0x0A; // -----
+        header[7] = 0x51; // -----
+        header[8] = 0x55; // -----
+        header[9] = 0x49; // -----
         header[10] = 0x54; // -----
         header[11] = 0x0A; // -----
 
@@ -534,16 +536,16 @@ public class HAProxyMessageDecoderTest {
     @Test
     public void testV2UnknownProtocolDecode() {
         byte[] header = new byte[28];
-        header[0]  = 0x0D; // Binary Prefix
-        header[1]  = 0x0A; // -----
-        header[2]  = 0x0D; // -----
-        header[3]  = 0x0A; // -----
-        header[4]  = 0x00; // -----
-        header[5]  = 0x0D; // -----
-        header[6]  = 0x0A; // -----
-        header[7]  = 0x51; // -----
-        header[8]  = 0x55; // -----
-        header[9]  = 0x49; // -----
+        header[0] = 0x0D; // Binary Prefix
+        header[1] = 0x0A; // -----
+        header[2] = 0x0D; // -----
+        header[3] = 0x0A; // -----
+        header[4] = 0x00; // -----
+        header[5] = 0x0D; // -----
+        header[6] = 0x0A; // -----
+        header[7] = 0x51; // -----
+        header[8] = 0x55; // -----
+        header[9] = 0x49; // -----
         header[10] = 0x54; // -----
         header[11] = 0x0A; // -----
 
@@ -587,20 +589,85 @@ public class HAProxyMessageDecoderTest {
     }
 
     @Test
+    public void testV2WithSslTLVs() throws Exception {
+        ch = new EmbeddedChannel(new HAProxyMessageDecoder());
+
+        final byte[] bytes = {
+                13, 10, 13, 10, 0, 13, 10, 81, 85, 73, 84, 10, 33, 17, 0, 35, 127, 0, 0, 1, 127, 0, 0, 1,
+                -55, -90, 7, 89, 32, 0, 20, 5, 0, 0, 0, 0, 33, 0, 5, 84, 76, 83, 118, 49, 34, 0, 4, 76, 69, 65, 70
+        };
+
+        int startChannels = ch.pipeline().names().size();
+        assertTrue(ch.writeInbound(copiedBuffer(bytes)));
+        Object msgObj = ch.readInbound();
+        assertEquals(startChannels - 1, ch.pipeline().names().size());
+        HAProxyMessage msg = (HAProxyMessage) msgObj;
+
+        assertEquals(HAProxyProtocolVersion.V2, msg.protocolVersion());
+        assertEquals(HAProxyCommand.PROXY, msg.command());
+        assertEquals(HAProxyProxiedProtocol.TCP4, msg.proxiedProtocol());
+        assertEquals("127.0.0.1", msg.sourceAddress());
+        assertEquals("127.0.0.1", msg.destinationAddress());
+        assertEquals(51622, msg.sourcePort());
+        assertEquals(1881, msg.destinationPort());
+        final List<HAProxyTLV> tlvs = msg.tlvs();
+
+        assertEquals(3, tlvs.size());
+        final HAProxyTLV firstTlv = tlvs.get(0);
+        assertEquals(HAProxyTLV.Type.PP2_TYPE_SSL, firstTlv.type());
+        final HAProxySSLTLV sslTlv = (HAProxySSLTLV) firstTlv;
+        assertEquals(0, sslTlv.verify());
+        assertTrue(sslTlv.isPP2ClientSSL());
+        assertTrue(sslTlv.isPP2ClientCertSess());
+        assertFalse(sslTlv.isPP2ClientCertConn());
+
+        final HAProxyTLV secondTlv = tlvs.get(1);
+
+        assertEquals(HAProxyTLV.Type.PP2_TYPE_SSL_VERSION, secondTlv.type());
+        ByteBuf secondContentBuf = secondTlv.content();
+        byte[] secondContent = new byte[secondContentBuf.readableBytes()];
+        secondContentBuf.readBytes(secondContent);
+        assertArrayEquals("TLSv1".getBytes(CharsetUtil.US_ASCII), secondContent);
+
+        final HAProxyTLV thirdTLV = tlvs.get(2);
+        assertEquals(HAProxyTLV.Type.PP2_TYPE_SSL_CN, thirdTLV.type());
+        ByteBuf thirdContentBuf = thirdTLV.content();
+        byte[] thirdContent = new byte[thirdContentBuf.readableBytes()];
+        thirdContentBuf.readBytes(thirdContent);
+        assertArrayEquals("LEAF".getBytes(CharsetUtil.US_ASCII), thirdContent);
+
+        assertTrue(sslTlv.encapsulatedTLVs().contains(secondTlv));
+        assertTrue(sslTlv.encapsulatedTLVs().contains(thirdTLV));
+
+        assertTrue(0 < firstTlv.refCnt());
+        assertTrue(0 < secondTlv.refCnt());
+        assertTrue(0 < thirdTLV.refCnt());
+        assertFalse(thirdTLV.release());
+        assertFalse(secondTlv.release());
+        assertTrue(firstTlv.release());
+        assertEquals(0, firstTlv.refCnt());
+        assertEquals(0, secondTlv.refCnt());
+        assertEquals(0, thirdTLV.refCnt());
+
+        assertNull(ch.readInbound());
+        assertFalse(ch.finish());
+    }
+
+    @Test
     public void testV2WithTLV() {
         ch = new EmbeddedChannel(new HAProxyMessageDecoder(4));
 
         byte[] header = new byte[236];
-        header[0]  = 0x0D; // Binary Prefix
-        header[1]  = 0x0A; // -----
-        header[2]  = 0x0D; // -----
-        header[3]  = 0x0A; // -----
-        header[4]  = 0x00; // -----
-        header[5]  = 0x0D; // -----
-        header[6]  = 0x0A; // -----
-        header[7]  = 0x51; // -----
-        header[8]  = 0x55; // -----
-        header[9]  = 0x49; // -----
+        header[0] = 0x0D; // Binary Prefix
+        header[1] = 0x0A; // -----
+        header[2] = 0x0D; // -----
+        header[3] = 0x0A; // -----
+        header[4] = 0x00; // -----
+        header[5] = 0x0D; // -----
+        header[6] = 0x0A; // -----
+        header[7] = 0x51; // -----
+        header[8] = 0x55; // -----
+        header[9] = 0x49; // -----
         header[10] = 0x54; // -----
         header[11] = 0x0A; // -----
 
@@ -676,16 +743,16 @@ public class HAProxyMessageDecoderTest {
     @Test(expected = HAProxyProtocolException.class)
     public void testV2InvalidProtocol() {
         byte[] header = new byte[28];
-        header[0]  = 0x0D; // Binary Prefix
-        header[1]  = 0x0A; // -----
-        header[2]  = 0x0D; // -----
-        header[3]  = 0x0A; // -----
-        header[4]  = 0x00; // -----
-        header[5]  = 0x0D; // -----
-        header[6]  = 0x0A; // -----
-        header[7]  = 0x51; // -----
-        header[8]  = 0x55; // -----
-        header[9]  = 0x49; // -----
+        header[0] = 0x0D; // Binary Prefix
+        header[1] = 0x0A; // -----
+        header[2] = 0x0D; // -----
+        header[3] = 0x0A; // -----
+        header[4] = 0x00; // -----
+        header[5] = 0x0D; // -----
+        header[6] = 0x0A; // -----
+        header[7] = 0x51; // -----
+        header[8] = 0x55; // -----
+        header[9] = 0x49; // -----
         header[10] = 0x54; // -----
         header[11] = 0x0A; // -----
 
@@ -717,16 +784,16 @@ public class HAProxyMessageDecoderTest {
     @Test(expected = HAProxyProtocolException.class)
     public void testV2MissingParams() {
         byte[] header = new byte[26];
-        header[0]  = 0x0D; // Binary Prefix
-        header[1]  = 0x0A; // -----
-        header[2]  = 0x0D; // -----
-        header[3]  = 0x0A; // -----
-        header[4]  = 0x00; // -----
-        header[5]  = 0x0D; // -----
-        header[6]  = 0x0A; // -----
-        header[7]  = 0x51; // -----
-        header[8]  = 0x55; // -----
-        header[9]  = 0x49; // -----
+        header[0] = 0x0D; // Binary Prefix
+        header[1] = 0x0A; // -----
+        header[2] = 0x0D; // -----
+        header[3] = 0x0A; // -----
+        header[4] = 0x00; // -----
+        header[5] = 0x0D; // -----
+        header[6] = 0x0A; // -----
+        header[7] = 0x51; // -----
+        header[8] = 0x55; // -----
+        header[9] = 0x49; // -----
         header[10] = 0x54; // -----
         header[11] = 0x0A; // -----
 
@@ -755,16 +822,16 @@ public class HAProxyMessageDecoderTest {
     @Test(expected = HAProxyProtocolException.class)
     public void testV2InvalidCommand() {
         byte[] header = new byte[28];
-        header[0]  = 0x0D; // Binary Prefix
-        header[1]  = 0x0A; // -----
-        header[2]  = 0x0D; // -----
-        header[3]  = 0x0A; // -----
-        header[4]  = 0x00; // -----
-        header[5]  = 0x0D; // -----
-        header[6]  = 0x0A; // -----
-        header[7]  = 0x51; // -----
-        header[8]  = 0x55; // -----
-        header[9]  = 0x49; // -----
+        header[0] = 0x0D; // Binary Prefix
+        header[1] = 0x0A; // -----
+        header[2] = 0x0D; // -----
+        header[3] = 0x0A; // -----
+        header[4] = 0x00; // -----
+        header[5] = 0x0D; // -----
+        header[6] = 0x0A; // -----
+        header[7] = 0x51; // -----
+        header[8] = 0x55; // -----
+        header[9] = 0x49; // -----
         header[10] = 0x54; // -----
         header[11] = 0x0A; // -----
 
@@ -796,16 +863,16 @@ public class HAProxyMessageDecoderTest {
     @Test(expected = HAProxyProtocolException.class)
     public void testV2InvalidVersion() {
         byte[] header = new byte[28];
-        header[0]  = 0x0D; // Binary Prefix
-        header[1]  = 0x0A; // -----
-        header[2]  = 0x0D; // -----
-        header[3]  = 0x0A; // -----
-        header[4]  = 0x00; // -----
-        header[5]  = 0x0D; // -----
-        header[6]  = 0x0A; // -----
-        header[7]  = 0x51; // -----
-        header[8]  = 0x55; // -----
-        header[9]  = 0x49; // -----
+        header[0] = 0x0D; // Binary Prefix
+        header[1] = 0x0A; // -----
+        header[2] = 0x0D; // -----
+        header[3] = 0x0A; // -----
+        header[4] = 0x00; // -----
+        header[5] = 0x0D; // -----
+        header[6] = 0x0A; // -----
+        header[7] = 0x51; // -----
+        header[8] = 0x55; // -----
+        header[9] = 0x49; // -----
         header[10] = 0x54; // -----
         header[11] = 0x0A; // -----
 
@@ -839,16 +906,16 @@ public class HAProxyMessageDecoderTest {
         ch = new EmbeddedChannel(new HAProxyMessageDecoder(0));
 
         byte[] header = new byte[248];
-        header[0]  = 0x0D; // Binary Prefix
-        header[1]  = 0x0A; // -----
-        header[2]  = 0x0D; // -----
-        header[3]  = 0x0A; // -----
-        header[4]  = 0x00; // -----
-        header[5]  = 0x0D; // -----
-        header[6]  = 0x0A; // -----
-        header[7]  = 0x51; // -----
-        header[8]  = 0x55; // -----
-        header[9]  = 0x49; // -----
+        header[0] = 0x0D; // Binary Prefix
+        header[1] = 0x0A; // -----
+        header[2] = 0x0D; // -----
+        header[3] = 0x0A; // -----
+        header[4] = 0x00; // -----
+        header[5] = 0x0D; // -----
+        header[6] = 0x0A; // -----
+        header[7] = 0x51; // -----
+        header[8] = 0x55; // -----
+        header[9] = 0x49; // -----
         header[10] = 0x54; // -----
         header[11] = 0x0A; // -----
 
@@ -880,16 +947,16 @@ public class HAProxyMessageDecoderTest {
     @Test
     public void testV2IncompleteHeader() {
         byte[] header = new byte[13];
-        header[0]  = 0x0D; // Binary Prefix
-        header[1]  = 0x0A; // -----
-        header[2]  = 0x0D; // -----
-        header[3]  = 0x0A; // -----
-        header[4]  = 0x00; // -----
-        header[5]  = 0x0D; // -----
-        header[6]  = 0x0A; // -----
-        header[7]  = 0x51; // -----
-        header[8]  = 0x55; // -----
-        header[9]  = 0x49; // -----
+        header[0] = 0x0D; // Binary Prefix
+        header[1] = 0x0A; // -----
+        header[2] = 0x0D; // -----
+        header[3] = 0x0A; // -----
+        header[4] = 0x00; // -----
+        header[5] = 0x0D; // -----
+        header[6] = 0x0A; // -----
+        header[7] = 0x51; // -----
+        header[8] = 0x55; // -----
+        header[9] = 0x49; // -----
         header[10] = 0x54; // -----
         header[11] = 0x0A; // -----
 

--- a/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxySSLTLVTest.java
+++ b/codec-haproxy/src/test/java/io/netty/handler/codec/haproxy/HAProxySSLTLVTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.haproxy;
+
+import io.netty.buffer.Unpooled;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+
+public class HAProxySSLTLVTest {
+
+    @Test
+    public void testClientBitmask() throws Exception {
+
+        // 0b0000_0111
+        final byte allClientsEnabled = 0x7;
+        final HAProxySSLTLV allClientsEnabledTLV =
+                new HAProxySSLTLV(0, allClientsEnabled, Collections.<HAProxyTLV>emptyList(), Unpooled.buffer());
+
+        assertTrue(allClientsEnabledTLV.isPP2ClientCertConn());
+        assertTrue(allClientsEnabledTLV.isPP2ClientSSL());
+        assertTrue(allClientsEnabledTLV.isPP2ClientCertSess());
+
+        assertTrue(allClientsEnabledTLV.release());
+
+        // 0b0000_0101
+        final byte clientSSLandClientCertSessEnabled = 0x5;
+
+        final HAProxySSLTLV clientSSLandClientCertSessTLV =
+                new HAProxySSLTLV(0, clientSSLandClientCertSessEnabled, Collections.<HAProxyTLV>emptyList(),
+                                  Unpooled.buffer());
+
+        assertFalse(clientSSLandClientCertSessTLV.isPP2ClientCertConn());
+        assertTrue(clientSSLandClientCertSessTLV.isPP2ClientSSL());
+        assertTrue(clientSSLandClientCertSessTLV.isPP2ClientCertSess());
+
+        assertTrue(clientSSLandClientCertSessTLV.release());
+        // 0b0000_0000
+        final byte noClientEnabled = 0x0;
+
+        final HAProxySSLTLV noClientTlv =
+                new HAProxySSLTLV(0, noClientEnabled, Collections.<HAProxyTLV>emptyList(),
+                                  Unpooled.buffer());
+
+        assertFalse(noClientTlv.isPP2ClientCertConn());
+        assertFalse(noClientTlv.isPP2ClientSSL());
+        assertFalse(noClientTlv.isPP2ClientCertSess());
+
+        assertTrue(noClientTlv.release());
+    }
+}


### PR DESCRIPTION
This pull request continues where Dominik (https://github.com/netty/netty/pull/5872) left off. 

Motivation:

The current PROXY protocol implementation does not have support for optional Type-Length-Value fields. This pull requests adds the TLV values as specified in the PROXY protocol specification (http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt) and adds support for arbitrary TLVs.

Modifications:

The existing HAProxyMessage implements an additional TLV reading operation.

Result:

The PROXY protocol supports TLVs