### PR TITLE
Allow to configure a maximum select timeout / epoll wait timeout

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -58,9 +58,10 @@ public final class NioEventLoop extends SingleThreadEventLoop {
 
     private static final int CLEANUP_INTERVAL = 256; // XXX Hard-coded value, but won't need customization.
 
+    private static final long MAX_SELECT_TIMEOUT =
+            SystemPropertyUtil.getLong("io.netty.maxSelectTimeout", Long.MAX_VALUE);
     private static final boolean DISABLE_KEYSET_OPTIMIZATION =
             SystemPropertyUtil.getBoolean("io.netty.noKeySetOptimization", false);
-
     private static final int MIN_PREMATURE_SELECTOR_RETURNS = 3;
     private static final int SELECTOR_AUTO_REBUILD_THRESHOLD;
 
@@ -724,7 +725,8 @@ public final class NioEventLoop extends SingleThreadEventLoop {
             long currentTimeNanos = System.nanoTime();
             long selectDeadLineNanos = currentTimeNanos + delayNanos(currentTimeNanos);
             for (;;) {
-                long timeoutMillis = (selectDeadLineNanos - currentTimeNanos + 500000L) / 1000000L;
+                long timeoutMillis = Math.min(MAX_SELECT_TIMEOUT,
+                        (selectDeadLineNanos - currentTimeNanos + 500000L) / 1000000L);
                 if (timeoutMillis <= 0) {
                     if (selectCnt == 0) {
                         selector.selectNow();


### PR DESCRIPTION
Motivation:

To optimize throughput it can be useful to allow set a maximum select / epoll wait timeout.

Modifications:

Add system property which allows to set a max value.

Result:

More flexible configuration