### PR TITLE
Add uber-staging and uber-snapshot profile that can be used to genera…

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -36,7 +36,7 @@
   <profiles>
     <!-- If the uber profile is used it will automatically fetch the missing native jar from maven and add it to the all jar as well. -->
     <profile>
-      <id>uber</id>
+      <id>uber-staging</id>
       <repositories>
         <repository>
           <id>staged-releases</id>
@@ -44,6 +44,30 @@
           <url>https://oss.sonatype.org/service/local/repositories/${stagingRepositoryId}/content/</url>
         </repository>
       </repositories>
+
+      <dependencies>
+        <!-- Depend on all our native jars -->
+        <!-- As this is executed on either macOS or Linux we directly need to specify the classifier -->
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
+          <classifier>linux-x86_64</classifier>
+          <scope>compile</scope>
+          <optional>true</optional>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <version>${project.version}</version>
+          <classifier>osx-x86_64</classifier>
+          <scope>compile</scope>
+          <optional>true</optional>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>uber-snapshot</id>
 
       <dependencies>
         <!-- Depend on all our native jars -->

--- a/pom.xml
+++ b/pom.xml
@@ -919,8 +919,8 @@
           <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
         </configuration>
       </plugin>
-      <!-- After artifacts were deployed from linux and macos we need to execute the following for this module:
-           mvn -Psonatype-oss-release,full,uber clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId=${netty-id} -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging
+      <!-- After artifacts were deployed from linux and macos we need to execute the following on macOS (in the root of the project).
+           mvn -Psonatype-oss-release,full,uber-staging -pl transport-native-kqueue,transport-native-unix-common,all,tarball clean package gpg:sign org.sonatype.plugins:nexus-staging-maven-plugin:deploy -DstagingRepositoryId=${netty-id} -DnexusUrl=https://oss.sonatype.org -DserverId=sonatype-nexus-staging
       -->
       <plugin>
         <artifactId>maven-release-plugin</artifactId>

--- a/tarball/pom.xml
+++ b/tarball/pom.xml
@@ -96,7 +96,7 @@
   <profiles>
     <!-- If the uber profile is used it will automatically fetch the missing native jar from maven and add it to the all jar as well. -->
     <profile>
-      <id>uber</id>
+      <id>uber-staging</id>
       <repositories>
         <repository>
           <id>staged-releases</id>
@@ -105,6 +105,28 @@
         </repository>
       </repositories>
 
+      <dependencies>
+        <!-- Depend on all our native jars -->
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
+          <classifier>linux-x86_64</classifier>
+          <scope>compile</scope>
+          <optional>true</optional>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <version>${project.version}</version>
+          <classifier>osx-x86_64</classifier>
+          <scope>compile</scope>
+          <optional>true</optional>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>uber-snapshot</id>
       <dependencies>
         <!-- Depend on all our native jars -->
         <dependency>


### PR DESCRIPTION
…te uber all jars.

Motivation:

As we now include native code for multiple platforms we need to generate an uber all jar before release it from the staging repository. For this the uber-staging profile can be used. To create a snapshot uber jar the uber-snapshot profile can be used.

Modifications:

- Add uber-staging and uber-snapshot profile
- Correct comment in pom.xml file to show usage.

Result:

Easier to create snapshot and release uber jars.