### PR TITLE
TunTapChannel -- A channel for communicating via Linux TUN/TAP devices

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -37,6 +37,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport-sctp</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/example/src/main/java/io/netty/example/tunechoserver/InetUtils.java
+++ b/example/src/main/java/io/netty/example/tunechoserver/InetUtils.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.tunechoserver;
+
+import java.net.InetAddress;
+
+import io.netty.buffer.ByteBuf;
+
+public final class InetUtils {
+
+    public static int computeInetChecksum(byte[] buf, int offset, int len) {
+
+        if (len > 65536) {
+            throw new IllegalArgumentException("checksum input too large");
+        }
+
+        int sum = 0;
+
+        // Sum each whole 2-byte word in the input.
+        for (; len > 1; offset += 2, len -= 2) {
+            sum += ((buf[offset] & 0xff) << 8) + (buf[offset + 1] & 0xff);
+        }
+
+        // If the input length is odd, treat the input as if it had an extra 0 byte at the end.
+        if (len > 0) {
+            sum += (buf[offset] & 0xff) << 8;
+        }
+
+        // Complete the one's compliment sum by performing end-around carry.
+        sum = ((sum >> 16) & 0xFFFF) + (sum & 0xFFFF);
+        sum = ((sum >> 16) & 0xFFFF) + (sum & 0xFFFF);
+
+        // Negate the resultant sum to form the new checksum.
+        sum = ~sum & 0xFFFF;
+
+        return sum;
+    }
+
+    public static int updateInetChecksum(byte[] oldDataBuf, int oldDataOffset, byte[] newDataBuf,
+            int newDataOffset, int len, int oldSum) {
+
+        if (len > 65536) {
+            throw new IllegalArgumentException("checksum input too large");
+        }
+        if ((len & 1) != 0) {
+            throw new IllegalArgumentException("checksum input not multiple of two");
+        }
+
+        // NOTE: This algorithm is an adaptation of Equation 3 from RFC-1624.
+
+        // Start with the one's compliment negative of the previous checksum value.
+        int sum = ~oldSum & 0xFFFF;
+
+        // For each 2-byte word being updated...
+        for (; len > 1; oldDataOffset += 2, newDataOffset += 2, len -= 2) {
+
+            // Sum the one's compliment negative of the old word value.
+            sum += ~(((oldDataBuf[oldDataOffset] & 0xff) << 8) + (oldDataBuf[oldDataOffset + 1] & 0xff)) & 0xFFFF;
+
+            // Sum the new word value.
+            sum +=  ((newDataBuf[newDataOffset] & 0xff) << 8) + (newDataBuf[newDataOffset + 1] & 0xff);
+        }
+
+        // Complete the one's compliment sum by performing end-around carry.
+        sum = (sum & 0xFFFF) + ((sum >> 16) & 0xFFFF);
+        sum = (sum & 0xFFFF) + ((sum >> 16) & 0xFFFF);
+
+        // Negate the resultant sum to form the new checksum.
+        sum = ~sum & 0xFFFF;
+
+        return sum;
+    }
+
+    public static String ipVersionToString(int ipVersion) {
+        switch (ipVersion) {
+        case IP_VERSION_4:
+            return "IPv4";
+        case IP_VERSION_6:
+            return "IPv6";
+        default:
+            return Integer.toHexString(ipVersion).toUpperCase();
+        }
+    }
+
+    public static String ipProtocolToString(int ipProtocol) {
+        switch (ipProtocol) {
+        case IP_PROTOCOL_ICMP:
+            return "ICMP";
+        case IP_PROTOCOL_TCP:
+            return "TCP";
+        case IP_PROTOCOL_UDP:
+            return "UDP";
+        case IP_PROTOCOL_ICMPV6:
+            return "ICMPv6";
+        default:
+            return Integer.toHexString(ipProtocol).toUpperCase();
+        }
+    }
+
+    public static String ipAddressToString(byte[] addr) {
+        try {
+            return InetAddress.getByAddress(addr).getHostAddress();
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Not an IP address");
+        }
+    }
+
+    public static final class IPHeader {
+        public int ipVersion;
+        public int protocol;
+        public byte[] sourceAddress;
+        public byte[] destAddress;
+        public int headerLength;
+        public int payloadLength;
+        public int checksum;
+    }
+
+    public static IPHeader decodeIPHeader(ByteBuf packetBuf) {
+        return decodeIPHeader(packetBuf, packetBuf.readerIndex());
+    }
+
+    public static IPHeader decodeIPHeader(ByteBuf packetBuf, int ipHeaderOffset) {
+        IPHeader ipHeader = new InetUtils.IPHeader();
+
+        // Fail if the packet is too small.
+        if (packetBuf.readableBytes() < ipHeaderOffset + 1) {
+            throw new IllegalArgumentException("IP packet too small");
+        }
+
+        ipHeader.ipVersion = packetBuf.getUnsignedByte(ipHeaderOffset) & 0xF0;
+
+        // If the packet is an IPv6 packet...
+        if (ipHeader.ipVersion == IP_VERSION_6) {
+
+            // Set the header length.
+            ipHeader.headerLength = IPV6_HEADER_LENGTH;
+
+            // Fail if the packet is too small to contain the IPv6 header.
+            if (packetBuf.readableBytes() < ipHeaderOffset + IPV6_HEADER_LENGTH) {
+                throw new IllegalArgumentException("IP packet too small");
+            }
+
+            // Get the IP payload length.
+            ipHeader.payloadLength = packetBuf.getUnsignedShort(ipHeaderOffset + IPV6_HEADER_OFFSET_PAYLOAD_LENGTH);
+
+            // Fail if the packet is too small, counting the payload.
+            if (packetBuf.readableBytes() < ipHeaderOffset + IPV6_HEADER_LENGTH + ipHeader.payloadLength) {
+                throw new IllegalArgumentException("IP packet too small");
+            }
+
+            // Get the protocol.
+            ipHeader.protocol = packetBuf.getUnsignedByte(ipHeaderOffset + IPV6_HEADER_OFFSET_NEXT_HEADER);
+
+            // Get the source and destination addresses.
+            ipHeader.sourceAddress = new byte[16];
+            ipHeader.destAddress = new byte[16];
+            packetBuf.getBytes(ipHeaderOffset + InetUtils.IPV6_HEADER_OFFSET_SOURCE_ADDR, ipHeader.sourceAddress);
+            packetBuf.getBytes(ipHeaderOffset + InetUtils.IPV6_HEADER_OFFSET_DEST_ADDR, ipHeader.destAddress);
+
+        // Otherwise if the packet is an IPv6 packet...
+        } else if (ipHeader.ipVersion == IP_VERSION_4) {
+
+            // Get the length of the header.
+            ipHeader.headerLength =
+                    (packetBuf.getUnsignedByte(ipHeaderOffset + IPV4_HEADER_OFFSET_HEADER_LENGTH) & 0x0F) * 4;
+
+            // Fail if header length value is too small.
+            if (ipHeader.headerLength < IPV4_MIN_HEADER_LENGTH) {
+                throw new IllegalArgumentException("Invalid IPv4 header length");
+            }
+
+            // Fail if the packet is too small to contain the IPv4 header.
+            if (packetBuf.readableBytes() < ipHeaderOffset + ipHeader.headerLength) {
+                throw new IllegalArgumentException("IP packet too small");
+            }
+
+            // Get the total length of the packet.
+            int totalLength = packetBuf.getUnsignedShort(ipHeaderOffset + IPV4_HEADER_OFFSET_TOTAL_LENGTH);
+
+            // Fail if the packet is smaller than the total length.
+            if (packetBuf.readableBytes() < ipHeaderOffset + totalLength) {
+                throw new IllegalArgumentException("IP packet too small");
+            }
+
+            // Compute the payload length
+            ipHeader.payloadLength = totalLength - ipHeader.headerLength;
+
+            // Get the protocol.
+            ipHeader.protocol = packetBuf.getUnsignedByte(ipHeaderOffset + IPV4_HEADER_OFFSET_PROTOCOL);
+
+            // Get the source and destination addresses.
+            ipHeader.sourceAddress = new byte[4];
+            ipHeader.destAddress = new byte[4];
+            packetBuf.getBytes(ipHeaderOffset + InetUtils.IPV4_HEADER_OFFSET_SOURCE_ADDR, ipHeader.sourceAddress);
+            packetBuf.getBytes(ipHeaderOffset + InetUtils.IPV4_HEADER_OFFSET_DEST_ADDR, ipHeader.destAddress);
+
+            // Get IP checksum.
+            ipHeader.checksum = packetBuf.getUnsignedShort(ipHeaderOffset + IPV4_HEADER_OFFSET_CHECKSUM);
+
+        // Otherwise the packet type is unknown.
+        } else {
+            throw new UnsupportedOperationException(
+                    "IP version unsupported: " + ipVersionToString(ipHeader.ipVersion));
+        }
+
+        return ipHeader;
+    }
+
+    public static final class ICMPHeader {
+        public int type;
+        public int code;
+        public int checksum;
+    }
+
+    public static ICMPHeader decodeICMPHeader(ByteBuf packetBuf) {
+        return decodeICMPHeader(packetBuf, packetBuf.readerIndex());
+    }
+
+    public static ICMPHeader decodeICMPHeader(ByteBuf packetBuf, int headerOffset) {
+        // Fail if the packet is too small.
+        if (packetBuf.readableBytes() < headerOffset + ICMP_HEADER_LENGTH) {
+            throw new IllegalArgumentException("ICMP packet too small");
+        }
+
+        ICMPHeader icmpHeader = new InetUtils.ICMPHeader();
+        icmpHeader.type = packetBuf.getUnsignedByte(headerOffset + ICMP_HEADER_OFFSET_TYPE);
+        icmpHeader.code = packetBuf.getUnsignedByte(headerOffset + ICMP_HEADER_OFFSET_CODE);
+        icmpHeader.checksum = packetBuf.getUnsignedShort(headerOffset + ICMP_HEADER_OFFSET_CHECKSUM);
+
+        return icmpHeader;
+    }
+
+    public static final class UDPHeader {
+        public int sourcePort;
+        public int destPort;
+        public int length;
+        public int checksum;
+    }
+
+    public static UDPHeader decodeUDPHeader(ByteBuf packetBuf, int headerOffset) {
+        // Fail if the packet is too small.
+        if (packetBuf.readableBytes() < headerOffset + UDP_HEADER_LENGTH) {
+            throw new IllegalArgumentException("ICMP packet too small");
+        }
+
+        UDPHeader udpHeader = new InetUtils.UDPHeader();
+        udpHeader.sourcePort = packetBuf.getUnsignedShort(headerOffset + UDP_HEADER_OFFSET_SOURCE_PORT);
+        udpHeader.destPort = packetBuf.getUnsignedShort(headerOffset + UDP_HEADER_OFFSET_DEST_PORT);
+        udpHeader.length = packetBuf.getUnsignedShort(headerOffset + UDP_HEADER_OFFSET_LENGTH);
+        udpHeader.checksum = packetBuf.getUnsignedShort(headerOffset + UDP_HEADER_OFFSET_CHECKSUM);
+
+        return udpHeader;
+    }
+
+    public static final int IP_VERSION_4                        = 0x40;
+    public static final int IP_VERSION_6                        = 0x60;
+
+    public static final int IP_PROTOCOL_TCP                     = 0x06;
+    public static final int IP_PROTOCOL_UDP                     = 0x11;
+    public static final int IP_PROTOCOL_ICMP                    = 0x01;
+    public static final int IP_PROTOCOL_ICMPV6                  = 0x3A;
+
+    public static final int IPV4_MIN_HEADER_LENGTH              = 20;
+    public static final int IPV4_HEADER_OFFSET_VERSION          = 0;
+    public static final int IPV4_HEADER_OFFSET_HEADER_LENGTH    = 0;
+    public static final int IPV4_HEADER_OFFSET_TOTAL_LENGTH     = 2;
+    public static final int IPV4_HEADER_OFFSET_PROTOCOL         = 9;
+    public static final int IPV4_HEADER_OFFSET_CHECKSUM         = 10;
+    public static final int IPV4_HEADER_OFFSET_SOURCE_ADDR      = 12;
+    public static final int IPV4_HEADER_OFFSET_DEST_ADDR        = 16;
+
+    public static final byte[] IPV6_LINK_LOCAL_PREFIX           = { (byte) 0xFE, (byte) 0x80, 0, 0, 0, 0, 0, 0 };
+
+    public static final int IPV6_HEADER_LENGTH                  = 40;
+    public static final int IPV6_HEADER_OFFSET_VERSION          = 0;
+    public static final int IPV6_HEADER_OFFSET_PAYLOAD_LENGTH   = 4;
+    public static final int IPV6_HEADER_OFFSET_NEXT_HEADER      = 6;
+    public static final int IPV6_HEADER_OFFSET_SOURCE_ADDR      = 8;
+    public static final int IPV6_HEADER_OFFSET_DEST_ADDR        = 24;
+
+    public static final int TCP_HEADER_LENGTH                   = 20;
+    public static final int TCP_HEADER_OFFSET_SOURCE_PORT       = 0;
+    public static final int TCP_HEADER_OFFSET_DEST_PORT         = 2;
+    public static final int TCP_HEADER_OFFSET_FLAGS             = 13;
+    public static final int TCP_HEADER_OFFSET_CHECKSUM          = 16;
+
+    public static final int UDP_HEADER_LENGTH                   = 8;
+    public static final int UDP_HEADER_OFFSET_SOURCE_PORT       = 0;
+    public static final int UDP_HEADER_OFFSET_DEST_PORT         = 2;
+    public static final int UDP_HEADER_OFFSET_LENGTH            = 4;
+    public static final int UDP_HEADER_OFFSET_CHECKSUM          = 6;
+
+    public static final int ICMP_HEADER_LENGTH                  = 8;
+    public static final int ICMP_HEADER_OFFSET_TYPE             = 0;
+    public static final int ICMP_HEADER_OFFSET_CODE             = 1;
+    public static final int ICMP_HEADER_OFFSET_CHECKSUM         = 2;
+    public static final int ICMP_HEADER_REST_OF_HEADER          = 4;
+
+    public static final int ICMPV6_HEADER_LENGTH                = 4;
+    public static final int ICMPV6_HEADER_OFFSET_TYPE           = 0;
+    public static final int ICMPV6_HEADER_OFFSET_CODE           = 1;
+    public static final int ICMPV6_HEADER_OFFSET_CHECKSUM       = 2;
+
+    public static final int TCP_FLAG_URG                        = 0x20;
+    public static final int TCP_FLAG_ACK                        = 0x10;
+    public static final int TCP_FLAG_PSH                        = 0x08;
+    public static final int TCP_FLAG_RST                        = 0x04;
+    public static final int TCP_FLAG_SYN                        = 0x02;
+    public static final int TCP_FLAG_FIN                        = 0x01;
+
+    public static final int ICMP_MESSAGE_TYPE_ECHO_REQUEST      = 8;
+    public static final int ICMP_MESSAGE_TYPE_ECHO_REPLY        = 0;
+
+    public static final int ICMPV6_MESSAGE_TYPE_ECHO_REQUEST    = 128;
+    public static final int ICMPV6_MESSAGE_TYPE_ECHO_REPLY      = 129;
+}

