### PR TITLE
PlatformDependent0 should enforce array index scale for byte[] explic…

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -167,6 +167,16 @@ final class PlatformDependent0 {
                     unsafe = null;
                 }
             }
+
+            if (unsafe != null) {
+                // There are assumptions made where ever BYTE_ARRAY_BASE_OFFSET is used (equals, hashCodeAscii, and
+                // primitive accessors) that arrayIndexScale == 1, and results are undefined if this is not the case.
+                long byteArrayIndexScale = unsafe.arrayIndexScale(byte[].class);
+                if (byteArrayIndexScale != 1) {
+                    logger.debug("unsafe.arrayIndexScale is {} (expected: 1). Not using unsafe.", byteArrayIndexScale);
+                    unsafe = null;
+                }
+            }
         }
         UNSAFE = unsafe;
 


### PR DESCRIPTION
…itly

Motivation:
PlatformDependent0 makes assumptions that the array index scale for byte[] is always 1. If this is not the case the results from methods which make this assumption will be undefined.

Modifications:
- PlatformDependent0 should check if unsafe.arrayIndexScale(byte[].class) is not 1, and if so not use unsafe

Result:
Assumptions made by optimizations in PlatformDependent0 which use byte[] are explicitly enforced.