### PR TITLE
Enforce java8 for compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -596,9 +596,9 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <!-- Enforce JDK 1.7+ for compilation. -->
+                  <!-- Enforce JDK 1.8+ for compilation. -->
                   <!-- This is needed because of java.util.zip.Deflater and NIO UDP multicast. -->
-                  <version>[1.7.0,)</version>
+                  <version>[1.8.0,)</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
                   <version>[3.1.1,)</version>


### PR DESCRIPTION
Motivation:

Commit 591293bfb4f6a48a311d195303ce772fb801ec95 changed the build to need java8 but missed to adjust the enforce rule as well.

Modifications:

Enforce java8+

Result:

Quickly fail when user tries to compile with pre java8