### PR TITLE
Remove duplicate call to SSLContext.setVerify from ReferenceCountedOp…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslServerContext.java
@@ -21,7 +21,6 @@ import io.netty.internal.tcnative.SSLContext;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
@@ -109,9 +108,6 @@ public final class ReferenceCountedOpenSslServerContext extends ReferenceCounted
                                 "KeyManagerFactory not supported");
                     }
                     checkNotNull(keyCertChain, "keyCertChain");
-
-                        /* Set certificate verification policy. */
-                    SSLContext.setVerify(ctx, SSL.SSL_CVERIFY_NONE, VERIFY_DEPTH);
 
                     setKeyMaterial(ctx, keyCertChain, key, keyPassword);
                 } else {


### PR DESCRIPTION
…enSslServerContext

Motivation:
5e649850898889a8d2f1e526db610a8fca19c1ff introduced support for the KeyManagerFactory while using OpenSSL. This same commit also introduced 2 calls to SSLContext.setVerify when 1 should be sufficient.

Modifications:
- Remove the duplicate call to SSLContext.setVerify

Result:
Less duplicate code in ReferenceCountedOpenSslServerContext.