### PR TITLE
Replace outdated leak detection property for microbenchmarks

### DIFF
--- a/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
+++ b/microbench/src/main/java/io/netty/microbench/util/AbstractMicrobenchmarkBase.java
@@ -45,7 +45,7 @@ public abstract class AbstractMicrobenchmarkBase {
     protected static final String[] BASE_JVM_ARGS = {
         "-server", "-dsa", "-da", "-ea:io.netty...", "-XX:+AggressiveOpts", "-XX:+UseBiasedLocking",
         "-XX:+UseFastAccessorMethods", "-XX:+OptimizeStringConcat",
-        "-XX:+HeapDumpOnOutOfMemoryError", "-Dio.netty.noResourceLeakDetection"};
+        "-XX:+HeapDumpOnOutOfMemoryError", "-Dio.netty.leakDetection.level=disabled"};
 
     static {
         ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.DISABLED);


### PR DESCRIPTION
Motivation:

When I run Netty micro benchmarks I get many warnings like:

> WARNING: -Dio.netty.noResourceLeakDetection is deprecated. Use '-Dio.netty.leakDetection.level=simple' instead.

Modification:

`-Dio.netty.noResourceLeakDetection` replaced with `-Dio.netty.leakDetection.level=disabled`.

Result:

No warnings.
