### PR TITLE
Allow to access memoryAddress of wrapped ByteBuf for ReadOnlyByteBuf

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
@@ -103,12 +103,12 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
 
     @Override
     public boolean hasMemoryAddress() {
-        return false;
+        return unwrap().hasMemoryAddress();
     }
 
     @Override
     public long memoryAddress() {
-        throw new ReadOnlyBufferException();
+        return unwrap().memoryAddress();
     }
 
     @Override


### PR DESCRIPTION
Motivation:

We should allow to access the memoryAddress of the wrapped ByteBuf when using ReadOnlyByteBuf for peformance reasons. If a user act on a memoryAddress its his responsible anyway to do nothing "stupid".

Modifications:

Delegate to wrapped ByteBuf.

Result:

Less performance overhead for various operations and also when writing to a native transport (which needs the memoryAddress).