### PR TITLE
OpenSsl tests incomplete check for supporting key manager

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -144,13 +144,17 @@ public final class OpenSsl {
                             certBio = ReferenceCountedOpenSslContext.toBIO(cert.cert());
                             SSL.setCertificateChainBio(ssl, certBio, false);
                             supportsKeyManagerFactory = true;
-                            useKeyManagerFactory = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-                                @Override
-                                public Boolean run() {
-                                    return SystemPropertyUtil.getBoolean(
-                                            "io.netty.handler.ssl.openssl.useKeyManagerFactory", true);
-                                }
-                            });
+                            try {
+                                useKeyManagerFactory = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+                                    @Override
+                                    public Boolean run() {
+                                        return SystemPropertyUtil.getBoolean(
+                                                "io.netty.handler.ssl.openssl.useKeyManagerFactory", true);
+                                    }
+                                });
+                            } catch (Throwable ignore) {
+                                logger.debug("Failed to get useKeyManagerFactory system property.");
+                            }
                         } catch (Throwable ignore) {
                             logger.debug("KeyManagerFactory not supported.");
                         }

--- a/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkOpenSslEngineInteroptTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import javax.net.ssl.SSLException;
 
+import static io.netty.handler.ssl.OpenSslTestUtils.checkShouldUseKeyManagerFactory;
 import static io.netty.internal.tcnative.SSL.SSL_CVERIFY_IGNORED;
 import static org.junit.Assume.assumeTrue;
 
@@ -47,35 +48,35 @@ public class JdkOpenSslEngineInteroptTest extends SSLEngineTest {
     @Override
     @Test
     public void testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth() throws Exception {
-        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        checkShouldUseKeyManagerFactory();
         super.testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth();
     }
 
     @Override
     @Test
     public void testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth() throws Exception {
-        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        checkShouldUseKeyManagerFactory();
         super.testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth();
     }
 
     @Override
     @Test
     public void testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth() throws Exception {
-        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        checkShouldUseKeyManagerFactory();
         super.testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth();
     }
 
     @Override
     @Test
     public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth() throws Exception {
-        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        checkShouldUseKeyManagerFactory();
         super.testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth();
     }
 
     @Override
     @Test
     public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth() throws Exception {
-        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        checkShouldUseKeyManagerFactory();
         super.testMutualAuthValidClientCertChainTooLongFailRequireClientAuth();
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -39,6 +39,7 @@ import javax.net.ssl.SSLEngineResult;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 
+import static io.netty.handler.ssl.OpenSslTestUtils.checkShouldUseKeyManagerFactory;
 import static io.netty.handler.ssl.ReferenceCountedOpenSslEngine.MAX_ENCRYPTED_PACKET_LENGTH;
 import static io.netty.handler.ssl.ReferenceCountedOpenSslEngine.MAX_TLS_RECORD_OVERHEAD_LENGTH;
 import static io.netty.handler.ssl.ReferenceCountedOpenSslEngine.MAX_PLAINTEXT_LENGTH;
@@ -67,35 +68,35 @@ public class OpenSslEngineTest extends SSLEngineTest {
     @Override
     @Test
     public void testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth() throws Exception {
-        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        checkShouldUseKeyManagerFactory();
         super.testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth();
     }
 
     @Override
     @Test
     public void testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth() throws Exception {
-        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        checkShouldUseKeyManagerFactory();
         super.testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth();
     }
 
     @Override
     @Test
     public void testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth() throws Exception {
-        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        checkShouldUseKeyManagerFactory();
         super.testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth();
     }
 
     @Override
     @Test
     public void testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth() throws Exception {
-        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        checkShouldUseKeyManagerFactory();
         super.testMutualAuthValidClientCertChainTooLongFailOptionalClientAuth();
     }
 
     @Override
     @Test
     public void testMutualAuthValidClientCertChainTooLongFailRequireClientAuth() throws Exception {
-        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        checkShouldUseKeyManagerFactory();
         super.testMutualAuthValidClientCertChainTooLongFailRequireClientAuth();
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslJdkSslEngineInteroptTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslJdkSslEngineInteroptTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import javax.net.ssl.SSLException;
 
+import static io.netty.handler.ssl.OpenSslTestUtils.checkShouldUseKeyManagerFactory;
 import static org.junit.Assume.assumeTrue;
 
 public class OpenSslJdkSslEngineInteroptTest extends SSLEngineTest {
@@ -57,21 +58,21 @@ public class OpenSslJdkSslEngineInteroptTest extends SSLEngineTest {
     @Override
     @Test
     public void testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth() throws Exception {
-        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        checkShouldUseKeyManagerFactory();
         super.testMutualAuthInvalidIntermediateCASucceedWithOptionalClientAuth();
     }
 
     @Override
     @Test
     public void testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth() throws Exception {
-        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        checkShouldUseKeyManagerFactory();
         super.testMutualAuthInvalidIntermediateCAFailWithOptionalClientAuth();
     }
 
     @Override
     @Test
     public void testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth() throws Exception {
-        assumeTrue(OpenSsl.supportsKeyManagerFactory());
+        checkShouldUseKeyManagerFactory();
         super.testMutualAuthInvalidIntermediateCAFailWithRequiredClientAuth();
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslTestUtils.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslTestUtils.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import static org.junit.Assume.assumeTrue;
+
+final class OpenSslTestUtils {
+    private OpenSslTestUtils() {
+    }
+
+    static void checkShouldUseKeyManagerFactory() {
+        assumeTrue(OpenSsl.supportsKeyManagerFactory() && OpenSsl.useKeyManagerFactory());
+    }
+}


### PR DESCRIPTION
Motivaiton:
It is possible that if the OpenSSL library supports the interfaces required to use the KeyManagerFactory, but we fail to get the io.netty.handler.ssl.openssl.useKeyManagerFactory system property (or this property is set to false) that SSLEngineTest based unit tests which use a KeyManagerFactory will fail.

Modifications:
- We should check if the OpenSSL library supports the KeyManagerFactory interfaces and if the system property allows them to be used in OpenSslEngineTests

Result:
Unit tests which use OpenSSL and KeyManagerFactory will be skipped instead of failing.