### PR TITLE
HTTP/2 Make DefaultHttp2HeadersDecoder's Http2Headers object creation extensible

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
@@ -112,7 +112,7 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
     @Override
     public Http2Headers decodeHeaders(int streamId, ByteBuf headerBlock) throws Http2Exception {
         try {
-            final Http2Headers headers = new DefaultHttp2Headers(validateHeaders, (int) headerArraySizeAccumulator);
+            final Http2Headers headers = newHeaders();
             hpackDecoder.decode(streamId, headerBlock, headers);
             headerArraySizeAccumulator = HEADERS_COUNT_WEIGHT_NEW * headers.size() +
                                          HEADERS_COUNT_WEIGHT_HISTORICAL * headerArraySizeAccumulator;
@@ -125,5 +125,29 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
             // for any reason (e.g. the key was an invalid pseudo-header).
             throw connectionError(COMPRESSION_ERROR, e, e.getMessage());
         }
+    }
+
+    /**
+     * A weighted moving average estimating how many headers are expected during the decode process.
+     * @return an estimate of how many headers are expected during the decode process.
+     */
+    protected final int numberOfHeadersGuess() {
+        return (int) headerArraySizeAccumulator;
+    }
+
+    /**
+     * Determine if the headers should be validated as a result of the decode operation.
+     * @return {@code true} if the headers should be validated as a result of the decode operation.
+     */
+    protected final boolean validateHeaders() {
+        return validateHeaders;
+    }
+
+    /**
+     * Create a new {@link Http2Headers} object which will store the results of the decode operation.
+     * @return a new {@link Http2Headers} object which will store the results of the decode operation.
+     */
+    protected Http2Headers newHeaders() {
+        return new DefaultHttp2Headers(validateHeaders, (int) headerArraySizeAccumulator);
     }
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
@@ -49,7 +49,7 @@ import static io.netty.util.AsciiString.EMPTY_STRING;
 import static io.netty.util.internal.ObjectUtil.checkPositive;
 import static io.netty.util.internal.ThrowableUtil.unknownStackTrace;
 
-public final class HpackDecoder {
+final class HpackDecoder {
     private static final Http2Exception DECODE_ULE_128_DECOMPRESSION_EXCEPTION = unknownStackTrace(
             connectionError(COMPRESSION_ERROR, "HPACK - decompression failure"), HpackDecoder.class,
             "decodeULE128(..)");
@@ -96,7 +96,7 @@ public final class HpackDecoder {
      *  (which is dangerous).
      * @param initialHuffmanDecodeCapacity Size of an intermediate buffer used during huffman decode.
      */
-    public HpackDecoder(long maxHeaderListSize, int initialHuffmanDecodeCapacity) {
+    HpackDecoder(long maxHeaderListSize, int initialHuffmanDecodeCapacity) {
         this(maxHeaderListSize, initialHuffmanDecodeCapacity, DEFAULT_HEADER_TABLE_SIZE);
     }
 
@@ -104,7 +104,7 @@ public final class HpackDecoder {
      * Exposed Used for testing only! Default values used in the initial settings frame are overriden intentionally
      * for testing but violate the RFC if used outside the scope of testing.
      */
-    public HpackDecoder(long maxHeaderListSize, int initialHuffmanDecodeCapacity, int maxHeaderTableSize) {
+    HpackDecoder(long maxHeaderListSize, int initialHuffmanDecodeCapacity, int maxHeaderTableSize) {
         this.maxHeaderListSize = checkPositive(maxHeaderListSize, "maxHeaderListSize");
         this.maxHeaderListSizeGoAway = Http2CodecUtil.calculateMaxHeaderListSizeGoAway(maxHeaderListSize);
 


### PR DESCRIPTION
Motivation:
It is generally useful to override DefaultHttp2HeadersDecoder's creation of a new Http2Headers object so more optimized versions can be substituted if the use case allows for it.

Modifications:
- DefaultHttp2HeadersDecoder should support an overridable method to generate the new Http2Headers object for each decode operation

Result:
DefaultHttp2HeadersDecoder is more extensible.
Fixes #6591.