### PR TITLE
Regulation of the InternetProtocolFamily usage

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -78,21 +78,21 @@ public class DnsNameResolver extends InetNameResolver {
     private static final InetAddress LOCALHOST_ADDRESS;
     private static final DnsRecord[] EMPTY_ADDITIONALS = new DnsRecord[0];
     private static final DnsRecordType[] IPV4_ONLY_RESOLVED_RECORD_TYPES =
-            new DnsRecordType[] {DnsRecordType.A};
+            {DnsRecordType.A};
     private static final InternetProtocolFamily[] IPV4_ONLY_RESOLVED_PROTOCOL_FAMILIES =
-            new InternetProtocolFamily[] {InternetProtocolFamily.IPv4};
+            {InternetProtocolFamily.IPv4};
     private static final DnsRecordType[] IPV4_PREFERRED_RESOLVED_RECORD_TYPES =
-            new DnsRecordType[] {DnsRecordType.A, DnsRecordType.AAAA};
+            {DnsRecordType.A, DnsRecordType.AAAA};
     private static final InternetProtocolFamily[] IPV4_PREFERRED_RESOLVED_PROTOCOL_FAMILIES =
-            new InternetProtocolFamily[] {InternetProtocolFamily.IPv4, InternetProtocolFamily.IPv6};
+            {InternetProtocolFamily.IPv4, InternetProtocolFamily.IPv6};
     private static final DnsRecordType[] IPV6_ONLY_RESOLVED_RECORD_TYPES =
-            new DnsRecordType[] {DnsRecordType.AAAA};
+            {DnsRecordType.AAAA};
     private static final InternetProtocolFamily[] IPV6_ONLY_RESOLVED_PROTOCOL_FAMILIES =
-            new InternetProtocolFamily[] {InternetProtocolFamily.IPv6};
+            {InternetProtocolFamily.IPv6};
     private static final DnsRecordType[] IPV6_PREFERRED_RESOLVED_RECORD_TYPES =
-            new DnsRecordType[] {DnsRecordType.AAAA, DnsRecordType.A};
+            {DnsRecordType.AAAA, DnsRecordType.A};
     private static final InternetProtocolFamily[] IPV6_PREFERRED_RESOLVED_PROTOCOL_FAMILIES =
-            new InternetProtocolFamily[] {InternetProtocolFamily.IPv6, InternetProtocolFamily.IPv4};
+            {InternetProtocolFamily.IPv6, InternetProtocolFamily.IPv4};
 
     static final ResolvedAddressTypes DEFAULT_RESOLVE_ADDRESS_TYPES;
     static final String[] DEFAULT_SEARCH_DOMAINS;
@@ -536,8 +536,7 @@ public class DnsNameResolver extends InetNameResolver {
     }
 
     private InetAddress loopbackAddress() {
-        return preferredAddressType() == InternetProtocolFamily.IPv4 ?
-                    NetUtil.LOCALHOST4 : NetUtil.LOCALHOST6;
+        return preferredAddressType().localhost();
     }
 
     /**

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -38,8 +38,6 @@ import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.StringUtil;
 
 import java.net.IDN;
-import java.net.Inet4Address;
-import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -576,25 +574,13 @@ abstract class DnsNameResolverContext<T> {
         }
 
         final int size = resolvedEntries.size();
-        switch (parent.preferredAddressType()) {
-        case IPv4:
-            for (int i = 0; i < size; i ++) {
-                if (resolvedEntries.get(i).address() instanceof Inet4Address) {
-                    return true;
-                }
+        final Class<? extends InetAddress> inetAddressType = parent.preferredAddressType().addressType();
+        for (int i = 0; i < size; i++) {
+            InetAddress address = resolvedEntries.get(i).address();
+            if (inetAddressType.isInstance(address)) {
+                return true;
             }
-            break;
-        case IPv6:
-            for (int i = 0; i < size; i ++) {
-                if (resolvedEntries.get(i).address() instanceof Inet6Address) {
-                    return true;
-                }
-            }
-            break;
-        default:
-            throw new Error();
         }
-
         return false;
     }
 

--- a/transport/src/main/java/io/netty/channel/socket/InternetProtocolFamily.java
+++ b/transport/src/main/java/io/netty/channel/socket/InternetProtocolFamily.java
@@ -25,17 +25,17 @@ import java.net.InetAddress;
  * Internet Protocol (IP) families used byte the {@link DatagramChannel}
  */
 public enum InternetProtocolFamily {
-    IPv4(Inet4Address.class),
-    IPv6(Inet6Address.class);
+    IPv4(Inet4Address.class, 1, NetUtil.LOCALHOST4),
+    IPv6(Inet6Address.class, 2, NetUtil.LOCALHOST6);
 
     private final Class<? extends InetAddress> addressType;
     private final int addressNumber;
     private final InetAddress localHost;
 
-    InternetProtocolFamily(Class<? extends InetAddress> addressType) {
+    InternetProtocolFamily(Class<? extends InetAddress> addressType, int addressNumber, InetAddress localHost) {
         this.addressType = addressType;
-        addressNumber = addressNumber(addressType);
-        localHost = localhost(addressType);
+        this.addressNumber = addressNumber;
+        this.localHost = localHost;
     }
 
     /**
@@ -59,26 +59,6 @@ public enum InternetProtocolFamily {
      */
     public InetAddress localhost() {
         return localHost;
-    }
-
-    private static InetAddress localhost(Class<? extends InetAddress> addressType) {
-        if (addressType.isAssignableFrom(Inet4Address.class)) {
-            return NetUtil.LOCALHOST4;
-        }
-        if (addressType.isAssignableFrom(Inet6Address.class)) {
-            return NetUtil.LOCALHOST6;
-        }
-        throw new Error();
-    }
-
-    private static int addressNumber(Class<? extends InetAddress> addressType) {
-        if (addressType.isAssignableFrom(Inet4Address.class)) {
-            return 1;
-        }
-        if (addressType.isAssignableFrom(Inet6Address.class)) {
-            return 2;
-        }
-        throw new IllegalArgumentException("addressType " + addressType + " not supported");
     }
 
     /**


### PR DESCRIPTION
Motivation:

1. The use of the `InternetProtocolFamily` is not consistent:
   the `DnsNameResolverContext` and `DnsNameResolver` contains switches
   instead of appropriate methods usage.
2. The `InternetProtocolFamily` class contains redundant switches in the
   constructor.

Modifications:

1. Replacing switches to the use of an appropriate methods.
2. Simplifying the `InternetProtocolFamily` constructor.

Result:

Code is cleaner and simpler.