### PR TITLE
Only add port to HOST header value if needed

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker.java
@@ -33,9 +33,11 @@ import io.netty.handler.codec.http.HttpRequestEncoder;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseDecoder;
 import io.netty.handler.codec.http.HttpScheme;
+import io.netty.util.NetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.ThrowableUtil;
 
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.channels.ClosedChannelException;
 
@@ -448,9 +450,32 @@ public abstract class WebSocketClientHandshaker {
         // check if the URI contained a port if not set the correct one depending on the schema.
         // See https://github.com/netty/netty/pull/1558
         if (wsPort == -1) {
-            return "wss".equals(wsURL.getScheme()) ? HttpScheme.HTTPS.port() : HttpScheme.HTTP.port();
+            return WebSocketScheme.WSS.name().contentEquals(wsURL.getScheme())
+                    ? WebSocketScheme.WSS.port() : WebSocketScheme.WS.port();
         }
         return wsPort;
+    }
+
+    static CharSequence websocketHostValue(URI wsURL) {
+        int port = wsURL.getPort();
+        if (port == -1) {
+            return wsURL.getHost();
+        }
+        String host = wsURL.getHost();
+        if (port == HttpScheme.HTTP.port()) {
+            return HttpScheme.HTTP.name().contentEquals(wsURL.getScheme())
+                    || WebSocketScheme.WS.name().contentEquals(wsURL.getScheme()) ?
+                    host : NetUtil.toSocketAddressString(host, port);
+        }
+        if (port == HttpScheme.HTTPS.port()) {
+            return HttpScheme.HTTPS.name().contentEquals(wsURL.getScheme())
+                    || WebSocketScheme.WSS.name().contentEquals(wsURL.getScheme()) ?
+                    host : NetUtil.toSocketAddressString(host, port);
+        }
+
+        // if the port is not standard (80/443) its needed to add the port to the header.
+        // See http://tools.ietf.org/html/rfc6454#section-6.2
+        return NetUtil.toSocketAddressString(InetSocketAddress.createUnresolved(host, port));
     }
 
     static CharSequence websocketOriginValue(String host, int wsPort) {
@@ -459,7 +484,7 @@ public abstract class WebSocketClientHandshaker {
         if (wsPort != HttpScheme.HTTP.port() && wsPort != HttpScheme.HTTPS.port()) {
             // if the port is not standard (80/443) its needed to add the port to the header.
             // See http://tools.ietf.org/html/rfc6454#section-6.2
-            return originValue + ':' + wsPort;
+            return NetUtil.toSocketAddressString(originValue, wsPort);
         }
         return originValue;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker00.java
@@ -135,7 +135,7 @@ public class WebSocketClientHandshaker00 extends WebSocketClientHandshaker {
         HttpHeaders headers = request.headers();
         headers.add(HttpHeaderNames.UPGRADE, WEBSOCKET)
                .add(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
-               .add(HttpHeaderNames.HOST, host)
+               .add(HttpHeaderNames.HOST, websocketHostValue(wsURL))
                .add(HttpHeaderNames.ORIGIN, websocketOriginValue(host, wsPort))
                .add(HttpHeaderNames.SEC_WEBSOCKET_KEY1, key1)
                .add(HttpHeaderNames.SEC_WEBSOCKET_KEY2, key2);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker07.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker07.java
@@ -151,7 +151,7 @@ public class WebSocketClientHandshaker07 extends WebSocketClientHandshaker {
         headers.add(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET)
                .add(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
                .add(HttpHeaderNames.SEC_WEBSOCKET_KEY, key)
-               .add(HttpHeaderNames.HOST, host)
+               .add(HttpHeaderNames.HOST, websocketHostValue(wsURL))
                .add(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, websocketOriginValue(host, wsPort));
 
         String expectedSubprotocol = expectedSubprotocol();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker08.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker08.java
@@ -152,7 +152,7 @@ public class WebSocketClientHandshaker08 extends WebSocketClientHandshaker {
         headers.add(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET)
                .add(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
                .add(HttpHeaderNames.SEC_WEBSOCKET_KEY, key)
-               .add(HttpHeaderNames.HOST, host)
+               .add(HttpHeaderNames.HOST, websocketHostValue(wsURL))
                .add(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, websocketOriginValue(host, wsPort));
 
         String expectedSubprotocol = expectedSubprotocol();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker13.java
@@ -151,7 +151,7 @@ public class WebSocketClientHandshaker13 extends WebSocketClientHandshaker {
         headers.add(HttpHeaderNames.UPGRADE, HttpHeaderValues.WEBSOCKET)
                .add(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE)
                .add(HttpHeaderNames.SEC_WEBSOCKET_KEY, key)
-               .add(HttpHeaderNames.HOST, host + ':' + wsPort)
+               .add(HttpHeaderNames.HOST, websocketHostValue(wsURL))
                .add(HttpHeaderNames.SEC_WEBSOCKET_ORIGIN, websocketOriginValue(host, wsPort));
 
         String expectedSubprotocol = expectedSubprotocol();

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketScheme.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketScheme.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2017 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,30 +13,29 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.handler.codec.http;
+package io.netty.handler.codec.http.websocketx;
 
 import io.netty.util.AsciiString;
 
 /**
- * Defines the common schemes used for the HTTP protocol as defined by
- * <a href="https://tools.ietf.org/html/rfc7230">rfc7230</a>.
+ * Defines the common schemes used for the WebSocket protocol as defined by
+ * <a href="https://tools.ietf.org/html/rfc6455">rfc6455</a>.
  */
-public final class HttpScheme {
+public final class WebSocketScheme {
+    /**
+     * Scheme for non-secure WebSocket connection.
+     */
+    public static final WebSocketScheme WS = new WebSocketScheme(80, "ws");
 
     /**
-     * Scheme for non-secure HTTP connection.
+     * Scheme for secure WebSocket connection.
      */
-    public static final HttpScheme HTTP = new HttpScheme(80, "http");
-
-    /**
-     * Scheme for secure HTTP connection.
-     */
-    public static final HttpScheme HTTPS = new HttpScheme(443, "https");
+    public static final WebSocketScheme WSS = new WebSocketScheme(443, "wss");
 
     private final int port;
     private final AsciiString name;
 
-    private HttpScheme(int port, String name) {
+    private WebSocketScheme(int port, String name) {
         this.port = port;
         this.name = new AsciiString(name);
     }
@@ -51,10 +50,10 @@ public final class HttpScheme {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof HttpScheme)) {
+        if (!(o instanceof WebSocketScheme)) {
             return false;
         }
-        HttpScheme other = (HttpScheme) o;
+        WebSocketScheme other = (WebSocketScheme) o;
         return other.port() == port && other.name().equals(name);
     }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshakerTest.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequestEncoder;
 import io.netty.handler.codec.http.HttpResponseDecoder;
@@ -39,6 +40,37 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class WebSocketClientHandshakerTest {
     protected abstract WebSocketClientHandshaker newHandshaker(URI uri);
+
+    @Test
+    public void testHostHeader() {
+        testHostHeaderDefaultHttp(URI.create("ws://localhost:80/"), "localhost");
+        testHostHeaderDefaultHttp(URI.create("http://localhost:80/"), "localhost");
+        testHostHeaderDefaultHttp(URI.create("ws://[::1]:80/"), "[::1]");
+        testHostHeaderDefaultHttp(URI.create("http://[::1]:80/"), "[::1]");
+        testHostHeaderDefaultHttp(URI.create("ws://localhost:9999/"), "localhost:9999");
+        testHostHeaderDefaultHttp(URI.create("http://localhost:9999/"), "localhost:9999");
+        testHostHeaderDefaultHttp(URI.create("ws://[::1]:9999/"), "[::1]:9999");
+        testHostHeaderDefaultHttp(URI.create("http://[::1]:9999/"), "[::1]:9999");
+
+        testHostHeaderDefaultHttp(URI.create("wss://localhost:443/"), "localhost");
+        testHostHeaderDefaultHttp(URI.create("https://localhost:443/"), "localhost");
+        testHostHeaderDefaultHttp(URI.create("wss://[::1]:443/"), "[::1]");
+        testHostHeaderDefaultHttp(URI.create("https://[::1]:443/"), "[::1]");
+        testHostHeaderDefaultHttp(URI.create("wss://localhost:9999/"), "localhost:9999");
+        testHostHeaderDefaultHttp(URI.create("https://localhost:9999/"), "localhost:9999");
+        testHostHeaderDefaultHttp(URI.create("wss://[::1]:9999/"), "[::1]:9999");
+        testHostHeaderDefaultHttp(URI.create("https://[::1]:9999/"), "[::1]:9999");
+    }
+
+    private void testHostHeaderDefaultHttp(URI uri, String expected) {
+        WebSocketClientHandshaker handshaker = newHandshaker(uri);
+        FullHttpRequest request = handshaker.newHandshakeRequest();
+        try {
+            assertEquals(expected, request.headers().get(HttpHeaderNames.HOST));
+        } finally {
+            request.release();
+        }
+    }
 
     @Test
     public void testRawPath() {

--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -960,14 +960,27 @@ public final class NetUtil {
         return sb.append(':').append(port).toString();
     }
 
-    private static StringBuilder newSocketAddressStringBuilder(String hostString, String port, boolean ipv4) {
+    /**
+     * Returns the {@link String} representation of a host port combo.
+     */
+    public static String toSocketAddressString(String host, int port) {
+        String portStr = String.valueOf(port);
+        return newSocketAddressStringBuilder(
+                host, portStr, isValidIpV4Address(host)).append(portStr).toString();
+    }
+
+    private static StringBuilder newSocketAddressStringBuilder(String host, String port, boolean ipv4) {
+        int hostLen = host.length();
         if (ipv4) {
             // Need to include enough space for hostString:port.
-            return new StringBuilder(hostString.length() + 1 + port.length()).append(hostString);
+            return new StringBuilder(hostLen + 1 + port.length()).append(host);
         }
         // Need to include enough space for [hostString]:port.
-        return new StringBuilder(
-                hostString.length() + 3 + port.length()).append('[').append(hostString).append(']');
+        StringBuilder stringBuilder = new StringBuilder(hostLen + 3 + port.length());
+        if (hostLen > 1 && host.charAt(0) == '[' && host.charAt(hostLen - 1) == ']') {
+            return stringBuilder.append(host);
+        }
+        return stringBuilder.append('[').append(host).append(']');
     }
 
     /**


### PR DESCRIPTION
Motivation:

We only need to add the port to the HOST header value if its not a standard port.

Modifications:

- Only add port if needed.
- Fix parsing of ipv6 address which is enclosed by [].

Result:

Fixes [#6426].