### PR TITLE
Mark transport udt as deprecated as barchart-udt is not maintained an…

### DIFF
--- a/transport-udt/src/main/java/io/netty/channel/udt/DefaultUdtChannelConfig.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/DefaultUdtChannelConfig.java
@@ -39,7 +39,10 @@ import static io.netty.channel.udt.UdtChannelOption.SYSTEM_SEND_BUFFER_SIZE;
 
 /**
  * The default {@link UdtChannelConfig} implementation.
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public class DefaultUdtChannelConfig extends DefaultChannelConfig implements
         UdtChannelConfig {
 

--- a/transport-udt/src/main/java/io/netty/channel/udt/DefaultUdtServerChannelConfig.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/DefaultUdtServerChannelConfig.java
@@ -29,7 +29,10 @@ import static io.netty.channel.ChannelOption.SO_BACKLOG;
 
 /**
  * The default {@link UdtServerChannelConfig} implementation.
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public class DefaultUdtServerChannelConfig extends DefaultUdtChannelConfig
         implements UdtServerChannelConfig {
 

--- a/transport-udt/src/main/java/io/netty/channel/udt/UdtChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/UdtChannel.java
@@ -24,7 +24,10 @@ import java.net.InetSocketAddress;
  * UDT {@link Channel}.
  * <p>
  * Supported UDT {@link UdtChannel} are available via {@link NioUdtProvider}.
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public interface UdtChannel extends Channel {
 
     /**

--- a/transport-udt/src/main/java/io/netty/channel/udt/UdtChannelConfig.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/UdtChannelConfig.java
@@ -70,7 +70,10 @@ import io.netty.channel.WriteBufferWaterMark;
  * {@code "receiveBufferSize"} and {@code "sendBufferSize"} as maximum message
  * size. If received or sent message does not fit specified sizes,
  * {@link ChannelException} will be thrown.
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public interface UdtChannelConfig extends ChannelConfig {
 
     /**

--- a/transport-udt/src/main/java/io/netty/channel/udt/UdtChannelOption.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/UdtChannelOption.java
@@ -20,7 +20,10 @@ import io.netty.channel.ChannelOption;
 
 /**
  * Options for the UDT transport
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public final class UdtChannelOption<T> extends ChannelOption<T> {
 
     /**

--- a/transport-udt/src/main/java/io/netty/channel/udt/UdtMessage.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/UdtMessage.java
@@ -24,7 +24,10 @@ import io.netty.channel.udt.nio.NioUdtProvider;
  * The message container that is used for {@link TypeUDT#DATAGRAM} messages.
  * @see NioUdtProvider#MESSAGE_CONNECTOR
  * @see NioUdtProvider#MESSAGE_RENDEZVOUS
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public final class UdtMessage extends DefaultByteBufHolder {
 
     public UdtMessage(final ByteBuf data) {

--- a/transport-udt/src/main/java/io/netty/channel/udt/UdtServerChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/UdtServerChannel.java
@@ -22,7 +22,10 @@ import io.netty.channel.udt.nio.NioUdtProvider;
  * UDT {@link ServerChannel}.
  * <p>
  * Supported UDT {@link UdtServerChannel} are available via {@link NioUdtProvider}.
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public interface UdtServerChannel extends ServerChannel, UdtChannel {
 
 }

--- a/transport-udt/src/main/java/io/netty/channel/udt/UdtServerChannelConfig.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/UdtServerChannelConfig.java
@@ -32,7 +32,10 @@ import io.netty.channel.WriteBufferWaterMark;
  * {@code "receiveBufferSize"} and {@code "sendBufferSize"} as maximum message
  * size. If received or sent message does not fit specified sizes,
  * {@link ChannelException} will be thrown.
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public interface UdtServerChannelConfig extends UdtChannelConfig {
 
     /**

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtAcceptorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtAcceptorChannel.java
@@ -38,7 +38,10 @@ import static java.nio.channels.SelectionKey.*;
 
 /**
  * Common base for Netty Byte/Message UDT Stream/Datagram acceptors.
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public abstract class NioUdtAcceptorChannel extends AbstractNioMessageChannel implements UdtServerChannel {
 
     protected static final InternalLogger logger =

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteAcceptorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteAcceptorChannel.java
@@ -21,7 +21,10 @@ import io.netty.channel.udt.UdtChannel;
 
 /**
  * Byte Channel Acceptor for UDT Streams.
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public class NioUdtByteAcceptorChannel extends NioUdtAcceptorChannel {
 
     public NioUdtByteAcceptorChannel() {

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteConnectorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteConnectorChannel.java
@@ -42,7 +42,10 @@ import static java.nio.channels.SelectionKey.OP_CONNECT;
 
 /**
  * Byte Channel Connector for UDT Streams.
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public class NioUdtByteConnectorChannel extends AbstractNioByteChannel implements UdtChannel {
 
     private static final InternalLogger logger =

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteRendezvousChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtByteRendezvousChannel.java
@@ -19,7 +19,10 @@ import com.barchart.udt.TypeUDT;
 
 /**
  * Byte Channel Rendezvous for UDT Streams.
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public class NioUdtByteRendezvousChannel extends NioUdtByteConnectorChannel {
 
     public NioUdtByteRendezvousChannel() {

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageAcceptorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageAcceptorChannel.java
@@ -21,7 +21,10 @@ import io.netty.channel.udt.UdtChannel;
 
 /**
  * Message Channel Acceptor for UDT Datagrams.
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public class NioUdtMessageAcceptorChannel extends NioUdtAcceptorChannel {
 
     public NioUdtMessageAcceptorChannel() {

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageConnectorChannel.java
@@ -41,7 +41,10 @@ import static java.nio.channels.SelectionKey.*;
  * Message Connector for UDT Datagrams.
  * <p>
  * Note: send/receive must use {@link UdtMessage} in the pipeline
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public class NioUdtMessageConnectorChannel extends AbstractNioMessageChannel implements UdtChannel {
 
     private static final InternalLogger logger =

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageRendezvousChannel.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtMessageRendezvousChannel.java
@@ -22,7 +22,10 @@ import io.netty.channel.udt.UdtMessage;
  * Message Rendezvous for UDT Datagrams.
  * <p>
  * Note: send/receive must use {@link UdtMessage} in the pipeline
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public class NioUdtMessageRendezvousChannel extends NioUdtMessageConnectorChannel {
 
     public NioUdtMessageRendezvousChannel() {

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtProvider.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/NioUdtProvider.java
@@ -38,7 +38,10 @@ import java.nio.channels.spi.SelectorProvider;
  * Provides {@link ChannelFactory} for UDT channels.
  * <p>
  * Provides {@link SelectorProvider} for UDT channels.
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 public final class NioUdtProvider<T extends UdtChannel> implements ChannelFactory<T> {
 
     /**

--- a/transport-udt/src/main/java/io/netty/channel/udt/nio/package-info.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/nio/package-info.java
@@ -17,6 +17,9 @@
  * UDT Transport for NIO Channels.
  * <p>
  * @see io.netty.example.udt
+ *
+ * @deprecated The UDT transport is no longer maintained.
  */
+@Deprecated
 package io.netty.channel.udt.nio;
 

--- a/transport-udt/src/main/java/io/netty/channel/udt/package-info.java
+++ b/transport-udt/src/main/java/io/netty/channel/udt/package-info.java
@@ -17,6 +17,9 @@
  * UDT Transport.
  * <p>
  * @see io.netty.example.udt
+ *
+ * @deprecated The UDT transport is no longer maintained and will be removed.
  */
+@Deprecated
 package io.netty.channel.udt;
 


### PR DESCRIPTION
…ymore

Motivation:

barchart-udt is not maintained anymore so there is not way for us to get fixes for udt. Because of this we should mark the transport as deprecated.

Modifications:

Deprecate all udt classes.

Result:

transport udt is deprecated and so the user knows it will be removed in the future.