### PR TITLE
Fix class references of its subclass issue

### DIFF
--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -146,13 +146,7 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
      *              {@value #GLOBALCHANNEL_DEFAULT_USER_DEFINED_WRITABILITY_INDEX}.
      */
     protected int userDefinedWritabilityIndex() {
-        if (this instanceof GlobalChannelTrafficShapingHandler) {
-            return GLOBALCHANNEL_DEFAULT_USER_DEFINED_WRITABILITY_INDEX;
-        } else if (this instanceof GlobalTrafficShapingHandler) {
-            return GLOBAL_DEFAULT_USER_DEFINED_WRITABILITY_INDEX;
-        } else {
-            return CHANNEL_DEFAULT_USER_DEFINED_WRITABILITY_INDEX;
-        }
+        return CHANNEL_DEFAULT_USER_DEFINED_WRITABILITY_INDEX;
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalTrafficShapingHandler.java
@@ -111,6 +111,11 @@ public class GlobalTrafficShapingHandler extends AbstractTrafficShapingHandler {
         tc.start();
     }
 
+    @Override
+    protected int userDefinedWritabilityIndex() {
+        return AbstractTrafficShapingHandler.GLOBAL_DEFAULT_USER_DEFINED_WRITABILITY_INDEX;
+    }
+
     /**
      * Create a new instance.
      *


### PR DESCRIPTION
Motivation:

Realization of `AbstractTrafficShapingHandler.userDefinedWritabilityIndex()` has references to subclasses.
In addition, one of the subclasses overriding it, but the other does not.

Modifications:

Add overriding to the second subclass. Remove references to subclasses from parent class.

Result:

More consistent and clean code (OOP-stylish).