### PR TITLE
Added test for multi header, HttpObjectDecoder cleanup and small performance improvement

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -574,12 +574,11 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
             do {
                 char firstChar = line.charAt(0);
                 if (name != null && (firstChar == ' ' || firstChar == '\t')) {
+                    //please do not make one line from below code
+                    //as it breaks +XX:OptimizeStringConcat optimization
                     String trimmedLine = line.toString().trim();
-                    StringBuilder buf = new StringBuilder(value.length() + trimmedLine.length() + 1);
-                    buf.append(value)
-                       .append(' ')
-                       .append(trimmedLine);
-                    value = buf.toString();
+                    String valueStr = String.valueOf(value);
+                    value = valueStr + ' ' + trimmedLine;
                 } else {
                     if (name != null) {
                         headers.add(name, value);
@@ -641,14 +640,11 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
                     List<String> current = trailer.trailingHeaders().getAll(lastHeader);
                     if (!current.isEmpty()) {
                         int lastPos = current.size() - 1;
+                        //please do not make one line from below code
+                        //as it breaks +XX:OptimizeStringConcat optimization
                         String lineTrimmed = line.toString().trim();
-                        CharSequence currentLastPos = current.get(lastPos);
-                        StringBuilder b = new StringBuilder(currentLastPos.length() + lineTrimmed.length());
-                        b.append(currentLastPos)
-                         .append(lineTrimmed);
-                        current.set(lastPos, b.toString());
-                    } else {
-                        // Content-Length, Transfer-Encoding, or Trailer
+                        String currentLastPos = current.get(lastPos);
+                        current.set(lastPos, currentLastPos + lineTrimmed);
                     }
                 } else {
                     splitHeader(line);


### PR DESCRIPTION
Motivation:

For multi-line headers `HttpObjectDecoder` uses `StringBuilder.append(a).append(b)` pattern that could be easily replaced with regular `a + b`. Also oparations with `a` and `b` moved out from concat operation to make it friendly for `StringOptimizeConcat` optimization and thus - faster.

Modification:

`StringBuilder.append(a).append(b)` reaplced with `a + b`. Operations with `a` and `b` moved out from concat oparation.

Result:
Code simpler to read and faster.

Micro benchmark:
```
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(1)
@State(Scope.Thread)
@Warmup(iterations = 5, time = 1)
@Measurement(iterations = 5, time = 1)
public class BuilderVsRegularConcat {

    CharSequence value;

    @Param({"Some Another Char sequence2"})
    String line;

    @Setup
    public void seupt() {
        value = "Some Char sequence";
    }

    @Benchmark
    public String builder() {
        StringBuilder buf = new StringBuilder(value.length() + line.length() + 1);
        buf.append(value)
                .append(' ')
                .append(line);
        return buf.toString();
    }

    @Benchmark
    public String builderWithChaining() {
        return new StringBuilder(value.length() + line.length() + 1)
                .append(value)
                .append(' ')
                .append(line)
                .toString();
    }


    @Benchmark
    public String naiveWithLocalVariable() {
        String loc = String.valueOf(value);
        return loc + ' ' + line;
    }

}
```

```
Benchmark                                                           (line)  Mode  Cnt   Score   Error  Units
BuilderVsRegularConcat.builder                 Some Another Char sequence2  avgt    5  47.420 ± 2.691  ns/op
BuilderVsRegularConcat.builderWithChaining     Some Another Char sequence2  avgt    5  45.455 ± 6.624  ns/op
BuilderVsRegularConcat.naiveWithLocalVariable  Some Another Char sequence2  avgt    5  22.755 ± 3.780  ns/op
```

Global Benchmark:

```
@State(Scope.Benchmark)
@Warmup(iterations = 10)
@Measurement(iterations = 40)
public class HttpRequestDecoderConcatBenchmark extends AbstractMicrobenchmark {

    private static final byte[] CONTENT_MIXED_DELIMITERS = createContent();
    private static final String crlf = "\r\n";

    private static byte[] createContent() {
        return ("GET /some/path HTTP/1.1" + crlf +
                "Host: localhost" + crlf +
                "MyTestHeader: part1" + crlf +
                "              newLinePart2" + crlf +
                "MyTestHeader2: part21" + crlf +
                "\t            newLinePart22"
                + crlf + crlf).getBytes(CharsetUtil.US_ASCII);
    }

    private EmbeddedChannel channelOld = new EmbeddedChannel(new HttpRequestDecoder());
    private EmbeddedChannel channelNew = new EmbeddedChannel(new HttpRequestDecoderNew());

    @Benchmark
    public HttpRequest oldImplementation() {
        channelOld.writeInbound(Unpooled.wrappedBuffer(CONTENT_MIXED_DELIMITERS));
        HttpRequest req = channelOld.readInbound();
        LastHttpContent c = channelOld.readInbound();
        c.release();
        return req;
    }

    @Benchmark
    public HttpRequest newImplementation() {
        channelNew.writeInbound(Unpooled.wrappedBuffer(CONTENT_MIXED_DELIMITERS));
        HttpRequest req = channelNew.readInbound();
        LastHttpContent c = channelNew.readInbound();
        c.release();
        return req;
    }

}
```

Result:
```
Benchmark                                             Mode  Cnt       Score       Error  Units
HttpRequestDecoderConcatBenchmark.newImplementation  thrpt   80  823777.360 ± 12349.239  ops/s
HttpRequestDecoderConcatBenchmark.oldImplementation  thrpt   80  774542.988 ± 13682.708  ops/s
```