### PR TITLE
Adding new length-based frame decoder for cases when the length field…

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilLengthOfBomTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilLengthOfBomTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer;
+
+import com.google.common.base.Charsets;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class ByteBufUtilLengthOfBomTest {
+
+    private final Charset charset;
+    private final int expectedBomLength;
+    private final boolean injectBom;
+
+    public ByteBufUtilLengthOfBomTest(Charset charset, int expectedBomLength, boolean injectBom) {
+        this.charset = charset;
+        this.expectedBomLength = expectedBomLength;
+        this.injectBom = injectBom;
+    }
+
+    @Test
+    public void lengthOfBom() throws IOException {
+        final byte[] bytes = ((injectBom ? ByteBufUtil.BOM_STR : "") + "Hello there").getBytes(charset);
+
+        ByteBuf buf = Unpooled.copiedBuffer(bytes);
+        try {
+            int length = ByteBufUtil.lengthOfByteOrderMark(buf, charset);
+            assertThat(length, equalTo(expectedBomLength));
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Parameterized.Parameters(name = "{index}: charset = {0}, expectedBomLength = {1}, injectBom = {2}")
+    public static Collection<Object> data() {
+        List<Object> params = new ArrayList<Object>();
+        params.add(new Object[]{Charsets.UTF_8, 3, true});
+        params.add(new Object[]{Charsets.UTF_16BE, 2, true});
+        params.add(new Object[]{Charsets.UTF_16LE, 2, true});
+        params.add(new Object[]{Charsets.UTF_8, 0, false});
+        params.add(new Object[]{Charsets.UTF_16BE, 0, false});
+        params.add(new Object[]{Charsets.UTF_16LE, 0, false});
+        return params;
+    }
+
+}

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -15,10 +15,13 @@
  */
 package io.netty.buffer;
 
+import com.google.common.base.Charsets;
 import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 import org.junit.Test;
+import org.junit.runners.Parameterized;
 
+import java.io.IOException;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -29,11 +32,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
 
 public class ByteBufUtilTest {
     @Test

--- a/codec/src/main/java/io/netty/handler/codec/BaseLengthBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/BaseLengthBasedFrameDecoder.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.serialization.ObjectDecoder;
+
+import java.util.List;
+
+/**
+ * Encapsulates common logic and state for message decoders that attempt to detect frames
+ * of a certain length
+ */
+public abstract class BaseLengthBasedFrameDecoder extends ByteToMessageDecoder {
+
+    protected final int maxFrameLength;
+    protected final boolean failFast;
+    protected boolean discardingTooLongFrame;
+    protected long tooLongFrameLength;
+    protected long bytesToDiscard;
+
+    protected BaseLengthBasedFrameDecoder(int maxFrameLength, boolean failFast) {
+        this.maxFrameLength = maxFrameLength;
+        this.failFast = failFast;
+    }
+
+    /**
+     * Fail the decoding due to a frame that is too long, as per {@link #maxFrameLength}
+     *
+     * @param firstDetectionOfTooLongFrame true if this is the first time the too-long frame was detected
+     * @return true if all bytes from the too-long frame were discarded
+     */
+    protected boolean failIfNecessary(boolean firstDetectionOfTooLongFrame) {
+        if (bytesToDiscard == 0) {
+            // Reset to the initial state and tell the handlers that
+            // the frame was too large.
+            final long prevTooLongFrameLength = tooLongFrameLength;
+            tooLongFrameLength = 0;
+            discardingTooLongFrame = false;
+            if (!failFast || firstDetectionOfTooLongFrame) {
+                fail(prevTooLongFrameLength);
+            }
+            return true;
+        }
+        // Keep discarding and notify handlers if necessary.
+        if (failFast && firstDetectionOfTooLongFrame) {
+            fail(tooLongFrameLength);
+        }
+        return false;
+    }
+
+    protected void resetStateOnTooLongFrame() {
+        // do nothing by default
+    }
+
+    /**
+     * Extract the sub-region of the specified buffer.
+     * <p>
+     * If you are sure that the frame and its content are not accessed after
+     * the current {@link #decode(ChannelHandlerContext, ByteBuf)}
+     * call returns, you can even avoid memory copy by returning the sliced
+     * sub-region (i.e. <tt>return buffer.slice(index, length)</tt>).
+     * It's often useful when you convert the extracted frame into an object.
+     * Refer to the source code of {@link ObjectDecoder} to see how this method
+     * is overridden to avoid memory copy.
+     */
+    protected ByteBuf extractFrame(ByteBuf buffer, int index, int length) {
+        return buffer.retainedSlice(index, length);
+    }
+
+    /**
+     * @deprecated - use {@link #extractFrame(ByteBuf, int, int)} instead, since the
+     * {@link ChannelHandlerContext} is not actually needed for implementation
+     */
+    @Deprecated
+    protected ByteBuf extractFrame(@SuppressWarnings({ "unused", "squid:S1172" }) ChannelHandlerContext ignored,
+                                   ByteBuf buffer, int index, int length) {
+        return buffer.retainedSlice(index, length);
+    }
+
+    @Override
+    protected final void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+        Object decoded = decode(ctx, in);
+        if (decoded != null) {
+            out.add(decoded);
+        }
+    }
+
+    protected abstract Object decode(@SuppressWarnings({ "unused", "squid:S1172" }) ChannelHandlerContext ctx,
+                                     ByteBuf in) throws Exception;
+
+    protected void discardingTooLongFrame(ByteBuf in) {
+        long bytesToDiscard = this.bytesToDiscard;
+        int localBytesToDiscard = (int) Math.min(bytesToDiscard, in.readableBytes());
+        in.skipBytes(localBytesToDiscard);
+        bytesToDiscard -= localBytesToDiscard;
+        this.bytesToDiscard = bytesToDiscard;
+
+        failIfNecessary(false);
+    }
+
+    protected void fail(long frameLength) {
+        resetStateOnTooLongFrame();
+        if (frameLength > 0) {
+            throw new TooLongFrameException(
+                "Adjusted frame length exceeds " + maxFrameLength +
+                    ": " + frameLength + " - discarded");
+        } else {
+            throw new TooLongFrameException(
+                "Adjusted frame length exceeds " + maxFrameLength +
+                    " - discarding");
+        }
+    }
+}

--- a/codec/src/main/java/io/netty/handler/codec/DelimitedLengthFieldBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/DelimitedLengthFieldBasedFrameDecoder.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.CharsetUtil;
+
+import java.nio.charset.Charset;
+
+/**
+ * <p> Frames input by looking for a length field (in bytes) that is delimited, as opposed to being a fixed byte length.
+ *  Only single-byte encoding (i.e. UTF-8) of the length field and delimiter characters are supported, although the
+ * remaining frame can be anything (i.e. is not interpreted by this decoder). </p><p> Uses the same approach as the
+ * {@link DelimiterBasedFrameDecoder} to find delimiter in input </p>
+ */
+public class DelimitedLengthFieldBasedFrameDecoder extends BaseLengthBasedFrameDecoder {
+
+    public static final Charset CHARSET = CharsetUtil.UTF_8;
+
+    private final int lengthAdjustment;
+    private final ByteBuf delimiter;
+    private final boolean trimLengthString;
+
+    private boolean consumingLength = true;
+    private long frameLength;
+
+    private final int maxPossibleLengthInBytes;
+
+    public DelimitedLengthFieldBasedFrameDecoder(
+            int maxFrameLength,
+            int lengthAdjustment,
+            boolean failFast,
+            ByteBuf delimiter,
+            boolean trimLengthString
+    ) {
+        super(maxFrameLength, failFast);
+        if (delimiter == null) {
+            throw new NullPointerException("delimiter");
+        }
+        if (!delimiter.isReadable()) {
+            throw new IllegalArgumentException("empty delimiter");
+        }
+
+        this.delimiter = delimiter.slice(delimiter.readerIndex(), delimiter.readableBytes());
+        this.lengthAdjustment = lengthAdjustment;
+        this.trimLengthString = trimLengthString;
+
+        maxPossibleLengthInBytes = String.valueOf(maxFrameLength).length();
+    }
+
+    protected int indexWithin(ByteBuf haystack, ByteBuf needle) {
+        return DelimiterBasedFrameDecoder.indexWithin(haystack, needle);
+    }
+
+    /**
+     * Create a frame out of the {@link ByteBuf} and return it.
+     *
+     * @param ctx the {@link ChannelHandlerContext} which this {@link ByteToMessageDecoder} belongs to
+     * @param in the {@link ByteBuf} from which to read data
+     *
+     * @return the {@link ByteBuf} which represents the frame or {@code null} if no frame could be created.
+     */
+    @Override
+    protected Object decode(@SuppressWarnings({ "unused", "squid:S1172" }) ChannelHandlerContext ctx, ByteBuf in)
+            throws Exception {
+        if (discardingTooLongFrame) {
+            long bytesToDiscard = this.bytesToDiscard;
+            int localBytesToDiscard = (int) Math.min(bytesToDiscard, in.readableBytes());
+            in.skipBytes(localBytesToDiscard);
+            bytesToDiscard -= localBytesToDiscard;
+            this.bytesToDiscard = bytesToDiscard;
+
+            failIfNecessary(false);
+
+            // if exception was not thrown, reader has been advanced by readable bytes already, so return null to
+            // continue processing too long frame
+            return null;
+        }
+
+        if (consumingLength) {
+            int delimIndex = indexWithin(in, delimiter);
+            if (delimIndex < 0) {
+                return null;
+            }
+
+            frameLength = extractFrameLength(in, delimIndex);
+
+            if (frameLength < 0) {
+                throw new CorruptedFrameException("negative pre-adjustment length field: " + frameLength);
+            }
+
+            // this will not overflow because lengthAdjustment is an int
+            frameLength += lengthAdjustment;
+
+            //consume length field and delimiter bytes
+            in.skipBytes(delimIndex + delimiter.capacity());
+
+            //consume delimiter bytes
+            consumingLength = false;
+        }
+
+        if (frameLength > maxFrameLength) {
+            long discard = frameLength - in.readableBytes();
+            tooLongFrameLength = frameLength;
+
+            if (discard < 0) {
+                // buffer contains more bytes then the frameLength so we can discard all now
+                // will not overflow because frameLength must be less than in.readableBytes, an int
+                in.skipBytes((int) frameLength);
+            } else {
+                // Enter the discard mode and discard everything received so far.
+                discardingTooLongFrame = true;
+                bytesToDiscard = discard;
+                in.skipBytes(in.readableBytes());
+            }
+            failIfNecessary(true);
+            return null;
+        }
+
+        // never overflows because it's less than maxFrameLength
+        int frameLengthInt = (int) frameLength;
+        if (in.readableBytes() < frameLengthInt) {
+            // need more bytes available to read actual frame
+            return null;
+        }
+
+        // extract frame
+        int readerIndex = in.readerIndex();
+        ByteBuf frame = extractFrame(in, readerIndex, frameLengthInt);
+        in.readerIndex(readerIndex + frameLengthInt);
+
+        // the frame is now entirely present, reset state vars
+        consumingLength = true;
+        frameLength = 0;
+
+        return frame;
+    }
+
+    private int extractFrameLength(ByteBuf in, int delimIndex) {
+        if (delimIndex > maxPossibleLengthInBytes) {
+            throw new TooLongFrameException(
+                    "Length field delimiter offset (" + delimIndex + ") exceeds maximum possible byte length for" +
+                    " specified frame size (" + maxPossibleLengthInBytes + ")"
+            );
+        }
+        final String lengthStr = in.toString(in.readerIndex(), delimIndex, CHARSET);
+        try {
+            return Integer.parseInt(trimLengthString? lengthStr.trim() : lengthStr);
+
+        } catch (NumberFormatException e) {
+            throw new CorruptedFrameException(
+                    String.format(
+                            "Invalid length field decoded: %s",
+                            lengthStr
+                    ),
+                    e
+            );
+        }
+    }
+
+    @Override
+    protected void resetStateOnTooLongFrame() {
+        consumingLength = true;
+        frameLength = 0;
+    }
+}

--- a/codec/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/DelimiterBasedFrameDecoder.java
@@ -233,7 +233,7 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoder {
         int minFrameLength = Integer.MAX_VALUE;
         ByteBuf minDelim = null;
         for (ByteBuf delim: delimiters) {
-            int frameLength = indexOf(buffer, delim);
+            int frameLength = indexWithin(buffer, delim);
             if (frameLength >= 0 && frameLength < minFrameLength) {
                 minFrameLength = frameLength;
                 minDelim = delim;
@@ -250,10 +250,10 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoder {
                 discardingTooLongFrame = false;
                 buffer.skipBytes(minFrameLength + minDelimLength);
 
-                int tooLongFrameLength = this.tooLongFrameLength;
-                this.tooLongFrameLength = 0;
+                final int prevTooLongFrameLength = tooLongFrameLength;
+                tooLongFrameLength = 0;
                 if (!failFast) {
-                    fail(tooLongFrameLength);
+                    fail(prevTooLongFrameLength);
                 }
                 return null;
             }
@@ -309,8 +309,13 @@ public class DelimiterBasedFrameDecoder extends ByteToMessageDecoder {
      * Returns the number of bytes between the readerIndex of the haystack and
      * the first needle found in the haystack.  -1 is returned if no needle is
      * found in the haystack.
+     *
+     * @param haystack the buffer to search for an occurence of the needle
+     * @param needle the buffer to find in the haystack
+     *
+     * @return the first relative byte index of the needle found within the haystack, or -1 if not found
      */
-    private static int indexOf(ByteBuf haystack, ByteBuf needle) {
+    protected static int indexWithin(ByteBuf haystack, ByteBuf needle) {
         for (int i = haystack.readerIndex(); i < haystack.writerIndex(); i ++) {
             int haystackIndex = i;
             int needleIndex;

--- a/codec/src/main/java/io/netty/handler/codec/marshalling/MarshallingDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/marshalling/MarshallingDecoder.java
@@ -81,7 +81,18 @@ public class MarshallingDecoder extends LengthFieldBasedFrameDecoder {
     }
 
     @Override
-    protected ByteBuf extractFrame(ChannelHandlerContext ctx, ByteBuf buffer, int index, int length) {
+    protected ByteBuf extractFrame(ByteBuf buffer, int index, int length) {
         return buffer.slice(index, length);
+    }
+
+    /**
+     * @deprecated - use {@link #extractFrame(ByteBuf, int, int)} instead, since the
+     * {@link ChannelHandlerContext} is not actually needed for implementation
+     */
+    @Override
+    @Deprecated
+    protected ByteBuf extractFrame(@SuppressWarnings({ "unused", "squid:S1172" }) ChannelHandlerContext ignored,
+                                   ByteBuf buffer, int index, int length) {
+        return extractFrame(buffer, index, length);
     }
 }

--- a/codec/src/test/java/io/netty/handler/codec/DelimitedLengthFieldBasedFrameDecoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DelimitedLengthFieldBasedFrameDecoderTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec;
+
+import com.google.common.primitives.Bytes;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.CharsetUtil;
+import io.netty.util.internal.ThreadLocalRandom;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+public class DelimitedLengthFieldBasedFrameDecoderTest {
+
+    public static final String TEST_DELIM = " ";
+    private static final Charset CHARSET = DelimitedLengthFieldBasedFrameDecoder.CHARSET;
+
+    private static List<List<Byte>> getRandomByteSlices(byte[] bytes) {
+        List<Byte> byteList = Bytes.asList(bytes);
+
+        int numSlices = nextInt(2, 10);
+        List<Integer> sliceIndexes = new ArrayList<Integer>();
+        for (int i = 0; i < numSlices; i++) {
+            sliceIndexes.add(nextInt(0, bytes.length));
+        }
+        Collections.sort(sliceIndexes);
+
+        List<List<Byte>> slices = new ArrayList<List<Byte>>(numSlices);
+
+        int byteInd = 0;
+        for (int sliceIndex : sliceIndexes) {
+            slices.add(byteList.subList(byteInd, sliceIndex));
+            byteInd = sliceIndex;
+        }
+        slices.add(byteList.subList(byteInd, byteList.size()));
+
+        return slices;
+    }
+
+    /**
+     * Generates a new pseudo-random integer within the specific range.
+     * <p>
+     * This is essentially the same method that is present in Apache commons-lang.  It is simply copied here to avoid
+     * bringing in a new dependency
+     *
+     * @param startInclusive the lowest value that can be generated
+     * @param endExclusive
+     *
+     * @return a pseurandom number in [startInclusive, endExclusive)
+     */
+    private static int nextInt(final int startInclusive, final int endExclusive) {
+        if (startInclusive == endExclusive) {
+            return startInclusive;
+        }
+
+        return startInclusive + ThreadLocalRandom.current().nextInt(endExclusive - startInclusive);
+    }
+
+    @Test
+    public void delimitedLengths() throws Exception {
+        EmbeddedChannel ch = getTestChannel(100, 0, false, true);
+
+        String v1 = "a";
+        String v2 = "abcdefghij";
+        String v3 =
+                "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv" +
+                "wxyz";
+
+        writeStringAndAssert(ch, v1, false, false);
+        writeStringAndAssert(ch, v2, false, false);
+        writeStringAndAssert(ch, v3, false, true);
+
+        writeStringAndAssert(ch, v1, true, false);
+        writeStringAndAssert(ch, v2, true, false);
+        writeStringAndAssert(ch, v3, true, true);
+
+        writeStringAndAssert(ch, v1, false, false);
+
+        Assert.assertFalse(ch.finishAndReleaseAll());
+    }
+
+    @Test
+    public void multipleFramesSingleBuffer() throws Exception {
+        for (Charset charset : new Charset[] {
+                CharsetUtil.ISO_8859_1, CharsetUtil.UTF_8
+        }) {
+            channelForMultiMessageTest(charset, charset.name().startsWith("UTF"), false);
+            channelForMultiMessageTest(charset, charset.name().startsWith("UTF"), true);
+        }
+    }
+
+    private void channelForMultiMessageTest(Charset charset, boolean includeUnicodeChars, boolean trimLengthString) {
+        EmbeddedChannel ch = getTestChannel(100, 0, false, trimLengthString);
+
+        List<String> frames = new LinkedList<String>(Arrays.asList("a", "xy", "xyz"));
+        if (includeUnicodeChars) {
+            frames.add("блин");
+        }
+        frames.add("cba");
+        StringBuilder longFrame = new StringBuilder();
+        for (String frame : frames) {
+            longFrame.append(makeFrame(frame));
+            if (trimLengthString) {
+                longFrame.append("\n");
+            }
+        }
+
+        ch.writeInbound(Unpooled.copiedBuffer(longFrame.toString(), charset));
+
+        for (String frame : frames) {
+            ByteBuf in = ch.readInbound();
+            Assert.assertNotNull(in);
+            Assert.assertEquals(frame, in.toString(charset));
+        }
+
+        Assert.assertFalse(ch.finishAndReleaseAll());
+    }
+
+    @Test
+    public void maxFrameLengthOverflow() throws Exception {
+        Charset charset = CharsetUtil.ISO_8859_1;
+        // maxFrameLength plus adjustment would overflow an int
+        final long numBytes = Integer.MAX_VALUE - 1;
+        final int lengthAdjustment = 10;
+        EmbeddedChannel ch = getTestChannel((int) numBytes, lengthAdjustment, true, true);
+
+        //this is a bad frame, but will still test the overflow condition
+        String longString = String.valueOf(numBytes) + " abcd";
+
+        try {
+            ch.writeInbound(Unpooled.copiedBuffer(longString, charset));
+            Assert.fail("TooLongFrameException should have been thrown");
+        } catch (TooLongFrameException ignored) {
+            //expected
+        }
+        Assert.assertNull(ch.readInbound());
+
+        Assert.assertFalse(ch.finishAndReleaseAll());
+    }
+
+    @Test(expected = TooLongFrameException.class)
+    public void delimiterTooFar() throws Exception {
+        EmbeddedChannel ch = getTestChannel(Integer.MAX_VALUE, 0, true, true);
+        ch.writeInbound(Unpooled.copiedBuffer("" + Long.MAX_VALUE + TEST_DELIM + "a", CHARSET));
+    }
+
+    /**
+     * Tests Syslog message frames, using the Octet Counting method described in section 3.4.1 of
+     * RFC 6587
+     */
+    @Test
+    public void rfc6587SyslogMessages() {
+        final List<String> syslogMessages = new LinkedList<String>();
+        syslogMessages.add("<29>Apr 7 11:23:55 yourmachine su: 'su root' failed for bart on /dev/pts/5");
+        syslogMessages.add("<13>Jun 3 17:32:18 10.0.2.199 sometag ls not found on path");
+
+        syslogMessages.add("<34>1 2016-09-22T13:14:15.003Z mymachine.example.com su - \n" +
+                           "ID47 - BOM'su root' failed for bart on /dev/pts/5");
+
+        syslogMessages.add("<0>2012-08-16T09:14:29-08:00 127.0.0.1 test gcc not found");
+
+        EmbeddedChannel ch = getTestChannel(Integer.MAX_VALUE, 0, true, false);
+
+        for (String syslogMessage : syslogMessages) {
+            writeStringAndAssert(ch, syslogMessage, true, false);
+        }
+
+        Assert.assertFalse(ch.finishAndReleaseAll());
+    }
+
+    private static EmbeddedChannel getTestChannel(int maxFrameLength, int lengthAdjustment,
+                                                  boolean failFast, boolean trimLengthString) {
+        return new EmbeddedChannel(
+                new DelimitedLengthFieldBasedFrameDecoder(
+                        maxFrameLength,
+                        lengthAdjustment,
+                        failFast,
+                        Unpooled.copiedBuffer(TEST_DELIM, CHARSET),
+                        trimLengthString
+                )
+        );
+    }
+
+    private static void writeStringAndAssert(EmbeddedChannel channel, String value,
+                                             boolean randomlyPartition, boolean expectFrameTooLarge) {
+        String frame = makeFrame(value);
+
+        try {
+            if (randomlyPartition) {
+                for (List<Byte> chunk : getRandomByteSlices(frame.getBytes())) {
+                    channel.writeInbound(Unpooled.copiedBuffer(Bytes.toArray(chunk)));
+                }
+            } else {
+                channel.writeInbound(Unpooled.copiedBuffer(frame, CHARSET));
+            }
+        } catch (TooLongFrameException e) {
+            if (!expectFrameTooLarge) {
+                Assert.fail("TooLongFrameException unexpectedly thrown");
+            } else {
+                Assert.assertNull(channel.readInbound());
+            }
+        }
+        if (!expectFrameTooLarge) {
+            ByteBuf in = channel.readInbound();
+            Assert.assertEquals(value, in.toString(CHARSET));
+            in.release();
+        }
+    }
+
+    private static String makeFrame(String value) {
+        final byte[] bytes = value.getBytes(CHARSET);
+        final int bomLength = ByteBufUtil.lengthOfByteOrderMark(Unpooled.copiedBuffer(bytes), CHARSET);
+        int byteLength = bytes.length - bomLength;
+
+        return byteLength + TEST_DELIM + value;
+    }
+}


### PR DESCRIPTION
… is delimited, not fixed length, adding unit test

Motivation:

I am working on parsing Syslog over TCP ([RFC 6587](https://tools.ietf.org/html/rfc6587#section-3.4.1)).  In this format, the frame length is in a field that is separated by a space from the data itself.  I wasn't able to find a built-in decoder in Netty to handle it, since the existing LengthFieldBasedFrameDecoder relies in a fixed-width length field.


Modification:

Added new decoder class and unit test, made io.netty.handler.codec.DelimiterBasedFrameDecoder#indexOf public so new class can call it

Result:

New decoder class and unit test
