### PR TITLE
Update to netty-tcnative 2.0.0.Beta6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
-    <tcnative.version>2.0.0.Beta5</tcnative.version>
+    <tcnative.version>2.0.0.Beta6</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <epoll.classifier>${os.detected.name}-${os.detected.arch}</epoll.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>


### PR DESCRIPTION
Motivation:

New version of netty-tcnative was released.

Modifications:

Bump up version number

Result:

Using latest netty-tcnative