### PR TITLE
Update to autobahntestsuite-maven-plugin 0.1.4 to support Java9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,6 @@
         <asm.version>6.0_ALPHA</asm.version>
         <!-- Skip as maven plugin not works with Java9 yet --> 
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
-        <!-- Skip as jython not works with Java9 yet -->
-        <skipAutobahnTestsuite>true</skipAutobahnTestsuite>
       </properties>
       <activation>
         <jdk>9</jdk>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -117,7 +117,7 @@
       <plugin>
         <groupId>me.normanmaurer.maven.autobahntestsuite</groupId>
         <artifactId>autobahntestsuite-maven-plugin</artifactId>
-        <version>0.1.3</version>
+        <version>0.1.4</version>
         <configuration>
           <mainClass>io.netty.testsuite.websockets.autobahn.AutobahnServer</mainClass>
           <cases>


### PR DESCRIPTION
Motivation:

autobahntestsuite-maven-plugin 0.1.4 was released and supports Java9.

Modifications:

Update plugin to be able to run tests on Java9

Result:

Autobahntestsuite can also be run on Java9.