### PR TITLE
Update surefire and failsafe plugins to 2.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1125,12 +1125,12 @@
         <!-- keep surefire and failsafe in sync -->
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>2.20</version>
         </plugin>
         <!-- keep surefire and failsafe in sync -->
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.19.1</version>
+          <version>2.20</version>
         </plugin>
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>


### PR DESCRIPTION
Motivation

Maven 3.5.0 was released a few days ago and the current versions of the surefire and failsafe plugins no longer work.

https://maven.apache.org/docs/3.5.0/release-notes.html

Modifications

Update surefire and failsafe plugins to 2.20

Result

Fixes issue #6666 and it's possible to build Netty with Maven 3.5.0

Tested versions:

$ mvn -version
Apache Maven 3.3.9 (NON-CANONICAL_2015-11-23T13:17:27+03:00_root; 2015-11-23T05:17:27-05:00)
Maven home: /opt/maven
Java version: 1.8.0_121, vendor: Oracle Corporation
Java home: /usr/lib/jvm/java-8-openjdk/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "4.10.11-1-arch", arch: "amd64", family: "unix"

$ mvn -version
Apache Maven 3.5.0 (NON-CANONICAL_2017-04-10T13:56:20+03:00_root; 2017-04-10T06:56:20-04:00)
Maven home: /opt/maven
Java version: 1.8.0_121, vendor: Oracle Corporation
Java home: /usr/lib/jvm/java-8-openjdk/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "4.10.11-1-arch", arch: "amd64", family: "unix"

