### PR TITLE
Fix misordered 'assertEquals' arguments in tests

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractCompositeByteBufTest.java
@@ -1004,8 +1004,7 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
         CompositeByteBuf cbuf = compositeBuffer();
         ByteBuf buf1 = buffer().writeByte((byte) 1);
         cbuf.addComponent(true, buf1);
-        ByteBuf buf2 = EMPTY_BUFFER;
-        cbuf.addComponent(true, buf2);
+        cbuf.addComponent(true, EMPTY_BUFFER);
         ByteBuf buf3 = buffer().writeByte((byte) 2);
         cbuf.addComponent(true, buf3);
 
@@ -1104,17 +1103,17 @@ public abstract class AbstractCompositeByteBufTest extends AbstractByteBufTest {
             .addComponents(s2, s3, s4)
             .order(ByteOrder.LITTLE_ENDIAN);
 
-        assertEquals(composite.refCnt(), 1);
-        assertEquals(buffer.refCnt(), 5);
+        assertEquals(1, composite.refCnt());
+        assertEquals(5, buffer.refCnt());
 
         // releasing composite should release the 4 components
         ReferenceCountUtil.release(composite);
-        assertEquals(composite.refCnt(), 0);
-        assertEquals(buffer.refCnt(), 1);
+        assertEquals(0, composite.refCnt());
+        assertEquals(1, buffer.refCnt());
 
         // last remaining ref to buffer
         ReferenceCountUtil.release(buffer);
-        assertEquals(buffer.refCnt(), 0);
+        assertEquals(0, buffer.refCnt());
     }
 
 }

--- a/buffer/src/test/java/io/netty/buffer/UnsafeByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/UnsafeByteBufUtilTest.java
@@ -35,7 +35,7 @@ public class UnsafeByteBufUtilTest {
 
     @Test
     public void testSetBytesOnReadOnlyByteBuffer() throws Exception {
-        byte[] testData = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        byte[] testData = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         int length = testData.length;
 
         ByteBuffer readOnlyBuffer = ByteBuffer.wrap(testData).asReadOnlyBuffer();
@@ -57,7 +57,7 @@ public class UnsafeByteBufUtilTest {
 
     @Test
     public void testSetBytesOnReadOnlyByteBufferWithPooledAlloc() throws Exception {
-        byte[] testData = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        byte[] testData = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         int length = testData.length;
 
         ByteBuffer readOnlyBuffer = ByteBuffer.wrap(testData).asReadOnlyBuffer();
@@ -73,8 +73,8 @@ public class UnsafeByteBufUtilTest {
 
         try {
             // just check that two following buffers share same array but different offset
-            assertEquals(b1.array().length, pageSize);
-            assertEquals(b1.array(), b2.array());
+            assertEquals(pageSize, b1.array().length);
+            assertArrayEquals(b1.array(), b2.array());
             assertNotEquals(b1.arrayOffset(), b2.arrayOffset());
 
             UnsafeByteBufUtil.setBytes(targetBuffer, directBufferAddress(targetBuffer.nioBuffer()), 0, readOnlyBuffer);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientUpgradeHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientUpgradeHandlerTest.java
@@ -21,7 +21,6 @@ import io.netty.channel.embedded.EmbeddedChannel;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
 
 import org.junit.Test;
 
@@ -84,11 +83,11 @@ public class HttpClientUpgradeHandlerTest {
             channel.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "netty.io")));
         FullHttpRequest request = channel.readOutbound();
 
-        assertEquals(request.headers().size(), 2);
+        assertEquals(2, request.headers().size());
         assertTrue(request.headers().contains(HttpHeaderNames.UPGRADE, "fancyhttp", false));
         assertTrue(request.headers().contains("connection", "upgrade", false));
         assertTrue(request.release());
-        assertEquals(catcher.getUserEvent(), HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_ISSUED);
+        assertEquals(HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_ISSUED, catcher.getUserEvent());
 
         HttpResponse upgradeResponse =
             new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS);
@@ -97,12 +96,12 @@ public class HttpClientUpgradeHandlerTest {
         assertFalse(channel.writeInbound(upgradeResponse));
         assertFalse(channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT));
 
-        assertEquals(catcher.getUserEvent(), HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_SUCCESSFUL);
+        assertEquals(HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_SUCCESSFUL, catcher.getUserEvent());
         assertNull(channel.pipeline().get("upgrade"));
 
         assertTrue(channel.writeInbound(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)));
         FullHttpResponse response = channel.readInbound();
-        assertEquals(response.status(), HttpResponseStatus.OK);
+        assertEquals(HttpResponseStatus.OK, response.status());
         assertTrue(response.release());
         assertFalse(channel.finish());
     }
@@ -120,11 +119,11 @@ public class HttpClientUpgradeHandlerTest {
             channel.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "netty.io")));
         FullHttpRequest request = channel.readOutbound();
 
