### PR TITLE
Ensure we release the previous retained AddressedEnvelope when we fai…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -191,7 +191,10 @@ final class DnsQueryContext {
             @SuppressWarnings("unchecked")
             AddressedEnvelope<DnsResponse, InetSocketAddress> castResponse =
                     (AddressedEnvelope<DnsResponse, InetSocketAddress>) envelope.retain();
-            promise.setSuccess(castResponse);
+            if (!promise.trySuccess(castResponse)) {
+                // We failed to notify the promise as it was failed before, thus we need to release the envelope
+                envelope.release();
+            }
         }
     }
 


### PR DESCRIPTION
…l to notify the promise.

Motivation:

We need to ensure we release the AddressedEnvelope if we fail to notify the future (as it may be notified before because of an timeout). Otherwise we may leak.

Modifications:

Call release() if we fail to notify the future.

Result:

No memory leaks possible. 