### PR TITLE
Allow to free direct buffers on java9 again

### DIFF
--- a/common/src/main/java/io/netty/util/internal/Cleaner.java
+++ b/common/src/main/java/io/netty/util/internal/Cleaner.java
@@ -1,0 +1,29 @@
+/*
+* Copyright 2017 The Netty Project
+*
+* The Netty Project licenses this file to you under the Apache License,
+* version 2.0 (the "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at:
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+package io.netty.util.internal;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Allows to free direct {@link ByteBuffer}s.
+ */
+interface Cleaner {
+
+    /**
+     * Free a direct {@link ByteBuffer} if possible
+     */
+    void freeDirectBuffer(ByteBuffer buffer);
+}

--- a/common/src/main/java/io/netty/util/internal/CleanerJava9.java
+++ b/common/src/main/java/io/netty/util/internal/CleanerJava9.java
@@ -1,0 +1,82 @@
+/*
+* Copyright 2017 The Netty Project
+*
+* The Netty Project licenses this file to you under the Apache License,
+* version 2.0 (the "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at:
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+package io.netty.util.internal;
+
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+/**
+ * Provide a way to clean a ByteBuffer on Java9+.
+ */
+final class CleanerJava9 implements Cleaner {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(CleanerJava9.class);
+
+    private static final Method INVOKE_CLEANER;
+
+    static {
+        final Method method;
+        final Throwable error;
+        if (PlatformDependent0.hasUnsafe()) {
+            ByteBuffer buffer = ByteBuffer.allocateDirect(1);
+            Object maybeInvokeMethod;
+            try {
+                // See https://bugs.openjdk.java.net/browse/JDK-8171377
+                Method m = PlatformDependent0.UNSAFE.getClass().getDeclaredMethod("invokeCleaner", ByteBuffer.class);
+                m.invoke(PlatformDependent0.UNSAFE, buffer);
+                maybeInvokeMethod = m;
+            } catch (NoSuchMethodException e) {
+                maybeInvokeMethod = e;
+            } catch (InvocationTargetException e) {
+                maybeInvokeMethod = e;
+            } catch (IllegalAccessException e) {
+                maybeInvokeMethod = e;
+            }
+            if (maybeInvokeMethod instanceof Throwable) {
+                method = null;
+                error = (Throwable) maybeInvokeMethod;
+            } else {
+                method = (Method) maybeInvokeMethod;
+                error = null;
+            }
+        } else {
+            method = null;
+            error = new UnsupportedOperationException("sun.misc.Unsafe unavailable");
+        }
+        if (error == null) {
+            logger.debug("java.nio.ByteBuffer.cleaner(): available");
+        } else {
+            logger.debug("java.nio.ByteBuffer.cleaner(): unavailable", error);
+        }
+        INVOKE_CLEANER = method;
+    }
+
+    static boolean isSupported() {
+        return INVOKE_CLEANER != null;
+    }
+
+    @Override
+    public void freeDirectBuffer(ByteBuffer buffer) {
+        try {
+            INVOKE_CLEANER.invoke(PlatformDependent0.UNSAFE, buffer);
+        } catch (Throwable cause) {
+            PlatformDependent0.throwException(cause);
+        }
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -36,10 +36,12 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 final class PlatformDependent0 {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(PlatformDependent0.class);
-    private static final Unsafe UNSAFE;
     private static final long ADDRESS_FIELD_OFFSET;
     private static final long BYTE_ARRAY_BASE_OFFSET;
     private static final Constructor<?> DIRECT_BUFFER_CONSTRUCTOR;
+    private static final boolean IS_EXPLICIT_NO_UNSAFE = explicitNoUnsafe0();
+
+    static final Unsafe UNSAFE;
 
     // constants borrowed from murmur3
     static final int HASH_CODE_ASCII_SEED = 0xc2b2ae35;
@@ -59,7 +61,7 @@ final class PlatformDependent0 {
         Field addressField = null;
         Unsafe unsafe;
 
-        if (PlatformDependent.isExplicitNoUnsafe()) {
+        if (isExplicitNoUnsafe()) {
             direct = null;
             addressField = null;
             unsafe = null;
@@ -244,7 +246,7 @@ final class PlatformDependent0 {
                 public Object run() {
                     try {
                         Class<?> bitsClass =
-                                Class.forName("java.nio.Bits", false, PlatformDependent.getSystemClassLoader());
+                                Class.forName("java.nio.Bits", false, getSystemClassLoader());
                         Method unalignedMethod = bitsClass.getDeclaredMethod("unaligned");
                         Throwable cause = ReflectionUtil.trySetAccessible(unalignedMethod);
                         if (cause != null) {
@@ -281,10 +283,35 @@ final class PlatformDependent0 {
 
         logger.debug("java.nio.DirectByteBuffer.<init>(long, int): {}",
                 DIRECT_BUFFER_CONSTRUCTOR != null ? "available" : "unavailable");
+    }
 
-        if (direct != null) {
-            freeDirectBuffer(direct);
+    static boolean isExplicitNoUnsafe() {
+        return IS_EXPLICIT_NO_UNSAFE;
+    }
+
+    private static boolean explicitNoUnsafe0() {
+        final boolean noUnsafe = SystemPropertyUtil.getBoolean("io.netty.noUnsafe", false);
+        logger.debug("-Dio.netty.noUnsafe: {}", noUnsafe);
+
+        if (noUnsafe) {
+            logger.debug("sun.misc.Unsafe: unavailable (io.netty.noUnsafe)");
+            return true;
         }
+
+        // Legacy properties
+        boolean tryUnsafe;
+        if (SystemPropertyUtil.contains("io.netty.tryUnsafe")) {
+            tryUnsafe = SystemPropertyUtil.getBoolean("io.netty.tryUnsafe", true);
+        } else {
+            tryUnsafe = SystemPropertyUtil.getBoolean("org.jboss.netty.tryUnsafe", true);
+        }
+
+        if (!tryUnsafe) {
+            logger.debug("sun.misc.Unsafe: unavailable (io.netty.tryUnsafe/org.jboss.netty.tryUnsafe)");
+            return true;
+        }
+
+        return false;
     }
 
     static boolean isUnaligned() {
@@ -329,12 +356,6 @@ final class PlatformDependent0 {
             }
             throw new Error(cause);
         }
-    }
-
-    static void freeDirectBuffer(ByteBuffer buffer) {
-        // Delegate to other class to not break on android
-        // See https://github.com/netty/netty/issues/2604
-        Cleaner0.freeDirectBuffer(buffer);
     }
 
     static long directBufferAddress(ByteBuffer buffer) {


### PR DESCRIPTION
Motivation:

Java9 adds a new method to Unsafe which allows to free direct ByteBuffer via the cleaner without the need to use an commandline arguments.

Modifications:

- Add Cleaner interface
- Add CleanerJava9 which will be used when using Java9+ and take care of release direct ByteBuffer
- Let Cleaner0 implement Cleaner

Result:

Be able to free direct ByteBuffer on Java9+ again without any commandline arguments.