### PR TITLE
Allow in RFC2965 cookies comma as a cookies separator

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieDecoderTest.java
@@ -172,6 +172,48 @@ public class ServerCookieDecoderTest {
     }
 
     @Test
+    public void testDecodingOldRFC2965CookiesWithCommaSeparatorAfterVersion() {
+        String source = "$Version=\"1\", " +
+                "Part_Number1=\"Riding_Rocket_0023\"; $Path=\"/acme/ammo\", " +
+                "Part_Number2=\"Rocket_Launcher_0001\"; $Path=\"/acme\"";
+
+        Set<Cookie> cookies = ServerCookieDecoder.STRICT.decode(source);
+        Iterator<Cookie> it = cookies.iterator();
+        Cookie c;
+
+        c = it.next();
+        assertEquals("Part_Number1", c.name());
+        assertEquals("Riding_Rocket_0023", c.value());
+
+        c = it.next();
+        assertEquals("Part_Number2", c.name());
+        assertEquals("Rocket_Launcher_0001", c.value());
+
+        assertFalse(it.hasNext());
+    }
+
+    @Test
+    public void testDecodingOldRFC2965CookiesWithCommaSeparatorBetweenCookies() {
+        String source = "$Version=\"1\"; " +
+                "Part_Number1=\"Riding_Rocket_0023\"; $Path=\"/acme/ammo\", " +
+                "Part_Number2=\"Rocket_Launcher_0001\"; $Path=\"/acme\"";
+
+        Set<Cookie> cookies = ServerCookieDecoder.STRICT.decode(source);
+        Iterator<Cookie> it = cookies.iterator();
+        Cookie c;
+
+        c = it.next();
+        assertEquals("Part_Number1", c.name());
+        assertEquals("Riding_Rocket_0023", c.value());
+
+        c = it.next();
+        assertEquals("Part_Number2", c.name());
+        assertEquals("Rocket_Launcher_0001", c.value());
+
+        assertFalse(it.hasNext());
+    }
+
+    @Test
     public void testRejectCookieValueWithSemicolon() {
         Set<Cookie> cookies = ServerCookieDecoder.STRICT.decode("name=\"foo;bar\";");
         assertTrue(cookies.isEmpty());


### PR DESCRIPTION
Motivation:

To be more complient with RFC2965, which is being partially supported
within the decoder, the code should also allow comma to be a cookies separator:

"Note: For backward compatibility, the separator in the Cookie header
   is semi-colon (;) everywhere.  A server SHOULD also accept comma (,)
   as the separator between cookie-values for future compatibility."

Modifications:

In tokenizing part of a decoder additional logic condition added, that if
the cookie has RFC2965 compliant format, then comma is also considered
as a cookies separator.

Result:

In case the cookie has RFC2965 format comma will be allowed as
a cookies separator.