### PR TITLE
UnixResolverDnsServerAddressStreamProvider default name server selection and ordering bug

### DIFF
--- a/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.util.CharsetUtil;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+import static org.junit.Assert.assertEquals;
+
+public class UnixResolverDnsServerAddressStreamProviderTest {
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void defaultLookupShouldReturnResultsIfOnlySingleFileSpecified() throws Exception {
+        File f = buildFile("domain linecorp.local\n" +
+                           "nameserver 127.0.0.2\n" +
+                           "nameserver 127.0.0.3\n");
+        UnixResolverDnsServerAddressStreamProvider p =
+                new UnixResolverDnsServerAddressStreamProvider(f, null);
+
+        DnsServerAddressStream stream = p.nameServerAddressStream("somehost");
+        assertHostNameEquals("127.0.0.2", stream.next());
+        assertHostNameEquals("127.0.0.3", stream.next());
+    }
+
+    @Test
+    public void defaultReturnedWhenNoBetterMatch() throws Exception {
+        File f = buildFile("domain linecorp.local\n" +
+                           "nameserver 127.0.0.2\n" +
+                           "nameserver 127.0.0.3\n");
+        File f2 = buildFile("domain squarecorp.local\n" +
+                            "nameserver 127.0.0.4\n" +
+                            "nameserver 127.0.0.5\n");
+        UnixResolverDnsServerAddressStreamProvider p =
+                new UnixResolverDnsServerAddressStreamProvider(f, f2);
+
+        DnsServerAddressStream stream = p.nameServerAddressStream("somehost");
+        assertHostNameEquals("127.0.0.2", stream.next());
+        assertHostNameEquals("127.0.0.3", stream.next());
+    }
+
+    @Test
+    public void moreRefinedSelectionReturnedWhenMatch() throws Exception {
+        File f = buildFile("domain linecorp.local\n" +
+                           "nameserver 127.0.0.2\n" +
+                           "nameserver 127.0.0.3\n");
+        File f2 = buildFile("domain dc1.linecorp.local\n" +
+                            "nameserver 127.0.0.4\n" +
+                            "nameserver 127.0.0.5\n");
+        UnixResolverDnsServerAddressStreamProvider p =
+                new UnixResolverDnsServerAddressStreamProvider(f, f2);
+
+        DnsServerAddressStream stream = p.nameServerAddressStream("myhost.dc1.linecorp.local");
+        assertHostNameEquals("127.0.0.4", stream.next());
+        assertHostNameEquals("127.0.0.5", stream.next());
+    }
+
+    private File buildFile(String contents) throws IOException {
+        File f = folder.newFile();
+        OutputStream out = new FileOutputStream(f);
+        try {
+            out.write(contents.getBytes(CharsetUtil.UTF_8));
+        } finally {
+            out.close();
+        }
+        return f;
+    }
+
+    private static void assertHostNameEquals(String expectedHostname, InetSocketAddress next) {
+        assertEquals("unexpected hostname: " + next, expectedHostname, next.getHostName());
+    }
+}


### PR DESCRIPTION
Motivation:
UnixResolverDnsServerAddressStreamProvider allows the default name server address stream to be null, but there should always be a default stream to fall back to ([1] Search Strategy).
UnixResolverDnsServerAddressStreamProvider currently shuffles the names servers are multiple are present, but the defined behavior is to try them sequentially [2].

[1] Search Strategy Section - https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man5/resolver.5.html
[2] DESCRIPTION/nameserver Section - https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man5/resolver.5.html

Modifications:
- UnixResolverDnsServerAddressStreamProvider should always use the first file provided to derive the default domain server address stream. Currently if there are multiple domain names in the file identified by the first argument of the constructor then one will be selected at random.
- UnixResolverDnsServerAddressStreamProvider should return name servers sequentially.
- Reduce access level on some methods which don't have known use-cases externally.

Result:
Fixes #6736