### PR TITLE
Deprecate and ignore ResourceLeakDetector's maxActive parameter

### DIFF
--- a/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetectorFactory.java
@@ -37,7 +37,7 @@ public abstract class ResourceLeakDetectorFactory {
     /**
      * Get the singleton instance of this factory class.
      *
-     * @return - the current {@link ResourceLeakDetectorFactory}
+     * @return the current {@link ResourceLeakDetectorFactory}
      */
     public static ResourceLeakDetectorFactory instance() {
         return factoryInstance;
@@ -48,7 +48,7 @@ public abstract class ResourceLeakDetectorFactory {
      * {@link ResourceLeakDetector} is called by all the callers of this factory. That is, before initializing a
      * Netty Bootstrap.
      *
-     * @param factory - the instance that will become the current {@link ResourceLeakDetectorFactory}'s singleton
+     * @param factory the instance that will become the current {@link ResourceLeakDetectorFactory}'s singleton
      */
     public static void setResourceLeakDetectorFactory(ResourceLeakDetectorFactory factory) {
         factoryInstance = ObjectUtil.checkNotNull(factory, "factory");
@@ -57,30 +57,47 @@ public abstract class ResourceLeakDetectorFactory {
     /**
      * Returns a new instance of a {@link ResourceLeakDetector} with the given resource class.
      *
-     * @param resource - the resource class used to initialize the {@link ResourceLeakDetector}
-     * @param <T> - the type of the resource class
-     * @return - a new instance of {@link ResourceLeakDetector}
+     * @param resource the resource class used to initialize the {@link ResourceLeakDetector}
+     * @param <T> the type of the resource class
+     * @return a new instance of {@link ResourceLeakDetector}
      */
     public final <T> ResourceLeakDetector<T> newResourceLeakDetector(Class<T> resource) {
-        return newResourceLeakDetector(resource, ResourceLeakDetector.DEFAULT_SAMPLING_INTERVAL, Long.MAX_VALUE);
+        return newResourceLeakDetector(resource, ResourceLeakDetector.DEFAULT_SAMPLING_INTERVAL);
     }
+
+    /**
+     * @deprecated Use {@link #newResourceLeakDetector(Class, int)} instead.
+     * <p>
+     * Returns a new instance of a {@link ResourceLeakDetector} with the given resource class.
+     *
+     * @param resource the resource class used to initialize the {@link ResourceLeakDetector}
+     * @param samplingInterval the interval on which sampling takes place
+     * @param maxActive This is deprecated and will be ignored.
+     * @param <T> the type of the resource class
+     * @return a new instance of {@link ResourceLeakDetector}
+     */
+    @Deprecated
+    public abstract <T> ResourceLeakDetector<T> newResourceLeakDetector(
+            Class<T> resource, int samplingInterval, long maxActive);
 
     /**
      * Returns a new instance of a {@link ResourceLeakDetector} with the given resource class.
      *
-     * @param resource - the resource class used to initialize the {@link ResourceLeakDetector}
-     * @param samplingInterval - the interval on which sampling takes place
-     * @param maxActive - the maximum active instances
-     * @param <T> - the type of the resource class
-     * @return - a new instance of {@link ResourceLeakDetector}
+     * @param resource the resource class used to initialize the {@link ResourceLeakDetector}
+     * @param samplingInterval the interval on which sampling takes place
+     * @param <T> the type of the resource class
+     * @return a new instance of {@link ResourceLeakDetector}
      */
-    public abstract <T> ResourceLeakDetector<T> newResourceLeakDetector(
-            Class<T> resource, int samplingInterval, long maxActive);
+    @SuppressWarnings("deprecation")
+    public <T> ResourceLeakDetector<T> newResourceLeakDetector(Class<T> resource, int samplingInterval) {
+        return newResourceLeakDetector(resource, ResourceLeakDetector.DEFAULT_SAMPLING_INTERVAL, Long.MAX_VALUE);
+    }
 
     /**
      * Default implementation that loads custom leak detector via system property
      */
     private static final class DefaultResourceLeakDetectorFactory extends ResourceLeakDetectorFactory {
+        private final Constructor<?> obsoleteCustomClassConstructor;
         private final Constructor<?> customClassConstructor;
 
         DefaultResourceLeakDetectorFactory() {
@@ -96,10 +113,15 @@ public abstract class ResourceLeakDetectorFactory {
                 logger.error("Could not access System property: io.netty.customResourceLeakDetector", cause);
                 customLeakDetector = null;
             }
-            customClassConstructor = customLeakDetector == null ? null : customClassConstructor(customLeakDetector);
+            if (customLeakDetector == null) {
+                obsoleteCustomClassConstructor = customClassConstructor = null;
+            } else {
+                obsoleteCustomClassConstructor = obsoleteCustomClassConstructor(customLeakDetector);
+                customClassConstructor = customClassConstructor(customLeakDetector);
+            }
         }
 
-        private static Constructor<?> customClassConstructor(String customLeakDetector) {
+        private static Constructor<?> obsoleteCustomClassConstructor(String customLeakDetector) {
             try {
                 final Class<?> detectorClass = Class.forName(customLeakDetector, true,
                         PlatformDependent.getSystemClassLoader());
@@ -116,15 +138,56 @@ public abstract class ResourceLeakDetectorFactory {
             return null;
         }
 
+        private static Constructor<?> customClassConstructor(String customLeakDetector) {
+            try {
+                final Class<?> detectorClass = Class.forName(customLeakDetector, true,
+                        PlatformDependent.getSystemClassLoader());
+
+                if (ResourceLeakDetector.class.isAssignableFrom(detectorClass)) {
+                    return detectorClass.getConstructor(Class.class, int.class);
+                } else {
+                    logger.error("Class {} does not inherit from ResourceLeakDetector.", customLeakDetector);
+                }
+            } catch (Throwable t) {
+                logger.error("Could not load custom resource leak detector class provided: {}",
+                        customLeakDetector, t);
+            }
+            return null;
+        }
+
+        @SuppressWarnings("deprecation")
         @Override
-        public <T> ResourceLeakDetector<T> newResourceLeakDetector(
-                Class<T> resource, int samplingInterval, long maxActive) {
+        public <T> ResourceLeakDetector<T> newResourceLeakDetector(Class<T> resource, int samplingInterval,
+                                                                   long maxActive) {
+            if (obsoleteCustomClassConstructor != null) {
+                try {
+                    @SuppressWarnings("unchecked")
+                    ResourceLeakDetector<T> leakDetector =
+                            (ResourceLeakDetector<T>) obsoleteCustomClassConstructor.newInstance(
+                                    resource, samplingInterval, maxActive);
+                    logger.debug("Loaded custom ResourceLeakDetector: {}",
+                            obsoleteCustomClassConstructor.getDeclaringClass().getName());
+                    return leakDetector;
+                } catch (Throwable t) {
+                    logger.error(
+                            "Could not load custom resource leak detector provided: {} with the given resource: {}",
+                            obsoleteCustomClassConstructor.getDeclaringClass().getName(), resource, t);
+                }
+            }
+
+            ResourceLeakDetector<T> resourceLeakDetector = new ResourceLeakDetector<T>(resource, samplingInterval,
+                                                                                       maxActive);
+            logger.debug("Loaded default ResourceLeakDetector: {}", resourceLeakDetector);
+            return resourceLeakDetector;
+        }
+
+        @Override
+        public <T> ResourceLeakDetector<T> newResourceLeakDetector(Class<T> resource, int samplingInterval) {
             if (customClassConstructor != null) {
                 try {
                     @SuppressWarnings("unchecked")
                     ResourceLeakDetector<T> leakDetector =
-                            (ResourceLeakDetector<T>) customClassConstructor.newInstance(
-                                    resource, samplingInterval, maxActive);
+                            (ResourceLeakDetector<T>) customClassConstructor.newInstance(resource, samplingInterval);
                     logger.debug("Loaded custom ResourceLeakDetector: {}",
                             customClassConstructor.getDeclaringClass().getName());
                     return leakDetector;
@@ -135,8 +198,7 @@ public abstract class ResourceLeakDetectorFactory {
                 }
             }
 
-            ResourceLeakDetector<T> resourceLeakDetector = new ResourceLeakDetector<T>(
-                    resource, samplingInterval, maxActive);
+            ResourceLeakDetector<T> resourceLeakDetector = new ResourceLeakDetector<T>(resource, samplingInterval);
             logger.debug("Loaded default ResourceLeakDetector: {}", resourceLeakDetector);
             return resourceLeakDetector;
         }


### PR DESCRIPTION
Motivation:
ResourceLeakDetector supports a parameter called maxActive. This parameter is used in attempt to limit the amount of objects which are being tracked for leaks at any given time, and generates an error log message if this limit is exceeded. This assumes that there is a relationship between leak sample rate and object lifetime for objects which are already being tracked. This relationship may appear to work in cases were there are a single leak record per object and those leak records live for the lifetime of the application but in general this relationship doesn't exist. The original motivation was to provide a limit for cases such as HashedWheelTimer to limit the number of instances which exist at any given time. This limit is not enforced in all circumstances in HashedWheelTimer (e.g. if the thread is a daemon) and can be implemented outside ResourceLeakDetector.

Modifications:
- Deprecate all methods which interact with maxActive in ResourceLeakDetectorFactory and ResourceLeakDetector
- Remove all logic related to maxActive in ResourceLeakDetector
- HashedWheelTimer implements its own logic to impose a limit and warn users if too many instances exists at any given time.

Result:
Fixes https://github.com/netty/netty/issues/6225.
