### PR TITLE
SSLEngineTest issue introduced by d8e6fbb9c3656663f41797a15f38bb25fdc…

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
@@ -88,6 +88,6 @@ public class JdkOpenSslEngineInteroptTest extends SSLEngineTest {
     @Override
     protected boolean mySetupMutualAuthServerIsValidClientException(Throwable cause) {
         // TODO(scott): work around for a JDK issue. The exception should be SSLHandshakeException.
-        return super.mySetupMutualAuthServerIsValidClientException(cause) || cause instanceof SSLException;
+        return super.mySetupMutualAuthServerIsValidClientException(cause) || causedBySSLException(cause);
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslJdkSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslJdkSslEngineInteroptTest.java
@@ -92,6 +92,6 @@ public class OpenSslJdkSslEngineInteroptTest extends SSLEngineTest {
     @Override
     protected boolean mySetupMutualAuthServerIsValidServerException(Throwable cause) {
         // TODO(scott): work around for a JDK issue. The exception should be SSLHandshakeException.
-        return super.mySetupMutualAuthServerIsValidServerException(cause) || cause instanceof SSLException;
+        return super.mySetupMutualAuthServerIsValidServerException(cause) || causedBySSLException(cause);
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -593,6 +593,17 @@ public abstract class SSLEngineTest {
                 mySetupMutualAuthServerIsValidServerException(serverException));
     }
 
+    protected static boolean causedBySSLException(Throwable cause) {
+        Throwable next = cause;
+        while (next != null) {
+            if (next instanceof SSLException) {
+                return true;
+            }
+            next = next.getCause();
+        }
+        return false;
+    }
+
     protected boolean mySetupMutualAuthServerIsValidServerException(Throwable cause) {
         return mySetupMutualAuthServerIsValidException(cause);
     }


### PR DESCRIPTION
…ab834

Motivation:
d8e6fbb9c3656663f41797a15f38bb25fdcab834 attempted to account for the JDK not throwing the expected SSLHandshakeException by allowing a SSLException to also pass the test. However in some situations the SSLException will not be the top level exception and the Throwable must be unwrapped to see if the root cause is an SSLException.

Modifications:
- Unwrap exceptions thrown by the JDK's SSLEngine to check for SSLException.

Result:
SSLEngineTest (and derived classes) are more reliable.