### PR TITLE
Fix HTTP/2 dependency tree corruption

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
@@ -229,6 +229,10 @@ public final class WeightedFairQueueByteDistributor implements StreamByteDistrib
             newParent = new State(parentStreamId);
             stateOnlyRemovalQueue.add(newParent);
             stateOnlyMap.put(parentStreamId, newParent);
+            // Only the stream which was just added will change parents. So we only need an array of size 1.
+            List<ParentChangedEvent> events = new ArrayList<ParentChangedEvent>(1);
+            connectionState.takeChild(newParent, false, events);
+            notifyParentChanged(events);
         }
 
         // if activeCountForTree == 0 then it will not be in its parent's pseudoTimeQueue and thus should not be counted


### PR DESCRIPTION
Motivation:

Chrome was randomly getting stuck loading the tiles examples.
Investigation showed that the Netty flow controller thought it had
nothing to send for the connection even though some streams has queued
data and window available.

Modifications:

Fixed an accounting error where an implicitly created parent was not
being added to the dependency tree, thus it and all of its children were
orphaned from the connection's tree and would never have data written.

Result:

Fixes #6621