### PR TITLE
Accept two ways to start HTTP/2 over clear text

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/ClearTextHttp2ServerDispatcher.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/ClearTextHttp2ServerDispatcher.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.internal.UnstableApi;
+
+import static io.netty.buffer.Unpooled.*;
+import static io.netty.util.CharsetUtil.UTF_8;
+
+/**
+ * Provide how starting http2 protocol by h2c (Upgrade) or h2 (Prior Knowledge) by peaking the
+ * first bytes is prior knowledge or not, see {@link #PRI_KNOWLEDGE_FIRST_BYTES}
+ * The dispatcher should be the first {@link ChannelInboundHandler} in the
+ * {@link io.netty.channel.ChannelPipeline}
+ * The msg from {@link #channelRead(ChannelHandlerContext, Object)} must be {@link ByteBuf}
+ */
+@UnstableApi
+public abstract class ClearTextHttp2ServerDispatcher extends ChannelInboundHandlerAdapter {
+    private static final String PRI_KNOWLEDGE_MAGIC = "PRI";
+    private static final int PRI_KNOWLEDGE_PEAK_LENGTH = PRI_KNOWLEDGE_MAGIC.length();
+    private static final ByteBuf PRI_KNOWLEDGE_FIRST_BYTES = unreleasableBuffer(
+            directBuffer(PRI_KNOWLEDGE_PEAK_LENGTH).writeBytes(PRI_KNOWLEDGE_MAGIC.getBytes(UTF_8)));
+
+    /**
+     * Peak the first n bytes of msg, and verify that if it matches to {@link #PRI_KNOWLEDGE_FIRST_BYTES}
+     * then assume client want to start HTTP/2 connection with prior knowledge,
+     * call {@link #configurePriorKnowledge(ChannelHandlerContext)} to configure pipeline
+     * for handling HTTP/2 connection. If it didn't match, then call
+     * {@link #configureUpgrade(ChannelHandlerContext)} for HTTP/2 upgrade
+     *
+     * @param ctx {@link ChannelHandlerContext} of this handler
+     * @param msg the message from inbound
+     * @throws IllegalStateException
+     *     if {@code !(msg instanceof io.netty.ByteBuf}
+     *     or if {@code msg.readableBytes() < PRI_KNOWLEDGE_PEAK_LENGTH}
+     */
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (!(msg instanceof ByteBuf)) {
+            throw new IllegalStateException("Only can handle ByteBuf");
+        }
+
+        ByteBuf inbound = (ByteBuf) msg;
+        if (inbound.readableBytes() < PRI_KNOWLEDGE_PEAK_LENGTH) {
+            throw new IllegalStateException(
+                    String.format("must have first %d bytes to determine the protocol",
+                                  PRI_KNOWLEDGE_PEAK_LENGTH));
+        }
+
+        if (ByteBufUtil.equals(PRI_KNOWLEDGE_FIRST_BYTES, 0,
+                               inbound, 0, PRI_KNOWLEDGE_PEAK_LENGTH)) {
+            configurePriorKnowledge(ctx);
+        } else {
+            configureUpgrade(ctx);
+        }
+
+        ctx.fireChannelRead(msg);
+
+        // If the ctx removed before {@code ctx.fireChannelRead(msg)}, then the
+        // message will disappear because {@code ctx.next} would be the tail of
+        // pipeline.
+        ctx.pipeline().remove(this);
+    }
+
+    public abstract void configureUpgrade(ChannelHandlerContext ctx);
+
+    public abstract void configurePriorKnowledge(ChannelHandlerContext ctx);
+}

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/ClearTextHttp2ServerDispatcher.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/ClearTextHttp2ServerDispatcher.java
@@ -19,11 +19,13 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
-import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.util.AsciiString;
 import io.netty.util.internal.UnstableApi;
 
+import java.util.List;
+
 import static io.netty.buffer.Unpooled.*;
-import static io.netty.util.CharsetUtil.UTF_8;
 
 /**
  * Provide how starting http2 protocol by h2c (Upgrade) or h2 (Prior Knowledge) by peaking the
@@ -33,54 +35,49 @@ import static io.netty.util.CharsetUtil.UTF_8;
  * The msg from {@link #channelRead(ChannelHandlerContext, Object)} must be {@link ByteBuf}
  */
 @UnstableApi
