### PR TITLE
Do not log on explicit no unsafe again

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -128,7 +128,11 @@ public final class PlatformDependent {
             logger.debug("-Dio.netty.noPreferDirect: {}", !DIRECT_BUFFER_PREFERRED);
         }
 
-        if (!hasUnsafe() && !isAndroid()) {
+        /*
+         * We do not want to log this message if unsafe is explicitly disabled. Do not remove the explicit no unsafe
+         * guard.
+         */
+        if (!hasUnsafe() && !isAndroid() && !PlatformDependent0.isExplicitNoUnsafe()) {
             logger.info(
                     "Your platform does not provide complete low-level API for accessing direct buffers reliably. " +
                     "Unless explicitly requested, heap buffer will always be preferred to avoid potential system " +


### PR DESCRIPTION
Motivation:

Users should not see a scary log message when Netty is initialized if Netty configuration explicitly disables unsafe. The log message that produces this warning was previously guarded but the guard was lost.

Modifications:

This commit brings back the guard against the scary log message if unsafe is explicitly disabled.

Result:

No log message is produced when unsafe is unavailable because Netty was told to not look for it.

Relates #5624, relates #6568
