### PR TITLE
Correctly include native modules

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -186,7 +186,23 @@
         <artifactId>netty-all</artifactId>
         <version>4.1.12.Final-SNAPSHOT</version>
       </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-unix-common</artifactId>
+        <version>4.1.12.Final-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
+        <version>4.1.12.Final-SNAPSHOT</version>
+        <classifier>linux-x86_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-kqueue</artifactId>
+        <version>4.1.12.Final-SNAPSHOT</version>
+        <classifier>osx-x86_64</classifier>
+      </dependency>
     </dependencies>
   </dependencyManagement>
-
 </project>


### PR DESCRIPTION
Motivation:

We need to include the native modules on the bom to ensure there is no version missmatch.

Modifications:

Add native modules.

Result:

Fixes [#6738]
