### PR TITLE
Add a constant for Cookie "undefined maxAge"

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/Cookie.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/Cookie.java
@@ -22,6 +22,11 @@ package io.netty.handler.codec.http.cookie;
 public interface Cookie extends Comparable<Cookie> {
 
     /**
+     * Constant for undefined MaxAge attribute value.
+     */
+    long UNDEFINED_MAX_AGE = Long.MIN_VALUE;
+
+    /**
      * Returns the name of this {@link Cookie}.
      *
      * @return The name of this {@link Cookie}
@@ -87,7 +92,7 @@ public interface Cookie extends Comparable<Cookie> {
     void setPath(String path);
 
     /**
-     * Returns the maximum age of this {@link Cookie} in seconds or {@link Long#MIN_VALUE} if unspecified
+     * Returns the maximum age of this {@link Cookie} in seconds or {@link Cookie#UNDEFINED_MAX_AGE} if unspecified
      *
      * @return The maximum age of this {@link Cookie}
      */
@@ -97,7 +102,7 @@ public interface Cookie extends Comparable<Cookie> {
      * Sets the maximum age of this {@link Cookie} in seconds.
      * If an age of {@code 0} is specified, this {@link Cookie} will be
      * automatically removed by browser because it will expire immediately.
-     * If {@link Long#MIN_VALUE} is specified, this {@link Cookie} will be removed when the
+     * If {@link Cookie#UNDEFINED_MAX_AGE} is specified, this {@link Cookie} will be removed when the
      * browser is closed.
      *
      * @param maxAge The maximum age of this {@link Cookie} in seconds

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/DefaultCookie.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/DefaultCookie.java
@@ -28,7 +28,7 @@ public class DefaultCookie implements Cookie {
     private boolean wrap;
     private String domain;
     private String path;
-    private long maxAge = Long.MIN_VALUE;
+    private long maxAge = UNDEFINED_MAX_AGE;
     private boolean secure;
     private boolean httpOnly;
 


### PR DESCRIPTION
Motivation:

DefaultCookie currently used an undocumented magic value for undefined
maxAge.

Clients need to be able to identify such value so they can implement a
proper CookieJar.

Ideally, we should add a `Cookie::isMaxAgeDefined` method but I guess
we can’t add a new method without breaking API :(

Modifications:

Add a new constant on `Cookie` interface so clients can use it to
compare with value return by `Cookie.maxAge` and decide if `maxAge` was
actually defined.

Result:

Clients have a better documented way to check if the maxAge attribute
was defined.