### PR TITLE
non-latin character broken on HttpHeader by HttpObjectDecoder

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -805,7 +805,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
         @Override
         public boolean process(byte value) throws Exception {
-            char nextByte = (char) value;
+            char nextByte = (char) (value & 0xFF);
             if (nextByte == HttpConstants.CR) {
                 return true;
             }


### PR DESCRIPTION
I encountered non-latin character broken on HttpHeader by HttpObjectDecoder.

Steps to reproduce:
1. request with non-ascii character in Request Header
$ curl -v http://localhost/testurl -H"Host:www.foo.com" -H"foo:한글中文"
2. Then, request.headers().get("foo") have broken characters. "????"

$ java -version
java version "1.8.0_101"
Java(TM) SE Runtime Environment (build 1.8.0_101-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.101-b13, mixed mode)

Operating system: Ubuntu Linux 16.04 64-bit

$ uname -a
Linux myhost 4.4.0-66-generic #87-Ubuntu SMP Fri Mar 3 15:29:05 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
