### PR TITLE
Null out references to tmpNioBuf and chunk to allow quicker collecting

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -34,6 +34,7 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
     int maxLength;
     PoolThreadCache cache;
     private ByteBuffer tmpNioBuf;
+    private ByteBufAllocator allocator;
 
     @SuppressWarnings("unchecked")
     protected PooledByteBuf(Recycler.Handle<? extends PooledByteBuf<T>> recyclerHandle, int maxCapacity) {
@@ -48,6 +49,7 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
         this.chunk = chunk;
         this.handle = handle;
         memory = chunk.memory;
+        allocator = chunk.arena.parent;
         this.offset = offset;
         this.length = length;
         this.maxLength = maxLength;
@@ -123,7 +125,7 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
 
     @Override
     public final ByteBufAllocator alloc() {
-        return chunk.arena.parent;
+        return allocator;
     }
 
     @Override
@@ -168,7 +170,9 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
             final long handle = this.handle;
             this.handle = -1;
             memory = null;
+            tmpNioBuf = null;
             chunk.arena.free(chunk, handle, maxLength, cache);
+            chunk = null;
             recycle();
         }
     }


### PR DESCRIPTION
Motivation:

In PooledByteBuf we missed to null out the chunk and tmpNioBuf fields before recycle it to the Recycler. This could lead to keep objects longer alive then necessary which may hold a lot of memory.

Modifications:

Null out tmpNioBuf and chunk before recycle.

Result:

Possible to earlier GC objects.