### PR TITLE
Limit the maximum size of the allocated outbound buffer to MAX_ENCRYP…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -1611,7 +1611,8 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     }
 
     static int calculateOutNetBufSize(int pendingBytes, int numComponents) {
-        return (int) min(Integer.MAX_VALUE, pendingBytes + (long) MAX_TLS_RECORD_OVERHEAD_LENGTH * numComponents);
+        return (int) min(MAX_ENCRYPTED_PACKET_LENGTH,
+                pendingBytes + (long) MAX_TLS_RECORD_OVERHEAD_LENGTH * numComponents);
     }
 
     private final class OpenSslSession implements SSLSession, ApplicationProtocolAccessor {

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -318,7 +318,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
 
     @Test
     public void testCalculateOutNetBufSizeOverflow() {
-        assertEquals(MAX_VALUE,
+        assertEquals(OpenSslEngine.MAX_ENCRYPTED_PACKET_LENGTH,
                 ReferenceCountedOpenSslEngine.calculateOutNetBufSize(MAX_VALUE, 1));
     }
 
@@ -326,6 +326,12 @@ public class OpenSslEngineTest extends SSLEngineTest {
     public void testCalculateOutNetBufSize0() {
         assertEquals(MAX_TLS_RECORD_OVERHEAD_LENGTH,
                 ReferenceCountedOpenSslEngine.calculateOutNetBufSize(0, 1));
+    }
+
+    @Test
+    public void testCalculateOutNetBufSizeMaxEncryptedPacketLength() {
+        assertEquals(MAX_ENCRYPTED_PACKET_LENGTH,
+                ReferenceCountedOpenSslEngine.calculateOutNetBufSize(MAX_ENCRYPTED_PACKET_LENGTH + 1, 2));
     }
 
     @Override


### PR DESCRIPTION
…TED_PACKET_LENGTH

Motivation:

We should limit the size of the allocated outbound buffer to MAX_ENCRYPTED_PACKET_LENGTH to ensure we not cause an OOME when the user tries to encrypt a very big buffer.

Modifications:

Limit the size of the allocated outbound buffer to MAX_ENCRYPTED_PACKET_LENGTH

Result:

Fixes [#6564]