### PR TITLE
InternalThreadLocalMap#stringBuilder: ensure memory overhead

### DIFF
--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -35,6 +35,7 @@ import java.util.WeakHashMap;
  */
 public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap {
 
+    private static final int STRING_BUILDER_MAX_CAPACITY = 1024 << 6;
     private static final int DEFAULT_ARRAY_LIST_INITIAL_CAPACITY = 8;
 
     public static final Object UNSET = new Object();
@@ -164,7 +165,7 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
 
     public StringBuilder stringBuilder() {
         StringBuilder builder = stringBuilder;
-        if (builder == null) {
+        if (builder == null || builder.capacity() > STRING_BUILDER_MAX_CAPACITY /* ensure memory overhead */ ) {
             stringBuilder = builder = new StringBuilder(512);
         } else {
             builder.setLength(0);

--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -165,7 +165,7 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
 
     public StringBuilder stringBuilder() {
         StringBuilder builder = stringBuilder;
-        if (builder == null || builder.capacity() > STRING_BUILDER_MAX_CAPACITY /* ensure memory overhead */ ) {
+        if (builder == null || builder.capacity() > STRING_BUILDER_MAX_CAPACITY) {
             stringBuilder = builder = new StringBuilder(512);
         } else {
             builder.setLength(0);


### PR DESCRIPTION
Motivation:

InternalThreadLocalMap#stringBuilder: ensure memory overhead

Modification:

If the capacity of StringBuilder is greater than 65536 then release it on the next time you get StringBuilder and re-create a StringBuilder. 

I'm not sure if this is a good idea.
