### PR TITLE
SslHandler#wrapNonAppData return early

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -796,9 +796,14 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                         runDelegatedTasks();
                         break;
                     case NEED_UNWRAP:
-                        if (!inUnwrap) {
-                            unwrapNonAppData(ctx);
+                        if (inUnwrap) {
+                            // If we asked for a wrap, the engine requested an unwrap, and we are in unwrap there is
+                            // no use in trying to call wrap again because we have already attempted (or will after we
+                            // return) to feed more data to the engine.
+                            return;
                         }
+
+                        unwrapNonAppData(ctx);
                         break;
                     case NEED_WRAP:
                         break;


### PR DESCRIPTION
Motivation:

SslHandler#wrapNonAppData may be able to return early if it is called from a unwrap method and the status is NEED_UNWRAP. This has been observed to occur while using the OpenSslEngine and can avoid allocation of an extra ByteBuf of size 2048.

Modifications:
- Return early from SslHandler#wrapNonAppData if NEED_UNWRAP and we are called from an unwrap method

Result:
Less buffer allocations and early return from SslHandler#wrapNonAppData.