### PR TITLE
Update jetty-alpn-agent to support latest JDK releases.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <netty.build.version>22</netty.build.version>
     <jboss.marshalling.version>1.4.11.Final</jboss.marshalling.version>
-    <jetty.alpnAgent.version>2.0.4</jetty.alpnAgent.version>
+    <jetty.alpnAgent.version>2.0.6</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>"${settings.localRepository}"/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
     <argLine.common>
       -server


### PR DESCRIPTION
Motivation:

We need to update jetty-alpn-agent to support latest JDK releases.

Modifications:

Update jetty-alpn-agent to 2.0.6

Result:

Be able to run tests with latest JDK releases.