### PR TITLE
HttpObjectEncoder#isContentAlwaysEmpty cannot be overridden by subcla…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
@@ -200,7 +200,7 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
      * a content without having an actual content, e.g the response to an HEAD or CONNECT request.
      *
      * @param msg the message to test
-     * @return true to signal the message has no content
+     * @return {@code true} to signal the message has no content
      */
     protected boolean isContentAlwaysEmpty(@SuppressWarnings("unused") H msg) {
         return false;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
@@ -195,7 +195,14 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
         }
     }
 
-    boolean isContentAlwaysEmpty(@SuppressWarnings("unused") H msg) {
+    /**
+     * Determine whether a message has a content or not. Some message may have headers indicating
+     * a content without having an actual content, e.g the response to an HEAD or CONNECT request.
+     *
+     * @param msg the message to test
+     * @return true to signal the message has no content
+     */
+    protected boolean isContentAlwaysEmpty(@SuppressWarnings("unused") H msg) {
         return false;
     }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerCodec.java
@@ -112,7 +112,7 @@ public final class HttpServerCodec extends CombinedChannelDuplexHandler<HttpRequ
     private final class HttpServerResponseEncoder extends HttpResponseEncoder {
 
         @Override
-        boolean isContentAlwaysEmpty(@SuppressWarnings("unused") HttpResponse msg) {
+        protected boolean isContentAlwaysEmpty(@SuppressWarnings("unused") HttpResponse msg) {
             return HttpMethod.HEAD.equals(queue.poll());
         }
     }


### PR DESCRIPTION
…sses

Motivation:

Allow subclasses of HttpObjectEncoder other than HttpServerCodec to override the isContentAlwaysEmpty method

Modification:

Change the method visibility from package private to protected

Result:

Fixes #6761