-public abstract class ClearTextHttp2ServerDispatcher extends ChannelInboundHandlerAdapter {
-    private static final String PRI_KNOWLEDGE_MAGIC = "PRI";
+public abstract class ClearTextHttp2ServerDispatcher extends ByteToMessageDecoder {
+    private static final AsciiString PRI_KNOWLEDGE_MAGIC = AsciiString.of("PRI");
     private static final int PRI_KNOWLEDGE_PEAK_LENGTH = PRI_KNOWLEDGE_MAGIC.length();
     private static final ByteBuf PRI_KNOWLEDGE_FIRST_BYTES = unreleasableBuffer(
-            directBuffer(PRI_KNOWLEDGE_PEAK_LENGTH).writeBytes(PRI_KNOWLEDGE_MAGIC.getBytes(UTF_8)));
+            directBuffer(PRI_KNOWLEDGE_PEAK_LENGTH).writeBytes(PRI_KNOWLEDGE_MAGIC.array()));
+
+    private boolean pipelineConfigured;
 
     /**
-     * Peak the first n bytes of msg, and verify that if it matches to {@link #PRI_KNOWLEDGE_FIRST_BYTES}
-     * then assume client want to start HTTP/2 connection with prior knowledge,
-     * call {@link #configurePriorKnowledge(ChannelHandlerContext)} to configure pipeline
-     * for handling HTTP/2 connection. If it didn't match, then call
-     * {@link #configureUpgrade(ChannelHandlerContext)} for HTTP/2 upgrade
+     * Peak the first {@link #PRI_KNOWLEDGE_PEAK_LENGTH} bytes of msg, and verify that
+     * if it matches to {@link #PRI_KNOWLEDGE_FIRST_BYTES} then assume client want to
+     * start HTTP/2 connection with prior knowledge, call {@link #configurePriorKnowledge(ChannelHandlerContext)}
+     * to configure pipeline for handling HTTP/2 connection. If it didn't match, then
+     * call {@link #configureUpgrade(ChannelHandlerContext)} for HTTP/2 upgrade
      *
-     * @param ctx {@link ChannelHandlerContext} of this handler
-     * @param msg the message from inbound
      * @throws IllegalStateException
      *     if {@code !(msg instanceof io.netty.ByteBuf}
      *     or if {@code msg.readableBytes() < PRI_KNOWLEDGE_PEAK_LENGTH}
      */
     @Override
-    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        if (!(msg instanceof ByteBuf)) {
-            throw new IllegalStateException("Only can handle ByteBuf");
+    public void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+        if (pipelineConfigured) {
+            // After pipeline configured, just forward data to next inbound handler
+            out.add(in.readBytes(in.readableBytes()));
+            return;
         }
 
-        ByteBuf inbound = (ByteBuf) msg;
-        if (inbound.readableBytes() < PRI_KNOWLEDGE_PEAK_LENGTH) {
-            throw new IllegalStateException(
-                    String.format("must have first %d bytes to determine the protocol",
-                                  PRI_KNOWLEDGE_PEAK_LENGTH));
+        if (in.readableBytes() < PRI_KNOWLEDGE_PEAK_LENGTH) {
+            return;
         }
 
         if (ByteBufUtil.equals(PRI_KNOWLEDGE_FIRST_BYTES, 0,
-                               inbound, 0, PRI_KNOWLEDGE_PEAK_LENGTH)) {
+                               in, 0, PRI_KNOWLEDGE_PEAK_LENGTH)) {
             configurePriorKnowledge(ctx);
         } else {
             configureUpgrade(ctx);
         }
 
-        ctx.fireChannelRead(msg);
-
-        // If the ctx removed before {@code ctx.fireChannelRead(msg)}, then the
-        // message will disappear because {@code ctx.next} would be the tail of
-        // pipeline.
-        ctx.pipeline().remove(this);
+        pipelineConfigured = true;
+        out.add(in.readBytes(in.readableBytes()));
     }
 
-    public abstract void configureUpgrade(ChannelHandlerContext ctx);
+    protected abstract void configureUpgrade(ChannelHandlerContext ctx);
 
-    public abstract void configurePriorKnowledge(ChannelHandlerContext ctx);
+    protected abstract void configurePriorKnowledge(ChannelHandlerContext ctx);
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/ClearTextHttp2ServerDispatcher.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/ClearTextHttp2ServerDispatcher.java
@@ -77,7 +77,15 @@ public abstract class ClearTextHttp2ServerDispatcher extends ByteToMessageDecode
         out.add(in.readBytes(in.readableBytes()));
     }
 
