### PR TITLE
Update links from code.google.com to github

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -79,7 +79,7 @@ It can be obtained at:
   * LICENSE:
     * license/LICENSE.abstractnodequeue.txt (Public Domain)
   * HOMEPAGE:
-    * https://github.com/akka/akka/blob/wip-2.2.3-for-scala-2.11/akka-actor/src/main/java/akka/dispatch/AbstractNodeQueue.java
+    * https://github.com/akka/akka/blob/master/akka-actor/src/main/java/akka/dispatch/AbstractNodeQueue.java
 
 This product contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
@@ -96,7 +96,7 @@ a constant-size alphabet written by Yuta Mori. It can be obtained at:
   * LICENSE:
     * license/LICENSE.libdivsufsort.txt (MIT License)
   * HOMEPAGE:
-    * https://code.google.com/p/libdivsufsort/
+    * https://github.com/y-256/libdivsufsort
 
 This product contains a modified portion of Nitsan Wakart's 'JCTools', Java Concurrency Tools for the JVM,
  which can be obtained at:
@@ -152,7 +152,7 @@ interchange format, which can be obtained at:
   * LICENSE:
     * license/LICENSE.protobuf.txt (New BSD License)
   * HOMEPAGE:
-    * http://code.google.com/p/protobuf/
+    * https://github.com/google/protobuf
 
 This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
 a temporary self-signed X.509 certificate when the JVM does not provide the
@@ -169,7 +169,7 @@ by Google Inc, which can be obtained at:
   * LICENSE:
     * license/LICENSE.snappy.txt (New BSD License)
   * HOMEPAGE:
-    * http://code.google.com/p/snappy/
+    * https://github.com/google/snappy
 
 This product optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
@@ -185,7 +185,7 @@ benchmarking framework, which can be obtained at:
   * LICENSE:
     * license/LICENSE.caliper.txt (Apache License 2.0)
   * HOMEPAGE:
-    * http://code.google.com/p/caliper/
+    * https://github.com/google/caliper
 
 This product optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameDecoder.java
