### PR TITLE
Update Groovy to 2.4.8 for Java 9-ea+154 support.

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -176,7 +176,7 @@
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.7</version>
+            <version>2.4.8</version>
           </dependency>
           <dependency>
             <groupId>ant</groupId>


### PR DESCRIPTION
This change allows Netty to be successfully compiled on more recent Java 9 previews.

Motivation:

Netty could not be compiled on recent OpenJDK preview builds.

Modification:

Update Groovy to allow code generation to function on these builds.

Result:

Addresses comments in #6088. 

