### PR TITLE
Only call ctx.fireChannelReadComplete() if ByteToMessageDecoder decod…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyFrameCodec.java
@@ -125,13 +125,10 @@ public class SpdyFrameCodec extends ByteToMessageDecoder
 
     @Override
     public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-        if (!read) {
-            if (!ctx.channel().config().isAutoRead()) {
-                ctx.read();
-            }
-        }
+        boolean wasRead = read;
         read = false;
-        super.channelReadComplete(ctx);
+
+        channelReadComplete(ctx, wasRead);
     }
 
     @Override

--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -313,15 +313,18 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
 
     @Override
     public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        channelReadComplete(ctx, !decodeWasNull);
+    }
+
+    protected final void channelReadComplete(ChannelHandlerContext ctx, boolean readData) throws Exception {
         numReads = 0;
         discardSomeReadBytes();
-        if (decodeWasNull) {
-            decodeWasNull = false;
-            if (!ctx.channel().config().isAutoRead()) {
-                ctx.read();
-            }
+        decodeWasNull = false;
+        if (readData) {
+            ctx.fireChannelReadComplete();
+        } else if (!ctx.channel().config().isAutoRead()) {
+            ctx.read();
         }
-        ctx.fireChannelReadComplete();
     }
 
     protected final void discardSomeReadBytes() {

--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1167,14 +1167,15 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
     @Override
     public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
-        // Discard bytes of the cumulation buffer if needed.
-        discardSomeReadBytes();
-
         flushIfNeeded(ctx);
-        readIfNeeded(ctx);
-
+        boolean readData = firedChannelRead;
         firedChannelRead = false;
-        ctx.fireChannelReadComplete();
+        // if readData is false channelReadComplete(....) will take care of calling read.
+        if (readData && !handshakePromise.isDone() && !ctx.channel().config().isAutoRead()) {
+            // If handshake is not finished yet, we need more data.
+            ctx.read();
+        }
+        channelReadComplete(ctx, readData);
     }
 
     private void readIfNeeded(ChannelHandlerContext ctx) {


### PR DESCRIPTION
…ed at least one message.

Motivation:

Its wasteful and also confusing that channelReadComplete() is called even if there was no message forwarded to the next handler.

Modifications:

- Only call ctx.fireChannelReadComplete() if at least one message was decoded
- Add unit test

Result:

Less confusing behavior. Fixes [#4312].