### PR TITLE
Add support for IBM J9 Http2 cipher names.

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
@@ -34,26 +34,51 @@ public final class Http2SecurityUtil {
      * href="https://wiki.mozilla.org/Security/Server_Side_TLS#Non-Backward_Compatible_Ciphersuite">Mozilla Cipher
      * Suites</a> in accordance with the <a
      * href="https://tools.ietf.org/html/draft-ietf-httpbis-http2-16#section-9.2.2">HTTP/2 Specification</a>.
+     *
+     * According to the <a href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html">
+     * JSSE documentation</a> "the names mentioned in the TLS RFCs prefixed with TLS_ are functionally equivalent
+     * to the JSSE cipher suites prefixed with SSL_".
+     * Both variants are used to support JVMs supporting the one or the other.
      */
     public static final List<String> CIPHERS;
 
     private static final List<String> CIPHERS_JAVA_MOZILLA_INCREASED_SECURITY = Collections.unmodifiableList(Arrays
             .asList(
             /* Java 8 */
-            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", /* openssl = ECDHE-ECDSA-AES256-GCM-SHA384 */
-            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", /* openssl = ECDHE-ECDSA-AES128-GCM-SHA256 */
-            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", /* openssl = ECDHE-RSA-AES256-GCM-SHA384 */
+            /* openssl = ECDHE-ECDSA-AES256-GCM-SHA384 */
+            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+            "SSL_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+            /* openssl = ECDHE-ECDSA-AES128-GCM-SHA256 */
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            "SSL_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            /* openssl = ECDHE-RSA-AES256-GCM-SHA384 */
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            "SSL_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+
             /* REQUIRED BY HTTP/2 SPEC */
-            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", /* openssl = ECDHE-RSA-AES128-GCM-SHA256 */
+            /* openssl = ECDHE-RSA-AES128-GCM-SHA256 */
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+            "SSL_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+
             /* REQUIRED BY HTTP/2 SPEC */
-            "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256", /* openssl = DHE-RSA-AES128-GCM-SHA256 */
-            "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256" /* openssl = DHE-DSS-AES128-GCM-SHA256 */));
+            /* openssl = DHE-RSA-AES128-GCM-SHA256 */
+            "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+            "SSL_DHE_RSA_WITH_AES_128_GCM_SHA256",
+            /* openssl = DHE-DSS-AES128-GCM-SHA256 */
+            "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256",
+            "SSL_DHE_DSS_WITH_AES_128_GCM_SHA256"
+            ));
 
     private static final List<String> CIPHERS_JAVA_NO_MOZILLA_INCREASED_SECURITY = Collections.unmodifiableList(Arrays
             .asList(
             /* Java 8 */
-            "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384", /* openssl = DHE-RSA-AES256-GCM-SHA384 */
-            "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384" /* openssl = DHE-DSS-AES256-GCM-SHA384 */));
+            /* openssl = DHE-RSA-AES256-GCM-SHA384 */
+            "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+            "SSL_DHE_RSA_WITH_AES_256_GCM_SHA384",
+            /* openssl = DHE-DSS-AES256-GCM-SHA384 */
+            "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384",
+            "SSL_DHE_DSS_WITH_AES_256_GCM_SHA384"
+            ));
 
     static {
         List<String> ciphers = new ArrayList<String>(CIPHERS_JAVA_MOZILLA_INCREASED_SECURITY.size()


### PR DESCRIPTION
Motivation:
Http2SecurityUtil currently lists HTTP/2 ciphers as documented by
JSSE docs [1] and the IANA [2] using the TLS_ prefix.
In some IBM J9 implementations the SSL_ prefix is used, which is also
covered by the JSSE.

[1] http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html
[2] http://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml

Modifications:
Add both variants of the cipher names (prefixed with SSL_ in additon to TLS_)

Result:
HTTP/2 connections can now be created using the SslProvider.JDK on IBM J9
and potentially other JVMs which use the SSL_ prefix.