### PR TITLE
Adding method to assert XML decoder framing works

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/xml/XmlFrameDecoderTest.java
@@ -143,17 +143,24 @@ public class XmlFrameDecoderTest {
     }
 
     @Test
+    public void testFraming() {
+        testDecodeWithXml(Arrays.asList("<abc", ">123</a", "bc>"), "<abc>123</abc>");
+    }
+
+    @Test
     public void testDecodeWithSampleXml() {
         for (final String xmlSample : xmlSamples) {
             testDecodeWithXml(xmlSample, xmlSample);
         }
     }
 
-    private static void testDecodeWithXml(String xml, Object... expected) {
+    private static void testDecodeWithXml(List<String> xmlFrames, Object... expected) {
         EmbeddedChannel ch = new EmbeddedChannel(new XmlFrameDecoder(1048576));
         Exception cause = null;
         try {
-            ch.writeInbound(Unpooled.copiedBuffer(xml, CharsetUtil.UTF_8));
+            for (String xmlFrame : xmlFrames) {
+                ch.writeInbound(Unpooled.copiedBuffer(xmlFrame, CharsetUtil.UTF_8));
+            }
         } catch (Exception e) {
             cause = e;
         }
@@ -178,6 +185,10 @@ public class XmlFrameDecoderTest {
         } finally {
             ch.finish();
         }
+    }
+
+    private static void testDecodeWithXml(String xml, Object... expected) {
+        testDecodeWithXml(Collections.singletonList(xml), expected);
     }
 
     private String sample(String number) throws IOException, URISyntaxException {


### PR DESCRIPTION
Motivation:

In an effort to better understand how the XmlFrameDecoder works, I consulted the tests to find a method that would reframe the inputs as per the Javadocs for that class.  I couldn't find any methods that seemed to be doing it, so I wanted to add one to reinforce my understanding.

Modification:

Add a new test method to XmlFrameDecoder to assert that the reframing works as described.

Result:

New test method is added to XmlFrameDecoder