@@ -31,7 +31,7 @@ import static io.netty.handler.codec.compression.Lz4Constants.*;
 /**
  * Uncompresses a {@link ByteBuf} encoded with the LZ4 format.
  *
- * See original <a href="http://code.google.com/p/lz4/">LZ4 website</a>
+ * See original <a href="https://github.com/Cyan4973/lz4">LZ4 Github project</a>
  * and <a href="http://fastcompression.blogspot.ru/2011/05/lz4-explained.html">LZ4 block format</a>
  * for full description.
  *
@@ -121,7 +121,7 @@ public class Lz4FrameDecoder extends ByteToMessageDecoder {
      *                           uncompressed data, and if the checksums do not match, a suitable
      *                           {@link DecompressionException} will be thrown. In this case encoder will use
      *                           xxhash hashing for Java, based on Yann Collet's work available at
-     *                           <a href="http://code.google.com/p/xxhash/">Google Code</a>.
+     *                           <a href="https://github.com/Cyan4973/xxHash">Github</a>.
      */
     public Lz4FrameDecoder(LZ4Factory factory, boolean validateChecksums) {
         this(factory, validateChecksums ?

--- a/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/Lz4FrameEncoder.java
@@ -42,7 +42,7 @@ import static io.netty.handler.codec.compression.Lz4Constants.*;
 /**
  * Compresses a {@link ByteBuf} using the LZ4 format.
  *
- * See original <a href="http://code.google.com/p/lz4/">LZ4 website</a>
+ * See original <a href="https://github.com/Cyan4973/lz4">LZ4 Github project</a>
  * and <a href="http://fastcompression.blogspot.ru/2011/05/lz4-explained.html">LZ4 block format</a>
  * for full description.
  *
@@ -98,7 +98,7 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
     /**
      * Creates the fastest LZ4 encoder with default block size (64 KB)
      * and xxhash hashing for Java, based on Yann Collet's work available at
-     * <a href="http://code.google.com/p/xxhash/">Google Code</a>.
+     * <a href="https://github.com/Cyan4973/xxHash">Github</a>.
      */
     public Lz4FrameEncoder() {
         this(false);
@@ -107,7 +107,7 @@ public class Lz4FrameEncoder extends MessageToByteEncoder<ByteBuf> {
     /**
      * Creates a new LZ4 encoder with hight or fast compression, default block size (64 KB)
      * and xxhash hashing for Java, based on Yann Collet's work available at
-     * <a href="http://code.google.com/p/xxhash/">Google Code</a>.
+     * <a href="https://github.com/Cyan4973/xxHash">Github</a>.
      *
      * @param highCompressor  if {@code true} codec will use compressor which requires more memory
      *                        and is slower but compresses more efficiently

--- a/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameDecoder.java
@@ -26,7 +26,7 @@ import static io.netty.handler.codec.compression.Snappy.validateChecksum;
 /**
  * Uncompresses a {@link ByteBuf} encoded with the Snappy framing format.
  *
- * See http://code.google.com/p/snappy/source/browse/trunk/framing_format.txt
+ * See <a href="https://github.com/google/snappy/blob/master/framing_format.txt">Snappy framing format</a>.
  *
  * Note that by default, validation of the checksum header in each chunk is
  * DISABLED for performance improvements. If performance is less of an issue,

--- a/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/SnappyFrameEncoder.java
@@ -24,7 +24,7 @@ import static io.netty.handler.codec.compression.Snappy.*;
 /**
  * Compresses a {@link ByteBuf} using the Snappy framing format.
  *
- * See http://code.google.com/p/snappy/source/browse/trunk/framing_format.txt
+ * See <a href="https://github.com/google/snappy/blob/master/framing_format.txt">Snappy framing format</a>.
  */
 public class SnappyFrameEncoder extends MessageToByteEncoder<ByteBuf> {
     /**

--- a/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
@@ -32,7 +32,7 @@ import java.util.List;
 
 /**
  * Decodes a received {@link ByteBuf} into a
- * <a href="http://code.google.com/p/protobuf/">Google Protocol Buffers</a>
+ * <a href="https://github.com/google/protobuf">Google Protocol Buffers</a>
  * {@link Message} and {@link MessageLite}. Please note that this decoder must
  * be used with a proper {@link ByteToMessageDecoder} such as {@link ProtobufVarint32FrameDecoder}
  * or {@link LengthFieldBasedFrameDecoder} if you are using a stream-based

--- a/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoderNano.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoderNano.java
@@ -30,7 +30,7 @@ import io.netty.util.internal.ObjectUtil;
 
 /**
  * Decodes a received {@link ByteBuf} into a
- * <a href="http://code.google.com/p/protobuf/">Google Protocol Buffers</a>
+ * <a href="https://github.com/google/protobuf">Google Protocol Buffers</a>
  * {@link MessageNano}. Please note that this decoder must
  * be used with a proper {@link ByteToMessageDecoder} such as {@link LengthFieldBasedFrameDecoder}
  * if you are using a stream-based transport such as TCP/IP. A typical setup for TCP/IP would be:

--- a/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufEncoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufEncoder.java
@@ -31,7 +31,7 @@ import java.util.List;
 import static io.netty.buffer.Unpooled.*;
 
 /**
- * Encodes the requested <a href="http://code.google.com/p/protobuf/">Google
+ * Encodes the requested <a href="https://github.com/google/protobuf">Google
  * Protocol Buffers</a> {@link Message} and {@link MessageLite} into a
  * {@link ByteBuf}. A typical setup for TCP/IP would be:
  * <pre>

--- a/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufEncoderNano.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufEncoderNano.java
@@ -29,7 +29,7 @@ import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.codec.MessageToMessageEncoder;
 
 /**
- * Encodes the requested <a href="http://code.google.com/p/protobuf/">Google
+ * Encodes the requested <a href="https://github.com/google/protobuf">Google
  * Protocol Buffers</a> {@link MessageNano} into a
  * {@link ByteBuf}. A typical setup for TCP/IP would be:
  * <pre>


### PR DESCRIPTION
Motivation:

This pull request does not solve any problem but we find that several links in the code refer to project websites under the domain of http://code.google.com which are either moved to github or not maintained anymore.


Modification:

Update the project links from code.google.com to the relevant project in github.com
