### PR TITLE
HttpServerKeepAliveHandler 204 response with no Content-Length should…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerKeepAliveHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerKeepAliveHandler.java
@@ -103,6 +103,7 @@ public class HttpServerKeepAliveHandler extends ChannelDuplexHandler {
      * <p>
      * <ul>
      *     <li>See <a href="https://tools.ietf.org/html/rfc7230#section-6.3"/></li>
+     *     <li>See <a href="https://tools.ietf.org/html/rfc7230#section-3.3.2"/></li>
      *     <li>See <a href="https://tools.ietf.org/html/rfc7230#section-3.3.3"/></li>
      * </ul>
      *
@@ -112,7 +113,7 @@ public class HttpServerKeepAliveHandler extends ChannelDuplexHandler {
      */
     private static boolean isSelfDefinedMessageLength(HttpResponse response) {
         return isContentLengthSet(response) || isTransferEncodingChunked(response) || isMultipart(response) ||
-               isInformational(response);
+               isInformational(response) || response.status().code() == HttpResponseStatus.NO_CONTENT.code();
     }
 
     private static boolean isInformational(HttpResponse response) {


### PR DESCRIPTION
… keepalive

Motivation:
https://tools.ietf.org/html/rfc7230#section-3.3.2 states that a 204 response MUST NOT include a Content-Length header. If the HTTP version permits keep alive these responses should be treated as keeping the connection alive even if there is no Content-Length header.

Modifications:
- HttpServerKeepAliveHandler#isSelfDefinedMessageLength should account for 204 respones

Result:
Fixes https://github.com/netty/netty/issues/6549.