### PR TITLE
EpollRecvByteAllocatorHandle doesn't inform delegate of more data

### DIFF
--- a/common/src/main/java/io/netty/util/UncheckedBooleanSupplier.java
+++ b/common/src/main/java/io/netty/util/UncheckedBooleanSupplier.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util;
+
+/**
+ * Represents a supplier of {@code boolean}-valued results which doesn't throw any checked exceptions.
+ */
+public interface UncheckedBooleanSupplier extends BooleanSupplier {
+    /**
+     * Gets a boolean value.
+     * @return a boolean value.
+     */
+    @Override
+    boolean get();
+
+    /**
+     * A supplier which always returns {@code false} and never throws.
+     */
+    UncheckedBooleanSupplier FALSE_SUPPLIER = new UncheckedBooleanSupplier() {
+        @Override
+        public boolean get() {
+            return false;
+        }
+    };
+
+    /**
+     * A supplier which always returns {@code true} and never throws.
+     */
+    UncheckedBooleanSupplier TRUE_SUPPLIER = new UncheckedBooleanSupplier() {
+        @Override
+        public boolean get() {
+            return true;
+        }
+    };
+}

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
@@ -28,6 +28,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.UncheckedBooleanSupplier;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -161,8 +162,8 @@ public class SocketAutoReadTest extends AbstractSocketTest {
      */
     private static final class TestRecvByteBufAllocator implements RecvByteBufAllocator {
         @Override
-        public Handle newHandle() {
-            return new Handle() {
+        public ExtendedHandle newHandle() {
+            return new ExtendedHandle() {
                 private ChannelConfig config;
                 private int attemptedBytesRead;
                 private int lastBytesRead;
@@ -208,6 +209,11 @@ public class SocketAutoReadTest extends AbstractSocketTest {
 
                 @Override
                 public boolean continueReading() {
+                    return config.isAutoRead();
+                }
+
+                @Override
+                public boolean continueReading(UncheckedBooleanSupplier maybeMoreDataSupplier) {
                     return config.isAutoRead();
                 }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.testsuite.transport.socket;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.RecvByteBufAllocator;
+import io.netty.channel.socket.ChannelInputShutdownEvent;
+import io.netty.channel.socket.ChannelInputShutdownReadComplete;
+import io.netty.channel.socket.DuplexChannel;
+import io.netty.util.UncheckedBooleanSupplier;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertTrue;
+
+public class SocketHalfClosedTest extends AbstractSocketTest {
+    @Test
+    public void testAllDataReadAfterHalfClosure() throws Throwable {
+        run();
+    }
+
+    public void testAllDataReadAfterHalfClosure(ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        testAllDataReadAfterHalfClosure(true, sb, cb);
+        testAllDataReadAfterHalfClosure(false, sb, cb);
+    }
+
+    public void testAllDataReadAfterHalfClosure(final boolean autoRead,
+                                                ServerBootstrap sb, Bootstrap cb) throws Throwable {
+        final int totalServerBytesWritten = 1024 * 16;
+        final int numReadsPerReadLoop = 2;
+        final CountDownLatch serverInitializedLatch = new CountDownLatch(1);
+        final CountDownLatch clientReadAllDataLatch = new CountDownLatch(1);
+        final CountDownLatch clientHalfClosedLatch = new CountDownLatch(1);
+        final AtomicInteger clientReadCompletes = new AtomicInteger();
+        Channel serverChannel = null;
+        Channel clientChannel = null;
+        try {
+            cb.option(ChannelOption.ALLOW_HALF_CLOSURE, true)
+              .option(ChannelOption.AUTO_READ, autoRead)
+              .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvByteBufAllocator(numReadsPerReadLoop));
+
+            sb.childHandler(new ChannelInitializer<Channel>() {
+                @Override
+                protected void initChannel(Channel ch) throws Exception {
+                    ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                            ByteBuf buf = ctx.alloc().buffer(totalServerBytesWritten);
+                            buf.writerIndex(buf.capacity());
+                            ctx.writeAndFlush(buf).addListener(new ChannelFutureListener() {
+                                @Override
+                                public void operationComplete(ChannelFuture future) throws Exception {
+                                    ((DuplexChannel) future.channel()).shutdownOutput();
+                                }
+                            });
+                            serverInitializedLatch.countDown();
+                        }
+
+                        @Override
+                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                            ctx.close();
+                        }
+                    });
+                }
+            });
+
+            cb.handler(new ChannelInitializer<Channel>() {
+                @Override
+                protected void initChannel(Channel ch) throws Exception {
+                    ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
+                        private int bytesRead;
+
+                        @Override
+                        public void channelRead(ChannelHandlerContext ctx, Object msg) {
+                            ByteBuf buf = (ByteBuf) msg;
+                            bytesRead += buf.readableBytes();
+                            buf.release();
+                        }
+
+                        @Override
+                        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+                            if (evt == ChannelInputShutdownEvent.INSTANCE) {
+                                clientHalfClosedLatch.countDown();
+                            } else if (evt == ChannelInputShutdownReadComplete.INSTANCE) {
+                                ctx.close();
+                            }
+                        }
+
+                        @Override
+                        public void channelReadComplete(ChannelHandlerContext ctx) {
+                            clientReadCompletes.incrementAndGet();
+                            if (bytesRead == totalServerBytesWritten) {
+                                clientReadAllDataLatch.countDown();
+                            }
+                            if (!autoRead) {
+                                ctx.read();
+                            }
+                        }
+
+                        @Override
+                        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                            ctx.close();
+                        }
+                    });
+                }
+            });
+
+            serverChannel = sb.bind().sync().channel();
+            clientChannel = cb.connect(serverChannel.localAddress()).sync().channel();
+            clientChannel.read();
+
+            serverInitializedLatch.await();
+            clientReadAllDataLatch.await();
+            clientHalfClosedLatch.await();
+            assertTrue("too many read complete events: " + clientReadCompletes.get(),
+                    totalServerBytesWritten / numReadsPerReadLoop + 10 > clientReadCompletes.get());
+        } finally {
+            if (clientChannel != null) {
+                clientChannel.close().sync();
+            }
+            if (serverChannel != null) {
+                serverChannel.close().sync();
+            }
+        }
+    }
+
+    /**
+     * Designed to read a single byte at a time to control the number of reads done at a fine granularity.
+     */
+    private static final class TestNumReadsRecvByteBufAllocator implements RecvByteBufAllocator {
+        private final int numReads;
+        TestNumReadsRecvByteBufAllocator(int numReads) {
+            this.numReads = numReads;
+        }
+
+        @Override
+        public ExtendedHandle newHandle() {
+            return new ExtendedHandle() {
+                private int attemptedBytesRead;
+                private int lastBytesRead;
+                private int numMessagesRead;
+                @Override
+                public ByteBuf allocate(ByteBufAllocator alloc) {
+                    return alloc.ioBuffer(guess(), guess());
+                }
+
+                @Override
+                public int guess() {
+                    return 1; // only ever allocate buffers of size 1 to ensure the number of reads is controlled.
+                }
+
+                @Override
+                public void reset(ChannelConfig config) {
+                    numMessagesRead = 0;
+                }
+
+                @Override
+                public void incMessagesRead(int numMessages) {
+                    numMessagesRead += numMessages;
+                }
+
+                @Override
+                public void lastBytesRead(int bytes) {
+                    lastBytesRead = bytes;
+                }
+
+                @Override
+                public int lastBytesRead() {
+                    return lastBytesRead;
+                }
+
+                @Override
+                public void attemptedBytesRead(int bytes) {
+                    attemptedBytesRead = bytes;
+                }
+
+                @Override
+                public int attemptedBytesRead() {
+                    return attemptedBytesRead;
+                }
+
+                @Override
+                public boolean continueReading() {
+                    return numMessagesRead < numReads;
+                }
+
+                @Override
+                public boolean continueReading(UncheckedBooleanSupplier maybeMoreDataSupplier) {
+                    return continueReading() && maybeMoreDataSupplier.get();
+                }
+
+                @Override
+                public void readComplete() {
+                    // Nothing needs to be done or adjusted after each read cycle is completed.
+                }
+            };
+        }
+    }
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -107,11 +107,11 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
         @Override
         void epollInReady() {
             assert eventLoop().inEventLoop();
-            if (fd().isInputShutdown()) {
+            final ChannelConfig config = config();
+            if (shouldBreakEpollInReady(config)) {
                 clearEpollIn0();
                 return;
             }
-            final ChannelConfig config = config();
             final EpollRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
             allocHandle.edgeTriggered(isFlagSet(Native.EPOLLET));
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollChannelConfig.java
@@ -86,6 +86,10 @@ public class EpollChannelConfig extends DefaultChannelConfig {
 
     @Override
     public EpollChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
+        if (!(allocator.newHandle() instanceof RecvByteBufAllocator.ExtendedHandle)) {
+            throw new IllegalArgumentException("allocator.newHandle() must return an object of type: " +
+                    RecvByteBufAllocator.ExtendedHandle.class);
+        }
         super.setRecvByteBufAllocator(allocator);
         return this;
     }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -523,11 +523,11 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
         @Override
         void epollInReady() {
             assert eventLoop().inEventLoop();
-            if (fd().isInputShutdown()) {
+            DatagramChannelConfig config = config();
+            if (shouldBreakEpollInReady(config)) {
                 clearEpollIn0();
                 return;
             }
-            DatagramChannelConfig config = config();
             final EpollRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
             allocHandle.edgeTriggered(isFlagSet(Native.EPOLLET));
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollRecvByteAllocatorStreamingHandle.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollRecvByteAllocatorStreamingHandle.java
@@ -15,12 +15,11 @@
  */
 package io.netty.channel.epoll;
 
-import io.netty.channel.ChannelConfig;
 import io.netty.channel.RecvByteBufAllocator;
 
 final class EpollRecvByteAllocatorStreamingHandle extends EpollRecvByteAllocatorHandle {
-    public EpollRecvByteAllocatorStreamingHandle(RecvByteBufAllocator.Handle handle, ChannelConfig config) {
-        super(handle, config);
+    public EpollRecvByteAllocatorStreamingHandle(RecvByteBufAllocator.ExtendedHandle handle) {
+        super(handle);
     }
 
     @Override
@@ -31,6 +30,6 @@ final class EpollRecvByteAllocatorStreamingHandle extends EpollRecvByteAllocator
          *
          * If EPOLLRDHUP has been received we must read until we get a read error.
          */
-        return isEdgeTriggered() && (lastBytesRead() == attemptedBytesRead() || isReceivedRdHup());
+        return lastBytesRead() == attemptedBytesRead() || isReceivedRdHup();
     }
 }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollETSocketHalfClosed.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollETSocketHalfClosed.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketHalfClosedTest;
+
+import java.util.List;
+
+public class EpollETSocketHalfClosed extends SocketHalfClosedTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return EpollSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap bootstrap, Bootstrap bootstrap2, ByteBufAllocator allocator) {
+        super.configure(bootstrap, bootstrap2, allocator);
+        bootstrap.option(EpollChannelOption.EPOLL_MODE, EpollMode.EDGE_TRIGGERED)
+                .childOption(EpollChannelOption.EPOLL_MODE, EpollMode.EDGE_TRIGGERED);
+        bootstrap2.option(EpollChannelOption.EPOLL_MODE, EpollMode.EDGE_TRIGGERED);
+    }
+}

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollLTSocketHalfClosed.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollLTSocketHalfClosed.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketHalfClosedTest;
+
+import java.util.List;
+
+public class EpollLTSocketHalfClosed extends SocketHalfClosedTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return EpollSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void configure(ServerBootstrap bootstrap, Bootstrap bootstrap2, ByteBufAllocator allocator) {
+        super.configure(bootstrap, bootstrap2, allocator);
+        bootstrap.option(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED)
+                .childOption(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED);
+        bootstrap2.option(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED);
+    }
+}

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
@@ -140,7 +140,7 @@ public class EpollSocketChannelConfigTest {
     public void testGetOptionWhenClosed() {
         ch.close().syncUninterruptibly();
         try {
-        ch.config().getSoLinger();
+            ch.config().getSoLinger();
             fail();
         } catch (ChannelException e) {
             assertTrue(e.getCause() instanceof ClosedChannelException);

--- a/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/AdaptiveRecvByteBufAllocator.java
@@ -175,6 +175,7 @@ public class AdaptiveRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufA
         this.initial = initial;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public Handle newHandle() {
         return new HandleImpl(minIndex, maxIndex, initial);

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -29,8 +29,8 @@ import static io.netty.channel.ChannelOption.AUTO_READ;
 import static io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS;
 import static io.netty.channel.ChannelOption.MAX_MESSAGES_PER_READ;
 import static io.netty.channel.ChannelOption.MESSAGE_SIZE_ESTIMATOR;
-import static io.netty.channel.ChannelOption.SINGLE_EVENTEXECUTOR_PER_GROUP;
 import static io.netty.channel.ChannelOption.RCVBUF_ALLOCATOR;
+import static io.netty.channel.ChannelOption.SINGLE_EVENTEXECUTOR_PER_GROUP;
 import static io.netty.channel.ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK;
 import static io.netty.channel.ChannelOption.WRITE_BUFFER_LOW_WATER_MARK;
 import static io.netty.channel.ChannelOption.WRITE_BUFFER_WATER_MARK;
@@ -307,7 +307,7 @@ public class DefaultChannelConfig implements ChannelConfig {
         } else if (allocator == null) {
             throw new NullPointerException("allocator");
         }
-        rcvBufAllocator = allocator;
+        setRecvByteBufAllocator(allocator);
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/DefaultMaxBytesRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/DefaultMaxBytesRecvByteBufAllocator.java
@@ -15,11 +15,12 @@
  */
 package io.netty.channel;
 
-import java.util.AbstractMap;
-import java.util.Map.Entry;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.UncheckedBooleanSupplier;
+
+import java.util.AbstractMap;
+import java.util.Map.Entry;
 
 /**
  * The {@link RecvByteBufAllocator} that yields a buffer size prediction based upon decrementing the value from
@@ -29,11 +30,17 @@ public class DefaultMaxBytesRecvByteBufAllocator implements MaxBytesRecvByteBufA
     private volatile int maxBytesPerRead;
     private volatile int maxBytesPerIndividualRead;
 
-    private final class HandleImpl implements Handle {
+    private final class HandleImpl implements ExtendedHandle {
         private int individualReadMax;
         private int bytesToRead;
         private int lastBytesRead;
         private int attemptBytesRead;
+        private final UncheckedBooleanSupplier defaultMaybeMoreSupplier = new UncheckedBooleanSupplier() {
+            @Override
+            public boolean get() {
+                return attemptBytesRead == lastBytesRead;
+            }
+        };
 
         @Override
         public ByteBuf allocate(ByteBufAllocator alloc) {
@@ -70,8 +77,13 @@ public class DefaultMaxBytesRecvByteBufAllocator implements MaxBytesRecvByteBufA
 
         @Override
         public boolean continueReading() {
+            return continueReading(defaultMaybeMoreSupplier);
+        }
+
+        @Override
+        public boolean continueReading(UncheckedBooleanSupplier maybeMoreDataSupplier) {
             // Keep reading if we are allowed to read more bytes, and our last read filled up the buffer we provided.
-            return bytesToRead > 0 && attemptBytesRead == lastBytesRead;
+            return bytesToRead > 0 && maybeMoreDataSupplier.get();
         }
 
         @Override
@@ -99,6 +111,7 @@ public class DefaultMaxBytesRecvByteBufAllocator implements MaxBytesRecvByteBufA
         this.maxBytesPerIndividualRead = maxBytesPerIndividualRead;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public Handle newHandle() {
         return new HandleImpl();

--- a/transport/src/main/java/io/netty/channel/FixedRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/FixedRecvByteBufAllocator.java
@@ -48,6 +48,7 @@ public class FixedRecvByteBufAllocator extends DefaultMaxMessagesRecvByteBufAllo
         this.bufferSize = bufferSize;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public Handle newHandle() {
         return new HandleImpl(bufferSize);

--- a/transport/src/main/java/io/netty/channel/RecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/RecvByteBufAllocator.java
@@ -17,6 +17,9 @@ package io.netty.channel;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.netty.util.UncheckedBooleanSupplier;
+import io.netty.util.internal.UnstableApi;
+
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -24,13 +27,16 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
  * not to waste its space.
  */
 public interface RecvByteBufAllocator {
-
     /**
      * Creates a new handle.  The handle provides the actual operations and keeps the internal information which is
      * required for predicting an optimal buffer capacity.
      */
     Handle newHandle();
 
+    /**
+     * @Deprecated Use {@link ExtendedHandle}.
+     */
+    @Deprecated
     interface Handle {
         /**
          * Creates a new receive buffer whose capacity is probably large enough to read all inbound data and small
@@ -99,6 +105,16 @@ public interface RecvByteBufAllocator {
          * The read has completed.
          */
         void readComplete();
+    }
+
+    @SuppressWarnings("deprecation")
+    @UnstableApi
+    interface ExtendedHandle extends Handle {
+        /**
+         * Same as {@link Handle#continueReading()} except "more data" is determined by the supplier parameter.
+         * @param maybeMoreDataSupplier A supplier that determines if there maybe more data to read.
+         */
+        boolean continueReading(UncheckedBooleanSupplier maybeMoreDataSupplier);
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/socket/ChannelInputShutdownReadComplete.java
+++ b/transport/src/main/java/io/netty/channel/socket/ChannelInputShutdownReadComplete.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.socket;
+
+/**
+ * User event that signifies the channel's input side is shutdown, and we tried to shut it down again. This typically
+ * indicates that there is no more data to read.
+ */
+public final class ChannelInputShutdownReadComplete {
+    public static final ChannelInputShutdownReadComplete INSTANCE = new ChannelInputShutdownReadComplete();
+
+    private ChannelInputShutdownReadComplete() {
+    }
+}

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioSocketChannel.java
@@ -183,6 +183,11 @@ public class NioSocketChannel extends AbstractNioByteChannel implements io.netty
     }
 
     @Override
+    protected boolean isInputShutdown0() {
+        return isInputShutdown();
+    }
+
+    @Override
     public ChannelFuture shutdownInput(final ChannelPromise promise) {
         Executor closeExecutor = ((NioSocketChannelUnsafe) unsafe()).prepareToClose();
         if (closeExecutor != null) {


### PR DESCRIPTION
Motivation:
EpollRecvByteAllocatorHandle intends to override the meaning of "maybe more data to read" which is a concept also used in all existing implementations of RecvByteBufAllocator$Handle but the interface doesn't support overriding. Because the interfaces lack the ability to propagate this computation EpollRecvByteAllocatorHandle attempts to implement a heuristic on top of the delegate which may lead to reading when we shouldn't or not reading data.

Modifications:
- Create a new interface ExtendedRecvByteBufAllocator and ExtendedHandle which allows the "maybe more data to read" between interfaces
- Deprecate RecvByteBufAllocator and change all existing implementations to extend ExtendedRecvByteBufAllocator
- transport-native-epoll should require ExtendedRecvByteBufAllocator so the "maybe more data to read" can be propagated to the ExtendedHandle

Result:
Fixes https://github.com/netty/netty/issues/6303.