### PR TITLE
Add 'io.netty.tryAllocateUninitializedArray' system property which al…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PoolArena.java
+++ b/buffer/src/main/java/io/netty/buffer/PoolArena.java
@@ -672,6 +672,10 @@ abstract class PoolArena<T> implements PoolArenaMetric {
                     directMemoryCacheAlignment);
         }
 
+        private static byte[] newByteArray(int size) {
+            return PlatformDependent.allocateUninitializedArray(size);
+        }
+
         @Override
         boolean isDirect() {
             return false;
@@ -679,12 +683,12 @@ abstract class PoolArena<T> implements PoolArenaMetric {
 
         @Override
         protected PoolChunk<byte[]> newChunk(int pageSize, int maxOrder, int pageShifts, int chunkSize) {
-            return new PoolChunk<byte[]>(this, new byte[chunkSize], pageSize, maxOrder, pageShifts, chunkSize, 0);
+            return new PoolChunk<byte[]>(this, newByteArray(chunkSize), pageSize, maxOrder, pageShifts, chunkSize, 0);
         }
 
         @Override
         protected PoolChunk<byte[]> newUnpooledChunk(int capacity) {
-            return new PoolChunk<byte[]>(this, new byte[capacity], capacity, 0);
+            return new PoolChunk<byte[]>(this, newByteArray(capacity), capacity, 0);
         }
 
         @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
@@ -30,6 +30,11 @@ class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     }
 
     @Override
+    byte[] allocateArray(int initialCapacity) {
+        return PlatformDependent.allocateUninitializedArray(initialCapacity);
+    }
+
+    @Override
     public byte getByte(int index) {
         checkIndex(index);
         return _getByte(index);

--- a/microbench/src/main/java/io/netty/microbench/internal/UnitializedArrayBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/internal/UnitializedArrayBenchmark.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.internal;
+
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.internal.PlatformDependent;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(2)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class UnitializedArrayBenchmark extends AbstractMicrobenchmark {
+
+    @Param({ "1", "10", "100", "1000", "10000", "100000" })
+    private int size;
+
+    @Setup(Level.Trial)
+    public void setupTrial() {
+        if (PlatformDependent.javaVersion() < 9) {
+            throw new IllegalStateException("Needs Java9");
+        }
+        if (!PlatformDependent.hasUnsafe()) {
+            throw new IllegalStateException("Needs Unsafe");
+        }
+    }
+
+    @Override
+    protected String[] jvmArgs() {
+        // Ensure we minimize the GC overhead for this benchmark and also open up required package.
+        // See also https://shipilev.net/jvm-anatomy-park/7-initialization-costs/
+        return new String[] { "-XX:+UseParallelOldGC", "-Xmx8g", "-Xms8g",
+                "-Xmn6g", "--add-opens", "java.base/jdk.internal.misc=ALL-UNNAMED" };
+    }
+
+    @Benchmark
+    public byte[] allocateInitializedByteArray() {
+        return new byte[size];
+    }
+
+    @Benchmark
+    public byte[] allocateUninitializedByteArray() {
+        return PlatformDependent.allocateUninitializedArray(size);
+    }
+}


### PR DESCRIPTION
…lows to allocate byte[] without memset in Java9+

Motivation:

Java9 added a new method to Unsafe which allows to allocate a byte[] without memset it. This can have a massive impact in allocation times when the byte[] is big. This change allows to enable this when using Java9 with the io.netty.tryAllocateUninitializedArray property when running Java9+.
Please note that you will need to open up the jdk.internal.misc package via '--add-opens java.base/jdk.internal.misc=ALL-UNNAMED' as well.

Modifications:

Allow to allocate byte[] without memset on Java9+

Result:

Better performance when allocate big heap buffers and using java9.