### PR TITLE
Correctly exclude netty-tcnative classes from the all jar.

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -551,7 +551,7 @@
               <goal>unpack-dependencies</goal>
             </goals>
             <configuration>
-              <excludes>io/netty/example/**,META-INF/native/libnetty-tcnative*,META-INF/native/include/**,META-INF/native/**/*.a</excludes>
+              <excludes>io/netty/internal/tcnative/**,io/netty/example/**,META-INF/native/libnetty-tcnative*,META-INF/native/include/**,META-INF/native/**/*.a</excludes>
               <includes>io/netty/**,META-INF/native/**</includes>
               <includeScope>runtime</includeScope>
               <includeGroupIds>${project.groupId}</includeGroupIds>


### PR DESCRIPTION
Motivation:

We need to exclude the netty-tcnative classes from the all jar when building it as otherwise there may be classloader issues.

Modifications:

Add io/netty/internal/tcnative to the exclude list.

Result:

Fixes [#6791]