### PR TITLE
Improvement : "if" construction replaced with "switch" for ServerCookieDecoder

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieDecoder.java
@@ -87,10 +87,17 @@ public final class ServerCookieDecoder extends CookieDecoder {
                     break loop;
                 }
                 char c = header.charAt(i);
-                if (c == '\t' || c == '\n' || c == 0x0b || c == '\f'
-                        || c == '\r' || c == ' ' || c == ',' || c == ';') {
-                    i++;
-                    continue;
+                switch (c) {
+                    case '\t':
+                    case '\n':
+                    case 0x0b:
+                    case '\f':
+                    case '\r':
+                    case ' ':
+                    case ',':
+                    case ';':
+                        i++;
+                        continue;
                 }
                 break;
             }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieDecoderTest.java
@@ -34,6 +34,26 @@ public class ServerCookieDecoderTest {
     }
 
     @Test
+    public void testDecodingSingleCookieWithSemicolon() {
+        String cookieString = "myCookie=myValue;";
+        Set<Cookie> cookies = ServerCookieDecoder.STRICT.decode(cookieString);
+        assertEquals(1, cookies.size());
+        Cookie cookie = cookies.iterator().next();
+        assertNotNull(cookie);
+        assertEquals("myValue", cookie.value());
+    }
+
+    @Test
+    public void testDecodingSingleCookieWithStartNewLine() {
+        String cookieString = "\t\nmyCookie=myValue";
+        Set<Cookie> cookies = ServerCookieDecoder.STRICT.decode(cookieString);
+        assertEquals(1, cookies.size());
+        Cookie cookie = cookies.iterator().next();
+        assertNotNull(cookie);
+        assertEquals("myValue", cookie.value());
+    }
+
+    @Test
     public void testDecodingMultipleCookies() {
         String c1 = "myCookie=myValue;";
         String c2 = "myCookie2=myValue2;";


### PR DESCRIPTION
Motivation:

Usually, cookies don't start with special chars, so `Switch` statement is more efficient for cookie decoder as it performs less operations.

Modification:

`If` statement replaced with `switch`. Added 2 more tests for corner cases.

Result:

Cookie decoding is a bit faster.