### PR TITLE
Fix regression in QueryStringEncoder

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/QueryStringEncoder.java
@@ -108,7 +108,7 @@ public class QueryStringEncoder {
     private static String encodeComponent(String s, Charset charset) {
         // TODO: Optimize me.
         try {
-            return URLEncoder.encode(s, PATTERN.matcher(charset.name()).replaceAll("%20"));
+            return PATTERN.matcher(URLEncoder.encode(s, charset.name())).replaceAll("%20");
         } catch (UnsupportedEncodingException ignored) {
             throw new UnsupportedCharsetException(charset.name());
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/QueryStringEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/QueryStringEncoderTest.java
@@ -59,4 +59,12 @@ public class QueryStringEncoderTest {
         Assert.assertEquals("/foo/\u00A5?a=%FE%FF%00%A5", e.toString());
         Assert.assertEquals(new URI("/foo/\u00A5?a=%FE%FF%00%A5"), e.toUri());
     }
+
+    @Test
+    public void testWhitespaceEncoding() throws Exception {
+        QueryStringEncoder e = new QueryStringEncoder("/foo");
+        e.addParam("a", "b c");
+        Assert.assertEquals("/foo?a=b%20c", e.toString());
+        Assert.assertEquals(new URI("/foo?a=b%20c"), e.toUri());
+    }
 }


### PR DESCRIPTION
Motivation:

Commit d675febf07d14d4dff82471829f974369705655a introduced a regression in QueryStringEncoder, resulting in whitespace being converted into a literal `+` sign instead of `%20`.

Modification:

Modify `encodeComponent` to pattern match and replace on the result of the call to `URLEncoder#encode`

Result:

Fixes regression