### PR TITLE
Make netty build work on Java9

### DIFF
--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -26,6 +26,11 @@
   <artifactId>netty-handler-proxy</artifactId>
   <packaging>jar</packaging>
 
+  <properties>
+    <!-- Needed for SelfSignedCertificate -->
+    <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED</argLine.java9.extras>
+  </properties>
+
   <name>Netty/Handler/Proxy</name>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,10 @@
         <!-- https://issues.apache.org/jira/browse/MSHADE-242 -->
         <!-- https://github.com/netty/netty/issues/6100 -->
         <asm.version>6.0_ALPHA</asm.version>
+        <!-- Skip as maven plugin not works with Java9 yet --> 
+        <skipOsgiTestsuite>true</skipOsgiTestsuite>
+        <!-- Skip as jython not works with Java9 yet -->
+        <skipAutobahnTestsuite>true</skipAutobahnTestsuite>
       </properties>
       <activation>
         <jdk>9</jdk>
@@ -248,6 +252,8 @@
     <log4j2.version>2.6.2</log4j2.version>
     <asm.version>5.1</asm.version>
     <testJavaHome>${env.JAVA_HOME}</testJavaHome>
+    <skipOsgiTestsuite>false</skipOsgiTestsuite>
+    <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
   </properties>
 
   <modules>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <exam.version>4.9.1</exam.version>
-    <skipOsgiTestsuite>false</skipOsgiTestsuite>
+    <argLine.java9.extras>--add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED</argLine.java9.extras>
   </properties>
 
   <profiles>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -87,7 +87,6 @@
   </dependencies>
 
   <properties>
-    <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
     <!-- Needed for SSL tests as these use the SelfSignedCertificate --> 
     <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED</argLine.java9.extras>
   </properties>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -29,7 +29,7 @@
   <properties>
     <jni.compiler.args.ldflags>LDFLAGS=-Wl,--no-as-needed -lrt</jni.compiler.args.ldflags>
     <!-- Needed by the native transport as we need the memoryAddress of the ByteBuffer -->
-    <argLine.java9.extras>--add-opens=java.base/java.nio=ALL-UNNAMED</argLine.java9.extras>
+    <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED</argLine.java9.extras>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Motivation:

We missed some stuff in 5728e0eb2cf0d2fe267d25c9f85a0a061dc7ab5f and so the build failed on java9

Modifications:

- Add extra cmdline args when needed
- skip the autobahntestsuite as jython not works with java9
- skip the osgi testsuite as the maven plugin not works with java9

Result:

Build finally passed on java9