### PR TITLE
Fix forced encode

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpContentCompressor.java
@@ -101,7 +101,9 @@ public class HttpContentCompressor extends HttpContentEncoder {
     @Override
     protected Result beginEncode(HttpResponse headers, String acceptEncoding) throws Exception {
         String contentEncoding = headers.headers().get(HttpHeaderNames.CONTENT_ENCODING);
-        if (HttpHeaderValues.IDENTITY.contentEqualsIgnoreCase(contentEncoding)) {
+        if (contentEncoding != null) {
+            // Content-Encoding was set, either as something specific or as the IDENTITY encoding
+            // Therefore, we should NOT encode here
             return null;
         }
 

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpContentCompressorTest.java
@@ -395,6 +395,28 @@ public class HttpContentCompressorTest {
         assertTrue(ch.finishAndReleaseAll());
     }
 
+    @Test
+    public void testCustomEncoding() throws Exception {
+        EmbeddedChannel ch = new EmbeddedChannel(new HttpContentCompressor());
+        assertTrue(ch.writeInbound(newRequest()));
+
+        FullHttpResponse res = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1, HttpResponseStatus.OK,
+                Unpooled.copiedBuffer("Hello, World", CharsetUtil.US_ASCII));
+        int len = res.content().readableBytes();
+        res.headers().set(HttpHeaderNames.CONTENT_LENGTH, len);
+        res.headers().set(HttpHeaderNames.CONTENT_ENCODING, "ascii");
+        assertTrue(ch.writeOutbound(res));
+
+        FullHttpResponse response = (FullHttpResponse) ch.readOutbound();
+        assertEquals(String.valueOf(len), response.headers().get(HttpHeaderNames.CONTENT_LENGTH));
+        assertEquals("ascii", response.headers().get(HttpHeaderNames.CONTENT_ENCODING));
+        assertEquals("Hello, World", response.content().toString(CharsetUtil.US_ASCII));
+        response.release();
+
+        assertTrue(ch.finishAndReleaseAll());
+    }
+
     private static FullHttpRequest newRequest() {
         FullHttpRequest req = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
         req.headers().set(HttpHeaderNames.ACCEPT_ENCODING, "gzip");


### PR DESCRIPTION
Motivation:

Fix the regression recently introduced that causes already encoded responses to be encoded again as gzip

Modification:

instead of just looking for IDENTITY, anything set for Content-Encoding should be respected and left as-is

added unit tests to capture this use case

Result:

Fixes #6784  