### PR TITLE
DNS Resolve ambiguity in which DNS servers are used during resolution

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddressStreamProvider.java
@@ -17,15 +17,21 @@ package io.netty.resolver.dns;
 
 import io.netty.util.internal.UnstableApi;
 
-@UnstableApi
-public final class NoopDnsServerAddressStreamProvider implements DnsServerAddressStreamProvider {
-    public static final NoopDnsServerAddressStreamProvider INSTANCE = new NoopDnsServerAddressStreamProvider();
+import static io.netty.resolver.dns.DnsServerAddresses.defaultAddresses;
 
-    private NoopDnsServerAddressStreamProvider() {
+/**
+ * A {@link DnsServerAddressStreamProvider} which will use predefined default DNS servers to use for DNS resolution.
+ * These defaults do not respect your host's machines defaults.
+ */
+@UnstableApi
+public final class DefaultDnsServerAddressStreamProvider implements DnsServerAddressStreamProvider {
+    public static final DefaultDnsServerAddressStreamProvider INSTANCE = new DefaultDnsServerAddressStreamProvider();
+
+    private DefaultDnsServerAddressStreamProvider() {
     }
 
     @Override
     public DnsServerAddressStream nameServerAddressStream(String hostname) {
-        return null;
+        return defaultAddresses().stream();
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -27,6 +27,7 @@ import io.netty.util.internal.UnstableApi;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.netty.resolver.dns.DnsServerAddressStreamProviders.platformDefault;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.intValue;
 
@@ -35,14 +36,8 @@ import static io.netty.util.internal.ObjectUtil.intValue;
  */
 @UnstableApi
 public final class DnsNameResolverBuilder {
-    // TODO(scott): how is this done on Windows? This may require a JNI call to GetNetworkParams
-    // https://msdn.microsoft.com/en-us/library/aa365968(VS.85).aspx.
-    private static final DnsServerAddressStreamProvider DEFAULT_DNS_SERVER_ADDRESS_STREAM_PROVIDER =
-            UnixResolverDnsServerAddressStreamProvider.parseSilently();
-
     private final EventLoop eventLoop;
     private ChannelFactory<? extends DatagramChannel> channelFactory;
-    private DnsServerAddresses nameServerAddresses = DnsServerAddresses.defaultAddresses();
     private DnsCache resolveCache;
     private DnsCache authoritativeDnsServerCache;
     private Integer minTtl;
@@ -56,7 +51,7 @@ public final class DnsNameResolverBuilder {
     private int maxPayloadSize = 4096;
     private boolean optResourceEnabled = true;
     private HostsFileEntriesResolver hostsFileEntriesResolver = HostsFileEntriesResolver.DEFAULT;
-    private DnsServerAddressStreamProvider dnsServerAddressStreamProvider = DEFAULT_DNS_SERVER_ADDRESS_STREAM_PROVIDER;
+    private DnsServerAddressStreamProvider dnsServerAddressStreamProvider = platformDefault();
     private String[] searchDomains = DnsNameResolver.DEFAULT_SEARCH_DOMAINS;
     private int ndots = 1;
     private boolean decodeIdn = true;
@@ -91,17 +86,6 @@ public final class DnsNameResolverBuilder {
      */
     public DnsNameResolverBuilder channelType(Class<? extends DatagramChannel> channelType) {
         return channelFactory(new ReflectiveChannelFactory<DatagramChannel>(channelType));
-    }
-
-    /**
-     * Sets the addresses of the DNS server.
-     *
-     * @param nameServerAddresses the DNS server addresses
-     * @return {@code this}
-     */
-    public DnsNameResolverBuilder nameServerAddresses(DnsServerAddresses nameServerAddresses) {
-        this.nameServerAddresses = nameServerAddresses;
-        return this;
     }
 
     /**
@@ -282,7 +266,7 @@ public final class DnsNameResolverBuilder {
      * each hostname.
      * @return {@code this}.
      */
-    public DnsNameResolverBuilder nameServerCache(DnsServerAddressStreamProvider dnsServerAddressStreamProvider) {
+    public DnsNameResolverBuilder nameServerProvider(DnsServerAddressStreamProvider dnsServerAddressStreamProvider) {
         this.dnsServerAddressStreamProvider =
                 checkNotNull(dnsServerAddressStreamProvider, "dnsServerAddressStreamProvider");
         return this;
@@ -364,7 +348,6 @@ public final class DnsNameResolverBuilder {
         return new DnsNameResolver(
                 eventLoop,
                 channelFactory,
-                nameServerAddresses,
                 resolveCache,
                 authoritativeDnsServerCache,
                 queryTimeoutMillis,

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -34,6 +34,7 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.net.IDN;
@@ -96,7 +97,7 @@ abstract class DnsNameResolverContext<T> {
         this.additionals = additionals;
         this.resolveCache = resolveCache;
 
-        this.nameServerAddrs = nameServerAddrs;
+        this.nameServerAddrs = ObjectUtil.checkNotNull(nameServerAddrs, "nameServerAddrs");
         maxAllowedQueries = parent.maxQueriesPerResolve();
         resolvedInternetProtocolFamilies = parent.resolvedInternetProtocolFamiliesUnsafe();
         traceEnabled = parent.isTraceEnabled();

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProvider.java
@@ -29,8 +29,9 @@ public interface DnsServerAddressStreamProvider {
     /**
      * Ask this provider for the name servers to query for {@code hostname}.
      * @param hostname The hostname for which to lookup the DNS server addressed to use.
-     * @return The {@link DnsServerAddressStream} which should be used to resolve {@code hostname} or {@code null} to
-     * use the default resolvers.
+     *                 If this is the final {@link DnsServerAddressStreamProvider} to be queried then generally empty
+     *                 string or {@code '.'} correspond to the default {@link DnsServerAddressStream}.
+     * @return The {@link DnsServerAddressStream} which should be used to resolve {@code hostname}.
      */
     DnsServerAddressStream nameServerAddressStream(String hostname);
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.util.internal.UnstableApi;
+
+/**
+ * Utility methods related to {@link DnsServerAddressStreamProvider}.
+ */
+@UnstableApi
+public final class DnsServerAddressStreamProviders {
+    // TODO(scott): how is this done on Windows? This may require a JNI call to GetNetworkParams
+    // https://msdn.microsoft.com/en-us/library/aa365968(VS.85).aspx.
+    private static final DnsServerAddressStreamProvider DEFAULT_DNS_SERVER_ADDRESS_STREAM_PROVIDER =
+            UnixResolverDnsServerAddressStreamProvider.parseSilently();
+
+    private DnsServerAddressStreamProviders() {
+    }
+
+    /**
+     * A {@link DnsServerAddressStreamProvider} which inherits the DNS servers from your local host's configuration.
+     * <p>
+     * Note that only macOS and Linux are currently supported.
+     * @return A {@link DnsServerAddressStreamProvider} which inherits the DNS servers from your local host's
+     * configuration.
+     */
+    public static DnsServerAddressStreamProvider platformDefault() {
+        return DEFAULT_DNS_SERVER_ADDRESS_STREAM_PROVIDER;
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/MultiDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/MultiDnsServerAddressStreamProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.util.internal.UnstableApi;
+
+import java.util.List;
+
+/**
+ * A {@link DnsServerAddressStreamProvider} which iterates through a collection of
+ * {@link DnsServerAddressStreamProvider} until the first non-{@code null} result is found.
+ */
+@UnstableApi
+public final class MultiDnsServerAddressStreamProvider implements DnsServerAddressStreamProvider {
+    private final DnsServerAddressStreamProvider[] providers;
+
+    /**
+     * Create a new instance.
+     * @param providers The providers to use for DNS resolution. They will be queried in order.
+     */
+    public MultiDnsServerAddressStreamProvider(List<DnsServerAddressStreamProvider> providers) {
+        this.providers = providers.toArray(new DnsServerAddressStreamProvider[0]);
+    }
+
+    /**
+     * Create a new instance.
+     * @param providers The providers to use for DNS resolution. They will be queried in order.
+     */
+    public MultiDnsServerAddressStreamProvider(DnsServerAddressStreamProvider... providers) {
+        this.providers = providers.clone();
+    }
+
+    @Override
+    public DnsServerAddressStream nameServerAddressStream(String hostname) {
+        for (DnsServerAddressStreamProvider provider : providers) {
+            DnsServerAddressStream stream = provider.nameServerAddressStream(hostname);
+            if (stream != null) {
+                return stream;
+            }
+        }
+        return null;
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/RoundRobinDnsAddressResolverGroup.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/RoundRobinDnsAddressResolverGroup.java
@@ -21,8 +21,8 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.resolver.AddressResolver;
 import io.netty.resolver.AddressResolverGroup;
-import io.netty.resolver.RoundRobinInetAddressResolver;
 import io.netty.resolver.NameResolver;
+import io.netty.resolver.RoundRobinInetAddressResolver;
 import io.netty.util.internal.UnstableApi;
 
 import java.net.InetAddress;
@@ -38,21 +38,22 @@ public class RoundRobinDnsAddressResolverGroup extends DnsAddressResolverGroup {
 
     public RoundRobinDnsAddressResolverGroup(
             Class<? extends DatagramChannel> channelType,
-            DnsServerAddresses nameServerAddresses) {
-        super(channelType, nameServerAddresses);
+            DnsServerAddressStreamProvider nameServerProvider) {
+        super(channelType, nameServerProvider);
     }
 
     public RoundRobinDnsAddressResolverGroup(
             ChannelFactory<? extends DatagramChannel> channelFactory,
-            DnsServerAddresses nameServerAddresses) {
-        super(channelFactory, nameServerAddresses);
+            DnsServerAddressStreamProvider nameServerProvider) {
+        super(channelFactory, nameServerProvider);
     }
 
     /**
      * We need to override this method, not
-     * {@link #newNameResolver(EventLoop, ChannelFactory, DnsServerAddresses)},
+     * {@link #newNameResolver(EventLoop, ChannelFactory, DnsServerAddressStreamProvider)},
      * because we need to eliminate possible caching of {@link io.netty.resolver.NameResolver#resolve}
-     * by {@link InflightNameResolver} created in {@link #newResolver(EventLoop, ChannelFactory, DnsServerAddresses)}.
+     * by {@link InflightNameResolver} created in
+     * {@link #newResolver(EventLoop, ChannelFactory, DnsServerAddressStreamProvider)}.
      */
     @Override
     protected final AddressResolver<InetSocketAddress> newAddressResolver(EventLoop eventLoop,

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/SingletonDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/SingletonDnsServerAddressStreamProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.util.internal.UnstableApi;
+
+import java.net.InetSocketAddress;
+
+/**
+ * A {@link DnsServerAddressStreamProvider} which always uses a single DNS server for resolution.
+ */
+@UnstableApi
+public final class SingletonDnsServerAddressStreamProvider implements DnsServerAddressStreamProvider {
+    private final DnsServerAddresses addresses;
+
+    /**
+     * Create a new instance.
+     * @param address The singleton address to use for every DNS resolution.
+     */
+    public SingletonDnsServerAddressStreamProvider(final InetSocketAddress address) {
+        addresses = DnsServerAddresses.singleton(address);
+    }
+
+    @Override
+    public DnsServerAddressStream nameServerAddressStream(String hostname) {
+        return addresses.stream();
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProvider.java
@@ -52,17 +52,17 @@ public final class UnixResolverDnsServerAddressStreamProvider implements DnsServ
 
     /**
      * Attempt to parse {@code /etc/resolv.conf} and files in the {@code /etc/resolver} directory by default.
-     * A failure to parse will return {@link NoopDnsServerAddressStreamProvider}.
+     * A failure to parse will return {@link DefaultDnsServerAddressStreamProvider}.
      */
     public static DnsServerAddressStreamProvider parseSilently() {
         try {
             UnixResolverDnsServerAddressStreamProvider nameServerCache =
                     new UnixResolverDnsServerAddressStreamProvider("/etc/resolv.conf", "/etc/resolver");
             return nameServerCache.mayOverrideNameServers() ? nameServerCache
-                                                            : NoopDnsServerAddressStreamProvider.INSTANCE;
+                                                            : DefaultDnsServerAddressStreamProvider.INSTANCE;
         } catch (Exception e) {
             logger.debug("failed to parse /etc/resolv.conf and/or /etc/resolver", e);
-            return NoopDnsServerAddressStreamProvider.INSTANCE;
+            return DefaultDnsServerAddressStreamProvider.INSTANCE;
         }
     }
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverClientSubnetTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverClientSubnetTest.java
@@ -60,8 +60,8 @@ public class DnsNameResolverClientSubnetTest {
     private static DnsNameResolverBuilder newResolver(EventLoopGroup group) {
         return new DnsNameResolverBuilder(group.next())
                 .channelType(NioDatagramChannel.class)
-                .nameServerAddresses(DnsServerAddresses.singleton(SocketUtils.socketAddress("8.8.8.8", 53)))
-                .nameServerCache(NoopDnsServerAddressStreamProvider.INSTANCE)
+                .nameServerProvider(
+                        new SingletonDnsServerAddressStreamProvider(SocketUtils.socketAddress("8.8.8.8", 53)))
                 .maxQueriesPerResolve(1)
                 .optResourceEnabled(false);
     }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
@@ -33,20 +33,19 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.StringContains.containsString;
 
 public class SearchDomainTest {
 
     private DnsNameResolverBuilder newResolver() {
         return new DnsNameResolverBuilder(group.next())
             .channelType(NioDatagramChannel.class)
-            .nameServerAddresses(DnsServerAddresses.singleton(dnsServer.localAddress()))
-            .nameServerCache(NoopDnsServerAddressStreamProvider.INSTANCE)
+            .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer.localAddress()))
             .maxQueriesPerResolve(1)
             .optResourceEnabled(false);
     }


### PR DESCRIPTION
Motivation:
Recently DnsServerAddressStreamProvider was introduced to allow control for each query as to which DNS server should be used for resolution to respect the local host's default DNS server configuration. However resolver-dns also accepts a stream of DNS servers to use by default, but this stream is not host name aware. This creates an ambiguity as to which method is used to determine the DNS server to user during resolution, and in which order. We can remove this ambiguity and provide a more general API by just supporting DnsServerAddressStreamProvider.

Modifications:
- Remove the fixed DnsServerAddresses and instead only accept a DnsServerAddressStreamProvider.
- Add utility methods to help use DnsServerAddressStreamProvider for a single entry, a list of entries, and get the default for the current machine.

Result:
Fixes https://github.com/netty/netty/issues/6573.