### PR TITLE
NetUtil IPv6 bugs related to IPv4 and compression

### DIFF
--- a/common/src/main/java/io/netty/util/internal/ConstantTimeUtils.java
+++ b/common/src/main/java/io/netty/util/internal/ConstantTimeUtils.java
@@ -95,8 +95,8 @@ public final class ConstantTimeUtils {
         // Benchmarking demonstrates that using an int to accumulate is faster than other data types.
         int b = 0;
         final int end = startPos1 + length;
-        for (int i = startPos1, j = startPos2; i < end; ++i, ++j) {
-            b |= bytes1[i] ^ bytes2[j];
+        for (; startPos1 < end; ++startPos1, ++startPos2) {
+            b |= bytes1[startPos1] ^ bytes2[startPos2];
         }
         return equalsConstantTime(b, 0);
     }

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -646,6 +646,19 @@ public final class PlatformDependent {
     }
 
     /**
+     * Determine if a subsection of an array is zero.
+     * @param bytes The byte array.
+     * @param startPos The starting index (inclusive) in {@code bytes}.
+     * @param length The amount of bytes to check for zero.
+     * @return {@code false} if {@code bytes[startPos:startsPos+length)} contains a value other than zero.
+     */
+    public static boolean isZero(byte[] bytes, int startPos, int length) {
+        return !hasUnsafe() || !unalignedAccess() ?
+                isZeroSafe(bytes, startPos, length) :
+                PlatformDependent0.isZero(bytes, startPos, length);
+    }
+
+    /**
      * Compare two {@code byte} arrays for equality without leaking timing information.
      * For performance reasons no bounds checking on the parameters is performed.
      * <p>
@@ -1179,8 +1192,18 @@ public final class PlatformDependent {
 
     private static boolean equalsSafe(byte[] bytes1, int startPos1, byte[] bytes2, int startPos2, int length) {
         final int end = startPos1 + length;
-        for (int i = startPos1, j = startPos2; i < end; ++i, ++j) {
-            if (bytes1[i] != bytes2[j]) {
+        for (; startPos1 < end; ++startPos1, ++startPos2) {
+            if (bytes1[startPos1] != bytes2[startPos2]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isZeroSafe(byte[] bytes, int startPos, int length) {
+        final int end = startPos + length;
+        for (; startPos < end; ++startPos) {
+            if (bytes[startPos] != 0) {
                 return false;
             }
         }

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -552,7 +552,7 @@ final class PlatformDependent0 {
     }
 
     static boolean equals(byte[] bytes1, int startPos1, byte[] bytes2, int startPos2, int length) {
-        if (length == 0) {
+        if (length <= 0) {
             return true;
         }
         final long baseOffset1 = BYTE_ARRAY_BASE_OFFSET + startPos1;
@@ -618,6 +618,32 @@ final class PlatformDependent0 {
             default:
                 return ConstantTimeUtils.equalsConstantTime(result, 0);
         }
+    }
+
+    static boolean isZero(byte[] bytes, int startPos, int length) {
+        if (length <= 0) {
+            return true;
+        }
+        final long baseOffset = BYTE_ARRAY_BASE_OFFSET + startPos;
+        int remainingBytes = length & 7;
+        final long end = baseOffset + remainingBytes;
+        for (long i = baseOffset - 8 + length; i >= end; i -= 8) {
+            if (UNSAFE.getLong(bytes, i) != 0) {
+                return false;
+            }
+        }
+
+        if (remainingBytes >= 4) {
+            remainingBytes -= 4;
+            if (UNSAFE.getInt(bytes, baseOffset + remainingBytes) != 0) {
+                return false;
+            }
+        }
+        if (remainingBytes >= 2) {
+            return UNSAFE.getChar(bytes, baseOffset) == 0 &&
+                    (remainingBytes == 2 || bytes[startPos + 2] == 0);
+        }
+        return bytes[startPos] == 0;
     }
 
     static int hashCodeAscii(byte[] bytes, int startPos, int length) {

--- a/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
+++ b/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
@@ -49,6 +49,20 @@ public class PlatformDependentTest {
         });
     }
 
+    @Test
+    public void testIsZero() {
+        byte[] bytes = new byte[100];
+        assertTrue(PlatformDependent.isZero(bytes, 0, 0));
+        assertTrue(PlatformDependent.isZero(bytes, 0, -1));
+        assertTrue(PlatformDependent.isZero(bytes, 0, 100));
+        assertTrue(PlatformDependent.isZero(bytes, 10, 90));
+        bytes[10] = 1;
+        assertTrue(PlatformDependent.isZero(bytes, 0, 10));
+        assertFalse(PlatformDependent.isZero(bytes, 0, 11));
+        assertFalse(PlatformDependent.isZero(bytes, 10, 1));
+        assertTrue(PlatformDependent.isZero(bytes, 11, 89));
+    }
+
     private interface EqualityChecker {
         boolean equals(byte[] bytes1, int startPos1, byte[] bytes2, int startPos2, int length);
     }
@@ -105,6 +119,9 @@ public class PlatformDependentTest {
             bytes2 = bytes1.clone();
             assertTrue(equalsChecker.equals(bytes1, 0, bytes2, 0, bytes1.length));
         }
+
+        assertTrue(equalsChecker.equals(bytes1, 0, bytes2, 0, 0));
+        assertTrue(equalsChecker.equals(bytes1, 0, bytes2, 0, -1));
     }
 
     private static char randomCharInByteRange() {


### PR DESCRIPTION
Motivation:
NetUtil#getByName and NetUtil#isValidIpV6Address do not strictly enforce the format of IPv4 addresses that are allowed to be embedded in IPv6 addresses as specified in https://tools.ietf.org/html/rfc4291#section-2.5.5. This may lead to invalid addresses being parsed, or invalid addresses being considered valid.

Modifications:
- NetUtil#isValidIpV6Address should enforce the IPv4-Compatible and IPv4-Mapped are the only valid formats for including IPv4 addresses as specified in https://tools.ietf.org/html/rfc4291#section-2.5.5
- NetUtil#getByName should more stritcly parse IPv6 addresses which contain IPv4 addresses as specified in https://tools.ietf.org/html/rfc4291#section-2.5.5

Result:
NetUtil#getByName and NetUtil#isValidIpV6Address respect the IPv6 RFC which defines the valid formats for embedding IPv4 addresses.