### PR TITLE
fix failure logging of value on channel option set

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -461,7 +461,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
             }
         } catch (Throwable t) {
             logger.warn(
-                    "Failed to set channel option '{}' with value '{}' for channel '{}'", option, channel, channel, t);
+                    "Failed to set channel option '{}' with value '{}' for channel '{}'", option, value, channel, t);
         }
     }
 


### PR DESCRIPTION
Pass value to failure log as value instead of accidentally passing channel.

Motivation:

The code accidentally passes channel twice instead of value, resulting in logs like:
`Failed to set channel option 'SO_SNDBUF' with value '[id: 0x2c5b2eb4]' for channel '[id: 0x2c5b2eb4]'`

Modifications:

Pass value instead of channel where it needs to be.

Result:

`Failed to set channel option 'SO_SNDBUF' with value '0' for channel '[id: 0x9bd3c5b8]'`


