### PR TITLE
Introduce ReferenceCounted.refCnt()

### DIFF
--- a/common/src/main/java/io/netty/util/ReferenceCountUtil.java
+++ b/common/src/main/java/io/netty/util/ReferenceCountUtil.java
@@ -157,6 +157,14 @@ public final class ReferenceCountUtil {
     }
 
     /**
+     * Returns reference count of a {@link ReferenceCounted} object. If object is not type of
+     * {@link ReferenceCounted}, {@code -1} is returned.
+     */
+    public static int refCnt(Object msg) {
+        return msg instanceof ReferenceCounted ? ((ReferenceCounted) msg).refCnt() : -1;
+    }
+
+    /**
      * Releases the objects when the thread that called {@link #releaseLater(Object)} has been terminated.
      */
     private static final class ReleasingTask implements Runnable {


### PR DESCRIPTION
## Motivation:

When debugging netty memory leaks, it's sometimes helpful to
print the object's reference count.

## Modifications:

Add `refCnt` methods to set of already exitsting helpers for ref coutned
objects.

## Result:

Users will have utility to print object's ref count without much of a
boilerplate.