### PR TITLE
Use SystemPropertyUtil to access system properties

### DIFF
--- a/common/src/main/java/io/netty/util/NetUtil.java
+++ b/common/src/main/java/io/netty/util/NetUtil.java
@@ -17,6 +17,7 @@ package io.netty.util;
 
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.SocketUtils;
+import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -121,12 +122,13 @@ public final class NetUtil {
     /**
      * {@code true} if IPv4 should be used even if the system supports both IPv4 and IPv6.
      */
-    private static final boolean IPV4_PREFERRED = Boolean.getBoolean("java.net.preferIPv4Stack");
+    private static final boolean IPV4_PREFERRED = SystemPropertyUtil.getBoolean("java.net.preferIPv4Stack", false);
 
     /**
      * {@code true} if an IPv6 address should be preferred when a host has both an IPv4 address and an IPv6 address.
      */
-    private static final boolean IPV6_ADDRESSES_PREFERRED = Boolean.getBoolean("java.net.preferIPv6Addresses");
+    private static final boolean IPV6_ADDRESSES_PREFERRED =
+            SystemPropertyUtil.getBoolean("java.net.preferIPv6Addresses", false);
 
     /**
      * The logger being used by this class

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -915,18 +915,7 @@ public final class PlatformDependent {
     }
 
     static int majorVersionFromJavaSpecificationVersion() {
-        try {
-            final String javaSpecVersion = AccessController.doPrivileged(new PrivilegedAction<String>() {
-                @Override
-                public String run() {
-                    return System.getProperty("java.specification.version");
-                }
-            });
-            return majorVersion(javaSpecVersion);
-        } catch (SecurityException e) {
-            logger.debug("security exception while reading java.specification.version", e);
-            return 6;
-        }
+        return majorVersion(SystemPropertyUtil.get("java.specification.version", "1.6"));
     }
 
     static int majorVersion(final String javaSpecVersion) {

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -27,7 +27,7 @@ import static io.netty.util.internal.ObjectUtil.*;
 public final class StringUtil {
 
     public static final String EMPTY_STRING = "";
-    public static final String NEWLINE = System.getProperty("line.separator");
+    public static final String NEWLINE = SystemPropertyUtil.get("line.separator", "\n");
 
     public static final char DOUBLE_QUOTE = '\"';
     public static final char COMMA = ',';

--- a/common/src/main/java/io/netty/util/internal/SystemPropertyUtil.java
+++ b/common/src/main/java/io/netty/util/internal/SystemPropertyUtil.java
@@ -75,7 +75,7 @@ public final class SystemPropertyUtil {
                     }
                 });
             }
-        } catch (Exception e) {
+        } catch (SecurityException e) {
             logger.warn("Unable to retrieve a system property '{}'; default values will be used.", key, e);
         }
 

--- a/common/src/main/java/io/netty/util/internal/ThreadLocalRandom.java
+++ b/common/src/main/java/io/netty/util/internal/ThreadLocalRandom.java
@@ -26,8 +26,6 @@ import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.lang.Thread.UncaughtExceptionHandler;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.SecureRandom;
 import java.util.Random;
 import java.util.concurrent.BlockingQueue;
@@ -74,21 +72,9 @@ public final class ThreadLocalRandom extends Random {
     private static volatile long seedGeneratorEndTime;
 
     static {
-        initialSeedUniquifier = AccessController.doPrivileged(new PrivilegedAction<Long>() {
-            @Override
-            public Long run() {
-                return Long.getLong("io.netty.initialSeedUniquifier", 0);
-            }
-        });
-
+        initialSeedUniquifier = SystemPropertyUtil.getLong("io.netty.initialSeedUniquifier", 0);
         if (initialSeedUniquifier == 0) {
-            boolean secureRandom = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-                @Override
-                public Boolean run() {
-                    return Boolean.getBoolean("java.util.secureRandomSeed");
-                }
-            });
-
+            boolean secureRandom = SystemPropertyUtil.getBoolean("java.util.secureRandomSeed", false);
             if (secureRandom) {
                 seedQueue = new LinkedBlockingQueue<Long>();
                 seedGeneratorStartTime = System.nanoTime();


### PR DESCRIPTION
Motivation:

We should use SystemPropertyUtil to access system properties and so always handle SecurityExceptions.

Modifications:

Use SystemPropertyUtil everywhere.

Result:

Better and consist handling of SecurityException.