### PR TITLE
http2: Http2StreamChannel now shares options of its parent channel

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -305,6 +305,12 @@ public final class Http2MultiplexCodec extends ChannelDuplexHandler {
         }
         channel.pipeline().addLast(handler);
 
+        // We need to copy parent's channel options into a child's options to make
+        // sure they share same allocator, same receive buffer allocator, etc.
+        //
+        // See https://github.com/netty/netty/issues/6551
+        channel.config().setOptions(parentChannel.config().getOptions());
+
         initOpts(channel, options);
         initAttrs(channel, attrs);
 


### PR DESCRIPTION
Fixes #6551

# Motivation

`Http2StreamChannel` ignores options of its parent channel when being created. That leads to surprising results when, for example, unpooled allocator could be silently replaced with pooled allocator (default setting).

# Modification

Copy parent channel's options over to the `Http2StreamChannel`.

# Result

Channel options are now consistent between `Http2StreamChannel` and its parent channel. Newly added test passes on this branch and fails on master.

# Implementation Notes

My initial idea was to just return `parent().config()` in `Http2StreamChannel.config` implementation but I gave up on it by the following reasons:

1) It immediately failed the `Http2MultiplexCodecTest.channelReadShouldRespectAutoRead` test since `child.config().setAutoRead(true)` was no longer triggering `child.read()` request (it triggered `child.parent().read()` request instead). I assumed it was essential to keep this behaviour (`Http2StreamChannel.config().setAutoRead(true)` triggers read) in place.

2) Just referencing parent channel's options means they will be amended by `Http2StreamChannelBootstrap.options` at the moment the first HTTP/2 stream channel is created, which is not necessary what we want.

Presumably, I might be missing some context here so please let me know how do you feel about this approach. I'm happy to change the direction in this PR if people think it's better to reference parent's options (do not copy) and solve that auto-read problem in some ad-hoc way.