### PR TITLE
 Add dependency management for missing entries

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -138,6 +138,11 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-dev-tools</artifactId>
+        <version>4.1.13.Final-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
         <version>4.1.13.Final-SNAPSHOT</version>
       </dependency>
@@ -193,9 +198,31 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-transport-unix-common</artifactId>
+        <version>4.1.13.Final-SNAPSHOT</version>
+        <classifier>linux-x86_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-unix-common</artifactId>
+        <version>4.1.13.Final-SNAPSHOT</version>
+        <classifier>osx-x86_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
+        <version>4.1.13.Final-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-epoll</artifactId>
         <version>4.1.13.Final-SNAPSHOT</version>
         <classifier>linux-x86_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-kqueue</artifactId>
+        <version>4.1.13.Final-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
Motivation:

The bom does not provide entries for a number of netty modules, in
particular those that are deployed with classifiers. As a result, they
can't be used without defining a version.

Modifications:

Provide dependency management for the missing modules.

Result:

Fixes [#6852]