--- a/example/src/main/java/io/netty/example/tunechoserver/InetUtils.java
+++ b/example/src/main/java/io/netty/example/tunechoserver/InetUtils.java
@@ -347,8 +347,6 @@ public final class InetUtils {
     public static final int IPV4_HEADER_OFFSET_SOURCE_ADDR      = 12;
     public static final int IPV4_HEADER_OFFSET_DEST_ADDR        = 16;
 
-    public static final byte[] IPV6_LINK_LOCAL_PREFIX           = { (byte) 0xFE, (byte) 0x80, 0, 0, 0, 0, 0, 0 };
-
     public static final int IPV6_HEADER_LENGTH                  = 40;
     public static final int IPV6_HEADER_OFFSET_VERSION          = 0;
     public static final int IPV6_HEADER_OFFSET_PAYLOAD_LENGTH   = 4;

--- a/example/src/main/java/io/netty/example/tunechoserver/InetUtils.java
+++ b/example/src/main/java/io/netty/example/tunechoserver/InetUtils.java
@@ -392,4 +392,8 @@ public final class InetUtils {
 
     public static final int ICMPV6_MESSAGE_TYPE_ECHO_REQUEST    = 128;
     public static final int ICMPV6_MESSAGE_TYPE_ECHO_REPLY      = 129;
+
+    private InetUtils() {
+        // Not accessible.
+    }
 }

--- a/example/src/main/java/io/netty/example/tunechoserver/TunEchoServer.java
+++ b/example/src/main/java/io/netty/example/tunechoserver/TunEchoServer.java
@@ -1,0 +1,452 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.tunechoserver;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.AbstractByteBufAllocator;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelException;
+import io.netty.channel.ChannelFactory;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.TunAddress;
+import io.netty.channel.epoll.TunTapChannel;
+import io.netty.channel.epoll.TunTapChannelOption;
+import io.netty.channel.epoll.TunTapPacket;
+import io.netty.channel.epoll.TunTapPacketLogger;
+
+/**
+ * A simple TunTapChannel server that echos UDP and ICMP packets back to a sender.
+ *
+ * TunEchoServer is a Netty server designed to exercise Netty's TunTapChannel class.
+ * TunEchoServer effectively emulates a very simple IPv4/IPv6 host system which echos
+ * any UDP or ICMP packet it receives back to the sender.  TunEchoServer is designed
+ * to be usable from the command line to facilitate testing, and accepts various system
+ * properties to control its behavior (see below).
+ *
+ * Note that the TunEchoServer does not listen on a particular address or port in
+ * the same sense as a traditional server would.  Rather the TunEchoServer listens
+ * on a Linux TUN device, and reflects back any IP packet sent to it by reversing the
+ * source and destination addresses in the packet.  It does this without regard to the
+ * destination address in the original packet.  Thus the TunEchoServer effectively
+ * "listens" on all IP addresses and port numbers that are reachable via the configured
+ * interface.
+ *
+ *
+ * <h3>Running TunEchoServer</h3>
+ *
+ * To run TunEchoServer, perform the following steps:
+ *
+ * 1) Initialize a TUN device over which the server will receive packets. Configure this
+ * device with a set of private addresses and subnets.  (Note that the specific addresses
+ * assigned here represent the local host machine, <b>not</b> the address of the TunEchoServer).
+ *
+ * <pre>
+ *     sudo ip tuntap add dev tun-echo-server mode tun user $USER group $USER
+ *     sudo ip link set tun-echo-server up
+ *     sudo ip addr add 172.20.0.1/12 dev tun-echo-server
+ *     sudo ip addr add fd00:0:1::1/64 dev tun-echo-server
+ * </pre>
+ *
+ * 2) Start the server process, supplying paths to the necessary jar files.
+ *
+ * <pre>
+ *     java -cp <path to netty-all-*.jar>:<path to netty-example-*.jar> io.netty.example.tunechoserver.TunEchoServer
+ * </pre>
+ *
+ * 3) From a second shell, ping the server from the local host.
+ *
+ * <pre>
+ *     ping -c 10 172.20.0.2
+ *
+ *     ping6 -c 10 fd00:0:1::2
+ * </pre>
+ *
+ * 4) The ping command should indicate that responses are being received.
+ *    Additionally you should see logging output from the server like this:
+ *
+ * <pre>
+ *     Feb 01, 2017 7:26:16 PM io.netty.channel.epoll.TunTapPacketLogger logPacket
+ *     INFO: TUN/TAP PACKET RECEIVED (protocol IPv6, len 104):
+ *       IPv6: src fd00:0:1:0:0:0:0:1, dest fd00:0:1:0:0:0:0:2, protocol ICMPv6
+ *              +-------------------------------------------------+
+ *              |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ *     +--------+-------------------------------------------------+----------------+
+ *     |00000000| 60 03 62 2f 00 40 3a 40 fd 00 00 00 00 01 00 00 |`.b/.@:@........|
+ *     |00000010| 00 00 00 00 00 00 00 01 fd 00 00 00 00 01 00 00 |................|
+ *     |00000020| 00 00 00 00 00 00 00 02 80 00 5b 5c 19 8a 00 01 |..........[\....|
+ *     |00000030| d8 a6 92 58 00 00 00 00 da c4 0c 00 00 00 00 00 |...X............|
+ *     |00000040| 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f |................|
+ *     |00000050| 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f | !"#$%&'()*+,-./|
+ *     |00000060| 30 31 32 33 34 35 36 37                         |01234567        |
+ *     +--------+-------------------------------------------------+----------------+
+ *
+ *     Feb 01, 2017 7:26:16 PM io.netty.channel.epoll.TunTapPacketLogger logPacket
+ *     INFO: TUN/TAP PACKET SENT (protocol IPv6, len 104):
+ *       IPv6: src fd00:0:1:0:0:0:0:2, dest fd00:0:1:0:0:0:0:1, protocol ICMPv6
+ *              +-------------------------------------------------+
+ *              |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+ *     +--------+-------------------------------------------------+----------------+
+ *     |00000000| 60 03 62 2f 00 40 3a 40 fd 00 00 00 00 01 00 00 |`.b/.@:@........|
+ *     |00000010| 00 00 00 00 00 00 00 02 fd 00 00 00 00 01 00 00 |................|
+ *     |00000020| 00 00 00 00 00 00 00 01 81 00 5a 5c 19 8a 00 01 |..........Z\....|
+ *     |00000030| d8 a6 92 58 00 00 00 00 da c4 0c 00 00 00 00 00 |...X............|
+ *     |00000040| 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f |................|
+ *     |00000050| 20 21 22 23 24 25 26 27 28 29 2a 2b 2c 2d 2e 2f | !"#$%&'()*+,-./|
+ *     |00000060| 30 31 32 33 34 35 36 37                         |01234567        |
+ *     +--------+-------------------------------------------------+----------------+
+ * </pre>
+ *
+ * 5) To test UDP, use the netcat (nc) tool to send and receive UDP packets from the server.
+ *
+ * <pre>
+ *     echo "HELLO via UDP!" | nc -u 172.20.0.2 7
+ *
+ *     echo "HELLO via UDP!" | nc -u -6 fd00:0:1::2 7
+ * </pre>
+ *
+ *
+ * <h3>Configurable Properties</h3>
+ *
+ * TunEchoServer supports the following system properties for configuring its behavior:
+ *
+ * tun-device=<device-name>
+ *
+ * Open the specified linux TUN device. Defaults to 'tun-echo-server'.
+ *
+ * thread-pool-size=<int>
+ *
+ * Use a ThreadPoolExecutor with the specified number of threads to respond to incoming packets.
+ * A value of 0 causes the responses to be sent on the Netty channel thread. Defaults to 0.
+ *
+ * use-unpooled=<true|false>
+ *
+ * Enable/disable use of Netty UnpooledByteBufAllocator for allocating buffers. Defaults to false.
+ *
+ * read-buf-size=<int>
+ *
+ * Set the TunTapChannel read buffer size.  Defaults to 2048.
+ *
+ * force-gc=<true|false>
+ *
+ * Enable/disable garbage collection and finalizers after each packet is processed. Defaults to false.
+ *
+ * debug=<true|false>
+ *
+ * Enable/disable verbose logging of server activity. Disabling debug logging is using running
+ * performance tests.  Defaults to true.
+ *
+ */
+
+public class TunEchoServer extends SimpleChannelInboundHandler<TunTapPacket> {
+
+    private static AbstractByteBufAllocator _bufAllocator = PooledByteBufAllocator.DEFAULT;
+    private static ThreadPoolExecutor _threadPool;
+    private static Logger _logger;
+    private static boolean _forceGC;
+    private static boolean _debug;
+    private static String _tunDeviceName;
+    private static int _threadPoolSize;
+    private static int _readBufSize;
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.flush();
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        cause.printStackTrace();
+        // We don't close the channel because we can keep serving requests.
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, final TunTapPacket inPacket) throws Exception {
+        final Channel channel = ctx.channel();
+
+        // If a thread pool has been configured, use it to run the handlePacket().  Otherwise call
+        // handlePacket() directly on the channel thread.
+        if (_threadPool != null) {
+            inPacket.retain();
+            _threadPool.execute(
+                new Runnable() {
+                    @Override
+                    public void run() {
+                        handlePacket(channel, inPacket);
+                        inPacket.release();
+                    }
+                }
+            );
+        } else {
+            handlePacket(channel, inPacket);
+        }
+    }
+
+    private static void handlePacket(Channel channel, TunTapPacket inPacket) {
+        ByteBuf inPacketBuf = inPacket.packetData();
+        TunTapPacket outPacket = null;
+        ByteBuf outPacketBuf = null;
+
+        try {
+            // Ignore anything that isn't marked as an IPv4 or IPv6 packet by the kernel.
+            if (inPacket.protocol() != TunTapPacket.PROTOCOL_IPV4 &&
+                inPacket.protocol() != TunTapPacket.PROTOCOL_IPV6) {
+                return;
+            }
+
+            // Parse the IP header.
+            InetUtils.IPHeader ipHeader = InetUtils.decodeIPHeader(inPacketBuf);
+
+            // Ingore the packet if the version in the IP header doesn't match the kernel packet type.
+            if ((inPacket.protocol() == TunTapPacket.PROTOCOL_IPV4 && ipHeader.ipVersion != InetUtils.IP_VERSION_4) ||
+                (inPacket.protocol() == TunTapPacket.PROTOCOL_IPV6 && ipHeader.ipVersion != InetUtils.IP_VERSION_6)) {
+                return;
+            }
+
+            // Create a copy of the inbound packet that will become the response packet.
+            outPacketBuf = inPacketBuf.copy();
+            outPacket = new TunTapPacket(inPacket.protocol(), outPacketBuf);
+
+            // Swap the source and destination addresses in the response packet.
+            swapSourceDestAddresses(outPacketBuf, ipHeader);
+
+            // If the packet is an ICMP or ICMPv6 packet...
+            if ((ipHeader.ipVersion == InetUtils.IP_VERSION_4 && ipHeader.protocol == InetUtils.IP_PROTOCOL_ICMP) ||
+                (ipHeader.ipVersion == InetUtils.IP_VERSION_6 && ipHeader.protocol == InetUtils.IP_PROTOCOL_ICMPV6)) {
+
+                // Decode ICMP header.
+                InetUtils.ICMPHeader icmpHeader = InetUtils.decodeICMPHeader(inPacketBuf, ipHeader.headerLength);
+
+                // Ignore anything other than an ICMP or ICMPv6 Echo Request
+                if ((ipHeader.ipVersion == InetUtils.IP_VERSION_4 &&
+                     icmpHeader.type != InetUtils.ICMP_MESSAGE_TYPE_ECHO_REQUEST) ||
+                    (ipHeader.ipVersion == InetUtils.IP_VERSION_6 &&
+                     icmpHeader.type != InetUtils.ICMPV6_MESSAGE_TYPE_ECHO_REQUEST) ||
+                    icmpHeader.code != 0) {
+                    return;
+                }
+
+                // Change the message type to Echo Reply.
+                int newType = (ipHeader.ipVersion == InetUtils.IP_VERSION_4)
+                    ? InetUtils.ICMP_MESSAGE_TYPE_ECHO_REPLY
+                    : InetUtils.ICMPV6_MESSAGE_TYPE_ECHO_REPLY;
+                changeICMPTypeAndCode(outPacketBuf, ipHeader, icmpHeader, newType, 0);
+
+            // Otherwise if the packet is a UDP packet...
+            } else if (ipHeader.protocol == InetUtils.IP_PROTOCOL_UDP) {
+
+                // Decode the UDP header.
+                InetUtils.UDPHeader udpHeader = InetUtils.decodeUDPHeader(inPacketBuf, ipHeader.headerLength);
+
+                // Swap the source and destination port numbers in the response packet.
+                swapSourceDestPorts(outPacketBuf, ipHeader, udpHeader);
+
+            // Otherwise, not an ICMP or UDP packet, so ignore it.
+            } else {
+                return;
+            }
+
+            // Write the response packet to the TUN device.
+            channel.writeAndFlush(outPacket);
+            outPacket = null;
+            outPacketBuf = null;
+        } finally {
+            if (outPacket != null) {
+                outPacket.release();
+            } else if (outPacketBuf != null) {
+                outPacketBuf.release();
+            }
+        }
+
+        // If requested, provoke GC as an aid to detecting buffer leaks.
+        if (_forceGC) {
+            System.gc();
+            System.runFinalization();
+        }
+    }
+
+    private static void swapSourceDestAddresses(ByteBuf packetBuf, InetUtils.IPHeader ipHeader) {
+
+        // Swap the source and destination addresses in the IP header.  Note that this does not affect the
+        // packet's checksums values.
+        if (ipHeader.ipVersion == InetUtils.IP_VERSION_4) {
+            packetBuf.setBytes(InetUtils.IPV4_HEADER_OFFSET_SOURCE_ADDR, ipHeader.destAddress);
+            packetBuf.setBytes(InetUtils.IPV4_HEADER_OFFSET_DEST_ADDR, ipHeader.sourceAddress);
+        } else if (ipHeader.ipVersion == InetUtils.IP_VERSION_6) {
+            packetBuf.setBytes(InetUtils.IPV6_HEADER_OFFSET_SOURCE_ADDR, ipHeader.destAddress);
+            packetBuf.setBytes(InetUtils.IPV6_HEADER_OFFSET_DEST_ADDR, ipHeader.sourceAddress);
+        }
+    }
+
+    private static void swapSourceDestPorts(ByteBuf packetBuf, InetUtils.IPHeader ipHeader,
+            InetUtils.UDPHeader udpHeader) {
+
+        // Swap the source and destination port numbers in the UDP header.  Note that this does not affect the
+        // packet's checksums values.
+        packetBuf.setShort(ipHeader.headerLength +
+                InetUtils.UDP_HEADER_OFFSET_SOURCE_PORT, udpHeader.destPort);
+        packetBuf.setShort(ipHeader.headerLength +
+                InetUtils.UDP_HEADER_OFFSET_DEST_PORT, udpHeader.sourcePort);
+    }
+
+    private static void changeICMPTypeAndCode(ByteBuf packetBuf, InetUtils.IPHeader ipHeader,
+            InetUtils.ICMPHeader icmpHeader, int newType, int newCode) {
+
+        // Read the portion of the packet containing the ICMP type and code.
+        byte[] oldTypeAndCodeBytes = new byte[2];
+        packetBuf.getBytes(ipHeader.headerLength, oldTypeAndCodeBytes);
+
+        // Read the portion of the packet containing the original ICMP checksum.
+        byte[] oldICMPChecksumBytes = new byte[2];
+        packetBuf.getBytes(ipHeader.headerLength + InetUtils.ICMP_HEADER_OFFSET_CHECKSUM, oldICMPChecksumBytes);
+
+        // Construct a byte array containing the new type and code in the form these fields will appear in
+        // updated the packet.
+        byte[] newTypeAndCode = new byte[2];
+        newTypeAndCode[0] = (byte) newType;
+        newTypeAndCode[1] = (byte) newCode;
+
+        // Update the packet with the new type and code.
+        packetBuf.setBytes(ipHeader.headerLength, newTypeAndCode);
+
+        // Compute a new ICMP checksum based on the updated type and code.
+        int newICMPChecksum = InetUtils.updateInetChecksum(oldTypeAndCodeBytes, 0,
+                newTypeAndCode, 0, 2, icmpHeader.checksum);
+
+        // Update the checksum field in the ICMP header.
+        packetBuf.setShort(ipHeader.headerLength + InetUtils.ICMP_HEADER_OFFSET_CHECKSUM, newICMPChecksum);
+
+        // If the packet is an ICMP packet (vs ICMPv6)...
+        if (ipHeader.ipVersion == InetUtils.IP_VERSION_4) {
+
+            // Read the portion of the packet containing the new ICMP checksum bytes.
+            byte[] newICMPChecksumBytes = new byte[2];
+            packetBuf.getBytes(ipHeader.headerLength + InetUtils.ICMP_HEADER_OFFSET_CHECKSUM, newICMPChecksumBytes);
+
+            // Compute an updated IP checksum.
+            int newIPChecksum = InetUtils.updateInetChecksum(oldICMPChecksumBytes, 0, newICMPChecksumBytes,
+                    0, 2, ipHeader.checksum);
+            newIPChecksum = InetUtils.updateInetChecksum(oldTypeAndCodeBytes, 0, newTypeAndCode, 0, 2, newIPChecksum);
+
+            // Update the checksum field in the IPv4 header.
+            packetBuf.setShort(InetUtils.IPV4_HEADER_OFFSET_CHECKSUM, newIPChecksum);
+        }
+    }
+
+    private static boolean readProps() {
+
+        _tunDeviceName = System.getProperty("tun-device-name", "tun-echo-server");
+
+        try {
+            _threadPoolSize = Integer.parseInt(System.getProperty("thread-pool-size", "0"));
+            if (_threadPoolSize < 0) {
+                throw new IllegalArgumentException();
+            }
+        } catch (Exception ex) {
+            System.err.println("Invalid value specified for thread-pool-size property: " +
+                    System.getProperty("thread-pool-size"));
+            return false;
+        }
+
+        try {
+            _readBufSize = Integer.parseInt(System.getProperty("read-buf-size", "2048"));
+            if (_readBufSize < 1) {
+                throw new IllegalArgumentException();
+            }
+        } catch (Exception ex) {
+            System.err.println("Invalid value specified for read-buf-size property: " +
+                    System.getProperty("read-buf-size"));
+            return false;
+        }
+
+        if (Boolean.parseBoolean(System.getProperty("use-unpooled", "false"))) {
+            _bufAllocator = UnpooledByteBufAllocator.DEFAULT;
+        }
+
+        _forceGC = Boolean.parseBoolean(System.getProperty("force-gc", "false"));
+
+        _debug = Boolean.parseBoolean(System.getProperty("debug", "true"));
+
+        return true;
+    }
+
+    public static void main(String[] args) {
+
+        if (!readProps()) {
+            return;
+        }
+
+        System.out.println("TunEchoServer starting");
+
+        try {
+            _logger = Logger.getLogger("");
+            _logger.setLevel(_debug ? Level.FINEST : Level.SEVERE);
+
+            if (_threadPoolSize > 0) {
+                _threadPool = (ThreadPoolExecutor) Executors.newFixedThreadPool(_threadPoolSize);
+            }
+
+            final TunEchoServer server = new TunEchoServer();
+
+            EventLoopGroup group = new EpollEventLoopGroup(1);
+
+            ChannelFactory<Channel> channelFactory = new ChannelFactory<Channel>() {
+                @Override
+                public Channel newChannel() {
+                    try {
+                        Channel channel = new TunTapChannel();
+                        if (_debug) {
+                            channel.pipeline().addLast(new TunTapPacketLogger());
+                        }
+                        return channel;
+                    } catch (Throwable t) {
+                        throw new ChannelException("Unable to create TunTapChannel", t);
+                    }
+                }
+            };
+
+            Bootstrap bootstrap = new Bootstrap()
+                .group(group)
+                .channelFactory(channelFactory)
+                .option(ChannelOption.ALLOCATOR, _bufAllocator)
+                .option(TunTapChannelOption.READ_BUF_SIZE, _readBufSize)
+                .handler(server);
+
+            final TunTapChannel channel =
+                    (TunTapChannel) bootstrap.bind(new TunAddress(_tunDeviceName)).sync().channel();
+
+            System.out.println("TunEchoServer ready");
+
+            channel.closeFuture().await();
+        } catch (Exception ex) {
+            _logger.log(Level.SEVERE, "Exception in TunEchoServer", ex);
+        }
+
+        System.out.println("TunEchoServer exiting");
+    }
+
+}

