### PR TITLE
Not force to run autoconf and compile multiple times

### DIFF
--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -150,8 +150,6 @@
                        This hack will make the hawtjni plugin to put the native library
                        under 'META-INF/native' rather than 'META-INF/native/${platform}'. -->
                   <platform>.</platform>
-                  <forceConfigure>true</forceConfigure>
-                  <forceAutogen>true</forceAutogen>
                   <configureArgs>
                     <arg>${jni.compiler.args.ldflags}</arg>
                     <arg>${jni.compiler.args.cflags}</arg>

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -76,8 +76,6 @@
                        This hack will make the hawtjni plugin to put the native library
                        under 'META-INF/native' rather than 'META-INF/native/${platform}'. -->
                   <platform>.</platform>
-                  <forceConfigure>true</forceConfigure>
-                  <forceAutogen>true</forceAutogen>
                   <configureArgs>
                     <arg>${jni.compiler.args.ldflags}</arg>
                     <arg>${jni.compiler.args.cflags}</arg>


### PR DESCRIPTION
Motivation:

We should not force autoconf and compile as this will result in multiple executions and so slow down the build.

Modifications:

Remove force declarations

Result:

Faster build of native modules