### PR TITLE
Convert fields to the local variable when possible

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentEncoder.java
@@ -61,7 +61,6 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
     private static final int CONTINUE_CODE = HttpResponseStatus.CONTINUE.code();
 
     private final Queue<CharSequence> acceptEncodingQueue = new ArrayDeque<CharSequence>();
-    private CharSequence acceptEncoding;
     private EmbeddedChannel encoder;
     private State state = State.AWAIT_HEADERS;
 
@@ -99,6 +98,7 @@ public abstract class HttpContentEncoder extends MessageToMessageCodec<HttpReque
 
                 final HttpResponse res = (HttpResponse) msg;
                 final int code = res.status().code();
+                final CharSequence acceptEncoding;
                 if (code == CONTINUE_CODE) {
                     // We need to not poll the encoding when response with CONTINUE as another response will follow
                     // for the issued request. See https://github.com/netty/netty/issues/4079

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -55,7 +55,6 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
 
     private MqttFixedHeader mqttFixedHeader;
     private Object variableHeader;
-    private Object payload;
     private int bytesRemainingInVariablePart;
 
     private final int maxBytesInMessage;
@@ -99,7 +98,6 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
                                 mqttFixedHeader.messageType(),
                                 bytesRemainingInVariablePart,
                                 variableHeader);
-                payload = decodedPayload.value;
                 bytesRemainingInVariablePart -= decodedPayload.numberOfBytesConsumed;
                 if (bytesRemainingInVariablePart != 0) {
                     throw new DecoderException(
@@ -107,10 +105,10 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
                                     bytesRemainingInVariablePart + " (" + mqttFixedHeader.messageType() + ')');
                 }
                 checkpoint(DecoderState.READ_FIXED_HEADER);
-                MqttMessage message = MqttMessageFactory.newMessage(mqttFixedHeader, variableHeader, payload);
+                MqttMessage message = MqttMessageFactory.newMessage(
+                        mqttFixedHeader, variableHeader, decodedPayload.value);
                 mqttFixedHeader = null;
                 variableHeader = null;
