### PR TITLE
Allow to unwrap ByteBuffer > MAX_ENCRYPTED_PACKET_LENGTH

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -808,12 +808,6 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 return isOutboundDone() || isDestroyed() ? CLOSED_NOT_HANDSHAKING : NEED_WRAP_CLOSED;
             }
 
-            // protect against protocol overflow attack vector
-            if (len > MAX_ENCRYPTED_PACKET_LENGTH) {
-                shutdown();
-                throw ENCRYPTED_PACKET_OVERSIZED;
-            }
-
             SSLEngineResult.HandshakeStatus status = NOT_HANDSHAKING;
             // Prepare OpenSSL to work in server mode and receive handshake
             if (handshakeState != HandshakeState.FINISHED) {


### PR DESCRIPTION
Motivation:

We should remove the restriction to only allow to call unwrap with a ByteBuffer[] whose cumulative length exceeds MAX_ENCRYPTED_PACKET_LENGTH.

Modifications:

Remove guard.

Result:

Fixes [#6335].