### PR TITLE
Issue №6802. Not specified field in MQTT codec

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPublishVariableHeader.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPublishVariableHeader.java
@@ -35,6 +35,9 @@ public final class MqttPublishVariableHeader {
         return topicName;
     }
 
+    /**
+     * @deprecated Use {@link #packetId()} instead.
+     */
     @Deprecated
     public int messageId() {
         return packetId;

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPublishVariableHeader.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttPublishVariableHeader.java
@@ -24,19 +24,24 @@ import io.netty.util.internal.StringUtil;
 public final class MqttPublishVariableHeader {
 
     private final String topicName;
-    private final int messageId;
+    private final int packetId;
 
-    public MqttPublishVariableHeader(String topicName, int messageId) {
+    public MqttPublishVariableHeader(String topicName, int packetId) {
         this.topicName = topicName;
-        this.messageId = messageId;
+        this.packetId = packetId;
     }
 
     public String topicName() {
         return topicName;
     }
 
+    @Deprecated
     public int messageId() {
-        return messageId;
+        return packetId;
+    }
+
+    public int packetId() {
+        return packetId;
     }
 
     @Override
@@ -44,7 +49,7 @@ public final class MqttPublishVariableHeader {
         return new StringBuilder(StringUtil.simpleClassName(this))
             .append('[')
             .append("topicName=").append(topicName)
-            .append(", messageId=").append(messageId)
+            .append(", packetId=").append(packetId)
             .append(']')
             .toString();
     }


### PR DESCRIPTION
Motivation:
According to the [MQTT 3.1.1 spec](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/csprd02/mqtt-v3.1.1-csprd02.html), the variable header must not have a messageId field in the variable header when publishing PUBLISH packet. It must have only these two: Topic Name and Packet Identifier.

Fields should are named in the same way as it in a protocol otherwise it can be tricky for new users to understand what the field really mean.

Modification:
public method messageId() was annotated with @Deprecated and instead of messageId users should use packetId as it defined in [MQTT 3.1.1 spec](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/csprd02/mqtt-v3.1.1-csprd02.html).

Result:
Fixes #6802. 

