### PR TITLE
Replace system.out.println with InternalLoggerFactory

### DIFF
--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
@@ -33,11 +33,15 @@ public class AbstractMicrobenchmark extends AbstractMicrobenchmarkBase {
 
     protected static final int DEFAULT_FORKS = 2;
 
+    private final InternalLogger logger = InternalLoggerFactory.getInstance(getClass());
+
     public static final class HarnessExecutor extends ThreadPoolExecutor {
         public HarnessExecutor(int maxThreads, String prefix) {
             super(maxThreads, maxThreads, 0, TimeUnit.MILLISECONDS,
                     new LinkedBlockingQueue<Runnable>(), new DefaultThreadFactory(prefix));
-            System.out.println("Using harness executor");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Using harness executor");
+            }
         }
     }
 

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
@@ -28,68 +28,69 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 
 /**
- * Default implementation of the JMH microbenchmark adapter.  There may be context switches introduced by this harness.
+ * Default implementation of the JMH microbenchmark adapter. There may be
+ * context switches introduced by this harness.
  */
 @Fork(AbstractMicrobenchmark.DEFAULT_FORKS)
 public class AbstractMicrobenchmark extends AbstractMicrobenchmarkBase {
 
-    protected static final int DEFAULT_FORKS = 2;
+	protected static final int DEFAULT_FORKS = 2;
 
-    private final InternalLogger logger = InternalLoggerFactory.getInstance(getClass());
+	public static final class HarnessExecutor extends ThreadPoolExecutor {
+		private final InternalLogger logger = InternalLoggerFactory.getInstance(getClass());
 
-    public static final class HarnessExecutor extends ThreadPoolExecutor {
-        public HarnessExecutor(int maxThreads, String prefix) {
-            super(maxThreads, maxThreads, 0, TimeUnit.MILLISECONDS,
-                    new LinkedBlockingQueue<Runnable>(), new DefaultThreadFactory(prefix));
-            if (logger.isDebugEnabled()) {
-                logger.debug("Using harness executor");
-            }
-        }
-    }
+		public HarnessExecutor(int maxThreads, String prefix) {
+			super(maxThreads, maxThreads, 0, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>(),
+					new DefaultThreadFactory(prefix));
+			if (logger.isDebugEnabled()) {
+				logger.debug("Using harness executor");
+			}
+		}
+	}
 
-    private final String[] jvmArgs;
+	private final String[] jvmArgs;
 
-    public AbstractMicrobenchmark() {
-        this(false, false);
-    }
+	public AbstractMicrobenchmark() {
+		this(false, false);
+	}
 
-    public AbstractMicrobenchmark(boolean disableAssertions) {
-        this(disableAssertions, false);
-    }
+	public AbstractMicrobenchmark(boolean disableAssertions) {
+		this(disableAssertions, false);
+	}
 
-    public AbstractMicrobenchmark(boolean disableAssertions, boolean disableHarnessExecutor) {
-        final String[] customArgs;
-        if (disableHarnessExecutor) {
-            customArgs = new String[]{"-Xms768m", "-Xmx768m", "-XX:MaxDirectMemorySize=768m"};
-        } else {
-            customArgs = new String[]{"-Xms768m", "-Xmx768m", "-XX:MaxDirectMemorySize=768m", "-Djmh.executor=CUSTOM",
-                    "-Djmh.executor.class=io.netty.microbench.util.AbstractMicrobenchmark$HarnessExecutor"};
-        }
-        String[] jvmArgs = new String[BASE_JVM_ARGS.length + customArgs.length];
-        System.arraycopy(BASE_JVM_ARGS, 0, jvmArgs, 0, BASE_JVM_ARGS.length);
-        System.arraycopy(customArgs, 0, jvmArgs, BASE_JVM_ARGS.length, customArgs.length);
-        if (disableAssertions) {
-            jvmArgs = removeAssertions(jvmArgs);
-        }
-        this.jvmArgs = jvmArgs;
-    }
+	public AbstractMicrobenchmark(boolean disableAssertions, boolean disableHarnessExecutor) {
+		final String[] customArgs;
+		if (disableHarnessExecutor) {
+			customArgs = new String[] { "-Xms768m", "-Xmx768m", "-XX:MaxDirectMemorySize=768m" };
+		} else {
+			customArgs = new String[] { "-Xms768m", "-Xmx768m", "-XX:MaxDirectMemorySize=768m", "-Djmh.executor=CUSTOM",
+					"-Djmh.executor.class=io.netty.microbench.util.AbstractMicrobenchmark$HarnessExecutor" };
+		}
+		String[] jvmArgs = new String[BASE_JVM_ARGS.length + customArgs.length];
+		System.arraycopy(BASE_JVM_ARGS, 0, jvmArgs, 0, BASE_JVM_ARGS.length);
+		System.arraycopy(customArgs, 0, jvmArgs, BASE_JVM_ARGS.length, customArgs.length);
+		if (disableAssertions) {
+			jvmArgs = removeAssertions(jvmArgs);
+		}
+		this.jvmArgs = jvmArgs;
+	}
 
-    @Override
-    protected String[] jvmArgs() {
-        return jvmArgs;
-    }
+	@Override
+	protected String[] jvmArgs() {
+		return jvmArgs;
+	}
 
-    @Override
-    protected ChainedOptionsBuilder newOptionsBuilder() throws Exception {
-        ChainedOptionsBuilder runnerOptions = super.newOptionsBuilder();
-        if (getForks() > 0) {
-            runnerOptions.forks(getForks());
-        }
+	@Override
+	protected ChainedOptionsBuilder newOptionsBuilder() throws Exception {
+		ChainedOptionsBuilder runnerOptions = super.newOptionsBuilder();
+		if (getForks() > 0) {
+			runnerOptions.forks(getForks());
+		}
 
-        return runnerOptions;
-    }
+		return runnerOptions;
+	}
 
-    protected int getForks() {
-        return SystemPropertyUtil.getInt("forks", -1);
-    }
+	protected int getForks() {
+		return SystemPropertyUtil.getInt("forks", -1);
+	}
 }

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
@@ -17,6 +17,8 @@ package io.netty.microbench.util;
 
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmark.java
@@ -28,69 +28,68 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 
 /**
- * Default implementation of the JMH microbenchmark adapter. There may be
- * context switches introduced by this harness.
+ * Default implementation of the JMH microbenchmark adapter.  There may be context switches introduced by this harness.
  */
 @Fork(AbstractMicrobenchmark.DEFAULT_FORKS)
 public class AbstractMicrobenchmark extends AbstractMicrobenchmarkBase {
 
-	protected static final int DEFAULT_FORKS = 2;
+    protected static final int DEFAULT_FORKS = 2;
 
-	public static final class HarnessExecutor extends ThreadPoolExecutor {
-		private final InternalLogger logger = InternalLoggerFactory.getInstance(getClass());
+    public static final class HarnessExecutor extends ThreadPoolExecutor {
+        private final  InternalLogger logger = InternalLoggerFactory.getInstance(AbstractMicrobenchmark.class);
 
-		public HarnessExecutor(int maxThreads, String prefix) {
-			super(maxThreads, maxThreads, 0, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<Runnable>(),
-					new DefaultThreadFactory(prefix));
-			if (logger.isDebugEnabled()) {
-				logger.debug("Using harness executor");
-			}
-		}
-	}
+        public HarnessExecutor(int maxThreads, String prefix) {
+            super(maxThreads, maxThreads, 0, TimeUnit.MILLISECONDS,
+                    new LinkedBlockingQueue<Runnable>(), new DefaultThreadFactory(prefix));
+            if (logger.isDebugEnabled()) {
+                logger.debug("Using harness executor");
+            }
+        }
+    }
 
-	private final String[] jvmArgs;
+    private final String[] jvmArgs;
 
-	public AbstractMicrobenchmark() {
-		this(false, false);
-	}
+    public AbstractMicrobenchmark() {
+        this(false, false);
+    }
 
-	public AbstractMicrobenchmark(boolean disableAssertions) {
-		this(disableAssertions, false);
-	}
+    public AbstractMicrobenchmark(boolean disableAssertions) {
+        this(disableAssertions, false);
+    }
 
-	public AbstractMicrobenchmark(boolean disableAssertions, boolean disableHarnessExecutor) {
-		final String[] customArgs;
-		if (disableHarnessExecutor) {
-			customArgs = new String[] { "-Xms768m", "-Xmx768m", "-XX:MaxDirectMemorySize=768m" };
-		} else {
-			customArgs = new String[] { "-Xms768m", "-Xmx768m", "-XX:MaxDirectMemorySize=768m", "-Djmh.executor=CUSTOM",
-					"-Djmh.executor.class=io.netty.microbench.util.AbstractMicrobenchmark$HarnessExecutor" };
-		}
-		String[] jvmArgs = new String[BASE_JVM_ARGS.length + customArgs.length];
-		System.arraycopy(BASE_JVM_ARGS, 0, jvmArgs, 0, BASE_JVM_ARGS.length);
-		System.arraycopy(customArgs, 0, jvmArgs, BASE_JVM_ARGS.length, customArgs.length);
-		if (disableAssertions) {
-			jvmArgs = removeAssertions(jvmArgs);
-		}
-		this.jvmArgs = jvmArgs;
-	}
+    public AbstractMicrobenchmark(boolean disableAssertions, boolean disableHarnessExecutor) {
+        final String[] customArgs;
+        if (disableHarnessExecutor) {
+            customArgs = new String[]{"-Xms768m", "-Xmx768m", "-XX:MaxDirectMemorySize=768m"};
+        } else {
+            customArgs = new String[]{"-Xms768m", "-Xmx768m", "-XX:MaxDirectMemorySize=768m", "-Djmh.executor=CUSTOM",
+                    "-Djmh.executor.class=io.netty.microbench.util.AbstractMicrobenchmark$HarnessExecutor"};
+        }
+        String[] jvmArgs = new String[BASE_JVM_ARGS.length + customArgs.length];
+        System.arraycopy(BASE_JVM_ARGS, 0, jvmArgs, 0, BASE_JVM_ARGS.length);
+        System.arraycopy(customArgs, 0, jvmArgs, BASE_JVM_ARGS.length, customArgs.length);
+        if (disableAssertions) {
+            jvmArgs = removeAssertions(jvmArgs);
+        }
+        this.jvmArgs = jvmArgs;
+    }
 
-	@Override
-	protected String[] jvmArgs() {
-		return jvmArgs;
-	}
+    @Override
+    protected String[] jvmArgs() {
+        return jvmArgs;
+    }
 
-	@Override
-	protected ChainedOptionsBuilder newOptionsBuilder() throws Exception {
-		ChainedOptionsBuilder runnerOptions = super.newOptionsBuilder();
-		if (getForks() > 0) {
-			runnerOptions.forks(getForks());
-		}
+    @Override
+    protected ChainedOptionsBuilder newOptionsBuilder() throws Exception {
+        ChainedOptionsBuilder runnerOptions = super.newOptionsBuilder();
+        if (getForks() > 0) {
+            runnerOptions.forks(getForks());
+        }
 
-		return runnerOptions;
-	}
+        return runnerOptions;
+    }
 
-	protected int getForks() {
-		return SystemPropertyUtil.getInt("forks", -1);
-	}
+    protected int getForks() {
+        return SystemPropertyUtil.getInt("forks", -1);
+    }
 }

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
@@ -18,8 +18,6 @@ package io.netty.microbench.util;
 import static org.junit.Assert.assertNull;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.internal.SystemPropertyUtil;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
