### PR TITLE
Let DnsNameResolver constructor use a default value for searchDomains

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -195,6 +195,7 @@ public class DnsNameResolver extends InetNameResolver {
      * @param dnsServerAddressStreamProvider The {@link DnsServerAddressStreamProvider} used to determine the name
      *                                       servers for each hostname lookup.
      * @param searchDomains the list of search domain
+     *                      (can be null, if so, will try to default to the underlying platform ones)
      * @param ndots the ndots value
      * @param decodeIdn {@code true} if domain / host names should be decoded to unicode when received.
      *                        See <a href="https://tools.ietf.org/html/rfc3492">rfc3492</a>.
@@ -232,7 +233,7 @@ public class DnsNameResolver extends InetNameResolver {
         this.authoritativeDnsServerCache = checkNotNull(authoritativeDnsServerCache, "authoritativeDnsServerCache");
         this.dnsQueryLifecycleObserverFactory =
                 checkNotNull(dnsQueryLifecycleObserverFactory, "dnsQueryLifecycleObserverFactory");
-        this.searchDomains = checkNotNull(searchDomains, "searchDomains").clone();
+        this.searchDomains = searchDomains != null ? searchDomains.clone() : DEFAULT_SEARCH_DOMAINS;
         this.ndots = checkPositiveOrZero(ndots, "ndots");
         this.decodeIdn = decodeIdn;
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -54,7 +54,7 @@ public final class DnsNameResolverBuilder {
     private DnsServerAddressStreamProvider dnsServerAddressStreamProvider = platformDefault();
     private DnsQueryLifecycleObserverFactory dnsQueryLifecycleObserverFactory =
             NoopDnsQueryLifecycleObserverFactory.INSTANCE;
-    private String[] searchDomains = DnsNameResolver.DEFAULT_SEARCH_DOMAINS;
+    private String[] searchDomains;
     private int ndots = 1;
     private boolean decodeIdn = true;
 


### PR DESCRIPTION
Motivation:

It’s currently complicated to extend `DnsNameResolver` as the default
value for `searchDomain` is package private.

Modifications:

* let `DnsNameResolver` accept a null `searchDomains` and then default
to `DEFAULT_SEARCH_DOMAINS`, just like it’s being done with
`resolvedAddressTypes`.
* set default `DnsNameResolverBuilder#searchDomains` value to null to
avoid cloning internal `DnsNameResolver.DEFAULT_SEARCH_DOMAINS` in
`DnsNameResolver` constructor.

Result:

More versatile `DnsNameResolver` constructor.
No array copy when using default search domains.