### PR TITLE
Recognizing TLS Extension "HeartBeat" as Valid TLS Packet

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -182,6 +182,7 @@ final class SslUtils {
             case SSL_CONTENT_TYPE_ALERT:
             case SSL_CONTENT_TYPE_HANDSHAKE:
             case SSL_CONTENT_TYPE_APPLICATION_DATA:
+            case SSL_CONTENT_TYPE_EXTENSION_HEARTBEAT:
                 tls = true;
                 break;
             default:

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -49,6 +49,11 @@ final class SslUtils {
     static final int SSL_CONTENT_TYPE_APPLICATION_DATA = 23;
 
     /**
+     * HeartBeat Extension
+     */
+    static final int SSL_CONTENT_TYPE_EXTENSION_HEARTBEAT = 24;
+
+    /**
      * the length of the ssl record header (in bytes)
      */
     static final int SSL_RECORD_HEADER_LENGTH = 5;
@@ -90,6 +95,7 @@ final class SslUtils {
             case SSL_CONTENT_TYPE_ALERT:
             case SSL_CONTENT_TYPE_HANDSHAKE:
             case SSL_CONTENT_TYPE_APPLICATION_DATA:
+            case SSL_CONTENT_TYPE_EXTENSION_HEARTBEAT:
                 tls = true;
                 break;
             default:


### PR DESCRIPTION
Motivation:

The widely used SSL Implementation, OpenSSL, already supports Heartbeat Extension; both sending and responding to Heartbeat Messages. But, since Netty is not recognizing that extension as valid packet, peers won't be able to use this extension.

Modification:

Update SslUtils.java to recognize Heartbeat Extension as valid tls packet.

Result:

With this change, softwares using Netty + OpenSSL will be able to respond for TLS Heartbeat requests (actually taken care by OpenSSL - no need of any extra implementation from Clients)