@@ -18,6 +18,8 @@ package io.netty.microbench.util;
 import static org.junit.Assert.assertNull;
 import io.netty.util.ResourceLeakDetector;
 import io.netty.util.internal.SystemPropertyUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.io.File;
 import java.util.ArrayList;

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractSharedExecutorMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractSharedExecutorMicrobenchmark.java
@@ -21,6 +21,8 @@ import io.netty.util.concurrent.AbstractEventExecutor;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.ProgressivePromise;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.concurrent.TimeUnit;
 
@@ -35,7 +37,6 @@ public class AbstractSharedExecutorMicrobenchmark extends AbstractMicrobenchmark
 
     protected static final int DEFAULT_FORKS = 1;
     protected static final String[] JVM_ARGS;
-    private final InternalLogger logger = InternalLoggerFactory.getInstance(getClass());
 
     static {
         final String[] customArgs = {
@@ -64,9 +65,11 @@ public class AbstractSharedExecutorMicrobenchmark extends AbstractMicrobenchmark
      */
     public static final class DelegateHarnessExecutor extends AbstractEventExecutor {
         private static EventLoop executor;
+        private InternalLogger logger = InternalLoggerFactory.getInstance(DelegateHarnessExecutor.class);
+
         public DelegateHarnessExecutor(int maxThreads, String prefix) {
             if (logger.isDebugEnabled()) {
-                logger.debug("Using DelegateHarnessExecutor executor {}" + this);
+                logger.debug("Using DelegateHarnessExecutor executor " + this);
             }
         }
 

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractSharedExecutorMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractSharedExecutorMicrobenchmark.java
@@ -35,6 +35,7 @@ public class AbstractSharedExecutorMicrobenchmark extends AbstractMicrobenchmark
 
     protected static final int DEFAULT_FORKS = 1;
     protected static final String[] JVM_ARGS;
+    private final InternalLogger logger = InternalLoggerFactory.getInstance(getClass());
 
     static {
         final String[] customArgs = {
@@ -64,7 +65,9 @@ public class AbstractSharedExecutorMicrobenchmark extends AbstractMicrobenchmark
     public static final class DelegateHarnessExecutor extends AbstractEventExecutor {
         private static EventLoop executor;
         public DelegateHarnessExecutor(int maxThreads, String prefix) {
-            System.out.println("Using DelegateHarnessExecutor executor " + this);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Using DelegateHarnessExecutor executor " + this);
+            }
         }
 
         /**

--- a/microbench/src/main/java/io/netty/microbench/util/AbstractSharedExecutorMicrobenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractSharedExecutorMicrobenchmark.java
@@ -66,7 +66,7 @@ public class AbstractSharedExecutorMicrobenchmark extends AbstractMicrobenchmark
         private static EventLoop executor;
         public DelegateHarnessExecutor(int maxThreads, String prefix) {
             if (logger.isDebugEnabled()) {
-                logger.debug("Using DelegateHarnessExecutor executor " + this);
+                logger.debug("Using DelegateHarnessExecutor executor {}" + this);
             }
         }
 


### PR DESCRIPTION
Motivation:

There are two files that still use `system.out.println` to log their status

Modification:

Replace `system.out.println` with a `debug` function inside an instance of `InternalLoggerFactory`

Result:

Introduce an instance of `InternalLoggerFactory` in class `AbstractMicrobenchmark.java` and `AbstractSharedExecutorMicrobenchmark.java`