### PR TITLE
LoggingHandler does not override channelReadComplete or channelWritab…

### DIFF
--- a/handler/src/main/java/io/netty/handler/logging/LoggingHandler.java
+++ b/handler/src/main/java/io/netty/handler/logging/LoggingHandler.java
@@ -226,9 +226,17 @@ public class LoggingHandler extends ChannelDuplexHandler {
     }
 
     @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        if (logger.isEnabled(internalLevel)) {
+            logger.log(internalLevel, format(ctx, "READ COMPLETE"));
+        }
+        ctx.fireChannelReadComplete();
+    }
+
+    @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         if (logger.isEnabled(internalLevel)) {
-            logger.log(internalLevel, format(ctx, "RECEIVED", msg));
+            logger.log(internalLevel, format(ctx, "READ", msg));
         }
         ctx.fireChannelRead(msg);
     }
@@ -239,6 +247,14 @@ public class LoggingHandler extends ChannelDuplexHandler {
             logger.log(internalLevel, format(ctx, "WRITE", msg));
         }
         ctx.write(msg, promise);
+    }
+
+    @Override
+    public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+        if (logger.isEnabled(internalLevel)) {
+            logger.log(internalLevel, format(ctx, "WRITABILITY CHANGED"));
+        }
+        ctx.fireChannelWritabilityChanged();
     }
 
     @Override


### PR DESCRIPTION
…ilityChanged

Motivation:

`io.netty.handler.logging.LoggingHandler` does not log when these
events happen.

Modifiations:

Add overrides with logging to these methods.

Result:

Logging now happens for these two events.

Fixes #6566. 
