### PR TITLE
EmptyByteBuf allows writing ByteBufs with 0 readable bytes

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/EmptyByteBuf.java
@@ -760,7 +760,7 @@ public final class EmptyByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf writeBytes(ByteBuf src) {
-        throw new IndexOutOfBoundsException();
+        return checkLength(src.readableBytes());
     }
 
     @Override

--- a/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/EmptyByteBufTest.java
@@ -29,6 +29,19 @@ public class EmptyByteBufTest {
     }
 
     @Test
+    public void testWriteEmptyByteBuf() {
+        EmptyByteBuf empty = new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT);
+        empty.writeBytes(Unpooled.EMPTY_BUFFER); // Ok
+        ByteBuf nonEmpty = UnpooledByteBufAllocator.DEFAULT.buffer().writeBoolean(false);
+        try {
+            empty.writeBytes(nonEmpty);
+            fail();
+        } catch (IndexOutOfBoundsException ignored) {
+            // Ignore.
+        }
+    }
+
+    @Test
     public void testIsReadable() {
         EmptyByteBuf empty = new EmptyByteBuf(UnpooledByteBufAllocator.DEFAULT);
         assertFalse(empty.isReadable());


### PR DESCRIPTION
Motivation:

The contract of `ByteBuf.writeBytes(ByteBuf src)` is such that it will throw an `IndexOutOfBoundsException` if `src.readableBytes()` is greater than `this.writableBytes()`. The EmptyByteBuf class will throw the exception, even if the source buffer has zero readable bytes, in violation of the contract.

Modifications:

Use the helper method `checkLength(..)` to check the length and throw the exception, if appropriate.

Result:

Conformance with the stated behavior of ByteBuf.