### PR TITLE
Correct expect header handling

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -156,14 +156,19 @@ public class HttpObjectAggregator
 
     @Override
     protected Object newContinueResponse(HttpMessage start, int maxContentLength, ChannelPipeline pipeline) {
-        if (HttpUtil.is100ContinueExpected(start)) {
+        if (HttpUtil.isUnsupportedExpectation(start)) {
+            // if the request contains an unsupported expectation, we return 417
+            pipeline.fireUserEventTriggered(HttpExpectationFailedEvent.INSTANCE);
+            return EXPECTATION_FAILED.retainedDuplicate();
+        } else if (HttpUtil.is100ContinueExpected(start)) {
+            // if the request contains 100-continue but the content-length is too large, we return 413
             if (getContentLength(start, -1L) <= maxContentLength) {
                 return CONTINUE.retainedDuplicate();
             }
-
             pipeline.fireUserEventTriggered(HttpExpectationFailedEvent.INSTANCE);
-            return EXPECTATION_FAILED.retainedDuplicate();
+            return TOO_LARGE.retainedDuplicate();
         }
+
         return null;
     }
 
@@ -174,8 +179,11 @@ public class HttpObjectAggregator
 
     @Override
     protected boolean ignoreContentAfterContinueResponse(Object msg) {
-        return msg instanceof HttpResponse &&
-               ((HttpResponse) msg).status().code() == HttpResponseStatus.EXPECTATION_FAILED.code();
+        if (msg instanceof HttpResponse) {
+            final HttpResponse httpResponse = (HttpResponse) msg;
+            return httpResponse.status().codeClass().equals(HttpStatusClass.CLIENT_ERROR);
+        }
+        return false;
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -251,31 +251,49 @@ public final class HttpUtil {
     }
 
     /**
-     * Returns {@code true} if and only if the specified message contains the
-     * {@code "Expect: 100-continue"} header.
+     * Returns {@code true} if and only if the specified message contains an expect header and the only expectation
+     * present is the 100-continue expectation. Note that this method returns {@code false} if the expect header is
+     * not valid for the message (e.g., the message is a response, or the version on the message is HTTP/1.0).
+     *
+     * @param message the message
+     * @return {@code true} if and only if the expectation 100-continue is present and it is the only expectation
+     * present
      */
     public static boolean is100ContinueExpected(HttpMessage message) {
-        // Expect: 100-continue is for requests only.
-        if (!(message instanceof HttpRequest)) {
+        if (!isExpectHeaderValid(message)) {
             return false;
         }
 
-        // It works only on HTTP/1.1 or later.
-        if (message.protocolVersion().compareTo(HttpVersion.HTTP_1_1) < 0) {
+        final String expectValue = message.headers().get(HttpHeaderNames.EXPECT);
+        // unquoted tokens in the expect header are case-insensitive, thus 100-continue is case insensitive
+        return HttpHeaderValues.CONTINUE.toString().equalsIgnoreCase(expectValue);
+    }
+
+    /**
+     * Returns {@code true} if the specified message contains an expect header specifying an expectation that is not
+     * supported. Note that this method returns {@code false} if the expect header is not valid for the message
+     * (e.g., the message is a response, or the version on the message is HTTP/1.0).
+     *
+     * @param message the message
+     * @return {@code true} if and only if an expectation is present that is not supported
+     */
+    static boolean isUnsupportedExpectation(HttpMessage message) {
+        if (!isExpectHeaderValid(message)) {
             return false;
         }
 
-        // In most cases, there will be one or zero 'Expect' header.
-        CharSequence value = message.headers().get(HttpHeaderNames.EXPECT);
-        if (value == null) {
-            return false;
-        }
-        if (HttpHeaderValues.CONTINUE.contentEqualsIgnoreCase(value)) {
-            return true;
-        }
+        final String expectValue = message.headers().get(HttpHeaderNames.EXPECT);
+        return expectValue != null && !HttpHeaderValues.CONTINUE.toString().equalsIgnoreCase(expectValue);
+    }
 
-        // Multiple 'Expect' headers.  Search through them.
-        return message.headers().contains(HttpHeaderNames.EXPECT, HttpHeaderValues.CONTINUE, true);
+    private static boolean isExpectHeaderValid(final HttpMessage message) {
+        /*
+         * Expect: 100-continue is for requests only and it works only on HTTP/1.1 or later. Note further that RFC 7231
+         * section 5.1.1 says "A server that receives a 100-continue expectation in an HTTP/1.0 request MUST ignore
+         * that expectation."
+         */
+        return message instanceof HttpRequest &&
+                message.protocolVersion().compareTo(HttpVersion.HTTP_1_1) >= 0;
     }
 
     /**


### PR DESCRIPTION
Motivation:

Today, the HTTP codec in Netty responds to HTTP/1.1 requests containing an "expect: 100-continue" header and a content-length that exceeds the max content length for the server with a 417 status (Expectation Failed). This is a violation of the HTTP specification. The purpose of this commit is to address this situation by modifying the HTTP codec to respond in this situation with a 413 status (Request Entity Too Large). Additionally, the HTTP codec ignores expectations in the expect header that are currently unsupported. This commit also addresses this situation by responding with a 417 status.

Handling the expect header is tricky business as the specification (RFC 2616) is more complicated than it needs to be. The specification defines the legitimate values for this header as "100-continue" and defines the notion of expectatation extensions. Further, the specification defines a 417 status (Expectation Failed) and this is where implementations go astray. The intent of the specification was for servers to respond with 417 status when they do not support the expectation in the expect header.

The key sentence from the specification follows:

> The server MUST respond with a 417 (Expectation Failed) status if any of the expectations cannot be met or, if there are other problems with the request, some other 4xx status.

That is, a server should respond with a 417 status if and only if there is an expectation that the server does not support (whether it be 100-continue, or another expectation extension), and should respond with another 4xx status code if the expectation is supported but there is something else wrong with the request.

Modifications:

This commit modifies the HTTP codec by changing the handling for the expect header in the HTTP object aggregator. In particular, the codec will now respond with 417 status if any expectation other than 100-continue is present in the expect header, the codec will respond with 413 status if the 100-continue expectation is present in the expect header and the content-length is larger than the max content length for the aggregator, and otherwise the codec will respond with 100 status.

Result:

The HTTP codec can now be used to correctly reply to clients that send a 100-continue expectation with a content-length that is too large for the server with a 413 status, and servers that use the HTTP codec will now no longer ignore expectations that are not supported (any value other than 100-continue).