### PR TITLE
Removing a SeekAheadNoBackArrayException to avoid exception handling

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostBodyUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostBodyUtil.java
@@ -62,10 +62,6 @@ final class HttpPostBodyUtil {
             this.value = value;
         }
 
-        TransferEncodingMechanism() {
-            value = name();
-        }
-
         public String value() {
             return value;
         }
@@ -80,13 +76,6 @@ final class HttpPostBodyUtil {
     }
 
     /**
-    * Exception when NO Backend Array is found
-    */
-    static class SeekAheadNoBackArrayException extends Exception {
-        private static final long serialVersionUID = -630418804938699495L;
-    }
-
-    /**
     * This class intends to decrease the CPU in seeking ahead some bytes in
     * HttpPostRequestDecoder
     */
@@ -98,9 +87,12 @@ final class HttpPostBodyUtil {
         int limit;
         ByteBuf buffer;
 
-        SeekAheadOptimize(ByteBuf buffer) throws SeekAheadNoBackArrayException {
+        /**
+         * @param buffer buffer with a backing byte array
+         */
+        SeekAheadOptimize(ByteBuf buffer) {
             if (!buffer.hasArray()) {
-                throw new SeekAheadNoBackArrayException();
+                throw new IllegalArgumentException("buffer hasn't backing byte array");
             }
             this.buffer = buffer;
             bytes = buffer.array();
@@ -128,14 +120,6 @@ final class HttpPostBodyUtil {
         int getReadPosition(int index) {
             return index - origPos + readerIndex;
         }
-
-        void clear() {
-            buffer = null;
-            bytes = null;
-            limit = 0;
-            pos = 0;
-            readerIndex = 0;
-        }
     }
 
     /**
@@ -146,20 +130,6 @@ final class HttpPostBodyUtil {
         int result;
         for (result = offset; result < sb.length(); result ++) {
             if (!Character.isWhitespace(sb.charAt(result))) {
-                break;
-            }
-        }
-        return result;
-    }
-
-    /**
-     * Find the first whitespace
-     * @return the rank of the first whitespace
-     */
-    static int findWhitespace(String sb, int offset) {
-        int result;
-        for (result = offset; result < sb.length(); result ++) {
-            if (Character.isWhitespace(sb.charAt(result))) {
                 break;
             }
         }


### PR DESCRIPTION
Motivation:

A `SeekAheadNoBackArrayException` used as check for `ByteBuf#hasArray`. The catch of exceptions carries a large overhead on stack trace filling, and this should be avoided.

Modifications:

- Remove the class `SeekAheadNoBackArrayException` and replace its usage with `if` statements.
- Use methods from `ObjectUtils` for better readability.
- Make private methods static where it make sense.
- Remove unused private methods.

Result:

Less of exception handling logic, better performance.