### PR TITLE
Skip SSLEngineTests that depend on KeyManagerFactory when this is not…

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
@@ -16,6 +16,7 @@
 package io.netty.handler.ssl;
 
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import javax.net.ssl.SSLException;
 
@@ -41,6 +42,41 @@ public class JdkOpenSslEngineInteroptTest extends SSLEngineTest {
     @Override
     protected SslProvider sslServerProvider() {
         return SslProvider.OPENSSL;
+    }
+
+    @Override
+    @Test
+    public void testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth() throws Exception {
+        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        super.testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth();
+    }
+
+    @Override
+    @Test
+    public void testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth() throws Exception {
+        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        super.testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth();
+    }
+
+    @Override
+    @Test
+    public void testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth() throws Exception {
+        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        super.testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth();
+    }
+
+    @Override
+    @Test
+    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth() throws Exception {
+        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        super.testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth();
+    }
+
+    @Override
+    @Test
+    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth() throws Exception {
+        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        super.testMutualAuthValidClientCertChainTooLongFailRequireClientAuth();
     }
 
     @Override

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -54,6 +54,41 @@ public class OpenSslEngineTest extends SSLEngineTest {
         assumeTrue(OpenSsl.isAvailable());
     }
 
+    @Override
+    @Test
+    public void testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth() throws Exception {
+        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        super.testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth();
+    }
+
+    @Override
+    @Test
+    public void testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth() throws Exception {
+        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        super.testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth();
+    }
+
+    @Override
+    @Test
+    public void testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth() throws Exception {
+        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        super.testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth();
+    }
+
+    @Override
+    @Test
+    public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth() throws Exception {
+        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        super.testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth();
+    }
+
+    @Override
+    @Test
+    public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth() throws Exception {
+        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        super.testMutualAuthValidClientCertChainTooLongFailRequireClientAuth();
+    }
+
     @Test
     public void testNpn() throws Exception {
         ApplicationProtocolConfig apn = acceptingNegotiator(Protocol.NPN,

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslJdkSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslJdkSslEngineInteroptTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.ssl;
 
 import org.junit.BeforeClass;
 import org.junit.Ignore;
+import org.junit.Test;
 
 import static org.junit.Assume.assumeTrue;
 
@@ -49,5 +50,26 @@ public class OpenSslJdkSslEngineInteroptTest extends SSLEngineTest {
     @Ignore /* Does the JDK support a "max certificate chain length"? */
     @Override
     public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth() throws Exception {
+    }
+
+    @Override
+    @Test
+    public void testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth() throws Exception {
+        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        super.testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth();
+    }
+
+    @Override
+    @Test
+    public void testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth() throws Exception {
+        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        super.testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth();
+    }
+
+    @Override
+    @Test
+    public void testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth() throws Exception {
+        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        super.testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth();
     }
 }


### PR DESCRIPTION
… supported by the openssl version.

Motivation:

Some version of openssl dont support the needed APIs to use a KeyManagerFactory. In this case we should skip the tests.

Modifications:

- Use assumeTrue(...) to skip tests that need a KeyManagerFactory and its not supported.

Result:

Tests pass on all openssl versions we support.