### PR TITLE
fix UnixChannelUtil#isBufferCopyNeededForWrite

### DIFF
--- a/transport-native-unix-common-tests/pom.xml
+++ b/transport-native-unix-common-tests/pom.xml
@@ -29,11 +29,6 @@
     Tests for the static library which contains common unix utilities.
   </description>
 
-  <properties>
-    <!-- Don't deploy this artifact to Maven Central -->
-    <maven.deploy.skip>true</maven.deploy.skip>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.netty</groupId>

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/UnixChannelUtil.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/UnixChannelUtil.java
@@ -29,6 +29,10 @@ public final class UnixChannelUtil {
      * (We check this because otherwise we need to make it a new direct buffer.)
      */
     public static boolean isBufferCopyNeededForWrite(ByteBuf byteBuf) {
-        return !byteBuf.hasMemoryAddress() || !byteBuf.isDirect() || byteBuf.nioBufferCount() > IOV_MAX;
+        return isBufferCopyNeededForWrite(byteBuf, IOV_MAX);
+    }
+
+    static boolean isBufferCopyNeededForWrite(ByteBuf byteBuf, int iovMax) {
+        return !byteBuf.hasMemoryAddress() && (!byteBuf.isDirect() || byteBuf.nioBufferCount() > iovMax);
     }
 }

--- a/transport-native-unix-common/src/test/java/io/netty/channel/unix/UnixChannelUtilTest.java
+++ b/transport-native-unix-common/src/test/java/io/netty/channel/unix/UnixChannelUtilTest.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package io.netty.channel.unix.tests;
+package io.netty.channel.unix;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -27,13 +27,15 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-import static io.netty.channel.unix.Limits.IOV_MAX;
 import static io.netty.channel.unix.UnixChannelUtil.isBufferCopyNeededForWrite;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class UnixChannelUtilTest {
+
+    private static final int IOV_MAX = 1024;
+
     @Test
     public void testPooledAllocatorIsBufferCopyNeededForWrite() {
         testIsBufferCopyNeededForWrite(PooledByteBufAllocator.DEFAULT);
@@ -46,16 +48,16 @@ public class UnixChannelUtilTest {
 
     private static void testIsBufferCopyNeededForWrite(ByteBufAllocator alloc) {
         ByteBuf byteBuf = alloc.directBuffer();
-        assertFalse(isBufferCopyNeededForWrite(byteBuf));
-        assertFalse(isBufferCopyNeededForWrite(byteBuf.asReadOnly()));
+        assertFalse(isBufferCopyNeededForWrite(byteBuf, IOV_MAX));
+        assertFalse(isBufferCopyNeededForWrite(byteBuf.asReadOnly(), IOV_MAX));
         assertTrue(byteBuf.release());
 
         byteBuf = alloc.heapBuffer();
-        assertTrue(isBufferCopyNeededForWrite(byteBuf));
-        assertTrue(isBufferCopyNeededForWrite(byteBuf.asReadOnly()));
+        assertTrue(isBufferCopyNeededForWrite(byteBuf, IOV_MAX));
+        assertTrue(isBufferCopyNeededForWrite(byteBuf.asReadOnly(), IOV_MAX));
         assertTrue(byteBuf.release());
 
-        assertCompositeByteBufIsBufferCopyNeededForWrite(alloc, 2, 0, true);
+        assertCompositeByteBufIsBufferCopyNeededForWrite(alloc, 2, 0, false);
         assertCompositeByteBufIsBufferCopyNeededForWrite(alloc, IOV_MAX + 1, 0, true);
         assertCompositeByteBufIsBufferCopyNeededForWrite(alloc, 0, 2, true);
         assertCompositeByteBufIsBufferCopyNeededForWrite(alloc, 1, 1, true);
@@ -80,7 +82,7 @@ public class UnixChannelUtilTest {
             comp.addComponent(byteBuf);
         }
 
-        assertEquals(byteBufs.toString(), expected, isBufferCopyNeededForWrite(comp));
+        assertEquals(byteBufs.toString(), expected, isBufferCopyNeededForWrite(comp, IOV_MAX));
         assertTrue(comp.release());
     }
 }


### PR DESCRIPTION
fix not execute unit test in transport-native-unix-common-tests module

Motivation:
- Commit 047da11 introduced an bug for still copy byteBuf for composed of n(n <= IOV_MAX) NIO direct buffers
- Commit 3c4dfed add UnixChannelUtilTest in transport-native-unix-common-tests module, but not execute in maven compile

as issue #6825, #6870

Modifications:
- modified UnixChannelUtil#isBufferCopyNeededForWrite(ByteBuf), and UnixChannelUtilTest
- move UnixChannelUtilTest into transport-native-unix-common module, and add packet scope method UnixChannelUtil#isBufferCopyNeededForWrite(ByteBuf, int)

Result:
- no copy byteBuf for composed of n(n <= IOV_MAX) NIO direct buffers
- auto execute unit tests in UnixChannelUtilTest and it is easier to mock IOV_MAX
