### PR TITLE
#6657 do not throw ClassCastException when rule subnet version doesn'…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
+++ b/handler/src/main/java/io/netty/handler/ipfilter/IpSubnetFilterRule.java
@@ -91,9 +91,12 @@ public final class IpSubnetFilterRule implements IpFilterRule {
 
         @Override
         public boolean matches(InetSocketAddress remoteAddress) {
-            int ipAddress = ipToInt((Inet4Address) remoteAddress.getAddress());
-
-            return (ipAddress & subnetMask) == networkAddress;
+            final InetAddress inetAddress = remoteAddress.getAddress();
+            if (inetAddress instanceof Inet4Address) {
+                int ipAddress = ipToInt((Inet4Address) inetAddress);
+                return (ipAddress & subnetMask) == networkAddress;
+            }
+            return false;
         }
 
         @Override
@@ -147,9 +150,12 @@ public final class IpSubnetFilterRule implements IpFilterRule {
 
         @Override
         public boolean matches(InetSocketAddress remoteAddress) {
-            BigInteger ipAddress = ipToInt((Inet6Address) remoteAddress.getAddress());
-
-            return ipAddress.and(subnetMask).equals(networkAddress);
+            final InetAddress inetAddress = remoteAddress.getAddress();
+            if (inetAddress instanceof Inet6Address) {
+                BigInteger ipAddress = ipToInt((Inet6Address) inetAddress);
+                return ipAddress.and(subnetMask).equals(networkAddress);
+            }
+            return false;
         }
 
         @Override

--- a/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ipfilter/IpSubnetFilterTest.java
@@ -39,6 +39,18 @@ public class IpSubnetFilterTest {
     }
 
     @Test
+    public void testIpv4SubnetMaskCorrectlyHandlesIpv6() {
+        IpSubnetFilterRule rule = new IpSubnetFilterRule("0.0.0.0", 0, IpFilterRuleType.ACCEPT);
+        Assert.assertFalse(rule.matches(newSockAddress("2001:db8:abcd:0000::1")));
+    }
+
+    @Test
+    public void testIpv6SubnetMaskCorrectlyHandlesIpv4() {
+        IpSubnetFilterRule rule = new IpSubnetFilterRule("::", 0, IpFilterRuleType.ACCEPT);
+        Assert.assertFalse(rule.matches(newSockAddress("91.114.240.43")));
+    }
+
+    @Test
     public void testIp4SubnetFilterRule() throws Exception {
         IpSubnetFilterRule rule = new IpSubnetFilterRule("192.168.56.1", 24, IpFilterRuleType.ACCEPT);
         for (int i = 0; i <= 255; i++) {


### PR DESCRIPTION
…t match remote IP version

Motivation:

`IpSubnetFilterRule.match` throws excpetion while should return false for another IP version.

Modification:

Added `instanceOf` check for `IpSubnetFilterRule.match` method. So Rule will not throw `ClassCastException` when remote address has another IP version.

Result:

Fix for https://github.com/netty/netty/issues/6657
