### PR TITLE
Try to detect the cacheline size automatically

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -18,6 +18,7 @@ package io.netty.buffer;
 
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.FastThreadLocalThread;
+import io.netty.util.internal.MathUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.SystemPropertyUtil;
@@ -208,9 +209,18 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator {
             throw new IllegalArgumentException("nDirectArea: " + nDirectArena + " (expected: >= 0)");
         }
 
-        if (directMemoryCacheAlignment < 0) {
+        if (directMemoryCacheAlignment < -1) {
             throw new IllegalArgumentException("directMemoryCacheAlignment: "
-                    + directMemoryCacheAlignment + " (expected: >= 0)");
+                    + directMemoryCacheAlignment + " (expected: >= -1)");
+        }
+
+        if (directMemoryCacheAlignment == -1) {
+            directMemoryCacheAlignment = PlatformDependent.cacheLineSize();
+            if (directMemoryCacheAlignment == -1) {
+                directMemoryCacheAlignment = DEFAULT_DIRECT_MEMORY_CACHE_ALIGNMENT;
+            } else {
+                directMemoryCacheAlignment = MathUtil.findNextPositivePowerOfTwo(directMemoryCacheAlignment);
+            }
         }
 
         if ((directMemoryCacheAlignment & -directMemoryCacheAlignment) != directMemoryCacheAlignment) {


### PR DESCRIPTION
Motivation:

For max performance it may be worthwhile to allocate buffers from PooledByteBufAllocator alligned by the cacheline size.  In previous code-change we allowed to do so but the users needs to manually specify the cacheline size. On linux and osx (macos) its possible to detect it automatically and so let the user use -1 to signal it should be automatically detected.

Modifications:

- Add new code in PlatformDependent which allows detecting the cacheline size on a system
- Allow -1 as value when specify the cacheline size in PooledByteBufAllocator which will try to detect it automatically then.

Result:

Easier configuration of PooledByteBufAllocator.