### PR TITLE
Missing release modules in netty-all project

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -244,6 +244,13 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-redis</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-smtp</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>
@@ -259,6 +266,13 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>netty-codec-stomp</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-xml</artifactId>
       <version>${project.version}</version>
       <scope>compile</scope>
       <optional>true</optional>


### PR DESCRIPTION
Motivation:

codec-redis and codec-xml are release modules and should be included in netty-all.

Modifications:

Add codec-redis and codec-xml modules to netty-all pom.

Result:

codec-redis and codec-xml can be used with the netty-all artifact.