### PR TITLE
Set the Transfer-Encoding header instead of adding

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -312,7 +312,7 @@ public final class HttpUtil {
      */
     public static void setTransferEncodingChunked(HttpMessage m, boolean chunked) {
         if (chunked) {
-            m.headers().add(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+            m.headers().set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
             m.headers().remove(HttpHeaderNames.CONTENT_LENGTH);
         } else {
             List<String> encodings = m.headers().getAll(HttpHeaderNames.TRANSFER_ENCODING);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -18,6 +18,7 @@ package io.netty.handler.codec.http;
 import io.netty.util.CharsetUtil;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static io.netty.handler.codec.http.HttpHeadersTestUtils.of;
@@ -107,5 +108,14 @@ public class HttpUtilTest {
         message.headers().set(HttpHeaderNames.CONTENT_LENGTH, "bar");
         assertEquals("bar", message.headers().get(HttpHeaderNames.CONTENT_LENGTH));
         assertEquals(1L, HttpUtil.getContentLength(message, 1L));
+    }
+
+    @Test
+    public void testDoubleChunkedHeader() {
+        HttpMessage message = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        message.headers().add(HttpHeaderNames.TRANSFER_ENCODING, "chunked");
+        HttpUtil.setTransferEncodingChunked(message, true);
+        List<String> expected = Collections.singletonList("chunked");
+        assertEquals(expected, message.headers().getAll(HttpHeaderNames.TRANSFER_ENCODING));
     }
 }


### PR DESCRIPTION
Motivation:

HttpUtil.setTransferEncodingChunked could add a second Transfer-Encoding
header if one was already present. While this is technically valid, it
does not appear to be the intent of the method.

Result:

Only one Transfer-Encoding header is present after calling this method.