### PR TITLE
Resolver package is unstable

### DIFF
--- a/resolver/src/main/java/io/netty/resolver/AbstractAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/AbstractAddressResolver.java
@@ -20,6 +20,7 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.TypeParameterMatcher;
+import io.netty.util.internal.UnstableApi;
 
 import java.net.SocketAddress;
 import java.nio.channels.UnsupportedAddressTypeException;
@@ -31,6 +32,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 /**
  * A skeletal {@link AddressResolver} implementation.
  */
+@UnstableApi
 public abstract class AbstractAddressResolver<T extends SocketAddress> implements AddressResolver<T> {
 
     private final EventExecutor executor;

--- a/resolver/src/main/java/io/netty/resolver/AddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/AddressResolver.java
@@ -17,6 +17,7 @@ package io.netty.resolver;
 
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.UnstableApi;
 
 import java.io.Closeable;
 import java.net.SocketAddress;
@@ -26,6 +27,7 @@ import java.util.List;
 /**
  * Resolves a possibility unresolved {@link SocketAddress}.
  */
+@UnstableApi
 public interface AddressResolver<T extends SocketAddress> extends Closeable {
 
   /**

--- a/resolver/src/main/java/io/netty/resolver/AddressResolverGroup.java
+++ b/resolver/src/main/java/io/netty/resolver/AddressResolverGroup.java
@@ -19,6 +19,7 @@ package io.netty.resolver;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
+import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -31,6 +32,7 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * Creates and manages {@link NameResolver}s so that each {@link EventExecutor} has its own resolver instance.
  */
+@UnstableApi
 public abstract class AddressResolverGroup<T extends SocketAddress> implements Closeable {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(AddressResolverGroup.class);

--- a/resolver/src/main/java/io/netty/resolver/CompositeNameResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/CompositeNameResolver.java
@@ -19,6 +19,7 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.UnstableApi;
 
 import java.util.Arrays;
 import java.util.List;
@@ -30,6 +31,7 @@ import static io.netty.util.internal.ObjectUtil.*;
  *
  * In case of a failure, only the last one will be reported.
  */
+@UnstableApi
 public final class CompositeNameResolver<T> extends SimpleNameResolver<T> {
 
     private final NameResolver<T>[] resolvers;

--- a/resolver/src/main/java/io/netty/resolver/DefaultAddressResolverGroup.java
+++ b/resolver/src/main/java/io/netty/resolver/DefaultAddressResolverGroup.java
@@ -17,12 +17,14 @@
 package io.netty.resolver;
 
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.internal.UnstableApi;
 
 import java.net.InetSocketAddress;
 
 /**
  * A {@link AddressResolverGroup} of {@link DefaultNameResolver}s.
  */
+@UnstableApi
 public final class DefaultAddressResolverGroup extends AddressResolverGroup<InetSocketAddress> {
 
     public static final DefaultAddressResolverGroup INSTANCE = new DefaultAddressResolverGroup();

--- a/resolver/src/main/java/io/netty/resolver/DefaultNameResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/DefaultNameResolver.java
@@ -19,6 +19,7 @@ package io.netty.resolver;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.UnstableApi;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -29,6 +30,7 @@ import java.util.List;
  * A {@link InetNameResolver} that resolves using JDK's built-in domain name lookup mechanism.
  * Note that this resolver performs a blocking name lookup from the caller thread.
  */
+@UnstableApi
 public class DefaultNameResolver extends InetNameResolver {
 
     public DefaultNameResolver(EventExecutor executor) {

--- a/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/InetSocketAddressResolver.java
@@ -19,6 +19,7 @@ import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.UnstableApi;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -28,6 +29,7 @@ import java.util.List;
 /**
  * A {@link AbstractAddressResolver} that resolves {@link InetSocketAddress}.
  */
+@UnstableApi
 public class InetSocketAddressResolver extends AbstractAddressResolver<InetSocketAddress> {
 
     final NameResolver<InetAddress> nameResolver;

--- a/resolver/src/main/java/io/netty/resolver/NameResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/NameResolver.java
@@ -18,6 +18,7 @@ package io.netty.resolver;
 
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.UnstableApi;
 
 import java.io.Closeable;
 import java.util.List;
@@ -25,6 +26,7 @@ import java.util.List;
 /**
  * Resolves an arbitrary string that represents the name of an endpoint into an address.
  */
+@UnstableApi
 public interface NameResolver<T> extends Closeable {
 
     /**

--- a/resolver/src/main/java/io/netty/resolver/NoopAddressResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/NoopAddressResolver.java
@@ -18,6 +18,7 @@ package io.netty.resolver;
 
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.UnstableApi;
 
 import java.net.SocketAddress;
 import java.util.Collections;
@@ -27,6 +28,7 @@ import java.util.List;
  * A {@link AddressResolver} that does not perform any resolution but always reports successful resolution.
  * This resolver is useful when name resolution is performed by a handler in a pipeline, such as a proxy handler.
  */
+@UnstableApi
 public class NoopAddressResolver extends AbstractAddressResolver<SocketAddress> {
 
     public NoopAddressResolver(EventExecutor executor) {

--- a/resolver/src/main/java/io/netty/resolver/NoopAddressResolverGroup.java
+++ b/resolver/src/main/java/io/netty/resolver/NoopAddressResolverGroup.java
@@ -17,12 +17,14 @@
 package io.netty.resolver;
 
 import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.internal.UnstableApi;
 
 import java.net.SocketAddress;
 
 /**
  * A {@link AddressResolverGroup} of {@link NoopAddressResolver}s.
  */
+@UnstableApi
 public final class NoopAddressResolverGroup extends AddressResolverGroup<SocketAddress> {
 
     public static final NoopAddressResolverGroup INSTANCE = new NoopAddressResolverGroup();

--- a/resolver/src/main/java/io/netty/resolver/SimpleNameResolver.java
+++ b/resolver/src/main/java/io/netty/resolver/SimpleNameResolver.java
@@ -19,6 +19,7 @@ package io.netty.resolver;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.UnstableApi;
 
 import java.util.List;
 
@@ -27,6 +28,7 @@ import static io.netty.util.internal.ObjectUtil.*;
 /**
  * A skeletal {@link NameResolver} implementation.
  */
+@UnstableApi
 public abstract class SimpleNameResolver<T> implements NameResolver<T> {
 
     private final EventExecutor executor;

--- a/resolver/src/main/java/io/netty/resolver/package-info.java
+++ b/resolver/src/main/java/io/netty/resolver/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Resolves an arbitrary string that represents the name of an endpoint into an address.
  */
+@UnstableApi
 package io.netty.resolver;
+
+import io.netty.util.internal.UnstableApi;


### PR DESCRIPTION
Motivation:
The resolver package had some changes late in the 4.1.CR phase and the intention was to mark this package as unstable until these interfaces solidify, but we forgot to mark the package and public classes with the unstable annotation.

Modifications:
- resolver package public interfaces and package-info should be annotated with @UnstableApi

Result:
The unstable nature of the resolver package is more clearly communicated.