### PR TITLE
HttpServerKeepAliveHandler doesn't correctly handle VoidChannelPromise

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerKeepAliveHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerKeepAliveHandler.java
@@ -82,7 +82,7 @@ public class HttpServerKeepAliveHandler extends ChannelDuplexHandler {
             }
         }
         if (msg instanceof LastHttpContent && !shouldKeepAlive()) {
-            promise.addListener(ChannelFutureListener.CLOSE);
+            promise = promise.unvoid().addListener(ChannelFutureListener.CLOSE);
         }
         super.write(ctx, msg, promise);
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerKeepAliveHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpServerKeepAliveHandlerTest.java
@@ -118,6 +118,34 @@ public class HttpServerKeepAliveHandlerTest {
     }
 
     @Test
+    public void testConnectionCloseHeaderHandledCorrectly() throws Exception {
+        HttpResponse response = new DefaultFullHttpResponse(httpVersion, responseStatus);
+        response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
+        setupMessageLength(response);
+
+        channel.writeAndFlush(response);
+        HttpResponse writtenResponse = channel.readOutbound();
+
+        assertFalse(channel.isOpen());
+        ReferenceCountUtil.release(writtenResponse);
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
+    public void testConnectionCloseHeaderHandledCorrectlyForVoidPromise() throws Exception {
+        HttpResponse response = new DefaultFullHttpResponse(httpVersion, responseStatus);
+        response.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
+        setupMessageLength(response);
+
+        channel.writeAndFlush(response, channel.voidPromise());
+        HttpResponse writtenResponse = channel.readOutbound();
+
+        assertFalse(channel.isOpen());
+        ReferenceCountUtil.release(writtenResponse);
+        assertFalse(channel.finishAndReleaseAll());
+    }
+
+    @Test
     public void test_PipelineKeepAlive() {
         FullHttpRequest firstRequest = new DefaultFullHttpRequest(httpVersion, HttpMethod.GET, "/v1/foo/bar");
         setKeepAlive(firstRequest, true);


### PR DESCRIPTION
Motivation:

HttpServerKeepAliveHandler throws unexpected error when I do `ctx.writeAndFlush(msg, ctx.voidPromise());` where msg is with header "Connection:close".

Modification:

`HttpServerKeepAliveHandler` does `promise.unvoid()` before adding close listener.

Result:

Fix for #6698.
No error for VoidChannelPromise with HttpServerKeepAliveHandler.
