### PR TITLE
Simplify Http2FrameCodec by directly extending HttpConnectionHandler

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Codec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Codec.java
@@ -75,13 +75,13 @@ public final class Http2Codec extends ChannelDuplexHandler {
      * @param initialSettings non default initial settings to send to peer
      */
     public Http2Codec(boolean server, Http2StreamChannelBootstrap bootstrap, Http2FrameLogger frameLogger,
-                      Http2Settings initialSettings) {
+                Http2Settings initialSettings) {
         this(server, bootstrap, new DefaultHttp2FrameWriter(), frameLogger, initialSettings);
     }
 
     // Visible for testing
     Http2Codec(boolean server, Http2StreamChannelBootstrap bootstrap, Http2FrameWriter frameWriter,
-               Http2FrameLogger frameLogger, Http2Settings initialSettings) {
+                Http2FrameLogger frameLogger, Http2Settings initialSettings) {
         frameCodec = new Http2FrameCodec(server, frameWriter, frameLogger, initialSettings);
         multiplexCodec = new Http2MultiplexCodec(server, bootstrap);
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodec.java
@@ -92,7 +92,7 @@ public class Http2ServerUpgradeCodec implements HttpServerUpgradeHandler.Upgrade
      * @param http2Codec the HTTP/2 multiplexing handler.
      */
     public Http2ServerUpgradeCodec(String handlerName, Http2Codec http2Codec) {
-        this(handlerName, http2Codec.frameCodec().connectionHandler(), http2Codec);
+        this(handlerName, http2Codec.frameCodec(), http2Codec);
     }
 
     Http2ServerUpgradeCodec(String handlerName, Http2ConnectionHandler connectionHandler,


### PR DESCRIPTION
Motiviation:

Http2FrameCodec should just extend HttpConnectionHandler and so remove some uncessary levels of abstraction. This way we can make it faster and less hacky.

Modifications:

- Let HttpFrameCodec extend HttpConnectionHandler
- Adjust tests

Result:

Less indirection and cleaner implementation.