+    /**
+     * Invoked when dispatcher knows that the client want to start HTTP/2 by upgrade.
+     * Implement this method to configure your pipeline for handling HTTP -> HTTP/2 upgrade.
+     */
     protected abstract void configureUpgrade(ChannelHandlerContext ctx);
 
+    /**
+     * Invoked when dispatcher knows that the client want to start HTTP/2 by sending prior knowledge.
+     * Implement this method to configure your pipeline for HTTP/2 protocol.
+     */
     protected abstract void configurePriorKnowledge(ChannelHandlerContext ctx);
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/ClearTextHttp2ServerDispatcherTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/ClearTextHttp2ServerDispatcherTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.AsciiString;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link ClearTextHttp2ServerDispatcher}
+ */
+public class ClearTextHttp2ServerDispatcherTest {
+    private EmbeddedChannel channel;
+
+    private ClearTextHttp2ServerDispatcher dispatcher;
+
+    private List<ByteBuf> upgradeInbounds;
+
+    private ChannelInboundHandler upgradeHandler;
+
+    private List<ByteBuf> priorKnowledgeInbounds;
+
+    private ChannelInboundHandler priorKnowledgeHandler;
+
+    @Before
+    public void setUp() throws Exception {
+        upgradeInbounds = new ArrayList<ByteBuf>();
+        upgradeHandler = new SimpleChannelInboundHandler<ByteBuf>() {
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) throws Exception {
+                upgradeInbounds.add(msg.retain());
+            }
+        };
+
+        priorKnowledgeInbounds = new ArrayList<ByteBuf>();
+        priorKnowledgeHandler = new SimpleChannelInboundHandler<ByteBuf>() {
+            @Override
+            protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) throws Exception {
+                priorKnowledgeInbounds.add(msg.retain());
+            }
+        };
+
+        dispatcher = new ClearTextHttp2ServerDispatcher() {
+            @Override
+            protected void configureUpgrade(ChannelHandlerContext ctx) {
+                ctx.pipeline().addLast(upgradeHandler);
+            }
+
+            @Override
+            protected void configurePriorKnowledge(ChannelHandlerContext ctx) {
+                ctx.pipeline().addLast(priorKnowledgeHandler);
+
+            }
+        };
+
+        channel = new EmbeddedChannel();
+        channel.connect(new InetSocketAddress(0));
+        channel.pipeline().addLast(dispatcher);
+    }
+
+    @After
+    public void tearDown() {
+        channel.finishAndReleaseAll();
+
+        for (ByteBuf byteBuf : upgradeInbounds) {
+            byteBuf.release();
+        }
+
+        for (ByteBuf byteBuf : priorKnowledgeInbounds) {
+            byteBuf.release();
+        }
+    }
+
+    @Test
+    public void priorKnowledge() throws Exception {
+        ByteBuf firstInbound = Unpooled.directBuffer().writeBytes(
+                AsciiString.of("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n").array());
+        ByteBuf secondInbound = Unpooled.directBuffer().writeBytes(
+                AsciiString.of("This is payload").array());
+
+        try {
+            channel.writeInbound(firstInbound.copy());
+            channel.writeInbound(secondInbound.copy());
+
+            assertTrue(upgradeInbounds.isEmpty());
+
+            assertEquals(2, priorKnowledgeInbounds.size());
+            assertEquals(firstInbound, priorKnowledgeInbounds.get(0));
+            assertEquals(secondInbound, priorKnowledgeInbounds.get(1));
+        } finally {
+            firstInbound.release();
+            secondInbound.release();
+        }
+    }
+
+    @Test
+    public void upgrade() throws Exception {
+        ByteBuf firstInbound = Unpooled.directBuffer().writeBytes(
+                AsciiString.of("GET / HTTP/1.1").array());
+        ByteBuf secondInbound = Unpooled.directBuffer().writeBytes(
+                AsciiString.of("This is payload").array());
+
+        try {
+            channel.writeInbound(firstInbound.copy());
+            channel.writeInbound(secondInbound.copy());
+
+            assertTrue(priorKnowledgeInbounds.isEmpty());
+
+            assertEquals(2, upgradeInbounds.size());
+            assertEquals(firstInbound, upgradeInbounds.get(0));
+            assertEquals(secondInbound, upgradeInbounds.get(1));
+        } finally {
+            firstInbound.release();
+            secondInbound.release();
+        }
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/ClearTextHttp2ServerDispatcherTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/ClearTextHttp2ServerDispatcherTest.java
@@ -72,7 +72,6 @@ public class ClearTextHttp2ServerDispatcherTest {
             @Override
             protected void configurePriorKnowledge(ChannelHandlerContext ctx) {
                 ctx.pipeline().addLast(priorKnowledgeHandler);
-
             }
         };
 

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp2Handler.java
@@ -18,6 +18,8 @@ package io.netty.example.http2.helloworld.server;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
@@ -55,11 +57,8 @@ public final class HelloWorldHttp2Handler extends Http2ConnectionHandler impleme
     @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof HttpServerUpgradeHandler.UpgradeEvent) {
-            // Write an HTTP/2 response to the upgrade request
-            Http2Headers headers =
-                    new DefaultHttp2Headers().status(OK.codeAsText())
-                    .set(new AsciiString(UPGRADE_RESPONSE_HEADER), new AsciiString("true"));
-            encoder().writeHeaders(ctx, 1, headers, 0, true, ctx.newPromise());
+            HttpServerUpgradeHandler.UpgradeEvent upgradeEvent = (HttpServerUpgradeHandler.UpgradeEvent) evt;
+            onHeadersRead(ctx, 1, http1HeadersToHttp2Headers(upgradeEvent.upgradeRequest()), 0 , true);
         }
         super.userEventTriggered(ctx, evt);
     }
