### PR TITLE
Allow to obtain informations of used direct and heap memory for ByteBufAllocator implementations

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/InstrumentedByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/InstrumentedByteBufAllocator.java
@@ -15,15 +15,17 @@
  */
 package io.netty.buffer;
 
-public class UnpooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<UnpooledByteBufAllocator> {
+/**
+ * {@link ByteBufAllocator} which exposes metrics.
+ */
+public interface InstrumentedByteBufAllocator extends ByteBufAllocator {
+    /**
+     * Returns the number of bytes of heap memory used by a {@link ByteBufAllocator} or {@code -1} if unknown.
+     */
+    long usedHeapMemory();
 
-    @Override
-    protected UnpooledByteBufAllocator newAllocator(boolean preferDirect) {
-        return new UnpooledByteBufAllocator(preferDirect);
-    }
-
-    @Override
-    protected UnpooledByteBufAllocator newUnpooledAllocator() {
-        return new UnpooledByteBufAllocator(false);
-    }
+    /**
+     * Returns the number of bytes of direct memory used by a {@link ByteBufAllocator} or {@code -1} if unknown.
+     */
+    long usedDirectMemory();
 }

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -27,6 +27,8 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
 /**
  * Big endian Java heap buffer implementation.
  */
@@ -43,7 +45,18 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
      * @param maxCapacity the max capacity of the underlying byte array
      */
     protected UnpooledHeapByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
-        this(alloc, new byte[initialCapacity], 0, 0, maxCapacity);
+        super(maxCapacity);
+
+        checkNotNull(alloc, "alloc");
+
+        if (initialCapacity > maxCapacity) {
+            throw new IllegalArgumentException(String.format(
+                    "initialCapacity(%d) > maxCapacity(%d)", initialCapacity, maxCapacity));
+        }
+
+        this.alloc = alloc;
+        setArray(allocateArray(initialCapacity));
+        setIndex(0, 0);
     }
 
     /**
@@ -53,20 +66,11 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
      * @param maxCapacity the max capacity of the underlying byte array
      */
     protected UnpooledHeapByteBuf(ByteBufAllocator alloc, byte[] initialArray, int maxCapacity) {
-        this(alloc, initialArray, 0, initialArray.length, maxCapacity);
-    }
-
-    private UnpooledHeapByteBuf(
-            ByteBufAllocator alloc, byte[] initialArray, int readerIndex, int writerIndex, int maxCapacity) {
-
         super(maxCapacity);
 
-        if (alloc == null) {
-            throw new NullPointerException("alloc");
-        }
-        if (initialArray == null) {
-            throw new NullPointerException("initialArray");
-        }
+        checkNotNull(alloc, "alloc");
+        checkNotNull(initialArray, "initialArray");
+
         if (initialArray.length > maxCapacity) {
             throw new IllegalArgumentException(String.format(
                     "initialCapacity(%d) > maxCapacity(%d)", initialArray.length, maxCapacity));
@@ -74,7 +78,15 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
         this.alloc = alloc;
         setArray(initialArray);
-        setIndex(readerIndex, writerIndex);
+        setIndex(0, initialArray.length);
+    }
+
+    byte[] allocateArray(int initialCapacity) {
+        return new byte[initialCapacity];
+    }
+
+    void freeArray(byte[] array) {
+        // NOOP
     }
 
     private void setArray(byte[] initialArray) {
@@ -108,23 +120,26 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
         checkNewCapacity(newCapacity);
 
         int oldCapacity = array.length;
+        byte[] oldArray = array;
         if (newCapacity > oldCapacity) {
-            byte[] newArray = new byte[newCapacity];
-            System.arraycopy(array, 0, newArray, 0, array.length);
+            byte[] newArray = allocateArray(newCapacity);
+            System.arraycopy(oldArray, 0, newArray, 0, oldArray.length);
             setArray(newArray);
+            freeArray(oldArray);
         } else if (newCapacity < oldCapacity) {
-            byte[] newArray = new byte[newCapacity];
+            byte[] newArray = allocateArray(newCapacity);
             int readerIndex = readerIndex();
             if (readerIndex < newCapacity) {
                 int writerIndex = writerIndex();
                 if (writerIndex > newCapacity) {
                     writerIndex(writerIndex = newCapacity);
                 }
-                System.arraycopy(array, readerIndex, newArray, readerIndex, writerIndex - readerIndex);
+                System.arraycopy(oldArray, readerIndex, newArray, readerIndex, writerIndex - readerIndex);
             } else {
                 setIndex(newCapacity, newCapacity);
             }
             setArray(newArray);
+            freeArray(oldArray);
         }
         return this;
     }
@@ -534,6 +549,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     protected void deallocate() {
+        freeArray(array);
         array = null;
     }
 

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
@@ -17,7 +17,7 @@ package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
 
-final class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
+class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
 
     /**
      * Creates a new heap buffer with a newly allocated byte array.

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
@@ -19,7 +19,7 @@ import io.netty.util.internal.PlatformDependent;
 
 import java.nio.ByteBuffer;
 
-final class UnpooledUnsafeNoCleanerDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
+class UnpooledUnsafeNoCleanerDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
 
     UnpooledUnsafeNoCleanerDirectByteBuf(ByteBufAllocator alloc, int initialCapacity, int maxCapacity) {
         super(alloc, initialCapacity, maxCapacity);
@@ -28,6 +28,10 @@ final class UnpooledUnsafeNoCleanerDirectByteBuf extends UnpooledUnsafeDirectByt
     @Override
     protected ByteBuffer allocateDirect(int initialCapacity) {
         return PlatformDependent.allocateDirectNoCleaner(initialCapacity);
+    }
+
+    ByteBuffer reallocateDirect(ByteBuffer oldBuffer, int initialCapacity) {
+        return PlatformDependent.reallocateDirectNoCleaner(oldBuffer, initialCapacity);
     }
 
     @Override
@@ -45,7 +49,7 @@ final class UnpooledUnsafeNoCleanerDirectByteBuf extends UnpooledUnsafeDirectByt
 
         if (newCapacity > oldCapacity) {
             ByteBuffer oldBuffer = buffer;
-            ByteBuffer newBuffer = PlatformDependent.reallocateDirectNoCleaner(oldBuffer, newCapacity);
+            ByteBuffer newBuffer = reallocateDirect(oldBuffer, newCapacity);
             setByteBuffer(newBuffer, false);
         } else if (newCapacity < oldCapacity) {
             ByteBuffer oldBuffer = buffer;

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
@@ -16,18 +16,19 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
+import org.junit.Assume;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public abstract class AbstractByteBufAllocatorTest extends ByteBufAllocatorTest {
+public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllocator> extends ByteBufAllocatorTest {
 
     @Override
-    protected abstract AbstractByteBufAllocator newAllocator(boolean preferDirect);
+    protected abstract T newAllocator(boolean preferDirect);
 
-    protected abstract AbstractByteBufAllocator newUnpooledAllocator();
+    protected abstract T newUnpooledAllocator();
 
     @Override
     protected boolean isDirectExpected(boolean preferDirect) {
@@ -51,7 +52,7 @@ public abstract class AbstractByteBufAllocatorTest extends ByteBufAllocatorTest 
     }
 
     private void testCalculateNewCapacity(boolean preferDirect) {
-        ByteBufAllocator allocator = newAllocator(preferDirect);
+        T allocator = newAllocator(preferDirect);
         assertEquals(8, allocator.calculateNewCapacity(1, 8));
         assertEquals(7, allocator.calculateNewCapacity(1, 7));
         assertEquals(64, allocator.calculateNewCapacity(1, 129));
@@ -78,7 +79,7 @@ public abstract class AbstractByteBufAllocatorTest extends ByteBufAllocatorTest 
 
     @Test
     public void testUnsafeHeapBufferAndUnsafeDirectBuffer() {
-        AbstractByteBufAllocator allocator = newUnpooledAllocator();
+        T allocator = newUnpooledAllocator();
         ByteBuf directBuffer = allocator.directBuffer();
         assertInstanceOf(directBuffer,
                 PlatformDependent.hasUnsafe() ? UnpooledUnsafeDirectByteBuf.class : UnpooledDirectByteBuf.class);
@@ -93,5 +94,51 @@ public abstract class AbstractByteBufAllocatorTest extends ByteBufAllocatorTest 
     protected static void assertInstanceOf(ByteBuf buffer, Class<? extends ByteBuf> clazz) {
         // Unwrap if needed
         assertTrue(clazz.isInstance(buffer instanceof SimpleLeakAwareByteBuf ? buffer.unwrap() : buffer));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUsedDirectMemory() {
+        InstrumentedByteBufAllocator allocator = (InstrumentedByteBufAllocator) newAllocator(true);
+        assertEquals(0, allocator.usedDirectMemory());
+        ByteBuf buffer = allocator.directBuffer(1024, 4096);
+        int capacity = buffer.capacity();
+        assertEquals(expectedUsedMemory((T) allocator, capacity), allocator.usedDirectMemory());
+
+        // Double the size of the buffer
+        buffer.capacity(capacity << 1);
+        capacity = buffer.capacity();
+        assertEquals(buffer.toString(), expectedUsedMemory((T) allocator, capacity), allocator.usedDirectMemory());
+
+        buffer.release();
+        assertEquals(expectedUsedMemoryAfterRelease((T) allocator, capacity), allocator.usedDirectMemory());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testUsedHeapMemory() {
+        InstrumentedByteBufAllocator allocator = (InstrumentedByteBufAllocator) newAllocator(true);
+        Assume.assumeTrue(allocator instanceof InstrumentedByteBufAllocator);
+
+        assertEquals(0, allocator.usedHeapMemory());
+        ByteBuf buffer = allocator.heapBuffer(1024, 4096);
+        int capacity = buffer.capacity();
+        assertEquals(expectedUsedMemory((T) allocator, capacity), allocator.usedHeapMemory());
+
+        // Double the size of the buffer
+        buffer.capacity(capacity << 1);
+        capacity = buffer.capacity();
+        assertEquals(expectedUsedMemory((T) allocator, capacity), allocator.usedHeapMemory());
+
+        buffer.release();
+        assertEquals(expectedUsedMemoryAfterRelease((T) allocator, capacity), allocator.usedHeapMemory());
+    }
+
+    protected long expectedUsedMemory(T allocator, int capacity) {
+        return capacity;
+    }
+
+    protected long expectedUsedMemoryAfterRelease(T allocator, int capacity) {
+        return 0;
     }
 }

--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorConcurrentBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufAllocatorConcurrentBenchmark.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.buffer;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@Threads(8)
+public class ByteBufAllocatorConcurrentBenchmark  extends AbstractMicrobenchmark {
+
+    private static final ByteBufAllocator unpooledAllocator = new UnpooledByteBufAllocator(true, true);
+
+    @Param({ "00064", "00256", "01024", "04096" })
+    public int size;
+
+    @Benchmark
+    public boolean allocateRelease() {
+        return unpooledAllocator.directBuffer(size).release();
+    }
+}


### PR DESCRIPTION
Motivation:

Often its useful for the user to be able to get some stats about the memory allocated via an allocator.

Modifications:

Allow to obtain the used heap and direct memory for an allocator
Add test case

Result:

Fixes [#6341]