### PR TITLE
CipherSuiteConverter NPE

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/CipherSuiteConverter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/CipherSuiteConverter.java
@@ -276,6 +276,11 @@ final class CipherSuiteConverter {
         Map<String, String> p2j = o2j.get(openSslCipherSuite);
         if (p2j == null) {
             p2j = cacheFromOpenSsl(openSslCipherSuite);
+            // This may happen if this method is queried when OpenSSL doesn't yet have a cipher setup. It will return
+            // "(NONE)" in this case.
+            if (p2j == null) {
+                return null;
+            }
         }
 
         String javaCipherSuite = p2j.get(protocol);

--- a/handler/src/test/java/io/netty/handler/ssl/CipherSuiteConverterTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/CipherSuiteConverterTest.java
@@ -20,8 +20,10 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 public class CipherSuiteConverterTest {
 
@@ -269,6 +271,34 @@ public class CipherSuiteConverterTest {
     @Test
     public void testCachedJ2OMappings() {
         testCachedJ2OMapping("TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256", "ECDHE-ECDSA-AES128-SHA256");
+    }
+
+    @Test
+    public void testUnknownOpenSSLCiphersToJava() {
+        testUnknownOpenSSLCiphersToJava("(NONE)");
+        testUnknownOpenSSLCiphersToJava("unknown");
+        testUnknownOpenSSLCiphersToJava("");
+    }
+
+    @Test
+    public void testUnknownJavaCiphersToOpenSSL() {
+        testUnknownJavaCiphersToOpenSSL("(NONE)");
+        testUnknownJavaCiphersToOpenSSL("unknown");
+        testUnknownJavaCiphersToOpenSSL("");
+    }
+
+    private void testUnknownOpenSSLCiphersToJava(String openSslCipherSuite) {
+        CipherSuiteConverter.clearCache();
+
+        assertNull(CipherSuiteConverter.toJava(openSslCipherSuite, "TLS"));
+        assertNull(CipherSuiteConverter.toJava(openSslCipherSuite, "SSL"));
+    }
+
+    private void testUnknownJavaCiphersToOpenSSL(String javaCipherSuite) {
+        CipherSuiteConverter.clearCache();
+
+        assertNull(CipherSuiteConverter.toOpenSsl(javaCipherSuite));
+        assertNull(CipherSuiteConverter.toOpenSsl(javaCipherSuite));
     }
 
     private static void testCachedJ2OMapping(String javaCipherSuite, String openSslCipherSuite) {


### PR DESCRIPTION
Motivation:
CipherSuiteConverter may throw a NPE if a cipher suite from OpenSSL does not match the precomputed regular expression for OpenSSL ciphers. This method shouldn't throw and instead just return null.

Modifications:
- if cacheFromOpenSsl(..) fails the conversion toJava should return null

Result:
Fixes https://github.com/netty/netty/issues/6336.