### PR TITLE
Add explicit message when `noexec` prevents library loading.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -709,6 +709,13 @@
 
             <!-- Resolver -->
             <ignore>java.net.InetAddress</ignore>
+
+            <!-- NoexecVolumeDetector -->
+            <ignore>java.nio.file.attribute.PosixFilePermission</ignore>
+            <ignore>java.nio.file.Files</ignore>
+            <ignore>java.nio.file.LinkOption</ignore>
+            <ignore>java.nio.file.Path</ignore>
+            <ignore>java.io.File</ignore>
           </ignores>
         </configuration>
         <executions>


### PR DESCRIPTION
Add explicit message when `noexec` prevents library loading.

Motivation:

Docker's `--tmpfs` flag mounts the temp volume with `noexec` by default, resulting in an UnsatisfiedLinkError.  While this is good security practice, it is a surprising failure from a seemingly innocuous flag.

Modifications:

Add a best-effort attempt to detect the `noexec` flag in `NativeLibraryLoader`.  This solution is (probably) limited to Oracle/OpenJDK VM's and requires Java 7 or higher, and also requires `--add-opens=java.base/sun.nio.fs=...` for Java 9.  It avoids error message parsing and it does not directly attempt to read mount information.

Also upgraded animal-sniffer-maven-plugin and added configuration to make it ignore code annotated with `io.netty.util.SuppressForbidden` to address @Scottmitch's feedback from original PR.

Result:

Fixes [#6678].