-        assertEquals(request.headers().size(), 2);
+        assertEquals(2, request.headers().size());
         assertTrue(request.headers().contains(HttpHeaderNames.UPGRADE, "fancyhttp", false));
         assertTrue(request.headers().contains("connection", "upgrade", false));
         assertTrue(request.release());
-        assertEquals(catcher.getUserEvent(), HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_ISSUED);
+        assertEquals(HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_ISSUED, catcher.getUserEvent());
 
         HttpResponse upgradeResponse =
             new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS);
@@ -132,14 +131,14 @@ public class HttpClientUpgradeHandlerTest {
         assertTrue(channel.writeInbound(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)));
         assertTrue(channel.writeInbound(LastHttpContent.EMPTY_LAST_CONTENT));
 
-        assertEquals(catcher.getUserEvent(), HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_REJECTED);
+        assertEquals(HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_REJECTED, catcher.getUserEvent());
         assertNull(channel.pipeline().get("upgrade"));
 
         HttpResponse response = channel.readInbound();
-        assertEquals(response.status(), HttpResponseStatus.OK);
+        assertEquals(HttpResponseStatus.OK, response.status());
 
         LastHttpContent last = channel.readInbound();
-        assertEquals(last, LastHttpContent.EMPTY_LAST_CONTENT);
+        assertEquals(LastHttpContent.EMPTY_LAST_CONTENT, last);
         assertFalse(last.release());
         assertFalse(channel.finish());
     }
@@ -157,22 +156,22 @@ public class HttpClientUpgradeHandlerTest {
             channel.writeOutbound(new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "netty.io")));
         FullHttpRequest request = channel.readOutbound();
 
-        assertEquals(request.headers().size(), 2);
+        assertEquals(2, request.headers().size());
         assertTrue(request.headers().contains(HttpHeaderNames.UPGRADE, "fancyhttp", false));
         assertTrue(request.headers().contains("connection", "upgrade", false));
         assertTrue(request.release());
-        assertEquals(catcher.getUserEvent(), HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_ISSUED);
+        assertEquals(HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_ISSUED, catcher.getUserEvent());
 
         HttpResponse upgradeResponse =
             new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.SWITCHING_PROTOCOLS);
         upgradeResponse.headers().add(HttpHeaderNames.UPGRADE, "fancyhttp");
         assertTrue(channel.writeInbound(new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)));
 
-        assertEquals(catcher.getUserEvent(), HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_REJECTED);
+        assertEquals(HttpClientUpgradeHandler.UpgradeEvent.UPGRADE_REJECTED, catcher.getUserEvent());
         assertNull(channel.pipeline().get("upgrade"));
 
         HttpResponse response = channel.readInbound();
-        assertEquals(response.status(), HttpResponseStatus.OK);
+        assertEquals(HttpResponseStatus.OK, response.status());
         assertFalse(channel.finish());
     }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpObjectAggregatorTest.java
@@ -65,7 +65,7 @@ public class HttpObjectAggregatorTest {
 
         assertEquals(chunk1.content().readableBytes() + chunk2.content().readableBytes(),
                 HttpUtil.getContentLength(aggratedMessage));
-        assertEquals(aggratedMessage.headers().get(of("X-Test")), Boolean.TRUE.toString());
+        assertEquals(Boolean.TRUE.toString(), aggratedMessage.headers().get(of("X-Test")));
         checkContentBuffer(aggratedMessage);
         assertNull(embedder.readInbound());
     }
