### PR TITLE
Ensure Unsafe buffer implementations are used when sun.misc.Unsafe is…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -296,11 +296,13 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator {
         PoolThreadCache cache = threadCache.get();
         PoolArena<byte[]> heapArena = cache.heapArena;
 
-        ByteBuf buf;
+        final ByteBuf buf;
         if (heapArena != null) {
             buf = heapArena.allocate(cache, initialCapacity, maxCapacity);
         } else {
-            buf = new UnpooledHeapByteBuf(this, initialCapacity, maxCapacity);
+            buf = PlatformDependent.hasUnsafe() ?
+                    new UnpooledUnsafeHeapByteBuf(this, initialCapacity, maxCapacity) :
+                    new UnpooledHeapByteBuf(this, initialCapacity, maxCapacity);
         }
 
         return toLeakAwareBuffer(buf);
@@ -311,15 +313,13 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator {
         PoolThreadCache cache = threadCache.get();
         PoolArena<ByteBuffer> directArena = cache.directArena;
 
-        ByteBuf buf;
+        final ByteBuf buf;
         if (directArena != null) {
             buf = directArena.allocate(cache, initialCapacity, maxCapacity);
         } else {
-            if (PlatformDependent.hasUnsafe()) {
-                buf = UnsafeByteBufUtil.newUnsafeDirectByteBuf(this, initialCapacity, maxCapacity);
-            } else {
-                buf = new UnpooledDirectByteBuf(this, initialCapacity, maxCapacity);
-            }
+            buf = PlatformDependent.hasUnsafe() ?
+                    UnsafeByteBufUtil.newUnsafeDirectByteBuf(this, initialCapacity, maxCapacity) :
+                    new UnpooledDirectByteBuf(this, initialCapacity, maxCapacity);
         }
 
         return toLeakAwareBuffer(buf);

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -18,6 +18,7 @@ package io.netty.buffer;
 
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.FastThreadLocalThread;
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SystemPropertyUtil;
 import org.junit.Assume;
 import org.junit.Test;
@@ -41,6 +42,25 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest {
     @Override
     protected AbstractByteBufAllocator newAllocator(boolean preferDirect) {
         return new PooledByteBufAllocator(preferDirect);
+    }
+
+    @Override
+    protected AbstractByteBufAllocator newUnpooledAllocator() {
+        return new PooledByteBufAllocator(0, 0, 8192, 1);
+    }
+
+    @Test
+    public void testPooledUnsafeHeapBufferAndUnsafeDirectBuffer() {
+        AbstractByteBufAllocator allocator = newAllocator(true);
+        ByteBuf directBuffer = allocator.directBuffer();
+        assertInstanceOf(directBuffer,
+                PlatformDependent.hasUnsafe() ? PooledUnsafeDirectByteBuf.class : PooledDirectByteBuf.class);
+        directBuffer.release();
+
+        ByteBuf heapBuffer = allocator.heapBuffer();
+        assertInstanceOf(heapBuffer,
+                PlatformDependent.hasUnsafe() ? PooledUnsafeHeapByteBuf.class : PooledHeapByteBuf.class);
+        heapBuffer.release();
     }
 
     @Test

--- a/buffer/src/test/java/io/netty/buffer/UnpooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnpooledByteBufAllocatorTest.java
@@ -21,4 +21,9 @@ public class UnpooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest {
     protected AbstractByteBufAllocator newAllocator(boolean preferDirect) {
         return new UnpooledByteBufAllocator(preferDirect);
     }
+
+    @Override
+    protected AbstractByteBufAllocator newUnpooledAllocator() {
+        return new UnpooledByteBufAllocator(false);
+    }
 }


### PR DESCRIPTION
… present

Motivation:

When sun.misc.Unsafe is present we want to use *Unsafe*ByteBuf implementations. We missed to do so in PooledByteBufAllocator when the heapArena is null.

Modifications:

- Correctly use UnpooledUnsafeHeapByteBuf
- Add unit tests

Result:

Use most optimal ByteBuf implementation.