--- a/example/src/main/java/io/netty/example/tunechoserver/clear-test-env.sh
+++ b/example/src/main/java/io/netty/example/tunechoserver/clear-test-env.sh
@@ -1,0 +1,3 @@
+:
+sudo ip link set tun-echo-server down
+sudo ip tuntap del dev tun-echo-server mode tun

--- a/example/src/main/java/io/netty/example/tunechoserver/setup-test-env.sh
+++ b/example/src/main/java/io/netty/example/tunechoserver/setup-test-env.sh
@@ -1,0 +1,5 @@
+:
+sudo ip tuntap add dev tun-echo-server mode tun user $USER group $USER
+sudo ip link set tun-echo-server up
+sudo ip addr add 172.20.0.1/12 dev tun-echo-server
+sudo ip addr add fd00:0:1::1/64 dev tun-echo-server

--- a/run-example.sh
+++ b/run-example.sh
@@ -42,6 +42,7 @@ EXAMPLE_MAP=(
   'sctpecho-client:io.netty.example.sctp.SctpEchoClient'
   'sctpecho-server:io.netty.example.sctp.SctpEchoServer'
   'localecho:io.netty.example.localecho.LocalEcho'
+  'tun-echo-server:io.netty.example.tunechoserver.TunEchoServer'
 )
 
 NEEDS_NPN_MAP=(

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -327,6 +327,11 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-testsuite</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
@@ -21,6 +21,9 @@ import io.netty.channel.unix.Socket;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.nio.ByteBuffer;
+
+import static io.netty.channel.unix.Errors.newIOException;
 
 /**
  * A socket which provides access Linux native methods.
@@ -144,49 +147,28 @@ final class LinuxSocket extends Socket {
         return new LinuxSocket(newSocketDomain0());
     }
 
-    public void writeTunTapPacket(int protocol, ByteBuffer buf, int pos, int maxLen) throws IOException {
-        int res = writeTunTapPacket(fd, protocol, buf, pos, maxLen);
-        if (res < 0) {
-            throw newIOException("writeTunTapPacket", res);
-        }
-    }
-
-    public void writeTunTapPacketAddress(int protocol, long addr, int pos, int maxLen) throws IOException {
-        int res = writeTunTapPacketAddress(fd, protocol, addr, pos, maxLen);
-        if (res < 0) {
-            throw newIOException("writeTunTapPacketAddress", res);
-        }
-    }
-
-    public long readTunTapPacket(ByteBuffer buf, int pos, int maxLen) throws IOException {
-        long res = readTunTapPacket(fd, buf, pos, maxLen);
-        if (res < 0) {
-            throw newIOException("readTunTapPacket", (int) res);
-        }
-        return res;
-    }
-
-    public long readTunTapPacketAddress(long addr, int pos, int maxLen) throws IOException {
-        long res = readTunTapPacketAddress(fd, addr, pos, maxLen);
-        if (res < 0) {
-            throw newIOException("readTunTapPacketAddress", (int) res);
-        }
-        return res;
-    }
-
-    public static Socket openTunTapCloneDevice(String cloneDevName) {
-        int res = openTunTapCloneDevice0(cloneDevName);
-        if (res < 0) {
-            throw new ChannelException(newIOException("openTunTapCloneDevice", res));
-        }
-        return new Socket(res);
+    public static LinuxSocket openTunTapCloneDevice(String cloneDevName) {
+        return new LinuxSocket(openTunTapCloneDevice0(cloneDevName));
     }
 
     public void allocTunTapInterface(String ifName, boolean isTapDev) {
-        int res = allocTunTapInterface(fd, ifName, isTapDev);
-        if (res < 0) {
-            throw new ChannelException(newIOException("allocTunTapInterface", res));
-        }
+        allocTunTapInterface(intValue(), ifName, isTapDev);
+    }
+
+    public long readTunTapPacket(ByteBuffer buf, int pos, int maxLen) throws IOException {
+        return readTunTapPacket(intValue(), buf, pos, maxLen);
+    }
+
+    public long readTunTapPacketAddress(long addr, int pos, int maxLen) throws IOException {
+        return readTunTapPacketAddress(intValue(), addr, pos, maxLen);
+    }
+
+    public void writeTunTapPacket(int protocol, ByteBuffer buf, int pos, int maxLen) throws IOException {
+        writeTunTapPacket(intValue(), protocol, buf, pos, maxLen);
+    }
+
+    public void writeTunTapPacketAddress(int protocol, long addr, int pos, int maxLen) throws IOException {
+        writeTunTapPacketAddress(intValue(), protocol, addr, pos, maxLen);
     }
 
     private static native int getTcpDeferAccept(int fd) throws IOException;
@@ -220,8 +202,8 @@ final class LinuxSocket extends Socket {
 
     public static native long readTunTapPacket(int fd, ByteBuffer buf, int pos, int limit) throws IOException;
     public static native long readTunTapPacketAddress(int fd, long addr, int pos, int limit) throws IOException;
-    public static native int writeTunTapPacket(
-           int fd, int protocol, ByteBuffer buf, int pos, int limit) throws IOException;
-    public static native int writeTunTapPacketAddress(
-           int fd, int protocol, long addr, int pos, int limit) throws IOException;
+    public static native void writeTunTapPacket(int fd, int protocol, ByteBuffer buf, int pos, int limit)
+            throws IOException;
+    public static native void writeTunTapPacketAddress(int fd, int protocol, long addr, int pos, int limit)
+            throws IOException;
 }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/LinuxSocket.java
@@ -144,6 +144,51 @@ final class LinuxSocket extends Socket {
         return new LinuxSocket(newSocketDomain0());
     }
 
+    public void writeTunTapPacket(int protocol, ByteBuffer buf, int pos, int maxLen) throws IOException {
+        int res = writeTunTapPacket(fd, protocol, buf, pos, maxLen);
+        if (res < 0) {
+            throw newIOException("writeTunTapPacket", res);
+        }
+    }
+
+    public void writeTunTapPacketAddress(int protocol, long addr, int pos, int maxLen) throws IOException {
+        int res = writeTunTapPacketAddress(fd, protocol, addr, pos, maxLen);
+        if (res < 0) {
+            throw newIOException("writeTunTapPacketAddress", res);
+        }
+    }
+
+    public long readTunTapPacket(ByteBuffer buf, int pos, int maxLen) throws IOException {
+        long res = readTunTapPacket(fd, buf, pos, maxLen);
+        if (res < 0) {
+            throw newIOException("readTunTapPacket", (int) res);
+        }
+        return res;
+    }
+
+    public long readTunTapPacketAddress(long addr, int pos, int maxLen) throws IOException {
+        long res = readTunTapPacketAddress(fd, addr, pos, maxLen);
+        if (res < 0) {
+            throw newIOException("readTunTapPacketAddress", (int) res);
+        }
+        return res;
+    }
+
+    public static Socket openTunTapCloneDevice(String cloneDevName) {
+        int res = openTunTapCloneDevice0(cloneDevName);
+        if (res < 0) {
+            throw new ChannelException(newIOException("openTunTapCloneDevice", res));
+        }
+        return new Socket(res);
+    }
+
+    public void allocTunTapInterface(String ifName, boolean isTapDev) {
+        int res = allocTunTapInterface(fd, ifName, isTapDev);
+        if (res < 0) {
+            throw new ChannelException(newIOException("allocTunTapInterface", res));
+        }
+    }
+
     private static native int getTcpDeferAccept(int fd) throws IOException;
     private static native int isTcpQuickAck(int fd) throws IOException;
     private static native int isTcpCork(int fd) throws IOException;
@@ -169,4 +214,14 @@ final class LinuxSocket extends Socket {
     private static native void setIpFreeBind(int fd, int freeBind) throws IOException;
     private static native void setIpTransparent(int fd, int transparent) throws IOException;
     private static native void setTcpMd5Sig(int fd, byte[] address, int scopeId, byte[] key) throws IOException;
+
+    private static native int openTunTapCloneDevice0(String cloneDevName);
+    private static native int allocTunTapInterface(int cloneDevFd, String ifName, boolean isTapDev);
+
+    public static native long readTunTapPacket(int fd, ByteBuffer buf, int pos, int limit) throws IOException;
+    public static native long readTunTapPacketAddress(int fd, long addr, int pos, int limit) throws IOException;
+    public static native int writeTunTapPacket(
+           int fd, int protocol, ByteBuffer buf, int pos, int limit) throws IOException;
+    public static native int writeTunTapPacketAddress(
+           int fd, int protocol, long addr, int pos, int limit) throws IOException;
 }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TapAddress.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TapAddress.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.epoll;
+
+/**
+ * An address object that identifies a tap device to which a {@link TunTapChannel}
+ * can be bound.
+ */
+public final class TapAddress extends TunTapAddress {
+
+    public TapAddress(String ifName) {
+        super(ifName);
+    }
+
+    @Override
+    public boolean isTapAddress() {
+        return true;
+    }
+
+    private static final long serialVersionUID = 0;
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunAddress.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunAddress.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.epoll;
+
+/**
+ * An address object that identifies a tun device to which a {@link TunTapChannel}
+ * can be bound.
+ */
+public final class TunAddress extends TunTapAddress {
+
+    public TunAddress(String ifName) {
+        super(ifName);
+    }
+
+    @Override
+    public boolean isTapAddress() {
+        return false;
+    }
+
+    private static final long serialVersionUID = 0;
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapAddress.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapAddress.java
@@ -24,17 +24,17 @@ import java.net.SocketAddress;
  */
 public abstract class TunTapAddress extends SocketAddress {
 
-    private String _ifName;
+    private String ifName;
 
     protected TunTapAddress(String ifName) {
-        this._ifName = ifName;
+        this.ifName = ifName;
     }
 
     /**
      * The name of the tun/tap device.
      */
     public String interfaceName() {
-        return this._ifName;
+        return this.ifName;
     }
 
     /**

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapAddress.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapAddress.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.epoll;
+
+import java.net.SocketAddress;
+
+/**
+ * An abstract address object that identifies a tun or tap device to which
+ * a {@link TunTapChannel} can be bound.
+ */
+public abstract class TunTapAddress extends SocketAddress {
+
+    private String _ifName;
+
+    protected TunTapAddress(String ifName) {
+        this._ifName = ifName;
+    }
+
+    /**
+     * The name of the tun/tap device.
+     */
+    public String interfaceName() {
+        return this._ifName;
+    }
+
+    /**
+     * True if this address identifies a tap device (verses a tun device).
+     */
+    public abstract boolean isTapAddress();
+
+    private static final long serialVersionUID = 0;
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapChannel.java
@@ -184,7 +184,7 @@ public class TunTapChannel extends AbstractEpollChannel {
 
     final class TunTapChannelUnsafe extends AbstractEpollUnsafe {
 
-        private final List<TunTapPacket> _rcvdPackets = new ArrayList<TunTapPacket>();
+        private final List<TunTapPacket> rcvdPackets = new ArrayList<TunTapPacket>();
 
         @Override
         public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
@@ -255,7 +255,7 @@ public class TunTapChannel extends AbstractEpollChannel {
 
                         // Allocate a TunTapPacket object containing the packet data and the protocol information.
                         TunTapPacket packet = new TunTapPacket(protocol, packetData);
-                        _rcvdPackets.add(packet);
+                        rcvdPackets.add(packet);
 
                         // Avoid releasing the packet data buffer now that its wrapped in a TunTapPacket.
                         packetData = null;
@@ -275,12 +275,12 @@ public class TunTapChannel extends AbstractEpollChannel {
                 ChannelPipeline pipeline = pipeline();
 
                 // For each received packet, fire a read event up the pipeline.
-                int packetCount = _rcvdPackets.size();
+                int packetCount = rcvdPackets.size();
                 for (int i = 0; i < packetCount; i ++) {
                     readPending = false;
-                    pipeline.fireChannelRead(_rcvdPackets.get(i));
+                    pipeline.fireChannelRead(rcvdPackets.get(i));
                 }
-                _rcvdPackets.clear();
+                rcvdPackets.clear();
 
                 // Tell the allocator handle the read is complete.
                 allocHandle.readComplete();

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapChannel.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.epoll;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelMetadata;
+import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.unix.Socket;
+
+/**
+ * A {@link Channel} implementation that can be used to send or receive packets over
+ * a Linux TUN/TAP interface.
+ * <p>
+ * To initialize a {@link TunTapChannel}, create a {@link TunAddress} or {@link TapAddress}
+ * object containing the name of the TUN/TAP device to open, and then bind the {@link TunTapChannel}
+ * to the address.
+ * <p>
+ * To send packets into the device (causing them to be received by the local host's network
+ * stack) create a {@link TunTapPacket} object containing the packet type and data, and call
+ * {@link TunTapChannel} write() or writeAndFlush().
+ * <p>
+ * When the kernel sends packets out via the device, the packets are delivered to the channel
+ * handlers via the channelRead() method, wrapped in {@link TunTapPacket} objects.
+ */
+public class TunTapChannel extends AbstractEpollChannel {
+
+    private boolean _isOpen = true;
+    private TunTapChannelConfig _config;
+    private TunTapAddress _localAddress;
+    private boolean _isTapChannel;
+    private static final ChannelMetadata _metadata = new ChannelMetadata(true);
+
+    /**
+     * Create a new {@link TunTapChannel} object that uses the default TUN/TAP clone device.
+     */
+    public TunTapChannel() throws IOException {
+        this(defaultCloneDeviceName());
+    }
+
+    /**
+     * Create a new {@link TunTapChannel} object that uses the specified TUN/TAP clone device.
+     */
+    public TunTapChannel(String cloneDevName) throws IOException {
+        // Open the specified clone device and pass the fd to the base class.
+        super(Socket.openTunTapCloneDevice(cloneDevName), Native.EPOLLIN);
+
+        _config = new TunTapChannelConfig(this);
+    }
+
+    @Override
+    public TunTapChannelConfig config() {
+        return _config;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return _isOpen;
+    }
+
+    public boolean isTapChannel() {
+        return _isTapChannel;
+    }
+
+    @Override
+    public ChannelMetadata metadata() {
+        return _metadata;
+    }
+
+    public static String defaultCloneDeviceName() {
+        return "/dev/net/tun";
+    }
+
+    @Override
+    protected SocketAddress localAddress0() {
+        return _localAddress;
+    }
+
+    @Override
+    protected SocketAddress remoteAddress0() {
+        return null;
+    }
+
+    @Override
+    protected void doRegister() throws Exception {
+        // Override doRegester() to prevent the base class from adding the TUN/TAP file descriptor
+        // to the epoll set until after the call is made to allocate/open the network interface
+        // (see doBind() below).  If the file descriptor is added to the epoll set before the
+        // network interface is allocated, epoll will never wake on incoming packets.  This
+        // appears to be an idiosyncrasy of the Linux kernel.
+    }
+
+    @Override
+    protected void doBind(SocketAddress localAddress) throws Exception {
+        if (isActive()) {
+            throw new IllegalStateException("TunTapChannel already bound to interface");
+        }
+
+        TunTapAddress tunTapAddr = (TunTapAddress) localAddress;
+
+        String ifName = tunTapAddr.interfaceName();
+        boolean isTapDevice = tunTapAddr.isTapAddress();
+
+        // Allocate/open the specified network interface name.
+        fd().allocTunTapInterface(ifName, isTapDevice);
+
+        _localAddress = tunTapAddr;
+        _isTapChannel = isTapDevice;
+
+        // Add the TUN/TAP file descriptor to the epoll set.
+        // NOTE: this must happen *after* the call to allocInterface() above (see
+        // doRegister() for further details).
+        EpollEventLoop loop = (EpollEventLoop) eventLoop();
+        loop.add(this);
+
+        // Mark the channel as active.
+        active = true;
+    }
+
+    @Override
+    protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+        for (;;) {
+            // Get the next packet to be written.  Bail if no more packets.
+            TunTapPacket packet = (TunTapPacket) in.current();
+            if (packet == null) {
+                break;
+            }
+
+            ByteBuf packetData = packet.packetData();
+
+            try {
+                // If the buffer has an accessible memory address, write the packet data
+                // directly from buffer memory. Otherwise, get the packet data as an NIO
+                // buffer and write the data from that.
+                if (packetData.hasMemoryAddress()) {
+                    long memoryAddress = packetData.memoryAddress();
+                    int readerIndex = packetData.readerIndex();
+                    int len = packetData.readableBytes();
+                    fd().writeTunTapPacketAddress(packet.protocol(), memoryAddress, readerIndex, len);
+                } else {
+                    ByteBuffer nioBuf = packetData.nioBuffer();
+                    int pos = nioBuf.position();
+                    int limit = nioBuf.limit();
+                    fd().writeTunTapPacket(packet.protocol(), nioBuf, pos, limit - pos);
+                }
+
+                // Drop the packet from the outbound queue.
+                in.remove();
+            } catch (Exception e) {
+                in.remove(e);
+            }
+        }
+    }
+
+    @Override
+    protected AbstractEpollUnsafe newUnsafe() {
+        return new TunTapChannelUnsafe();
+    }
+
+    final class TunTapChannelUnsafe extends AbstractEpollUnsafe {
+
+        private final List<TunTapPacket> _rcvdPackets = new ArrayList<TunTapPacket>();
+
+        @Override
+        public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+            throw new UnsupportedOperationException("TunTapChannelUnsafe.connect");
+        }
+
+        @Override
+        void epollInReady() {
+            assert eventLoop().inEventLoop();
+            if (fd().isInputShutdown()) {
+                clearEpollIn0();
+                return;
+            }
+
+            EpollRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
+            allocHandle.edgeTriggered(isFlagSet(Native.EPOLLET));
+
+            ByteBufAllocator allocator = _config.getAllocator();
+
+            // Tell the allocator handle we're about to start another read loop.
+            allocHandle.reset(_config);
+
+            epollInBefore();
+
+            try {
+                Throwable exception = null;
+                ByteBuf packetData = null;
+                Socket tunTapFd = fd();
+
+                try {
+                    // Repeatedly read packets from the interface for as long as there are
+                    // packets to be read and the allocator handle tells us its okay...
+                    do {
+                        // Allocate an appropriately sized buffer in which to receive data.
+                        packetData = allocHandle.allocate(allocator);
+
+                        // Tell the allocator handle how much data we're attempting to read.
+                        allocHandle.attemptedBytesRead(packetData.writableBytes());
+
+                        int writerIndex = packetData.writerIndex();
+                        long readRes;
+
+                        // If the buffer has an accessible memory address, read packet data directly into the
+                        // buffer memory. Otherwise, get the internal NIO buffer associated with the ByteBuf
+                        // and read into that.
+                        if (packetData.hasMemoryAddress()) {
+                            readRes = tunTapFd.readTunTapPacketAddress(packetData.memoryAddress(), writerIndex,
+                                packetData.capacity());
+                        } else {
+                            ByteBuffer nioData = packetData.internalNioBuffer(writerIndex, packetData.writableBytes());
+                            readRes = tunTapFd.readTunTapPacket(nioData, nioData.position(), nioData.limit());
+                        }
+
+                        // Stop reading if no packet was received.
+                        if (readRes == 0) {
+                            allocHandle.lastBytesRead(-1);
+                            packetData.release();
+                            packetData = null;
+                            break;
+                        }
+
+                        // Extract the length of the packet and the protocol from the read result.
+                        int packetLen = (int) (readRes & 0xFFFFFFFF);
+                        int protocol = (int) ((readRes >> 32) & 0xFFFF);
+
+                        // Advance the writer index in the packet data buffer by the length of the packet.
+                        packetData.writerIndex(writerIndex + packetLen);
+
+                        // Allocate a TunTapPacket object containing the packet data and the protocol information.
+                        TunTapPacket packet = new TunTapPacket(protocol, packetData);
+                        _rcvdPackets.add(packet);
+
+                        // Avoid releasing the packet data buffer now that its wrapped in a TunTapPacket.
+                        packetData = null;
+
+                        // Tell the allocator handle about the newly received packet.
+                        allocHandle.incMessagesRead(1);
+                        allocHandle.lastBytesRead(packetLen);
+
+                    } while (allocHandle.continueReading());
+                } catch (Throwable ex) {
+                    if (packetData != null) {
+                        packetData.release();
+                        packetData = null;
+                    }
+                    exception = ex;
+                }
+
+                ChannelPipeline pipeline = pipeline();
+
+                // For each received packet, fire a read event up the pipeline.
+                int packetCount = _rcvdPackets.size();
+                for (int i = 0; i < packetCount; i ++) {
+                    readPending = false;
+                    pipeline.fireChannelRead(_rcvdPackets.get(i));
+                }
+                _rcvdPackets.clear();
+
+                // Tell the allocator handle the read is complete.
+                allocHandle.readComplete();
+
+                // Fire a channel read complete event up the pipeline.
+                pipeline.fireChannelReadComplete();
+
+                // If an exception occurred, fire a exception caught event up the pipeline.
+                if (exception != null) {
+                    pipeline.fireExceptionCaught(exception);
+                }
+            } finally {
+                epollInFinally(_config);
+            }
+        }
+    }
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapChannelConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.epoll;
+
+import java.util.Map;
+
+import io.netty.channel.ChannelOption;
+import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.RecvByteBufAllocator;
+import static io.netty.channel.epoll.TunTapChannelOption.*;
+
+public class TunTapChannelConfig extends EpollChannelConfig {
+
+    private Integer _READ_BUF_SIZE    = 2048;
+    private static final RecvByteBufAllocator _DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvByteBufAllocator(2048);
+
+    public TunTapChannelConfig(AbstractEpollChannel channel) {
+        super(channel);
+        setRecvByteBufAllocator(_DEFAULT_RCVBUF_ALLOCATOR);
+    }
+
+    @Override
+    public Map<ChannelOption<?>, Object> getOptions() {
+        return getOptions(super.getOptions(), READ_BUF_SIZE);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getOption(ChannelOption<T> option) {
+        if (option == READ_BUF_SIZE) {
+            return (T) _READ_BUF_SIZE;
+        }
+        return super.getOption(option);
+    }
+
+    @Override
+    public <T> boolean setOption(ChannelOption<T> option, T value) {
+        validate(option, value);
+        if (option == READ_BUF_SIZE) {
+            _READ_BUF_SIZE = (Integer) value;
+            if (getRecvByteBufAllocator().getClass().equals(FixedRecvByteBufAllocator.class)) {
+                setRecvByteBufAllocator(new FixedRecvByteBufAllocator(_READ_BUF_SIZE));
+            }
+        } else {
+            return super.setOption(option, value);
+        }
+        return true;
+    }
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapChannelConfig.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapChannelConfig.java
@@ -25,12 +25,12 @@ import static io.netty.channel.epoll.TunTapChannelOption.*;
 
 public class TunTapChannelConfig extends EpollChannelConfig {
 
-    private Integer _READ_BUF_SIZE    = 2048;
-    private static final RecvByteBufAllocator _DEFAULT_RCVBUF_ALLOCATOR = new FixedRecvByteBufAllocator(2048);
+    private Integer readBufSize = 2048;
+    private static final RecvByteBufAllocator defaultRcvBufAllocator = new FixedRecvByteBufAllocator(2048);
 
     public TunTapChannelConfig(AbstractEpollChannel channel) {
         super(channel);
-        setRecvByteBufAllocator(_DEFAULT_RCVBUF_ALLOCATOR);
+        setRecvByteBufAllocator(defaultRcvBufAllocator);
     }
 
     @Override
@@ -42,7 +42,7 @@ public class TunTapChannelConfig extends EpollChannelConfig {
     @Override
     public <T> T getOption(ChannelOption<T> option) {
         if (option == READ_BUF_SIZE) {
-            return (T) _READ_BUF_SIZE;
+            return (T) readBufSize;
         }
         return super.getOption(option);
     }
@@ -51,9 +51,9 @@ public class TunTapChannelConfig extends EpollChannelConfig {
     public <T> boolean setOption(ChannelOption<T> option, T value) {
         validate(option, value);
         if (option == READ_BUF_SIZE) {
-            _READ_BUF_SIZE = (Integer) value;
+            readBufSize = (Integer) value;
             if (getRecvByteBufAllocator().getClass().equals(FixedRecvByteBufAllocator.class)) {
-                setRecvByteBufAllocator(new FixedRecvByteBufAllocator(_READ_BUF_SIZE));
+                setRecvByteBufAllocator(new FixedRecvByteBufAllocator(readBufSize));
             }
         } else {
             return super.setOption(option, value);

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapChannelOption.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapChannelOption.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.epoll;
+
+import io.netty.channel.ChannelOption;
+
+public final class TunTapChannelOption<T> extends ChannelOption<T> {
+
+    public static final ChannelOption<Integer> READ_BUF_SIZE = valueOf("READ_BUF_SIZE");
+
+    @SuppressWarnings({ "deprecation" })
+    private TunTapChannelOption(String name) {
+        super(name);
+    }
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapPacket.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapPacket.java
@@ -24,107 +24,106 @@ import io.netty.buffer.ByteBufHolder;
  */
 public final class TunTapPacket implements ByteBufHolder {
 
-    private int _protocol;
-    private ByteBuf _packetData;
+    private int protocol;
+    private ByteBuf packetData;
 
     public TunTapPacket() {
+        // Nothing to do.
     }
 
     public TunTapPacket(int protocol, ByteBuf packetData) {
         if (packetData == null) {
             throw new NullPointerException("packetData");
         }
-        _protocol = protocol;
-        _packetData = packetData;
+        this.protocol = protocol;
+        this.packetData = packetData;
     }
 
     public TunTapPacket(ByteBuf packetData) {
         if (packetData == null) {
             throw new NullPointerException("packetData");
         }
-        _protocol = inferProtocolFromIPPacket(packetData);
-        _packetData = packetData;
+        protocol = inferProtocolFromIPPacket(packetData);
+        this.packetData = packetData;
     }
 
     public int protocol() {
-        return _protocol;
+        return protocol;
     }
 
     public void setProtocol(int protocol) {
-        _protocol = protocol;
+        this.protocol = protocol;
     }
 
     public ByteBuf packetData() {
-        return _packetData;
+        return packetData;
     }
 
     public void setPacketData(ByteBuf packetData) {
-        _packetData = packetData;
+        this.packetData = packetData;
     }
 
     @Override
     public int refCnt() {
-        return _packetData.refCnt();
+        return packetData.refCnt();
     }
 
     @Override
     public boolean release() {
-        return _packetData.release();
+        return packetData.release();
     }
 
     @Override
     public boolean release(int decrement) {
-        return _packetData.release(decrement);
+        return packetData.release(decrement);
     }
 
     @Override
     public ByteBuf content() {
-        return _packetData;
+        return packetData;
     }
 
     @Override
     public TunTapPacket copy() {
-        return new TunTapPacket(_protocol, _packetData.copy());
+        return new TunTapPacket(protocol, packetData.copy());
     }
 
     @Override
     public TunTapPacket duplicate() {
-        return new TunTapPacket(_protocol, _packetData.duplicate());
+        return new TunTapPacket(protocol, packetData.duplicate());
     }
 
     @Override
     public TunTapPacket retain() {
-        _packetData.retain();
+        packetData.retain();
         return this;
     }
 
     @Override
     public TunTapPacket retain(int increment) {
-        _packetData.retain(increment);
+        packetData.retain(increment);
         return this;
     }
 
     @Override
     public TunTapPacket touch() {
-        _packetData.touch();
+        packetData.touch();
         return this;
     }
 
     @Override
     public TunTapPacket touch(Object hint) {
-        _packetData.touch(hint);
+        packetData.touch(hint);
         return this;
     }
 
     @Override
     public ByteBufHolder retainedDuplicate() {
-        // TODO Auto-generated method stub
         return null;
     }
 
     @Override
     public ByteBufHolder replace(ByteBuf content) {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapPacket.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapPacket.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.epoll;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+
+/**
+ * Represents a packet being received or sent via a {@link TunTapChannel}.
+ */
+public final class TunTapPacket implements ByteBufHolder {
+
+    private int _protocol;
+    private ByteBuf _packetData;
+
+    public TunTapPacket() {
+    }
+
+    public TunTapPacket(int protocol, ByteBuf packetData) {
+        if (packetData == null) {
+            throw new NullPointerException("packetData");
+        }
+        _protocol = protocol;
+        _packetData = packetData;
+    }
+
+    public TunTapPacket(ByteBuf packetData) {
+        if (packetData == null) {
+            throw new NullPointerException("packetData");
+        }
+        _protocol = inferProtocolFromIPPacket(packetData);
+        _packetData = packetData;
+    }
+
+    public int protocol() {
+        return _protocol;
+    }
+
+    public void setProtocol(int protocol) {
+        _protocol = protocol;
+    }
+
+    public ByteBuf packetData() {
+        return _packetData;
+    }
+
+    public void setPacketData(ByteBuf packetData) {
+        _packetData = packetData;
+    }
+
+    @Override
+    public int refCnt() {
+        return _packetData.refCnt();
+    }
+
+    @Override
+    public boolean release() {
+        return _packetData.release();
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        return _packetData.release(decrement);
+    }
+
+    @Override
+    public ByteBuf content() {
+        return _packetData;
+    }
+
+    @Override
+    public TunTapPacket copy() {
+        return new TunTapPacket(_protocol, _packetData.copy());
+    }
+
+    @Override
+    public TunTapPacket duplicate() {
+        return new TunTapPacket(_protocol, _packetData.duplicate());
+    }
+
+    @Override
+    public TunTapPacket retain() {
+        _packetData.retain();
+        return this;
+    }
+
+    @Override
+    public TunTapPacket retain(int increment) {
+        _packetData.retain(increment);
+        return this;
+    }
+
+    @Override
+    public TunTapPacket touch() {
+        _packetData.touch();
+        return this;
+    }
+
+    @Override
+    public TunTapPacket touch(Object hint) {
+        _packetData.touch(hint);
+        return this;
+    }
+
+    @Override
+    public ByteBufHolder retainedDuplicate() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public ByteBufHolder replace(ByteBuf content) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    public static final int PROTOCOL_IPV4 = 0x0800;
+    public static final int PROTOCOL_IPV6 = 0x86DD;
+    public static final int PROTOCOL_ARP = 0x0806;
+    public static final int PROTOCOL_NOT_SPECIFIED = 0;
+
+    public static int inferProtocolFromIPPacket(ByteBuf packetData) {
+        int ipVersionField = packetData.getUnsignedByte(packetData.readerIndex()) & 0xF0;
+        switch (ipVersionField) {
+        case 0x60:
+            return PROTOCOL_IPV6;
+        case 0x40:
+            return PROTOCOL_IPV4;
+        default:
+            return PROTOCOL_NOT_SPECIFIED;
+        }
+    }
+
+    public static String getProtocolName(int protocol) {
+        switch (protocol) {
+        case TunTapPacket.PROTOCOL_IPV4:
+            return "IPv4";
+        case TunTapPacket.PROTOCOL_IPV6:
+            return "IPv6";
+        case TunTapPacket.PROTOCOL_ARP:
+            return "ARP";
+        default:
+            return Integer.toHexString(protocol).toUpperCase();
+        }
+    }
+}

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapPacketLogger.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapPacketLogger.java
@@ -32,7 +32,7 @@ import io.netty.handler.logging.LoggingHandler;
  */
 public class TunTapPacketLogger extends LoggingHandler {
 
-    private boolean _logPacketData = true;
+    private boolean logPacketData = true;
 
     public TunTapPacketLogger() {
         super(LogLevel.INFO);
@@ -51,11 +51,11 @@ public class TunTapPacketLogger extends LoggingHandler {
     }
 
     public boolean logPacketData() {
-        return _logPacketData;
+        return logPacketData;
     }
 
     public void setLogPacketData(boolean logPacketData) {
-        _logPacketData = logPacketData();
+        this.logPacketData = logPacketData;
     }
 
     @Override
@@ -80,7 +80,7 @@ public class TunTapPacketLogger extends LoggingHandler {
 
     private void logPacket(TunTapPacket packet, boolean isEtherFrame, String eventName) {
         if (logger.isEnabled(internalLevel)) {
-            logger.log(internalLevel, formatPacket(packet, isEtherFrame, eventName, _logPacketData));
+            logger.log(internalLevel, formatPacket(packet, isEtherFrame, eventName, logPacketData));
         }
     }
 
@@ -101,8 +101,7 @@ public class TunTapPacketLogger extends LoggingHandler {
 
             // Generally a sender doesn't specify a protocol when sending an Ethernet frame, since
             // Linux doesn't require it.  Therefore extract the protocol from the Ethernet frame data.
-            protocol = ((int) packetData.getUnsignedByte(packetData.readerIndex() + 12)) << 8 |
-                    ((int) packetData.getUnsignedByte(packetData.readerIndex() + 13));
+            protocol = packetData.getUnsignedShort(packetData.readerIndex() + 12);
 
             // Print the Ethernet header
             formatEthernetHeader(packetData, 0, protocol, formatter);

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapPacketLogger.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapPacketLogger.java
@@ -91,7 +91,7 @@ public class TunTapPacketLogger extends LoggingHandler {
         int protocol = packet.protocol();
         int ipPacketOffset = 0;
 
-        formatter.format("%s (protocol %s, len %d):\n",
+        formatter.format("%s (protocol %s, len %d):%n",
                 title,
                 TunTapPacket.getProtocolName(packet.protocol()),
                 packetData.readableBytes());
@@ -135,11 +135,11 @@ public class TunTapPacketLogger extends LoggingHandler {
         packetData.getBytes(readerIndex + headerOffset + 6, srcMACAddr);
         packetData.getBytes(readerIndex + headerOffset + 0, destMACAddr);
 
-        formatter.format("  Ethernet: src ");
+        formatter.format("%s", "  Ethernet: src ");
         formatMAC48(srcMACAddr, formatter);
-        formatter.format(", dest ");
+        formatter.format("%s", ", dest ");
         formatMAC48(destMACAddr, formatter);
-        formatter.format(", protocol %s\n", TunTapPacket.getProtocolName(protocol));
+        formatter.format(", protocol %s%n", TunTapPacket.getProtocolName(protocol));
     }
 
     private static void formatIPv4Header(ByteBuf packetData, int headerOffset, Formatter formatter) {
@@ -164,7 +164,7 @@ public class TunTapPacketLogger extends LoggingHandler {
 
         int transportProtocol = packetData.getUnsignedByte(readerIndex + headerOffset + 9);
 
-        formatter.format("  IPv4: src %s, dest %s, protocol %s\n",
+        formatter.format("  IPv4: src %s, dest %s, protocol %s%n",
                 srcAddr, destAddr, transportProtocolToString(transportProtocol));
     }
 
@@ -190,7 +190,7 @@ public class TunTapPacketLogger extends LoggingHandler {
 
         int transportProtocol = packetData.getUnsignedByte(readerIndex + headerOffset + 6);
 
-        formatter.format("  IPv6: src %s, dest %s, protocol %s\n",
+        formatter.format("  IPv6: src %s, dest %s, protocol %s%n",
                 srcAddr, destAddr, transportProtocolToString(transportProtocol));
     }
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapPacketLogger.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/TunTapPacketLogger.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.channel.epoll;
+
+import java.net.InetAddress;
+import java.util.Formatter;
+import java.util.Locale;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+
+/**
+ * A {@link ChannelLogger} that logs packets sent or received via a {@link TunTapChannel}.
+ */
+public class TunTapPacketLogger extends LoggingHandler {
+
+    private boolean _logPacketData = true;
+
+    public TunTapPacketLogger() {
+        super(LogLevel.INFO);
+    }
+
+    public TunTapPacketLogger(LogLevel level) {
+        super(level);
+    }
+
+    public TunTapPacketLogger(String name) {
+        super(name);
+    }
+
+    public TunTapPacketLogger(String name, LogLevel level) {
+        super(name, level);
+    }
+
+    public boolean logPacketData() {
+        return _logPacketData;
+    }
+
+    public void setLogPacketData(boolean logPacketData) {
+        _logPacketData = logPacketData();
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (msg instanceof TunTapPacket) {
+            logPacket((TunTapPacket) msg, ((TunTapChannel) ctx.channel()).isTapChannel(), "TUN/TAP PACKET RECEIVED");
+            ctx.fireChannelRead(msg);
+        } else {
+            super.channelRead(ctx, msg);
+        }
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (msg instanceof TunTapPacket) {
+            logPacket((TunTapPacket) msg, ((TunTapChannel) ctx.channel()).isTapChannel(), "TUN/TAP PACKET SENT");
+            ctx.write(msg, promise);
+        } else {
+            super.write(ctx, msg, promise);
+        }
+    }
+
+    private void logPacket(TunTapPacket packet, boolean isEtherFrame, String eventName) {
+        if (logger.isEnabled(internalLevel)) {
+            logger.log(internalLevel, formatPacket(packet, isEtherFrame, eventName, _logPacketData));
+        }
+    }
+
+    public static String formatPacket(TunTapPacket packet, boolean isEtherFrame, String title, boolean logPacketData) {
+        StringBuilder out = new StringBuilder();
+        Formatter formatter = new Formatter(out, Locale.US);
+        ByteBuf packetData = packet.packetData();
+        int protocol = packet.protocol();
+        int ipPacketOffset = 0;
+
+        formatter.format("%s (protocol %s, len %d):\n",
+                title,
+                TunTapPacket.getProtocolName(packet.protocol()),
+                packetData.readableBytes());
+
+        // If the packet is an Ethernet frame...
+        if (isEtherFrame) {
+
+            // Generally a sender doesn't specify a protocol when sending an Ethernet frame, since
+            // Linux doesn't require it.  Therefore extract the protocol from the Ethernet frame data.
+            protocol = ((int) packetData.getUnsignedByte(packetData.readerIndex() + 12)) << 8 |
+                    ((int) packetData.getUnsignedByte(packetData.readerIndex() + 13));
+
+            // Print the Ethernet header
+            formatEthernetHeader(packetData, 0, protocol, formatter);
+
+            // Adjust where we look for the IP header within the packet.
+            ipPacketOffset = 14;
+        }
+
+        // If the packet contains an IPv4 or IPv6 packet, print the appropriate header information.
+        if (protocol == TunTapPacket.PROTOCOL_IPV6) {
+            formatIPv6Header(packetData, ipPacketOffset, formatter);
+        } else if (protocol == TunTapPacket.PROTOCOL_IPV4) {
+            formatIPv4Header(packetData, ipPacketOffset, formatter);
+        }
+
+        // Print the full contents of the packet.
+        if (logPacketData) {
+            formatter.format("%s", ByteBufUtil.prettyHexDump(packetData));
+        }
+
+        formatter.close();
+
+        return out.toString();
+    }
+
+    private static void formatEthernetHeader(ByteBuf packetData, int headerOffset, int protocol, Formatter formatter) {
+        int readerIndex = packetData.readerIndex();
+        byte[] srcMACAddr = new byte[6];
+        byte[] destMACAddr = new byte[6];
+
+        packetData.getBytes(readerIndex + headerOffset + 6, srcMACAddr);
+        packetData.getBytes(readerIndex + headerOffset + 0, destMACAddr);
+
+        formatter.format("  Ethernet: src ");
+        formatMAC48(srcMACAddr, formatter);
+        formatter.format(", dest ");
+        formatMAC48(destMACAddr, formatter);
+        formatter.format(", protocol %s\n", TunTapPacket.getProtocolName(protocol));
+    }
+
+    private static void formatIPv4Header(ByteBuf packetData, int headerOffset, Formatter formatter) {
+        int readerIndex = packetData.readerIndex();
+        String srcAddr, destAddr;
+
+        try {
+            byte[] srcAddrData = new byte[4];
+            packetData.getBytes(readerIndex + headerOffset + 12, srcAddrData);
+            srcAddr = InetAddress.getByAddress(srcAddrData).getHostAddress();
+        } catch (Exception ex) {
+            srcAddr = "(invalid)";
+        }
+
+        try {
+            byte[] destAddrData = new byte[4];
+            packetData.getBytes(readerIndex + headerOffset + 16, destAddrData);
+            destAddr = InetAddress.getByAddress(destAddrData).getHostAddress();
+        } catch (Exception ex) {
+            destAddr = "(invalid)";
+        }
+
+        int transportProtocol = packetData.getUnsignedByte(readerIndex + headerOffset + 9);
+
+        formatter.format("  IPv4: src %s, dest %s, protocol %s\n",
+                srcAddr, destAddr, transportProtocolToString(transportProtocol));
+    }
+
+    private static void formatIPv6Header(ByteBuf packetData, int headerOffset, Formatter formatter) {
+        int readerIndex = packetData.readerIndex();
+        String srcAddr, destAddr;
+
+        try {
+            byte[] srcAddrData = new byte[16];
+            packetData.getBytes(readerIndex + headerOffset + 8, srcAddrData);
+            srcAddr = InetAddress.getByAddress(srcAddrData).getHostAddress();
+        } catch (Exception ex) {
+            srcAddr = "(invalid)";
+        }
+
+        try {
+            byte[] destAddrData = new byte[16];
+            packetData.getBytes(readerIndex + headerOffset + 24, destAddrData);
+            destAddr = InetAddress.getByAddress(destAddrData).getHostAddress();
+        } catch (Exception ex) {
+            destAddr = "(invalid)";
+        }
+
+        int transportProtocol = packetData.getUnsignedByte(readerIndex + headerOffset + 6);
+
+        formatter.format("  IPv6: src %s, dest %s, protocol %s\n",
+                srcAddr, destAddr, transportProtocolToString(transportProtocol));
+    }
+
+    private static void formatMAC48(byte[] mac48, Formatter formatter) {
+        for (int i = 0; i < 6; i++) {
+            formatter.format("%s%02X", i != 0 ? ":" : "", mac48[i]);
+        }
+    }
+
+    private static String transportProtocolToString(int transportProtocol) {
+        switch (transportProtocol) {
+        case 1:
+            return "ICMP";
+        case 6:
+            return "TCP";
+        case 0x11:
+            return "UDP";
+        case 0x3A:
+            return "ICMPv6";
+        default:
+            return Integer.toHexString(transportProtocol).toUpperCase();
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

The Linux TUN/TAP device driver provides a means to create software-defined network interfaces by allowing user-space applications to send and receive raw IP and Ethernet packets.  It has applications in the construction of VPN clients and terminators, network simulators, and software-defined networking (SDN) tools.  The Netty TunTapChannel enables the creation of such tools in JVM-based languages using the standard Netty framework.

Modifications:

- Implemented the io.netty.channel.epoll.TunTapChannel class and supporting classes (TunTapPacket, TunTapAddress, TunAddress, TapAddress, TunTapChannelConfig, TunTapChannelOption).  TunTapChannel is an extension of AbstractEpollChannel.

- Enhanced io.netty.channel.unix.Socket with native methods for interacting with Linux TUN/TAP devices.

- Implemented TunTapPacketLogger which extends LoggingHandler to provide detailed information about IP/Ethernet packets traversing a channel.

- Added the TunEchoServer example server which listens on a TUN device and echos UDP and ICMP packets back to a sender.  TunEchoServer supports both IPv6 and IPv4.

Result:

The ability to create a range of new servers and applications that make use of Linux TUN/TAP devices.
