### PR TITLE
Make EpollEventLoopGroup non final

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -32,7 +32,7 @@ import java.util.concurrent.ThreadFactory;
  * {@link EventLoopGroup} which uses epoll under the covers. Because of this
  * it only works on linux.
  */
-public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
+public class EpollEventLoopGroup extends MultithreadEventLoopGroup {
 
     /**
      * Create a new instance using the default number of threads and the default {@link ThreadFactory}.


### PR DESCRIPTION
This is to make it inline with NioEventLoopGroup, which is non final, allowing extension where needed. 

As detailed in wiki it should be a straight swap but this isn't the case, as class's in user code extending NioEventLoopGroup cannot be changed to extend EpollEventLoopGroup

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
