### PR TITLE
 remove redundant compare

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -835,10 +835,8 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     private static final long SCHEDULE_PURGE_INTERVAL = TimeUnit.SECONDS.toNanos(1);
 
     private void startThread() {
-        if (STATE_UPDATER.get(this) == ST_NOT_STARTED) {
-            if (STATE_UPDATER.compareAndSet(this, ST_NOT_STARTED, ST_STARTED)) {
-                doStartThread();
-            }
+        if (STATE_UPDATER.compareAndSet(this, ST_NOT_STARTED, ST_STARTED)) {
+            doStartThread();
         }
     }
 


### PR DESCRIPTION
Motivation:

STATE_UPDATER.get(this) == ST_NOT_STARTED is redundant, because it will compare again after.

Modification:

remove STATE_UPDATER.get(this) == ST_NOT_STARTED compare

Result:

remove redundant compare