@@ -106,8 +106,8 @@ public class HttpObjectAggregatorTest {
 
         assertEquals(chunk1.content().readableBytes() + chunk2.content().readableBytes(),
                 HttpUtil.getContentLength(aggratedMessage));
-        assertEquals(aggratedMessage.headers().get(of("X-Test")), Boolean.TRUE.toString());
-        assertEquals(aggratedMessage.trailingHeaders().get(of("X-Trailer")), Boolean.TRUE.toString());
+        assertEquals(Boolean.TRUE.toString(), aggratedMessage.headers().get(of("X-Test")));
+        assertEquals(Boolean.TRUE.toString(), aggratedMessage.trailingHeaders().get(of("X-Trailer")));
         checkContentBuffer(aggratedMessage);
         assertNull(embedder.readInbound());
     }
@@ -250,7 +250,7 @@ public class HttpObjectAggregatorTest {
 
         assertEquals(chunk1.content().readableBytes() + chunk2.content().readableBytes(),
                 HttpUtil.getContentLength(aggratedMessage));
-        assertEquals(aggratedMessage.headers().get(of("X-Test")), Boolean.TRUE.toString());
+        assertEquals(Boolean.TRUE.toString(), aggratedMessage.headers().get(of("X-Test")));
         checkContentBuffer(aggratedMessage);
         assertNull(embedder.readInbound());
     }
