### PR TITLE
Not try to compresses HttpMessage if IDENTITY header value is set.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -101,8 +101,7 @@ public class HttpContentCompressor extends HttpContentEncoder {
     @Override
     protected Result beginEncode(HttpResponse headers, String acceptEncoding) throws Exception {
         String contentEncoding = headers.headers().get(HttpHeaders.Names.CONTENT_ENCODING);
-        if (contentEncoding != null &&
-            !HttpHeaders.Values.IDENTITY.equalsIgnoreCase(contentEncoding)) {
+        if (HttpHeaders.Values.IDENTITY.equalsIgnoreCase(contentEncoding)) {
             return null;
         }
 


### PR DESCRIPTION
Motivation:

If Content-Encoding: IDENTITY is used we should not try to compress the http message but just let it pass-through.

Modifications:

Remove "!"

Result:

Fixes [#6689]