### PR TITLE
Cleanup : 'for each' loops for arrays and removed unnecessary toLowerCase()

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -440,8 +440,7 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
     private static List<PoolSubpageMetric> subPageMetricList(PoolSubpage<?>[] pages) {
         List<PoolSubpageMetric> metrics = new ArrayList<PoolSubpageMetric>();
-        for (int i = 0; i < pages.length; i ++) {
-            PoolSubpage<?> head = pages[i];
+        for (PoolSubpage<?> head : pages) {
             if (head.next == head) {
                 continue;
             }

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -448,8 +448,8 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator {
         }
 
         int total = 0;
-        for (int i = 0; i < arenas.length; i++) {
-            total += arenas[i].numThreadCaches.get();
+        for (PoolArena<?> arena : arenas) {
+            total += arena.numThreadCaches.get();
         }
 
         return total;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Error.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Error.java
@@ -42,8 +42,7 @@ public enum Http2Error {
     static {
         Http2Error[] errors = Http2Error.values();
         Http2Error[] map = new Http2Error[errors.length];
-        for (int i = 0; i < errors.length; ++i) {
-            Http2Error error = errors[i];
+        for (Http2Error error : errors) {
             map[(int) error.code()] = error;
         }
         INT_TO_ENUM_MAP = map;

--- a/codec/src/main/java/io/netty/handler/codec/compression/Bzip2BlockCompressor.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Bzip2BlockCompressor.java
@@ -117,8 +117,8 @@ final class Bzip2BlockCompressor {
             }
         }
 
-        for (int i = 0; i < condensedInUse.length; i++) {
-            writer.writeBoolean(out, condensedInUse[i]);
+        for (boolean isCondensedInUse : condensedInUse) {
+            writer.writeBoolean(out, isCondensedInUse);
         }
 
         for (int i = 0; i < condensedInUse.length; i++) {

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -893,11 +893,11 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
      */
     private boolean ignoreException(Throwable t) {
         if (!(t instanceof SSLException) && t instanceof IOException && sslClosePromise.isDone()) {
-            String message = String.valueOf(t.getMessage()).toLowerCase();
+            String message = t.getMessage();
 
             // first try to match connection reset / broke peer based on the regex. This is the fastest way
             // but may fail on different jdk impls or OS's
-            if (IGNORABLE_ERROR_MESSAGE.matcher(message).matches()) {
+            if (message != null && IGNORABLE_ERROR_MESSAGE.matcher(message).matches()) {
                 return true;
             }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/IovArray.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/IovArray.java
@@ -134,8 +134,7 @@ final class IovArray implements MessageProcessor {
             // No more room!
             return false;
         }
-        for (int i = 0; i < buffers.length; i++) {
-            ByteBuffer nioBuffer = buffers[i];
+        for (ByteBuffer nioBuffer : buffers) {
             int offset = nioBuffer.position();
             int len = nioBuffer.limit() - nioBuffer.position();
             if (len == 0) {

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/NativeDatagramPacketArray.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/NativeDatagramPacketArray.java
@@ -39,10 +39,10 @@ final class NativeDatagramPacketArray implements ChannelOutboundBuffer.MessagePr
 
                 @Override
                 protected void onRemoval(NativeDatagramPacketArray value) throws Exception {
-                    NativeDatagramPacket[] array = value.packets;
+                    NativeDatagramPacket[] packetsArray = value.packets;
                     // Release all packets
-                    for (int i = 0; i < array.length; i++) {
-                        array[i].release();
+                    for (NativeDatagramPacket datagramPacket : packetsArray) {
+                        datagramPacket.release();
                     }
                 }
             };


### PR DESCRIPTION
Motivation:

1. Make code easier to read with `for each` loops instead of `for (int i )`.
2. Simplify old code.

Modification:

1. `for each` loops introduced instead of `for (int i )` for arrays only (no iterator allocation).
2. Removed unnecessary `valueOf` and `toLowerCase` in `SslHandler.ignoreException` as `Pattern IGNORABLE_ERROR_MESSAGE` is `Pattern.CASE_INSENSITIVE`.

Result:

Code easier to read. No unnecessary operations.