### PR TITLE
Correct bom entry for netty-transport-native-unix-common

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -188,8 +188,8 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty-transport-unix-common</artifactId>
-        <version>4.1.12.Final-SNAPSHOT</version>
+        <artifactId>netty-transport-native-unix-common</artifactId>
+        <version>4.1.13.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
Motivation:

The entry for the netty-transport-native-unix-common module in the bom
was using the wrong artifact ID and version.

Modifications:

Correct the artifact ID for the netty-transport-native-unix-common
module in the bom.

Result:

Fixes [#6849]