### PR TITLE
Enable HTTPS algorithm when directly creating a SslHandler from a Ssl…

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -653,7 +653,7 @@ public abstract class SSLEngineTest {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
 
                 ChannelPipeline p = ch.pipeline();
-                SslHandler handler = serverSslCtx.newHandler(ch.alloc());
+                SslHandler handler = new SslHandler(serverSslCtx.newEngine(ch.alloc()));
                 if (serverInitEngine) {
                     mySetupMutualAuthServerInitSslHandler(handler);
                 }
@@ -696,7 +696,7 @@ public abstract class SSLEngineTest {
             protected void initChannel(Channel ch) throws Exception {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
                 ChannelPipeline p = ch.pipeline();
-                p.addLast(clientSslCtx.newHandler(ch.alloc()));
+                p.addLast(new SslHandler(clientSslCtx.newEngine(ch.alloc())));
                 p.addLast(new MessageDelegatorChannelHandler(clientReceiver, clientLatch));
                 p.addLast(new ChannelInboundHandlerAdapter() {
                     @Override
@@ -791,7 +791,7 @@ public abstract class SSLEngineTest {
             protected void initChannel(Channel ch) throws Exception {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
                 ChannelPipeline p = ch.pipeline();
-                p.addLast(serverSslCtx.newHandler(ch.alloc()));
+                p.addLast(new SslHandler(serverSslCtx.newEngine(ch.alloc())));
                 p.addLast(new MessageDelegatorChannelHandler(serverReceiver, serverLatch));
                 p.addLast(new ChannelInboundHandlerAdapter() {
                     @Override
@@ -831,7 +831,7 @@ public abstract class SSLEngineTest {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
                 ChannelPipeline p = ch.pipeline();
                 InetSocketAddress remoteAddress = (InetSocketAddress) serverChannel.localAddress();
-                SslHandler sslHandler = clientSslCtx.newHandler(ch.alloc(), expectedHost, 0);
+                SslHandler sslHandler = new SslHandler(clientSslCtx.newEngine(ch.alloc(), expectedHost, 0));
                 SSLParameters parameters = sslHandler.engine().getSSLParameters();
                 parameters.setEndpointIdentificationAlgorithm("HTTPS");
                 sslHandler.engine().setSSLParameters(parameters);
@@ -970,7 +970,7 @@ public abstract class SSLEngineTest {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
 
                 ChannelPipeline p = ch.pipeline();
-                p.addLast(clientSslCtx.newHandler(ch.alloc()));
+                p.addLast(new SslHandler(clientSslCtx.newEngine(ch.alloc())));
                 p.addLast(new MessageDelegatorChannelHandler(clientReceiver, clientLatch));
                 p.addLast(new ChannelInboundHandlerAdapter() {
                     @Override
@@ -1124,7 +1124,7 @@ public abstract class SSLEngineTest {
                         ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
 
                         ChannelPipeline p = ch.pipeline();
-                        p.addLast(serverSslCtx.newHandler(ch.alloc()));
+                        p.addLast(new SslHandler(serverSslCtx.newEngine(ch.alloc())));
                         p.addLast(new ChannelInboundHandlerAdapter() {
                             @Override
                             public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
@@ -1176,7 +1176,7 @@ public abstract class SSLEngineTest {
                         ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
 
                         ChannelPipeline p = ch.pipeline();
-                        SslHandler sslHandler = clientSslCtx.newHandler(ch.alloc());
+                        SslHandler sslHandler = new SslHandler(clientSslCtx.newEngine(ch.alloc()));
                         // The renegotiate is not expected to succeed, so we should stop trying in a timely manner so
                         // the unit test can terminate relativley quicly.
                         sslHandler.setHandshakeTimeout(1, TimeUnit.SECONDS);
@@ -1427,7 +1427,7 @@ public abstract class SSLEngineTest {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
 
                 ChannelPipeline p = ch.pipeline();
-                p.addLast(serverSslCtx.newHandler(ch.alloc()));
+                p.addLast(new SslHandler(serverSslCtx.newEngine(ch.alloc())));
                 p.addLast(new MessageDelegatorChannelHandler(serverReceiver, serverLatch));
                 p.addLast(new ChannelInboundHandlerAdapter() {
                     @Override
@@ -1452,7 +1452,7 @@ public abstract class SSLEngineTest {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
 
                 ChannelPipeline p = ch.pipeline();
-                p.addLast(clientSslCtx.newHandler(ch.alloc()));
+                p.addLast(new SslHandler(clientSslCtx.newEngine(ch.alloc())));
                 p.addLast(new MessageDelegatorChannelHandler(clientReceiver, clientLatch));
                 p.addLast(new ChannelInboundHandlerAdapter() {
                     @Override
@@ -1493,7 +1493,7 @@ public abstract class SSLEngineTest {
             protected void initChannel(Channel ch) throws Exception {
                 ch.config().setAllocator(new TestByteBufAllocator(ch.config().getAllocator(), type));
 
-                ch.pipeline().addFirst(serverSslCtx.newHandler(ch.alloc()));
+                ch.pipeline().addFirst(new SslHandler(serverSslCtx.newEngine(ch.alloc())));
                 ch.pipeline().addLast(new ChannelInboundHandlerAdapter() {
                     @Override
                     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -135,7 +135,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
             @SuppressWarnings("deprecation")
             public void initChannel(Channel sch) throws Exception {
                 serverChannel = sch;
-                serverSslHandler = serverCtx.newHandler(sch.alloc());
+                serverSslHandler = new SslHandler(serverCtx.newEngine(sch.alloc()));
 
                 sch.pipeline().addLast("ssl", serverSslHandler);
                 sch.pipeline().addLast("handler", serverHandler);
@@ -147,7 +147,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
             @SuppressWarnings("deprecation")
             public void initChannel(Channel sch) throws Exception {
                 clientChannel = sch;
-                clientSslHandler = clientCtx.newHandler(sch.alloc());
+                clientSslHandler = new SslHandler(clientCtx.newEngine(sch.alloc()));
 
                 sch.pipeline().addLast("ssl", clientSslHandler);
                 sch.pipeline().addLast("handler", clientHandler);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -247,7 +247,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                     SSLEngine sse = serverCtx.newEngine(sch.alloc());
                     serverSslHandler = new SslHandler(sse, delegatedTaskExecutor);
                 } else {
-                    serverSslHandler = serverCtx.newHandler(sch.alloc());
+                    serverSslHandler = new SslHandler(serverCtx.newEngine(sch.alloc()));
                 }
 
                 sch.pipeline().addLast("ssl", serverSslHandler);
@@ -268,7 +268,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
                     SSLEngine cse = clientCtx.newEngine(sch.alloc());
                     clientSslHandler = new SslHandler(cse, delegatedTaskExecutor);
                 } else {
-                    clientSslHandler = clientCtx.newHandler(sch.alloc());
+                    clientSslHandler = new SslHandler(clientCtx.newEngine(sch.alloc()));
                 }
 
                 sch.pipeline().addLast("ssl", clientSslHandler);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -123,7 +123,7 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
             @Override
             public void initChannel(Channel sch) throws Exception {
                 ChannelPipeline p = sch.pipeline();
-                p.addLast(serverCtx.newHandler(sch.alloc()));
+                p.addLast(new SslHandler(serverCtx.newEngine(sch.alloc())));
                 p.addLast(new LoggingHandler(LOG_LEVEL));
                 p.addLast(sh);
             }
@@ -133,7 +133,7 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
             @Override
             public void initChannel(Channel sch) throws Exception {
                 ChannelPipeline p = sch.pipeline();
-                p.addLast(clientCtx.newHandler(sch.alloc()));
+                p.addLast(new SslHandler(clientCtx.newEngine(sch.alloc())));
                 p.addLast(new LoggingHandler(LOG_LEVEL));
                 p.addLast(ch);
             }


### PR DESCRIPTION
…Context

Motivation:

`SslContext` has some helper methods to directly create SslHandler,
without having to first create the `SSLEngine`.

They are currently unsecure when used client side, as they don’t set
the « HTTP » endpointIdentificationAlgorithm, hence hostname
verification is not enabled.

IMHO, Netty should enforce security by default.

If one doesn’t want the HTTPS behavior, eg disabling hostname
verification, or a server that doesn’t support presenting hostname in
SslHello, he has to use the other methods: create the SSLEngine and
pass it to the handler.

Modification:

Always enable HTTPS algorithm in `newHandler` methods.

Result:

`newHandler` now returns `SslHandler` that are secured on the client
side when running JDK7+.