### PR TITLE
Ensure tests pass when sun.misc.Unsafe is not present

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
@@ -15,6 +15,7 @@
  */
 package io.netty.buffer;
 
+import io.netty.util.internal.PlatformDependent;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -24,6 +25,11 @@ public abstract class AbstractByteBufAllocatorTest extends ByteBufAllocatorTest 
 
     @Override
     protected abstract AbstractByteBufAllocator newAllocator(boolean preferDirect);
+
+    @Override
+    protected boolean isDirectExpected(boolean preferDirect) {
+        return preferDirect && PlatformDependent.hasUnsafe();
+    }
 
     @Override
     protected final int defaultMaxCapacity() {

--- a/buffer/src/test/java/io/netty/buffer/ByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufAllocatorTest.java
@@ -37,7 +37,7 @@ public abstract class ByteBufAllocatorTest {
         ByteBufAllocator allocator = newAllocator(preferDirect);
         ByteBuf buffer = allocator.buffer(1);
         try {
-            assertBuffer(buffer, preferDirect, 1, defaultMaxCapacity());
+            assertBuffer(buffer, isDirectExpected(preferDirect), 1, defaultMaxCapacity());
         } finally {
             buffer.release();
         }
@@ -53,11 +53,13 @@ public abstract class ByteBufAllocatorTest {
         ByteBufAllocator allocator = newAllocator(preferDirect);
         ByteBuf buffer = allocator.buffer(1, maxCapacity);
         try {
-            assertBuffer(buffer, preferDirect, 1, maxCapacity);
+            assertBuffer(buffer, isDirectExpected(preferDirect), 1, maxCapacity);
         } finally {
             buffer.release();
         }
     }
+
+    protected abstract boolean isDirectExpected(boolean preferDirect);
 
     @Test
     public void testHeapBuffer() {


### PR DESCRIPTION
Motivation:

We need to ensure we pass all tests when sun.misc.Unsafe is not present.

Modifications:

- Make *ByteBufAllocatorTest work whenever sun.misc.Unsafe is present or not
- Let Lz4FrameEncoderTest not depend on AbstractByteBufAllocator implementation details which take into account if sun.misc.Unsafe is present or not

Result:

Tests pass even without sun.misc.Unsafe.