### PR TITLE
Restore add(Promise) and addAll(Promise...) methods to PromiseCombiner (fixes #6283)

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/PromiseCombiner.java
+++ b/common/src/main/java/io/netty/util/concurrent/PromiseCombiner.java
@@ -49,8 +49,21 @@ public final class PromiseCombiner {
     };
 
     /**
+     * Adds a new promise to be combined. New promises may be added until an aggregate promise is added via the
+     * {@link PromiseCombiner#finish(Promise)} method.
+     *
+     * @param promise the promise to add to this promise combiner
+     *
+     * @deprecated Replaced by {@link PromiseCombiner#add(Future)}.
+     */
+    @Deprecated
+    public void add(Promise promise) {
+        add((Future) promise);
+    }
+
+    /**
      * Adds a new future to be combined. New futures may be added until an aggregate promise is added via the
-     * {@link PromiseCombiner#finish(Promise)} method has been called.
+     * {@link PromiseCombiner#finish(Promise)} method.
      *
      * @param future the future to add to this promise combiner
      */
@@ -62,8 +75,21 @@ public final class PromiseCombiner {
     }
 
     /**
+     * Adds new promises to be combined. New promises may be added until an aggregate promise is added via the
+     * {@link PromiseCombiner#finish(Promise)} method.
+     *
+     * @param promises the promises to add to this promise combiner
+     *
+     * @deprecated Replaced by {@link PromiseCombiner#addAll(Future[])}
+     */
+    @Deprecated
+    public void addAll(Promise... promises) {
+        addAll((Future[]) promises);
+    }
+
+    /**
      * Adds new futures to be combined. New futures may be added until an aggregate promise is added via the
-     * {@link PromiseCombiner#finish(Promise)} method has been called.
+     * {@link PromiseCombiner#finish(Promise)} method.
      *
      * @param futures the futures to add to this promise combiner
      */


### PR DESCRIPTION
## Motivation

A testing goof in 7c630fe introduced a binary incompatibility when the old Promise-specific `add` and `addAll` methods in `PromiseCombiner` were generalized to accept `Futures`.

## Modification

- Restore (but mark as `@Deprecated`) old `PromiseCombiner` methods.
- Fixed a couple minor documentation typos because sure why not.

## Result

Fixes #6283; `PromiseCombiner` is binary-compatible with previous versions of Netty.

----

Sorry for the trouble here! @normanmaurer totally called this one, but I managed to convince myself through (incorrect) testing that it wasn't an issue.