### PR TITLE
AggregatedFullHttpMessage.replace should also copy a decoder result

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -404,6 +404,7 @@ public class HttpObjectAggregator
             DefaultFullHttpRequest dup = new DefaultFullHttpRequest(protocolVersion(), method(), uri(), content);
             dup.headers().set(headers());
             dup.trailingHeaders().set(trailingHeaders());
+            dup.setDecoderResult(decoderResult());
             return dup;
         }
 
@@ -502,6 +503,7 @@ public class HttpObjectAggregator
             DefaultFullHttpResponse dup = new DefaultFullHttpResponse(getProtocolVersion(), getStatus(), content);
             dup.headers().set(headers());
             dup.trailingHeaders().set(trailingHeaders());
+            dup.setDecoderResult(decoderResult());
             return dup;
         }
 


### PR DESCRIPTION
## Motivation:

`HttpObjectAggregator` yields full HTTP messgaes (`AggregatedFullHttpMessage`s) that don't respect decoder result when copied/replaced.

## Modifications:

Copy the decoding result over to a new instance produced by `AggregatedFullHttpRequest.replace` or `AggregatedFullHttpResponse.replace` .

## Result:

`DecoderResult` is now copied over when an original `AggregatedFullHttpMessage` is being replaced (i.e., `AggregatedFullHttpRequest.replace` or `AggregatedFullHttpResponse.replace` is being called).

New unit tests are passing on this branch but are failing on master.