### PR TITLE
Reset the contentExpected flag when RSET is written

### DIFF
--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/SmtpRequestEncoder.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/SmtpRequestEncoder.java
@@ -47,13 +47,17 @@ public final class SmtpRequestEncoder extends MessageToMessageEncoder<Object> {
     @Override
     protected void encode(ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
         if (msg instanceof SmtpRequest) {
+            final SmtpRequest req = (SmtpRequest) msg;
             if (contentExpected) {
-                throw new IllegalStateException("SmtpContent expected");
+                if (req.command().equals(SmtpCommand.RSET)) {
+                    contentExpected = false;
+                } else {
+                    throw new IllegalStateException("SmtpContent expected");
+                }
             }
             boolean release = true;
             final ByteBuf buffer = ctx.alloc().buffer();
             try {
-                final SmtpRequest req = (SmtpRequest) msg;
                 req.command().encode(buffer);
                 writeParameters(req.parameters(), buffer);
                 buffer.writeBytes(CRLF);


### PR DESCRIPTION
Motivation:

If the remote server returns a 4xx/5xx error in response to
a DATA command (or earlier command if using pipelining),
`SmtpRequestEncoder` can become stuck in an invalid state,
not allowing any requests to be sent.

This makes the channel unusable and the connection has to be closed,
or the `SmtpRequestEncoder` has to be replaced.

Modifications:

If a RSET command is encountered, the `contentExpected`
flag is set to false, and the RSET is written to the channel.

Result:

Sending a RSET command after a server 4xx/5xx error will make it
possible to use the current connection for new mail transactions.

@normanmaurer 