### PR TITLE
DatagramPacketEncoder|Decoder should take into account if wrapped han…

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/DatagramPacketDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/DatagramPacketDecoder.java
@@ -108,4 +108,9 @@ public class DatagramPacketDecoder extends MessageToMessageDecoder<DatagramPacke
     public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
         decoder.handlerRemoved(ctx);
     }
+
+    @Override
+    public boolean isSharable() {
+        return decoder.isSharable();
+    }
 }

--- a/codec/src/main/java/io/netty/handler/codec/DatagramPacketEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/DatagramPacketEncoder.java
@@ -140,4 +140,9 @@ public class DatagramPacketEncoder<M> extends MessageToMessageEncoder<AddressedE
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
         encoder.exceptionCaught(ctx, cause);
     }
+
+    @Override
+    public boolean isSharable() {
+        return encoder.isSharable();
+    }
 }

--- a/codec/src/test/java/io/netty/handler/codec/DatagramPacketDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DatagramPacketDecoderTest.java
@@ -17,6 +17,7 @@ package io.netty.handler.codec;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.string.StringDecoder;
@@ -27,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -55,5 +57,40 @@ public class DatagramPacketDecoderTest {
         ByteBuf content = Unpooled.wrappedBuffer("netty".getBytes(CharsetUtil.UTF_8));
         assertTrue(channel.writeInbound(new DatagramPacket(content, recipient, sender)));
         assertEquals("netty", channel.readInbound());
+    }
+
+    @Test
+    public void testIsNotSharable() {
+        testIsSharable(false);
+    }
+
+    @Test
+    public void testIsSharable() {
+        testIsSharable(true);
+    }
+
+    private static void testIsSharable(boolean sharable) {
+        MessageToMessageDecoder<ByteBuf> wrapped = new TestMessageToMessageDecoder(sharable);
+        DatagramPacketDecoder decoder = new DatagramPacketDecoder(wrapped);
+        assertEquals(wrapped.isSharable(), decoder.isSharable());
+    }
+
+    private static final class TestMessageToMessageDecoder extends MessageToMessageDecoder<ByteBuf> {
+
+        private final boolean sharable;
+
+        TestMessageToMessageDecoder(boolean sharable) {
+            this.sharable = sharable;
+        }
+
+        @Override
+        protected void decode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) throws Exception {
+            // NOOP
+        }
+
+        @Override
+        public boolean isSharable() {
+            return sharable;
+        }
     }
 }


### PR DESCRIPTION
…dler is sharable

Motivation:

DatagramPacketEncoder|Decoder should respect if the wrapped handler is sharable or not and depending on that be sharable or not.

Modifications:

- Delegate isSharable() to wrapped handler
- Add test-cases