### PR TITLE
Add HTTP Status code 308 in HttpResponseStatus.java

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseStatus.java
@@ -120,6 +120,11 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
     public static final HttpResponseStatus TEMPORARY_REDIRECT = newStatus(307, "Temporary Redirect");
 
     /**
+     * 308 Permanent Redirect (RFC7538)
+     */
+    public static final HttpResponseStatus PERMANENT_REDIRECT = newStatus(308, "Permanent Redirect");
+
+    /**
      * 400 Bad Request
      */
     public static final HttpResponseStatus BAD_REQUEST = newStatus(400, "Bad Request");
@@ -359,6 +364,8 @@ public class HttpResponseStatus implements Comparable<HttpResponseStatus> {
             return USE_PROXY;
         case 307:
             return TEMPORARY_REDIRECT;
+        case 308:
+            return PERMANENT_REDIRECT;
         case 400:
             return BAD_REQUEST;
         case 401:


### PR DESCRIPTION
Motivation:

The status 308 is defined by RFC7538. 
This RFC has currently the state Proposed Standard since 2 years, but the status code is already handle by all browsers (Chrome, Firefox, Edge, Safari, …). 
To let developers handle easily this status code, it is added into this list.

Modifications:

Added this status code in the list of all status codes and changed the valueOf() method
