### PR TITLE
Move AutobahnTestsuite to extra module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,7 @@
     <module>handler-proxy</module>
     <module>example</module>
     <module>testsuite</module>
+    <module>testsuite-autobahn</module>
     <module>testsuite-osgi</module>
     <module>microbench</module>
     <module>all</module>

--- a/testsuite-autobahn/pom.xml
+++ b/testsuite-autobahn/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-parent</artifactId>
+    <version>4.1.9.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>netty-testsuite-autobahn</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Netty/Testsuite/Autobahn</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-codec-http</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>skipTests</id>
+      <activation>
+        <property>
+          <name>skipTests</name>
+        </property>
+      </activation>
+      <properties>
+        <skipAutobahnTestsuite>true</skipAutobahnTestsuite>
+      </properties>
+    </profile>
+  </profiles>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>me.normanmaurer.maven.autobahntestsuite</groupId>
+        <artifactId>autobahntestsuite-maven-plugin</artifactId>
+        <version>0.1.4</version>
+        <configuration>
+          <mainClass>io.netty.testsuite.autobahn.AutobahnServer</mainClass>
+          <cases>
+            <case>*</case>
+          </cases>
+          <excludeCases />
+          <failOnNonStrict>false</failOnNonStrict>
+          <skip>${skipAutobahnTestsuite}</skip>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>fuzzingclient</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServer.java
+++ b/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServer.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.testsuite.websockets.autobahn;
+package io.netty.testsuite.autobahn;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;

--- a/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServerHandler.java
+++ b/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServerHandler.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.testsuite.websockets.autobahn;
+package io.netty.testsuite.autobahn;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;

--- a/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServerInitializer.java
+++ b/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/AutobahnServerInitializer.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.testsuite.websockets.autobahn;
+package io.netty.testsuite.autobahn;
 
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;

--- a/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/package-info.java
+++ b/testsuite-autobahn/src/main/java/io/netty/testsuite/autobahn/package-info.java
@@ -60,5 +60,5 @@
  *
  * <p>10. See the results in <tt>./reports/servers/index.html</tt>
  */
-package io.netty.testsuite.websockets.autobahn;
+package io.netty.testsuite.autobahn;
 

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -91,20 +91,6 @@
     <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED</argLine.java9.extras>
   </properties>
 
-  <profiles>
-    <profile>
-      <id>skipTests</id>
-      <activation>
-        <property>
-          <name>skipTests</name>
-        </property>
-      </activation>
-      <properties>
-        <skipAutobahnTestsuite>true</skipAutobahnTestsuite>
-      </properties>
-    </profile>
-  </profiles>
-
   <build>
     <plugins>
       <plugin>
@@ -113,28 +99,6 @@
           <testSourceDirectory>${project.build.sourceDirectory}</testSourceDirectory>
           <testClassesDirectory>${project.build.outputDirectory}</testClassesDirectory>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>me.normanmaurer.maven.autobahntestsuite</groupId>
-        <artifactId>autobahntestsuite-maven-plugin</artifactId>
-        <version>0.1.4</version>
-        <configuration>
-          <mainClass>io.netty.testsuite.websockets.autobahn.AutobahnServer</mainClass>
-          <cases>
-            <case>*</case>
-          </cases>
-          <excludeCases />
-          <failOnNonStrict>false</failOnNonStrict>
-          <skip>${skipAutobahnTestsuite}</skip>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>test</phase>
-            <goals>
-              <goal>fuzzingclient</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Motivation:
We should move the AutobahnTestsuite to an extra module. This allows easier to run only the testsuite or only the autobahntestsuite

Modifications:

Create a new module (testsuite-autobahn)

Result:

Better project structure.