### PR TITLE
Fix ReferenceCountedOpenSslEngine.getEnabledProtocols() when using bo…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1145,22 +1145,28 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
                 return enabled.toArray(new String[1]);
             }
         }
-        if ((opts & SSL.SSL_OP_NO_TLSv1) == 0) {
+        if (isProtocolEnabled(opts, SSL.SSL_OP_NO_TLSv1, OpenSsl.PROTOCOL_TLS_V1)) {
             enabled.add(OpenSsl.PROTOCOL_TLS_V1);
         }
-        if ((opts & SSL.SSL_OP_NO_TLSv1_1) == 0) {
+        if (isProtocolEnabled(opts, SSL.SSL_OP_NO_TLSv1_1, OpenSsl.PROTOCOL_TLS_V1_1)) {
             enabled.add(OpenSsl.PROTOCOL_TLS_V1_1);
         }
-        if ((opts & SSL.SSL_OP_NO_TLSv1_2) == 0) {
+        if (isProtocolEnabled(opts, SSL.SSL_OP_NO_TLSv1_2, OpenSsl.PROTOCOL_TLS_V1_2)) {
             enabled.add(OpenSsl.PROTOCOL_TLS_V1_2);
         }
-        if ((opts & SSL.SSL_OP_NO_SSLv2) == 0) {
+        if (isProtocolEnabled(opts, SSL.SSL_OP_NO_SSLv2, OpenSsl.PROTOCOL_SSL_V2)) {
             enabled.add(OpenSsl.PROTOCOL_SSL_V2);
         }
-        if ((opts & SSL.SSL_OP_NO_SSLv3) == 0) {
+        if (isProtocolEnabled(opts, SSL.SSL_OP_NO_SSLv3, OpenSsl.PROTOCOL_SSL_V3)) {
             enabled.add(OpenSsl.PROTOCOL_SSL_V3);
         }
         return enabled.toArray(new String[enabled.size()]);
+    }
+
+    private static boolean isProtocolEnabled(int opts, int disableMask, String protocolString) {
+        // We also need to check if the actual protocolString is supported as depending on the openssl API
+        // implementations it may use a disableMask of 0 (BoringSSL is doing this for example).
+        return (opts & disableMask) == 0 && OpenSsl.SUPPORTED_PROTOCOLS_SET.contains(protocolString);
     }
 
     @Override

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1081,7 +1081,6 @@ public abstract class SSLEngineTest {
 
             // The only protocol that should be enabled is SSLv2Hello
             String[] enabledProtocols = sslEngine.getEnabledProtocols();
-            assertEquals(protocols1.length, enabledProtocols.length);
             assertArrayEquals(protocols1, enabledProtocols);
 
             // Enable a protocol that is currently disabled


### PR DESCRIPTION
…ringssl

Motivation:

Commit cd3bf3df58c3ab4462578284e7378571603a1721 made netty observe the latest version of netty-tcnative which changed the way how static fields are computed for various SSL.* values. This lead to have SSL_OP_NO_SSLv2 become 0 when using boringssl as boringssl not supports SSLv2 at all. In the logic of ReferenceCountedOpenSslEngine.getEnabledProtocols() we not expect to have a zero value and so our logic fails.

Modifications:

Check we actual support the protocol before return it as enabled.

Result:

SSLEngineTest.testEnablingAnAlreadyDisabledSslProtocol passes again with boringssl