-                payload = null;
                 out.add(message);
                 break;
             } catch (Exception cause) {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksAuthResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksAuthResponseDecoder.java
@@ -28,10 +28,6 @@ import java.util.List;
  */
 public class SocksAuthResponseDecoder extends ReplayingDecoder<State> {
 
-    private SocksSubnegotiationVersion version;
-    private SocksAuthStatus authStatus;
-    private SocksResponse msg = SocksCommonUtils.UNKNOWN_SOCKS_RESPONSE;
-
     public SocksAuthResponseDecoder() {
         super(State.CHECK_PROTOCOL_VERSION);
     }
@@ -41,19 +37,22 @@ public class SocksAuthResponseDecoder extends ReplayingDecoder<State> {
             throws Exception {
         switch (state()) {
             case CHECK_PROTOCOL_VERSION: {
-                version = SocksSubnegotiationVersion.valueOf(byteBuf.readByte());
-                if (version != SocksSubnegotiationVersion.AUTH_PASSWORD) {
+                if (byteBuf.readByte() != SocksSubnegotiationVersion.AUTH_PASSWORD.byteValue()) {
+                    out.add(SocksCommonUtils.UNKNOWN_SOCKS_RESPONSE);
                     break;
                 }
                 checkpoint(State.READ_AUTH_RESPONSE);
             }
             case READ_AUTH_RESPONSE: {
-                authStatus = SocksAuthStatus.valueOf(byteBuf.readByte());
-                msg = new SocksAuthResponse(authStatus);
+                SocksAuthStatus authStatus = SocksAuthStatus.valueOf(byteBuf.readByte());
+                out.add(new SocksAuthResponse(authStatus));
+                break;
+            }
+            default: {
+                throw new Error();
             }
         }
         channelHandlerContext.pipeline().remove(this);
-        out.add(msg);
     }
 
     enum State {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequestDecoder.java
@@ -28,15 +28,8 @@ import java.util.List;
  */
 public class SocksCmdRequestDecoder extends ReplayingDecoder<State> {
 
-    private SocksProtocolVersion version;
-    private int fieldLength;
     private SocksCmdType cmdType;
     private SocksAddressType addressType;
-    @SuppressWarnings("UnusedDeclaration")
-    private byte reserved;
-    private String host;
-    private int port;
-    private SocksRequest msg = SocksCommonUtils.UNKNOWN_SOCKS_REQUEST;
 
     public SocksCmdRequestDecoder() {
         super(State.CHECK_PROTOCOL_VERSION);
@@ -46,48 +39,56 @@ public class SocksCmdRequestDecoder extends ReplayingDecoder<State> {
     protected void decode(ChannelHandlerContext ctx, ByteBuf byteBuf, List<Object> out) throws Exception {
         switch (state()) {
             case CHECK_PROTOCOL_VERSION: {
-                version = SocksProtocolVersion.valueOf(byteBuf.readByte());
-                if (version != SocksProtocolVersion.SOCKS5) {
+                if (byteBuf.readByte() != SocksProtocolVersion.SOCKS5.byteValue()) {
+                    out.add(SocksCommonUtils.UNKNOWN_SOCKS_REQUEST);
                     break;
                 }
                 checkpoint(State.READ_CMD_HEADER);
             }
             case READ_CMD_HEADER: {
                 cmdType = SocksCmdType.valueOf(byteBuf.readByte());
-                reserved = byteBuf.readByte();
+                byteBuf.skipBytes(1); // reserved
                 addressType = SocksAddressType.valueOf(byteBuf.readByte());
                 checkpoint(State.READ_CMD_ADDRESS);
             }
             case READ_CMD_ADDRESS: {
                 switch (addressType) {
                     case IPv4: {
-                        host = SocksCommonUtils.intToIp(byteBuf.readInt());
-                        port = byteBuf.readUnsignedShort();
-                        msg = new SocksCmdRequest(cmdType, addressType, host, port);
+                        String host = SocksCommonUtils.intToIp(byteBuf.readInt());
+                        int port = byteBuf.readUnsignedShort();
+                        out.add(new SocksCmdRequest(cmdType, addressType, host, port));
                         break;
                     }
                     case DOMAIN: {
-                        fieldLength = byteBuf.readByte();
-                        host = SocksCommonUtils.readUsAscii(byteBuf, fieldLength);
-                        port = byteBuf.readUnsignedShort();
-                        msg = new SocksCmdRequest(cmdType, addressType, host, port);
+                        int fieldLength = byteBuf.readByte();
+                        String host = SocksCommonUtils.readUsAscii(byteBuf, fieldLength);
+                        int port = byteBuf.readUnsignedShort();
+                        out.add(new SocksCmdRequest(cmdType, addressType, host, port));
                         break;
                     }
                     case IPv6: {
                         byte[] bytes = new byte[16];
                         byteBuf.readBytes(bytes);
-                        host = SocksCommonUtils.ipv6toStr(bytes);
-                        port = byteBuf.readUnsignedShort();
-                        msg = new SocksCmdRequest(cmdType, addressType, host, port);
+                        String host = SocksCommonUtils.ipv6toStr(bytes);
+                        int port = byteBuf.readUnsignedShort();
+                        out.add(new SocksCmdRequest(cmdType, addressType, host, port));
                         break;
                     }
-                    case UNKNOWN:
+                    case UNKNOWN: {
+                        out.add(SocksCommonUtils.UNKNOWN_SOCKS_REQUEST);
                         break;
+                    }
+                    default: {
+                        throw new Error();
+                    }
                 }
+                break;
+            }
+            default: {
+                throw new Error();
             }
         }
         ctx.pipeline().remove(this);
-        out.add(msg);
     }
 
     enum State {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponseDecoder.java
@@ -28,14 +28,8 @@ import java.util.List;
  */
 public class SocksCmdResponseDecoder extends ReplayingDecoder<State> {
 
-    private SocksProtocolVersion version;
-    private int fieldLength;
     private SocksCmdStatus cmdStatus;
     private SocksAddressType addressType;
-    private byte reserved;
-    private String host;
-    private int port;
-    private SocksResponse msg = SocksCommonUtils.UNKNOWN_SOCKS_RESPONSE;
 
     public SocksCmdResponseDecoder() {
         super(State.CHECK_PROTOCOL_VERSION);
@@ -45,48 +39,56 @@ public class SocksCmdResponseDecoder extends ReplayingDecoder<State> {
     protected void decode(ChannelHandlerContext ctx, ByteBuf byteBuf, List<Object> out) throws Exception {
         switch (state()) {
             case CHECK_PROTOCOL_VERSION: {
-                version = SocksProtocolVersion.valueOf(byteBuf.readByte());
-                if (version != SocksProtocolVersion.SOCKS5) {
+                if (byteBuf.readByte() != SocksProtocolVersion.SOCKS5.byteValue()) {
+                    out.add(SocksCommonUtils.UNKNOWN_SOCKS_RESPONSE);
                     break;
                 }
                 checkpoint(State.READ_CMD_HEADER);
             }
             case READ_CMD_HEADER: {
                 cmdStatus = SocksCmdStatus.valueOf(byteBuf.readByte());
-                reserved = byteBuf.readByte();
+                byteBuf.skipBytes(1); // reserved
                 addressType = SocksAddressType.valueOf(byteBuf.readByte());
                 checkpoint(State.READ_CMD_ADDRESS);
             }
             case READ_CMD_ADDRESS: {
                 switch (addressType) {
                     case IPv4: {
-                        host = SocksCommonUtils.intToIp(byteBuf.readInt());
-                        port = byteBuf.readUnsignedShort();
-                        msg = new SocksCmdResponse(cmdStatus, addressType, host, port);
+                        String host = SocksCommonUtils.intToIp(byteBuf.readInt());
+                        int port = byteBuf.readUnsignedShort();
+                        out.add(new SocksCmdResponse(cmdStatus, addressType, host, port));
                         break;
                     }
                     case DOMAIN: {
-                        fieldLength = byteBuf.readByte();
-                        host = SocksCommonUtils.readUsAscii(byteBuf, fieldLength);
-                        port = byteBuf.readUnsignedShort();
-                        msg = new SocksCmdResponse(cmdStatus, addressType, host, port);
+                        int fieldLength = byteBuf.readByte();
+                        String host = SocksCommonUtils.readUsAscii(byteBuf, fieldLength);
+                        int port = byteBuf.readUnsignedShort();
+                        out.add(new SocksCmdResponse(cmdStatus, addressType, host, port));
                         break;
                     }
                     case IPv6: {
                         byte[] bytes = new byte[16];
                         byteBuf.readBytes(bytes);
-                        host = SocksCommonUtils.ipv6toStr(bytes);
-                        port = byteBuf.readUnsignedShort();
-                        msg = new SocksCmdResponse(cmdStatus, addressType, host, port);
+                        String host = SocksCommonUtils.ipv6toStr(bytes);
+                        int port = byteBuf.readUnsignedShort();
+                        out.add(new SocksCmdResponse(cmdStatus, addressType, host, port));
                         break;
                     }
-                    case UNKNOWN:
+                    case UNKNOWN: {
+                        out.add(SocksCommonUtils.UNKNOWN_SOCKS_RESPONSE);
                         break;
+                    }
+                    default: {
+                        throw new Error();
+                    }
                 }
+                break;
+            }
+            default: {
+                throw new Error();
             }
         }
         ctx.pipeline().remove(this);
-        out.add(msg);
     }
 
     enum State {

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksInitResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksInitResponseDecoder.java
@@ -28,11 +28,6 @@ import java.util.List;
  */
 public class SocksInitResponseDecoder extends ReplayingDecoder<State> {
 
-    private SocksProtocolVersion version;
-    private SocksAuthScheme authScheme;
-
-    private SocksResponse msg = SocksCommonUtils.UNKNOWN_SOCKS_RESPONSE;
-
     public SocksInitResponseDecoder() {
         super(State.CHECK_PROTOCOL_VERSION);
     }
@@ -41,20 +36,22 @@ public class SocksInitResponseDecoder extends ReplayingDecoder<State> {
     protected void decode(ChannelHandlerContext ctx, ByteBuf byteBuf, List<Object> out) throws Exception {
         switch (state()) {
             case CHECK_PROTOCOL_VERSION: {
-                version = SocksProtocolVersion.valueOf(byteBuf.readByte());
-                if (version != SocksProtocolVersion.SOCKS5) {
+                if (byteBuf.readByte() != SocksProtocolVersion.SOCKS5.byteValue()) {
+                    out.add(SocksCommonUtils.UNKNOWN_SOCKS_RESPONSE);
                     break;
                 }
                 checkpoint(State.READ_PREFFERED_AUTH_TYPE);
             }
             case READ_PREFFERED_AUTH_TYPE: {
-                authScheme = SocksAuthScheme.valueOf(byteBuf.readByte());
-                msg = new SocksInitResponse(authScheme);
+                SocksAuthScheme authScheme = SocksAuthScheme.valueOf(byteBuf.readByte());
+                out.add(new SocksInitResponse(authScheme));
                 break;
+            }
+            default: {
+                throw new Error();
             }
         }
         ctx.pipeline().remove(this);
-        out.add(msg);
     }
 
     enum State {


### PR DESCRIPTION
Motivation:

Some classes have fields which can be local.

Modifications:

Convert fields to the local variable when possible.

Result:

Clean up. More chances for young generation or scalar replacement.