### PR TITLE
Fix possible overflow when calculate in the size of the out buffer in…

### DIFF
--- a/codec/src/test/java/io/netty/handler/codec/base64/Base64Test.java
+++ b/codec/src/test/java/io/netty/handler/codec/base64/Base64Test.java
@@ -158,4 +158,15 @@ public class Base64Test {
             expectedBuf.release();
         }
     }
+
+    @Test
+    public void testOverflowEncodedBufferSize() {
+        assertEquals(Integer.MAX_VALUE, Base64.encodedBufferSize(Integer.MAX_VALUE, true));
+        assertEquals(Integer.MAX_VALUE, Base64.encodedBufferSize(Integer.MAX_VALUE, false));
+    }
+
+    @Test
+    public void testOverflowDecodedBufferSize() {
+        assertEquals(1610612736, Base64.decodedBufferSize(Integer.MAX_VALUE));
+    }
 }


### PR DESCRIPTION
… Base64

Motivation:

We not correctly guarded against overflow and so call Base64.encode(...) with a big buffer may lead to an overflow when calculate the size of the out buffer.

Modifications:

Correctly guard against overflow.

Result:

Fixes [#6620].