### PR TITLE
Initialization of PlatformDependent0 fails on Java 9

### DIFF
--- a/common/src/main/java/io/netty/util/internal/ReflectionUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ReflectionUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+import java.lang.reflect.AccessibleObject;
+
+public final class ReflectionUtil {
+
+    private ReflectionUtil() { }
+
+    /**
+     * Try to call {@link AccessibleObject#setAccessible(boolean)} but will catch any {@link SecurityException} and
+     * {@link java.lang.reflect.InaccessibleObjectException} and return it.
+     * The caller must check if it returns {@code null} and if not handle the returned exception.
+     */
+    public static Throwable trySetAccessible(AccessibleObject object) {
+        try {
+            object.setAccessible(true);
+            return null;
+        } catch (SecurityException e) {
+            return e;
+        } catch (RuntimeException e) {
+            return handleInaccessibleObjectException(e);
+        }
+    }
+
+    private static RuntimeException handleInaccessibleObjectException(RuntimeException e) {
+        // JDK 9 can throw an inaccessible object exception here; since Netty compiles
+        // against JDK 7 and this exception was only added in JDK 9, we have to weakly
+        // check the type
+        if ("java.lang.reflect.InaccessibleObjectException".equals(e.getClass().getName())) {
+            return e;
+        }
+        throw e;
+    }
+}


### PR DESCRIPTION
Motivation:

Initialization of PlatformDependent0 fails on Java 9 in static initializer when calling setAccessible(true).

Modifications:

Add RefelectionUtil which can be used to safely try if setAccessible(true) can be used or not and if not fail back to non reflection.

Result:

Fixed [#6345]