### PR TITLE
Mark conscrypt as optional

### DIFF
--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -74,6 +74,7 @@
       <groupId>${conscrypt.groupId}</groupId>
       <artifactId>${conscrypt.artifactId}</artifactId>
       <classifier>${conscrypt.classifier}</classifier>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
Motivation:

Conscrypt is not needed when using the handler module, so it should be marked as optional

Modifications:

Mark conscrypt as optional

Result:

Be able to use handler module without conscrypt