### PR TITLE
Correct usages of internalNioBuffer

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -588,7 +588,7 @@ public final class ByteBufUtil {
             dst = alloc.buffer(length);
         }
         try {
-            final ByteBuffer dstBuf = dst.internalNioBuffer(0, length);
+            final ByteBuffer dstBuf = dst.internalNioBuffer(dst.readerIndex(), length);
             final int pos = dstBuf.position();
             CoderResult cr = encoder.encode(src, dstBuf, true);
             if (!cr.isUnderflow()) {
@@ -635,7 +635,7 @@ public final class ByteBufUtil {
             try {
                 buffer.writeBytes(src, readerIndex, len);
                 // Use internalNioBuffer(...) to reduce object creation.
-                decodeString(decoder, buffer.internalNioBuffer(0, len), dst);
+                decodeString(decoder, buffer.internalNioBuffer(buffer.readerIndex(), len), dst);
             } finally {
                 // Release the temporary buffer again.
                 buffer.release();
@@ -1087,7 +1087,7 @@ public final class ByteBufUtil {
                     ByteBuf heapBuffer =  buf.alloc().heapBuffer(length);
                     try {
                         heapBuffer.writeBytes(buf, index, length);
-                        decoder.decode(heapBuffer.internalNioBuffer(0, length));
+                        decoder.decode(heapBuffer.internalNioBuffer(heapBuffer.readerIndex(), length));
                     } finally {
                         heapBuffer.release();
                     }

--- a/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractByteBufTest.java
@@ -2120,14 +2120,14 @@ public abstract class AbstractByteBufTest {
 
     private void testInternalNioBuffer(int a) {
         ByteBuf buffer = newBuffer(2);
-        ByteBuffer buf = buffer.internalNioBuffer(0, 1);
+        ByteBuffer buf = buffer.internalNioBuffer(buffer.readerIndex(), 1);
         assertEquals(1, buf.remaining());
 
         byte[] data = new byte[a];
         PlatformDependent.threadLocalRandom().nextBytes(data);
         buffer.writeBytes(data);
 
-        buf = buffer.internalNioBuffer(0, a);
+        buf = buffer.internalNioBuffer(buffer.readerIndex(), a);
         assertEquals(a, buf.remaining());
 
         for (int i = 0; i < a; i++) {
@@ -2972,7 +2972,8 @@ public abstract class AbstractByteBufTest {
 
     @Test(expected = IllegalReferenceCountException.class)
     public void testInternalNioBufferAfterRelease() {
-        releasedBuffer().internalNioBuffer(0, 1);
+        ByteBuf releasedBuffer = releasedBuffer();
+        releasedBuffer.internalNioBuffer(releasedBuffer.readerIndex(), 1);
     }
 
     @Test(expected = IllegalReferenceCountException.class)

--- a/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
@@ -50,7 +50,7 @@ public class EmptyByteBufTest {
         assertThat(empty.nioBuffer().position(), is(0));
         assertThat(empty.nioBuffer().limit(), is(0));
         assertThat(empty.nioBuffer(), is(sameInstance(empty.nioBuffer())));
-        assertThat(empty.nioBuffer(), is(sameInstance(empty.internalNioBuffer(0, 0))));
+        assertThat(empty.nioBuffer(), is(sameInstance(empty.internalNioBuffer(empty.readerIndex(), 0))));
     }
 
     @Test

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -198,7 +198,6 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                         handler.singleBuffer[0] = toByteBuffer(out, writerIndex,
                             out.writableBytes());
                         result = opensslEngine.unwrap(in.nioBuffers(readerIndex, len), handler.singleBuffer);
-                        out.writerIndex(writerIndex + result.bytesProduced());
                     } finally {
                         handler.singleBuffer[0] = null;
                     }
@@ -828,7 +827,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 newDirectIn = alloc.directBuffer(readableBytes);
                 newDirectIn.writeBytes(in, readerIndex, readableBytes);
                 in0 = singleBuffer;
-                in0[0] = newDirectIn.internalNioBuffer(0, readableBytes);
+                in0[0] = newDirectIn.internalNioBuffer(newDirectIn.readerIndex(), readableBytes);
             }
 
             for (;;) {

--- a/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelOutboundBufferTest.java
@@ -52,7 +52,7 @@ public class ChannelOutboundBufferTest {
         assertEquals(0, buffer.nioBufferCount());
 
         ByteBuf buf = copiedBuffer("buf1", CharsetUtil.US_ASCII);
-        ByteBuffer nioBuf = buf.internalNioBuffer(0, buf.readableBytes());
+        ByteBuffer nioBuf = buf.internalNioBuffer(buf.readerIndex(), buf.readableBytes());
         buffer.addMessage(buf, buf.readableBytes(), channel.voidPromise());
         assertEquals("Should still be 0 as not flushed yet", 0, buffer.nioBufferCount());
         buffer.addFlush();
@@ -84,7 +84,7 @@ public class ChannelOutboundBufferTest {
         ByteBuffer[] buffers = buffer.nioBuffers();
         assertEquals(64, buffer.nioBufferCount());
         for (int i = 0;  i < buffer.nioBufferCount(); i++) {
-            assertEquals(buffers[i], buf.internalNioBuffer(0, buf.readableBytes()));
+            assertEquals(buffers[i], buf.internalNioBuffer(buf.readerIndex(), buf.readableBytes()));
         }
         release(buffer);
         buf.release();
@@ -109,7 +109,7 @@ public class ChannelOutboundBufferTest {
         assertEquals(65, buffer.nioBufferCount());
         for (int i = 0;  i < buffer.nioBufferCount(); i++) {
             if (i < 65) {
-                assertEquals(buffers[i], buf.internalNioBuffer(0, buf.readableBytes()));
+                assertEquals(buffers[i], buf.internalNioBuffer(buf.readerIndex(), buf.readableBytes()));
             } else {
                 assertNull(buffers[i]);
             }


### PR DESCRIPTION
Motivation:
There are numerous usages of internalNioBuffer which hard code 0 for the index when the intention was to use the readerIndex().

Modifications:
- Remove hard coded 0 for the index and use readerIndex()

Result:
We are less susceptible to using the wrong index, and don't make assumptions about the ByteBufAllocator.