### PR TITLE
Adding 'final' keyword for private fields where possible

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufInputStream.java
@@ -50,7 +50,7 @@ public class ByteBufInputStream extends InputStream implements DataInput {
      * However in future releases ownership should always be transferred and callers of this class should call
      * {@link ReferenceCounted#retain()} if necessary.
      */
-    private boolean releaseOnClose;
+    private final boolean releaseOnClose;
 
     /**
      * Creates a new stream which reads data from the specified {@code buffer}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2GoAwayFrame.java
@@ -27,7 +27,7 @@ import io.netty.util.internal.UnstableApi;
 public final class DefaultHttp2GoAwayFrame extends DefaultByteBufHolder implements Http2GoAwayFrame {
 
     private final long errorCode;
-    private int lastStreamId;
+    private final int lastStreamId;
     private int extraStreamIds;
 
     /**

--- a/codec-redis/src/main/java/io/netty/handler/codec/redis/FixedRedisMessagePool.java
+++ b/codec-redis/src/main/java/io/netty/handler/codec/redis/FixedRedisMessagePool.java
@@ -71,13 +71,13 @@ public final class FixedRedisMessagePool implements RedisMessagePool {
     public static final FixedRedisMessagePool INSTANCE = new FixedRedisMessagePool();
 
     // internal caches.
-    private Map<ByteBuf, SimpleStringRedisMessage> byteBufToSimpleStrings;
-    private Map<String, SimpleStringRedisMessage> stringToSimpleStrings;
-    private Map<ByteBuf, ErrorRedisMessage> byteBufToErrors;
-    private Map<String, ErrorRedisMessage> stringToErrors;
-    private Map<ByteBuf, IntegerRedisMessage> byteBufToIntegers;
-    private LongObjectMap<IntegerRedisMessage> longToIntegers;
-    private LongObjectMap<byte[]> longToByteBufs;
+    private final Map<ByteBuf, SimpleStringRedisMessage> byteBufToSimpleStrings;
+    private final Map<String, SimpleStringRedisMessage> stringToSimpleStrings;
+    private final Map<ByteBuf, ErrorRedisMessage> byteBufToErrors;
+    private final Map<String, ErrorRedisMessage> stringToErrors;
+    private final Map<ByteBuf, IntegerRedisMessage> byteBufToIntegers;
+    private final LongObjectMap<IntegerRedisMessage> longToIntegers;
+    private final LongObjectMap<byte[]> longToByteBufs;
 
     /**
      * Creates a {@link FixedRedisMessagePool} instance.

--- a/common/src/main/java/io/netty/util/ConstantPool.java
+++ b/common/src/main/java/io/netty/util/ConstantPool.java
@@ -31,7 +31,7 @@ public abstract class ConstantPool<T extends Constant<T>> {
 
     private final ConcurrentMap<String, T> constants = PlatformDependent.newConcurrentHashMap();
 
-    private AtomicInteger nextId = new AtomicInteger(1);
+    private final AtomicInteger nextId = new AtomicInteger(1);
 
     /**
      * Shortcut of {@link #valueOf(String) valueOf(firstNameComponent.getName() + "#" + secondNameComponent)}.

--- a/example/src/main/java/io/netty/example/http2/helloworld/client/Http2SettingsHandler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/client/Http2SettingsHandler.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
  * Reads the first {@link Http2Settings} object and notifies a {@link io.netty.channel.ChannelPromise}
  */
 public class Http2SettingsHandler extends SimpleChannelInboundHandler<Http2Settings> {
-    private ChannelPromise promise;
+    private final ChannelPromise promise;
 
     /**
      * Create new instance

--- a/example/src/main/java/io/netty/example/http2/helloworld/client/HttpResponseHandler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/client/HttpResponseHandler.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class HttpResponseHandler extends SimpleChannelInboundHandler<FullHttpResponse> {
 
-    private Map<Integer, Entry<ChannelFuture, ChannelPromise>> streamidPromiseMap;
+    private final Map<Integer, Entry<ChannelFuture, ChannelPromise>> streamidPromiseMap;
 
     public HttpResponseHandler() {
         // Use a concurrent map because we add and iterate from the main thread (just for the purposes of the example),

--- a/transport/src/main/java/io/netty/channel/DefaultChannelId.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelId.java
@@ -154,7 +154,7 @@ public final class DefaultChannelId implements ChannelId {
     }
 
     private final byte[] data;
-    private int hashCode;
+    private final int hashCode;
 
     private transient String shortValue;
     private transient String longValue;


### PR DESCRIPTION
Motivation

Missing 'final' keyword for some private fields.

Modifications

Add 'final' for fields where possible.

Result

More safe and consistent code.