### PR TITLE
Log why it was not possible to use ByteBuffer.cleaner

### DIFF
--- a/common/src/main/java/io/netty/util/internal/Cleaner0.java
+++ b/common/src/main/java/io/netty/util/internal/Cleaner0.java
@@ -38,16 +38,15 @@ final class Cleaner0 {
 
     static {
         ByteBuffer direct = ByteBuffer.allocateDirect(1);
-        Field cleanerField;
         long fieldOffset = -1;
         Method clean = null;
         boolean cleanerIsRunnable = false;
+        Throwable error = null;
         if (PlatformDependent0.hasUnsafe()) {
             try {
-                cleanerField = direct.getClass().getDeclaredField("cleaner");
-                cleanerField.setAccessible(true);
+                Field cleanerField = direct.getClass().getDeclaredField("cleaner");
                 fieldOffset = PlatformDependent0.objectFieldOffset(cleanerField);
-                Object cleaner = cleanerField.get(direct);
+                Object cleaner = PlatformDependent0.getObject(direct, fieldOffset);
                 try {
                     // Cleaner implements Runnable from JDK9 onwards.
                     Runnable runnable = (Runnable) cleaner;
@@ -62,9 +61,14 @@ final class Cleaner0 {
                 fieldOffset = -1;
                 clean = null;
                 cleanerIsRunnable = false;
+                error = t;
             }
         }
-        logger.debug("java.nio.ByteBuffer.cleaner(): {}", fieldOffset != -1? "available" : "unavailable");
+        if (error == null) {
+            logger.debug("java.nio.ByteBuffer.cleaner(): {}", fieldOffset != -1? "available" : "unavailable");
+        } else {
+            logger.debug("java.nio.ByteBuffer.cleaner(): unavailable", error);
+        }
         CLEANER_FIELD_OFFSET = fieldOffset;
         CLEAN_METHOD = clean;
         CLEANER_IS_RUNNABLE = cleanerIsRunnable;


### PR DESCRIPTION
Motivation:

We should log why we can not use ByteBuffer.cleaner and so maybe allow the user to fix it.

Modifications:

- Use Unsafe to access the field
- Log the exception when we can not use ByteBuffer.cleaner

Result:

Easier to debug why using cleaner is not possible.