### PR TITLE
Make NioEventLoop group not final

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -53,7 +53,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * {@link Selector} and so does the multi-plexing of these in the event loop.
  *
  */
-public final class NioEventLoop extends SingleThreadEventLoop {
+public class NioEventLoop extends SingleThreadEventLoop {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(NioEventLoop.class);
 


### PR DESCRIPTION
Motivation: I want to be able to subclass `NioEventLoop` so I can slightly tweak behavior or add functionality such as timing how long each event in the EventLoop takes.

Modification: Remove the `final` modifier from `NioEventLoop`