### PR TITLE
Remove the comment which is a bit misleading

### DIFF
--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -175,10 +175,6 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
                     pipeline.addLast(handler);
                 }
 
-                // We add this handler via the EventLoop as the user may have used a ChannelInitializer as handler.
-                // In this case the initChannel(...) method will only be called after this method returns. Because
-                // of this we need to ensure we add our handler in a delayed fashion so all the users handler are
-                // placed in front of the ServerBootstrapAcceptor.
                 ch.eventLoop().execute(new Runnable() {
                     @Override
                     public void run() {


### PR DESCRIPTION
Motivation:

The invocation of `initChannel` of `ChannelInitializer` has been moved to as early as during `handlerAdded` is invoked in 26aa34853, whereas it was only invoked during `channelRegistered` was invoked before that. So the comment does not describe how handlers are added in normal circumstances anymore.

This change deletes the comment, hopefully reduce confusions.

Modification:

The comment is removed. However, the code is kept as-is since there might be unusual cases, and adding `ServerBootstrapAcceptor` via the event loop is always safe to enforce the correct order.

Result:

N/A

Fixes #6652.