### PR TITLE
Update hpack Decoder CTOR to allow for overflow in maxHeaderListSize

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -149,8 +149,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
      * @return the threshold in bytes which should trigger a {@code GO_AWAY} if a set of headers exceeds this amount.
      */
     protected long calculateMaxHeaderListSizeGoAway(long maxHeaderListSize) {
-        // This is equivalent to `maxHeaderListSize * 1.25` but we avoid floating point multiplication.
-        return maxHeaderListSize + (maxHeaderListSize >>> 2);
+        return Http2CodecUtil.calculateMaxHeaderListSizeGoAway(maxHeaderListSize);
     }
 
     private int unconsumedBytes(Http2Stream stream) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -113,6 +113,18 @@ public final class Http2CodecUtil {
     public static final int DEFAULT_MAX_FRAME_SIZE = MAX_FRAME_SIZE_LOWER_BOUND;
 
     /**
+     * Calculate the threshold in bytes which should trigger a {@code GO_AWAY} if a set of headers exceeds this amount.
+     * @param maxHeaderListSize
+     *      <a href="https://tools.ietf.org/html/rfc7540#section-6.5.2">SETTINGS_MAX_HEADER_LIST_SIZE</a> for the local
+     *      endpoint.
+     * @return the threshold in bytes which should trigger a {@code GO_AWAY} if a set of headers exceeds this amount.
+     */
+    public static long calculateMaxHeaderListSizeGoAway(long maxHeaderListSize) {
+        // This is equivalent to `maxHeaderListSize * 1.25` but we avoid floating point multiplication.
+        return maxHeaderListSize + (maxHeaderListSize >>> 2);
+    }
+
+    /**
      * Returns {@code true} if the stream is an outbound stream.
      *
      * @param server    {@code true} if the endpoint is a server, {@code false} otherwise.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/Decoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/internal/hpack/Decoder.java
@@ -32,6 +32,7 @@
 package io.netty.handler.codec.http2.internal.hpack;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.internal.hpack.HpackUtil.IndexType;
@@ -106,7 +107,9 @@ public final class Decoder {
      * for testing but violate the RFC if used outside the scope of testing.
      */
     Decoder(long maxHeaderListSize, int initialHuffmanDecodeCapacity, int maxHeaderTableSize) {
-        this.maxHeaderListSize = maxHeaderListSizeGoAway = checkPositive(maxHeaderListSize, "maxHeaderListSize");
+        this.maxHeaderListSize = checkPositive(maxHeaderListSize, "maxHeaderListSize");
+        this.maxHeaderListSizeGoAway = Http2CodecUtil.calculateMaxHeaderListSizeGoAway(maxHeaderListSize);
+
         maxDynamicTableSize = encoderMaxDynamicTableSize = maxHeaderTableSize;
         maxDynamicTableSizeChangeRequired = false;
         dynamicTable = new DynamicTable(maxHeaderTableSize);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoderTest.java
@@ -85,6 +85,21 @@ public class DefaultHttp2HeadersDecoderTest {
     }
 
     @Test
+    public void decodeLargerThanHeaderListSizeButLessThanGoAwayWithInitialDecoderSettings() throws Exception {
+        ByteBuf buf = encode(b(":method"), b("GET"), b("test_header"),
+            b(String.format("%09000d", 0).replace('0', 'A')));
+        final int streamId = 1;
+        try {
+            decoder.decodeHeaders(streamId, buf);
+            fail();
+        } catch (Http2Exception.HeaderListSizeException e) {
+            assertEquals(streamId, e.streamId());
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Test
     public void decodeLargerThanHeaderListSizeGoAway() throws Exception {
         decoder.maxHeaderListSize(MIN_HEADER_LIST_SIZE, MIN_HEADER_LIST_SIZE);
         ByteBuf buf = encode(b(":method"), b("GET"));


### PR DESCRIPTION
Motivation:
When testing the fixes from #6209 locally I noticed that the first request into the decoder still causes a GOAWAY even when it's below what I would expect to be in maxHeaderListSizeGoAway.

Turns out both of the limits are set to exactly the same thing in the decoder CTOR instead of using the same math that is used when the local settings are applied.

Modification:

Moved calculate calculateMaxHeaderListSizeGoAway into Http2CodecUtil and used that in the CTOR for the hpack Decoder.