### PR TITLE
Simplify JUnit assertions

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateClientExtensionHandshakerTest.java
@@ -52,7 +52,7 @@ public class PerMessageDeflateClientExtensionHandshakerTest {
         assertEquals(PERMESSAGE_DEFLATE_EXTENSION, data.name());
         assertTrue(data.parameters().containsKey(CLIENT_MAX_WINDOW));
         assertTrue(data.parameters().containsKey(SERVER_MAX_WINDOW));
-        assertTrue(data.parameters().get(SERVER_MAX_WINDOW).equals("10"));
+        assertEquals("10", data.parameters().get(SERVER_MAX_WINDOW));
         assertTrue(data.parameters().containsKey(CLIENT_MAX_WINDOW));
         assertTrue(data.parameters().containsKey(SERVER_MAX_WINDOW));
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshakerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/PerMessageDeflateServerExtensionHandshakerTest.java
@@ -122,9 +122,9 @@ public class PerMessageDeflateServerExtensionHandshakerTest {
         // test
         assertEquals(PERMESSAGE_DEFLATE_EXTENSION, data.name());
         assertTrue(data.parameters().containsKey(CLIENT_MAX_WINDOW));
-        assertTrue(data.parameters().get(CLIENT_MAX_WINDOW).equals("10"));
+        assertEquals("10", data.parameters().get(CLIENT_MAX_WINDOW));
         assertTrue(data.parameters().containsKey(SERVER_MAX_WINDOW));
-        assertTrue(data.parameters().get(SERVER_MAX_WINDOW).equals("12"));
+        assertEquals("12", data.parameters().get(SERVER_MAX_WINDOW));
         assertTrue(data.parameters().containsKey(CLIENT_MAX_WINDOW));
         assertTrue(data.parameters().containsKey(SERVER_MAX_WINDOW));
 
@@ -150,7 +150,7 @@ public class PerMessageDeflateServerExtensionHandshakerTest {
         assertEquals(PERMESSAGE_DEFLATE_EXTENSION, data.name());
         assertEquals(2, data.parameters().size());
         assertTrue(data.parameters().containsKey(SERVER_MAX_WINDOW));
-        assertTrue(data.parameters().get(SERVER_MAX_WINDOW).equals("12"));
+        assertEquals("12", data.parameters().get(SERVER_MAX_WINDOW));
         assertTrue(data.parameters().containsKey(SERVER_NO_CONTEXT));
 
         // initialize

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketServerCompressionHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/extensions/compression/WebSocketServerCompressionHandlerTest.java
@@ -50,8 +50,8 @@ public class WebSocketServerCompressionHandlerTest {
 
         Assert.assertEquals(PERMESSAGE_DEFLATE_EXTENSION, exts.get(0).name());
         Assert.assertTrue(exts.get(0).parameters().isEmpty());
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateDecoder.class) != null);
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateEncoder.class) != null);
+        Assert.assertNotNull(ch.pipeline().get(PerMessageDeflateDecoder.class));
+        Assert.assertNotNull(ch.pipeline().get(PerMessageDeflateEncoder.class));
     }
 
     @Test
@@ -71,8 +71,8 @@ public class WebSocketServerCompressionHandlerTest {
 
         Assert.assertEquals(PERMESSAGE_DEFLATE_EXTENSION, exts.get(0).name());
         Assert.assertEquals("10", exts.get(0).parameters().get(CLIENT_MAX_WINDOW));
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateDecoder.class) != null);
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateEncoder.class) != null);
+        Assert.assertNotNull(ch.pipeline().get(PerMessageDeflateDecoder.class));
+        Assert.assertNotNull(ch.pipeline().get(PerMessageDeflateEncoder.class));
     }
 
     @Test
@@ -92,8 +92,8 @@ public class WebSocketServerCompressionHandlerTest {
 
         Assert.assertEquals(PERMESSAGE_DEFLATE_EXTENSION, exts.get(0).name());
         Assert.assertTrue(exts.get(0).parameters().isEmpty());
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateDecoder.class) != null);
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateEncoder.class) != null);
+        Assert.assertNotNull(ch.pipeline().get(PerMessageDeflateDecoder.class));
+        Assert.assertNotNull(ch.pipeline().get(PerMessageDeflateEncoder.class));
     }
 
     @Test
