### PR TITLE
Not fail tests when running on JDK9+ and init of MarshallingFactory f…

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractCompatibleMarshallingDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractCompatibleMarshallingDecoderTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public abstract class AbstractCompatibleMarshallingDecoderTest {
+public abstract class AbstractCompatibleMarshallingDecoderTest extends AbstractMarshallingTest {
     @SuppressWarnings("RedundantStringConstructorCall")
     private final String testObject = new String("test");
 

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractCompatibleMarshallingEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractCompatibleMarshallingEncoderTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-public abstract class AbstractCompatibleMarshallingEncoderTest {
+public abstract class AbstractCompatibleMarshallingEncoderTest extends AbstractMarshallingTest {
 
     @Test
     public void testMarshalling() throws Exception {

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractMarshallingTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/AbstractMarshallingTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.marshalling;
+
+import io.netty.util.internal.PlatformDependent;
+import org.jboss.marshalling.Marshalling;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+
+public abstract class AbstractMarshallingTest {
+
+    protected static final String SERIAL_FACTORY = "serial";
+    protected static final String RIVER_FACTORY = "river";
+
+    @BeforeClass
+    public static void checkSupported() throws Throwable {
+        Throwable error = null;
+        try {
+            Marshalling.getProvidedMarshallerFactory(SERIAL_FACTORY);
+        } catch (Throwable cause) {
+            // This may fail on Java 9+ depending on which command-line arguments are used when building.
+            if (PlatformDependent.javaVersion() < 9) {
+                throw cause;
+            }
+            error = cause;
+        }
+        Assume.assumeNoException(error);
+    }
+}

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/RiverCompatibleMarshallingDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/RiverCompatibleMarshallingDecoderTest.java
@@ -23,7 +23,7 @@ public class RiverCompatibleMarshallingDecoderTest extends AbstractCompatibleMar
 
     @Override
     protected MarshallerFactory createMarshallerFactory() {
-        return Marshalling.getProvidedMarshallerFactory("river");
+        return Marshalling.getProvidedMarshallerFactory(RIVER_FACTORY);
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/RiverCompatibleMarshallingEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/RiverCompatibleMarshallingEncoderTest.java
@@ -23,7 +23,7 @@ public class RiverCompatibleMarshallingEncoderTest extends AbstractCompatibleMar
 
     @Override
     protected MarshallerFactory createMarshallerFactory() {
-        return Marshalling.getProvidedMarshallerFactory("river");
+        return Marshalling.getProvidedMarshallerFactory(RIVER_FACTORY);
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/SerialCompatibleMarshallingDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/SerialCompatibleMarshallingDecoderTest.java
@@ -23,7 +23,7 @@ public class SerialCompatibleMarshallingDecoderTest extends AbstractCompatibleMa
 
     @Override
     protected MarshallerFactory createMarshallerFactory() {
-        return Marshalling.getProvidedMarshallerFactory("serial");
+        return Marshalling.getProvidedMarshallerFactory(SERIAL_FACTORY);
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/marshalling/SerialCompatibleMarshallingEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/marshalling/SerialCompatibleMarshallingEncoderTest.java
@@ -23,7 +23,7 @@ public class SerialCompatibleMarshallingEncoderTest extends AbstractCompatibleMa
 
     @Override
     protected MarshallerFactory createMarshallerFactory() {
-        return Marshalling.getProvidedMarshallerFactory("serial");
+        return Marshalling.getProvidedMarshallerFactory(SERIAL_FACTORY);
     }
 
     @Override


### PR DESCRIPTION
…ails

Motivation:

To use jboss-marshalling extra command-line arguments are needed on JDK9+ as it makes use of reflection internally.

Modifications:

Skip jboss-marshalling tests when running on JDK9+ and init of MarshallingFactory fails.

Result:

Be able to build on latest JDK9 release.