### PR TITLE
Update tcnative package names

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -24,10 +24,10 @@ import io.netty.util.internal.NativeLibraryLoader;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import io.netty.tcnative.jni.Buffer;
-import io.netty.tcnative.jni.Library;
-import io.netty.tcnative.jni.SSL;
-import io.netty.tcnative.jni.SSLContext;
+import io.netty.internal.tcnative.Buffer;
+import io.netty.internal.tcnative.Library;
+import io.netty.internal.tcnative.SSL;
+import io.netty.internal.tcnative.SSLContext;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -68,7 +68,7 @@ public final class OpenSsl {
 
         // Test if netty-tcnative is in the classpath first.
         try {
-            Class.forName("io.netty.tcnative.jni.SSL", false, OpenSsl.class.getClassLoader());
+            Class.forName("io.netty.internal.tcnative.SSL", false, OpenSsl.class.getClassLoader());
         } catch (ClassNotFoundException t) {
             cause = t;
             logger.debug(

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateException.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateException.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.tcnative.jni.CertificateVerifier;
+import io.netty.internal.tcnative.CertificateVerifier;
 
 import java.security.cert.CertificateException;
 

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslClientContext.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.tcnative.jni.SSL;
+import io.netty.internal.tcnative.SSL;
 
 import java.io.File;
 import java.security.PrivateKey;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialManager.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslKeyMaterialManager.java
@@ -16,8 +16,8 @@
 package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.tcnative.jni.CertificateRequestedCallback;
-import io.netty.tcnative.jni.SSL;
+import io.netty.internal.tcnative.CertificateRequestedCallback;
+import io.netty.internal.tcnative.SSL;
 
 import javax.net.ssl.SSLException;
 import javax.net.ssl.X509KeyManager;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerContext.java
@@ -16,7 +16,7 @@
 package io.netty.handler.ssl;
 
 import io.netty.handler.ssl.ReferenceCountedOpenSslServerContext.ServerContext;
-import io.netty.tcnative.jni.SSL;
+import io.netty.internal.tcnative.SSL;
 
 import java.io.File;
 import java.security.PrivateKey;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslServerSessionContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslServerSessionContext.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.tcnative.jni.SSL;
-import io.netty.tcnative.jni.SSLContext;
+import io.netty.internal.tcnative.SSL;
+import io.netty.internal.tcnative.SSLContext;
 
 
 /**

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionContext.java
@@ -16,9 +16,9 @@
 package io.netty.handler.ssl;
 
 import io.netty.util.internal.ObjectUtil;
-import io.netty.tcnative.jni.SSL;
-import io.netty.tcnative.jni.SSLContext;
-import io.netty.tcnative.jni.SessionTicketKey;
+import io.netty.internal.tcnative.SSL;
+import io.netty.internal.tcnative.SSLContext;
+import io.netty.internal.tcnative.SessionTicketKey;
 
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionContext;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionStats.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionStats.java
@@ -16,7 +16,7 @@
 
 package io.netty.handler.ssl;
 
-import io.netty.tcnative.jni.SSLContext;
+import io.netty.internal.tcnative.SSLContext;
 
 /**
  * Stats exposed by an OpenSSL session context.

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionTicketKey.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslSessionTicketKey.java
@@ -15,7 +15,7 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.tcnative.jni.SessionTicketKey;
+import io.netty.internal.tcnative.SessionTicketKey;
 
 /**
  * Session Ticket Key

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslClientContext.java
@@ -17,9 +17,9 @@ package io.netty.handler.ssl;
 
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
-import io.netty.tcnative.jni.CertificateRequestedCallback;
-import io.netty.tcnative.jni.SSL;
-import io.netty.tcnative.jni.SSLContext;
+import io.netty.internal.tcnative.CertificateRequestedCallback;
+import io.netty.internal.tcnative.SSL;
+import io.netty.internal.tcnative.SSLContext;
 
 import java.security.KeyStore;
 import java.security.PrivateKey;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -17,9 +17,9 @@ package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.tcnative.jni.CertificateVerifier;
-import io.netty.tcnative.jni.SSL;
-import io.netty.tcnative.jni.SSLContext;
+import io.netty.internal.tcnative.CertificateVerifier;
+import io.netty.internal.tcnative.SSL;
+import io.netty.internal.tcnative.SSLContext;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.ResourceLeakDetector;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -17,8 +17,8 @@ package io.netty.handler.ssl;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.tcnative.jni.Buffer;
-import io.netty.tcnative.jni.SSL;
+import io.netty.internal.tcnative.Buffer;
+import io.netty.internal.tcnative.SSL;
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.ReferenceCounted;
 import io.netty.util.ResourceLeakDetector;

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
@@ -15,8 +15,8 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.tcnative.jni.SSL;
-import io.netty.tcnative.jni.SSLContext;
+import io.netty.internal.tcnative.SSL;
+import io.netty.internal.tcnative.SSLContext;
 
 import java.security.KeyStore;
 import java.security.PrivateKey;

--- a/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
@@ -19,7 +19,7 @@ import org.junit.BeforeClass;
 
 import javax.net.ssl.SSLException;
 
-import static io.netty.tcnative.jni.SSL.SSL_CVERIFY_IGNORED;
+import static io.netty.internal.tcnative.SSL.SSL_CVERIFY_IGNORED;
 import static org.junit.Assume.assumeTrue;
 
 public class JdkOpenSslEngineInteroptTest extends SSLEngineTest {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -33,7 +33,7 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLException;
 
-import static io.netty.tcnative.jni.SSL.SSL_CVERIFY_IGNORED;
+import static io.netty.internal.tcnative.SSL.SSL_CVERIFY_IGNORED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;

--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
-    <tcnative.version>2.0.0.Final-SNAPSHOT</tcnative.version>
+    <tcnative.version>2.0.0.Beta3</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <epoll.classifier>${os.detected.name}-${os.detected.arch}</epoll.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>


### PR DESCRIPTION
Motivation:

tcnative was moved into an internal package.

Modifications:

Update package for tcnative imports.

Result:

Use correct package names for tcnative.