### PR TITLE
MQTT CONNECT message should allow arbitrary byte strings in password and will message fields.

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnectPayload.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnectPayload.java
@@ -16,6 +16,7 @@
 
 package io.netty.handler.codec.mqtt;
 
+import io.netty.util.CharsetUtil;
 import io.netty.util.internal.StringUtil;
 
 /**
@@ -25,9 +26,9 @@ public final class MqttConnectPayload {
 
     private final String clientIdentifier;
     private final String willTopic;
-    private final String willMessage;
+    private final byte[] willMessage;
     private final String userName;
-    private final String password;
+    private final byte[] password;
 
     public MqttConnectPayload(
             String clientIdentifier,
@@ -35,6 +36,19 @@ public final class MqttConnectPayload {
             String willMessage,
             String userName,
             String password) {
+        this.clientIdentifier = clientIdentifier;
+        this.willTopic = willTopic;
+        this.willMessage = willMessage.getBytes(CharsetUtil.UTF_8);
+        this.userName = userName;
+        this.password = password.getBytes(CharsetUtil.UTF_8);
+    }
+
+     public MqttConnectPayload(
+            String clientIdentifier,
+            String willTopic,
+            byte[] willMessage,
+            String userName,
+            byte[] password) {
         this.clientIdentifier = clientIdentifier;
         this.willTopic = willTopic;
         this.willMessage = willMessage;
@@ -51,6 +65,10 @@ public final class MqttConnectPayload {
     }
 
     public String willMessage() {
+        return willMessageBytes() != null ? new String(willMessageBytes(), CharsetUtil.UTF_8) : null;
+    }
+
+    public byte[] willMessageBytes() {
         return willMessage;
     }
 
@@ -59,6 +77,10 @@ public final class MqttConnectPayload {
     }
 
     public String password() {
+        return passwordBytes() != null ? new String(passwordBytes(), CharsetUtil.UTF_8) : null;
+    }
+
+    public byte[] passwordBytes() {
         return password;
     }
 

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
@@ -113,8 +113,8 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
         // Will topic and message
         String willTopic = payload.willTopic();
         byte[] willTopicBytes = willTopic != null ? encodeStringUtf8(willTopic) : EmptyArrays.EMPTY_BYTES;
-        String willMessage = payload.willMessage();
-        byte[] willMessageBytes = willMessage != null ? encodeStringUtf8(willMessage) : EmptyArrays.EMPTY_BYTES;
+        byte[] willMessageBytes = payload.willMessageBytes() != null
+            ? payload.willMessageBytes() : EmptyArrays.EMPTY_BYTES;
         if (variableHeader.isWillFlag()) {
             payloadBufferSize += 2 + willTopicBytes.length;
             payloadBufferSize += 2 + willMessageBytes.length;
@@ -126,8 +126,8 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
             payloadBufferSize += 2 + userNameBytes.length;
         }
 
-        String password = payload.password();
-        byte[] passwordBytes = password != null ? encodeStringUtf8(password) : EmptyArrays.EMPTY_BYTES;
+        byte[] passwordBytes = payload.passwordBytes() != null
+            ? payload.passwordBytes() : EmptyArrays.EMPTY_BYTES;
         if (variableHeader.hasPassword()) {
             payloadBufferSize += 2 + passwordBytes.length;
         }


### PR DESCRIPTION
Motivation

    Mandated by OASIS MQTT v3.1.1 spec

Modifications

    Store password and will message data as byte[] fields in MqttConnectPayload.
    Modify MqttEncoder and MqttDecoder accordingly.
    MqttConnectPayload will handle the string conversion if required by users
    of older protocol versions.

Result

    Fixes #6750

Signed-off-by: Alex Dubov <oakad@yahoo.com>
