### PR TITLE
Cleanup ChannelId handling of basic methods

### DIFF
--- a/common/src/main/java/io/netty/util/internal/MathUtil.java
+++ b/common/src/main/java/io/netty/util/internal/MathUtil.java
@@ -65,6 +65,20 @@ public final class MathUtil {
     }
 
     /**
+     * Compares two {@code int} values.
+     *
+     * @param  x the first {@code int} to compare
+     * @param  y the second {@code int} to compare
+     * @return the value {@code 0} if {@code x == y};
+     *         {@code -1} if {@code x < y}; and
+     *         {@code 1} if {@code x > y}
+     */
+    public static int compare(final int x, final int y) {
+        // do not subtract for comparison, it could overflow
+        return x < y ? -1 : (x > y ? 1 : 0);
+    }
+
+    /**
      * Compare two {@code long} values.
      * @param x the first {@code long} to compare.
      * @param y the second {@code long} to compare.

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannelId.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannelId.java
@@ -40,7 +40,7 @@ final class EmbeddedChannelId implements ChannelId {
     }
 
     @Override
-    public int compareTo(ChannelId o) {
+    public int compareTo(final ChannelId o) {
         if (o instanceof EmbeddedChannelId) {
             return 0;
         }

--- a/transport/src/test/java/io/netty/channel/embedded/CustomChannelId.java
+++ b/transport/src/test/java/io/netty/channel/embedded/CustomChannelId.java
@@ -16,22 +16,25 @@
 package io.netty.channel.embedded;
 
 import io.netty.channel.ChannelId;
+import io.netty.util.internal.MathUtil;
 
 public class CustomChannelId implements ChannelId {
+
     private static final long serialVersionUID = 1L;
 
     private int id;
 
-    public CustomChannelId(int id) {
+    CustomChannelId(int id) {
         this.id = id;
     }
 
     @Override
-    public int compareTo(ChannelId o) {
+    public int compareTo(final ChannelId o) {
         if (o instanceof CustomChannelId) {
-            return id - ((CustomChannelId) o).id;
+            return MathUtil.compare(id, ((CustomChannelId)o).id);
         }
-        return -1;
+
+        return asLongText().compareTo(o.asLongText());
     }
 
     @Override
@@ -41,10 +44,7 @@ public class CustomChannelId implements ChannelId {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof CustomChannelId) {
-            return id == ((CustomChannelId) obj).id;
-        }
-        return false;
+        return obj instanceof CustomChannelId && id == ((CustomChannelId) obj).id;
     }
 
     @Override


### PR DESCRIPTION
Motiviation:

Simplify implementation of compareTo/equals/hashCode for ChannelIds.

Modifications:

We simplfy the hashCode implementation for DefaultChannelId by not making it random, but making it based on the underlying data. We fix the compareTo implementation for DefaultChannelId by using lexicographic comparison of the underlying data array. We fix the compareTo implementation for CustomChannelId to avoid the possibility of overflow.

Result:

Cleaner code that is easier to maintain.

Closes #6371