### PR TITLE
Allow to compile and run tests with different java versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,7 @@
     <logging.logLevel>debug</logging.logLevel>
     <log4j2.version>2.6.2</log4j2.version>
     <asm.version>5.1</asm.version>
+    <testJavaHome>${env.JAVA_HOME}</testJavaHome>
   </properties>
 
   <modules>
@@ -818,6 +819,7 @@
               <value>io.netty.build.junit.TimedOutTestsListener</value>
             </property>
           </properties>
+          <jvm>${testJavaHome}/bin/java</jvm>
         </configuration>
       </plugin>
       <!-- always produce osgi bundles -->


### PR DESCRIPTION
Motivation:

As we now need to compile with java8 we should still allow to run the tests with a different java version to ensure everythin also works with java 7 and 6.

Modifications:

Allow to pass "-DtestJavaHome" to the build and so use a different java version during running the tests.

Result:

Be able to run tests with different java versions.