### PR TITLE
add common DNS record types

### DIFF
--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsAAAARecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsAAAARecord.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.UnstableApi;
+
+import java.net.Inet6Address;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+@UnstableApi
+public class DefaultDnsAAAARecord extends AbstractDnsRecord implements DnsAAAARecord {
+    private final Inet6Address address;
+
+    /**
+     * Creates a new AAAA record.
+     *
+     * @param name the domain name
+     * @param dnsClass the class of the record, usually one of the following:
+     *                 <ul>
+     *                     <li>{@link #CLASS_IN}</li>
+     *                     <li>{@link #CLASS_CSNET}</li>
+     *                     <li>{@link #CLASS_CHAOS}</li>
+     *                     <li>{@link #CLASS_HESIOD}</li>
+     *                     <li>{@link #CLASS_NONE}</li>
+     *                     <li>{@link #CLASS_ANY}</li>
+     *                 </ul>
+     * @param timeToLive the TTL value of the record
+     * @param address the IPv6 Internet address this AAAA record resolves to.
+     */
+    public DefaultDnsAAAARecord(String name, int dnsClass, long timeToLive, Inet6Address address) {
+        super(name, DnsRecordType.AAAA, dnsClass, timeToLive);
+        this.address = checkNotNull(address, "address");
+    }
+
+    @Override
+    public Inet6Address address() { return address; }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder(64).append(StringUtil.simpleClassName(this)).append('(');
+        final DnsRecordType type = type();
+        buf.append(name().isEmpty()? "<root>" : name())
+                .append(' ')
+                .append(timeToLive())
+                .append(' ');
+
+        DnsMessageUtil.appendRecordClass(buf, dnsClass())
+                .append(' ')
+                .append(type.name());
+
+        buf.append(' ')
+                .append(address.getHostAddress());
+
+        return buf.toString();
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsAAAARecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsAAAARecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Netty Project
+ * Copyright 2018 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -22,6 +22,9 @@ import java.net.Inet6Address;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
+/**
+ * Default {@link DnsAAAARecord} implementation.
+ */
 @UnstableApi
 public class DefaultDnsAAAARecord extends AbstractDnsRecord implements DnsAAAARecord {
     private final Inet6Address address;
@@ -51,9 +54,27 @@ public class DefaultDnsAAAARecord extends AbstractDnsRecord implements DnsAAAARe
     public Inet6Address address() { return address; }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        if (!super.equals(o)) { return false; }
+        DefaultDnsAAAARecord that = (DefaultDnsAAAARecord) o;
+        return address.equals(that.address);
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = super.hashCode();
+
+        hashCode = hashCode * 31 + address.hashCode();
+
+        return hashCode;
+    }
+
+    @Override
     public String toString() {
         final StringBuilder buf = new StringBuilder(64).append(StringUtil.simpleClassName(this)).append('(');
-        final DnsRecordType type = type();
+
         buf.append(name().isEmpty()? "<root>" : name())
                 .append(' ')
                 .append(timeToLive())
@@ -61,7 +82,7 @@ public class DefaultDnsAAAARecord extends AbstractDnsRecord implements DnsAAAARe
 
         DnsMessageUtil.appendRecordClass(buf, dnsClass())
                 .append(' ')
-                .append(type.name());
+                .append(type().name());
 
         buf.append(' ')
                 .append(address.getHostAddress());

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsARecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsARecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Netty Project
+ * Copyright 2018 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -22,6 +22,9 @@ import java.net.Inet4Address;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
+/**
+ * Default {@link DnsARecord} implementation.
+ */
 @UnstableApi
 public class DefaultDnsARecord extends AbstractDnsRecord implements DnsARecord {
     private final Inet4Address address;
@@ -51,9 +54,27 @@ public class DefaultDnsARecord extends AbstractDnsRecord implements DnsARecord {
     public Inet4Address address() { return address; }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        if (!super.equals(o)) { return false; }
+        DefaultDnsARecord that = (DefaultDnsARecord) o;
+        return address.equals(that.address);
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = super.hashCode();
+
+        hashCode = hashCode * 31 + address.hashCode();
+
+        return hashCode;
+    }
+
+    @Override
     public String toString() {
         final StringBuilder buf = new StringBuilder(64).append(StringUtil.simpleClassName(this)).append('(');
-        final DnsRecordType type = type();
+
         buf.append(name().isEmpty()? "<root>" : name())
                 .append(' ')
                 .append(timeToLive())
@@ -61,7 +82,7 @@ public class DefaultDnsARecord extends AbstractDnsRecord implements DnsARecord {
 
         DnsMessageUtil.appendRecordClass(buf, dnsClass())
                 .append(' ')
-                .append(type.name());
+                .append(type().name());
 
         buf.append(' ')
                 .append(address.getHostAddress());

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsARecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsARecord.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.UnstableApi;
+
+import java.net.Inet4Address;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+@UnstableApi
+public class DefaultDnsARecord extends AbstractDnsRecord implements DnsARecord {
+    private final Inet4Address address;
+
+    /**
+     * Creates a new A record.
+     *
+     * @param name the domain name
+     * @param dnsClass the class of the record, usually one of the following:
+     *                 <ul>
+     *                     <li>{@link #CLASS_IN}</li>
+     *                     <li>{@link #CLASS_CSNET}</li>
+     *                     <li>{@link #CLASS_CHAOS}</li>
+     *                     <li>{@link #CLASS_HESIOD}</li>
+     *                     <li>{@link #CLASS_NONE}</li>
+     *                     <li>{@link #CLASS_ANY}</li>
+     *                 </ul>
+     * @param timeToLive the TTL value of the record
+     * @param address the IPv4 Internet address this A record resolves to.
+     */
+    public DefaultDnsARecord(String name, int dnsClass, long timeToLive, Inet4Address address) {
+        super(name, DnsRecordType.A, dnsClass, timeToLive);
+        this.address = checkNotNull(address, "address");
+    }
+
+    @Override
+    public Inet4Address address() { return address; }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder(64).append(StringUtil.simpleClassName(this)).append('(');
+        final DnsRecordType type = type();
+        buf.append(name().isEmpty()? "<root>" : name())
+                .append(' ')
+                .append(timeToLive())
+                .append(' ');
+
+        DnsMessageUtil.appendRecordClass(buf, dnsClass())
+                .append(' ')
+                .append(type.name());
+
+        buf.append(' ')
+                .append(address.getHostAddress());
+
+        return buf.toString();
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsCNameRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsCNameRecord.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.UnstableApi;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+@UnstableApi
+public class DefaultDnsCNameRecord extends AbstractDnsRecord implements DnsCNameRecord {
+    private final String hostname;
+
+    /**
+     * Creates a new CNAME record.
+     *
+     * @param name the domain name
+     * @param dnsClass the class of the record, usually one of the following:
+     *                 <ul>
+     *                     <li>{@link #CLASS_IN}</li>
+     *                     <li>{@link #CLASS_CSNET}</li>
+     *                     <li>{@link #CLASS_CHAOS}</li>
+     *                     <li>{@link #CLASS_HESIOD}</li>
+     *                     <li>{@link #CLASS_NONE}</li>
+     *                     <li>{@link #CLASS_ANY}</li>
+     *                 </ul>
+     * @param timeToLive the TTL value of the record
+     * @param hostname the canonical or primary name this CNAME record resolves to.
+     */
+    public DefaultDnsCNameRecord(String name, int dnsClass, long timeToLive, String hostname) {
+        super(name, DnsRecordType.CNAME, dnsClass, timeToLive);
+        this.hostname = checkNotNull(hostname, "hostname");
+    }
+
+    @Override
+    public String hostname() { return hostname; }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder(64).append(StringUtil.simpleClassName(this)).append('(');
+        final DnsRecordType type = type();
+        buf.append(name().isEmpty()? "<root>" : name())
+                .append(' ')
+                .append(timeToLive())
+                .append(' ');
+
+        DnsMessageUtil.appendRecordClass(buf, dnsClass())
+                .append(' ')
+                .append(type.name());
+
+        buf.append(' ')
+                .append(hostname);
+
+        return buf.toString();
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsCNameRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsCNameRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Netty Project
+ * Copyright 2018 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -20,6 +20,9 @@ import io.netty.util.internal.UnstableApi;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
+/**
+ * Default {@link DnsCNameRecord} implementation.
+ */
 @UnstableApi
 public class DefaultDnsCNameRecord extends AbstractDnsRecord implements DnsCNameRecord {
     private final String hostname;
@@ -49,9 +52,27 @@ public class DefaultDnsCNameRecord extends AbstractDnsRecord implements DnsCName
     public String hostname() { return hostname; }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        if (!super.equals(o)) { return false; }
+        DefaultDnsCNameRecord that = (DefaultDnsCNameRecord) o;
+        return hostname.equals(that.hostname);
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = super.hashCode();
+
+        hashCode = hashCode * 31 + hostname.hashCode();
+
+        return hashCode;
+    }
+
+    @Override
     public String toString() {
         final StringBuilder buf = new StringBuilder(64).append(StringUtil.simpleClassName(this)).append('(');
-        final DnsRecordType type = type();
+
         buf.append(name().isEmpty()? "<root>" : name())
                 .append(' ')
                 .append(timeToLive())
@@ -59,7 +80,7 @@ public class DefaultDnsCNameRecord extends AbstractDnsRecord implements DnsCName
 
         DnsMessageUtil.appendRecordClass(buf, dnsClass())
                 .append(' ')
-                .append(type.name());
+                .append(type().name());
 
         buf.append(' ')
                 .append(hostname);

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsMxRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsMxRecord.java
@@ -28,7 +28,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 @UnstableApi
 public class DefaultDnsMxRecord extends AbstractDnsRecord implements DnsMxRecord {
     private final int preference;
-    private final String hostname;
+    private final String exchange;
 
     /**
      * Creates a new MX record.
@@ -44,19 +44,19 @@ public class DefaultDnsMxRecord extends AbstractDnsRecord implements DnsMxRecord
      *                     <li>{@link #CLASS_ANY}</li>
      *                 </ul>
      * @param timeToLive the TTL value of the record
-     * @param hostname the canonical or primary name this MX record resolves to.
+     * @param exchange the canonical or primary name this MX record resolves to.
      */
-    public DefaultDnsMxRecord(String name, int dnsClass, long timeToLive, int preference, String hostname) {
+    public DefaultDnsMxRecord(String name, int dnsClass, long timeToLive, int preference, String exchange) {
         super(name, DnsRecordType.MX, dnsClass, timeToLive);
         this.preference = preference;
-        this.hostname = IDN.toASCII(checkNotNull(hostname, "hostname"));
+        this.exchange = IDN.toASCII(checkNotNull(exchange, "exchange"));
     }
 
     @Override
     public int preference() { return preference; }
 
     @Override
-    public String hostname() { return hostname; }
+    public String exchange() { return exchange; }
 
     @Override
     public boolean equals(Object o) {
@@ -64,7 +64,7 @@ public class DefaultDnsMxRecord extends AbstractDnsRecord implements DnsMxRecord
         if (o == null || getClass() != o.getClass()) { return false; }
         if (!super.equals(o)) { return false; }
         DefaultDnsMxRecord that = (DefaultDnsMxRecord) o;
-        return preference == that.preference && hostname.equals(that.hostname);
+        return preference == that.preference && exchange.equals(that.exchange);
     }
 
     @Override
@@ -72,7 +72,7 @@ public class DefaultDnsMxRecord extends AbstractDnsRecord implements DnsMxRecord
         int hashCode = super.hashCode();
 
         hashCode = hashCode * 31 + preference;
-        hashCode = hashCode * 31 + hostname.hashCode();
+        hashCode = hashCode * 31 + exchange.hashCode();
 
         return hashCode;
     }
@@ -93,7 +93,7 @@ public class DefaultDnsMxRecord extends AbstractDnsRecord implements DnsMxRecord
         buf.append(' ')
                 .append(preference)
                 .append(' ')
-                .append(hostname);
+                .append(exchange);
 
         return buf.toString();
     }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsMxRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsMxRecord.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.UnstableApi;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+@UnstableApi
+public class DefaultDnsMxRecord extends AbstractDnsRecord implements DnsMxRecord {
+    private final int preference;
+    private final String hostname;
+
+    /**
+     * Creates a new MX record.
+     *
+     * @param name the domain name
+     * @param dnsClass the class of the record, usually one of the following:
+     *                 <ul>
+     *                     <li>{@link #CLASS_IN}</li>
+     *                     <li>{@link #CLASS_CSNET}</li>
+     *                     <li>{@link #CLASS_CHAOS}</li>
+     *                     <li>{@link #CLASS_HESIOD}</li>
+     *                     <li>{@link #CLASS_NONE}</li>
+     *                     <li>{@link #CLASS_ANY}</li>
+     *                 </ul>
+     * @param timeToLive the TTL value of the record
+     * @param hostname the canonical or primary name this MX record resolves to.
+     */
+    public DefaultDnsMxRecord(String name, int dnsClass, long timeToLive, int preference, String hostname) {
+        super(name, DnsRecordType.MX, dnsClass, timeToLive);
+        this.preference = preference;
+        this.hostname = checkNotNull(hostname, "hostname");
+    }
+
+    @Override
+    public int preference() { return preference; }
+
+    @Override
+    public String hostname() { return hostname; }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder(64).append(StringUtil.simpleClassName(this)).append('(');
+        final DnsRecordType type = type();
+        buf.append(name().isEmpty()? "<root>" : name())
+                .append(' ')
+                .append(timeToLive())
+                .append(' ');
+
+        DnsMessageUtil.appendRecordClass(buf, dnsClass())
+                .append(' ')
+                .append(type.name());
+
+        buf.append(' ')
+                .append(preference)
+                .append(' ')
+                .append(hostname);
+
+        return buf.toString();
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsNsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsNsRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Netty Project
+ * Copyright 2018 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -20,6 +20,9 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.UnstableApi;
 
+/**
+ * Default {@link DnsNsRecord} implementation.
+ */
 @UnstableApi
 public class DefaultDnsNsRecord extends AbstractDnsRecord implements DnsNsRecord {
 
@@ -53,9 +56,27 @@ public class DefaultDnsNsRecord extends AbstractDnsRecord implements DnsNsRecord
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        if (!super.equals(o)) { return false; }
+        DefaultDnsNsRecord that = (DefaultDnsNsRecord) o;
+        return hostname.equals(that.hostname);
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = super.hashCode();
+
+        hashCode = hashCode * 31 + hostname.hashCode();
+
+        return hashCode;
+    }
+
+    @Override
     public String toString() {
         final StringBuilder buf = new StringBuilder(64).append(StringUtil.simpleClassName(this)).append('(');
-        final DnsRecordType type = type();
+
         buf.append(name().isEmpty()? "<root>" : name())
                 .append(' ')
                 .append(timeToLive())
@@ -63,7 +84,7 @@ public class DefaultDnsNsRecord extends AbstractDnsRecord implements DnsNsRecord
 
         DnsMessageUtil.appendRecordClass(buf, dnsClass())
                 .append(' ')
-                .append(type.name());
+                .append(type().name());
 
         buf.append(' ')
                 .append(hostname);

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsNsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsNsRecord.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
+public class DefaultDnsNsRecord extends AbstractDnsRecord implements DnsNsRecord {
+
+    private final String hostname;
+
+    /**
+     * Creates a new NS record.
+     *
+     * @param name the domain name
+     * @param dnsClass the class of the record, usually one of the following:
+     *                 <ul>
+     *                     <li>{@link #CLASS_IN}</li>
+     *                     <li>{@link #CLASS_CSNET}</li>
+     *                     <li>{@link #CLASS_CHAOS}</li>
+     *                     <li>{@link #CLASS_HESIOD}</li>
+     *                     <li>{@link #CLASS_NONE}</li>
+     *                     <li>{@link #CLASS_ANY}</li>
+     *                 </ul>
+     * @param timeToLive the TTL value of the record
+     * @param hostname the hostname which should be authoritative for the specified class and domain.
+     */
+    public DefaultDnsNsRecord(
+            String name, int dnsClass, long timeToLive, String hostname) {
+        super(name, DnsRecordType.NS, dnsClass, timeToLive);
+        this.hostname = checkNotNull(hostname, "hostname");
+    }
+
+    @Override
+    public String hostname() {
+        return hostname;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder(64).append(StringUtil.simpleClassName(this)).append('(');
+        final DnsRecordType type = type();
+        buf.append(name().isEmpty()? "<root>" : name())
+                .append(' ')
+                .append(timeToLive())
+                .append(' ');
+
+        DnsMessageUtil.appendRecordClass(buf, dnsClass())
+                .append(' ')
+                .append(type.name());
+
+        buf.append(' ')
+                .append(hostname);
+
+        return buf.toString();
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsNsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsNsRecord.java
@@ -20,13 +20,15 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.UnstableApi;
 
+import java.net.IDN;
+
 /**
  * Default {@link DnsNsRecord} implementation.
  */
 @UnstableApi
 public class DefaultDnsNsRecord extends AbstractDnsRecord implements DnsNsRecord {
 
-    private final String hostname;
+    private final String domain;
 
     /**
      * Creates a new NS record.
@@ -42,17 +44,17 @@ public class DefaultDnsNsRecord extends AbstractDnsRecord implements DnsNsRecord
      *                     <li>{@link #CLASS_ANY}</li>
      *                 </ul>
      * @param timeToLive the TTL value of the record
-     * @param hostname the hostname which should be authoritative for the specified class and domain.
+     * @param domain the domain name which should be authoritative for the specified class and domain.
      */
     public DefaultDnsNsRecord(
-            String name, int dnsClass, long timeToLive, String hostname) {
+            String name, int dnsClass, long timeToLive, String domain) {
         super(name, DnsRecordType.NS, dnsClass, timeToLive);
-        this.hostname = checkNotNull(hostname, "hostname");
+        this.domain = IDN.toASCII(checkNotNull(domain, "domain"));
     }
 
     @Override
-    public String hostname() {
-        return hostname;
+    public String domain() {
+        return domain;
     }
 
     @Override
@@ -61,14 +63,14 @@ public class DefaultDnsNsRecord extends AbstractDnsRecord implements DnsNsRecord
         if (o == null || getClass() != o.getClass()) { return false; }
         if (!super.equals(o)) { return false; }
         DefaultDnsNsRecord that = (DefaultDnsNsRecord) o;
-        return hostname.equals(that.hostname);
+        return domain.equals(that.domain);
     }
 
     @Override
     public int hashCode() {
         int hashCode = super.hashCode();
 
-        hashCode = hashCode * 31 + hostname.hashCode();
+        hashCode = hashCode * 31 + domain.hashCode();
 
         return hashCode;
     }
@@ -87,7 +89,7 @@ public class DefaultDnsNsRecord extends AbstractDnsRecord implements DnsNsRecord
                 .append(type().name());
 
         buf.append(' ')
-                .append(hostname);
+                .append(domain);
 
         return buf.toString();
     }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoder.java
@@ -154,6 +154,13 @@ public class DefaultDnsRecordDecoder implements DnsRecordDecoder {
                     name, dnsClass, timeToLive, decodeName0(in.duplicate().setIndex(offset, offset + length)));
         }
 
+        if (type == DnsRecordType.TXT) {
+            String text = in.retainedDuplicate().setIndex(offset, offset + length).toString(CharsetUtil.US_ASCII);
+
+            return new DefaultDnsTxtRecord(
+                    name, dnsClass, timeToLive, text);
+        }
+
         return new DefaultDnsRawRecord(
                 name, type, dnsClass, timeToLive, in.retainedDuplicate().setIndex(offset, offset + length));
     }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoder.java
@@ -199,6 +199,13 @@ public class DefaultDnsRecordEncoder implements DnsRecordEncoder {
         out.writeBytes(content, content.readerIndex(), contentLen);
     }
 
+    /**
+     * Encode a domain name as a list of labels
+     *
+     * @param name The domain name to be encoded
+     * @param buf The bytes buffer
+     * @throws Exception Thrown, if the bytes buffer could not be written.
+     */
     public static void encodeName(String name, ByteBuf buf) throws Exception {
         if (ROOT.equals(name)) {
             // Root domain

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoder.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsRecordEncoder.java
@@ -49,8 +49,22 @@ public class DefaultDnsRecordEncoder implements DnsRecordEncoder {
     public void encodeRecord(DnsRecord record, ByteBuf out) throws Exception {
         if (record instanceof DnsQuestion) {
             encodeQuestion((DnsQuestion) record, out);
+        } else if (record instanceof DnsARecord) {
+            encodeARecord((DnsARecord) record, out);
+        } else if (record instanceof DnsAAAARecord) {
+            encodeAAAARecord((DnsAAAARecord) record, out);
+        } else if (record instanceof DnsCNameRecord) {
+            encodeCNameRecord((DnsCNameRecord) record, out);
+        } else if (record instanceof DnsMxRecord) {
+            encodeMxRecord((DnsMxRecord) record, out);
+        } else if (record instanceof DnsNsRecord) {
+            encodeNsRecord((DnsNsRecord) record, out);
         } else if (record instanceof DnsPtrRecord) {
             encodePtrRecord((DnsPtrRecord) record, out);
+        } else if (record instanceof DnsSoaRecord) {
+            encodeSoaRecord((DnsSoaRecord) record, out);
+        } else if (record instanceof DnsSrvRecord) {
+            encodeSrvRecord((DnsSrvRecord) record, out);
         } else if (record instanceof DnsOptEcsRecord) {
             encodeOptEcsRecord((DnsOptEcsRecord) record, out);
         } else if (record instanceof DnsOptPseudoRecord) {
@@ -69,9 +83,54 @@ public class DefaultDnsRecordEncoder implements DnsRecordEncoder {
         out.writeInt((int) record.timeToLive());
     }
 
+    private void encodeARecord(DnsARecord record, ByteBuf out) throws Exception {
+        encodeRecord0(record, out);
+        out.writeBytes(record.address().getAddress());
+    }
+
+    private void encodeAAAARecord(DnsAAAARecord record, ByteBuf out) throws Exception {
+        encodeRecord0(record, out);
+        out.writeBytes(record.address().getAddress());
+    }
+
+    private void encodeCNameRecord(DnsCNameRecord record, ByteBuf out) throws Exception {
+        encodeRecord0(record, out);
+        encodeName(record.hostname(), out);
+    }
+
+    private void encodeMxRecord(DnsMxRecord record, ByteBuf out) throws Exception {
+        encodeRecord0(record, out);
+        out.writeShort(record.preference());
+        encodeName(record.hostname(), out);
+    }
+
+    private void encodeNsRecord(DnsNsRecord record, ByteBuf out) throws Exception {
+        encodeRecord0(record, out);
+        encodeName(record.hostname(), out);
+    }
+
     private void encodePtrRecord(DnsPtrRecord record, ByteBuf out) throws Exception {
         encodeRecord0(record, out);
         encodeName(record.hostname(), out);
+    }
+
+    private void encodeSoaRecord(DnsSoaRecord record, ByteBuf out) throws Exception {
+        encodeRecord0(record, out);
+        encodeName(record.primaryNameServer(), out);
+        encodeName(record.responsibleAuthorityMailbox(), out);
+        out.writeInt(record.serialNumber());
+        out.writeInt(record.refreshInterval());
+        out.writeInt(record.retryInterval());
+        out.writeInt(record.expireLimit());
+        out.writeInt(record.minimumTTL());
+    }
+
+    private void encodeSrvRecord(DnsSrvRecord record, ByteBuf out) throws Exception {
+        encodeRecord0(record, out);
+        out.writeShort(record.priority());
+        out.writeShort(record.weight());
+        out.writeShort(record.port());
+        encodeName(record.target(), out);
     }
 
     private void encodeOptPseudoRecord(DnsOptPseudoRecord record, ByteBuf out) throws Exception {
@@ -140,7 +199,7 @@ public class DefaultDnsRecordEncoder implements DnsRecordEncoder {
         out.writeBytes(content, content.readerIndex(), contentLen);
     }
 
-    protected void encodeName(String name, ByteBuf buf) throws Exception {
+    public static void encodeName(String name, ByteBuf buf) throws Exception {
         if (ROOT.equals(name)) {
             // Root domain
             buf.writeByte(0);

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsSoaRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsSoaRecord.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
+public class DefaultDnsSoaRecord extends AbstractDnsRecord implements DnsSoaRecord {
+    private final String primaryNameServer;
+    private final String responsibleAuthorityMailbox;
+    private final int serialNumber;
+    private final int refreshInterval;
+    private final int retryInterval;
+    private final int expireLimit;
+    private final int minimumTTL;
+
+    /**
+     * Creates a new SOA record.
+     *
+     * @param name the domain name
+     * @param dnsClass the class of the record, usually one of the following:
+     *                 <ul>
+     *                     <li>{@link #CLASS_IN}</li>
+     *                     <li>{@link #CLASS_CSNET}</li>
+     *                     <li>{@link #CLASS_CHAOS}</li>
+     *                     <li>{@link #CLASS_HESIOD}</li>
+     *                     <li>{@link #CLASS_NONE}</li>
+     *                     <li>{@link #CLASS_ANY}</li>
+     *                 </ul>
+     * @param timeToLive the TTL value of the record
+     * @param primaryNameServer the name server that was the original or primary source of data for this zone.
+     * @param responsibleAuthorityMailbox the mailbox of the person responsible for this zone.
+     * @param serialNumber the version number of the original copy of the zone.
+     * @param refreshInterval the time interval before the zone should be refreshed.
+     * @param retryInterval the time interval that should elapse before a failed refresh should be retried.
+     * @param expireLimit the time value that specifies the upper limit on the time interval
+     * @param minimumTTL the minimum TTL field that should be exported with any RR from this zone.
+     */
+    public DefaultDnsSoaRecord(
+            String name, int dnsClass, long timeToLive,
+            String primaryNameServer, String responsibleAuthorityMailbox,
+            int serialNumber, int refreshInterval, int retryInterval, int expireLimit, int minimumTTL) {
+        super(name, DnsRecordType.SOA, dnsClass, timeToLive);
+        this.primaryNameServer = checkNotNull(primaryNameServer, "primaryNameServer");
+        this.responsibleAuthorityMailbox = checkNotNull(responsibleAuthorityMailbox, "responsibleAuthorityMailbox");
+        this.serialNumber = serialNumber;
+        this.refreshInterval = refreshInterval;
+        this.retryInterval = retryInterval;
+        this.expireLimit = expireLimit;
+        this.minimumTTL = minimumTTL;
+    }
+
+    @Override
+    public String primaryNameServer() { return primaryNameServer; }
+
+    @Override
+    public String responsibleAuthorityMailbox() { return responsibleAuthorityMailbox; }
+
+    @Override
+    public int serialNumber() { return serialNumber; }
+
+    @Override
+    public int refreshInterval() { return refreshInterval; }
+
+    @Override
+    public int retryInterval() { return retryInterval; }
+
+    @Override
+    public int expireLimit() { return expireLimit; }
+
+    @Override
+    public int minimumTTL() { return minimumTTL; }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder(64).append(StringUtil.simpleClassName(this)).append('(');
+        final DnsRecordType type = type();
+        buf.append(name().isEmpty()? "<root>" : name())
+                .append(' ')
+                .append(timeToLive())
+                .append(' ');
+
+        DnsMessageUtil.appendRecordClass(buf, dnsClass())
+                .append(' ')
+                .append(type.name());
+
+        buf.append(' ')
+                .append(primaryNameServer)
+                .append(' ')
+                .append(responsibleAuthorityMailbox)
+                .append(' ')
+                .append(serialNumber)
+                .append(' ')
+                .append(refreshInterval)
+                .append(' ')
+                .append(retryInterval)
+                .append(' ')
+                .append(expireLimit)
+                .append(' ')
+                .append(minimumTTL);
+
+        return buf.toString();
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsSrvRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsSrvRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Netty Project
+ * Copyright 2018 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,10 +16,15 @@
 package io.netty.handler.codec.dns;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
+import static io.netty.util.internal.ObjectUtil.checkPositive;
+import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.UnstableApi;
 
+/**
+ * Default {@link DnsSrvRecord} implementation.
+ */
 @UnstableApi
 public class DefaultDnsSrvRecord extends AbstractDnsRecord implements DnsSrvRecord {
     private final int priority;
@@ -49,9 +54,9 @@ public class DefaultDnsSrvRecord extends AbstractDnsRecord implements DnsSrvReco
     public DefaultDnsSrvRecord(
             String name, int dnsClass, long timeToLive, int priority, int weight, int port, String target) {
         super(name, DnsRecordType.SRV, dnsClass, timeToLive);
-        this.priority = priority;
-        this.weight = weight;
-        this.port = port;
+        this.priority = checkPositiveOrZero(priority, "priority");
+        this.weight = checkPositiveOrZero(weight, "weight");
+        this.port = checkPositive(port, "port");
         this.target = checkNotNull(target, "target");
     }
 
@@ -70,9 +75,33 @@ public class DefaultDnsSrvRecord extends AbstractDnsRecord implements DnsSrvReco
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false;  }
+        if (!super.equals(o)) { return false;  }
+
+        DefaultDnsSrvRecord that = (DefaultDnsSrvRecord) o;
+
+        if (priority != that.priority) { return false;  }
+        if (weight != that.weight) { return false;  }
+        if (port != that.port) { return false;  }
+        return target.equals(that.target);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + priority;
+        result = 31 * result + weight;
+        result = 31 * result + port;
+        result = 31 * result + target.hashCode();
+        return result;
+    }
+
+    @Override
     public String toString() {
         final StringBuilder buf = new StringBuilder(64).append(StringUtil.simpleClassName(this)).append('(');
-        final DnsRecordType type = type();
+
         buf.append(name().isEmpty()? "<root>" : name())
                 .append(' ')
                 .append(timeToLive())
@@ -80,7 +109,7 @@ public class DefaultDnsSrvRecord extends AbstractDnsRecord implements DnsSrvReco
 
         DnsMessageUtil.appendRecordClass(buf, dnsClass())
                 .append(' ')
-                .append(type.name());
+                .append(type().name());
 
         buf.append(' ')
                 .append(priority)

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsSrvRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsSrvRecord.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
+public class DefaultDnsSrvRecord extends AbstractDnsRecord implements DnsSrvRecord {
+    private final int priority;
+    private final int weight;
+    private final int port;
+    private final String target;
+
+    /**
+     * Creates a new SRV record.
+     *
+     * @param name the domain name
+     * @param dnsClass the class of the record, usually one of the following:
+     *                 <ul>
+     *                     <li>{@link #CLASS_IN}</li>
+     *                     <li>{@link #CLASS_CSNET}</li>
+     *                     <li>{@link #CLASS_CHAOS}</li>
+     *                     <li>{@link #CLASS_HESIOD}</li>
+     *                     <li>{@link #CLASS_NONE}</li>
+     *                     <li>{@link #CLASS_ANY}</li>
+     *                 </ul>
+     * @param timeToLive the TTL value of the record
+     * @param priority the priority of this target host.
+     * @param weight the weight field specifies a relative weight for entries with the same priority.
+     * @param port the port on this target host of this service.
+     * @param target the domain name of the target host this SRV record resolves to.
+     */
+    public DefaultDnsSrvRecord(
+            String name, int dnsClass, long timeToLive, int priority, int weight, int port, String target) {
+        super(name, DnsRecordType.SRV, dnsClass, timeToLive);
+        this.priority = priority;
+        this.weight = weight;
+        this.port = port;
+        this.target = checkNotNull(target, "target");
+    }
+
+    @Override
+    public int priority() { return priority; }
+
+    @Override
+    public int weight() { return weight; }
+
+    @Override
+    public int port() { return port; }
+
+    @Override
+    public String target() {
+        return target;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder(64).append(StringUtil.simpleClassName(this)).append('(');
+        final DnsRecordType type = type();
+        buf.append(name().isEmpty()? "<root>" : name())
+                .append(' ')
+                .append(timeToLive())
+                .append(' ');
+
+        DnsMessageUtil.appendRecordClass(buf, dnsClass())
+                .append(' ')
+                .append(type.name());
+
+        buf.append(' ')
+                .append(priority)
+                .append(' ')
+                .append(weight)
+                .append(' ')
+                .append(port)
+                .append(' ')
+                .append(target);
+
+        return buf.toString();
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsTxtRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DefaultDnsTxtRecord.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+public class DefaultDnsTxtRecord extends AbstractDnsRecord implements DnsTxtRecord {
+    private static final Pattern RE_KEY = Pattern.compile("`([`=\\s])");
+    private static final Pattern RE_VALUE = Pattern.compile("``");
+
+    private final String key;
+    private final String value;
+
+    public DefaultDnsTxtRecord(String name, int dnsClass, long timeToLive, String text) {
+        super(name, DnsRecordType.TXT, dnsClass, timeToLive);
+
+        String[] parts = decodeTxt(checkNotNull(text, "text"));
+
+        this.key = parts[0];
+        this.value = parts[1];
+    }
+
+    @Override
+    public String key() {
+        return this.key;
+    }
+
+    @Override
+    public String value() {
+        return this.value;
+    }
+
+    static String[] decodeTxt(String s) {
+        String key = null, value = null;
+
+        int start = 0;
+        for (start = 0; start < s.length(); start++) {
+            if (!Character.isWhitespace(s.charAt(start))) {
+                break;
+            }
+        }
+
+        char prev = 0;
+        for (int i = start; i < s.length(); i++) {
+            char c = s.charAt(i);
+
+            if (c == '=' && prev != '`') {
+                key = s.substring(start, i);
+                value = s.substring(i + 1);
+
+                break;
+            }
+
+            prev = c;
+        }
+
+        if (key == null) {
+            key = "";
+            value = s;
+        }
+
+        key = RE_KEY.matcher(key).replaceAll("$1").toLowerCase(Locale.US);
+        value = RE_VALUE.matcher(value).replaceAll("`");
+
+        return new String[]{key, value};
+    }
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsAAAARecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsAAAARecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Netty Project
+ * Copyright 2018 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,6 +19,11 @@ import io.netty.util.internal.UnstableApi;
 
 import java.net.Inet6Address;
 
+/**
+ * An <a href="https://tools.ietf.org/html/rfc3596">AAAA</a> record.
+ * <p>
+ * A record type is defined to store a host's IPv6 address.
+ */
 @UnstableApi
 public interface DnsAAAARecord extends DnsRecord {
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsAAAARecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsAAAARecord.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.UnstableApi;
+
+import java.net.Inet6Address;
+
+@UnstableApi
+public interface DnsAAAARecord extends DnsRecord {
+    /**
+     * Returns the IPv6 Internet address this AAAA record resolves to.
+     */
+    Inet6Address address();
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsARecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsARecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Netty Project
+ * Copyright 2018 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,6 +19,11 @@ import io.netty.util.internal.UnstableApi;
 
 import java.net.Inet4Address;
 
+/**
+ * An <a href="https://tools.ietf.org/html/rfc1035#section-3.4.1">A</a> record.
+ * <p>
+ * A record type is defined to store a host's IPv4 address.
+ */
 @UnstableApi
 public interface DnsARecord extends DnsRecord {
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsARecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsARecord.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.UnstableApi;
+
+import java.net.Inet4Address;
+
+@UnstableApi
+public interface DnsARecord extends DnsRecord {
+    /**
+     * Returns the IPv4 Internet address this A record resolves to.
+     */
+    Inet4Address address();
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsCNameRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsCNameRecord.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
+public interface DnsCNameRecord extends DnsRecord {
+    /**
+     * Returns the canonical or primary name this CNAME record resolves to.
+     */
+    String hostname();
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsCNameRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsCNameRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Netty Project
+ * Copyright 2018 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -17,6 +17,12 @@ package io.netty.handler.codec.dns;
 
 import io.netty.util.internal.UnstableApi;
 
+/**
+ * A <a href="https://tools.ietf.org/html/rfc1035#section-3.3.1">CNAME</a> record.
+ * <p>
+ * A record type is defined to store <domain-name> which specifies the canonical or primary name for the owner.
+ * The owner name is an alias.
+ */
 @UnstableApi
 public interface DnsCNameRecord extends DnsRecord {
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMxRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMxRecord.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
+public interface DnsMxRecord extends DnsRecord {
+
+    /**
+     * Returns the preference given to this RR among others at the same owner.
+     */
+    int preference();
+
+    /**
+     * Returns the hostname this MX record resolves to.
+     */
+    String hostname();
+
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMxRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMxRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Netty Project
+ * Copyright 2018 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -17,6 +17,11 @@ package io.netty.handler.codec.dns;
 
 import io.netty.util.internal.UnstableApi;
 
+/**
+ * A <a href="https://tools.ietf.org/html/rfc1035#section-3.3.9">MX</a> record.
+ * <p>
+ * A record type is defined to maps a domain name to a list of message transfer agents for that domain.
+ */
 @UnstableApi
 public interface DnsMxRecord extends DnsRecord {
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMxRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsMxRecord.java
@@ -31,8 +31,8 @@ public interface DnsMxRecord extends DnsRecord {
     int preference();
 
     /**
-     * Returns the hostname this MX record resolves to.
+     * Returns the exchange hostname this MX record resolves to.
      */
-    String hostname();
+    String exchange();
 
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsNsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsNsRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Netty Project
+ * Copyright 2018 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -17,6 +17,11 @@ package io.netty.handler.codec.dns;
 
 import io.netty.util.internal.UnstableApi;
 
+/**
+ * A <a href="https://tools.ietf.org/html/rfc1035#section-3.3.11">NS</a> record.
+ * <p>
+ * A record type is defined to delegates a DNS zone to use the given authoritative name servers.
+ */
 @UnstableApi
 public interface DnsNsRecord extends DnsRecord {
     /**

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsNsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsNsRecord.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
+public interface DnsNsRecord extends DnsRecord {
+    /**
+     * Returns the hostname which should be authoritative for the specified class and domain.
+     */
+    String hostname();
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsNsRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsNsRecord.java
@@ -25,7 +25,7 @@ import io.netty.util.internal.UnstableApi;
 @UnstableApi
 public interface DnsNsRecord extends DnsRecord {
     /**
-     * Returns the hostname which should be authoritative for the specified class and domain.
+     * Returns the domain name which should be authoritative for the specified class and domain.
      */
-    String hostname();
+    String domain();
 }

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsSoaRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsSoaRecord.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
+public interface DnsSoaRecord extends DnsRecord {
+
+    /**
+     * Returns the name server that was the original or primary source of data for this zone.
+     */
+    String primaryNameServer();
+
+    /**
+     * Returns the mailbox of the person responsible for this zone.
+     */
+    String responsibleAuthorityMailbox();
+
+    /**
+     * Returns the version number of the original copy of the zone.
+     */
+    int serialNumber();
+
+    /**
+     * Returns the time interval before the zone should be refreshed.
+     */
+    int refreshInterval();
+
+    /**
+     * Returns the time interval that should elapse before a failed refresh should be retried.
+     */
+    int retryInterval();
+
+    /**
+     * Returns the time value that specifies the upper limit on the time interval
+     * that can elapse before the zone is no longer authoritative.
+     */
+    int expireLimit();
+
+    /**
+     * Returns the minimum TTL field that should be exported with any RR from this zone.
+     */
+    int minimumTTL();
+
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsSoaRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsSoaRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Netty Project
+ * Copyright 2018 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -17,6 +17,13 @@ package io.netty.handler.codec.dns;
 
 import io.netty.util.internal.UnstableApi;
 
+/**
+ * A <a href="https://tools.ietf.org/html/rfc1035#section-3.3.13">SOA</a> record.
+ * <p>
+ * A record type is defined to specifies authoritative information about a DNS zone,
+ * including the primary name server, the email of the domain administrator,
+ * the domain serial number, and several timers relating to refreshing the zone.
+ */
 @UnstableApi
 public interface DnsSoaRecord extends DnsRecord {
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsSrvRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsSrvRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Netty Project
+ * Copyright 2018 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -17,6 +17,12 @@ package io.netty.handler.codec.dns;
 
 import io.netty.util.internal.UnstableApi;
 
+/**
+ * A <a href="https://tools.ietf.org/html/rfc2782">SRV</a> record.
+ * <p>
+ * A record type is defined to store a generalized service location record,
+ * used for newer protocols instead of creating protocol-specific records such as MX.
+ */
 @UnstableApi
 public interface DnsSrvRecord extends DnsRecord {
 

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsSrvRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsSrvRecord.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
+public interface DnsSrvRecord extends DnsRecord {
+
+    /**
+     * Returns the priority of this target host.
+     */
+    int priority();
+
+    /**
+     * Returns the weight field specifies a relative weight for entries with the same priority.
+     */
+    int weight();
+
+    /**
+     * Returns the port on this target host of this service.
+     */
+    int port();
+
+    /**
+     * Returns the domain name of the target host this SRV record resolves to.
+     */
+    String target();
+
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsTxtRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsTxtRecord.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.dns;
+
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
+public interface DnsTxtRecord extends DnsRecord {
+    /**
+     * Returns the key of this TXT record.
+     */
+    String key();
+
+    /**
+     * Returns the value of this TXT record.
+     */
+    String value();
+}

--- a/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsTxtRecord.java
+++ b/codec-dns/src/main/java/io/netty/handler/codec/dns/DnsTxtRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 The Netty Project
+ * Copyright 2018 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -17,6 +17,12 @@ package io.netty.handler.codec.dns;
 
 import io.netty.util.internal.UnstableApi;
 
+/**
+ * A <a href="https://tools.ietf.org/html/rfc1035#section-3.3.14">TXT</a> record.
+ * <p>
+ * A record type is defined to hold descriptive text.
+ * The semantics of the text depends on the domain where it is found.
+ */
 @UnstableApi
 public interface DnsTxtRecord extends DnsRecord {
     /**

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoderTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoderTest.java
@@ -154,7 +154,7 @@ public class DefaultDnsRecordDecoderTest {
             assertEquals(readerIndex, buffer.readerIndex());
             assertEquals(writerIndex, buffer.writerIndex());
             assertEquals(0, record.preference());
-            assertEquals("smtp.netty.io.", record.hostname());
+            assertEquals("smtp.netty.io.", record.exchange());
         } finally {
             buffer.release();
         }
@@ -176,7 +176,7 @@ public class DefaultDnsRecordDecoderTest {
             assertEquals(DnsRecordType.NS, record.type());
             assertEquals(readerIndex, buffer.readerIndex());
             assertEquals(writerIndex, buffer.writerIndex());
-            assertEquals("ns.netty.io.", record.hostname());
+            assertEquals("ns.netty.io.", record.domain());
         } finally {
             buffer.release();
         }

--- a/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoderTest.java
+++ b/codec-dns/src/test/java/io/netty/handler/codec/dns/DefaultDnsRecordDecoderTest.java
@@ -19,6 +19,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.Test;
 
+import java.net.InetAddress;
+
 import static org.junit.Assert.assertEquals;
 
 public class DefaultDnsRecordDecoderTest {
@@ -70,6 +72,117 @@ public class DefaultDnsRecordDecoderTest {
     }
 
     @Test
+    public void testDecodeARecord() throws Exception {
+        DefaultDnsRecordDecoder decoder = new DefaultDnsRecordDecoder();
+        InetAddress addr = InetAddress.getByName("1.2.3.4");
+        ByteBuf buffer = Unpooled.buffer().writeBytes(addr.getAddress());
+        int readerIndex = buffer.readerIndex();
+        int writerIndex = buffer.writerIndex();
+        try {
+            DnsARecord record = (DnsARecord) decoder.decodeRecord(
+                    "netty.io", DnsRecordType.A, DnsRecord.CLASS_IN, 60, buffer, 0, buffer.readableBytes());
+            assertEquals("netty.io.", record.name());
+            assertEquals(DnsRecord.CLASS_IN, record.dnsClass());
+            assertEquals(60, record.timeToLive());
+            assertEquals(DnsRecordType.A, record.type());
+            assertEquals(readerIndex, buffer.readerIndex());
+            assertEquals(writerIndex, buffer.writerIndex());
+            assertEquals(addr, record.address());
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testDecodeAAAARecord() throws Exception {
+        DefaultDnsRecordDecoder decoder = new DefaultDnsRecordDecoder();
+        InetAddress addr = InetAddress.getByName("1080:0:0:0:8:800:200C:417A");
+        ByteBuf buffer = Unpooled.buffer().writeBytes(addr.getAddress());
+        int readerIndex = buffer.readerIndex();
+        int writerIndex = buffer.writerIndex();
+        try {
+            DnsAAAARecord record = (DnsAAAARecord) decoder.decodeRecord(
+                    "netty.io", DnsRecordType.AAAA, DnsRecord.CLASS_IN, 60, buffer, 0, buffer.readableBytes());
+            assertEquals("netty.io.", record.name());
+            assertEquals(DnsRecord.CLASS_IN, record.dnsClass());
+            assertEquals(60, record.timeToLive());
+            assertEquals(DnsRecordType.AAAA, record.type());
+            assertEquals(readerIndex, buffer.readerIndex());
+            assertEquals(writerIndex, buffer.writerIndex());
+            assertEquals(addr, record.address());
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testDecodeCNameRecord() throws Exception {
+        DefaultDnsRecordDecoder decoder = new DefaultDnsRecordDecoder();
+        ByteBuf buffer = Unpooled.buffer();
+        DefaultDnsRecordEncoder.encodeName("cname.netty.io.", buffer);
+        int readerIndex = buffer.readerIndex();
+        int writerIndex = buffer.writerIndex();
+        try {
+            DnsCNameRecord record = (DnsCNameRecord) decoder.decodeRecord(
+                    "netty.io", DnsRecordType.CNAME, DnsRecord.CLASS_IN, 60, buffer, 0, buffer.readableBytes());
+            assertEquals("netty.io.", record.name());
+            assertEquals(DnsRecord.CLASS_IN, record.dnsClass());
+            assertEquals(60, record.timeToLive());
+            assertEquals(DnsRecordType.CNAME, record.type());
+            assertEquals(readerIndex, buffer.readerIndex());
+            assertEquals(writerIndex, buffer.writerIndex());
+            assertEquals("cname.netty.io.", record.hostname());
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testDecodeMxRecord() throws Exception {
+        DefaultDnsRecordDecoder decoder = new DefaultDnsRecordDecoder();
+        ByteBuf buffer = Unpooled.buffer().writeShort(0);
+        DefaultDnsRecordEncoder.encodeName("smtp.netty.io.", buffer);
+        int readerIndex = buffer.readerIndex();
+        int writerIndex = buffer.writerIndex();
+        try {
+            DnsMxRecord record = (DnsMxRecord) decoder.decodeRecord(
+                    "netty.io", DnsRecordType.MX, DnsRecord.CLASS_IN, 60, buffer, 0, buffer.readableBytes());
+            assertEquals("netty.io.", record.name());
+            assertEquals(DnsRecord.CLASS_IN, record.dnsClass());
+            assertEquals(60, record.timeToLive());
+            assertEquals(DnsRecordType.MX, record.type());
+            assertEquals(readerIndex, buffer.readerIndex());
+            assertEquals(writerIndex, buffer.writerIndex());
+            assertEquals(0, record.preference());
+            assertEquals("smtp.netty.io.", record.hostname());
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testDecodeNsRecord() throws Exception {
+        DefaultDnsRecordDecoder decoder = new DefaultDnsRecordDecoder();
+        ByteBuf buffer = Unpooled.buffer();
+        DefaultDnsRecordEncoder.encodeName("ns.netty.io.", buffer);
+        int readerIndex = buffer.readerIndex();
+        int writerIndex = buffer.writerIndex();
+        try {
+            DnsNsRecord record = (DnsNsRecord) decoder.decodeRecord(
+                    "netty.io", DnsRecordType.NS, DnsRecord.CLASS_IN, 60, buffer, 0, buffer.readableBytes());
+            assertEquals("netty.io.", record.name());
+            assertEquals(DnsRecord.CLASS_IN, record.dnsClass());
+            assertEquals(60, record.timeToLive());
+            assertEquals(DnsRecordType.NS, record.type());
+            assertEquals(readerIndex, buffer.readerIndex());
+            assertEquals(writerIndex, buffer.writerIndex());
+            assertEquals("ns.netty.io.", record.hostname());
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
     public void testDecodePtrRecord() throws Exception {
         DefaultDnsRecordDecoder decoder = new DefaultDnsRecordDecoder();
         ByteBuf buffer = Unpooled.buffer().writeByte(0);
@@ -84,6 +197,62 @@ public class DefaultDnsRecordDecoderTest {
             assertEquals(DnsRecordType.PTR, record.type());
             assertEquals(readerIndex, buffer.readerIndex());
             assertEquals(writerIndex, buffer.writerIndex());
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testDecodeSoaRecord() throws Exception {
+        DefaultDnsRecordDecoder decoder = new DefaultDnsRecordDecoder();
+        ByteBuf buffer = Unpooled.buffer();
+        DefaultDnsRecordEncoder.encodeName("theo.ns.cloudflare.com.", buffer);
+        DefaultDnsRecordEncoder.encodeName("dns.cloudflare.com.", buffer);
+        buffer.writeInt(2024173464).writeInt(10000).writeInt(2400).writeInt(604800).writeInt(3600);
+        int readerIndex = buffer.readerIndex();
+        int writerIndex = buffer.writerIndex();
+        try {
+            DnsSoaRecord record = (DnsSoaRecord) decoder.decodeRecord(
+                    "netty.io", DnsRecordType.SOA, DnsRecord.CLASS_IN, 60, buffer, 0, buffer.readableBytes());
+            assertEquals("netty.io.", record.name());
+            assertEquals(DnsRecord.CLASS_IN, record.dnsClass());
+            assertEquals(60, record.timeToLive());
+            assertEquals(DnsRecordType.SOA, record.type());
+            assertEquals(readerIndex, buffer.readerIndex());
+            assertEquals(writerIndex, buffer.writerIndex());
+            assertEquals("theo.ns.cloudflare.com.", record.primaryNameServer());
+            assertEquals("dns.cloudflare.com.", record.responsibleAuthorityMailbox());
+            assertEquals(2024173464, record.serialNumber());
+            assertEquals(10000, record.refreshInterval());
+            assertEquals(2400, record.retryInterval());
+            assertEquals(604800, record.expireLimit());
+            assertEquals(3600, record.minimumTTL());
+        } finally {
+            buffer.release();
+        }
+    }
+
+    @Test
+    public void testDecodeSrvRecord() throws Exception {
+        DefaultDnsRecordDecoder decoder = new DefaultDnsRecordDecoder();
+        ByteBuf buffer = Unpooled.buffer().writeShort(0).writeShort(1).writeShort(8080);
+        DefaultDnsRecordEncoder.encodeName("srv.netty.io.", buffer);
+        buffer.writeInt(2024173464).writeInt(10000).writeInt(2400).writeInt(604800).writeInt(3600);
+        int readerIndex = buffer.readerIndex();
+        int writerIndex = buffer.writerIndex();
+        try {
+            DnsSrvRecord record = (DnsSrvRecord) decoder.decodeRecord(
+                    "netty.io", DnsRecordType.SRV, DnsRecord.CLASS_IN, 60, buffer, 0, buffer.readableBytes());
+            assertEquals("netty.io.", record.name());
+            assertEquals(DnsRecord.CLASS_IN, record.dnsClass());
+            assertEquals(60, record.timeToLive());
+            assertEquals(DnsRecordType.SRV, record.type());
+            assertEquals(readerIndex, buffer.readerIndex());
+            assertEquals(writerIndex, buffer.writerIndex());
+            assertEquals(0, record.priority());
+            assertEquals(1, record.weight());
+            assertEquals(8080, record.port());
+            assertEquals("srv.netty.io.", record.target());
         } finally {
             buffer.release();
         }
@@ -112,21 +281,20 @@ public class DefaultDnsRecordDecoderTest {
             assertEquals("FOO." + plainName, uncompressedIndexedName);
 
             // Now lets make sure out object parsing produces the same results for non PTR type (just use CNAME).
-            rawPlainRecord = (DefaultDnsRawRecord) decoder.decodeRecord(
+            DnsCNameRecord cnameRecord = (DnsCNameRecord) decoder.decodeRecord(
                     plainName, DnsRecordType.CNAME, DnsRecord.CLASS_IN, 60, buffer, 0, 11);
-            assertEquals(plainName, rawPlainRecord.name());
-            assertEquals(plainName, DefaultDnsRecordDecoder.decodeName(rawPlainRecord.content()));
+            assertEquals(plainName, cnameRecord.name());
+            assertEquals(plainName, cnameRecord.hostname());
 
-            rawUncompressedRecord = (DefaultDnsRawRecord) decoder.decodeRecord(
+            cnameRecord = (DnsCNameRecord) decoder.decodeRecord(
                     uncompressedPlainName, DnsRecordType.CNAME, DnsRecord.CLASS_IN, 60, buffer, 16, 4);
-            assertEquals(uncompressedPlainName, rawUncompressedRecord.name());
-            assertEquals(uncompressedPlainName, DefaultDnsRecordDecoder.decodeName(rawUncompressedRecord.content()));
+            assertEquals(uncompressedPlainName, cnameRecord.name());
+            assertEquals(uncompressedPlainName, cnameRecord.hostname());
 
-            rawUncompressedIndexedRecord = (DefaultDnsRawRecord) decoder.decodeRecord(
+            cnameRecord = (DnsCNameRecord) decoder.decodeRecord(
                     uncompressedIndexedName, DnsRecordType.CNAME, DnsRecord.CLASS_IN, 60, buffer, 12, 8);
-            assertEquals(uncompressedIndexedName, rawUncompressedIndexedRecord.name());
-            assertEquals(uncompressedIndexedName,
-                         DefaultDnsRecordDecoder.decodeName(rawUncompressedIndexedRecord.content()));
+            assertEquals(uncompressedIndexedName, cnameRecord.name());
+            assertEquals(uncompressedIndexedName, cnameRecord.hostname());
 
             // Now lets make sure out object parsing produces the same results for PTR type.
             DnsPtrRecord ptrRecord = (DnsPtrRecord) decoder.decodeRecord(

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -702,22 +702,8 @@ abstract class DnsResolveContext<T> {
         Map<String, String> cnames = null;
         for (int i = 0; i < answerCount; i ++) {
             final DnsRecord r = response.recordAt(DnsSection.ANSWER, i);
-            final DnsRecordType type = r.type();
-            if (type != DnsRecordType.CNAME) {
-                continue;
-            }
 
-            String domainName;
-
-            if (r instanceof DnsCNameRecord) {
-                domainName = ((DnsCNameRecord) r).hostname();
-            } else if (r instanceof DnsRawRecord) {
-                final ByteBuf recordContent = ((ByteBufHolder) r).content();
-                domainName = decodeDomainName(recordContent);
-                if (domainName == null) {
-                    continue;
-                }
-            } else {
+            if (!(r instanceof DnsCNameRecord)) {
                 continue;
             }
 
@@ -725,7 +711,7 @@ abstract class DnsResolveContext<T> {
                 cnames = new HashMap<String, String>(min(8, answerCount));
             }
 
-            cnames.put(r.name().toLowerCase(Locale.US), domainName.toLowerCase(Locale.US));
+            cnames.put(r.name().toLowerCase(Locale.US), ((DnsCNameRecord) r).hostname().toLowerCase(Locale.US));
         }
 
         return cnames != null? cnames : Collections.<String, String>emptyMap();

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -991,7 +991,7 @@ abstract class DnsResolveContext<T> {
             final String domainName;
 
             if (r instanceof DnsNsRecord) {
-                domainName = ((DnsNsRecord) r).hostname();
+                domainName = ((DnsNsRecord) r).domain();
             } else {
                 final ByteBuf recordContent = ((ByteBufHolder) r).content();
                 domainName = decodeDomainName(recordContent);

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -28,6 +28,7 @@ import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.handler.codec.dns.DefaultDnsQuestion;
+import io.netty.handler.codec.dns.DnsMxRecord;
 import io.netty.handler.codec.dns.DnsQuestion;
 import io.netty.handler.codec.dns.DnsRawRecord;
 import io.netty.handler.codec.dns.DnsRecord;
@@ -600,28 +601,26 @@ public class DnsNameResolverTest {
                 assertThat(response.code(), is(DnsResponseCode.NOERROR));
 
                 final int answerCount = response.count(DnsSection.ANSWER);
-                final List<DnsRecord> mxList = new ArrayList<DnsRecord>(answerCount);
+                final List<DnsMxRecord> mxList = new ArrayList<DnsMxRecord>(answerCount);
                 for (int i = 0; i < answerCount; i++) {
                     final DnsRecord r = response.recordAt(DnsSection.ANSWER, i);
                     if (r.type() == DnsRecordType.MX) {
-                        mxList.add(r);
+                        mxList.add((DnsMxRecord) r);
                     }
                 }
 
                 assertThat(mxList.size(), is(greaterThan(0)));
                 StringBuilder buf = new StringBuilder();
-                for (DnsRecord r : mxList) {
-                    ByteBuf recordContent = ((ByteBufHolder) r).content();
-
+                for (DnsMxRecord r : mxList) {
                     buf.append(StringUtil.NEWLINE);
                     buf.append('\t');
                     buf.append(r.name());
                     buf.append(' ');
                     buf.append(r.type().name());
                     buf.append(' ');
-                    buf.append(recordContent.readUnsignedShort());
+                    buf.append(r.preference());
                     buf.append(' ');
-                    buf.append(DnsResolveContext.decodeDomainName(recordContent));
+                    buf.append(r.hostname());
                 }
 
                 logger.info("{} has the following MX records:{}", hostname, buf);
@@ -983,17 +982,17 @@ public class DnsNameResolverTest {
                 assertThat(mxList.size(), is(greaterThan(0)));
                 StringBuilder buf = new StringBuilder();
                 for (DnsRecord r : mxList) {
-                    ByteBuf recordContent = ((ByteBufHolder) r).content();
+                    DnsMxRecord mx = (DnsMxRecord) r;
 
                     buf.append(StringUtil.NEWLINE);
                     buf.append('\t');
-                    buf.append(r.name());
+                    buf.append(mx.name());
                     buf.append(' ');
-                    buf.append(r.type().name());
+                    buf.append(mx.type().name());
                     buf.append(' ');
-                    buf.append(recordContent.readUnsignedShort());
+                    buf.append(mx.preference());
                     buf.append(' ');
-                    buf.append(DnsResolveContext.decodeDomainName(recordContent));
+                    buf.append(mx.hostname());
 
                     ReferenceCountUtil.release(r);
                 }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -622,7 +622,7 @@ public class DnsNameResolverTest {
                     buf.append(' ');
                     buf.append(r.preference());
                     buf.append(' ');
-                    buf.append(r.hostname());
+                    buf.append(r.exchange());
                 }
 
                 logger.info("{} has the following MX records:{}", hostname, buf);
@@ -994,7 +994,7 @@ public class DnsNameResolverTest {
                     buf.append(' ');
                     buf.append(mx.preference());
                     buf.append(' ');
-                    buf.append(mx.hostname());
+                    buf.append(mx.exchange());
 
                     ReferenceCountUtil.release(r);
                 }


### PR DESCRIPTION
Motivation:

add more common DNS record types

Modification:

define, decode and encode A, AAAA, CNAME, MX, NS, SOA, SRV and TXT record types

Result:


