### PR TITLE
Add UptimeServer and adjust UptimeClient's code style.

### DIFF
--- a/example/src/main/java/io/netty/example/uptime/UptimeClientHandler.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeClientHandler.java
@@ -15,10 +15,8 @@
  */
 package io.netty.example.uptime;
 
-import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.EventLoop;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
@@ -70,12 +68,11 @@ public class UptimeClientHandler extends SimpleChannelInboundHandler<Object> {
     public void channelUnregistered(final ChannelHandlerContext ctx) throws Exception {
         println("Sleeping for: " + UptimeClient.RECONNECT_DELAY + 's');
 
-        final EventLoop loop = ctx.channel().eventLoop();
-        loop.schedule(new Runnable() {
+        ctx.channel().eventLoop().schedule(new Runnable() {
             @Override
             public void run() {
                 println("Reconnecting to: " + UptimeClient.HOST + ':' + UptimeClient.PORT);
-                UptimeClient.connect(UptimeClient.configureBootstrap(new Bootstrap(), loop));
+                UptimeClient.connect();
             }
         }, UptimeClient.RECONNECT_DELAY, TimeUnit.SECONDS);
     }

--- a/example/src/main/java/io/netty/example/uptime/UptimeServer.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2017 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -32,6 +32,10 @@ import io.netty.handler.logging.LoggingHandler;
 public final class UptimeServer {
     private static final int PORT = Integer.parseInt(System.getProperty("port", "8080"));
     private static final UptimeServerHandler handler = new UptimeServerHandler();
+
+    private UptimeServer() {
+        throw new IllegalAccessError("Should not be instantiated");
+    }
 
     public static void main(String[] args) throws Exception {
 

--- a/example/src/main/java/io/netty/example/uptime/UptimeServer.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeServer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.uptime;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+
+/**
+ * Uptime server is served as a connection server.
+ * So it simply discards all message received.
+ */
+public final class UptimeServer {
+    private static final int PORT = Integer.parseInt(System.getProperty("port", "8080"));
+    private static final UptimeServerHandler handler = new UptimeServerHandler();
+
+    public static void main(String[] args) throws Exception {
+
+        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
+        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        try {
+            ServerBootstrap b = new ServerBootstrap();
+            b.group(bossGroup, workerGroup)
+                    .channel(NioServerSocketChannel.class)
+                    .handler(new LoggingHandler(LogLevel.INFO))
+                    .childHandler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        public void initChannel(SocketChannel ch) {
+                            ch.pipeline().addLast(handler);
+                        }
+                    });
+
+            // Bind and start to accept incoming connections.
+            ChannelFuture f = b.bind(PORT).sync();
+
+            // Wait until the server socket is closed.
+            // In this example, this does not happen, but you can do that to gracefully
+            // shut down your server.
+            f.channel().closeFuture().sync();
+        } finally {
+            workerGroup.shutdownGracefully();
+            bossGroup.shutdownGracefully();
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/uptime/UptimeServer.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeServer.java
@@ -34,7 +34,6 @@ public final class UptimeServer {
     private static final UptimeServerHandler handler = new UptimeServerHandler();
 
     private UptimeServer() {
-        throw new IllegalAccessError("Should not be instantiated");
     }
 
     public static void main(String[] args) throws Exception {

--- a/example/src/main/java/io/netty/example/uptime/UptimeServerHandler.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeServerHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.uptime;
+
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+@Sharable
+public class UptimeServerHandler extends SimpleChannelInboundHandler<Object> {
+    @Override
+    public void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
+        // discard
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        // Close the connection when an exception is raised.
+        cause.printStackTrace();
+        ctx.close();
+    }
+}

--- a/example/src/main/java/io/netty/example/uptime/UptimeServerHandler.java
+++ b/example/src/main/java/io/netty/example/uptime/UptimeServerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2017 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/run-example.sh
+++ b/run-example.sh
@@ -38,6 +38,7 @@ EXAMPLE_MAP=(
   'memcache-binary-client:io.netty.example.memcache.binary.MemcacheClient'
   'stomp-client:io.netty.example.stomp.StompClient'
   'uptime-client:io.netty.example.uptime.UptimeClient'
+  'uptime-server:io.netty.example.uptime.UptimeServer'
   'sctpecho-client:io.netty.example.sctp.SctpEchoClient'
   'sctpecho-server:io.netty.example.sctp.SctpEchoServer'
   'localecho:io.netty.example.localecho.LocalEcho'


### PR DESCRIPTION
Motivation:

1. Uptime example is lack of server.
2. UptimeClient's code style is a little bit different from others, which make reader feel confused.
3. We don't need to create a new Bootstrap instance each time client reconnect to server.

Modification:

1. Add UptimeServer and UptimeServerHandler which simply accept all connection and discard all message.
2. Change UptimeClient's code style.
3. Share a single Bootstrap instance.

Result:

1. Uptime server support.
2. Consistent code style.
3. Single Bootstrap for all reconnection.
