### PR TITLE
Base64 reduce byte manipulation operations

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/base64/Base64Test.java
+++ b/codec/src/test/java/io/netty/handler/codec/base64/Base64Test.java
@@ -16,11 +16,12 @@
 package io.netty.handler.codec.base64;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.StringUtil;
 import org.junit.Test;
-
 
 import java.io.ByteArrayInputStream;
 import java.nio.ByteOrder;
@@ -148,7 +149,8 @@ public class Base64Test {
         ByteBuf decoded = Base64.decode(encoded);
         ByteBuf expectedBuf = Unpooled.wrappedBuffer(bytes);
         try {
-            assertEquals(expectedBuf, decoded);
+            assertEquals(StringUtil.NEWLINE + "expected: " + ByteBufUtil.hexDump(expectedBuf) +
+                         StringUtil.NEWLINE + "actual--: " + ByteBufUtil.hexDump(decoded), expectedBuf, decoded);
         } finally {
             src.release();
             encoded.release();


### PR DESCRIPTION
Motivation:
Base64#decode4to3 generally calculates an int value where the contents of the decodabet straddle bytes, and then uses a byte shifting or a full byte swapping operation to get the resulting contents. We can directly calculate the contents and avoid any intermediate int values and full byte swap operations. This will reduce the number of operations required during the decode operation.

Modifications:
- remove the intermediate int in the Base64#decond4to3 method.
- manually do the byte shifting since we are already doing bit/byte manipulations here anyways.

Result:
Base64#decode4to3 requires less operations to compute the end result.