### PR TITLE
fix #6282: calculate correct count for PoolArena's tiny/small/normal allocation

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -210,7 +210,6 @@ abstract class PoolArena<T> implements PoolArenaMetric {
                 incTinySmallNormalAllocation(normCapacity);
             }
             return;
-                
         }
         if (normCapacity <= chunkSize) {
             if (cache.allocateNormal(this, buf, reqCapacity, normCapacity)) {

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -32,53 +32,48 @@ public class PoolArenaTest {
             Assert.assertEquals(expectedResult[i], arena.normalizeCapacity(reqCapacities[i]));
         }
     }
-    
+
     @Test
     public final void testAllocationCounter() {
         final PooledByteBufAllocator allocator = new PooledByteBufAllocator(
                 true,   // preferDirect
-                0,      // nHeapArena, 
-                1,      // nDirectArena, 
-                8192,   // pageSize, 
-                11,     // maxOrder,
-                0,      // tinyCacheSize, 
-                0,      // smallCacheSize, 
-                0,      // normalCacheSize,
+                0,      // nHeapArena
+                1,      // nDirectArena
+                8192,   // pageSize
+                11,     // maxOrder
+                0,      // tinyCacheSize
+                0,      // smallCacheSize
+                0,      // normalCacheSize
                 true    // useCacheForAllThreads
                 );
-        
+
         // create tiny buffer
         final ByteBuf b1 = allocator.directBuffer(24);
-        
         // create small buffer
         final ByteBuf b2 = allocator.directBuffer(800);
-        
         // create normal buffer
         final ByteBuf b3 = allocator.directBuffer(8192 * 2);
-        
+
         Assert.assertNotNull(b1);
         Assert.assertNotNull(b2);
         Assert.assertNotNull(b3);
-        
+
         // then release buffer to deallocated memory while threadlocal cache has been disabled
         // allocations counter value must equals deallocations counter value
         Assert.assertTrue(b1.release());
         Assert.assertTrue(b2.release());
         Assert.assertTrue(b3.release());
-        
+
         Assert.assertTrue(allocator.directArenas().size() >= 1);
-        
         final PoolArenaMetric metric = allocator.directArenas().get(0);
-        
+
         Assert.assertEquals(3, metric.numDeallocations());
         Assert.assertEquals(3, metric.numAllocations());
-        
+
         Assert.assertEquals(1, metric.numTinyDeallocations());
         Assert.assertEquals(1, metric.numTinyAllocations());
-        
         Assert.assertEquals(1, metric.numSmallDeallocations());
         Assert.assertEquals(1, metric.numSmallAllocations());
-        
         Assert.assertEquals(1, metric.numNormalDeallocations());
         Assert.assertEquals(1, metric.numNormalAllocations());
     }

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -32,4 +32,54 @@ public class PoolArenaTest {
             Assert.assertEquals(expectedResult[i], arena.normalizeCapacity(reqCapacities[i]));
         }
     }
+    
+    @Test
+    public final void testAllocationCounter() {
+        final PooledByteBufAllocator allocator = new PooledByteBufAllocator(
+                true,   // preferDirect
+                0,      // nHeapArena, 
+                1,      // nDirectArena, 
+                8192,   // pageSize, 
+                11,     // maxOrder,
+                0,      // tinyCacheSize, 
+                0,      // smallCacheSize, 
+                0,      // normalCacheSize,
+                true    // useCacheForAllThreads
+                );
+        
+        // create tiny buffer
+        final ByteBuf b1 = allocator.directBuffer(24);
+        
+        // create small buffer
+        final ByteBuf b2 = allocator.directBuffer(800);
+        
+        // create normal buffer
+        final ByteBuf b3 = allocator.directBuffer(8192 * 2);
+        
+        Assert.assertNotNull(b1);
+        Assert.assertNotNull(b2);
+        Assert.assertNotNull(b3);
+        
+        // then release buffer to deallocated memory while threadlocal cache has been disabled
+        // allocations counter value must equals deallocations counter value
+        Assert.assertTrue(b1.release());
+        Assert.assertTrue(b2.release());
+        Assert.assertTrue(b3.release());
+        
+        Assert.assertTrue(allocator.directArenas().size() >= 1);
+        
+        final PoolArenaMetric metric = allocator.directArenas().get(0);
+        
+        Assert.assertEquals(3, metric.numDeallocations());
+        Assert.assertEquals(3, metric.numAllocations());
+        
+        Assert.assertEquals(1, metric.numTinyDeallocations());
+        Assert.assertEquals(1, metric.numTinyAllocations());
+        
+        Assert.assertEquals(1, metric.numSmallDeallocations());
+        Assert.assertEquals(1, metric.numSmallAllocations());
+        
+        Assert.assertEquals(1, metric.numNormalDeallocations());
+        Assert.assertEquals(1, metric.numNormalAllocations());
+    }
 }


### PR DESCRIPTION
Motivation:

Disable ThreadLocal Cache, then allocate Pooled ByteBuf and release all these buffers, PoolArena's  tiny/small/normal allocation count incorrect.

Modifications:

- Calculate PoolArena's tiny/small/normal allocation one time 
- Add testAllocationCounter TestCase

Result:

Fixes #6282 .