@@ -71,6 +70,13 @@ public final class HelloWorldHttp2Handler extends Http2ConnectionHandler impleme
         ctx.close();
     }
 
+    private Http2Headers http1HeadersToHttp2Headers(FullHttpRequest request) {
+        return new DefaultHttp2Headers()
+                .authority(request.headers().get("Host"))
+                .method("GET")
+                .path(request.uri())
+                .scheme("http");
+    }
     /**
      * Sends a "Hello World" DATA frame to the client.
      */

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp2Handler.java
@@ -19,24 +19,19 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.FullHttpRequest;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
-import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Flags;
 import io.netty.handler.codec.http2.Http2FrameListener;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Settings;
-import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 
-import static io.netty.buffer.Unpooled.copiedBuffer;
-import static io.netty.buffer.Unpooled.unreleasableBuffer;
-import static io.netty.example.http2.Http2ExampleUtil.UPGRADE_RESPONSE_HEADER;
-import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.buffer.Unpooled.*;
+import static io.netty.handler.codec.http.HttpResponseStatus.*;
 
 /**
  * A simple handler that responds with the message "Hello World!".
@@ -70,13 +65,14 @@ public final class HelloWorldHttp2Handler extends Http2ConnectionHandler impleme
         ctx.close();
     }
 
-    private Http2Headers http1HeadersToHttp2Headers(FullHttpRequest request) {
+    private static Http2Headers http1HeadersToHttp2Headers(FullHttpRequest request) {
         return new DefaultHttp2Headers()
                 .authority(request.headers().get("Host"))
                 .method("GET")
                 .path(request.uri())
                 .scheme("http");
     }
+
     /**
      * Sends a "Hello World" DATA frame to the client.
      */

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/Http2ServerInitializer.java
@@ -85,7 +85,7 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
     private void configureClearText(SocketChannel ch) {
         ch.pipeline().addLast(new ClearTextHttp2ServerDispatcher() {
             @Override
-            public void configureUpgrade(ChannelHandlerContext ctx) {
+            protected void configureUpgrade(ChannelHandlerContext ctx) {
                 final HttpServerCodec sourceCodec = new HttpServerCodec();
                 ctx.pipeline().addLast(sourceCodec,
                                        new HttpServerUpgradeHandler(sourceCodec, upgradeCodecFactory),
@@ -95,7 +95,7 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
             }
 
             @Override
-            public void configurePriorKnowledge(ChannelHandlerContext ctx) {
+            protected void configurePriorKnowledge(ChannelHandlerContext ctx) {
                 ctx.pipeline().addLast(new HelloWorldHttp2HandlerBuilder().build());
             }
         });

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/Http2ServerInitializer.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/Http2ServerInitializer.java
@@ -19,20 +19,17 @@ package io.netty.example.http2.helloworld.server;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelPipeline;
-import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler.UpgradeCodec;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler.UpgradeCodecFactory;
 import io.netty.handler.codec.http2.Http2CodecUtil;
+import io.netty.handler.codec.http2.ClearTextHttp2ServerDispatcher;
 import io.netty.handler.codec.http2.Http2ServerUpgradeCodec;
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.AsciiString;
-import io.netty.util.ReferenceCountUtil;
 
 /**
  * Sets up the Netty pipeline for the example server. Depending on the endpoint config, sets up the
@@ -86,25 +83,22 @@ public class Http2ServerInitializer extends ChannelInitializer<SocketChannel> {
      * Configure the pipeline for a cleartext upgrade from HTTP to HTTP/2.0
      */
     private void configureClearText(SocketChannel ch) {
-        final ChannelPipeline p = ch.pipeline();
-        final HttpServerCodec sourceCodec = new HttpServerCodec();
-
-        p.addLast(sourceCodec);
-        p.addLast(new HttpServerUpgradeHandler(sourceCodec, upgradeCodecFactory));
-        p.addLast(new SimpleChannelInboundHandler<HttpMessage>() {
+        ch.pipeline().addLast(new ClearTextHttp2ServerDispatcher() {
             @Override
-            protected void channelRead0(ChannelHandlerContext ctx, HttpMessage msg) throws Exception {
-                // If this handler is hit then no upgrade has been attempted and the client is just talking HTTP.
-                System.err.println("Directly talking: " + msg.protocolVersion() + " (no upgrade was attempted)");
-                ChannelPipeline pipeline = ctx.pipeline();
-                ChannelHandlerContext thisCtx = pipeline.context(this);
-                pipeline.addAfter(thisCtx.name(), null, new HelloWorldHttp1Handler("Direct. No Upgrade Attempted."));
-                pipeline.replace(this, null, new HttpObjectAggregator(maxHttpContentLength));
-                ctx.fireChannelRead(ReferenceCountUtil.retain(msg));
+            public void configureUpgrade(ChannelHandlerContext ctx) {
+                final HttpServerCodec sourceCodec = new HttpServerCodec();
+                ctx.pipeline().addLast(sourceCodec,
+                                       new HttpServerUpgradeHandler(sourceCodec, upgradeCodecFactory),
+                                       new HttpObjectAggregator(maxHttpContentLength),
+                                       new HelloWorldHttp1Handler("Direct. No Upgrade Attempted."),
+                                       new UserEventLogger());
+            }
+
+            @Override
+            public void configurePriorKnowledge(ChannelHandlerContext ctx) {
+                ctx.pipeline().addLast(new HelloWorldHttp2HandlerBuilder().build());
             }
         });
-
-        p.addLast(new UserEventLogger());
     }
 
     /**


### PR DESCRIPTION
Related to #5857
Just a proposal, not sure that the approach is good or not, but it works fine.

Motivation:

HTTP/2 support upgrade and prior knowledge methodology to start HTTP/2
over clear text. Currently, the http2-client from example only support
for http upgrade. I think we can do a simple dispatch by peak first
bytes of inbound that match to magic bytes or not.

Modifications:

Add ClearTextHttp2ServerDispatcher to support start HTTP/2 via clear
text with two approach. And update example/http2-client to support
this.

Result:

netty HTTP/2 and the example http2-client support for two ways to start
HTTP/2 over clear text.
