### PR TITLE
Use more aggressive expanding strategy in HpackHuffmanDecoder

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHuffmanDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackHuffmanDecoder.java
@@ -231,8 +231,11 @@ final class HpackHuffmanDecoder {
 
         private void append(int i) {
             if (bytes.length == index) {
-                // Always just expand by INITIAL_SIZE
-                byte[] newBytes = new byte[bytes.length + initialCapacity];
+                // Choose an expanding strategy depending on how big the buffer already is.
+                // 1024 was choosen as a good guess and we may be able to investigate more if there are better choices.
+                // See also https://github.com/netty/netty/issues/6846
+                final int newLength = bytes.length >= 1024 ? bytes.length + initialCapacity : bytes.length << 1;
+                byte[] newBytes = new byte[newLength];
                 System.arraycopy(bytes, 0, newBytes, 0, bytes.length);
                 bytes = newBytes;
             }


### PR DESCRIPTION
Motivation:

Before we always expanded the buffer by the initialCapacity which by default is 32 bytes. This may lead to many expansions of the buffer until we finally reached the point that the buffer can fin everything.

Modifications:

Double the buffer size until the threshold of >= 1024 is hit. After this will grow it by the initialCapacity

Result:

Less expansion of the buffer (and so allocations / copies) when the intialCapacity is not big enough.
