### PR TITLE
JdkZlibDecoder and JZlibDecoder consistency

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/JZlibDecoder.java
@@ -107,16 +107,15 @@ public class JZlibDecoder extends ZlibDecoder {
                 z.next_in = array;
                 z.next_in_index = 0;
             }
-            int oldNextInIndex = z.next_in_index;
+            final int oldNextInIndex = z.next_in_index;
 
             // Configure output.
-            int maxOutputLength = inputLength << 1;
-            ByteBuf decompressed = ctx.alloc().heapBuffer(maxOutputLength);
+            ByteBuf decompressed = ctx.alloc().heapBuffer(inputLength << 1);
 
             try {
                 loop: for (;;) {
-                    z.avail_out = maxOutputLength;
-                    decompressed.ensureWritable(maxOutputLength);
+                    decompressed.ensureWritable(z.avail_in << 1);
+                    z.avail_out = decompressed.writableBytes();
                     z.next_out = decompressed.array();
                     z.next_out_index = decompressed.arrayOffset() + decompressed.writerIndex();
                     int oldNextOutIndex = z.next_out_index;


### PR DESCRIPTION
Motivation:
JdkZlibDecoder will allocate a new buffer when the previous buffer is filled with inflated data, but JZlibDecoder will attempt to use the same buffer by resizing. This leads to inconsistent results when these two decoders that are intended to be functionality equivalent.

Modifications:
- JdkZlibDecoder should attempt to resize and reuse the existing buffer instead of creating multiple buffers

Result:
Fixes https://github.com/netty/netty/issues/6804
