### PR TITLE
Only try to calculate direct memory offset when sun.misc.Unsafe is pr…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -722,7 +722,10 @@ abstract class PoolArena<T> implements PoolArenaMetric {
         }
 
         private int offsetCacheLine(ByteBuffer memory) {
-            return (int) (PlatformDependent.directBufferAddress(memory) & directMemoryCacheAlignmentMask);
+            // We can only calculate the offset if Unsafe is present as otherwise directBufferAddress(...) will
+            // throw an NPE.
+            return HAS_UNSAFE ?
+                    (int) (PlatformDependent.directBufferAddress(memory) & directMemoryCacheAlignmentMask) : 0;
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -212,6 +212,9 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator {
             throw new IllegalArgumentException("directMemoryCacheAlignment: "
                     + directMemoryCacheAlignment + " (expected: >= 0)");
         }
+        if (directMemoryCacheAlignment > 0 && !isDirectMemoryCacheAlignmentSupported()) {
+            throw new IllegalArgumentException("directMemoryCacheAlignment is not supported");
+        }
 
         if ((directMemoryCacheAlignment & -directMemoryCacheAlignment) != directMemoryCacheAlignment) {
             throw new IllegalArgumentException("directMemoryCacheAlignment: "
@@ -368,6 +371,13 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator {
      */
     public static int defaultNormalCacheSize() {
         return DEFAULT_NORMAL_CACHE_SIZE;
+    }
+
+    /**
+     * Return {@code true} if direct memory cache aligment is supported, {@code false} otherwise.
+     */
+    public static boolean isDirectMemoryCacheAlignmentSupported() {
+        return PlatformDependent.hasUnsafe();
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -19,6 +19,7 @@ package io.netty.buffer;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.FastThreadLocalThread;
 import io.netty.util.internal.SystemPropertyUtil;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -59,6 +60,7 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest {
 
     @Test
     public void testArenaMetricsCacheAlign() {
+        Assume.assumeTrue(PooledByteBufAllocator.isDirectMemoryCacheAlignmentSupported());
         testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 11, 1000, 1000, 1000, true, 64), 100, 1, 1, 0);
     }
 


### PR DESCRIPTION
…esent

Motivation:

We should only try to calculate the direct memory offset when sun.misc.Unsafe is present as otherwise it will fail with an NPE as PlatformDependent.directBufferAddress(...) will throw it.
This problem was introduced by 66b9be3a469a2cdcc5d18a8b94c679940ce002a9.

Modifications:

Use offset of 0 if no sun.misc.Unsafe is present.

Result:

PooledByteBufAllocator also works again when no sun.misc.Unsafe is present.