### PR TITLE
Fix test-failures introduced 325cc84a2ebbf4f5e362ec9ca09202b4647bd100…

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/Java8SslUtils.java
+++ b/handler/src/test/java/io/netty/handler/ssl/Java8SslUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.ssl;
+
+import javax.net.ssl.SNIMatcher;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLParameters;
+import java.util.Collections;
+
+final class Java8SslUtils {
+
+    private Java8SslUtils() { }
+
+    static void setSNIMatcher(SSLParameters parameters) {
+        SNIMatcher matcher = new SNIMatcher(0) {
+            @Override
+            public boolean matches(SNIServerName sniServerName) {
+                return false;
+            }
+        };
+        parameters.setSNIMatchers(Collections.singleton(matcher));
+    }
+}

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -32,11 +32,8 @@ import java.security.AlgorithmParameters;
 import java.security.CryptoPrimitive;
 import java.security.Key;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import javax.net.ssl.SNIMatcher;
-import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLException;
@@ -577,13 +574,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
         SSLEngine engine = serverSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT);
         try {
             SSLParameters parameters = new SSLParameters();
-            SNIMatcher matcher = new SNIMatcher(0) {
-                @Override
-                public boolean matches(SNIServerName sniServerName) {
-                    return false;
-                }
-            };
-            parameters.setSNIMatchers(Collections.singleton(matcher));
+            Java8SslUtils.setSNIMatcher(parameters);
             engine.setSSLParameters(parameters);
         } finally {
             cleanupServerSslEngine(engine);


### PR DESCRIPTION
… on Java7

Motivation:

325cc84a2ebbf4f5e362ec9ca09202b4647bd100 introduced new tests which uses classes only provided by Java8+. We need to ensure we only try to load classes needed for these when we run the tests on Java8+ so we still can run the testsuite with Java7.

Modifications:

Add extra class which only gets loaded when Java8+ is used and move code there.

Result:

No more class-loader issue when running tests with Java7.