### PR TITLE
Share code that is needed to support shaded native libraries.

### DIFF
--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -181,7 +181,10 @@ public final class NativeLibraryLoader {
     /**
      * Load the given library with the specified {@link ClassLoader}
      */
-    public static void load(String name, ClassLoader loader) {
+    public static void load(String originalName, ClassLoader loader) {
+        // Adjust expected name to support shading of native libraries.
+        String name = SystemPropertyUtil.get("io.netty.packagePrefix", "").replace('.', '-') + originalName;
+
         String libname = System.mapLibraryName(name);
         String path = NATIVE_RESOURCE_HOME + libname;
 

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -188,8 +188,7 @@ public final class Native {
         if (!name.startsWith("linux")) {
             throw new IllegalStateException("Only supported on Linux");
         }
-        NativeLibraryLoader.load(SystemPropertyUtil.get("io.netty.packagePrefix", "").replace('.', '-') +
-            "netty-transport-native-epoll", PlatformDependent.getClassLoader(Native.class));
+        NativeLibraryLoader.load("netty-transport-native-epoll", PlatformDependent.getClassLoader(Native.class));
     }
 
     private Native() {

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
@@ -100,8 +100,7 @@ final class Native {
         if (!name.startsWith("mac") && !name.contains("bsd") && !name.startsWith("darwin")) {
             throw new IllegalStateException("Only supported on BSD");
         }
-        NativeLibraryLoader.load(SystemPropertyUtil.get("io.netty.packagePrefix", "").replace('.', '-') +
-                "netty-transport-native-kqueue", PlatformDependent.getClassLoader(Native.class));
+        NativeLibraryLoader.load("netty-transport-native-kqueue", PlatformDependent.getClassLoader(Native.class));
     }
 
     private Native() {


### PR DESCRIPTION
Motivation:

For our native libraries in netty we support shading, to have this work on runtime the user needs to set a system property. This code should shared.

Modifications:

Move logic to NativeLbiraryLoader and so share for all native libs.

Result:

Less code duplication and also will work for netty-tcnative out of the box once it support shading