@@ -113,8 +113,8 @@ public class WebSocketServerCompressionHandlerTest {
 
         Assert.assertEquals(PERMESSAGE_DEFLATE_EXTENSION, exts.get(0).name());
         Assert.assertEquals("10", exts.get(0).parameters().get(SERVER_MAX_WINDOW));
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateDecoder.class) != null);
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateEncoder.class) != null);
+        Assert.assertNotNull(ch.pipeline().get(PerMessageDeflateDecoder.class));
+        Assert.assertNotNull(ch.pipeline().get(PerMessageDeflateEncoder.class));
     }
 
     @Test
@@ -131,8 +131,8 @@ public class WebSocketServerCompressionHandlerTest {
         HttpResponse res2 = ch.readOutbound();
 
         Assert.assertFalse(res2.headers().contains(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS));
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateDecoder.class) == null);
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateEncoder.class) == null);
+        Assert.assertNull(ch.pipeline().get(PerMessageDeflateDecoder.class));
+        Assert.assertNull(ch.pipeline().get(PerMessageDeflateEncoder.class));
     }
 
     @Test
@@ -148,8 +148,8 @@ public class WebSocketServerCompressionHandlerTest {
         HttpResponse res2 = ch.readOutbound();
 
         Assert.assertFalse(res2.headers().contains(HttpHeaderNames.SEC_WEBSOCKET_EXTENSIONS));
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateDecoder.class) == null);
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateEncoder.class) == null);
+        Assert.assertNull(ch.pipeline().get(PerMessageDeflateDecoder.class));
+        Assert.assertNull(ch.pipeline().get(PerMessageDeflateEncoder.class));
     }
 
     @Test
@@ -168,8 +168,8 @@ public class WebSocketServerCompressionHandlerTest {
 
         Assert.assertEquals(PERMESSAGE_DEFLATE_EXTENSION, exts.get(0).name());
         Assert.assertTrue(exts.get(0).parameters().isEmpty());
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateDecoder.class) != null);
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateEncoder.class) != null);
+        Assert.assertNotNull(ch.pipeline().get(PerMessageDeflateDecoder.class));
+        Assert.assertNotNull(ch.pipeline().get(PerMessageDeflateEncoder.class));
     }
 
     @Test
@@ -190,8 +190,8 @@ public class WebSocketServerCompressionHandlerTest {
 
         Assert.assertEquals(PERMESSAGE_DEFLATE_EXTENSION, exts.get(0).name());
         Assert.assertTrue(exts.get(0).parameters().isEmpty());
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateDecoder.class) != null);
-        Assert.assertTrue(ch.pipeline().get(PerMessageDeflateEncoder.class) != null);
+        Assert.assertNotNull(ch.pipeline().get(PerMessageDeflateDecoder.class));
+        Assert.assertNotNull(ch.pipeline().get(PerMessageDeflateEncoder.class));
     }
 
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/ReadOnlyHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/ReadOnlyHttp2HeadersTest.java
@@ -22,9 +22,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import static io.netty.handler.codec.http2.DefaultHttp2HeadersTest.verifyPseudoHeadersFirst;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class ReadOnlyHttp2HeadersTest {
     @Test(expected = IllegalArgumentException.class)
@@ -148,8 +146,8 @@ public class ReadOnlyHttp2HeadersTest {
         assertTrue(AsciiString.contentEqualsIgnoreCase("value1", headers.get("Name1")));
         assertTrue(AsciiString.contentEqualsIgnoreCase("/foo",
                    headers.get(Http2Headers.PseudoHeaderName.PATH.value())));
-        assertEquals(null, headers.get(Http2Headers.PseudoHeaderName.STATUS.value()));
-        assertEquals(null, headers.get("a missing header"));
+        assertNull(headers.get(Http2Headers.PseudoHeaderName.STATUS.value()));
+        assertNull(headers.get("a missing header"));
     }
 
     private void testIteratorReadOnly(Http2Headers headers) {


### PR DESCRIPTION
Motivation:

Some JUnit assert calls can be replaced by simpler.

Modifications:

Replacement with a more suitable methods.

Result:

More informative JUnit reports.