### PR TITLE
Handle the possibility of HTTP/0.9 with a better error message

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
@@ -60,7 +60,7 @@ public class HttpVersion implements Comparable<HttpVersion> {
         text = text.trim();
 
         if (text.isEmpty()) {
-            throw new IllegalArgumentException("text is empty");
+            throw new IllegalArgumentException("text is empty (possibly HTTP/0.9)");
         }
 
         // Try to match without convert to uppercase first as this is what 99% of all clients


### PR DESCRIPTION
Motivation

RFC 1945 (see section 3.1) says that request lines may not have a version in which case the request is assumed to be HTTP/0.9. We don't necessarily want to support that but the existing Exception should indicate the possibility of the request being HTTP/0.9 and give the user a chance to track it down.

Modifications

Indicate in the Exception's message that the request is possibly HTTP/0.9.

Result

Fixes #6739

