### PR TITLE
InternalThreadLocalMap#stringBuilder: ensure memory overhead

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/DefaultThreadFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultThreadFactory.java
@@ -107,14 +107,8 @@ public class DefaultThreadFactory implements ThreadFactory {
     public Thread newThread(Runnable r) {
         Thread t = newThread(new DefaultRunnableDecorator(r), prefix + nextId.incrementAndGet());
         try {
-            if (t.isDaemon()) {
-                if (!daemon) {
-                    t.setDaemon(false);
-                }
-            } else {
-                if (daemon) {
-                    t.setDaemon(true);
-                }
+            if (t.isDaemon() != daemon) {
+                t.setDaemon(daemon);
             }
 
             if (t.getPriority() != priority) {

--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -36,6 +36,7 @@ import java.util.WeakHashMap;
 public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap {
 
     private static final int DEFAULT_ARRAY_LIST_INITIAL_CAPACITY = 8;
+    private static final int STRING_BUILDER_MAX_CAPACITY = 1024 << 6;
 
     public static final Object UNSET = new Object();
 
@@ -164,7 +165,7 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
 
     public StringBuilder stringBuilder() {
         StringBuilder builder = stringBuilder;
-        if (builder == null) {
+        if (builder == null || builder.capacity() > STRING_BUILDER_MAX_CAPACITY /* ensure memory overhead */ ) {
             stringBuilder = builder = new StringBuilder(512);
         } else {
             builder.setLength(0);


### PR DESCRIPTION
Motivation:

InternalThreadLocalMap#stringBuilder: ensure memory overhead

Modification:

If the capacity of StringBuilder is greater than 65536 then release it on the next time you get StringBuilder and re-create a StringBuilder. 

I'm not sure if this is a good idea.


