### PR TITLE
Mention that the IdleStateHandler should be placed before any decoder…

### DIFF
--- a/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/IdleStateHandler.java
@@ -21,11 +21,12 @@ import io.netty.channel.Channel.Unsafe;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOutboundBuffer;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
-import io.netty.util.concurrent.EventExecutor;
 
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -33,6 +34,9 @@ import java.util.concurrent.TimeUnit;
 /**
  * Triggers an {@link IdleStateEvent} when a {@link Channel} has not performed
  * read, write, or both operation for a while.
+ *
+ * The {@link IdleStateHandler} should be placed as first {@link ChannelHandler}
+ * into the {@link ChannelPipeline} (before any decoder / encoder).
  *
  * <h3>Supported idle states</h3>
  * <table border="1">

--- a/handler/src/main/java/io/netty/handler/timeout/package-info.java
+++ b/handler/src/main/java/io/netty/handler/timeout/package-info.java
@@ -15,7 +15,6 @@
  */
 
 /**
- * Adds support for read and write timeout and idle connection notification
- * using a {@link io.netty.util.Timer}.
+ * Adds support for read and write timeout and idle connection notifications.
  */
 package io.netty.handler.timeout;


### PR DESCRIPTION
… / encoder in the pipeline.

Motivation:

To ensure that the IdleStateHandler works as expected its important to put it in the right position into the ChannelPipeline.

Modifications:

Add docs to make it clear.

Result:

Better docs.