### PR TITLE
HttpObjectAggregator should NOT add `Content-Length: 0` for 1xx and 204 FullHttpResponses

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -213,13 +213,14 @@ public class HttpObjectAggregator
 
     @Override
     protected void finishAggregation(FullHttpMessage aggregated) throws Exception {
-        // Set the 'Content-Length' header. If one isn't already set.
+        // Set the 'Content-Length' header if it's allowed and one isn't already set.
         // This is important as HEAD responses will use a 'Content-Length' header which
         // does not match the actual body, but the number of bytes that would be
         // transmitted if a GET would have been used.
         //
-        // See rfc2616 14.13 Content-Length
-        if (!HttpUtil.isContentLengthSet(aggregated)) {
+        // See RFC7230 3.3.2. Content-Length
+        // https://tools.ietf.org/html/rfc7230#section-3.3.2
+        if (!(HttpUtil.mustNotContainContentLength(aggregated) || HttpUtil.isContentLengthSet(aggregated))) {
             aggregated.headers().set(
                     CONTENT_LENGTH,
                     String.valueOf(aggregated.content().readableBytes()));

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -532,6 +532,20 @@ public final class HttpUtil {
         }
     }
 
+    public static boolean mustNotContainContentLength(HttpMessage msg) {
+        // RFC7230 Section 3.3.2
+        // https://tools.ietf.org/html/rfc7230#section-3.3.2
+        //
+        // A server MUST NOT send a Content-Length header field in any response with
+        // a status code of 1xx (Informational) or 204 (No Content).
+        if (msg instanceof HttpResponse) {
+            HttpResponseStatus status = ((HttpResponse) msg).status();
+            return HttpStatusClass.valueOf(status.code()) == HttpStatusClass.INFORMATIONAL ||
+                    status == HttpResponseStatus.NO_CONTENT;
+        }
+        return false;
+    }
+
     private static byte c2b(char c) {
         return c > 255 ? (byte) '?' : (byte) c;
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -224,4 +224,30 @@ public class HttpUtilTest {
         ReferenceCountUtil.release(message);
     }
 
+    @Test
+    public void testMustNotContainContentLength() {
+        // test all status codes that can't contain Content-Length header field
+        final List<HttpResponseStatus> statusesWithoutContentLength = new ArrayList<HttpResponseStatus>();
+        statusesWithoutContentLength.add(HttpResponseStatus.CONTINUE);
+        statusesWithoutContentLength.add(HttpResponseStatus.SWITCHING_PROTOCOLS);
+        statusesWithoutContentLength.add(HttpResponseStatus.PROCESSING);
+        statusesWithoutContentLength.add(HttpResponseStatus.NO_CONTENT);
+
+        for (final HttpResponseStatus status : statusesWithoutContentLength) {
+            HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
+            assertTrue(HttpUtil.mustNotContainContentLength(response));
+        }
+
+        // test some basic responses that can contain Content-Length header field
+        final List<HttpResponseStatus> statusesWithContentLength = new ArrayList<HttpResponseStatus>();
+        statusesWithContentLength.add(HttpResponseStatus.OK);
+        statusesWithContentLength.add(HttpResponseStatus.NOT_MODIFIED);
+        statusesWithContentLength.add(HttpResponseStatus.BAD_REQUEST);
+        statusesWithContentLength.add(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+
+        for (final HttpResponseStatus status : statusesWithContentLength) {
+            HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
+            assertFalse(HttpUtil.mustNotContainContentLength(response));
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

If a client receives a 1xx or 204 response, `HttpObjectAggregator` adds `Content-Length` header as these responses don't have the header field according to RFC7230 section 3.3.2. This results in violation of
the specification even if a client receives an appropriate response.

Modification:

`HttpObjectAggregator` adds `Content-Length` header if it doesn't violate the specification.

Result:

`FullHttpResponse` of 1xx or 204 doesn't contain Content-Length, which satisfies RFC7230, if a server follows the specification, i.e. sending 1xx or 204 responses without `Content-Length`.