### PR TITLE
Improvement : allocate less objects for multipart form parsing.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -764,12 +764,12 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
                     }
                 } else {
                     for (int i = 1; i < contents.length; i++) {
-                        if (contents[i].toLowerCase().startsWith(HttpHeaderValues.CHARSET.toString())) {
+                        final String charsetHeader = HttpHeaderValues.CHARSET.toString();
+                        if (contents[i].regionMatches(true, 0, charsetHeader, 0, charsetHeader.length())) {
                             String values = StringUtil.substringAfter(contents[i], '=');
                             Attribute attribute;
                             try {
-                                attribute = factory.createAttribute(request, HttpHeaderValues.CHARSET.toString(),
-                                        cleanString(values));
+                                attribute = factory.createAttribute(request, charsetHeader, cleanString(values));
                             } catch (NullPointerException e) {
                                 throw new ErrorDataDecoderException(e);
                             } catch (IllegalArgumentException e) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestDecoder.java
@@ -155,16 +155,15 @@ public class HttpPostRequestDecoder implements InterfaceHttpPostRequestDecoder {
     protected static String[] getMultipartDataBoundary(String contentType) {
         // Check if Post using "multipart/form-data; boundary=--89421926422648 [; charset=xxx]"
         String[] headerContentType = splitHeaderContentType(contentType);
-        if (headerContentType[0].toLowerCase().startsWith(
-                HttpHeaderValues.MULTIPART_FORM_DATA.toString())) {
+        final String multiPartHeader = HttpHeaderValues.MULTIPART_FORM_DATA.toString();
+        if (headerContentType[0].regionMatches(true, 0, multiPartHeader, 0 , multiPartHeader.length())) {
             int mrank;
             int crank;
-            if (headerContentType[1].toLowerCase().startsWith(
-                    HttpHeaderValues.BOUNDARY.toString())) {
+            final String boundaryHeader = HttpHeaderValues.BOUNDARY.toString();
+            if (headerContentType[1].regionMatches(true, 0, boundaryHeader, 0, boundaryHeader.length())) {
                 mrank = 1;
                 crank = 2;
-            } else if (headerContentType[2].toLowerCase().startsWith(
-                    HttpHeaderValues.BOUNDARY.toString())) {
+            } else if (headerContentType[2].regionMatches(true, 0, boundaryHeader, 0, boundaryHeader.length())) {
                 mrank = 2;
                 crank = 1;
             } else {
@@ -181,8 +180,8 @@ public class HttpPostRequestDecoder implements InterfaceHttpPostRequestDecoder {
                     boundary = bound.substring(1, index);
                 }
             }
-            if (headerContentType[crank].toLowerCase().startsWith(
-                    HttpHeaderValues.CHARSET.toString())) {
+            final String charsetHeader = HttpHeaderValues.CHARSET.toString();
+            if (headerContentType[crank].regionMatches(true, 0, charsetHeader, 0, charsetHeader.length())) {
                 String charset = StringUtil.substringAfter(headerContentType[crank], '=');
                 if (charset != null) {
                     return new String[] {"--" + boundary, charset};


### PR DESCRIPTION
Motivation:

MultipartRequestDecoder allocates unnecessary objects during multi-part form parsing.

Modification:

`toLowerCase().startsWith` constructions replaced with `regionMatches(true)`.

Result:

Less allocations, faster matching.
