### PR TITLE
Buffer alignment

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -47,6 +47,8 @@ abstract class PoolArena<T> implements PoolArenaMetric {
     final int chunkSize;
     final int subpageOverflowMask;
     final int numSmallSubpagePools;
+    final int directMemoryCacheAlignment;
+    final int directMemoryCacheAlignmentMask;
     private final PoolSubpage<T>[] tinySubpagePools;
     private final PoolSubpage<T>[] smallSubpagePools;
 
@@ -80,12 +82,15 @@ abstract class PoolArena<T> implements PoolArenaMetric {
     // TODO: Test if adding padding helps under contention
     //private long pad0, pad1, pad2, pad3, pad4, pad5, pad6, pad7;
 
-    protected PoolArena(PooledByteBufAllocator parent, int pageSize, int maxOrder, int pageShifts, int chunkSize) {
+    protected PoolArena(PooledByteBufAllocator parent, int pageSize,
+          int maxOrder, int pageShifts, int chunkSize, int cacheAlignment) {
         this.parent = parent;
         this.pageSize = pageSize;
         this.maxOrder = maxOrder;
         this.pageShifts = pageShifts;
         this.chunkSize = chunkSize;
+        this.directMemoryCacheAlignment = cacheAlignment;
+        this.directMemoryCacheAlignmentMask = cacheAlignment - 1;
         subpageOverflowMask = ~(pageSize - 1);
         tinySubpagePools = newSubpagePoolArray(numTinySubpagePools);
         for (int i = 0; i < tinySubpagePools.length; i ++) {
@@ -329,8 +334,9 @@ abstract class PoolArena<T> implements PoolArenaMetric {
         if (reqCapacity < 0) {
             throw new IllegalArgumentException("capacity: " + reqCapacity + " (expected: 0+)");
         }
+
         if (reqCapacity >= chunkSize) {
-            return reqCapacity;
+            return directMemoryCacheAlignment == 0 ? reqCapacity : alignCapacity(reqCapacity);
         }
 
         if (!isTiny(reqCapacity)) { // >= 512
@@ -348,8 +354,13 @@ abstract class PoolArena<T> implements PoolArenaMetric {
             if (normalizedCapacity < 0) {
                 normalizedCapacity >>>= 1;
             }
+            assert directMemoryCacheAlignment == 0 || (normalizedCapacity & directMemoryCacheAlignmentMask) == 0;
 
             return normalizedCapacity;
+        }
+
+        if (directMemoryCacheAlignment > 0) {
+            return alignCapacity(reqCapacity);
         }
 
         // Quantum-spaced
@@ -358,6 +369,11 @@ abstract class PoolArena<T> implements PoolArenaMetric {
         }
 
         return (reqCapacity & ~15) + 16;
+    }
+
+    int alignCapacity(int reqCapacity) {
+        int delta = reqCapacity & directMemoryCacheAlignmentMask;
+        return delta == 0 ? reqCapacity : reqCapacity + directMemoryCacheAlignment - delta;
     }
 
     void reallocate(PooledByteBuf<T> buf, int newCapacity, boolean freeOldMemory) {
@@ -651,8 +667,10 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
     static final class HeapArena extends PoolArena<byte[]> {
 
-        HeapArena(PooledByteBufAllocator parent, int pageSize, int maxOrder, int pageShifts, int chunkSize) {
-            super(parent, pageSize, maxOrder, pageShifts, chunkSize);
+        HeapArena(PooledByteBufAllocator parent, int pageSize, int maxOrder,
+                int pageShifts, int chunkSize, int directMemoryCacheAlignment) {
+            super(parent, pageSize, maxOrder, pageShifts, chunkSize,
+                    directMemoryCacheAlignment);
         }
 
         @Override
@@ -662,12 +680,12 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
         @Override
         protected PoolChunk<byte[]> newChunk(int pageSize, int maxOrder, int pageShifts, int chunkSize) {
-            return new PoolChunk<byte[]>(this, new byte[chunkSize], pageSize, maxOrder, pageShifts, chunkSize);
+            return new PoolChunk<byte[]>(this, new byte[chunkSize], pageSize, maxOrder, pageShifts, chunkSize, 0);
         }
 
         @Override
         protected PoolChunk<byte[]> newUnpooledChunk(int capacity) {
-            return new PoolChunk<byte[]>(this, new byte[capacity], capacity);
+            return new PoolChunk<byte[]>(this, new byte[capacity], capacity, 0);
         }
 
         @Override
@@ -693,8 +711,10 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
     static final class DirectArena extends PoolArena<ByteBuffer> {
 
-        DirectArena(PooledByteBufAllocator parent, int pageSize, int maxOrder, int pageShifts, int chunkSize) {
-            super(parent, pageSize, maxOrder, pageShifts, chunkSize);
+        DirectArena(PooledByteBufAllocator parent, int pageSize, int maxOrder,
+                int pageShifts, int chunkSize, int directMemoryCacheAlignment) {
+            super(parent, pageSize, maxOrder, pageShifts, chunkSize,
+                    directMemoryCacheAlignment);
         }
 
         @Override
@@ -702,16 +722,35 @@ abstract class PoolArena<T> implements PoolArenaMetric {
             return true;
         }
 
+        private int offsetCacheLine(ByteBuffer memory) {
+            return (int) (PlatformDependent.directBufferAddress(memory) & directMemoryCacheAlignmentMask);
+        }
+
         @Override
-        protected PoolChunk<ByteBuffer> newChunk(int pageSize, int maxOrder, int pageShifts, int chunkSize) {
-            return new PoolChunk<ByteBuffer>(
-                    this, allocateDirect(chunkSize),
-                    pageSize, maxOrder, pageShifts, chunkSize);
+        protected PoolChunk<ByteBuffer> newChunk(int pageSize, int maxOrder,
+                int pageShifts, int chunkSize) {
+            if (directMemoryCacheAlignment == 0) {
+                return new PoolChunk<ByteBuffer>(this,
+                        allocateDirect(chunkSize), pageSize, maxOrder,
+                        pageShifts, chunkSize, 0);
+            }
+            final ByteBuffer memory = allocateDirect(chunkSize
+                    + directMemoryCacheAlignment);
+            return new PoolChunk<ByteBuffer>(this, memory, pageSize,
+                    maxOrder, pageShifts, chunkSize,
+                    offsetCacheLine(memory));
         }
 
         @Override
         protected PoolChunk<ByteBuffer> newUnpooledChunk(int capacity) {
-            return new PoolChunk<ByteBuffer>(this, allocateDirect(capacity), capacity);
+            if (directMemoryCacheAlignment == 0) {
+                return new PoolChunk<ByteBuffer>(this,
+                        allocateDirect(capacity), capacity, 0);
+            }
+            final ByteBuffer memory = allocateDirect(capacity
+                    + directMemoryCacheAlignment);
+            return new PoolChunk<ByteBuffer>(this, memory, capacity,
+                    offsetCacheLine(memory));
         }
 
         private static ByteBuffer allocateDirect(int capacity) {

--- a/buffer/src/main/java/io/netty/buffer/PoolChunk.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolChunk.java
@@ -107,6 +107,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
     final PoolArena<T> arena;
     final T memory;
     final boolean unpooled;
+    final int offset;
 
     private final byte[] memoryMap;
     private final byte[] depthMap;
@@ -131,7 +132,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
     // TODO: Test if adding padding helps under contention
     //private long pad0, pad1, pad2, pad3, pad4, pad5, pad6, pad7;
 
-    PoolChunk(PoolArena<T> arena, T memory, int pageSize, int maxOrder, int pageShifts, int chunkSize) {
+    PoolChunk(PoolArena<T> arena, T memory, int pageSize, int maxOrder, int pageShifts, int chunkSize, int offset) {
         unpooled = false;
         this.arena = arena;
         this.memory = memory;
@@ -139,6 +140,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
         this.pageShifts = pageShifts;
         this.maxOrder = maxOrder;
         this.chunkSize = chunkSize;
+        this.offset = offset;
         unusable = (byte) (maxOrder + 1);
         log2ChunkSize = log2(chunkSize);
         subpageOverflowMask = ~(pageSize - 1);
@@ -165,10 +167,11 @@ final class PoolChunk<T> implements PoolChunkMetric {
     }
 
     /** Creates a special chunk that is not pooled. */
-    PoolChunk(PoolArena<T> arena, T memory, int size) {
+    PoolChunk(PoolArena<T> arena, T memory, int size, int offset) {
         unpooled = true;
         this.arena = arena;
         this.memory = memory;
+        this.offset = offset;
         memoryMap = null;
         depthMap = null;
         subpages = null;
@@ -371,7 +374,7 @@ final class PoolChunk<T> implements PoolChunkMetric {
         if (bitmapIdx == 0) {
             byte val = value(memoryMapIdx);
             assert val == unusable : String.valueOf(val);
-            buf.init(this, handle, runOffset(memoryMapIdx), reqCapacity, runLength(memoryMapIdx),
+            buf.init(this, handle, runOffset(memoryMapIdx) + offset, reqCapacity, runLength(memoryMapIdx),
                      arena.parent.threadCache());
         } else {
             initBufWithSubpage(buf, handle, bitmapIdx, reqCapacity);
@@ -393,8 +396,8 @@ final class PoolChunk<T> implements PoolChunkMetric {
 
         buf.init(
             this, handle,
-            runOffset(memoryMapIdx) + (bitmapIdx & 0x3FFFFFFF) * subpage.elemSize, reqCapacity, subpage.elemSize,
-            arena.parent.threadCache());
+            runOffset(memoryMapIdx) + (bitmapIdx & 0x3FFFFFFF) * subpage.elemSize + offset,
+                reqCapacity, subpage.elemSize, arena.parent.threadCache());
     }
 
     private byte value(int id) {

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
@@ -63,7 +63,7 @@ abstract class PooledByteBuf<T> extends AbstractReferenceCountedByteBuf {
         this.chunk = chunk;
         handle = 0;
         memory = chunk.memory;
-        offset = 0;
+        offset = chunk.offset;
         this.length = maxLength = length;
         tmpNioBuf = null;
         cache = null;

--- a/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
@@ -25,9 +25,19 @@ public class PoolArenaTest {
 
     @Test
     public void testNormalizeCapacity() throws Exception {
-        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, 0, 0, 9, 999999);
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, 0, 0, 9, 999999, 0);
         int[] reqCapacities = {0, 15, 510, 1024, 1023, 1025};
         int[] expectedResult = {0, 16, 512, 1024, 1024, 2048};
+        for (int i = 0; i < reqCapacities.length; i ++) {
+            Assert.assertEquals(expectedResult[i], arena.normalizeCapacity(reqCapacities[i]));
+        }
+    }
+
+    @Test
+    public void testNormalizeAlignedCapacity() throws Exception {
+        PoolArena<ByteBuffer> arena = new PoolArena.DirectArena(null, 0, 0, 9, 999999, 64);
+        int[] reqCapacities = {0, 15, 510, 1024, 1023, 1025};
+        int[] expectedResult = {0, 64, 512, 1024, 1024, 2048};
         for (int i = 0; i < reqCapacities.length; i ++) {
             Assert.assertEquals(expectedResult[i], arena.normalizeCapacity(reqCapacities[i]));
         }

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -47,6 +47,16 @@ public class PooledByteBufAllocatorTest {
         testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 11, 1000, 1000, 1000), 100, 1, 1, 0);
     }
 
+    @Test
+    public void testArenaMetricsNoCacheAlign() {
+        testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 11, 0, 0, 0, true, 64), 100, 0, 100, 100);
+    }
+
+    @Test
+    public void testArenaMetricsCacheAlign() {
+        testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 11, 1000, 1000, 1000, true, 64), 100, 1, 1, 0);
+    }
+
     private static void testArenaMetrics0(
             PooledByteBufAllocator allocator, int num, int expectedActive, int expectedAlloc, int expectedDealloc) {
         for (int i = 0; i < num; i++) {

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java
@@ -35,7 +35,7 @@ public class ByteBufAllocatorBenchmark extends AbstractMicrobenchmark {
 
     private static final ByteBufAllocator unpooledAllocator = new UnpooledByteBufAllocator(true);
     private static final ByteBufAllocator pooledAllocator =
-            new PooledByteBufAllocator(true, 4, 4, 8192, 11, 0, 0, 0); // Disable thread-local cache
+            new PooledByteBufAllocator(true, 4, 4, 8192, 11, 0, 0, 0, true, 0); // Disable thread-local cache
 
     private static final int MAX_LIVE_BUFFERS = 8192;
     private static final Random rand = new Random();

--- a/microbench/src/main/java/io/netty/microbench/buffer/PooledByteBufAllocatorAlignBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/PooledByteBufAllocatorAlignBenchmark.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.buffer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class PooledByteBufAllocatorAlignBenchmark extends
+        AbstractMicrobenchmark {
+
+    private static final Random rand = new Random();
+
+    /**
+     * Cache line power of 2.
+     */
+    private static final int CACHE_LINE_MAX = 256;
+
+    /**
+     * PRNG to walk the chunk randomly to avoid streaming reads.
+     */
+    private static final int OFFSET_ADD = CACHE_LINE_MAX * 1337;
+
+    /**
+     * Block of bytes to write/read. (Corresponds to int type)
+     */
+    private static final int BLOCK = 4;
+
+    @Param({ "0", "64" })
+    private int cacheAlign;
+
+    @Param({ "01024", "04096", "16384", "65536", "1048576" })
+    private int size;
+
+    private ByteBuf pooledDirectBuffer;
+
+    private byte[] bytes;
+
+    private int sizeMask;
+
+    private int alignOffset;
+
+    @Setup
+    public void doSetup() {
+        PooledByteBufAllocator pooledAllocator = new PooledByteBufAllocator(true, 4, 4, 8192, 11, 0,
+                0, 0, true, cacheAlign);
+        pooledDirectBuffer = pooledAllocator.directBuffer(size + 64);
+        sizeMask = size - 1;
+        if (cacheAlign == 0) {
+            long addr = pooledDirectBuffer.memoryAddress();
+            // make sure address is miss-aligned
+            if (addr % 64 == 0) {
+                alignOffset = 63;
+            }
+            int off = 0;
+            for (int c = 0; c < size; c++) {
+                off = (off + OFFSET_ADD) & sizeMask;
+                if ((addr + off + alignOffset) % BLOCK == 0) {
+                    throw new IllegalStateException(
+                            "Misaligned address is not really aligned");
+                }
+            }
+        } else {
+            alignOffset = 0;
+            int off = 0;
+            long addr = pooledDirectBuffer.memoryAddress();
+            for (int c = 0; c < size; c++) {
+                off = (off + OFFSET_ADD) & sizeMask;
+                if ((addr + off) % BLOCK != 0) {
+                    throw new IllegalStateException(
+                            "Aligned address is not really aligned");
+                }
+            }
+        }
+        bytes = new byte[BLOCK];
+        rand.nextBytes(bytes);
+    }
+
+    @TearDown
+    public void doTearDown() {
+        pooledDirectBuffer.release();
+    }
+
+    @Benchmark
+    public void writeRead() {
+        int off = 0;
+        int lSize = size;
+        int lSizeMask = sizeMask;
+        int lAlignOffset = alignOffset;
+        for (int i = 0; i < lSize; i++) {
+            off = (off + OFFSET_ADD) & lSizeMask;
+            pooledDirectBuffer.setBytes(off + lAlignOffset, bytes);
+            pooledDirectBuffer.getBytes(off + lAlignOffset, bytes);
+        }
+    }
+
+    @Benchmark
+    public void write() {
+        int off = 0;
+        int lSize = size;
+        int lSizeMask = sizeMask;
+        int lAlignOffset = alignOffset;
+        for (int i = 0; i < lSize; i++) {
+            off = (off + OFFSET_ADD) & lSizeMask;
+            pooledDirectBuffer.setBytes(off + lAlignOffset, bytes);
+        }
+    }
+
+    @Benchmark
+    public void read() {
+        int off = 0;
+        int lSize = size;
+        int lSizeMask = sizeMask;
+        int lAlignOffset = alignOffset;
+        for (int i = 0; i < lSize; i++) {
+            off = (off + OFFSET_ADD) & lSizeMask;
+            pooledDirectBuffer.getBytes(off + lAlignOffset, bytes);
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

64-byte alignment is recommended by the Intel performance guide (https://software.intel.com/en-us/articles/practical-intel-avx-optimization-on-2nd-generation-intel-core-processors) for data-structures over 64 bytes.
Requiring padding to a multiple of 64 bytes allows for using SIMD instructions consistently in loops without additional conditional checks. This should allow for simpler and more efficient code.

Modification:
At the moment cache alignment must be setup manually. But probably it might be taken from the system. The original code was introduced by @normanmaurer https://github.com/netty/netty/pull/4726/files

buffer/src/main/java/io/netty/buffer/PoolArena.java
buffer/src/main/java/io/netty/buffer/PoolChunk.java
buffer/src/main/java/io/netty/buffer/PooledByteBuf.java
buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
buffer/src/test/java/io/netty/buffer/PoolArenaTest.java
buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorBenchmark.java

microbench/src/main/java/io/netty/microbench/buffer/PooledByteBufAllocatorAlignBenchmark.java

```
Result:
Benchmark                                       (cacheAlign)   (size)  Mode  Cnt   Score   Error  Units
PooledByteBufAllocatorAlignBenchmark.read                  0    01024  avgt   25   0.013 ± 0.001  ms/op
PooledByteBufAllocatorAlignBenchmark.read                  0    04096  avgt   25   0.050 ± 0.004  ms/op
PooledByteBufAllocatorAlignBenchmark.read                  0    16384  avgt   25   0.202 ± 0.018  ms/op
PooledByteBufAllocatorAlignBenchmark.read                  0    65536  avgt   25   0.840 ± 0.065  ms/op
PooledByteBufAllocatorAlignBenchmark.read                  0  1048576  avgt   25  23.778 ± 4.068  ms/op
PooledByteBufAllocatorAlignBenchmark.read                 64    01024  avgt   25   0.012 ± 0.001  ms/op
PooledByteBufAllocatorAlignBenchmark.read                 64    04096  avgt   25   0.047 ± 0.003  ms/op
PooledByteBufAllocatorAlignBenchmark.read                 64    16384  avgt   25   0.200 ± 0.022  ms/op
PooledByteBufAllocatorAlignBenchmark.read                 64    65536  avgt   25   0.749 ± 0.079  ms/op
PooledByteBufAllocatorAlignBenchmark.read                 64  1048576  avgt   25  13.331 ± 1.396  ms/op
PooledByteBufAllocatorAlignBenchmark.write                 0    01024  avgt   25   0.013 ± 0.001  ms/op
PooledByteBufAllocatorAlignBenchmark.write                 0    04096  avgt   25   0.050 ± 0.004  ms/op
PooledByteBufAllocatorAlignBenchmark.write                 0    16384  avgt   25   0.220 ± 0.027  ms/op
PooledByteBufAllocatorAlignBenchmark.write                 0    65536  avgt   25   0.830 ± 0.067  ms/op
PooledByteBufAllocatorAlignBenchmark.write                 0  1048576  avgt   25  16.060 ± 0.484  ms/op
PooledByteBufAllocatorAlignBenchmark.write                64    01024  avgt   25   0.012 ± 0.001  ms/op
PooledByteBufAllocatorAlignBenchmark.write                64    04096  avgt   25   0.045 ± 0.003  ms/op
PooledByteBufAllocatorAlignBenchmark.write                64    16384  avgt   25   0.177 ± 0.011  ms/op
PooledByteBufAllocatorAlignBenchmark.write                64    65536  avgt   25   0.746 ± 0.076  ms/op
PooledByteBufAllocatorAlignBenchmark.write                64  1048576  avgt   25  14.150 ± 0.619  ms/op
PooledByteBufAllocatorAlignBenchmark.writeRead             0    01024  avgt   25   0.023 ± 0.002  ms/op
PooledByteBufAllocatorAlignBenchmark.writeRead             0    04096  avgt   25   0.094 ± 0.007  ms/op
PooledByteBufAllocatorAlignBenchmark.writeRead             0    16384  avgt   25   0.380 ± 0.028  ms/op
PooledByteBufAllocatorAlignBenchmark.writeRead             0    65536  avgt   25   1.477 ± 0.127  ms/op
PooledByteBufAllocatorAlignBenchmark.writeRead             0  1048576  avgt   25  27.154 ± 2.389  ms/op
PooledByteBufAllocatorAlignBenchmark.writeRead            64    01024  avgt   25   0.021 ± 0.002  ms/op
PooledByteBufAllocatorAlignBenchmark.writeRead            64    04096  avgt   25   0.087 ± 0.009  ms/op
PooledByteBufAllocatorAlignBenchmark.writeRead            64    16384  avgt   25   0.353 ± 0.037  ms/op
PooledByteBufAllocatorAlignBenchmark.writeRead            64    65536  avgt   25   1.367 ± 0.112  ms/op
PooledByteBufAllocatorAlignBenchmark.writeRead            64  1048576  avgt   25  22.501 ± 1.552  ms/op
```
Benchmarks show better write and read performance on large buffer size.