### PR TITLE
EPOLL include error description and cause in exceptions

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/unix/Errors.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/unix/Errors.java
@@ -61,7 +61,7 @@ public final class Errors {
         private static final long serialVersionUID = 8222160204268655526L;
         private final int expectedErr;
         public NativeIoException(String method, int expectedErr) {
-            super(method);
+            super(method + " failed: " + ERRORS[-expectedErr]);
             this.expectedErr = expectedErr;
         }
 
@@ -74,7 +74,7 @@ public final class Errors {
         private static final long serialVersionUID = -5532328671712318161L;
         private final int expectedErr;
         NativeConnectException(String method, int expectedErr) {
-            super(method);
+            super(method + " failed: " + ERRORS[-expectedErr]);
             this.expectedErr = expectedErr;
         }
 

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -1065,6 +1065,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
         AnnotatedConnectException(ConnectException exception, SocketAddress remoteAddress) {
             super(exception.getMessage() + ": " + remoteAddress);
+            initCause(exception);
             setStackTrace(exception.getStackTrace());
         }
 
@@ -1080,6 +1081,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
         AnnotatedNoRouteToHostException(NoRouteToHostException exception, SocketAddress remoteAddress) {
             super(exception.getMessage() + ": " + remoteAddress);
+            initCause(exception);
             setStackTrace(exception.getStackTrace());
         }
 
@@ -1095,6 +1097,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
 
         AnnotatedSocketException(SocketException exception, SocketAddress remoteAddress) {
             super(exception.getMessage() + ": " + remoteAddress);
+            initCause(exception);
             setStackTrace(exception.getStackTrace());
         }
 


### PR DESCRIPTION
Motivation:
EPOLL annotates some exceptions to provide the remote address, but the original exception is not preserved. This may make determining a root cause more difficult. The static EPOLL exceptions references the native method that failed, but does not provide a description of the actual error number. Without the description users have to know intimate details about the native calls and how they may fail to debug issues.

Modifications:
- annotated exceptions should preserve the original exception
- static exceptions should include the string description of the expected errno

Result:
EPOLL exceptions provide more context and are more useful to end users.