### PR TITLE
common: Introduce Timer.pendingTimeouts

### DIFF
--- a/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
+++ b/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
@@ -213,6 +213,23 @@ public class HashedWheelTimerTest {
         timer.stop();
     }
 
+    @Test()
+    public void reportPendingTimeouts() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final HashedWheelTimer timer = new HashedWheelTimer();
+        final Timeout t1 = timer.newTimeout(createNoOpTimerTask(), 100, TimeUnit.MINUTES);
+        final Timeout t2 = timer.newTimeout(createNoOpTimerTask(), 100, TimeUnit.MINUTES);
+        timer.newTimeout(createCountDownLatchTimerTask(latch), 90, TimeUnit.MILLISECONDS);
+
+        assertEquals(3, timer.pendingTimeouts());
+        t1.cancel();
+        t2.cancel();
+        latch.await();
+
+        assertEquals(0, timer.pendingTimeouts());
+        timer.stop();
+    }
+
     private static TimerTask createNoOpTimerTask() {
         return new TimerTask() {
             @Override


### PR DESCRIPTION
Motivation:

Fixes #6681.

Modification:

For the sake of better timer observability, expose the number of pending timeouts through the new `HashedWheelTimer.pendingTimeouts` method .

Result:

It's now ridiculously easy to observe Netty timer's very basic and yet important metric, the number of pending tasks/timeouts.
