### PR TITLE
Correctly parse package-prefix if the jni lib is contained in a path …

### DIFF
--- a/transport-native-unix-common/src/main/c/netty_unix_util.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_util.c
@@ -51,8 +51,20 @@ char* netty_unix_util_rstrstr(char* s1rbegin, const char* s1rend, const char* s2
     return NULL;
 }
 
+static char* netty_unix_util_strstr_last(const char* haystack, const char* needle) {
+    char* prevptr = NULL;
+    char* ptr = (char*) haystack;
+
+    while ((ptr = strstr(ptr, needle)) != NULL) {
+        // Just store the ptr and continue searching.
+        prevptr = ptr;
+        ++ptr;
+    }
+    return prevptr;
+}
+
 char* netty_unix_util_parse_package_prefix(const char* libraryPathName, const char* libraryName, jint* status) {
-    char* packageNameEnd = strstr(libraryPathName, libraryName);
+    char* packageNameEnd = netty_unix_util_strstr_last(libraryPathName, libraryName);
     if (packageNameEnd == NULL) {
         *status = JNI_ERR;
         return NULL;


### PR DESCRIPTION
…that matches the library name.

Motivation:

We used strstr to find the path to the library, which fails if the library is contained in a directory that also matches the library name.

Modifications:

- Introduce netty_unix_util_strstr_last which will return a pointer which points to the last accourance and so not fails if the direct also matches the library name.

Result:

Be able to load the library in all cases.