### PR TITLE
Cleanup code in ssl package.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/CipherSuiteConverter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/CipherSuiteConverter.java
@@ -194,7 +194,7 @@ final class CipherSuiteConverter {
         String handshakeAlgo = toOpenSslHandshakeAlgo(m.group(1));
         String bulkCipher = toOpenSslBulkCipher(m.group(2));
         String hmacAlgo = toOpenSslHmacAlgo(m.group(3));
-        if (handshakeAlgo.length() == 0) {
+        if (handshakeAlgo.isEmpty()) {
             return bulkCipher + '-' + hmacAlgo;
         } else {
             return handshakeAlgo + '-' + bulkCipher + '-' + hmacAlgo;
@@ -214,7 +214,7 @@ final class CipherSuiteConverter {
         }
 
         if (export) {
-            if (handshakeAlgo.length() == 0) {
+            if (handshakeAlgo.isEmpty()) {
                 handshakeAlgo = "EXP";
             } else {
                 handshakeAlgo = "EXP-" + handshakeAlgo;
@@ -341,7 +341,7 @@ final class CipherSuiteConverter {
     }
 
     private static String toJavaHandshakeAlgo(String handshakeAlgo, boolean export) {
-        if (handshakeAlgo.length() == 0) {
+        if (handshakeAlgo.isEmpty()) {
             handshakeAlgo = "RSA";
         } else if ("ADH".equals(handshakeAlgo)) {
             handshakeAlgo = "DH_anon";

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -125,14 +125,14 @@ public final class OpenSsl {
                     try {
                         for (String c: SSL.getCiphers(ssl)) {
                             // Filter out bad input.
-                            if (c == null || c.length() == 0 || availableOpenSslCipherSuites.contains(c)) {
+                            if (c == null || c.isEmpty() || availableOpenSslCipherSuites.contains(c)) {
                                 continue;
                             }
                             availableOpenSslCipherSuites.add(c);
                         }
                         try {
                             SelfSignedCertificate cert = new SelfSignedCertificate();
-                            certBio = OpenSslContext.toBIO(cert.cert());
+                            certBio = ReferenceCountedOpenSslContext.toBIO(cert.cert());
                             SSL.setCertificateChainBio(ssl, certBio, false);
                             supportsKeyManagerFactory = true;
                             useKeyManagerFactory = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
@@ -334,10 +334,6 @@ public final class OpenSsl {
 
     static boolean useKeyManagerFactory() {
         return USE_KEYMANAGER_FACTORY;
-    }
-
-    static boolean isError(long errorCode) {
-        return errorCode != SSL.SSL_ERROR_NONE;
     }
 
     static long memoryAddress(ByteBuf buf) {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -256,7 +256,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         }
 
         unmodifiableCiphers = Arrays.asList(checkNotNull(cipherFilter, "cipherFilter").filterCipherSuites(
-                convertedCiphers, DEFAULT_CIPHERS, OpenSsl.availableCipherSuites()));
+                convertedCiphers, DEFAULT_CIPHERS, OpenSsl.availableOpenSslCipherSuites()));
 
         this.apn = checkNotNull(apn, "apn");
 
@@ -453,9 +453,9 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
      * Set the size of the buffer used by the BIO for non-application based writes
      * (e.g. handshake, renegotiation, etc...).
      */
-    public void setBioNonApplicationBufferSize(int bioNonApplicationSize) {
+    public void setBioNonApplicationBufferSize(int bioNonApplicationBufferSize) {
         this.bioNonApplicationBufferSize =
-                checkPositiveOrZero(bioNonApplicationSize, "bioNonApplicationBufferSize");
+                checkPositiveOrZero(bioNonApplicationBufferSize, "bioNonApplicationBufferSize");
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -17,7 +17,6 @@ package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.Unpooled;
 import io.netty.tcnative.jni.Buffer;
 import io.netty.tcnative.jni.SSL;
 import io.netty.util.AbstractReferenceCounted;
@@ -175,9 +174,6 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             AtomicIntegerFieldUpdater.newUpdater(ReferenceCountedOpenSslEngine.class, "destroyed");
 
     private static final String INVALID_CIPHER = "SSL_NULL_WITH_NULL_NULL";
-
-    private static final long EMPTY_ADDR = Buffer.address(Unpooled.EMPTY_BUFFER.nioBuffer());
-
     private static final SSLEngineResult NEED_UNWRAP_OK = new SSLEngineResult(OK, NEED_UNWRAP, 0, 0);
     private static final SSLEngineResult NEED_UNWRAP_CLOSED = new SSLEngineResult(CLOSED, NEED_UNWRAP, 0, 0);
     private static final SSLEngineResult NEED_WRAP_OK = new SSLEngineResult(OK, NEED_WRAP, 0, 0);
@@ -573,9 +569,9 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                                     0, bytesProduced);
                         }
                         return newResult(NEED_WRAP, 0, bytesProduced);
-                    } else {
-                        status = handshake();
                     }
+
+                    status = handshake();
 
                     if (status == NEED_UNWRAP) {
                         // Signal if the outbound is done or not.
@@ -902,7 +898,8 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                                 if (!dst.hasRemaining()) {
                                     // Move to the next dst buffer as this one is full.
                                     continue;
-                                } else if (packetLength == 0) {
+                                }
+                                if (packetLength == 0) {
                                     // We read everything return now.
                                     return newResultMayFinishHandshake(isInboundDone() ? CLOSED : OK, status,
                                                                        bytesConsumed, bytesProduced);
@@ -1508,7 +1505,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
      */
     private static String toJavaCipherSuitePrefix(String protocolVersion) {
         final char c;
-        if (protocolVersion == null || protocolVersion.length() == 0) {
+        if (protocolVersion == null || protocolVersion.isEmpty()) {
             c = 0;
         } else {
             c = protocolVersion.charAt(0);
@@ -1567,13 +1564,13 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
             }
             switch (mode) {
                 case NONE:
-                    SSL.setVerify(ssl, SSL.SSL_CVERIFY_NONE, OpenSslContext.VERIFY_DEPTH);
+                    SSL.setVerify(ssl, SSL.SSL_CVERIFY_NONE, ReferenceCountedOpenSslContext.VERIFY_DEPTH);
                     break;
                 case REQUIRE:
-                    SSL.setVerify(ssl, SSL.SSL_CVERIFY_REQUIRE, OpenSslContext.VERIFY_DEPTH);
+                    SSL.setVerify(ssl, SSL.SSL_CVERIFY_REQUIRE, ReferenceCountedOpenSslContext.VERIFY_DEPTH);
                     break;
                 case OPTIONAL:
-                    SSL.setVerify(ssl, SSL.SSL_CVERIFY_OPTIONAL, OpenSslContext.VERIFY_DEPTH);
+                    SSL.setVerify(ssl, SSL.SSL_CVERIFY_OPTIONAL, ReferenceCountedOpenSslContext.VERIFY_DEPTH);
                     break;
                 default:
                     throw new Error(mode.toString());

--- a/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SniHandler.java
@@ -324,11 +324,11 @@ public class SniHandler extends ByteToMessageDecoder implements ChannelOutboundH
      * @see #select(ChannelHandlerContext, String)
      */
     private void onSslContext(ChannelHandlerContext ctx, String hostname, SslContext sslContext) {
-        this.selection = new Selection(sslContext, hostname);
+        selection = new Selection(sslContext, hostname);
         try {
             replaceHandler(ctx, hostname, sslContext);
         } catch (Throwable cause) {
-            this.selection = EMPTY_SELECTION;
+            selection = EMPTY_SELECTION;
             ctx.fireExceptionCaught(cause);
         }
     }

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -282,7 +282,7 @@ public abstract class SslContext {
      * @param keyFile a PKCS#8 private key file in PEM format
      * @param keyPassword the password of the {@code keyFile}.
      *                    {@code null} if it's not password-protected.
-     * @param trustManagerFactory the {@link TrustManagerFactory} that provides the {@link javax.net.ssl.TrustManager}s
+     * @param trustManagerFactory the {@link TrustManagerFactory} that provides the {@link TrustManager}s
      *                            that verifies the certificates sent from servers.
      *                            {@code null} to use the default.
      * @param ciphers the cipher suites to enable, in the order of preference.
@@ -777,7 +777,7 @@ public abstract class SslContext {
     }
 
     /**
-     * Creates a new instance (startTls set to <code>false</code>).
+     * Creates a new instance (startTls set to {@code false}).
      */
     protected SslContext() {
         this(false);
@@ -1096,12 +1096,5 @@ public abstract class SslContext {
         kmf.init(ks, keyPasswordChars);
 
         return kmf;
-    }
-
-    static KeyManagerFactory buildDefaultKeyManagerFactory()
-            throws NoSuchAlgorithmException, KeyStoreException, UnrecoverableKeyException {
-        KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        keyManagerFactory.init(null, null);
-        return keyManagerFactory;
     }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -34,6 +34,7 @@ import io.netty.channel.ChannelPromiseNotifier;
 import io.netty.channel.PendingWriteQueue;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.UnsupportedMessageTypeException;
+import io.netty.util.ReferenceCounted;
 import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
@@ -727,8 +728,8 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
     /**
      * This method will not call
-     * {@link #setHandshakeFailure(io.netty.channel.ChannelHandlerContext, Throwable, boolean)} or
-     * {@link #setHandshakeFailure(io.netty.channel.ChannelHandlerContext, Throwable)}.
+     * {@link #setHandshakeFailure(ChannelHandlerContext, Throwable, boolean)} or
+     * {@link #setHandshakeFailure(ChannelHandlerContext, Throwable)}.
      * @return {@code true} if this method ends on {@link SSLEngineResult.HandshakeStatus#NOT_HANDSHAKING}.
      */
     private boolean wrapNonAppData(ChannelHandlerContext ctx, boolean inUnwrap) throws SSLException {
@@ -995,7 +996,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
         boolean nonSslRecord = false;
 
-        while (totalLength < OpenSslEngine.MAX_ENCRYPTED_PACKET_LENGTH) {
+        while (totalLength < ReferenceCountedOpenSslEngine.MAX_ENCRYPTED_PACKET_LENGTH) {
             final int readableBytes = endOffset - offset;
             if (readableBytes < SslUtils.SSL_RECORD_HEADER_LENGTH) {
                 break;
@@ -1016,7 +1017,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             }
 
             int newTotalLength = totalLength + packetLength;
-            if (newTotalLength > OpenSslEngine.MAX_ENCRYPTED_PACKET_LENGTH) {
+            if (newTotalLength > ReferenceCountedOpenSslEngine.MAX_ENCRYPTED_PACKET_LENGTH) {
                 // Don't read too much.
                 break;
             }


### PR DESCRIPTION
Motivation:

There were some warnings for the code in the ssl package.

Modifications:

- Remove not needed else blocks
- Use correctly base class for static usage
- Replace String.length() == 0 with String.isEmpty()
- Remove unused code

Result:

Less warnings and cleaner code.