### PR TITLE
Make SslHandler configurable to either close or not close channel on …

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -310,6 +310,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     private volatile long handshakeTimeoutMillis = 10000;
     private volatile long closeNotifyFlushTimeoutMillis = 3000;
     private volatile long closeNotifyReadTimeoutMillis;
+    private volatile boolean closeOnHandshakeFailure = true;
 
     /**
      * Creates a new instance.
@@ -442,7 +443,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
     }
 
     /**
-     * Sets the timeout  for receiving the response for the close_notify that was triggered by closing the
+     * Sets the timeout for receiving the response for the close_notify that was triggered by closing the
      * {@link Channel}. This timeout starts after the close_notify message was successfully written to the
      * remote peer. Use {@code 0} to directly close the {@link Channel} and not wait for the response.
      */
@@ -459,6 +460,20 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                     "closeNotifyReadTimeoutMillis: " + closeNotifyReadTimeoutMillis + " (expected: >= 0)");
         }
         this.closeNotifyReadTimeoutMillis = closeNotifyReadTimeoutMillis;
+    }
+
+    /**
+     * Sets if the {@link Channel} should be closed on a handshake failure, default is {@code true}.
+     */
+    public final void setCloseOnHandshakeFailure(boolean closeOnHandshakeFailure) {
+        this.closeOnHandshakeFailure = closeOnHandshakeFailure;
+    }
+
+    /**
+     * Gets if the {@link Channel} should be closed on a handshake failure, default is {@code true}.
+     */
+    public final boolean getCloseOnHandshakeFailure() {
+        return closeOnHandshakeFailure;
     }
 
     /**
@@ -1389,7 +1404,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
     private void notifyHandshakeFailure(Throwable cause) {
         if (handshakePromise.tryFailure(cause)) {
-            SslUtils.notifyHandshakeFailure(ctx, cause);
+            SslUtils.notifyHandshakeFailure(ctx, cause, closeOnHandshakeFailure);
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -220,12 +220,14 @@ final class SslUtils {
         return packetLength;
     }
 
-    static void notifyHandshakeFailure(ChannelHandlerContext ctx, Throwable cause) {
+    static void notifyHandshakeFailure(final ChannelHandlerContext ctx, Throwable cause, boolean close) {
         // We have may haven written some parts of data before an exception was thrown so ensure we always flush.
         // See https://github.com/netty/netty/issues/3900#issuecomment-172481830
         ctx.flush();
         ctx.fireUserEventTriggered(new SslHandshakeCompletionEvent(cause));
-        ctx.close();
+        if (close) {
+            ctx.close();
+        }
     }
 
     /**


### PR DESCRIPTION
…handshake failure

Motivation:

We should allow to configure the SslHandler / SniHandler to either close or not close the Channel when an error during Handshake happened.

Modifications:

- Add new setter / getter to SslHandler / SniHandler
- Add test-case

Result:

Fixes [#6428].