@@ -311,7 +311,7 @@ public class HttpObjectAggregatorTest {
         assertFalse(embedder.writeInbound(chunk2));
         assertTrue(embedder.writeInbound(chunk3));
 
-        FullHttpRequest fullMsg = (FullHttpRequest) embedder.readInbound();
+        FullHttpRequest fullMsg = embedder.readInbound();
         assertNotNull(fullMsg);
 
         assertEquals(
@@ -330,7 +330,7 @@ public class HttpObjectAggregatorTest {
         runUnsupportedExceptHeaderExceptionTest(false);
     }
 
-    private void runUnsupportedExceptHeaderExceptionTest(final boolean close) {
+    private static void runUnsupportedExceptHeaderExceptionTest(final boolean close) {
         final HttpObjectAggregator aggregator;
         final int maxContentLength = 4;
         if (close) {
@@ -346,7 +346,7 @@ public class HttpObjectAggregatorTest {
                         "Content-Length: 100\r\n\r\n", CharsetUtil.US_ASCII)));
         assertNull(embedder.readInbound());
 
-        final FullHttpResponse response = (FullHttpResponse) embedder.readOutbound();
+        final FullHttpResponse response = embedder.readOutbound();
         assertEquals(HttpResponseStatus.EXPECTATION_FAILED, response.status());
         assertEquals("0", response.headers().get(HttpHeaderNames.CONTENT_LENGTH));
         response.release();
@@ -360,7 +360,7 @@ public class HttpObjectAggregatorTest {
             // the decoder should be reset by the aggregator at this point and be able to decode the next request
             assertTrue(embedder.writeInbound(Unpooled.copiedBuffer("GET / HTTP/1.1\r\n\r\n", CharsetUtil.US_ASCII)));
 
-            final FullHttpRequest request = (FullHttpRequest) embedder.readInbound();
+            final FullHttpRequest request = embedder.readInbound();
             assertThat(request.method(), is(HttpMethod.GET));
             assertThat(request.uri(), is("/"));
             assertThat(request.content().readableBytes(), is(0));
@@ -380,7 +380,7 @@ public class HttpObjectAggregatorTest {
 
         assertNull(embedder.readInbound());
 
-        FullHttpResponse response = (FullHttpResponse) embedder.readOutbound();
+        FullHttpResponse response = embedder.readOutbound();
         assertEquals(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, response.status());
         assertEquals("0", response.headers().get(HttpHeaderNames.CONTENT_LENGTH));
 
@@ -390,7 +390,7 @@ public class HttpObjectAggregatorTest {
         // The decoder should be reset by the aggregator at this point and be able to decode the next request.
         embedder.writeInbound(Unpooled.copiedBuffer("GET /max-upload-size HTTP/1.1\r\n\r\n", CharsetUtil.US_ASCII));
 
-        FullHttpRequest request = (FullHttpRequest) embedder.readInbound();
+        FullHttpRequest request = embedder.readInbound();
         assertThat(request.method(), is(HttpMethod.GET));
         assertThat(request.uri(), is("/max-upload-size"));
         assertThat(request.content().readableBytes(), is(0));
@@ -409,7 +409,7 @@ public class HttpObjectAggregatorTest {
 
         assertNull(embedder.readInbound());
 
-        FullHttpResponse response = (FullHttpResponse) embedder.readOutbound();
+        FullHttpResponse response = embedder.readOutbound();
         assertEquals(HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE, response.status());
         assertEquals("0", response.headers().get(HttpHeaderNames.CONTENT_LENGTH));
 
@@ -452,7 +452,7 @@ public class HttpObjectAggregatorTest {
         assertFalse(embedder.writeInbound(chunk2));
         assertTrue(embedder.writeInbound(chunk3));
 
-        FullHttpRequest fullMsg = (FullHttpRequest) embedder.readInbound();
+        FullHttpRequest fullMsg = embedder.readInbound();
         assertNotNull(fullMsg);
 
         assertEquals(

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -198,7 +198,7 @@ public class DefaultHttp2ConnectionEncoderTest {
         final ByteBuf data = dummyData();
         ChannelPromise p = newPromise();
         encoder.writeData(ctx, STREAM_ID, data, 0, true, p);
-        assertEquals(payloadCaptor.getValue().size(), 8);
+        assertEquals(8, payloadCaptor.getValue().size());
         payloadCaptor.getValue().write(ctx, 8);
         assertEquals(0, payloadCaptor.getValue().size());
         assertEquals("abcdefgh", writtenData.get(0));
@@ -308,7 +308,7 @@ public class DefaultHttp2ConnectionEncoderTest {
         when(frameSizePolicy.maxFrameSize()).thenReturn(5);
         ChannelPromise p = newPromise();
         encoder.writeData(ctx, STREAM_ID, data, 10, true, p);
-        assertEquals(payloadCaptor.getValue().size(), 10);
+        assertEquals(10, payloadCaptor.getValue().size());
         payloadCaptor.getValue().write(ctx, 10);
         // writer was called 2 times
         assertEquals(1, writtenData.size());

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoderTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/Socks5PasswordAuthRequestDecoderTest.java
@@ -24,14 +24,14 @@ public class Socks5PasswordAuthRequestDecoderTest {
 
     @Test
     public void testAuthRequestDecoder() {
-        String username = "test";
-        String password = "test";
+        String username = "testUsername";
+        String password = "testPassword";
         Socks5PasswordAuthRequest msg = new DefaultSocks5PasswordAuthRequest(username, password);
         EmbeddedChannel embedder = new EmbeddedChannel(new Socks5PasswordAuthRequestDecoder());
         Socks5CommonTestUtils.writeFromClientToServer(embedder, msg);
         msg = embedder.readInbound();
-        assertEquals(msg.username(), username);
-        assertEquals(msg.username(), password);
+        assertEquals(username, msg.username());
+        assertEquals(password, msg.password());
         assertNull(embedder.readInbound());
     }
 }

--- a/common/src/test/java/io/netty/util/DefaultAttributeMapTest.java
+++ b/common/src/test/java/io/netty/util/DefaultAttributeMapTest.java
@@ -59,7 +59,7 @@ public class DefaultAttributeMapTest {
         assertSame(one, map.attr(key));
 
         one.setIfAbsent(3653);
-        assertEquals(one.get(), Integer.valueOf(3653));
+        assertEquals(Integer.valueOf(3653), one.get());
 
         one.setIfAbsent(1);
         assertNotSame(1, one.get());

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -430,7 +430,7 @@ public class EmbeddedChannelTest {
 
       // There was no #flushInbound() call so nobody should have called
       // #channelReadComplete()
-      assertEquals(flushCount.get(), 0);
+      assertEquals(0, flushCount.get());
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Wrong order of the arguments in some 'assertEquals' applying.

Modifications:

Flip compared arguments.

Result:

Correct `assertEquals` usage.