### PR TITLE
Correctly manage buffer life-cycle in http2 multiplex example

### DIFF
--- a/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/HelloWorldHttp2Handler.java
@@ -65,7 +65,10 @@ public class HelloWorldHttp2Handler extends ChannelDuplexHandler {
      */
     public void onDataRead(ChannelHandlerContext ctx, Http2DataFrame data) throws Exception {
         if (data.isEndStream()) {
-            sendResponse(ctx, data.content().retain());
+            sendResponse(ctx, data.content());
+        } else {
+            // We do not send back the response to the remote-peer, so we need to release it.
+            data.release();
         }
     }
 


### PR DESCRIPTION
Motivation:

We not correctly managed the life-cycle of the buffer / frames in our http2 multiplex example which lead to a memory leak.

Modifications:

- Correctly release frame if not echo'ed back the remote peer.
- Not retain content before echo back to remote peer.

Result:

No more leak in the example, fixes [#6636].