### PR TITLE
Expose ByteBufAllocator metric in a more general way

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufAllocatorMetric.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufAllocatorMetric.java
@@ -15,10 +15,7 @@
  */
 package io.netty.buffer;
 
-/**
- * {@link ByteBufAllocator} which exposes metrics.
- */
-public interface InstrumentedByteBufAllocator extends ByteBufAllocator {
+public interface ByteBufAllocatorMetric {
     /**
      * Returns the number of bytes of heap memory used by a {@link ByteBufAllocator} or {@code -1} if unknown.
      */

--- a/buffer/src/main/java/io/netty/buffer/ByteBufAllocatorMetricProvider.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufAllocatorMetricProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+public interface ByteBufAllocatorMetricProvider {
+
+    /**
+     * Returns a {@link ByteBufAllocatorMetric} for a {@link ByteBufAllocator}.
+     */
+    ByteBufAllocatorMetric metric();
+}

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class PooledByteBufAllocator extends AbstractByteBufAllocator implements InstrumentedByteBufAllocator {
+public class PooledByteBufAllocator extends AbstractByteBufAllocator implements ByteBufAllocatorMetricProvider {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(PooledByteBufAllocator.class);
     private static final int DEFAULT_NUM_HEAP_ARENA;
@@ -147,6 +147,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     private final List<PoolArenaMetric> directArenaMetrics;
     private final PoolThreadLocalCache threadCache;
     private final int chunkSize;
+    private final PooledByteBufAllocatorMetric metric;
 
     public PooledByteBufAllocator() {
         this(false);
@@ -254,6 +255,7 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
             directArenas = null;
             directArenaMetrics = Collections.emptyList();
         }
+        metric = new PooledByteBufAllocatorMetric(this);
     }
 
     @SuppressWarnings("unchecked")
@@ -446,37 +448,57 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
         }
     }
 
+    @Override
+    public PooledByteBufAllocatorMetric metric() {
+        return metric;
+    }
+
     /**
      * Return the number of heap arenas.
+     *
+     * @deprecated use {@link PooledByteBufAllocatorMetric#numHeapArenas()}.
      */
+    @Deprecated
     public int numHeapArenas() {
         return heapArenaMetrics.size();
     }
 
     /**
      * Return the number of direct arenas.
+     *
+     * @deprecated use {@link PooledByteBufAllocatorMetric#numDirectArenas()}.
      */
+    @Deprecated
     public int numDirectArenas() {
         return directArenaMetrics.size();
     }
 
     /**
      * Return a {@link List} of all heap {@link PoolArenaMetric}s that are provided by this pool.
+     *
+     * @deprecated use {@link PooledByteBufAllocatorMetric#heapArenas()}.
      */
+    @Deprecated
     public List<PoolArenaMetric> heapArenas() {
         return heapArenaMetrics;
     }
 
     /**
      * Return a {@link List} of all direct {@link PoolArenaMetric}s that are provided by this pool.
+     *
+     * @deprecated use {@link PooledByteBufAllocatorMetric#directArenas()}.
      */
+    @Deprecated
     public List<PoolArenaMetric> directArenas() {
         return directArenaMetrics;
     }
 
     /**
      * Return the number of thread local caches used by this {@link PooledByteBufAllocator}.
+     *
+     * @deprecated use {@link PooledByteBufAllocatorMetric#numThreadLocalCaches()}.
      */
+    @Deprecated
     public int numThreadLocalCaches() {
         PoolArena<?>[] arenas = heapArenas != null ? heapArenas : directArenas;
         if (arenas == null) {
@@ -493,39 +515,49 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
 
     /**
      * Return the size of the tiny cache.
+     *
+     * @deprecated use {@link PooledByteBufAllocatorMetric#tinyCacheSize()}.
      */
+    @Deprecated
     public int tinyCacheSize() {
         return tinyCacheSize;
     }
 
     /**
      * Return the size of the small cache.
+     *
+     * @deprecated use {@link PooledByteBufAllocatorMetric#smallCacheSize()}.
      */
+    @Deprecated
     public int smallCacheSize() {
         return smallCacheSize;
     }
 
     /**
      * Return the size of the normal cache.
+     *
+     * @deprecated use {@link PooledByteBufAllocatorMetric#normalCacheSize()}.
      */
+    @Deprecated
     public int normalCacheSize() {
         return normalCacheSize;
     }
 
     /**
      * Return the chunk size for an arena.
+     *
+     * @deprecated use {@link PooledByteBufAllocatorMetric#chunkSize()}.
      */
+    @Deprecated
     public final int chunkSize() {
         return chunkSize;
     }
 
-    @Override
-    public final long usedHeapMemory() {
+    final long usedHeapMemory() {
         return usedMemory(heapArenas);
     }
 
-    @Override
-    public final long usedDirectMemory() {
+    final long usedDirectMemory() {
         return usedMemory(directArenas);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocatorMetric.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocatorMetric.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import io.netty.util.internal.StringUtil;
+
+import java.util.List;
+
+/**
+ * Exposed metric for {@link PooledByteBufAllocator}.
+ */
+@SuppressWarnings("deprecation")
+public final class PooledByteBufAllocatorMetric implements ByteBufAllocatorMetric {
+
+    private final PooledByteBufAllocator allocator;
+
+    PooledByteBufAllocatorMetric(PooledByteBufAllocator allocator) {
+        this.allocator = allocator;
+    }
+
+    /**
+     * Return the number of heap arenas.
+     */
+    public int numHeapArenas() {
+        return allocator.numHeapArenas();
+    }
+
+    /**
+     * Return the number of direct arenas.
+     */
+    public int numDirectArenas() {
+        return allocator.numDirectArenas();
+    }
+
+    /**
+     * Return a {@link List} of all heap {@link PoolArenaMetric}s that are provided by this pool.
+     */
+    public List<PoolArenaMetric> heapArenas() {
+        return allocator.heapArenas();
+    }
+
+    /**
+     * Return a {@link List} of all direct {@link PoolArenaMetric}s that are provided by this pool.
+     */
+    public List<PoolArenaMetric> directArenas() {
+        return allocator.directArenas();
+    }
+
+    /**
+     * Return the number of thread local caches used by this {@link PooledByteBufAllocator}.
+     */
+    public int numThreadLocalCaches() {
+        return allocator.numThreadLocalCaches();
+    }
+
+    /**
+     * Return the size of the tiny cache.
+     */
+    public int tinyCacheSize() {
+        return allocator.tinyCacheSize();
+    }
+
+    /**
+     * Return the size of the small cache.
+     */
+    public int smallCacheSize() {
+        return allocator.smallCacheSize();
+    }
+
+    /**
+     * Return the size of the normal cache.
+     */
+    public int normalCacheSize() {
+        return allocator.normalCacheSize();
+    }
+
+    /**
+     * Return the chunk size for an arena.
+     */
+    public int chunkSize() {
+        return allocator.chunkSize();
+    }
+
+    @Override
+    public long usedHeapMemory() {
+        return allocator.usedHeapMemory();
+    }
+
+    @Override
+    public long usedDirectMemory() {
+        return allocator.usedDirectMemory();
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(256);
+        sb.append(StringUtil.simpleClassName(this))
+                .append("(usedHeapMemory: ").append(usedHeapMemory())
+                .append("; usedDirectMemory: ").append(usedDirectMemory())
+                .append("; numHeapArenas: ").append(numHeapArenas())
+                .append("; numDirectArenas: ").append(numDirectArenas())
+                .append("; tinyCacheSize: ").append(tinyCacheSize())
+                .append("; smallCacheSize: ").append(smallCacheSize())
+                .append("; normalCacheSize: ").append(normalCacheSize())
+                .append("; numThreadLocalCaches: ").append(numThreadLocalCaches())
+                .append("; chunkSize: ").append(chunkSize()).append(')');
+        return sb.toString();
+    }
+}

--- a/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledByteBufAllocator.java
@@ -17,16 +17,16 @@ package io.netty.buffer;
 
 import io.netty.util.internal.LongCounter;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.StringUtil;
 
 import java.nio.ByteBuffer;
 
 /**
  * Simplistic {@link ByteBufAllocator} implementation that does not pool anything.
  */
-public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator implements InstrumentedByteBufAllocator {
+public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator implements ByteBufAllocatorMetricProvider {
 
-    private final LongCounter directCounter = PlatformDependent.newLongCounter();
-    private final LongCounter heapCounter = PlatformDependent.newLongCounter();
+    private final UnpooledByteBufAllocatorMetric metric = new UnpooledByteBufAllocatorMetric();
     private final boolean disableLeakDetector;
 
     /**
@@ -97,13 +97,24 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
     }
 
     @Override
-    public long usedHeapMemory() {
-        return heapCounter.value();
+    public ByteBufAllocatorMetric metric() {
+        return metric;
     }
 
-    @Override
-    public long usedDirectMemory() {
-        return directCounter.value();
+    void incrementDirect(int amount) {
+        metric.directCounter.add(amount);
+    }
+
+    void decrementDirect(int amount) {
+        metric.directCounter.add(-amount);
+    }
+
+    void incrementHeap(int amount) {
+        metric.heapCounter.add(amount);
+    }
+
+    void decrementHeap(int amount) {
+        metric.heapCounter.add(-amount);
     }
 
     private static final class InstrumentedUnpooledUnsafeHeapByteBuf extends UnpooledUnsafeHeapByteBuf {
@@ -114,7 +125,7 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         @Override
         byte[] allocateArray(int initialCapacity) {
             byte[] bytes = super.allocateArray(initialCapacity);
-            ((UnpooledByteBufAllocator) alloc()).heapCounter.add(bytes.length);
+            ((UnpooledByteBufAllocator) alloc()).incrementHeap(bytes.length);
             return bytes;
         }
 
@@ -122,7 +133,7 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         void freeArray(byte[] array) {
             int length = array.length;
             super.freeArray(array);
-            ((UnpooledByteBufAllocator) alloc()).heapCounter.add(-length);
+            ((UnpooledByteBufAllocator) alloc()).decrementHeap(length);
         }
     }
 
@@ -134,7 +145,7 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         @Override
         byte[] allocateArray(int initialCapacity) {
             byte[] bytes = super.allocateArray(initialCapacity);
-            ((UnpooledByteBufAllocator) alloc()).heapCounter.add(bytes.length);
+            ((UnpooledByteBufAllocator) alloc()).incrementHeap(bytes.length);
             return bytes;
         }
 
@@ -142,7 +153,7 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         void freeArray(byte[] array) {
             int length = array.length;
             super.freeArray(array);
-            ((UnpooledByteBufAllocator) alloc()).heapCounter.add(-length);
+            ((UnpooledByteBufAllocator) alloc()).decrementHeap(length);
         }
     }
 
@@ -156,7 +167,7 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         @Override
         protected ByteBuffer allocateDirect(int initialCapacity) {
             ByteBuffer buffer = super.allocateDirect(initialCapacity);
-            ((UnpooledByteBufAllocator) alloc()).directCounter.add(buffer.capacity());
+            ((UnpooledByteBufAllocator) alloc()).incrementDirect(buffer.capacity());
             return buffer;
         }
 
@@ -164,7 +175,7 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         ByteBuffer reallocateDirect(ByteBuffer oldBuffer, int initialCapacity) {
             int capacity = oldBuffer.capacity();
             ByteBuffer buffer = super.reallocateDirect(oldBuffer, initialCapacity);
-            ((UnpooledByteBufAllocator) alloc()).directCounter.add(buffer.capacity() - capacity);
+            ((UnpooledByteBufAllocator) alloc()).incrementDirect(buffer.capacity() - capacity);
             return buffer;
         }
 
@@ -172,7 +183,7 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         protected void freeDirect(ByteBuffer buffer) {
             int capacity = buffer.capacity();
             super.freeDirect(buffer);
-            ((UnpooledByteBufAllocator) alloc()).directCounter.add(-capacity);
+            ((UnpooledByteBufAllocator) alloc()).decrementDirect(capacity);
         }
     }
 
@@ -185,7 +196,7 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         @Override
         protected ByteBuffer allocateDirect(int initialCapacity) {
             ByteBuffer buffer = super.allocateDirect(initialCapacity);
-            ((UnpooledByteBufAllocator) alloc()).directCounter.add(buffer.capacity());
+            ((UnpooledByteBufAllocator) alloc()).incrementDirect(buffer.capacity());
             return buffer;
         }
 
@@ -193,7 +204,7 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         protected void freeDirect(ByteBuffer buffer) {
             int capacity = buffer.capacity();
             super.freeDirect(buffer);
-            ((UnpooledByteBufAllocator) alloc()).directCounter.add(-capacity);
+            ((UnpooledByteBufAllocator) alloc()).decrementDirect(capacity);
         }
     }
 
@@ -206,7 +217,7 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         @Override
         protected ByteBuffer allocateDirect(int initialCapacity) {
             ByteBuffer buffer = super.allocateDirect(initialCapacity);
-            ((UnpooledByteBufAllocator) alloc()).directCounter.add(buffer.capacity());
+            ((UnpooledByteBufAllocator) alloc()).incrementDirect(buffer.capacity());
             return buffer;
         }
 
@@ -214,7 +225,28 @@ public final class UnpooledByteBufAllocator extends AbstractByteBufAllocator imp
         protected void freeDirect(ByteBuffer buffer) {
             int capacity = buffer.capacity();
             super.freeDirect(buffer);
-            ((UnpooledByteBufAllocator) alloc()).directCounter.add(-capacity);
+            ((UnpooledByteBufAllocator) alloc()).decrementDirect(capacity);
+        }
+    }
+
+    private static final class UnpooledByteBufAllocatorMetric implements ByteBufAllocatorMetric {
+        final LongCounter directCounter = PlatformDependent.newLongCounter();
+        final LongCounter heapCounter = PlatformDependent.newLongCounter();
+
+        @Override
+        public long usedHeapMemory() {
+            return heapCounter.value();
+        }
+
+        @Override
+        public long usedDirectMemory() {
+            return directCounter.value();
+        }
+
+        @Override
+        public String toString() {
+            return StringUtil.simpleClassName(this) +
+                    "(usedHeapMemory: " + usedHeapMemory() + "; usedDirectMemory: " + usedDirectMemory() + ')';
         }
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufAllocatorTest.java
@@ -16,7 +16,6 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -99,39 +98,40 @@ public abstract class AbstractByteBufAllocatorTest<T extends AbstractByteBufAllo
     @SuppressWarnings("unchecked")
     @Test
     public void testUsedDirectMemory() {
-        InstrumentedByteBufAllocator allocator = (InstrumentedByteBufAllocator) newAllocator(true);
-        assertEquals(0, allocator.usedDirectMemory());
+        T allocator =  newAllocator(true);
+        ByteBufAllocatorMetric metric = ((ByteBufAllocatorMetricProvider) allocator).metric();
+        assertEquals(0, metric.usedDirectMemory());
         ByteBuf buffer = allocator.directBuffer(1024, 4096);
         int capacity = buffer.capacity();
-        assertEquals(expectedUsedMemory((T) allocator, capacity), allocator.usedDirectMemory());
+        assertEquals(expectedUsedMemory(allocator, capacity), metric.usedDirectMemory());
 
         // Double the size of the buffer
         buffer.capacity(capacity << 1);
         capacity = buffer.capacity();
-        assertEquals(buffer.toString(), expectedUsedMemory((T) allocator, capacity), allocator.usedDirectMemory());
+        assertEquals(buffer.toString(), expectedUsedMemory(allocator, capacity), metric.usedDirectMemory());
 
         buffer.release();
-        assertEquals(expectedUsedMemoryAfterRelease((T) allocator, capacity), allocator.usedDirectMemory());
+        assertEquals(expectedUsedMemoryAfterRelease(allocator, capacity), metric.usedDirectMemory());
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void testUsedHeapMemory() {
-        InstrumentedByteBufAllocator allocator = (InstrumentedByteBufAllocator) newAllocator(true);
-        Assume.assumeTrue(allocator instanceof InstrumentedByteBufAllocator);
+        T allocator =  newAllocator(true);
+        ByteBufAllocatorMetric metric = ((ByteBufAllocatorMetricProvider) allocator).metric();
 
-        assertEquals(0, allocator.usedHeapMemory());
+        assertEquals(0, metric.usedHeapMemory());
         ByteBuf buffer = allocator.heapBuffer(1024, 4096);
         int capacity = buffer.capacity();
-        assertEquals(expectedUsedMemory((T) allocator, capacity), allocator.usedHeapMemory());
+        assertEquals(expectedUsedMemory(allocator, capacity), metric.usedHeapMemory());
 
         // Double the size of the buffer
         buffer.capacity(capacity << 1);
         capacity = buffer.capacity();
-        assertEquals(expectedUsedMemory((T) allocator, capacity), allocator.usedHeapMemory());
+        assertEquals(expectedUsedMemory(allocator, capacity), metric.usedHeapMemory());
 
         buffer.release();
-        assertEquals(expectedUsedMemoryAfterRelease((T) allocator, capacity), allocator.usedHeapMemory());
+        assertEquals(expectedUsedMemoryAfterRelease(allocator, capacity), metric.usedHeapMemory());
     }
 
     protected long expectedUsedMemory(T allocator, int capacity) {


### PR DESCRIPTION
Motivation:

PR [#6460] added a way to access the used memory of an allocator. The used naming was not very good and how things were exposed are not consistent.

Modifications:

- Add a new ByteBufAllocatorMetric and ByteBufAllocatorMetricProvider interface
- Let the ByteBufAllocator implementations implement ByteBufAllocatorMetricProvider
- Move exposed stats / metric from PooledByteBufAllocator to PooledByteBufAllocatorMetric and mark old methods as `@Deprecated`.

Result:

More consistent way to expose metric / stats for ByteBufAllocator