### PR TITLE
Add ChannelOption which allows to wakeup EventLoop for write tasks (follow up to #5959)

### DIFF
--- a/microbench/src/main/java/io/netty/microbench/channel/AbstractChannelBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/AbstractChannelBenchmark.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.channel;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.microbench.util.AbstractMicrobenchmark;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.Future;
+import io.netty.util.internal.ThreadLocalRandom;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.net.SocketAddress;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+abstract class AbstractChannelBenchmark extends AbstractMicrobenchmark {
+
+    public static final ChannelInitializer<Channel> EMPTY_INITIALIZER = new ChannelInitializer<Channel>() {
+        @Override
+        protected void initChannel(Channel ch) throws Exception {
+            ch.pipeline().addLast(BufferReleaseHandler.INSTANCE);
+        }
+    };
+    protected ChannelPipeline pipeline;
+    protected ByteBuf payload;
+    protected Channel serverChannel;
+    protected Channel clientChannel;
+    protected NioEventLoopGroup serverEventloop;
+    protected NioEventLoopGroup clientEventLoop;
+
+    protected void setup0(ChannelInitializer<Channel> serverInitializer,
+                          ChannelInitializer<Channel> clientInitializer) {
+        serverEventloop = new NioEventLoopGroup(1, new DefaultThreadFactory("server", true));
+        clientEventLoop = new NioEventLoopGroup(1, new DefaultThreadFactory("client", true));
+        ServerBootstrap sb = new ServerBootstrap();
+        sb.group(serverEventloop)
+          .channel(NioServerSocketChannel.class)
+          .childHandler(serverInitializer);
+
+        payload = createData(1024);
+
+        Bootstrap cb = new Bootstrap();
+        cb.group(clientEventLoop)
+          .channel(NioSocketChannel.class)
+          .handler(clientInitializer);
+
+        ChannelFuture bind = sb.bind(0);
+        SocketAddress serverAddr;
+        try {
+            bind.sync();
+            serverChannel = bind.channel();
+            serverAddr = serverChannel.localAddress();
+            ChannelFuture clientChannelFuture = cb.connect(serverAddr);
+            clientChannelFuture.sync();
+            clientChannel = clientChannelFuture.channel();
+            pipeline = clientChannel.pipeline();
+        } catch (InterruptedException ie) {
+            throw new IllegalStateException(ie);
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() throws Exception {
+        if (clientChannel != null) {
+            clientChannel.close();
+        }
+        if (serverChannel != null) {
+            serverChannel.close();
+        }
+        Future<?> serverGroup = null;
+        Future<?> clientGroup = null;
+
+        if (serverEventloop != null) {
+            serverGroup = serverEventloop.shutdownGracefully(0, 0, MILLISECONDS);
+        }
+        if (clientEventLoop != null) {
+            clientGroup = clientEventLoop.shutdownGracefully(0, 0, MILLISECONDS);
+        }
+        if (serverGroup != null) {
+            serverGroup.sync();
+        }
+        if (clientGroup != null) {
+            clientGroup.sync();
+        }
+        payload.release();
+    }
+
+    protected static ByteBuf createData(int length) {
+        byte[] result = new byte[length];
+        ThreadLocalRandom.current().nextBytes(result);
+        return Unpooled.directBuffer().writeBytes(result);
+    }
+
+    protected void awaitCompletion(ChannelFuture lastWriteFuture) throws Exception {
+        if (lastWriteFuture != null) {
+            lastWriteFuture.await();
+        }
+    }
+
+    @Sharable
+    static final class BufferReleaseHandler extends SimpleChannelInboundHandler<Object> {
+
+        public static final BufferReleaseHandler INSTANCE = new BufferReleaseHandler();
+
+        @Override
+        protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
+            // No Op, just to release the buffer.
+        }
+    }
+}

--- a/microbench/src/main/java/io/netty/microbench/channel/WakeupOnEachWriteBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/channel/WakeupOnEachWriteBenchmark.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.microbench.channel;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class WakeupOnEachWriteBenchmark extends AbstractChannelBenchmark {
+
+    @Param({ "true", "false" })
+    public boolean wakeUpOnWrite;
+
+    @Param({ "1", "100", "1000" })
+    public int writeCount;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        setup0(EMPTY_INITIALIZER, new ChannelInitializer<Channel>() {
+            @Override
+            protected void initChannel(Channel ch) throws Exception {
+                ch.config().setOption(ChannelOption.WAKEUP_ON_WRITE, wakeUpOnWrite);
+                ch.pipeline().addFirst(BufferReleaseHandler.INSTANCE);
+            }
+        });
+    }
+
+    @Benchmark
+    public void writeFromOutsideEventLoop() throws Exception {
+        ChannelFuture lastWriteFuture = null;
+        for (int i = 0; i < writeCount; i++) {
+            lastWriteFuture = pipeline.write(payload.retainedDuplicate());
+        }
+        pipeline.flush();
+        awaitCompletion(lastWriteFuture);
+    }
+}

--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -95,6 +95,10 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
     public static final ChannelOption<WriteBufferWaterMark> WRITE_BUFFER_WATER_MARK =
             valueOf("WRITE_BUFFER_WATER_MARK");
 
+    /**
+     * Wakes up the eventloop on every write, if required, instead of waking up only on flush.
+     * Default value is {@code false}.
+     */
     public static final ChannelOption<Boolean> WAKEUP_ON_WRITE = valueOf("WAKEUP_ON_WRITE");
 
     public static final ChannelOption<Boolean> ALLOW_HALF_CLOSURE = valueOf("ALLOW_HALF_CLOSURE");

--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -95,6 +95,8 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
     public static final ChannelOption<WriteBufferWaterMark> WRITE_BUFFER_WATER_MARK =
             valueOf("WRITE_BUFFER_WATER_MARK");
 
+    public static final ChannelOption<Boolean> WAKEUP_ON_WRITE = valueOf("WAKEUP_ON_WRITE");
+
     public static final ChannelOption<Boolean> ALLOW_HALF_CLOSURE = valueOf("ALLOW_HALF_CLOSURE");
     public static final ChannelOption<Boolean> AUTO_READ = valueOf("AUTO_READ");
 

--- a/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelConfig.java
@@ -23,18 +23,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
-import static io.netty.channel.ChannelOption.ALLOCATOR;
-import static io.netty.channel.ChannelOption.AUTO_CLOSE;
-import static io.netty.channel.ChannelOption.AUTO_READ;
-import static io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS;
-import static io.netty.channel.ChannelOption.MAX_MESSAGES_PER_READ;
-import static io.netty.channel.ChannelOption.MESSAGE_SIZE_ESTIMATOR;
-import static io.netty.channel.ChannelOption.RCVBUF_ALLOCATOR;
-import static io.netty.channel.ChannelOption.SINGLE_EVENTEXECUTOR_PER_GROUP;
-import static io.netty.channel.ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK;
-import static io.netty.channel.ChannelOption.WRITE_BUFFER_LOW_WATER_MARK;
-import static io.netty.channel.ChannelOption.WRITE_BUFFER_WATER_MARK;
-import static io.netty.channel.ChannelOption.WRITE_SPIN_COUNT;
+import static io.netty.channel.ChannelOption.*;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -64,6 +53,7 @@ public class DefaultChannelConfig implements ChannelConfig {
     private volatile boolean autoClose = true;
     private volatile WriteBufferWaterMark writeBufferWaterMark = WriteBufferWaterMark.DEFAULT;
     private volatile boolean pinEventExecutor = true;
+    private volatile boolean wakeupOnWrite;
 
     public DefaultChannelConfig(Channel channel) {
         this(channel, new AdaptiveRecvByteBufAllocator());
@@ -82,7 +72,7 @@ public class DefaultChannelConfig implements ChannelConfig {
                 CONNECT_TIMEOUT_MILLIS, MAX_MESSAGES_PER_READ, WRITE_SPIN_COUNT,
                 ALLOCATOR, AUTO_READ, AUTO_CLOSE, RCVBUF_ALLOCATOR, WRITE_BUFFER_HIGH_WATER_MARK,
                 WRITE_BUFFER_LOW_WATER_MARK, WRITE_BUFFER_WATER_MARK, MESSAGE_SIZE_ESTIMATOR,
-                SINGLE_EVENTEXECUTOR_PER_GROUP);
+                SINGLE_EVENTEXECUTOR_PER_GROUP, WAKEUP_ON_WRITE);
     }
 
     protected Map<ChannelOption<?>, Object> getOptions(
@@ -156,6 +146,9 @@ public class DefaultChannelConfig implements ChannelConfig {
         if (option == SINGLE_EVENTEXECUTOR_PER_GROUP) {
             return (T) Boolean.valueOf(getPinEventExecutorPerGroup());
         }
+        if (option == WAKEUP_ON_WRITE) {
+            return (T) Boolean.valueOf(getWakeupOnWrite());
+        }
         return null;
     }
 
@@ -188,6 +181,8 @@ public class DefaultChannelConfig implements ChannelConfig {
             setMessageSizeEstimator((MessageSizeEstimator) value);
         } else if (option == SINGLE_EVENTEXECUTOR_PER_GROUP) {
             setPinEventExecutorPerGroup((Boolean) value);
+        } else if (option == WAKEUP_ON_WRITE) {
+            setWakeupOnWrite((Boolean) value);
         } else {
             return false;
         }
@@ -429,4 +424,12 @@ public class DefaultChannelConfig implements ChannelConfig {
         return pinEventExecutor;
     }
 
+    private ChannelConfig setWakeupOnWrite(boolean wakeupOnWrite) {
+        this.wakeupOnWrite = wakeupOnWrite;
+        return this;
+    }
+
+    private boolean getWakeupOnWrite() {
+        return wakeupOnWrite;
+    }
 }


### PR DESCRIPTION
This is a follow up on #5959. 

Following changes are done on top of the original commit by @normanmaurer 

- Added a benchmark to write variable number of items from outside the event loop with and without this new option enabled. Here is the result from the benchmark:

```
 Benchmark                                             (wakeUpOnWrite)  (writeCount)   Mode  Cnt      Score     Error  Units
WakeupOnEachWriteBenchmark.writeFromOutsideEventLoop             true             1  thrpt   20  45211.545 ± 304.884  ops/s
WakeupOnEachWriteBenchmark.writeFromOutsideEventLoop             true           100  thrpt   20  14645.364 ±  79.898  ops/s
WakeupOnEachWriteBenchmark.writeFromOutsideEventLoop             true          1000  thrpt   20   1761.138 ±  35.237  ops/s
WakeupOnEachWriteBenchmark.writeFromOutsideEventLoop            false             1  thrpt   20  44881.363 ± 429.171  ops/s
WakeupOnEachWriteBenchmark.writeFromOutsideEventLoop            false           100  thrpt   20  14787.720 ±  70.798  ops/s
WakeupOnEachWriteBenchmark.writeFromOutsideEventLoop            false          1000  thrpt   20   1783.418 ±  32.192  ops/s
```

- Instead of looking up this option on every write, cache the value on `channelActive()`. It would have been better if we could access the config in `AbstractChannelHandlerContext` constructor but the config isn't available with the channel for Head and Tail pipeline context.

- Added `AbstractChannelBenchmark` which is taken from my earlier [auto-flush PR](https://github.com/netty/netty/pull/5716/files#diff-0aa69930da7db31a252387d999826fba).