### PR TITLE
PlatformDependent#getClassLoader fails in restrictive classloader env…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -135,7 +135,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 @SuppressWarnings({ "rawtypes", "unused" })
                 List serverNames = (List) getServerNamesMethod.invoke(parameters);
                 setServerNamesMethod.invoke(parameters, Collections.emptyList());
-            } catch (Throwable ingore) {
+            } catch (Throwable ignore) {
                 sniHostNameClass = null;
                 getAsciiNameMethod = null;
                 getServerNamesMethod = null;

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -854,8 +854,9 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                             && "com.sun.nio.sctp.SctpChannel".equals(clazz.getSuperclass().getName())) {
                         return true;
                     }
-                } catch (ClassNotFoundException e) {
-                    // This should not happen just ignore
+                } catch (Throwable cause) {
+                    logger.debug("Unexpected exception while loading class {} classname {}",
+                                 getClass(), classname, cause);
                 }
             }
         }

--- a/transport/src/main/java/io/netty/channel/DefaultChannelId.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelId.java
@@ -107,9 +107,10 @@ public final class DefaultChannelId implements ChannelId {
     }
 
     private static int defaultProcessId() {
-        final ClassLoader loader = PlatformDependent.getClassLoader(DefaultChannelId.class);
+        ClassLoader loader = null;
         String value;
         try {
+            loader = PlatformDependent.getClassLoader(DefaultChannelId.class);
             // Invoke java.lang.management.ManagementFactory.getRuntimeMXBean().getName()
             Class<?> mgmtFactoryType = Class.forName("java.lang.management.ManagementFactory", true, loader);
             Class<?> runtimeMxBeanType = Class.forName("java.lang.management.RuntimeMXBean", true, loader);
@@ -118,15 +119,15 @@ public final class DefaultChannelId implements ChannelId {
             Object bean = getRuntimeMXBean.invoke(null, EmptyArrays.EMPTY_OBJECTS);
             Method getName = runtimeMxBeanType.getMethod("getName", EmptyArrays.EMPTY_CLASSES);
             value = (String) getName.invoke(bean, EmptyArrays.EMPTY_OBJECTS);
-        } catch (Exception e) {
-            logger.debug("Could not invoke ManagementFactory.getRuntimeMXBean().getName(); Android?", e);
+        } catch (Throwable t) {
+            logger.debug("Could not invoke ManagementFactory.getRuntimeMXBean().getName(); Android?", t);
             try {
                 // Invoke android.os.Process.myPid()
                 Class<?> processType = Class.forName("android.os.Process", true, loader);
                 Method myPid = processType.getMethod("myPid", EmptyArrays.EMPTY_CLASSES);
                 value = myPid.invoke(null, EmptyArrays.EMPTY_OBJECTS).toString();
-            } catch (Exception e2) {
-                logger.debug("Could not invoke Process.myPid(); not Android?", e2);
+            } catch (Throwable t2) {
+                logger.debug("Could not invoke Process.myPid(); not Android?", t2);
                 value = "";
             }
         }


### PR DESCRIPTION
…ironment

Motivation:
https://github.com/netty/netty/pull/6042 only addressed PlatformDependent#getSystemClassLoader but getClassLoader is also called in an optional manner in some common code paths but fails to catch a general enough exception to continue working.

Modifications:
- Calls to getClassLoader which can continue if results fail should catch Throwable

Result:
More resilient code in the presense of restrictive class loaders.
Fixes https://github.com/netty/netty/issues/6246.