### PR TITLE
HTTP/2 Unit Test LocalChannel Leaks

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DataCompressionHttp2Test.java
@@ -81,6 +81,7 @@ public class DataCompressionHttp2Test {
     private Bootstrap cb;
     private Channel serverChannel;
     private Channel clientChannel;
+    private volatile Channel serverConnectedChannel;
     private CountDownLatch serverLatch;
     private Http2Connection serverConnection;
     private Http2Connection clientConnection;
@@ -126,6 +127,11 @@ public class DataCompressionHttp2Test {
         if (serverChannel != null) {
             serverChannel.close().sync();
             serverChannel = null;
+        }
+        final Channel serverConnectedChannel = this.serverConnectedChannel;
+        if (serverConnectedChannel != null) {
+            serverConnectedChannel.close().sync();
+            this.serverConnectedChannel = null;
         }
         Future<?> serverGroup = sb.config().group().shutdownGracefully(0, 0, MILLISECONDS);
         Future<?> serverChildGroup = sb.config().childGroup().shutdownGracefully(0, 0, MILLISECONDS);
@@ -297,6 +303,7 @@ public class DataCompressionHttp2Test {
         sb.childHandler(new ChannelInitializer<Channel>() {
             @Override
             protected void initChannel(Channel ch) throws Exception {
+                serverConnectedChannel = ch;
                 ChannelPipeline p = ch.pipeline();
                 Http2FrameWriter frameWriter = new DefaultHttp2FrameWriter();
                 serverConnection.remote().flowController(

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2CodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2CodecTest.java
@@ -93,11 +93,18 @@ public class Http2CodecTest {
 
     @After
     public void tearDown() throws Exception {
-        clientChannel.close().sync();
-        serverChannel.close().sync();
+        if (clientChannel != null) {
+            clientChannel.close().sync();
+            clientChannel = null;
+        }
+        if (serverChannel != null) {
+            serverChannel.close().sync();
+            serverChannel = null;
+        }
+        final Channel serverConnectedChannel = this.serverConnectedChannel;
         if (serverConnectedChannel != null) {
             serverConnectedChannel.close().sync();
-            serverConnectedChannel = null;
+            this.serverConnectedChannel = null;
         }
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionRoundtripTest.java
@@ -118,9 +118,10 @@ public class Http2ConnectionRoundtripTest {
             serverChannel.close().sync();
             serverChannel = null;
         }
+        final Channel serverConnectedChannel = this.serverConnectedChannel;
         if (serverConnectedChannel != null) {
             serverConnectedChannel.close().sync();
-            serverConnectedChannel = null;
+            this.serverConnectedChannel = null;
         }
         Future<?> serverGroup = sb.config().group().shutdownGracefully(0, 0, MILLISECONDS);
         Future<?> serverChildGroup = sb.config().childGroup().shutdownGracefully(0, 0, MILLISECONDS);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpToHttp2ConnectionHandlerTest.java
@@ -113,9 +113,10 @@ public class HttpToHttp2ConnectionHandlerTest {
             serverChannel.close().sync();
             serverChannel = null;
         }
+        final Channel serverConnectedChannel = this.serverConnectedChannel;
         if (serverConnectedChannel != null) {
             serverConnectedChannel.close().sync();
-            serverConnectedChannel = null;
+            this.serverConnectedChannel = null;
         }
         Future<?> serverGroup = sb.config().group().shutdownGracefully(0, 0, MILLISECONDS);
         Future<?> serverChildGroup = sb.config().childGroup().shutdownGracefully(0, 0, MILLISECONDS);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -119,9 +119,10 @@ public class InboundHttp2ToHttpAdapterTest {
             serverChannel.close().sync();
             serverChannel = null;
         }
+        final Channel serverConnectedChannel = this.serverConnectedChannel;
         if (serverConnectedChannel != null) {
             serverConnectedChannel.close().sync();
-            serverConnectedChannel = null;
+            this.serverConnectedChannel = null;
         }
         Future<?> serverGroup = sb.config().group().shutdownGracefully(0, 0, MILLISECONDS);
         Future<?> serverChildGroup = sb.config().childGroup().shutdownGracefully(0, 0, MILLISECONDS);


### PR DESCRIPTION
Motivation:
Some unit HTTP/2 unit tests use LocalChannel. LocalChannel's doClose method will ensure any pending items in the queue will be released, but it may execute a Runnable on the peer's EventLoop to ensure the peer's queue is also cleaned up. The HTTP/2 unit tests close the event loop groups with no wait time so that unit tests will execute quickly, but if the doClose Runnable is in the EventLoop's queue it will not run and thus the items in the queue will not be released.

Modifications:
- Ensure all HTTP/2 unit tests which use LocalChannel wait for both client and server channels to be closed before closing the EventLoop.

Result:
Related to https://github.com/netty/netty/issues/5850.