### PR TITLE
Use Unsafe to read ByteBuffer.address field to make it work on Java9 …

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/WrappedUnpooledUnsafeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/WrappedUnpooledUnsafeByteBufTest.java
@@ -27,7 +27,8 @@ public class WrappedUnpooledUnsafeByteBufTest extends BigEndianUnsafeDirectByteB
     @Before
     @Override
     public void init() {
-        Assume.assumeTrue("sun.misc.Unsafe not found, skip tests", PlatformDependent.hasUnsafe());
+        Assume.assumeTrue("PlatformDependent.useDirectBufferNoCleaner() returned false, skip tests",
+                PlatformDependent.useDirectBufferNoCleaner());
         super.init();
     }
 


### PR DESCRIPTION
…as well.

Motivation:

Java9 does not allow changing access level via reflection by default. This lead to the situation that netty disabled Unsafe completely as ByteBuffer.address could not be read.

Modification:

Use Unsafe to read the address field as this works on all Java versions.

Result:

Again be able to use Unsafe optimisations when using Netty with Java9