### PR TITLE
Do proper bounds-checking in HpackHuffmanDecoder to reduce overhead o…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHuffmanDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHuffmanDecoder.java
@@ -230,16 +230,13 @@ final class HpackHuffmanDecoder {
         }
 
         private void append(int i) {
-            try {
-                bytes[index] = (byte) i;
-            } catch (IndexOutOfBoundsException ignore) {
+            if (bytes.length == index) {
                 // Always just expand by INITIAL_SIZE
                 byte[] newBytes = new byte[bytes.length + initialCapacity];
                 System.arraycopy(bytes, 0, newBytes, 0, bytes.length);
                 bytes = newBytes;
-                bytes[index] = (byte) i;
             }
-            index++;
+            bytes[index++] = (byte) i;
         }
     }
 }


### PR DESCRIPTION
…f IndexOutOfBoundsException creation

Motivation:

HpackHuffmanDecoder.Decoder did not do any bound-checking but just catched IndexOutOfBoundsException to detect if the array needs to grow. This can be very expensive because of fillInStackTrace()

Modifications:

Add proper bounds checking and grow the array if needed without catching IndexOutOfBoundsException.

Result:

Less overhead if the array needs to grow.