### PR TITLE
Update to netty-tcnative 2.0.0.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
-    <tcnative.version>2.0.0.Final-SNAPSHOT</tcnative.version>
+    <tcnative.version>2.0.0.Beta2</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <epoll.classifier>${os.detected.name}-${os.detected.arch}</epoll.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>


### PR DESCRIPTION
Motivation:

A new version of netty-tcnative is out.

Modifications:

Update to netty-tcnative 2.0.0.Beta2

Result:

Use latest release.
