### PR TITLE
Only use Mockito for mocking.

### DIFF
--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -34,5 +34,9 @@
       <artifactId>netty-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
@@ -16,6 +16,8 @@
 package io.netty.buffer;
 
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,8 +27,8 @@ import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 
 import static io.netty.buffer.Unpooled.*;
-import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests read-only channel buffers
@@ -74,30 +76,28 @@ public class ReadOnlyByteBufTest {
 
     @Test
     public void shouldForwardReadCallsBlindly() throws Exception {
-        ByteBuf buf = createStrictMock(ByteBuf.class);
-        expect(buf.order()).andReturn(BIG_ENDIAN).anyTimes();
-        expect(buf.maxCapacity()).andReturn(65536).anyTimes();
-        expect(buf.readerIndex()).andReturn(0).anyTimes();
-        expect(buf.writerIndex()).andReturn(0).anyTimes();
-        expect(buf.capacity()).andReturn(0).anyTimes();
+        ByteBuf buf = mock(ByteBuf.class);
+        when(buf.order()).thenReturn(BIG_ENDIAN);
+        when(buf.maxCapacity()).thenReturn(65536);
+        when(buf.readerIndex()).thenReturn(0);
+        when(buf.writerIndex()).thenReturn(0);
+        when(buf.capacity()).thenReturn(0);
 
-        expect(buf.getBytes(1, (GatheringByteChannel) null, 2)).andReturn(3);
-        expect(buf.getBytes(4, (OutputStream) null, 5)).andReturn(buf);
-        expect(buf.getBytes(6, (byte[]) null, 7, 8)).andReturn(buf);
-        expect(buf.getBytes(9, (ByteBuf) null, 10, 11)).andReturn(buf);
-        expect(buf.getBytes(12, (ByteBuffer) null)).andReturn(buf);
-        expect(buf.getByte(13)).andReturn(Byte.valueOf((byte) 14));
-        expect(buf.getShort(15)).andReturn(Short.valueOf((short) 16));
-        expect(buf.getUnsignedMedium(17)).andReturn(18);
-        expect(buf.getInt(19)).andReturn(20);
-        expect(buf.getLong(21)).andReturn(22L);
+        when(buf.getBytes(1, (GatheringByteChannel) null, 2)).thenReturn(3);
+        when(buf.getBytes(4, (OutputStream) null, 5)).thenReturn(buf);
+        when(buf.getBytes(6, (byte[]) null, 7, 8)).thenReturn(buf);
+        when(buf.getBytes(9, (ByteBuf) null, 10, 11)).thenReturn(buf);
+        when(buf.getBytes(12, (ByteBuffer) null)).thenReturn(buf);
+        when(buf.getByte(13)).thenReturn(Byte.valueOf((byte) 14));
+        when(buf.getShort(15)).thenReturn(Short.valueOf((short) 16));
+        when(buf.getUnsignedMedium(17)).thenReturn(18);
+        when(buf.getInt(19)).thenReturn(20);
+        when(buf.getLong(21)).thenReturn(22L);
 
         ByteBuffer bb = ByteBuffer.allocate(100);
 
-        expect(buf.nioBuffer(23, 24)).andReturn(bb);
-        expect(buf.capacity()).andReturn(27);
-
-        replay(buf);
+        when(buf.nioBuffer(23, 24)).thenReturn(bb);
+        when(buf.capacity()).thenReturn(27);
 
         ByteBuf roBuf = unmodifiableBuffer(buf);
         assertEquals(3, roBuf.getBytes(1, (GatheringByteChannel) null, 2));
@@ -116,8 +116,6 @@ public class ReadOnlyByteBufTest {
         assertTrue(roBB.isReadOnly());
 
         assertEquals(27, roBuf.capacity());
-
-        verify(buf);
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnpooledTest.java
@@ -15,9 +15,9 @@
  */
 package io.netty.buffer;
 
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -450,19 +450,23 @@ public class UnpooledTest {
             // Expected
         }
 
+        InputStream inputStream = Mockito.mock(InputStream.class);
         try {
-            buf.setBytes(0, EasyMock.createMock(InputStream.class), 0);
+            buf.setBytes(0, inputStream, 0);
             fail();
         } catch (UnsupportedOperationException e) {
             // Expected
         }
+        Mockito.verifyZeroInteractions(inputStream);
 
+        ScatteringByteChannel scatteringByteChannel = Mockito.mock(ScatteringByteChannel.class);
         try {
-            buf.setBytes(0, EasyMock.createMock(ScatteringByteChannel.class), 0);
+            buf.setBytes(0, scatteringByteChannel, 0);
             fail();
         } catch (UnsupportedOperationException e) {
             // Expected
         }
+        Mockito.verifyZeroInteractions(scatteringByteChannel);
     }
 
     @Test

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -45,6 +45,10 @@
       <artifactId>jzlib</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
@@ -24,8 +24,8 @@ import io.netty.handler.codec.DecoderResult;
 import io.netty.handler.codec.DecoderResultProvider;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.CharsetUtil;
-import org.easymock.EasyMock;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.nio.channels.ClosedChannelException;
 import java.util.List;
@@ -221,9 +221,9 @@ public class HttpObjectAggregatorTest {
     @Test(expected = IllegalStateException.class)
     public void testSetMaxCumulationBufferComponentsAfterInit() throws Exception {
         HttpObjectAggregator aggr = new HttpObjectAggregator(Integer.MAX_VALUE);
-        ChannelHandlerContext ctx = EasyMock.createMock(ChannelHandlerContext.class);
-        EasyMock.replay(ctx);
+        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
         aggr.handlerAdded(ctx);
+        Mockito.verifyNoMoreInteractions(ctx);
         aggr.setMaxCumulationBufferComponents(10);
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocket08FrameDecoderTest.java
@@ -14,16 +14,16 @@ package io.netty.handler.codec.http.websocketx;
 
 import io.netty.channel.ChannelHandlerContext;
 
-import org.easymock.EasyMock;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class WebSocket08FrameDecoderTest {
 
     @Test
     public void channelInactive() throws Exception {
         final WebSocket08FrameDecoder decoder = new WebSocket08FrameDecoder(true, true, 65535, false);
-        final ChannelHandlerContext ctx = EasyMock.createMock(ChannelHandlerContext.class);
+        final ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
         decoder.channelInactive(ctx);
+        Mockito.verify(ctx).fireChannelInactive();
     }
-
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketClientExtensionHandlerTest.java
@@ -27,37 +27,35 @@ import java.util.List;
 import org.junit.Test;
 
 import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionTestUtil.*;
-import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class WebSocketClientExtensionHandlerTest {
 
     WebSocketClientExtensionHandshaker mainHandshakerMock =
-            createMock("mainHandshaker", WebSocketClientExtensionHandshaker.class);
+            mock(WebSocketClientExtensionHandshaker.class, "mainHandshaker");
     WebSocketClientExtensionHandshaker fallbackHandshakerMock =
-            createMock("fallbackHandshaker", WebSocketClientExtensionHandshaker.class);
+            mock(WebSocketClientExtensionHandshaker.class, "fallbackHandshaker");
     WebSocketClientExtension mainExtensionMock =
-            createMock("mainExtension", WebSocketClientExtension.class);
+            mock(WebSocketClientExtension.class, "mainExtension");
     WebSocketClientExtension fallbackExtensionMock =
-            createMock("fallbackExtension", WebSocketClientExtension.class);
+            mock(WebSocketClientExtension.class, "fallbackExtension");
 
     @Test
     public void testMainSuccess() {
         // initialize
-        expect(mainHandshakerMock.newRequestData()).
-                andReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap())).once();
-        expect(mainHandshakerMock.handshakeExtension(
-                anyObject(WebSocketExtensionData.class))).andReturn(mainExtensionMock).once();
-        replay(mainHandshakerMock);
-
-        expect(fallbackHandshakerMock.newRequestData()).
-                andReturn(new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap())).once();
-        replay(fallbackHandshakerMock);
-
-        expect(mainExtensionMock.rsv()).andReturn(WebSocketExtension.RSV1).anyTimes();
-        expect(mainExtensionMock.newExtensionEncoder()).andReturn(new DummyEncoder()).once();
-        expect(mainExtensionMock.newExtensionDecoder()).andReturn(new DummyDecoder()).once();
-        replay(mainExtensionMock);
+        when(mainHandshakerMock.newRequestData()).
+                thenReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
+        when(mainHandshakerMock.handshakeExtension(any(WebSocketExtensionData.class))).thenReturn(mainExtensionMock);
+        when(fallbackHandshakerMock.newRequestData()).
+                thenReturn(new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap()));
+        when(mainExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
+        when(mainExtensionMock.newExtensionEncoder()).thenReturn(new DummyEncoder());
+        when(mainExtensionMock.newExtensionDecoder()).thenReturn(new DummyDecoder());
 
         // execute
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketClientExtensionHandler(
@@ -85,29 +83,30 @@ public class WebSocketClientExtensionHandlerTest {
         assertEquals(1, resExts.size());
         assertEquals("main", resExts.get(0).name());
         assertTrue(resExts.get(0).parameters().isEmpty());
-        assertTrue(ch.pipeline().get(DummyDecoder.class) != null);
-        assertTrue(ch.pipeline().get(DummyEncoder.class) != null);
+        assertNotNull(ch.pipeline().get(DummyDecoder.class));
+        assertNotNull(ch.pipeline().get(DummyEncoder.class) != null);
+
+        verify(mainHandshakerMock).newRequestData();
+        verify(mainHandshakerMock).handshakeExtension(any(WebSocketExtensionData.class));
+        verify(fallbackHandshakerMock).newRequestData();
+        verify(mainExtensionMock, atLeastOnce()).rsv();
+        verify(mainExtensionMock).newExtensionEncoder();
+        verify(mainExtensionMock).newExtensionDecoder();
     }
 
     @Test
     public void testFallbackSuccess() {
         // initialize
-        expect(mainHandshakerMock.newRequestData()).
-                andReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap())).once();
-        expect(mainHandshakerMock.handshakeExtension(
-                anyObject(WebSocketExtensionData.class))).andReturn(null).once();
-        replay(mainHandshakerMock);
-
-        expect(fallbackHandshakerMock.newRequestData()).
-                andReturn(new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap())).once();
-        expect(fallbackHandshakerMock.handshakeExtension(
-                anyObject(WebSocketExtensionData.class))).andReturn(fallbackExtensionMock).once();
-        replay(fallbackHandshakerMock);
-
-        expect(fallbackExtensionMock.rsv()).andReturn(WebSocketExtension.RSV1).anyTimes();
-        expect(fallbackExtensionMock.newExtensionEncoder()).andReturn(new DummyEncoder()).once();
-        expect(fallbackExtensionMock.newExtensionDecoder()).andReturn(new DummyDecoder()).once();
-        replay(fallbackExtensionMock);
+        when(mainHandshakerMock.newRequestData()).
+                thenReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
+        when(mainHandshakerMock.handshakeExtension(any(WebSocketExtensionData.class))).thenReturn(null);
+        when(fallbackHandshakerMock.newRequestData()).
+                thenReturn(new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap()));
+        when(fallbackHandshakerMock.handshakeExtension(
+                any(WebSocketExtensionData.class))).thenReturn(fallbackExtensionMock);
+        when(fallbackExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
+        when(fallbackExtensionMock.newExtensionEncoder()).thenReturn(new DummyEncoder());
+        when(fallbackExtensionMock.newExtensionDecoder()).thenReturn(new DummyDecoder());
 
         // execute
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketClientExtensionHandler(
@@ -135,42 +134,45 @@ public class WebSocketClientExtensionHandlerTest {
         assertEquals(1, resExts.size());
         assertEquals("fallback", resExts.get(0).name());
         assertTrue(resExts.get(0).parameters().isEmpty());
-        assertTrue(ch.pipeline().get(DummyDecoder.class) != null);
-        assertTrue(ch.pipeline().get(DummyEncoder.class) != null);
+        assertNotNull(ch.pipeline().get(DummyDecoder.class));
+        assertNotNull(ch.pipeline().get(DummyEncoder.class));
+
+        verify(mainHandshakerMock).newRequestData();
+        verify(mainHandshakerMock).handshakeExtension(any(WebSocketExtensionData.class));
+        verify(fallbackHandshakerMock).newRequestData();
+        verify(fallbackHandshakerMock).handshakeExtension(any(WebSocketExtensionData.class));
+        verify(fallbackExtensionMock, atLeastOnce()).rsv();
+        verify(fallbackExtensionMock).newExtensionEncoder();
+        verify(fallbackExtensionMock).newExtensionDecoder();
     }
 
     @Test
     public void testAllSuccess() {
         // initialize
-        expect(mainHandshakerMock.newRequestData()).
-                andReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap())).once();
-        expect(mainHandshakerMock.handshakeExtension(
-                webSocketExtensionDataEqual("main"))).andReturn(mainExtensionMock).anyTimes();
-        expect(mainHandshakerMock.handshakeExtension(
-                webSocketExtensionDataEqual("fallback"))).andReturn(null).anyTimes();
-        replay(mainHandshakerMock);
-
-        expect(fallbackHandshakerMock.newRequestData()).
-                andReturn(new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap())).once();
-        expect(fallbackHandshakerMock.handshakeExtension(
-                webSocketExtensionDataEqual("main"))).andReturn(null).anyTimes();
-        expect(fallbackHandshakerMock.handshakeExtension(
-                webSocketExtensionDataEqual("fallback"))).andReturn(fallbackExtensionMock).anyTimes();
-        replay(fallbackHandshakerMock);
+        when(mainHandshakerMock.newRequestData()).
+                thenReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
+        when(mainHandshakerMock.handshakeExtension(
+                webSocketExtensionDataMatcher("main"))).thenReturn(mainExtensionMock);
+        when(mainHandshakerMock.handshakeExtension(
+                webSocketExtensionDataMatcher("fallback"))).thenReturn(null);
+        when(fallbackHandshakerMock.newRequestData()).
+                thenReturn(new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap()));
+        when(fallbackHandshakerMock.handshakeExtension(
+                webSocketExtensionDataMatcher("main"))).thenReturn(null);
+        when(fallbackHandshakerMock.handshakeExtension(
+                webSocketExtensionDataMatcher("fallback"))).thenReturn(fallbackExtensionMock);
 
         DummyEncoder mainEncoder = new DummyEncoder();
         DummyDecoder mainDecoder = new DummyDecoder();
-        expect(mainExtensionMock.rsv()).andReturn(WebSocketExtension.RSV1).anyTimes();
-        expect(mainExtensionMock.newExtensionEncoder()).andReturn(mainEncoder).once();
-        expect(mainExtensionMock.newExtensionDecoder()).andReturn(mainDecoder).once();
-        replay(mainExtensionMock);
+        when(mainExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
+        when(mainExtensionMock.newExtensionEncoder()).thenReturn(mainEncoder);
+        when(mainExtensionMock.newExtensionDecoder()).thenReturn(mainDecoder);
 
         Dummy2Encoder fallbackEncoder = new Dummy2Encoder();
         Dummy2Decoder fallbackDecoder = new Dummy2Decoder();
-        expect(fallbackExtensionMock.rsv()).andReturn(WebSocketExtension.RSV2).anyTimes();
-        expect(fallbackExtensionMock.newExtensionEncoder()).andReturn(fallbackEncoder).once();
-        expect(fallbackExtensionMock.newExtensionDecoder()).andReturn(fallbackDecoder).once();
-        replay(fallbackExtensionMock);
+        when(fallbackExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV2);
+        when(fallbackExtensionMock.newExtensionEncoder()).thenReturn(fallbackEncoder);
+        when(fallbackExtensionMock.newExtensionDecoder()).thenReturn(fallbackDecoder);
 
         // execute
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketClientExtensionHandler(
@@ -198,36 +200,41 @@ public class WebSocketClientExtensionHandlerTest {
         assertEquals(2, resExts.size());
         assertEquals("main", resExts.get(0).name());
         assertEquals("fallback", resExts.get(1).name());
-        assertTrue(ch.pipeline().context(mainEncoder) != null);
-        assertTrue(ch.pipeline().context(mainDecoder) != null);
-        assertTrue(ch.pipeline().context(fallbackEncoder) != null);
-        assertTrue(ch.pipeline().context(fallbackDecoder) != null);
+        assertNotNull(ch.pipeline().context(mainEncoder));
+        assertNotNull(ch.pipeline().context(mainDecoder));
+        assertNotNull(ch.pipeline().context(fallbackEncoder));
+        assertNotNull(ch.pipeline().context(fallbackDecoder));
+
+        verify(mainHandshakerMock).newRequestData();
+        verify(mainHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("main"));
+        verify(mainHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("fallback"));
+        verify(fallbackHandshakerMock).newRequestData();
+        verify(fallbackHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("fallback"));
+        verify(mainExtensionMock, atLeastOnce()).rsv();
+        verify(mainExtensionMock).newExtensionEncoder();
+        verify(mainExtensionMock).newExtensionDecoder();
+        verify(fallbackExtensionMock, atLeastOnce()).rsv();
+        verify(fallbackExtensionMock).newExtensionEncoder();
+        verify(fallbackExtensionMock).newExtensionDecoder();
     }
 
     @Test(expected = CodecException.class)
     public void testIfMainAndFallbackUseRSV1WillFail() {
         // initialize
-        expect(mainHandshakerMock.newRequestData()).
-                andReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap())).once();
-        expect(mainHandshakerMock.handshakeExtension(
-                webSocketExtensionDataEqual("main"))).andReturn(mainExtensionMock).anyTimes();
-        expect(mainHandshakerMock.handshakeExtension(
-                webSocketExtensionDataEqual("fallback"))).andReturn(null).anyTimes();
-        replay(mainHandshakerMock);
-
-        expect(fallbackHandshakerMock.newRequestData()).
-                andReturn(new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap())).once();
-        expect(fallbackHandshakerMock.handshakeExtension(
-                webSocketExtensionDataEqual("main"))).andReturn(null).anyTimes();
-        expect(fallbackHandshakerMock.handshakeExtension(
-                webSocketExtensionDataEqual("fallback"))).andReturn(fallbackExtensionMock).anyTimes();
-        replay(fallbackHandshakerMock);
-
-        expect(mainExtensionMock.rsv()).andReturn(WebSocketExtension.RSV1).anyTimes();
-        replay(mainExtensionMock);
-
-        expect(fallbackExtensionMock.rsv()).andReturn(WebSocketExtension.RSV1).anyTimes();
-        replay(fallbackExtensionMock);
+        when(mainHandshakerMock.newRequestData()).
+                thenReturn(new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
+        when(mainHandshakerMock.handshakeExtension(
+                webSocketExtensionDataMatcher("main"))).thenReturn(mainExtensionMock);
+        when(mainHandshakerMock.handshakeExtension(
+                webSocketExtensionDataMatcher("fallback"))).thenReturn(null);
+        when(fallbackHandshakerMock.newRequestData()).
+                thenReturn(new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap()));
+        when(fallbackHandshakerMock.handshakeExtension(
+                webSocketExtensionDataMatcher("main"))).thenReturn(null);
+        when(fallbackHandshakerMock.handshakeExtension(
+                webSocketExtensionDataMatcher("fallback"))).thenReturn(fallbackExtensionMock);
+        when(mainExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
+        when(fallbackExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
 
         // execute
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketClientExtensionHandler(
@@ -247,6 +254,16 @@ public class WebSocketClientExtensionHandlerTest {
         assertEquals(2, reqExts.size());
         assertEquals("main", reqExts.get(0).name());
         assertEquals("fallback", reqExts.get(1).name());
-    }
 
+        verify(mainHandshakerMock).newRequestData();
+        verify(mainHandshakerMock, atLeastOnce()).handshakeExtension(webSocketExtensionDataMatcher("main"));
+        verify(mainHandshakerMock, atLeastOnce()).handshakeExtension(webSocketExtensionDataMatcher("fallback"));
+
+        verify(fallbackHandshakerMock).newRequestData();
+        verify(fallbackHandshakerMock, atLeastOnce()).handshakeExtension(webSocketExtensionDataMatcher("main"));
+        verify(fallbackHandshakerMock, atLeastOnce()).handshakeExtension(webSocketExtensionDataMatcher("fallback"));
+
+        verify(mainExtensionMock, atLeastOnce()).rsv();
+        verify(fallbackExtensionMock, atLeastOnce()).rsv();
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionTestUtil.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketExtensionTestUtil.java
@@ -19,8 +19,6 @@ import java.util.List;
 
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
-import org.easymock.EasyMock;
-import org.easymock.IArgumentMatcher;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultHttpRequest;
@@ -31,6 +29,9 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import org.mockito.ArgumentMatcher;
+
+import static org.mockito.ArgumentMatchers.argThat;
 
 public final class WebSocketExtensionTestUtil {
 
@@ -64,12 +65,7 @@ public final class WebSocketExtensionTestUtil {
         return res;
     }
 
-    public static WebSocketExtensionData webSocketExtensionDataEqual(String name) {
-        EasyMock.reportMatcher(new WebSocketExtensionDataMatcher(name));
-        return null;
-    }
-
-    public static class WebSocketExtensionDataMatcher implements IArgumentMatcher {
+    static final class WebSocketExtensionDataMatcher implements ArgumentMatcher<WebSocketExtensionData> {
 
         private final String name;
 
@@ -78,15 +74,13 @@ public final class WebSocketExtensionTestUtil {
         }
 
         @Override
-        public void appendTo(StringBuffer buf) {
-            buf.append("WebSocketExtensionData with name=" + name);
+        public boolean matches(WebSocketExtensionData data) {
+            return data != null && name.equals(data.name());
         }
+    }
 
-        @Override
-        public boolean matches(Object o) {
-            return o instanceof WebSocketExtensionData &&
-                    name.equals(((WebSocketExtensionData) o).name());
-        }
+    static WebSocketExtensionData webSocketExtensionDataMatcher(String text) {
+        return argThat(new WebSocketExtensionDataMatcher(text));
     }
 
     private WebSocketExtensionTestUtil() {
@@ -124,5 +118,4 @@ public final class WebSocketExtensionTestUtil {
             // unused
         }
     }
-
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/WebSocketServerExtensionHandlerTest.java
@@ -26,44 +26,40 @@ import java.util.List;
 import org.junit.Test;
 
 import static io.netty.handler.codec.http.websocketx.extensions.WebSocketExtensionTestUtil.*;
-import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public class WebSocketServerExtensionHandlerTest {
 
     WebSocketServerExtensionHandshaker mainHandshakerMock =
-            createMock("mainHandshaker", WebSocketServerExtensionHandshaker.class);
+            mock(WebSocketServerExtensionHandshaker.class, "mainHandshaker");
     WebSocketServerExtensionHandshaker fallbackHandshakerMock =
-            createMock("fallbackHandshaker", WebSocketServerExtensionHandshaker.class);
+            mock(WebSocketServerExtensionHandshaker.class, "fallbackHandshaker");
     WebSocketServerExtension mainExtensionMock =
-            createMock("mainExtension", WebSocketServerExtension.class);
+            mock(WebSocketServerExtension.class, "mainExtension");
     WebSocketServerExtension fallbackExtensionMock =
-            createMock("fallbackExtension", WebSocketServerExtension.class);
+            mock(WebSocketServerExtension.class, "fallbackExtension");
 
     @Test
     public void testMainSuccess() {
         // initialize
-        expect(mainHandshakerMock.handshakeExtension(webSocketExtensionDataEqual("main"))).
-                andReturn(mainExtensionMock).anyTimes();
-        expect(mainHandshakerMock.handshakeExtension(webSocketExtensionDataEqual("fallback"))).
-                andReturn(null).anyTimes();
-        replay(mainHandshakerMock);
+        when(mainHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("main"))).
+                thenReturn(mainExtensionMock);
+        when(mainHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("fallback"))).
+                thenReturn(null);
 
-        expect(fallbackHandshakerMock.handshakeExtension(webSocketExtensionDataEqual("fallback"))).
-                andReturn(fallbackExtensionMock).anyTimes();
-        expect(fallbackHandshakerMock.handshakeExtension(webSocketExtensionDataEqual("main"))).
-                andReturn(null).anyTimes();
-        replay(fallbackHandshakerMock);
+        when(fallbackHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("fallback"))).
+                thenReturn(fallbackExtensionMock);
+        when(fallbackHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("main"))).
+                thenReturn(null);
 
-        expect(mainExtensionMock.rsv()).andReturn(WebSocketExtension.RSV1).anyTimes();
-        expect(mainExtensionMock.newReponseData()).andReturn(
-                new WebSocketExtensionData("main", Collections.<String, String>emptyMap())).once();
-        expect(mainExtensionMock.newExtensionEncoder()).andReturn(new DummyEncoder()).once();
-        expect(mainExtensionMock.newExtensionDecoder()).andReturn(new DummyDecoder()).once();
-        replay(mainExtensionMock);
+        when(mainExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
+        when(mainExtensionMock.newReponseData()).thenReturn(
+                new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
+        when(mainExtensionMock.newExtensionEncoder()).thenReturn(new DummyEncoder());
+        when(mainExtensionMock.newExtensionDecoder()).thenReturn(new DummyDecoder());
 
-        expect(fallbackExtensionMock.rsv()).andReturn(WebSocketExtension.RSV1).anyTimes();
-        replay(fallbackExtensionMock);
+        when(fallbackExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
 
         // execute
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerExtensionHandler(
@@ -83,38 +79,44 @@ public class WebSocketServerExtensionHandlerTest {
         assertEquals(1, resExts.size());
         assertEquals("main", resExts.get(0).name());
         assertTrue(resExts.get(0).parameters().isEmpty());
-        assertTrue(ch.pipeline().get(DummyDecoder.class) != null);
-        assertTrue(ch.pipeline().get(DummyEncoder.class) != null);
+        assertNotNull(ch.pipeline().get(DummyDecoder.class));
+        assertNotNull(ch.pipeline().get(DummyEncoder.class));
+
+        verify(mainHandshakerMock, atLeastOnce()).handshakeExtension(webSocketExtensionDataMatcher("main"));
+        verify(mainHandshakerMock, atLeastOnce()).handshakeExtension(webSocketExtensionDataMatcher("fallback"));
+        verify(fallbackHandshakerMock, atLeastOnce()).handshakeExtension(webSocketExtensionDataMatcher("fallback"));
+
+        verify(mainExtensionMock, atLeastOnce()).rsv();
+        verify(mainExtensionMock).newReponseData();
+        verify(mainExtensionMock).newExtensionEncoder();
+        verify(mainExtensionMock).newExtensionDecoder();
+        verify(fallbackExtensionMock, atLeastOnce()).rsv();
     }
 
     @Test
     public void testCompatibleExtensionTogetherSuccess() {
         // initialize
-        expect(mainHandshakerMock.handshakeExtension(webSocketExtensionDataEqual("main"))).
-                andReturn(mainExtensionMock).anyTimes();
-        expect(mainHandshakerMock.handshakeExtension(webSocketExtensionDataEqual("fallback"))).
-                andReturn(null).anyTimes();
-        replay(mainHandshakerMock);
+        when(mainHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("main"))).
+                thenReturn(mainExtensionMock);
+        when(mainHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("fallback"))).
+                thenReturn(null);
 
-        expect(fallbackHandshakerMock.handshakeExtension(webSocketExtensionDataEqual("fallback"))).
-                andReturn(fallbackExtensionMock).anyTimes();
-        expect(fallbackHandshakerMock.handshakeExtension(webSocketExtensionDataEqual("main"))).
-                andReturn(null).anyTimes();
-        replay(fallbackHandshakerMock);
+        when(fallbackHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("fallback"))).
+                thenReturn(fallbackExtensionMock);
+        when(fallbackHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("main"))).
+                thenReturn(null);
 
-        expect(mainExtensionMock.rsv()).andReturn(WebSocketExtension.RSV1).anyTimes();
-        expect(mainExtensionMock.newReponseData()).andReturn(
-                new WebSocketExtensionData("main", Collections.<String, String>emptyMap())).once();
-        expect(mainExtensionMock.newExtensionEncoder()).andReturn(new DummyEncoder()).once();
-        expect(mainExtensionMock.newExtensionDecoder()).andReturn(new DummyDecoder()).once();
-        replay(mainExtensionMock);
+        when(mainExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV1);
+        when(mainExtensionMock.newReponseData()).thenReturn(
+                new WebSocketExtensionData("main", Collections.<String, String>emptyMap()));
+        when(mainExtensionMock.newExtensionEncoder()).thenReturn(new DummyEncoder());
+        when(mainExtensionMock.newExtensionDecoder()).thenReturn(new DummyDecoder());
 
-        expect(fallbackExtensionMock.rsv()).andReturn(WebSocketExtension.RSV2).anyTimes();
-        expect(fallbackExtensionMock.newReponseData()).andReturn(
-                new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap())).once();
-        expect(fallbackExtensionMock.newExtensionEncoder()).andReturn(new Dummy2Encoder()).once();
-        expect(fallbackExtensionMock.newExtensionDecoder()).andReturn(new Dummy2Decoder()).once();
-        replay(fallbackExtensionMock);
+        when(fallbackExtensionMock.rsv()).thenReturn(WebSocketExtension.RSV2);
+        when(fallbackExtensionMock.newReponseData()).thenReturn(
+                new WebSocketExtensionData("fallback", Collections.<String, String>emptyMap()));
+        when(fallbackExtensionMock.newExtensionEncoder()).thenReturn(new Dummy2Encoder());
+        when(fallbackExtensionMock.newExtensionDecoder()).thenReturn(new Dummy2Decoder());
 
         // execute
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerExtensionHandler(
@@ -134,26 +136,38 @@ public class WebSocketServerExtensionHandlerTest {
         assertEquals(2, resExts.size());
         assertEquals("main", resExts.get(0).name());
         assertEquals("fallback", resExts.get(1).name());
-        assertTrue(ch.pipeline().get(DummyDecoder.class) != null);
-        assertTrue(ch.pipeline().get(DummyEncoder.class) != null);
-        assertTrue(ch.pipeline().get(Dummy2Decoder.class) != null);
-        assertTrue(ch.pipeline().get(Dummy2Encoder.class) != null);
+        assertNotNull(ch.pipeline().get(DummyDecoder.class));
+        assertNotNull(ch.pipeline().get(DummyEncoder.class));
+        assertNotNull(ch.pipeline().get(Dummy2Decoder.class));
+        assertNotNull(ch.pipeline().get(Dummy2Encoder.class));
+
+        verify(mainHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("main"));
+        verify(mainHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("fallback"));
+        verify(fallbackHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("fallback"));
+        verify(mainExtensionMock, times(2)).rsv();
+        verify(mainExtensionMock).newReponseData();
+        verify(mainExtensionMock).newExtensionEncoder();
+        verify(mainExtensionMock).newExtensionDecoder();
+
+        verify(fallbackExtensionMock, times(2)).rsv();
+
+        verify(fallbackExtensionMock).newReponseData();
+        verify(fallbackExtensionMock).newExtensionEncoder();
+        verify(fallbackExtensionMock).newExtensionDecoder();
     }
 
     @Test
     public void testNoneExtensionMatchingSuccess() {
         // initialize
-        expect(mainHandshakerMock.handshakeExtension(webSocketExtensionDataEqual("unknown"))).
-                andReturn(null).anyTimes();
-        expect(mainHandshakerMock.handshakeExtension(webSocketExtensionDataEqual("unknown2"))).
-                andReturn(null).anyTimes();
-        replay(mainHandshakerMock);
+        when(mainHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("unknown"))).
+                thenReturn(null);
+        when(mainHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("unknown2"))).
+                thenReturn(null);
 
-        expect(fallbackHandshakerMock.handshakeExtension(webSocketExtensionDataEqual("unknown"))).
-                andReturn(null).anyTimes();
-        expect(fallbackHandshakerMock.handshakeExtension(webSocketExtensionDataEqual("unknown2"))).
-                andReturn(null).anyTimes();
-        replay(fallbackHandshakerMock);
+        when(fallbackHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("unknown"))).
+                thenReturn(null);
+        when(fallbackHandshakerMock.handshakeExtension(webSocketExtensionDataMatcher("unknown2"))).
+                thenReturn(null);
 
         // execute
         EmbeddedChannel ch = new EmbeddedChannel(new WebSocketServerExtensionHandler(
@@ -169,6 +183,11 @@ public class WebSocketServerExtensionHandlerTest {
 
         // test
         assertFalse(res2.headers().contains(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS));
-    }
 
+        verify(mainHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("unknown"));
+        verify(mainHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("unknown2"));
+
+        verify(fallbackHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("unknown"));
+        verify(fallbackHandshakerMock).handshakeExtension(webSocketExtensionDataMatcher("unknown2"));
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/spdy/SpdyFrameDecoderTest.java
@@ -17,110 +17,123 @@ package io.netty.handler.codec.spdy;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayDeque;
+import java.util.Queue;
 import java.util.Random;
 
 import static io.netty.handler.codec.spdy.SpdyCodecUtil.SPDY_HEADER_SIZE;
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.createStrictMock;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
 public class SpdyFrameDecoderTest {
 
     private static final Random RANDOM = new Random();
 
-    private final SpdyFrameDecoderDelegate delegate = createStrictMock(SpdyFrameDecoderDelegate.class);
+    private final SpdyFrameDecoderDelegate delegate = mock(SpdyFrameDecoderDelegate.class);
+    private final TestSpdyFrameDecoderDelegate testDelegate = new TestSpdyFrameDecoderDelegate();
     private SpdyFrameDecoder decoder;
 
     @Before
     public void createDecoder() {
-        decoder = new SpdyFrameDecoder(SpdyVersion.SPDY_3_1, new SpdyFrameDecoderDelegate() {
-            @Override
-            public void readDataFrame(int streamId, boolean last, ByteBuf data) {
-                try {
-                    delegate.readDataFrame(streamId, last, data);
-                } finally {
-                    // release the data after we delegate it and so checked it.
-                    data.release();
+        decoder = new SpdyFrameDecoder(SpdyVersion.SPDY_3_1, testDelegate);
+    }
+
+    @After
+    public void releaseBuffers() {
+        testDelegate.releaseAll();
+    }
+
+    private final class TestSpdyFrameDecoderDelegate implements SpdyFrameDecoderDelegate {
+        private final Queue<ByteBuf> buffers = new ArrayDeque<ByteBuf>();
+
+        @Override
+        public void readDataFrame(int streamId, boolean last, ByteBuf data) {
+            delegate.readDataFrame(streamId, last, data);
+            buffers.add(data);
+        }
+
+        @Override
+        public void readSynStreamFrame(int streamId, int associatedToStreamId,
+        byte priority, boolean last, boolean unidirectional) {
+            delegate.readSynStreamFrame(streamId, associatedToStreamId, priority, last, unidirectional);
+        }
+
+        @Override
+        public void readSynReplyFrame(int streamId, boolean last) {
+            delegate.readSynReplyFrame(streamId, last);
+        }
+
+        @Override
+        public void readRstStreamFrame(int streamId, int statusCode) {
+            delegate.readRstStreamFrame(streamId, statusCode);
+        }
+
+        @Override
+        public void readSettingsFrame(boolean clearPersisted) {
+            delegate.readSettingsFrame(clearPersisted);
+        }
+
+        @Override
+        public void readSetting(int id, int value, boolean persistValue, boolean persisted) {
+            delegate.readSetting(id, value, persistValue, persisted);
+        }
+
+        @Override
+        public void readSettingsEnd() {
+            delegate.readSettingsEnd();
+        }
+
+        @Override
+        public void readPingFrame(int id) {
+            delegate.readPingFrame(id);
+        }
+
+        @Override
+        public void readGoAwayFrame(int lastGoodStreamId, int statusCode) {
+            delegate.readGoAwayFrame(lastGoodStreamId, statusCode);
+        }
+
+        @Override
+        public void readHeadersFrame(int streamId, boolean last) {
+            delegate.readHeadersFrame(streamId, last);
+        }
+
+        @Override
+        public void readWindowUpdateFrame(int streamId, int deltaWindowSize) {
+            delegate.readWindowUpdateFrame(streamId, deltaWindowSize);
+        }
+
+        @Override
+        public void readHeaderBlock(ByteBuf headerBlock) {
+            delegate.readHeaderBlock(headerBlock);
+            buffers.add(headerBlock);
+        }
+
+        @Override
+        public void readHeaderBlockEnd() {
+            delegate.readHeaderBlockEnd();
+        }
+
+        @Override
+        public void readFrameError(String message) {
+            delegate.readFrameError(message);
+        }
+
+        void releaseAll() {
+            for (;;) {
+                ByteBuf buf = buffers.poll();
+                if (buf == null) {
+                    return;
                 }
+                buf.release();
             }
-
-            @Override
-            public void readSynStreamFrame(int streamId, int associatedToStreamId,
-                                           byte priority, boolean last, boolean unidirectional) {
-                delegate.readSynStreamFrame(streamId, associatedToStreamId, priority, last, unidirectional);
-            }
-
-            @Override
-            public void readSynReplyFrame(int streamId, boolean last) {
-                delegate.readSynReplyFrame(streamId, last);
-            }
-
-            @Override
-            public void readRstStreamFrame(int streamId, int statusCode) {
-                delegate.readRstStreamFrame(streamId, statusCode);
-            }
-
-            @Override
-            public void readSettingsFrame(boolean clearPersisted) {
-                delegate.readSettingsFrame(clearPersisted);
-            }
-
-            @Override
-            public void readSetting(int id, int value, boolean persistValue, boolean persisted) {
-                delegate.readSetting(id, value, persistValue, persisted);
-            }
-
-            @Override
-            public void readSettingsEnd() {
-                delegate.readSettingsEnd();
-            }
-
-            @Override
-            public void readPingFrame(int id) {
-                delegate.readPingFrame(id);
-            }
-
-            @Override
-            public void readGoAwayFrame(int lastGoodStreamId, int statusCode) {
-                delegate.readGoAwayFrame(lastGoodStreamId, statusCode);
-            }
-
-            @Override
-            public void readHeadersFrame(int streamId, boolean last) {
-                delegate.readHeadersFrame(streamId, last);
-            }
-
-            @Override
-            public void readWindowUpdateFrame(int streamId, int deltaWindowSize) {
-                delegate.readWindowUpdateFrame(streamId, deltaWindowSize);
-            }
-
-            @Override
-            public void readHeaderBlock(ByteBuf headerBlock) {
-                try {
-                    delegate.readHeaderBlock(headerBlock);
-                } finally {
-                    // release the data after we delegate it and so checked it.
-                    headerBlock.release();
-                }
-            }
-
-            @Override
-            public void readHeaderBlockEnd() {
-                delegate.readHeaderBlockEnd();
-            }
-
-            @Override
-            public void readFrameError(String message) {
-                delegate.readFrameError(message);
-            }
-        });
+        }
     }
 
     private static void encodeDataFrameHeader(ByteBuf buffer, int streamId, byte flags, int length) {
@@ -147,10 +160,8 @@ public class SpdyFrameDecoderTest {
         for (int i = 0; i < 256; i ++) {
             buf.writeInt(RANDOM.nextInt());
         }
-        delegate.readDataFrame(streamId, false, buf.slice(SPDY_HEADER_SIZE, length));
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readDataFrame(streamId, false, buf.slice(SPDY_HEADER_SIZE, length));
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -164,10 +175,8 @@ public class SpdyFrameDecoderTest {
         ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeDataFrameHeader(buf, streamId, flags, length);
 
-        delegate.readDataFrame(streamId, false, Unpooled.EMPTY_BUFFER);
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readDataFrame(streamId, false, Unpooled.EMPTY_BUFFER);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -181,10 +190,8 @@ public class SpdyFrameDecoderTest {
         ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeDataFrameHeader(buf, streamId, flags, length);
 
-        delegate.readDataFrame(streamId, true, Unpooled.EMPTY_BUFFER);
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readDataFrame(streamId, true, Unpooled.EMPTY_BUFFER);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -198,10 +205,8 @@ public class SpdyFrameDecoderTest {
         ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeDataFrameHeader(buf, streamId, flags, length);
 
-        delegate.readDataFrame(streamId, false, Unpooled.EMPTY_BUFFER);
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readDataFrame(streamId, false, Unpooled.EMPTY_BUFFER);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -215,10 +220,8 @@ public class SpdyFrameDecoderTest {
         ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeDataFrameHeader(buf, streamId, flags, length);
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError((String) any());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -234,11 +237,9 @@ public class SpdyFrameDecoderTest {
         encodeDataFrameHeader(buf, streamId1, flags, length);
         encodeDataFrameHeader(buf, streamId2, flags, length);
 
-        delegate.readDataFrame(streamId1, false, Unpooled.EMPTY_BUFFER);
-        delegate.readDataFrame(streamId2, false, Unpooled.EMPTY_BUFFER);
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readDataFrame(streamId1, false, Unpooled.EMPTY_BUFFER);
+        verify(delegate).readDataFrame(streamId2, false, Unpooled.EMPTY_BUFFER);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -259,11 +260,9 @@ public class SpdyFrameDecoderTest {
         buf.writeByte(priority << 5);
         buf.writeByte(0);
 
-        delegate.readSynStreamFrame(streamId, associatedToStreamId, priority, false, false);
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSynStreamFrame(streamId, associatedToStreamId, priority, false, false);
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -284,11 +283,9 @@ public class SpdyFrameDecoderTest {
         buf.writeByte(priority << 5);
         buf.writeByte(0);
 
-        delegate.readSynStreamFrame(streamId, associatedToStreamId, priority, true, false);
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSynStreamFrame(streamId, associatedToStreamId, priority, true, false);
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -309,11 +306,9 @@ public class SpdyFrameDecoderTest {
         buf.writeByte(priority << 5);
         buf.writeByte(0);
 
-        delegate.readSynStreamFrame(streamId, associatedToStreamId, priority, false, true);
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSynStreamFrame(streamId, associatedToStreamId, priority, false, true);
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -334,11 +329,9 @@ public class SpdyFrameDecoderTest {
         buf.writeByte(priority << 5);
         buf.writeByte(0);
 
-        delegate.readSynStreamFrame(streamId, associatedToStreamId, priority, false, false);
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSynStreamFrame(streamId, associatedToStreamId, priority, false, false);
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -359,11 +352,9 @@ public class SpdyFrameDecoderTest {
         buf.writeByte(priority << 5);
         buf.writeByte(0);
 
-        delegate.readSynStreamFrame(streamId, associatedToStreamId, priority, false, false);
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSynStreamFrame(streamId, associatedToStreamId, priority, false, false);
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -384,11 +375,9 @@ public class SpdyFrameDecoderTest {
         buf.writeByte(priority << 5 | 0x1F); // should ignore reserved bits
         buf.writeByte(0xFF); // should ignore reserved bits
 
-        delegate.readSynStreamFrame(streamId, associatedToStreamId, priority, false, false);
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSynStreamFrame(streamId, associatedToStreamId, priority, false, false);
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -406,10 +395,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(streamId);
         buf.writeInt(associatedToStreamId);
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -430,10 +417,8 @@ public class SpdyFrameDecoderTest {
         buf.writeByte(priority << 5);
         buf.writeByte(0);
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -460,13 +445,11 @@ public class SpdyFrameDecoderTest {
             headerBlock.writeInt(RANDOM.nextInt());
         }
 
-        delegate.readSynStreamFrame(streamId, associatedToStreamId, priority, false, false);
-        delegate.readHeaderBlock(headerBlock.duplicate());
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
         decoder.decode(headerBlock);
-        verify(delegate);
+        verify(delegate).readSynStreamFrame(streamId, associatedToStreamId, priority, false, false);
+        verify(delegate).readHeaderBlock(headerBlock.slice(0, headerBlock.writerIndex()));
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         assertFalse(headerBlock.isReadable());
         buf.release();
@@ -484,11 +467,9 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
-        delegate.readSynReplyFrame(streamId, false);
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSynReplyFrame(streamId, false);
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -504,11 +485,9 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
-        delegate.readSynReplyFrame(streamId, true);
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSynReplyFrame(streamId, true);
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -524,11 +503,9 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
-        delegate.readSynReplyFrame(streamId, false);
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSynReplyFrame(streamId, false);
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -544,11 +521,10 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId | 0x80000000); // should ignore reserved bit
 
-        delegate.readSynReplyFrame(streamId, false);
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSynReplyFrame(streamId, false);
+        verify(delegate).readHeaderBlockEnd();
+
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -562,10 +538,8 @@ public class SpdyFrameDecoderTest {
         ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -581,10 +555,8 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -606,13 +578,11 @@ public class SpdyFrameDecoderTest {
             headerBlock.writeInt(RANDOM.nextInt());
         }
 
-        delegate.readSynReplyFrame(streamId, false);
-        delegate.readHeaderBlock(headerBlock.duplicate());
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
         decoder.decode(headerBlock);
-        verify(delegate);
+        verify(delegate).readSynReplyFrame(streamId, false);
+        verify(delegate).readHeaderBlock(headerBlock.slice(0, headerBlock.writerIndex()));
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         assertFalse(headerBlock.isReadable());
         buf.release();
@@ -632,10 +602,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(streamId);
         buf.writeInt(statusCode);
 
-        delegate.readRstStreamFrame(streamId, statusCode);
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readRstStreamFrame(streamId, statusCode);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -653,10 +621,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(streamId | 0x80000000); // should ignore reserved bit
         buf.writeInt(statusCode);
 
-        delegate.readRstStreamFrame(streamId, statusCode);
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readRstStreamFrame(streamId, statusCode);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -674,10 +640,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(streamId);
         buf.writeInt(statusCode);
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -695,10 +659,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(streamId);
         buf.writeInt(statusCode);
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -716,10 +678,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(streamId);
         buf.writeInt(statusCode);
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -737,10 +697,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(streamId);
         buf.writeInt(statusCode);
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -764,13 +722,10 @@ public class SpdyFrameDecoderTest {
             buf.writeInt(value);
         }
 
-        delegate.readSettingsFrame(false);
-        delegate.readSetting(id, value, false, false);
-        expectLastCall().times(numSettings);
         delegate.readSettingsEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSettingsFrame(false);
+        verify(delegate, times(numSettings)).readSetting(id, value, false, false);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -786,11 +741,9 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(numSettings);
 
-        delegate.readSettingsFrame(false);
-        delegate.readSettingsEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSettingsFrame(false);
+        verify(delegate).readSettingsEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -806,11 +759,9 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(numSettings);
 
-        delegate.readSettingsFrame(true);
-        delegate.readSettingsEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSettingsFrame(true);
+        verify(delegate).readSettingsEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -834,13 +785,10 @@ public class SpdyFrameDecoderTest {
             buf.writeInt(value);
         }
 
-        delegate.readSettingsFrame(false);
-        delegate.readSetting(id, value, true, false);
-        expectLastCall().times(numSettings);
         delegate.readSettingsEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSettingsFrame(false);
+        verify(delegate, times(numSettings)).readSetting(id, value, true, false);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -864,13 +812,10 @@ public class SpdyFrameDecoderTest {
             buf.writeInt(value);
         }
 
-        delegate.readSettingsFrame(false);
-        delegate.readSetting(id, value, false, true);
-        expectLastCall().times(numSettings);
         delegate.readSettingsEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSettingsFrame(false);
+        verify(delegate, times(numSettings)).readSetting(id, value, false, true);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -886,11 +831,9 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(numSettings);
 
-        delegate.readSettingsFrame(false);
-        delegate.readSettingsEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSettingsFrame(false);
+        verify(delegate).readSettingsEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -914,13 +857,10 @@ public class SpdyFrameDecoderTest {
             buf.writeInt(value);
         }
 
-        delegate.readSettingsFrame(false);
-        delegate.readSetting(id, value, false, false);
-        expectLastCall().times(numSettings);
         delegate.readSettingsEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readSettingsFrame(false);
+        verify(delegate, times(numSettings)).readSetting(id, value, false, false);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -944,10 +884,8 @@ public class SpdyFrameDecoderTest {
             buf.writeInt(value);
         }
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -971,10 +909,8 @@ public class SpdyFrameDecoderTest {
             buf.writeInt(value);
         }
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -989,9 +925,8 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeLong(RANDOM.nextLong());
 
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verifyZeroInteractions(delegate);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1005,9 +940,8 @@ public class SpdyFrameDecoderTest {
         ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
 
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verifyZeroInteractions(delegate);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1026,11 +960,10 @@ public class SpdyFrameDecoderTest {
         segment1.writeInt(RANDOM.nextInt());
         segment2.writeInt(RANDOM.nextInt());
 
-        replay(delegate);
         decoder.decode(header);
         decoder.decode(segment1);
         decoder.decode(segment2);
-        verify(delegate);
+        verifyZeroInteractions(delegate);
         assertFalse(header.isReadable());
         assertFalse(segment1.isReadable());
         assertFalse(segment2.isReadable());
@@ -1050,10 +983,8 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(id);
 
-        delegate.readPingFrame(id);
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readPingFrame(id);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1069,10 +1000,8 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(id);
 
-        delegate.readPingFrame(id);
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readPingFrame(id);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1088,10 +1017,8 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(id);
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1109,10 +1036,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(lastGoodStreamId);
         buf.writeInt(statusCode);
 
-        delegate.readGoAwayFrame(lastGoodStreamId, statusCode);
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readGoAwayFrame(lastGoodStreamId, statusCode);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1130,10 +1055,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(lastGoodStreamId);
         buf.writeInt(statusCode);
 
-        delegate.readGoAwayFrame(lastGoodStreamId, statusCode);
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readGoAwayFrame(lastGoodStreamId, statusCode);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1151,10 +1074,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(lastGoodStreamId | 0x80000000); // should ignore reserved bit
         buf.writeInt(statusCode);
 
-        delegate.readGoAwayFrame(lastGoodStreamId, statusCode);
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readGoAwayFrame(lastGoodStreamId, statusCode);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1172,10 +1093,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(lastGoodStreamId);
         buf.writeInt(statusCode);
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1191,11 +1110,9 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
-        delegate.readHeadersFrame(streamId, false);
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readHeadersFrame(streamId, false);
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1211,11 +1128,9 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
-        delegate.readHeadersFrame(streamId, true);
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readHeadersFrame(streamId, true);
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1231,11 +1146,9 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
-        delegate.readHeadersFrame(streamId, false);
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readHeadersFrame(streamId, false);
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1251,11 +1164,9 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId | 0x80000000); // should ignore reserved bit
 
-        delegate.readHeadersFrame(streamId, false);
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readHeadersFrame(streamId, false);
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1269,10 +1180,8 @@ public class SpdyFrameDecoderTest {
         ByteBuf buf = Unpooled.buffer(SPDY_HEADER_SIZE + length);
         encodeControlFrameHeader(buf, type, flags, length);
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1288,10 +1197,8 @@ public class SpdyFrameDecoderTest {
         encodeControlFrameHeader(buf, type, flags, length);
         buf.writeInt(streamId);
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1312,14 +1219,11 @@ public class SpdyFrameDecoderTest {
         for (int i = 0; i < 256; i ++) {
             headerBlock.writeInt(RANDOM.nextInt());
         }
-
-        delegate.readHeadersFrame(streamId, false);
-        delegate.readHeaderBlock(headerBlock.duplicate());
-        delegate.readHeaderBlockEnd();
-        replay(delegate);
         decoder.decode(buf);
         decoder.decode(headerBlock);
-        verify(delegate);
+        verify(delegate).readHeadersFrame(streamId, false);
+        verify(delegate).readHeaderBlock(headerBlock.slice(0, headerBlock.writerIndex()));
+        verify(delegate).readHeaderBlockEnd();
         assertFalse(buf.isReadable());
         assertFalse(headerBlock.isReadable());
         buf.release();
@@ -1339,10 +1243,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(streamId);
         buf.writeInt(deltaWindowSize);
 
-        delegate.readWindowUpdateFrame(streamId, deltaWindowSize);
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readWindowUpdateFrame(streamId, deltaWindowSize);
         assertFalse(buf.isReadable());
     }
 
@@ -1359,10 +1261,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(streamId);
         buf.writeInt(deltaWindowSize);
 
-        delegate.readWindowUpdateFrame(streamId, deltaWindowSize);
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readWindowUpdateFrame(streamId, deltaWindowSize);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1380,10 +1280,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(streamId | 0x80000000); // should ignore reserved bit
         buf.writeInt(deltaWindowSize | 0x80000000); // should ignore reserved bit
 
-        delegate.readWindowUpdateFrame(streamId, deltaWindowSize);
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readWindowUpdateFrame(streamId, deltaWindowSize);
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1401,10 +1299,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(streamId);
         buf.writeInt(deltaWindowSize);
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }
@@ -1422,10 +1318,8 @@ public class SpdyFrameDecoderTest {
         buf.writeInt(streamId);
         buf.writeInt(deltaWindowSize);
 
-        delegate.readFrameError((String) anyObject());
-        replay(delegate);
         decoder.decode(buf);
-        verify(delegate);
+        verify(delegate).readFrameError(anyString());
         assertFalse(buf.isReadable());
         buf.release();
     }

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -48,6 +48,10 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 </project>
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/AbstractWeightedFairQueueByteDistributorDependencyTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/AbstractWeightedFairQueueByteDistributorDependencyTest.java
@@ -33,8 +33,8 @@ abstract class AbstractWeightedFairQueueByteDistributorDependencyTest {
         return new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock in) throws Throwable {
-                Http2Stream stream = in.getArgumentAt(0, Http2Stream.class);
-                int numBytes = in.getArgumentAt(1, Integer.class);
+                Http2Stream stream = in.getArgument(0);
+                int numBytes = in.getArgument(1);
                 int streamableBytes = distributor.streamableBytes0(stream) - numBytes;
                 boolean hasFrame = streamableBytes > 0;
                 updateStream(stream.id(), streamableBytes, hasFrame, hasFrame, closeIfNoFrame);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -93,8 +93,8 @@ public class DataCompressionHttp2Test {
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) throws Throwable {
-                if (invocation.getArgumentAt(4, Boolean.class)) {
-                    serverConnection.stream(invocation.getArgumentAt(1, Integer.class)).close();
+                if (invocation.getArgument(4)) {
+                    serverConnection.stream((Integer) invocation.getArgument(1)).close();
                 }
                 return null;
             }
@@ -103,8 +103,8 @@ public class DataCompressionHttp2Test {
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) throws Throwable {
-                if (invocation.getArgumentAt(7, Boolean.class)) {
-                    serverConnection.stream(invocation.getArgumentAt(1, Integer.class)).close();
+                if (invocation.getArgument(7)) {
+                    serverConnection.stream((Integer) invocation.getArgument(1)).close();
                 }
                 return null;
             }
@@ -283,8 +283,8 @@ public class DataCompressionHttp2Test {
 
                 buf.readBytes(serverOut, buf.readableBytes());
 
-                if (in.getArgumentAt(4, Boolean.class)) {
-                    serverConnection.stream(in.getArgumentAt(1, Integer.class)).close();
+                if (in.getArgument(4)) {
+                    serverConnection.stream((Integer) in.getArgument(1)).close();
                 }
                 return processedBytes;
             }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -108,6 +108,9 @@ public class DefaultHttp2ConnectionDecoderTest {
     private Http2FrameReader reader;
 
     @Mock
+    private Http2FrameWriter writer;
+
+    @Mock
     private Http2ConnectionEncoder encoder;
 
     @Mock
@@ -127,7 +130,7 @@ public class DefaultHttp2ConnectionDecoderTest {
         doAnswer(new Answer<Http2Stream>() {
             @Override
             public Http2Stream answer(InvocationOnMock in) throws Throwable {
-                Http2StreamVisitor visitor = in.getArgumentAt(0, Http2StreamVisitor.class);
+                Http2StreamVisitor visitor = in.getArgument(0);
                 if (!visitor.visit(stream)) {
                     return stream;
                 }
@@ -139,6 +142,7 @@ public class DefaultHttp2ConnectionDecoderTest {
         when(connection.local()).thenReturn(local);
         when(local.flowController()).thenReturn(localFlow);
         when(encoder.flowController()).thenReturn(remoteFlow);
+        when(encoder.frameWriter()).thenReturn(writer);
         when(connection.remote()).thenReturn(remote);
         when(local.reservePushStream(eq(PUSH_STREAM_ID), eq(stream))).thenReturn(pushStream);
         when(remote.reservePushStream(eq(PUSH_STREAM_ID), eq(stream))).thenReturn(pushStream);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -288,7 +288,7 @@ public class DefaultHttp2ConnectionEncoderTest {
                 .then(new Answer<ChannelFuture>() {
                     @Override
                     public ChannelFuture answer(InvocationOnMock invocationOnMock) throws Throwable {
-                        ChannelPromise promise = invocationOnMock.getArgumentAt(8, ChannelPromise.class);
+                        ChannelPromise promise = invocationOnMock.getArgument(8);
                         assertFalse(promise.isVoid());
                         return promise.setFailure(cause);
                     }
@@ -422,7 +422,7 @@ public class DefaultHttp2ConnectionEncoderTest {
         stream(STREAM_ID);
         ChannelPromise promise = newPromise();
         encoder.writeRstStream(ctx, STREAM_ID, PROTOCOL_ERROR.code(), promise);
-        verify(lifecycleManager).resetStream(eq(ctx), eq(STREAM_ID), anyInt(), eq(promise));
+        verify(lifecycleManager).resetStream(eq(ctx), eq(STREAM_ID), anyLong(), eq(promise));
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -89,14 +89,14 @@ public class DefaultHttp2ConnectionTest {
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) throws Throwable {
-                assertNotNull(client.stream(invocation.getArgumentAt(0, Http2Stream.class).id()));
+                assertNotNull(client.stream(((Http2Stream) invocation.getArgument(0)).id()));
                 return null;
             }
         }).when(clientListener).onStreamClosed(any(Http2Stream.class));
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) throws Throwable {
-                assertNull(client.stream(invocation.getArgumentAt(0, Http2Stream.class).id()));
+                assertNull(client.stream(((Http2Stream) invocation.getArgument(0)).id()));
                 return null;
             }
         }).when(clientListener).onStreamRemoved(any(Http2Stream.class));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -137,10 +137,10 @@ public class Http2ConnectionRoundtripTest {
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
-                ChannelHandlerContext ctx = invocationOnMock.getArgumentAt(0, ChannelHandlerContext.class);
+                ChannelHandlerContext ctx = invocationOnMock.getArgument(0);
                 http2Server.encoder().writeHeaders(ctx,
-                        invocationOnMock.getArgumentAt(1, Integer.class),
-                        invocationOnMock.getArgumentAt(2, Http2Headers.class),
+                        (Integer) invocationOnMock.getArgument(1),
+                        (Http2Headers) invocationOnMock.getArgument(2),
                         0,
                         false,
                         ctx.newPromise());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/UniformStreamByteDistributorTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/UniformStreamByteDistributorTest.java
@@ -81,8 +81,8 @@ public class UniformStreamByteDistributorTest {
         return new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock in) throws Throwable {
-                Http2Stream stream = in.getArgumentAt(0, Http2Stream.class);
-                int numBytes = in.getArgumentAt(1, Integer.class);
+                Http2Stream stream = in.getArgument(0);
+                int numBytes = in.getArgument(1);
                 int streamableBytes = distributor.streamableBytes0(stream) - numBytes;
                 updateStream(stream.id(), streamableBytes, streamableBytes > 0);
                 return null;

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributorTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributorTest.java
@@ -18,6 +18,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.mockito.verification.VerificationMode;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.DEFAULT_PRIORITY_WEIGHT;

--- a/codec-mqtt/pom.xml
+++ b/codec-mqtt/pom.xml
@@ -34,5 +34,9 @@
       <artifactId>netty-codec</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -23,9 +23,9 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.util.CharsetUtil;
-import org.easymock.Mock;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.LinkedList;

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -70,6 +70,11 @@
       <optional>true</optional>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+
     <!-- Test dependencies for jboss marshalling encoder/decoder -->
     <dependency>
       <groupId>org.jboss.marshalling</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -77,6 +77,10 @@
       <artifactId>log4j-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/common/src/test/java/io/netty/util/concurrent/PromiseAggregatorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/PromiseAggregatorTest.java
@@ -16,9 +16,10 @@
 
 package io.netty.util.concurrent;
 
-import static org.easymock.EasyMock.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,7 +39,7 @@ public class PromiseAggregatorTest {
     @Test
     public void testAddNullFuture() {
         @SuppressWarnings("unchecked")
-        Promise<Void> p = createStrictMock(Promise.class);
+        Promise<Void> p = mock(Promise.class);
         PromiseAggregator<Void, Future<Void>> a =
                 new PromiseAggregator<Void, Future<Void>>(p);
         expectedException.expect(NullPointerException.class);
@@ -48,85 +49,95 @@ public class PromiseAggregatorTest {
     @SuppressWarnings("unchecked")
     @Test
     public void testSucessfulNoPending() throws Exception {
-        Promise<Void> p = createStrictMock(Promise.class);
+        Promise<Void> p = mock(Promise.class);
         PromiseAggregator<Void, Future<Void>> a =
                 new PromiseAggregator<Void, Future<Void>>(p);
 
-        Future<Void> future = createStrictMock(Future.class);
-        expect(p.setSuccess(null)).andReturn(p);
-        replay(future, p);
+        Future<Void> future = mock(Future.class);
+        when(p.setSuccess(null)).thenReturn(p);
 
         a.add();
         a.operationComplete(future);
-        verify(future, p);
+        verifyNoMoreInteractions(future);
+        verify(p).setSuccess(null);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testSuccessfulPending() throws Exception {
-        Promise<Void> p = createStrictMock(Promise.class);
+        Promise<Void> p = mock(Promise.class);
         PromiseAggregator<Void, Future<Void>> a =
                 new PromiseAggregator<Void, Future<Void>>(p);
-        Promise<Void> p1 = createStrictMock(Promise.class);
-        Promise<Void> p2 = createStrictMock(Promise.class);
+        Promise<Void> p1 = mock(Promise.class);
+        Promise<Void> p2 = mock(Promise.class);
 
-        expect(p1.addListener(a)).andReturn(p1);
-        expect(p2.addListener(a)).andReturn(p2);
-        expect(p1.isSuccess()).andReturn(true);
-        expect(p2.isSuccess()).andReturn(true);
-        expect(p.setSuccess(null)).andReturn(p);
-        replay(p1, p2, p);
+        when(p1.addListener(a)).thenReturn(p1);
+        when(p2.addListener(a)).thenReturn(p2);
+        when(p1.isSuccess()).thenReturn(true);
+        when(p2.isSuccess()).thenReturn(true);
+        when(p.setSuccess(null)).thenReturn(p);
 
         assertThat(a.add(p1, null, p2), is(a));
         a.operationComplete(p1);
         a.operationComplete(p2);
 
-        verify(p1, p2, p);
+        verify(p1).addListener(a);
+        verify(p2).addListener(a);
+        verify(p1).isSuccess();
+        verify(p2).isSuccess();
+        verify(p).setSuccess(null);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testFailedFutureFailPending() throws Exception {
-        Promise<Void> p = createStrictMock(Promise.class);
+        Promise<Void> p = mock(Promise.class);
         PromiseAggregator<Void, Future<Void>> a =
                 new PromiseAggregator<Void, Future<Void>>(p);
-        Promise<Void> p1 = createStrictMock(Promise.class);
-        Promise<Void> p2 = createStrictMock(Promise.class);
-        Throwable t = createStrictMock(Throwable.class);
+        Promise<Void> p1 = mock(Promise.class);
+        Promise<Void> p2 = mock(Promise.class);
+        Throwable t = mock(Throwable.class);
 
-        expect(p1.addListener(a)).andReturn(p1);
-        expect(p2.addListener(a)).andReturn(p2);
-        expect(p1.isSuccess()).andReturn(false);
-        expect(p1.cause()).andReturn(t);
-        expect(p.setFailure(t)).andReturn(p);
-        expect(p2.setFailure(t)).andReturn(p2);
-        replay(p1, p2, p);
+        when(p1.addListener(a)).thenReturn(p1);
+        when(p2.addListener(a)).thenReturn(p2);
+        when(p1.isSuccess()).thenReturn(false);
+        when(p1.cause()).thenReturn(t);
+        when(p.setFailure(t)).thenReturn(p);
+        when(p2.setFailure(t)).thenReturn(p2);
 
         a.add(p1, p2);
         a.operationComplete(p1);
-        verify(p1, p2, p);
+
+        verify(p1).addListener(a);
+        verify(p2).addListener(a);
+        verify(p1).cause();
+        verify(p).setFailure(t);
+        verify(p2).setFailure(t);
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testFailedFutureNoFailPending() throws Exception {
-        Promise<Void> p = createStrictMock(Promise.class);
+        Promise<Void> p = mock(Promise.class);
         PromiseAggregator<Void, Future<Void>> a =
                 new PromiseAggregator<Void, Future<Void>>(p, false);
-        Promise<Void> p1 = createStrictMock(Promise.class);
-        Promise<Void> p2 = createStrictMock(Promise.class);
-        Throwable t = createStrictMock(Throwable.class);
+        Promise<Void> p1 = mock(Promise.class);
+        Promise<Void> p2 = mock(Promise.class);
+        Throwable t = mock(Throwable.class);
 
-        expect(p1.addListener(a)).andReturn(p1);
-        expect(p2.addListener(a)).andReturn(p2);
-        expect(p1.isSuccess()).andReturn(false);
-        expect(p1.cause()).andReturn(t);
-        expect(p.setFailure(t)).andReturn(p);
-        replay(p1, p2, p);
+        when(p1.addListener(a)).thenReturn(p1);
+        when(p2.addListener(a)).thenReturn(p2);
+        when(p1.isSuccess()).thenReturn(false);
+        when(p1.cause()).thenReturn(t);
+        when(p.setFailure(t)).thenReturn(p);
 
         a.add(p1, p2);
         a.operationComplete(p1);
-        verify(p1, p2, p);
-    }
 
+        verify(p1).addListener(a);
+        verify(p2).addListener(a);
+        verify(p1).isSuccess();
+        verify(p1).cause();
+        verify(p).setFailure(t);
+    }
 }

--- a/common/src/test/java/io/netty/util/concurrent/PromiseCombinerTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/PromiseCombinerTest.java
@@ -61,7 +61,7 @@ public class PromiseCombinerTest {
     @Test
     public void testNullAggregatePromise() {
         combiner.finish(p1);
-        verify(p1).trySuccess(any(Void.class));
+        verify(p1).trySuccess(null);
     }
 
     @Test(expected = NullPointerException.class)
@@ -153,7 +153,7 @@ public class PromiseCombinerTest {
     }
 
     private void verifySuccess(Promise<Void> p) {
-        verify(p).trySuccess(any(Void.class));
+        verify(p).trySuccess(null);
     }
 
     private void verifyNotCompleted(Promise<Void> p) {
@@ -179,10 +179,10 @@ public class PromiseCombinerTest {
     @SuppressWarnings("unchecked")
     private void mockListener(final Promise<Void> p, final GenericFutureListenerConsumer consumer) {
         doAnswer(new Answer<Promise<Void>>() {
-            @SuppressWarnings("unchecked")
+            @SuppressWarnings({ "unchecked", "raw-types" })
             @Override
             public Promise<Void> answer(InvocationOnMock invocation) throws Throwable {
-                consumer.accept(invocation.getArgumentAt(0, GenericFutureListener.class));
+                consumer.accept((GenericFutureListener) invocation.getArgument(0));
                 return p;
             }
         }).when(p).addListener(any(GenericFutureListener.class));

--- a/common/src/test/java/io/netty/util/concurrent/PromiseNotifierTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/PromiseNotifierTest.java
@@ -16,7 +16,7 @@
 
 package io.netty.util.concurrent;
 
-import static org.easymock.EasyMock.*;
+import static org.mockito.Mockito.*;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,49 +43,49 @@ public class PromiseNotifierTest {
     @Test
     public void testListenerSuccess() throws Exception {
         @SuppressWarnings("unchecked")
-        Promise<Void> p1 = createStrictMock(Promise.class);
+        Promise<Void> p1 = mock(Promise.class);
         @SuppressWarnings("unchecked")
-        Promise<Void> p2 = createStrictMock(Promise.class);
+        Promise<Void> p2 = mock(Promise.class);
 
         @SuppressWarnings("unchecked")
         PromiseNotifier<Void, Future<Void>> notifier =
                 new PromiseNotifier<Void, Future<Void>>(p1, p2);
 
         @SuppressWarnings("unchecked")
-        Future<Void> future = createStrictMock(Future.class);
-        expect(future.isSuccess()).andReturn(true);
-        expect(future.get()).andReturn(null);
-        expect(p1.trySuccess(null)).andReturn(true);
-        expect(p2.trySuccess(null)).andReturn(true);
-        replay(p1, p2, future);
+        Future<Void> future = mock(Future.class);
+        when(future.isSuccess()).thenReturn(true);
+        when(future.get()).thenReturn(null);
+        when(p1.trySuccess(null)).thenReturn(true);
+        when(p2.trySuccess(null)).thenReturn(true);
 
         notifier.operationComplete(future);
-        verify(p1, p2);
+        verify(p1).trySuccess(null);
+        verify(p2).trySuccess(null);
     }
 
     @Test
     public void testListenerFailure() throws Exception {
         @SuppressWarnings("unchecked")
-        Promise<Void> p1 = createStrictMock(Promise.class);
+        Promise<Void> p1 = mock(Promise.class);
         @SuppressWarnings("unchecked")
-        Promise<Void> p2 = createStrictMock(Promise.class);
+        Promise<Void> p2 = mock(Promise.class);
 
         @SuppressWarnings("unchecked")
         PromiseNotifier<Void, Future<Void>> notifier =
                 new PromiseNotifier<Void, Future<Void>>(p1, p2);
 
         @SuppressWarnings("unchecked")
-        Future<Void> future = createStrictMock(Future.class);
-        Throwable t = createStrictMock(Throwable.class);
-        expect(future.isSuccess()).andReturn(false);
-        expect(future.isCancelled()).andReturn(false);
-        expect(future.cause()).andReturn(t);
-        expect(p1.tryFailure(t)).andReturn(true);
-        expect(p2.tryFailure(t)).andReturn(true);
-        replay(p1, p2, future);
+        Future<Void> future = mock(Future.class);
+        Throwable t = mock(Throwable.class);
+        when(future.isSuccess()).thenReturn(false);
+        when(future.isCancelled()).thenReturn(false);
+        when(future.cause()).thenReturn(t);
+        when(p1.tryFailure(t)).thenReturn(true);
+        when(p2.tryFailure(t)).thenReturn(true);
 
         notifier.operationComplete(future);
-        verify(p1, p2);
+        verify(p1).tryFailure(t);
+        verify(p2).tryFailure(t);
     }
 
 }

--- a/common/src/test/java/io/netty/util/internal/logging/CommonsLoggerTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/CommonsLoggerTest.java
@@ -18,204 +18,169 @@ package io.netty.util.internal.logging;
 import org.apache.commons.logging.Log;
 import org.junit.Test;
 
-import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public class CommonsLoggerTest {
     private static final Exception e = new Exception();
 
     @Test
     public void testIsTraceEnabled() {
-        Log mock =
-            createStrictMock(Log.class);
+        Log mockLog = mock(Log.class);
 
-        expect(mock.isTraceEnabled()).andReturn(true);
-        replay(mock);
+        when(mockLog.isTraceEnabled()).thenReturn(true);
 
-        InternalLogger logger = new CommonsLogger(mock, "foo");
+        InternalLogger logger = new CommonsLogger(mockLog, "foo");
         assertTrue(logger.isTraceEnabled());
-        verify(mock);
+
+        verify(mockLog).isTraceEnabled();
     }
 
     @Test
     public void testIsDebugEnabled() {
-        Log mock =
-            createStrictMock(Log.class);
+        Log mockLog = mock(Log.class);
 
-        expect(mock.isDebugEnabled()).andReturn(true);
-        replay(mock);
+        when(mockLog.isDebugEnabled()).thenReturn(true);
 
-        InternalLogger logger = new CommonsLogger(mock, "foo");
+        InternalLogger logger = new CommonsLogger(mockLog, "foo");
         assertTrue(logger.isDebugEnabled());
-        verify(mock);
+
+        verify(mockLog).isDebugEnabled();
     }
 
     @Test
     public void testIsInfoEnabled() {
-        Log mock =
-            createStrictMock(Log.class);
+        Log mockLog = mock(Log.class);
 
-        expect(mock.isInfoEnabled()).andReturn(true);
-        replay(mock);
+        when(mockLog.isInfoEnabled()).thenReturn(true);
 
-        InternalLogger logger = new CommonsLogger(mock, "foo");
+        InternalLogger logger = new CommonsLogger(mockLog, "foo");
         assertTrue(logger.isInfoEnabled());
-        verify(mock);
+
+        verify(mockLog).isInfoEnabled();
     }
 
     @Test
     public void testIsWarnEnabled() {
-        Log mock =
-            createStrictMock(Log.class);
+        Log mockLog = mock(Log.class);
 
-        expect(mock.isWarnEnabled()).andReturn(true);
-        replay(mock);
+        when(mockLog.isWarnEnabled()).thenReturn(true);
 
-        InternalLogger logger = new CommonsLogger(mock, "foo");
+        InternalLogger logger = new CommonsLogger(mockLog, "foo");
         assertTrue(logger.isWarnEnabled());
-        verify(mock);
+
+        verify(mockLog).isWarnEnabled();
     }
 
     @Test
     public void testIsErrorEnabled() {
-        Log mock =
-            createStrictMock(Log.class);
+        Log mockLog = mock(Log.class);
 
-        expect(mock.isErrorEnabled()).andReturn(true);
-        replay(mock);
+        when(mockLog.isErrorEnabled()).thenReturn(true);
 
-        InternalLogger logger = new CommonsLogger(mock, "foo");
+        InternalLogger logger = new CommonsLogger(mockLog, "foo");
         assertTrue(logger.isErrorEnabled());
-        verify(mock);
+
+        verify(mockLog).isErrorEnabled();
     }
 
     @Test
     public void testTrace() {
-        Log mock =
-            createStrictMock(Log.class);
+        Log mockLog = mock(Log.class);
 
-        mock.trace("a");
-        replay(mock);
-
-        InternalLogger logger = new CommonsLogger(mock, "foo");
+        InternalLogger logger = new CommonsLogger(mockLog, "foo");
         logger.trace("a");
-        verify(mock);
+
+        verify(mockLog).trace("a");
     }
 
     @Test
     public void testTraceWithException() {
-        Log mock =
-            createStrictMock(Log.class);
+        Log mockLog = mock(Log.class);
 
-        mock.trace("a", e);
-        replay(mock);
-
-        InternalLogger logger = new CommonsLogger(mock, "foo");
+        InternalLogger logger = new CommonsLogger(mockLog, "foo");
         logger.trace("a", e);
-        verify(mock);
+
+        verify(mockLog).trace("a", e);
     }
 
     @Test
     public void testDebug() {
-        Log mock =
-            createStrictMock(Log.class);
+        Log mockLog = mock(Log.class);
 
-        mock.debug("a");
-        replay(mock);
-
-        InternalLogger logger = new CommonsLogger(mock, "foo");
+        InternalLogger logger = new CommonsLogger(mockLog, "foo");
         logger.debug("a");
-        verify(mock);
+
+        verify(mockLog).debug("a");
     }
 
     @Test
     public void testDebugWithException() {
-        Log mock =
-            createStrictMock(Log.class);
+        Log mockLog = mock(Log.class);
 
-        mock.debug("a", e);
-        replay(mock);
-
-        InternalLogger logger = new CommonsLogger(mock, "foo");
+        InternalLogger logger = new CommonsLogger(mockLog, "foo");
         logger.debug("a", e);
-        verify(mock);
+
+        verify(mockLog).debug("a", e);
     }
 
     @Test
     public void testInfo() {
-        Log mock =
-            createStrictMock(Log.class);
+        Log mockLog = mock(Log.class);
 
-        mock.info("a");
-        replay(mock);
-
-        InternalLogger logger = new CommonsLogger(mock, "foo");
+        InternalLogger logger = new CommonsLogger(mockLog, "foo");
         logger.info("a");
-        verify(mock);
+
+        verify(mockLog).info("a");
     }
 
     @Test
     public void testInfoWithException() {
-        Log mock =
-            createStrictMock(Log.class);
+        Log mockLog = mock(Log.class);
 
-        mock.info("a", e);
-        replay(mock);
-
-        InternalLogger logger = new CommonsLogger(mock, "foo");
+        InternalLogger logger = new CommonsLogger(mockLog, "foo");
         logger.info("a", e);
-        verify(mock);
+
+        verify(mockLog).info("a", e);
     }
 
     @Test
     public void testWarn() {
-        Log mock =
-            createStrictMock(Log.class);
+        Log mockLog = mock(Log.class);
 
-        mock.warn("a");
-        replay(mock);
-
-        InternalLogger logger = new CommonsLogger(mock, "foo");
+        InternalLogger logger = new CommonsLogger(mockLog, "foo");
         logger.warn("a");
-        verify(mock);
+
+        verify(mockLog).warn("a");
     }
 
     @Test
     public void testWarnWithException() {
-        Log mock =
-            createStrictMock(Log.class);
+        Log mockLog = mock(Log.class);
 
-        mock.warn("a", e);
-        replay(mock);
-
-        InternalLogger logger = new CommonsLogger(mock, "foo");
+        InternalLogger logger = new CommonsLogger(mockLog, "foo");
         logger.warn("a", e);
-        verify(mock);
+
+        verify(mockLog).warn("a", e);
     }
 
     @Test
     public void testError() {
-        Log mock =
-            createStrictMock(Log.class);
+        Log mockLog = mock(Log.class);
 
-        mock.error("a");
-        replay(mock);
-
-        InternalLogger logger = new CommonsLogger(mock, "foo");
+        InternalLogger logger = new CommonsLogger(mockLog, "foo");
         logger.error("a");
-        verify(mock);
+
+        verify(mockLog).error("a");
     }
 
     @Test
     public void testErrorWithException() {
-        Log mock =
-            createStrictMock(Log.class);
+        Log mockLog = mock(Log.class);
 
-        mock.error("a", e);
-        replay(mock);
-
-        InternalLogger logger = new CommonsLogger(mock, "foo");
+        InternalLogger logger = new CommonsLogger(mockLog, "foo");
         logger.error("a", e);
-        verify(mock);
+
+        verify(mockLog).error("a", e);
     }
 }

--- a/common/src/test/java/io/netty/util/internal/logging/InternalLoggerFactoryTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/InternalLoggerFactoryTest.java
@@ -19,27 +19,29 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.easymock.EasyMock.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
 
 public class InternalLoggerFactoryTest {
     private static final Exception e = new Exception();
     private InternalLoggerFactory oldLoggerFactory;
-    private InternalLogger mock;
+    private InternalLogger mockLogger;
 
     @Before
     public void init() {
         oldLoggerFactory = InternalLoggerFactory.getDefaultFactory();
-        InternalLoggerFactory mockFactory = createMock(InternalLoggerFactory.class);
-        mock = createStrictMock(InternalLogger.class);
-        expect(mockFactory.newInstance("mock")).andReturn(mock).anyTimes();
-        replay(mockFactory);
+
+        final InternalLoggerFactory mockFactory = mock(InternalLoggerFactory.class);
+        mockLogger = mock(InternalLogger.class);
+        when(mockFactory.newInstance("mock")).thenReturn(mockLogger);
         InternalLoggerFactory.setDefaultFactory(mockFactory);
     }
 
     @After
     public void destroy() {
-        reset(mock);
+        reset(mockLogger);
         InternalLoggerFactory.setDefaultFactory(oldLoggerFactory);
     }
 
@@ -64,151 +66,116 @@ public class InternalLoggerFactoryTest {
 
     @Test
     public void testIsTraceEnabled() {
-        expect(mock.isTraceEnabled()).andReturn(true);
-        replay(mock);
+        when(mockLogger.isTraceEnabled()).thenReturn(true);
 
         InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         assertTrue(logger.isTraceEnabled());
-        verify(mock);
+        verify(mockLogger).isTraceEnabled();
     }
 
     @Test
     public void testIsDebugEnabled() {
-        expect(mock.isDebugEnabled()).andReturn(true);
-        replay(mock);
+        when(mockLogger.isDebugEnabled()).thenReturn(true);
 
         InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         assertTrue(logger.isDebugEnabled());
-        verify(mock);
+        verify(mockLogger).isDebugEnabled();
     }
 
     @Test
     public void testIsInfoEnabled() {
-        expect(mock.isInfoEnabled()).andReturn(true);
-        replay(mock);
+        when(mockLogger.isInfoEnabled()).thenReturn(true);
 
         InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         assertTrue(logger.isInfoEnabled());
-        verify(mock);
+        verify(mockLogger).isInfoEnabled();
     }
 
     @Test
     public void testIsWarnEnabled() {
-        expect(mock.isWarnEnabled()).andReturn(true);
-        replay(mock);
+        when(mockLogger.isWarnEnabled()).thenReturn(true);
 
         InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         assertTrue(logger.isWarnEnabled());
-        verify(mock);
+        verify(mockLogger).isWarnEnabled();
     }
 
     @Test
     public void testIsErrorEnabled() {
-        expect(mock.isErrorEnabled()).andReturn(true);
-        replay(mock);
+        when(mockLogger.isErrorEnabled()).thenReturn(true);
 
         InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         assertTrue(logger.isErrorEnabled());
-        verify(mock);
+        verify(mockLogger).isErrorEnabled();
     }
 
     @Test
     public void testTrace() {
-        mock.trace("a");
-        replay(mock);
-
-        InternalLogger logger = InternalLoggerFactory.getInstance("mock");
+        final InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         logger.trace("a");
-        verify(mock);
+        verify(mockLogger).trace("a");
     }
 
     @Test
     public void testTraceWithException() {
-        mock.trace("a", e);
-        replay(mock);
-
-        InternalLogger logger = InternalLoggerFactory.getInstance("mock");
+        final InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         logger.trace("a", e);
-        verify(mock);
+        verify(mockLogger).trace("a", e);
     }
 
     @Test
     public void testDebug() {
-        mock.debug("a");
-        replay(mock);
-
-        InternalLogger logger = InternalLoggerFactory.getInstance("mock");
+        final InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         logger.debug("a");
-        verify(mock);
+        verify(mockLogger).debug("a");
     }
 
     @Test
     public void testDebugWithException() {
-        mock.debug("a", e);
-        replay(mock);
-
-        InternalLogger logger = InternalLoggerFactory.getInstance("mock");
+        final InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         logger.debug("a", e);
-        verify(mock);
+        verify(mockLogger).debug("a", e);
     }
 
     @Test
     public void testInfo() {
-        mock.info("a");
-        replay(mock);
-
-        InternalLogger logger = InternalLoggerFactory.getInstance("mock");
+        final InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         logger.info("a");
-        verify(mock);
+        verify(mockLogger).info("a");
     }
 
     @Test
     public void testInfoWithException() {
-        mock.info("a", e);
-        replay(mock);
-
-        InternalLogger logger = InternalLoggerFactory.getInstance("mock");
+        final InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         logger.info("a", e);
-        verify(mock);
+        verify(mockLogger).info("a", e);
     }
 
     @Test
     public void testWarn() {
-        mock.warn("a");
-        replay(mock);
-
-        InternalLogger logger = InternalLoggerFactory.getInstance("mock");
+        final InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         logger.warn("a");
-        verify(mock);
+        verify(mockLogger).warn("a");
     }
 
     @Test
     public void testWarnWithException() {
-        mock.warn("a", e);
-        replay(mock);
-
-        InternalLogger logger = InternalLoggerFactory.getInstance("mock");
+        final InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         logger.warn("a", e);
-        verify(mock);
+        verify(mockLogger).warn("a", e);
     }
 
     @Test
     public void testError() {
-        mock.error("a");
-        replay(mock);
-
-        InternalLogger logger = InternalLoggerFactory.getInstance("mock");
+        final InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         logger.error("a");
-        verify(mock);
+        verify(mockLogger).error("a");
     }
 
     @Test
     public void testErrorWithException() {
-        mock.error("a", e);
-        replay(mock);
-
-        InternalLogger logger = InternalLoggerFactory.getInstance("mock");
+        final InternalLogger logger = InternalLoggerFactory.getInstance("mock");
         logger.error("a", e);
-        verify(mock);
+        verify(mockLogger).error("a", e);
     }
 }

--- a/common/src/test/java/io/netty/util/internal/logging/Log4J2LoggerTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/Log4J2LoggerTest.java
@@ -18,207 +18,208 @@ package io.netty.util.internal.logging;
 import org.junit.Test;
 import org.apache.logging.log4j.Logger;
 
-import static org.easymock.EasyMock.createStrictMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
 
 public class Log4J2LoggerTest {
     private static final Exception e = new Exception();
 
     @Test
     public void testIsTraceEnabled() {
-        Logger mock = createStrictMock(Logger.class);
+        Logger mock = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        expect(mock.isTraceEnabled()).andReturn(true);
-        replay(mock);
-
+        when(mock.getName()).thenReturn("foo");
+        when(mock.isTraceEnabled()).thenReturn(true);
         InternalLogger logger = new Log4J2Logger(mock);
         assertTrue(logger.isTraceEnabled());
-        verify(mock);
+
+        verify(mock).getName();
+        verify(mock).isTraceEnabled();
     }
 
     @Test
     public void testIsDebugEnabled() {
-        Logger mock = createStrictMock(Logger.class);
+        Logger mock = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        expect(mock.isDebugEnabled()).andReturn(true);
-        replay(mock);
+        when(mock.getName()).thenReturn("foo");
+        when(mock.isDebugEnabled()).thenReturn(true);
 
         InternalLogger logger = new Log4J2Logger(mock);
         assertTrue(logger.isDebugEnabled());
-        verify(mock);
+
+        verify(mock).getName();
+        verify(mock).isDebugEnabled();
     }
 
     @Test
     public void testIsInfoEnabled() {
-        Logger mock = createStrictMock(Logger.class);
+        Logger mock = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        expect(mock.isInfoEnabled()).andReturn(true);
-        replay(mock);
+        when(mock.getName()).thenReturn("foo");
+        when(mock.isInfoEnabled()).thenReturn(true);
 
         InternalLogger logger = new Log4J2Logger(mock);
         assertTrue(logger.isInfoEnabled());
-        verify(mock);
+
+        verify(mock).getName();
+        verify(mock).isInfoEnabled();
     }
 
     @Test
     public void testIsWarnEnabled() {
-        Logger mock = createStrictMock(Logger.class);
+        Logger mock = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        expect(mock.isWarnEnabled()).andReturn(true);
-        replay(mock);
+        when(mock.getName()).thenReturn("foo");
+        when(mock.isWarnEnabled()).thenReturn(true);
 
         InternalLogger logger = new Log4J2Logger(mock);
         assertTrue(logger.isWarnEnabled());
-        verify(mock);
+
+        verify(mock).getName();
+        verify(mock).isWarnEnabled();
     }
 
     @Test
     public void testIsErrorEnabled() {
-        Logger mock = createStrictMock(Logger.class);
+        Logger mock = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        expect(mock.isErrorEnabled()).andReturn(true);
-        replay(mock);
+        when(mock.getName()).thenReturn("foo");
+        when(mock.isErrorEnabled()).thenReturn(true);
 
         InternalLogger logger = new Log4J2Logger(mock);
         assertTrue(logger.isErrorEnabled());
-        verify(mock);
+
+        verify(mock).getName();
+        verify(mock).isErrorEnabled();
     }
 
     @Test
     public void testTrace() {
-        Logger mock = createStrictMock(Logger.class);
+        Logger mock = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.trace("a");
-        replay(mock);
+        when(mock.getName()).thenReturn("foo");
 
         InternalLogger logger = new Log4J2Logger(mock);
         logger.trace("a");
-        verify(mock);
+
+        verify(mock).getName();
+        verify(mock).trace("a");
     }
 
     @Test
     public void testTraceWithException() {
-        Logger mock = createStrictMock(Logger.class);
+        Logger mock = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.trace("a", e);
-        replay(mock);
+        when(mock.getName()).thenReturn("foo");
 
         InternalLogger logger = new Log4J2Logger(mock);
         logger.trace("a", e);
-        verify(mock);
+
+        verify(mock).getName();
+        verify(mock).trace("a", e);
     }
 
     @Test
     public void testDebug() {
-        Logger mock = createStrictMock(Logger.class);
+        Logger mock = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.debug("a");
-        replay(mock);
+        when(mock.getName()).thenReturn("foo");
 
         InternalLogger logger = new Log4J2Logger(mock);
         logger.debug("a");
-        verify(mock);
+
+        verify(mock).getName();
+        verify(mock).debug("a");
     }
 
     @Test
     public void testDebugWithException() {
-        Logger mock = createStrictMock(Logger.class);
+        Logger mock = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.debug("a", e);
-        replay(mock);
+        when(mock.getName()).thenReturn("foo");
 
         InternalLogger logger = new Log4J2Logger(mock);
         logger.debug("a", e);
-        verify(mock);
+
+        verify(mock).getName();
+        verify(mock).debug("a", e);
     }
 
     @Test
     public void testInfo() {
-        Logger mock = createStrictMock(Logger.class);
+        Logger mock = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.info("a");
-        replay(mock);
+        when(mock.getName()).thenReturn("foo");
 
         InternalLogger logger = new Log4J2Logger(mock);
         logger.info("a");
-        verify(mock);
+
+        verify(mock).getName();
+        verify(mock).info("a");
     }
 
     @Test
     public void testInfoWithException() {
-        Logger mock = createStrictMock(Logger.class);
+        Logger mock = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.info("a", e);
-        replay(mock);
+        when(mock.getName()).thenReturn("foo");
 
         InternalLogger logger = new Log4J2Logger(mock);
         logger.info("a", e);
-        verify(mock);
+
+        verify(mock).getName();
+        verify(mock).info("a", e);
     }
 
     @Test
     public void testWarn() {
-        Logger mock = createStrictMock(Logger.class);
+        Logger mock = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.warn("a");
-        replay(mock);
+        when(mock.getName()).thenReturn("foo");
 
         InternalLogger logger = new Log4J2Logger(mock);
         logger.warn("a");
-        verify(mock);
+
+        verify(mock).getName();
+        verify(mock).warn("a");
     }
 
     @Test
     public void testWarnWithException() {
-        Logger mock = createStrictMock(Logger.class);
+        Logger mock = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.warn("a", e);
-        replay(mock);
+        when(mock.getName()).thenReturn("foo");
 
         InternalLogger logger = new Log4J2Logger(mock);
         logger.warn("a", e);
-        verify(mock);
+
+        verify(mock).getName();
+        verify(mock).warn("a", e);
     }
 
     @Test
     public void testError() {
-        Logger mock = createStrictMock(Logger.class);
+        Logger mock = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.error("a");
-        replay(mock);
+        when(mock.getName()).thenReturn("foo");
 
         InternalLogger logger = new Log4J2Logger(mock);
         logger.error("a");
-        verify(mock);
+
+        verify(mock).getName();
+        verify(mock).error("a");
     }
 
     @Test
     public void testErrorWithException() {
-        Logger mock = createStrictMock(Logger.class);
+        Logger mock = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.error("a", e);
-        replay(mock);
+        when(mock.getName()).thenReturn("foo");
 
         InternalLogger logger = new Log4J2Logger(mock);
         logger.error("a", e);
-        verify(mock);
+
+        verify(mock).getName();
+        verify(mock).error("a", e);
     }
 }

--- a/common/src/test/java/io/netty/util/internal/logging/Slf4JLoggerTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/Slf4JLoggerTest.java
@@ -18,219 +18,209 @@ package io.netty.util.internal.logging;
 import org.junit.Test;
 import org.slf4j.Logger;
 
-import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public class Slf4JLoggerTest {
     private static final Exception e = new Exception();
 
     @Test
     public void testIsTraceEnabled() {
-        Logger mock =
-            createStrictMock(Logger.class);
+        Logger mockLogger = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        expect(mock.isTraceEnabled()).andReturn(true);
-        replay(mock);
+        when(mockLogger.getName()).thenReturn("foo");
+        when(mockLogger.isTraceEnabled()).thenReturn(true);
 
-        InternalLogger logger = new Slf4JLogger(mock);
+        InternalLogger logger = new Slf4JLogger(mockLogger);
         assertTrue(logger.isTraceEnabled());
-        verify(mock);
+
+        verify(mockLogger).getName();
+        verify(mockLogger).isTraceEnabled();
     }
 
     @Test
     public void testIsDebugEnabled() {
-        Logger mock =
-            createStrictMock(Logger.class);
+        Logger mockLogger = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        expect(mock.isDebugEnabled()).andReturn(true);
-        replay(mock);
+        when(mockLogger.getName()).thenReturn("foo");
+        when(mockLogger.isDebugEnabled()).thenReturn(true);
 
-        InternalLogger logger = new Slf4JLogger(mock);
+        InternalLogger logger = new Slf4JLogger(mockLogger);
         assertTrue(logger.isDebugEnabled());
-        verify(mock);
+
+        verify(mockLogger).getName();
+        verify(mockLogger).isDebugEnabled();
     }
 
     @Test
     public void testIsInfoEnabled() {
-        Logger mock =
-            createStrictMock(Logger.class);
+        Logger mockLogger = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        expect(mock.isInfoEnabled()).andReturn(true);
-        replay(mock);
+        when(mockLogger.getName()).thenReturn("foo");
+        when(mockLogger.isInfoEnabled()).thenReturn(true);
 
-        InternalLogger logger = new Slf4JLogger(mock);
+        InternalLogger logger = new Slf4JLogger(mockLogger);
         assertTrue(logger.isInfoEnabled());
-        verify(mock);
+
+        verify(mockLogger).getName();
+        verify(mockLogger).isInfoEnabled();
     }
 
     @Test
     public void testIsWarnEnabled() {
-        Logger mock =
-            createStrictMock(Logger.class);
+        Logger mockLogger = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        expect(mock.isWarnEnabled()).andReturn(true);
-        replay(mock);
+        when(mockLogger.getName()).thenReturn("foo");
+        when(mockLogger.isWarnEnabled()).thenReturn(true);
 
-        InternalLogger logger = new Slf4JLogger(mock);
+        InternalLogger logger = new Slf4JLogger(mockLogger);
         assertTrue(logger.isWarnEnabled());
-        verify(mock);
+
+        verify(mockLogger).getName();
+        verify(mockLogger).isWarnEnabled();
     }
 
     @Test
     public void testIsErrorEnabled() {
-        Logger mock =
-            createStrictMock(Logger.class);
+        Logger mockLogger = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        expect(mock.isErrorEnabled()).andReturn(true);
-        replay(mock);
+        when(mockLogger.getName()).thenReturn("foo");
+        when(mockLogger.isErrorEnabled()).thenReturn(true);
 
-        InternalLogger logger = new Slf4JLogger(mock);
+        InternalLogger logger = new Slf4JLogger(mockLogger);
         assertTrue(logger.isErrorEnabled());
-        verify(mock);
+
+        verify(mockLogger).getName();
+        verify(mockLogger).isErrorEnabled();
     }
 
     @Test
     public void testTrace() {
-        Logger mock =
-            createStrictMock(Logger.class);
+        Logger mockLogger = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.trace("a");
-        replay(mock);
+        when(mockLogger.getName()).thenReturn("foo");
 
-        InternalLogger logger = new Slf4JLogger(mock);
+        InternalLogger logger = new Slf4JLogger(mockLogger);
         logger.trace("a");
-        verify(mock);
+
+        verify(mockLogger).getName();
+        verify(mockLogger).trace("a");
     }
 
     @Test
     public void testTraceWithException() {
-        Logger mock =
-            createStrictMock(Logger.class);
+        Logger mockLogger = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.trace("a", e);
-        replay(mock);
+        when(mockLogger.getName()).thenReturn("foo");
 
-        InternalLogger logger = new Slf4JLogger(mock);
+        InternalLogger logger = new Slf4JLogger(mockLogger);
         logger.trace("a", e);
-        verify(mock);
+
+        verify(mockLogger).getName();
+        verify(mockLogger).trace("a", e);
     }
 
     @Test
     public void testDebug() {
-        Logger mock =
-            createStrictMock(Logger.class);
+        Logger mockLogger = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.debug("a");
-        replay(mock);
+        when(mockLogger.getName()).thenReturn("foo");
 
-        InternalLogger logger = new Slf4JLogger(mock);
+        InternalLogger logger = new Slf4JLogger(mockLogger);
         logger.debug("a");
-        verify(mock);
+
+        verify(mockLogger).getName();
+        verify(mockLogger).debug("a");
     }
 
     @Test
     public void testDebugWithException() {
-        Logger mock =
-            createStrictMock(Logger.class);
+        Logger mockLogger = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.debug("a", e);
-        replay(mock);
+        when(mockLogger.getName()).thenReturn("foo");
 
-        InternalLogger logger = new Slf4JLogger(mock);
+        InternalLogger logger = new Slf4JLogger(mockLogger);
         logger.debug("a", e);
-        verify(mock);
+
+        verify(mockLogger).getName();
+        verify(mockLogger).debug("a", e);
     }
 
     @Test
     public void testInfo() {
-        Logger mock =
-            createStrictMock(Logger.class);
+        Logger mockLogger = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.info("a");
-        replay(mock);
+        when(mockLogger.getName()).thenReturn("foo");
 
-        InternalLogger logger = new Slf4JLogger(mock);
+        InternalLogger logger = new Slf4JLogger(mockLogger);
         logger.info("a");
-        verify(mock);
+
+        verify(mockLogger).getName();
+        verify(mockLogger).info("a");
     }
 
     @Test
     public void testInfoWithException() {
-        Logger mock =
-            createStrictMock(Logger.class);
+        Logger mockLogger = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.info("a", e);
-        replay(mock);
+        when(mockLogger.getName()).thenReturn("foo");
 
-        InternalLogger logger = new Slf4JLogger(mock);
+        InternalLogger logger = new Slf4JLogger(mockLogger);
         logger.info("a", e);
-        verify(mock);
+
+        verify(mockLogger).getName();
+        verify(mockLogger).info("a", e);
     }
 
     @Test
     public void testWarn() {
-        Logger mock =
-            createStrictMock(Logger.class);
+        Logger mockLogger = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.warn("a");
-        replay(mock);
+        when(mockLogger.getName()).thenReturn("foo");
 
-        InternalLogger logger = new Slf4JLogger(mock);
+        InternalLogger logger = new Slf4JLogger(mockLogger);
         logger.warn("a");
-        verify(mock);
+
+        verify(mockLogger).getName();
+        verify(mockLogger).warn("a");
     }
 
     @Test
     public void testWarnWithException() {
-        Logger mock =
-            createStrictMock(Logger.class);
+        Logger mockLogger = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.warn("a", e);
-        replay(mock);
+        when(mockLogger.getName()).thenReturn("foo");
 
-        InternalLogger logger = new Slf4JLogger(mock);
+        InternalLogger logger = new Slf4JLogger(mockLogger);
         logger.warn("a", e);
-        verify(mock);
+
+        verify(mockLogger).getName();
+        verify(mockLogger).warn("a", e);
     }
 
     @Test
     public void testError() {
-        Logger mock =
-            createStrictMock(Logger.class);
+        Logger mockLogger = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.error("a");
-        replay(mock);
+        when(mockLogger.getName()).thenReturn("foo");
 
-        InternalLogger logger = new Slf4JLogger(mock);
+        InternalLogger logger = new Slf4JLogger(mockLogger);
         logger.error("a");
-        verify(mock);
+
+        verify(mockLogger).getName();
+        verify(mockLogger).error("a");
     }
 
     @Test
     public void testErrorWithException() {
-        Logger mock =
-            createStrictMock(Logger.class);
+        Logger mockLogger = mock(Logger.class);
 
-        expect(mock.getName()).andReturn("foo");
-        mock.error("a", e);
-        replay(mock);
+        when(mockLogger.getName()).thenReturn("foo");
 
-        InternalLogger logger = new Slf4JLogger(mock);
+        InternalLogger logger = new Slf4JLogger(mockLogger);
         logger.error("a", e);
-        verify(mock);
+
+        verify(mockLogger).getName();
+        verify(mockLogger).error("a", e);
     }
 }

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -50,6 +50,10 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 </project>
 

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -65,6 +65,10 @@
       <artifactId>alpn-api</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 </project>
 

--- a/handler/src/test/java/io/netty/handler/logging/LoggingHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/logging/LoggingHandlerTest.java
@@ -26,12 +26,12 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelMetadata;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
-import org.easymock.IArgumentMatcher;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.ArgumentMatcher;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
@@ -39,15 +39,12 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.easymock.EasyMock.createNiceMock;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.reportMatcher;
-import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
 import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 
 /**
@@ -87,7 +84,7 @@ public class LoggingHandlerTest {
     @Before
     @SuppressWarnings("unchecked")
     public void setup() {
-        appender = createNiceMock(Appender.class);
+        appender = mock(Appender.class);
         logger.addAppender(appender);
     }
 
@@ -110,116 +107,94 @@ public class LoggingHandlerTest {
 
     @Test
     public void shouldLogChannelActive() {
-        appender.doAppend(matchesLog(".+ACTIVE$"));
-        replay(appender);
         new EmbeddedChannel(new LoggingHandler());
-        verify(appender);
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+ACTIVE$")));
     }
 
     @Test
     public void shouldLogChannelRegistered() {
-        appender.doAppend(matchesLog(".+REGISTERED$"));
-        replay(appender);
         new EmbeddedChannel(new LoggingHandler());
-        verify(appender);
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+REGISTERED$")));
     }
 
     @Test
     public void shouldLogChannelClose() throws Exception {
-        appender.doAppend(matchesLog(".+CLOSE$"));
-        replay(appender);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
         channel.close().await();
-        verify(appender);
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+CLOSE$")));
     }
 
     @Test
     public void shouldLogChannelConnect() throws Exception {
-        appender.doAppend(matchesLog(".+CONNECT: 0.0.0.0/0.0.0.0:80$"));
-        replay(appender);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
         channel.connect(new InetSocketAddress(80)).await();
-        verify(appender);
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+CONNECT: 0.0.0.0/0.0.0.0:80$")));
     }
 
     @Test
     public void shouldLogChannelConnectWithLocalAddress() throws Exception {
-        appender.doAppend(matchesLog(".+CONNECT: 0.0.0.0/0.0.0.0:80, 0.0.0.0/0.0.0.0:81$"));
-        replay(appender);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
         channel.connect(new InetSocketAddress(80), new InetSocketAddress(81)).await();
-        verify(appender);
+        verify(appender).doAppend(argThat(
+                new RegexLogMatcher(".+CONNECT: 0.0.0.0/0.0.0.0:80, 0.0.0.0/0.0.0.0:81$")));
     }
 
     @Test
     public void shouldLogChannelDisconnect() throws Exception {
-        appender.doAppend(matchesLog(".+DISCONNECT$"));
-        replay(appender);
         EmbeddedChannel channel = new DisconnectingEmbeddedChannel(new LoggingHandler());
         channel.connect(new InetSocketAddress(80)).await();
         channel.disconnect().await();
-        verify(appender);
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+DISCONNECT$")));
     }
 
     @Test
     public void shouldLogChannelInactive() throws Exception {
-        appender.doAppend(matchesLog(".+INACTIVE$"));
-        replay(appender);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
         channel.pipeline().fireChannelInactive();
-        verify(appender);
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+INACTIVE$")));
     }
 
     @Test
     public void shouldLogChannelBind() throws Exception {
-        appender.doAppend(matchesLog(".+BIND: 0.0.0.0/0.0.0.0:80$"));
-        replay(appender);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
         channel.bind(new InetSocketAddress(80));
-        verify(appender);
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+BIND: 0.0.0.0/0.0.0.0:80$")));
     }
 
     @Test
     @SuppressWarnings("RedundantStringConstructorCall")
     public void shouldLogChannelUserEvent() throws Exception {
         String userTriggered = "iAmCustom!";
-        appender.doAppend(matchesLog(".+USER_EVENT: " + userTriggered + '$'));
-        replay(appender);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
         channel.pipeline().fireUserEventTriggered(new String(userTriggered));
-        verify(appender);
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+USER_EVENT: " + userTriggered + '$')));
     }
 
     @Test
     public void shouldLogChannelException() throws Exception {
         String msg = "illegalState";
         Throwable cause = new IllegalStateException(msg);
-        appender.doAppend(matchesLog(".+EXCEPTION: " + cause.getClass().getCanonicalName() + ": " + msg + '$'));
-        replay(appender);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
         channel.pipeline().fireExceptionCaught(cause);
-        verify(appender);
+        verify(appender).doAppend(argThat(new RegexLogMatcher(
+                ".+EXCEPTION: " + cause.getClass().getCanonicalName() + ": " + msg + '$')));
     }
 
     @Test
     public void shouldLogDataWritten() throws Exception {
         String msg = "hello";
-        appender.doAppend(matchesLog(".+WRITE: " + msg + '$'));
-        appender.doAppend(matchesLog(".+FLUSH$"));
-        replay(appender);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
         channel.writeOutbound(msg);
-        verify(appender);
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+WRITE: " + msg + '$')));
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+FLUSH$")));
     }
 
     @Test
     public void shouldLogNonByteBufDataRead() throws Exception {
         String msg = "hello";
-        appender.doAppend(matchesLog(".+RECEIVED: " + msg + '$'));
-        replay(appender);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
         channel.writeInbound(msg);
-        verify(appender);
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+RECEIVED: " + msg + '$')));
 
         String handledMsg = channel.readInbound();
         assertThat(msg, is(sameInstance(handledMsg)));
@@ -229,11 +204,9 @@ public class LoggingHandlerTest {
     @Test
     public void shouldLogByteBufDataRead() throws Exception {
         ByteBuf msg = Unpooled.copiedBuffer("hello", CharsetUtil.UTF_8);
-        appender.doAppend(matchesLog(".+RECEIVED: " + msg.readableBytes() + "B$"));
-        replay(appender);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
         channel.writeInbound(msg);
-        verify(appender);
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+RECEIVED: " + msg.readableBytes() + "B$")));
 
         ByteBuf handledMsg = channel.readInbound();
         assertThat(msg, is(sameInstance(handledMsg)));
@@ -244,11 +217,9 @@ public class LoggingHandlerTest {
     @Test
     public void shouldLogEmptyByteBufDataRead() throws Exception {
         ByteBuf msg = Unpooled.EMPTY_BUFFER;
-        appender.doAppend(matchesLog(".+RECEIVED: 0B$"));
-        replay(appender);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
         channel.writeInbound(msg);
-        verify(appender);
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+RECEIVED: 0B$")));
 
         ByteBuf handledMsg = channel.readInbound();
         assertThat(msg, is(sameInstance(handledMsg)));
@@ -264,11 +235,9 @@ public class LoggingHandlerTest {
             }
         };
 
-        appender.doAppend(matchesLog(".+RECEIVED: foobar, 5B$"));
-        replay(appender);
         EmbeddedChannel channel = new EmbeddedChannel(new LoggingHandler());
         channel.writeInbound(msg);
-        verify(appender);
+        verify(appender).doAppend(argThat(new RegexLogMatcher(".+RECEIVED: foobar, 5B$")));
 
         ByteBufHolder handledMsg = channel.readInbound();
         assertThat(msg, is(sameInstance(handledMsg)));
@@ -277,20 +246,9 @@ public class LoggingHandlerTest {
     }
 
     /**
-     * Static helper method for matching Logback messages.
-     *
-     * @param toMatch the regex to match.
-     * @return a mocked event to pass into the {@link Appender#doAppend(Object)} method.
-     */
-    private static ILoggingEvent matchesLog(String toMatch) {
-        reportMatcher(new RegexLogMatcher(toMatch));
-        return null;
-    }
-
-    /**
      * A custom EasyMock matcher that matches on Logback messages.
      */
-    private static final class RegexLogMatcher implements IArgumentMatcher {
+    private static final class RegexLogMatcher implements ArgumentMatcher<ILoggingEvent> {
 
         private final String expected;
         private String actualMsg;
@@ -301,22 +259,10 @@ public class LoggingHandlerTest {
 
         @Override
         @SuppressWarnings("DynamicRegexReplaceableByCompiledPattern")
-        public boolean matches(Object actual) {
-            if (!(actual instanceof ILoggingEvent)) {
-                return false;
-            }
-
+        public boolean matches(ILoggingEvent actual) {
             // Match only the first line to skip the validation of hex-dump format.
-            actualMsg = ((ILoggingEvent) actual).getMessage().split("(?s)[\\r\\n]+")[0];
+            actualMsg = actual.getMessage().split("(?s)[\\r\\n]+")[0];
             return actualMsg.matches(expected);
-        }
-
-        @Override
-        public void appendTo(StringBuffer buffer) {
-            buffer.append("matchesLog(")
-                  .append("expected: \"").append(expected)
-                  .append("\", got: \"").append(actualMsg)
-                  .append("\")");
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -472,33 +472,9 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.easymock</groupId>
-        <artifactId>easymock</artifactId>
-        <version>3.4</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.easymock</groupId>
-        <artifactId>easymockclassextension</artifactId>
-        <version>3.2</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jmock</groupId>
-        <artifactId>jmock-junit4</artifactId>
-        <version>2.8.2</version>
-        <scope>test</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>junit</groupId>
-            <artifactId>junit-dep</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>1.10.19</version>
+        <version>2.7.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -593,26 +569,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymockclassextension</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jmock</groupId>
-      <artifactId>jmock-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -34,6 +34,10 @@
       <artifactId>netty-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 </project>
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -75,21 +75,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymockclassextension</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jmock</groupId>
-      <artifactId>jmock-junit4</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>compile</scope>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -39,6 +39,10 @@
       <artifactId>netty-resolver</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 </project>
 

--- a/transport/src/test/java/io/netty/channel/CompleteChannelFutureTest.java
+++ b/transport/src/test/java/io/netty/channel/CompleteChannelFutureTest.java
@@ -15,23 +15,14 @@
  */
 package io.netty.channel;
 
-import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
 
 public class CompleteChannelFutureTest {
-
-    private final Channel channel = createMock(Channel.class);
-    private CompleteChannelFuture future;
-
-    @Before
-    public void init() {
-        future = new CompleteChannelFutureImpl(channel);
-    }
 
     @Test(expected = NullPointerException.class)
     public void shouldDisallowNullChannel() {
@@ -40,15 +31,19 @@ public class CompleteChannelFutureTest {
 
     @Test
     public void shouldNotDoAnythingOnRemove() throws Exception {
-        ChannelFutureListener l = createStrictMock(ChannelFutureListener.class);
-        replay(l);
-
+        Channel channel = Mockito.mock(Channel.class);
+        CompleteChannelFuture future = new CompleteChannelFutureImpl(channel);
+        ChannelFutureListener l = Mockito.mock(ChannelFutureListener.class);
         future.removeListener(l);
-        verify(l);
+        Mockito.verifyNoMoreInteractions(l);
+        Mockito.verifyZeroInteractions(channel);
     }
 
     @Test
     public void testConstantProperties() throws InterruptedException {
+        Channel channel = Mockito.mock(Channel.class);
+        CompleteChannelFuture future = new CompleteChannelFutureImpl(channel);
+
         assertSame(channel, future.channel());
         assertTrue(future.isDone());
         assertSame(future, future.await());
@@ -57,6 +52,7 @@ public class CompleteChannelFutureTest {
         assertSame(future, future.awaitUninterruptibly());
         assertTrue(future.awaitUninterruptibly(1));
         assertTrue(future.awaitUninterruptibly(1, TimeUnit.NANOSECONDS));
+        Mockito.verifyZeroInteractions(channel);
     }
 
     private static class CompleteChannelFutureImpl extends CompleteChannelFuture {

--- a/transport/src/test/java/io/netty/channel/FailedChannelFutureTest.java
+++ b/transport/src/test/java/io/netty/channel/FailedChannelFutureTest.java
@@ -16,14 +16,14 @@
 package io.netty.channel;
 
 import org.junit.Test;
+import org.mockito.Mockito;
 
-import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
 
 public class FailedChannelFutureTest {
     @Test
     public void testConstantProperties() {
-        Channel channel = createMock(Channel.class);
+        Channel channel = Mockito.mock(Channel.class);
         Exception e = new Exception();
         FailedChannelFuture future = new FailedChannelFuture(channel, null, e);
 
@@ -33,6 +33,6 @@ public class FailedChannelFutureTest {
 
     @Test(expected = NullPointerException.class)
     public void shouldDisallowNullException() {
-        new FailedChannelFuture(createMock(Channel.class), null, null);
+        new FailedChannelFuture(Mockito.mock(Channel.class), null, null);
     }
 }

--- a/transport/src/test/java/io/netty/channel/SucceededChannelFutureTest.java
+++ b/transport/src/test/java/io/netty/channel/SucceededChannelFutureTest.java
@@ -16,14 +16,14 @@
 package io.netty.channel;
 
 import org.junit.Test;
+import org.mockito.Mockito;
 
-import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
 
 public class SucceededChannelFutureTest {
     @Test
     public void testConstantProperties() {
-        Channel channel = createMock(Channel.class);
+        Channel channel = Mockito.mock(Channel.class);
         SucceededChannelFuture future = new SucceededChannelFuture(channel, null);
 
         assertTrue(future.isSuccess());


### PR DESCRIPTION
Motivation:

We used various mocking frameworks. We should only use one...

Modifications:

Make usage of mocking framework consistent by only using Mockito.

Result:

Less dependencies and more consistent mocking usage.