### PR TITLE
HTTP/2 remove unnecessary buffer operations

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodec.java
@@ -14,16 +14,6 @@
  */
 package io.netty.handler.codec.http2;
 
-import static io.netty.handler.codec.base64.Base64Dialect.URL_SAFE;
-import static io.netty.handler.codec.http2.Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME;
-import static io.netty.handler.codec.http2.Http2CodecUtil.HTTP_UPGRADE_SETTINGS_HEADER;
-import static io.netty.handler.codec.http2.Http2CodecUtil.SETTING_ENTRY_LENGTH;
-import static io.netty.handler.codec.http2.Http2CodecUtil.writeUnsignedInt;
-import static io.netty.handler.codec.http2.Http2CodecUtil.writeUnsignedShort;
-import static io.netty.util.CharsetUtil.UTF_8;
-import static io.netty.util.ReferenceCountUtil.release;
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.base64.Base64;
@@ -36,6 +26,14 @@ import io.netty.util.internal.UnstableApi;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+
+import static io.netty.handler.codec.base64.Base64Dialect.URL_SAFE;
+import static io.netty.handler.codec.http2.Http2CodecUtil.HTTP_UPGRADE_PROTOCOL_NAME;
+import static io.netty.handler.codec.http2.Http2CodecUtil.HTTP_UPGRADE_SETTINGS_HEADER;
+import static io.netty.handler.codec.http2.Http2CodecUtil.SETTING_ENTRY_LENGTH;
+import static io.netty.util.CharsetUtil.UTF_8;
+import static io.netty.util.ReferenceCountUtil.release;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * Client-side cleartext upgrade codec from HTTP to HTTP/2.
@@ -108,8 +106,8 @@ public class Http2ClientUpgradeCodec implements HttpClientUpgradeHandler.Upgrade
             int payloadLength = SETTING_ENTRY_LENGTH * settings.size();
             buf = ctx.alloc().buffer(payloadLength);
             for (CharObjectMap.PrimitiveEntry<Long> entry : settings.entries()) {
-                writeUnsignedShort(entry.key(), buf);
-                writeUnsignedInt(entry.value(), buf);
+                buf.writeChar(entry.key());
+                buf.writeInt(entry.value().intValue());
             }
 
             // Base64 encode the payload and then convert to a string for the header.

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -48,13 +48,13 @@ public final class Http2CodecUtil {
     public static final CharSequence TLS_UPGRADE_PROTOCOL_NAME = ApplicationProtocolNames.HTTP_2;
 
     public static final int PING_FRAME_PAYLOAD_LENGTH = 8;
-    public static final short MAX_UNSIGNED_BYTE = 0xFF;
+    public static final short MAX_UNSIGNED_BYTE = 0xff;
     /**
      * The maximum number of padding bytes. That is the 255 padding bytes appended to the end of a frame and the 1 byte
      * pad length field.
      */
     public static final int MAX_PADDING = 256;
-    public static final long MAX_UNSIGNED_INT = 0xFFFFFFFFL;
+    public static final long MAX_UNSIGNED_INT = 0xffffffffL;
     public static final int FRAME_HEADER_LENGTH = 9;
     public static final int SETTING_ENTRY_LENGTH = 6;
     public static final int PRIORITY_ENTRY_LENGTH = 5;
@@ -93,7 +93,7 @@ public final class Http2CodecUtil {
     public static final long MAX_CONCURRENT_STREAMS = MAX_UNSIGNED_INT;
     public static final int MAX_INITIAL_WINDOW_SIZE = Integer.MAX_VALUE;
     public static final int MAX_FRAME_SIZE_LOWER_BOUND = 0x4000;
-    public static final int MAX_FRAME_SIZE_UPPER_BOUND = 0xFFFFFF;
+    public static final int MAX_FRAME_SIZE_UPPER_BOUND = 0xffffff;
     public static final long MAX_HEADER_LIST_SIZE = MAX_UNSIGNED_INT;
 
     public static final long MIN_HEADER_TABLE_SIZE = 0;
@@ -202,26 +202,7 @@ public final class Http2CodecUtil {
      * Reads a big-endian (31-bit) integer from the buffer.
      */
     public static int readUnsignedInt(ByteBuf buf) {
-        return (buf.readByte() & 0x7F) << 24 | (buf.readByte() & 0xFF) << 16
-                | (buf.readByte() & 0xFF) << 8 | buf.readByte() & 0xFF;
-    }
-
-    /**
-     * Writes a big-endian (32-bit) unsigned integer to the buffer.
-     */
-    public static void writeUnsignedInt(long value, ByteBuf out) {
-        out.writeByte((int) (value >> 24 & 0xFF));
-        out.writeByte((int) (value >> 16 & 0xFF));
-        out.writeByte((int) (value >> 8 & 0xFF));
-        out.writeByte((int) (value & 0xFF));
-    }
-
-    /**
-     * Writes a big-endian (16-bit) unsigned integer to the buffer.
-     */
-    public static void writeUnsignedShort(int value, ByteBuf out) {
-        out.writeByte(value >> 8 & 0xFF);
-        out.writeByte(value & 0xFF);
+        return buf.readInt() & 0x7fffffff;
     }
 
     /**

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameReaderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameReaderTest.java
@@ -367,7 +367,7 @@ public class DefaultHttp2FrameReaderTest {
             Http2Flags flags, int streamDependency, int weight) throws Http2Exception {
         ByteBuf headerBlock = Unpooled.buffer();
         try {
-            writeUnsignedInt(streamDependency, headerBlock);
+            headerBlock.writeInt(streamDependency);
             headerBlock.writeByte(weight - 1);
             hpackEncoder.encodeHeaders(streamId, headerBlock, headers, Http2HeadersEncoder.NEVER_SENSITIVE);
             writeFrameHeader(output, headerBlock.readableBytes(), HEADERS, flags, streamId);
@@ -393,7 +393,7 @@ public class DefaultHttp2FrameReaderTest {
     private void writePriorityFrame(
             ByteBuf output, int streamId, int streamDependency, int weight) {
         writeFrameHeader(output, 5, PRIORITY, new Http2Flags(), streamId);
-        writeUnsignedInt(streamDependency, output);
+        output.writeInt(streamDependency);
         output.writeByte(weight - 1);
     }
 }


### PR DESCRIPTION
Motivation:
codec-http2 has some helper methods to write to ByteBuf in a big endian fashion. This is the default memory structure for ByteBuf so these helper methods are not necessary.

Modifications:
- remove writeUnsignedInt and writeUnsignedShort

Result:
codec-http2 has less ByteBuf helper methods which are not necessary.