### PR TITLE
Fire exceptionCaught before exception-caused close for WebSockets.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
@@ -39,6 +39,7 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        ctx.fireExceptionCaught(cause);
         ctx.close();
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -178,6 +178,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
                     HTTP_1_1, HttpResponseStatus.BAD_REQUEST, Unpooled.wrappedBuffer(cause.getMessage().getBytes()));
             ctx.channel().writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
         } else {
+            ctx.fireExceptionCaught(cause);
             ctx.close();
         }
     }


### PR DESCRIPTION
Motivation:

WebSocket decoding throws exceptions on failure that should cause the pipline to close.  These are currently ignored in the `WebSocketProtocolHandler` and `WebSocketServerProtocolHandler`.  In
particular, this means that messages exceding the max message size will cause the channel to close with no reported failure.

Modifications:

Re-fire the event just before closing the socket to allow it to be handled appropriately.

Result:

Closes [#3063].