### PR TITLE
Minor doc updates

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
@@ -265,7 +265,7 @@ public class SocketFileRegionTest extends AbstractSocketTest {
         @Override
         @Deprecated
         public long transfered() {
-            return region.transfered();
+            return region.transferred();
         }
 
         @Override

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -399,7 +399,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
             }
 
             flushedAmount += localFlushedAmount;
-            if (region.transfered() >= regionCount) {
+            if (region.transferred() >= regionCount) {
                 done = true;
                 break;
             }

--- a/transport/src/main/java/io/netty/channel/FileRegion.java
+++ b/transport/src/main/java/io/netty/channel/FileRegion.java
@@ -49,8 +49,6 @@ import java.nio.channels.WritableByteChannel;
  * performance.  For example, sending a large file doesn't work well in Windows.
  *
  * <h3>Not all transports support it</h3>
- *
- * Currently, the NIO transport is the only transport that supports {@link FileRegion}.
  */
 public interface FileRegion extends ReferenceCounted {
 


### PR DESCRIPTION
    Motivation:
    
    Make the FileRegion comments about which transports are supported more accurate.
    Also, eleminate any outstanding references to FileRegion.transfered as the method was renamed for spelling.
    
    Modifications:
    
    Class-level comment on FileRegion, can call renamed method.
    
    Result:
    
    More accurate documentation and less calls to deprecated methods.
