### PR TITLE
Ensure Netty is usable on Java7

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
@@ -16,15 +16,18 @@
 package io.netty.handler.ssl;
 
 import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIMatcher;
 import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLParameters;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
-final class Java8SslParametersUtils {
+final class Java8SslUtils {
 
-    private Java8SslParametersUtils() { }
+    private Java8SslUtils() { }
 
     static List<String> getSniHostNames(SSLParameters sslParameters) {
         List<SNIServerName> names = sslParameters.getServerNames();
@@ -58,5 +61,27 @@ final class Java8SslParametersUtils {
 
     static void setUseCipherSuitesOrder(SSLParameters sslParameters, boolean useOrder) {
         sslParameters.setUseCipherSuitesOrder(useOrder);
+    }
+
+    @SuppressWarnings("unchecked")
+    static void setSNIMatchers(SSLParameters sslParameters, Collection<?> matchers) {
+        sslParameters.setSNIMatchers((Collection<SNIMatcher>) matchers);
+    }
+
+    @SuppressWarnings("unchecked")
+    static boolean checkSniHostnameMatch(Collection<?> matchers, String hostname) {
+        if (matchers != null && !matchers.isEmpty()) {
+            SNIHostName name = new SNIHostName(hostname);
+            Iterator<SNIMatcher> matcherIt = (Iterator<SNIMatcher>) matchers.iterator();
+            while (matcherIt.hasNext()) {
+                SNIMatcher matcher = matcherIt.next();
+                // type 0 is for hostname
+                if (matcher.getType() == 0 && matcher.matches(name)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return true;
     }
 }

--- a/handler/src/test/java/io/netty/handler/ssl/ConscryptJdkSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ConscryptJdkSslEngineInteropTest.java
@@ -61,7 +61,7 @@ public class ConscryptJdkSslEngineInteropTest extends SSLEngineTest {
 
     @Override
     protected Provider clientSslContextProvider() {
-        return Java8SslUtils.conscryptProvider();
+        return Java8SslTestUtils.conscryptProvider();
     }
 
     @Ignore /* Does the JDK support a "max certificate chain length"? */

--- a/handler/src/test/java/io/netty/handler/ssl/Java8SslTestUtils.java
+++ b/handler/src/test/java/io/netty/handler/ssl/Java8SslTestUtils.java
@@ -24,9 +24,9 @@ import javax.net.ssl.SSLParameters;
 import java.security.Provider;
 import java.util.Collections;
 
-final class Java8SslUtils {
+final class Java8SslTestUtils {
 
-    private Java8SslUtils() { }
+    private Java8SslTestUtils() { }
 
     static void setSNIMatcher(SSLParameters parameters) {
         SNIMatcher matcher = new SNIMatcher(0) {

--- a/handler/src/test/java/io/netty/handler/ssl/JdkConscryptSslEngineInteropTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkConscryptSslEngineInteropTest.java
@@ -61,7 +61,7 @@ public class JdkConscryptSslEngineInteropTest extends SSLEngineTest {
 
     @Override
     protected Provider serverSslContextProvider() {
-        return Java8SslUtils.conscryptProvider();
+        return Java8SslTestUtils.conscryptProvider();
     }
 
     @Override

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -598,7 +598,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
         SSLEngine engine = serverSslCtx.newEngine(UnpooledByteBufAllocator.DEFAULT);
         try {
             SSLParameters parameters = new SSLParameters();
-            Java8SslUtils.setSNIMatcher(parameters);
+            Java8SslTestUtils.setSNIMatcher(parameters);
             engine.setSSLParameters(parameters);
         } finally {
             cleanupServerSslEngine(engine);

--- a/pom.xml
+++ b/pom.xml
@@ -869,7 +869,7 @@
           </includes>
           <excludes>
             <exclude>**/Abstract*</exclude>
-            <exclude>**/TestUtil*</exclude>
+            <exclude>**/*TestUtil*</exclude>
           </excludes>
           <runOrder>random</runOrder>
           <systemPropertyVariables>


### PR DESCRIPTION
Motivation:

When adding SNIMatcher support we missed to use static delegating methods and so may try to load classes that not exists in Java7. Which will lead to errors.

Modifications:

- Correctly only try to load classes when running on java8+
- Ensure Java8+ related tests only run when using java8+

Result:

Fixes [#6700]
