### PR TITLE
Add benchmarks for UnpooledUnsafeNoCleanerDirectByteBuf vs UnpooledUnsafeDirectByteBuf

### DIFF
--- a/microbench/src/main/java/io/netty/buffer/AbstractByteBufNoCleanerBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/AbstractByteBufNoCleanerBenchmark.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import org.openjdk.jmh.annotations.Param;
+
+public abstract class AbstractByteBufNoCleanerBenchmark extends AbstractMicrobenchmark {
+
+    public enum ByteBufType {
+        UNPOOLED_NO_CLEANER {
+            @Override
+            ByteBuf newBuffer(int initialCapacity) {
+                return new UnpooledUnsafeNoCleanerDirectByteBuf(
+                        UnpooledByteBufAllocator.DEFAULT, initialCapacity, Integer.MAX_VALUE);
+            }
+        },
+        UNPOOLED {
+            @Override
+            ByteBuf newBuffer(int initialCapacity) {
+                return new UnpooledUnsafeDirectByteBuf(
+                        UnpooledByteBufAllocator.DEFAULT, initialCapacity, Integer.MAX_VALUE);
+            }
+        };
+        abstract ByteBuf newBuffer(int initialCapacity);
+    }
+
+    @Param
+    public ByteBufType bufferType;
+}

--- a/microbench/src/main/java/io/netty/buffer/ByteBufNoCleanerAllocReleaseBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/ByteBufNoCleanerAllocReleaseBenchmark.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.Throughput)
+@Threads(16)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+public class ByteBufNoCleanerAllocReleaseBenchmark extends AbstractByteBufNoCleanerBenchmark {
+
+    @Param({ "64", "1024", "8192" })
+    public int initialCapacity;
+
+    @Benchmark
+    public boolean allocateRelease() {
+        ByteBuf buffer = bufferType.newBuffer(initialCapacity);
+        return buffer.release();
+    }
+}

--- a/microbench/src/main/java/io/netty/buffer/ByteBufNoCleanerChangeCapacityBenchmark.java
+++ b/microbench/src/main/java/io/netty/buffer/ByteBufNoCleanerChangeCapacityBenchmark.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.Throughput)
+@Threads(16)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+public class ByteBufNoCleanerChangeCapacityBenchmark extends AbstractByteBufNoCleanerBenchmark {
+    private static final int MAX_DIRECT_MEMORY_PER_THREAD = 1024 * 1024; // 1 mb per thread.
+
+    @Param("1024")
+    public int initialCapacity;
+
+    @Benchmark
+    public boolean capacityChange() {
+        ByteBuf buffer = bufferType.newBuffer(initialCapacity);
+        // Change capacity until we would exceed the 1mb per thread limit
+        for (int newCapacity = initialCapacity << 1; newCapacity <= MAX_DIRECT_MEMORY_PER_THREAD;
+             newCapacity += initialCapacity) {
+            buffer.capacity(newCapacity);
+        }
+        return buffer.release();
+    }
+}

--- a/microbench/src/main/java/io/netty/buffer/package-info.java
+++ b/microbench/src/main/java/io/netty/buffer/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Benchmarks for {@link io.netty.buffer}.
+ */
+package io.netty.buffer;


### PR DESCRIPTION
Motivation:

Issue [#6349] brought up the idea to not use UnpooledUnsafeNoCleanerDirectByteBuf by default. To decide what to do a benchmark is needed.

Modifications:

Add benchmarks for UnpooledUnsafeNoCleanerDirectByteBuf vs UnpooledUnsafeDirectB
yteBuf

Result:

Better idea about impact of using UnpooledUnsafeNoCleanerDirectByteBuf.