### PR TITLE
Make methods 'static' where it missed

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
@@ -227,7 +227,7 @@ public class CombinedHttpHeaders extends DefaultHttpHeaders {
             return sb;
         }
 
-        private CharSequence commaSeparateEscapedValues(CharSequence currentValue, CharSequence value) {
+        private static CharSequence commaSeparateEscapedValues(CharSequence currentValue, CharSequence value) {
             return new StringBuilder(currentValue.length() + 1 + value.length())
                     .append(currentValue)
                     .append(COMMA)

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
@@ -134,7 +134,7 @@ public final class ServerCookieEncoder extends CookieEncoder {
      * @param nameToLastIndex A map from cookie name to index of last cookie instance.
      * @return The encoded list with all but the last instance of a named cookie.
      */
-    private List<String> dedup(List<String> encoded, Map<String, Integer> nameToLastIndex) {
+    private static List<String> dedup(List<String> encoded, Map<String, Integer> nameToLastIndex) {
         boolean[] isLastInstance = new boolean[encoded.size()];
         for (int idx : nameToLastIndex.values()) {
             isLastInstance[idx] = true;

--- a/common/src/main/java/io/netty/util/ConstantPool.java
+++ b/common/src/main/java/io/netty/util/ConstantPool.java
@@ -113,7 +113,7 @@ public abstract class ConstantPool<T extends Constant<T>> {
         throw new IllegalArgumentException(String.format("'%s' is already in use", name));
     }
 
-    private String checkNotNullAndNotEmpty(String name) {
+    private static String checkNotNullAndNotEmpty(String name) {
         ObjectUtil.checkNotNull(name, "name");
 
         if (name.isEmpty()) {

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -203,7 +203,7 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
         return pollTaskFrom(taskQueue);
     }
 
-    protected final Runnable pollTaskFrom(Queue<Runnable> taskQueue) {
+    protected static Runnable pollTaskFrom(Queue<Runnable> taskQueue) {
         for (;;) {
             Runnable task = taskQueue.poll();
             if (task == WAKEUP_TASK) {

--- a/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/HelloWorldHttp2Handler.java
@@ -85,7 +85,7 @@ public class HelloWorldHttp2Handler extends ChannelDuplexHandler {
     /**
      * Sends a "Hello World" DATA frame to the client.
      */
-    private void sendResponse(ChannelHandlerContext ctx, ByteBuf payload) {
+    private static void sendResponse(ChannelHandlerContext ctx, ByteBuf payload) {
         // Send a frame for the response status
         Http2Headers headers = new DefaultHttp2Headers().status(OK.codeAsText());
         ctx.write(new DefaultHttp2HeadersFrame(headers));

--- a/example/src/main/java/io/netty/example/http2/tiles/Http2RequestHandler.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/Http2RequestHandler.java
@@ -106,11 +106,11 @@ public class Http2RequestHandler extends SimpleChannelInboundHandler<FullHttpReq
         }, latency, TimeUnit.MILLISECONDS);
     }
 
-    private String streamId(FullHttpRequest request) {
+    private static String streamId(FullHttpRequest request) {
         return request.headers().get(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text());
     }
 
-    private void streamId(FullHttpResponse response, String streamId) {
+    private static void streamId(FullHttpResponse response, String streamId) {
         response.headers().set(HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), streamId);
     }
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
@@ -49,7 +49,7 @@ public class SocketAutoReadTest extends AbstractSocketTest {
         testAutoReadOffDuringReadOnlyReadsOneTime(false, sb, cb);
     }
 
-    private void testAutoReadOffDuringReadOnlyReadsOneTime(boolean readOutsideEventLoopThread,
+    private static void testAutoReadOffDuringReadOnlyReadsOneTime(boolean readOutsideEventLoopThread,
                                                            ServerBootstrap sb, Bootstrap cb) throws Throwable {
         Channel serverChannel = null;
         Channel clientChannel = null;

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -147,7 +147,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         }
     }
 
-    private void rethrowHandlerExceptions(ReadAndDiscardHandler sh, ReadAndDiscardHandler ch) throws Throwable {
+    private static void rethrowHandlerExceptions(ReadAndDiscardHandler sh, ReadAndDiscardHandler ch) throws Throwable {
         if (sh.exception.get() != null && !(sh.exception.get() instanceof IOException)) {
             throw sh.exception.get();
         }
@@ -162,7 +162,7 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         }
     }
 
-    private Set<String> sessionIdSet(Enumeration<byte[]> sessionIds) {
+    private static Set<String> sessionIdSet(Enumeration<byte[]> sessionIds) {
         Set<String> idSet = new HashSet<String>();
         byte[] id;
         while (sessionIds.hasMoreElements()) {

--- a/transport/src/main/java/io/netty/channel/DefaultMaxBytesRecvByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/DefaultMaxBytesRecvByteBufAllocator.java
@@ -173,7 +173,7 @@ public class DefaultMaxBytesRecvByteBufAllocator implements MaxBytesRecvByteBufA
         return new AbstractMap.SimpleEntry<Integer, Integer>(maxBytesPerRead, maxBytesPerIndividualRead);
     }
 
-    private void checkMaxBytesPerReadPair(int maxBytesPerRead, int maxBytesPerIndividualRead) {
+    private static void checkMaxBytesPerReadPair(int maxBytesPerRead, int maxBytesPerIndividualRead) {
         if (maxBytesPerRead <= 0) {
             throw new IllegalArgumentException("maxBytesPerRead: " + maxBytesPerRead + " (expected: > 0)");
         }


### PR DESCRIPTION
Motivation:

Calling a static method is faster then dynamic

Modifications:

Add 'static' keyword for methods where it missed

Result:

A bit faster method calls