### PR TITLE
Add a default mapping from EventLoopGroup and ChannelFactory #6839

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -15,10 +15,12 @@
  */
 package io.netty.channel.epoll;
 
+import io.netty.channel.ChannelFactoriesRegistry;
 import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultithreadEventLoopGroup;
+import io.netty.channel.ReflectiveChannelFactory;
 import io.netty.channel.SelectStrategyFactory;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.EventExecutorChooserFactory;
@@ -36,6 +38,10 @@ public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
     {
         // Ensure JNI is initialized by the time this class is loaded.
         Epoll.ensureAvailability();
+
+        ChannelFactoriesRegistry.registerFactoryForEventLoopGroup(EpollEventLoopGroup.class,
+            new ReflectiveChannelFactory(EpollSocketChannel.class),
+            new ReflectiveChannelFactory(EpollServerSocketChannel.class));
     }
 
     /**

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
@@ -15,9 +15,11 @@
  */
 package io.netty.channel.kqueue;
 
+import io.netty.channel.ChannelFactoriesRegistry;
 import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.EventLoop;
 import io.netty.channel.MultithreadEventLoopGroup;
+import io.netty.channel.ReflectiveChannelFactory;
 import io.netty.channel.SelectStrategyFactory;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.EventExecutorChooserFactory;
@@ -33,6 +35,10 @@ public final class KQueueEventLoopGroup extends MultithreadEventLoopGroup {
     {
         // Ensure JNI is initialized by the time this class is loaded by this time!
         KQueue.ensureAvailability();
+
+         ChannelFactoriesRegistry.registerFactoryForEventLoopGroup(KQueueEventLoopGroup.class,
+            new ReflectiveChannelFactory(KQueueSocketChannel.class),
+            new ReflectiveChannelFactory(KQueueServerSocketChannel.class));
     }
     /**
      * Create a new instance using the default number of threads and the default {@link ThreadFactory}.

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -510,5 +510,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
         }
     }
 
-    protected abstract boolean isServerSide();
+    protected boolean isServerSide() {
+        return false;
+    }
 }

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -17,7 +17,6 @@
 package io.netty.bootstrap;
 
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFactoriesRegistry;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
@@ -209,10 +208,10 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
      * call the super method in that case.
      */
     public B validate() {
-        ensureChannelFactory();
         if (group == null) {
             throw new IllegalStateException("group not set");
         }
+        ensureChannelFactory();
         if (channelFactory == null) {
             throw new IllegalStateException("channel or channelFactory not set");
         }
@@ -221,7 +220,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
 
     private void ensureChannelFactory() {
         if (channelFactory == null) {
-            channelFactory = ChannelFactoriesRegistry.getFactoryForEventLoopGroup(group.getClass(), isServerSide());
+            channelFactory = getDefaultChannelFactory();
         }
     }
 
@@ -510,7 +509,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
         }
     }
 
-    protected boolean isServerSide() {
-        return false;
+    protected io.netty.channel.ChannelFactory getDefaultChannelFactory() {
+        return null;
     }
 }

--- a/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/AbstractBootstrap.java
@@ -17,6 +17,7 @@
 package io.netty.bootstrap;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFactoriesRegistry;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
@@ -208,6 +209,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
      * call the super method in that case.
      */
     public B validate() {
+        ensureChannelFactory();
         if (group == null) {
             throw new IllegalStateException("group not set");
         }
@@ -215,6 +217,12 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
             throw new IllegalStateException("channel or channelFactory not set");
         }
         return self();
+    }
+
+    private void ensureChannelFactory() {
+        if (channelFactory == null) {
+            channelFactory = ChannelFactoriesRegistry.getFactoryForEventLoopGroup(group.getClass(), isServerSide());
+        }
     }
 
     /**
@@ -279,6 +287,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
     }
 
     private ChannelFuture doBind(final SocketAddress localAddress) {
+        ensureChannelFactory();
         final ChannelFuture regFuture = initAndRegister();
         final Channel channel = regFuture.channel();
         if (regFuture.cause() != null) {
@@ -315,6 +324,7 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
     }
 
     final ChannelFuture initAndRegister() {
+        ensureChannelFactory();
         Channel channel = null;
         try {
             channel = channelFactory.newChannel();
@@ -499,4 +509,6 @@ public abstract class AbstractBootstrap<B extends AbstractBootstrap<B, C>, C ext
             return GlobalEventExecutor.INSTANCE;
         }
     }
+
+    protected abstract boolean isServerSide();
 }

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -315,4 +315,9 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
     final AddressResolverGroup<?> resolver() {
         return resolver;
     }
+
+    @Override
+    protected boolean isServerSide() {
+        return false;
+    }
 }

--- a/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/Bootstrap.java
@@ -16,6 +16,7 @@
 package io.netty.bootstrap;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFactoriesRegistry;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelOption;
@@ -317,7 +318,7 @@ public class Bootstrap extends AbstractBootstrap<Bootstrap, Channel> {
     }
 
     @Override
-    protected boolean isServerSide() {
-        return false;
+    protected io.netty.channel.ChannelFactory getDefaultChannelFactory() {
+        return ChannelFactoriesRegistry.getFactoryForEventLoopGroup(group.getClass(), false);
     }
 }

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -318,4 +318,10 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
     public final ServerBootstrapConfig config() {
         return config;
     }
+
+    @Override
+    protected boolean isServerSide() {
+        return true;
+    }
+
 }

--- a/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
+++ b/transport/src/main/java/io/netty/bootstrap/ServerBootstrap.java
@@ -17,6 +17,8 @@ package io.netty.bootstrap;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelFactoriesRegistry;
+import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
@@ -320,8 +322,7 @@ public class ServerBootstrap extends AbstractBootstrap<ServerBootstrap, ServerCh
     }
 
     @Override
-    protected boolean isServerSide() {
-        return true;
+    protected ChannelFactory getDefaultChannelFactory() {
+        return ChannelFactoriesRegistry.getFactoryForEventLoopGroup(group.getClass(), true);
     }
-
 }

--- a/transport/src/main/java/io/netty/channel/ChannelFactoriesRegistry.java
+++ b/transport/src/main/java/io/netty/channel/ChannelFactoriesRegistry.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * This class provides a default mapping between {@link EventLoopGroup} implementations and {@link ChannelFactory}
+ * implementations
+ */
+public abstract class ChannelFactoriesRegistry {
+
+    private static ConcurrentMap<Class<? extends EventLoopGroup>, ChannelFactory> clientSideFactories
+        = new ConcurrentHashMap<Class<? extends EventLoopGroup>, ChannelFactory>();
+
+    private static ConcurrentMap<Class<? extends EventLoopGroup>, ChannelFactory> serverSideFactories
+        = new ConcurrentHashMap<Class<? extends EventLoopGroup>, ChannelFactory>();
+
+    private ChannelFactoriesRegistry() { }
+
+    public static void registerFactoryForEventLoopGroup(Class<? extends EventLoopGroup> groupClass,
+        ChannelFactory factoryForClients, ChannelFactory factoryForServers) {
+        clientSideFactories.put(groupClass, factoryForClients);
+        serverSideFactories.put(groupClass, factoryForServers);
+    }
+
+    public static ChannelFactory getFactoryForEventLoopGroup(Class<? extends EventLoopGroup> groupClass,
+        boolean serverSide) {
+        return serverSide ? serverSideFactories.get(groupClass) : clientSideFactories.get(groupClass);
+    }
+}

--- a/transport/src/main/java/io/netty/channel/ChannelFactoriesRegistry.java
+++ b/transport/src/main/java/io/netty/channel/ChannelFactoriesRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2017 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -31,7 +31,7 @@ public abstract class ChannelFactoriesRegistry {
         private final ChannelFactory serverSideFactory;
 
         public ChannelFactoryDefaults(Class<? extends EventLoopGroup> eventLoopGroupType,
-            ChannelFactory clientSideFactory, ChannelFactory serverSideFactory) {
+                                      ChannelFactory clientSideFactory, ChannelFactory serverSideFactory) {
             this.eventLoopGroupType = eventLoopGroupType;
             this.clientSideFactory = clientSideFactory;
             this.serverSideFactory = serverSideFactory;
@@ -48,7 +48,8 @@ public abstract class ChannelFactoriesRegistry {
     private ChannelFactoriesRegistry() { }
 
     public static void registerFactoryForEventLoopGroup(Class<? extends EventLoopGroup> groupClass,
-        ChannelFactory factoryForClients, ChannelFactory factoryForServers) {
+                                                        ChannelFactory factoryForClients,
+                                                        ChannelFactory factoryForServers) {
         synchronized (DEFAULT_CHANNEL_FACTORIES) {
             for (Iterator<ChannelFactoryDefaults> it = DEFAULT_CHANNEL_FACTORIES.iterator(); it.hasNext();) {
                 ChannelFactoryDefaults channelFactoryDefaults = it.next();
@@ -61,7 +62,7 @@ public abstract class ChannelFactoriesRegistry {
     }
 
     public static ChannelFactory getFactoryForEventLoopGroup(Class<? extends EventLoopGroup> groupClass,
-        boolean serverSide) {
+                                                             boolean serverSide) {
         synchronized (DEFAULT_CHANNEL_FACTORIES) {
             for (ChannelFactoryDefaults channelFactoryDefaults : DEFAULT_CHANNEL_FACTORIES) {
                 if (channelFactoryDefaults.matchesClass(groupClass)) {

--- a/transport/src/main/java/io/netty/channel/DefaultEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/DefaultEventLoopGroup.java
@@ -15,6 +15,8 @@
  */
 package io.netty.channel;
 
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalServerChannel;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadFactory;
 
@@ -22,6 +24,12 @@ import java.util.concurrent.ThreadFactory;
  * {@link MultithreadEventLoopGroup} which must be used for the local transport.
  */
 public class DefaultEventLoopGroup extends MultithreadEventLoopGroup {
+
+    static {
+        ChannelFactoriesRegistry.registerFactoryForEventLoopGroup(DefaultEventLoopGroup.class,
+            new ReflectiveChannelFactory(LocalChannel.class),
+            new ReflectiveChannelFactory(LocalServerChannel.class));
+    }
 
     /**
      * Create a new instance with the default number of threads.

--- a/transport/src/main/java/io/netty/channel/MultithreadEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/MultithreadEventLoopGroup.java
@@ -96,4 +96,5 @@ public abstract class MultithreadEventLoopGroup extends MultithreadEventExecutor
     public ChannelFuture register(Channel channel, ChannelPromise promise) {
         return next().register(channel, promise);
     }
+
 }

--- a/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
@@ -93,5 +93,4 @@ public class ThreadPerChannelEventLoop extends SingleThreadEventLoop {
         parent.activeChildren.remove(this);
         parent.idleChildren.add(this);
     }
-
 }

--- a/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/ThreadPerChannelEventLoop.java
@@ -93,4 +93,5 @@ public class ThreadPerChannelEventLoop extends SingleThreadEventLoop {
         parent.activeChildren.remove(this);
         parent.idleChildren.add(this);
     }
+
 }

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoopGroup.java
@@ -16,10 +16,14 @@
 package io.netty.channel.nio;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFactoriesRegistry;
 import io.netty.channel.EventLoop;
 import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.MultithreadEventLoopGroup;
+import io.netty.channel.ReflectiveChannelFactory;
 import io.netty.channel.SelectStrategyFactory;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.EventExecutorChooserFactory;
 import io.netty.util.concurrent.RejectedExecutionHandler;
@@ -34,6 +38,12 @@ import java.util.concurrent.ThreadFactory;
  * {@link MultithreadEventLoopGroup} implementations which is used for NIO {@link Selector} based {@link Channel}s.
  */
 public class NioEventLoopGroup extends MultithreadEventLoopGroup {
+
+    static {
+        ChannelFactoriesRegistry.registerFactoryForEventLoopGroup(NioEventLoopGroup.class,
+            new ReflectiveChannelFactory(NioSocketChannel.class),
+            new ReflectiveChannelFactory(NioServerSocketChannel.class));
+    }
 
     /**
      * Create a new instance using the default number of threads, the default {@link ThreadFactory} and

--- a/transport/src/test/java/io/netty/channel/ChannelFactoriesRegistryTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelFactoriesRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2017 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/transport/src/test/java/io/netty/channel/ChannelFactoriesRegistryTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelFactoriesRegistryTest.java
@@ -213,7 +213,7 @@ public class ChannelFactoriesRegistryTest {
 
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-            logger.info(String.format("Received message: %s", msg));
+            logger.info("Received message: {}", msg);
             ReferenceCountUtil.safeRelease(msg);
         }
     }

--- a/transport/src/test/java/io/netty/channel/ChannelFactoriesRegistryTest.java
+++ b/transport/src/test/java/io/netty/channel/ChannelFactoriesRegistryTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2015 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.local.LocalAddress;
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.Future;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import java.util.concurrent.CountDownLatch;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+public class ChannelFactoriesRegistryTest {
+
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(ChannelFactoriesRegistryTest.class);
+
+    @Test
+    public void testLocalChannel() throws Exception {
+        final LocalAddress TEST_ADDRESS = new LocalAddress("test.id");
+
+        EventLoopGroup group1 = new DefaultEventLoopGroup(2);
+        EventLoopGroup group2 = new DefaultEventLoopGroup(2);
+        try {
+            Bootstrap cb = new Bootstrap();
+            ServerBootstrap sb = new ServerBootstrap();
+
+            cb.group(group1)
+                .handler(new TestHandler());
+
+            sb.group(group2)
+                .childHandler(new ChannelInitializer<LocalChannel>() {
+                    @Override
+                    public void initChannel(LocalChannel ch) throws Exception {
+                        ch.pipeline().addLast(new TestHandler());
+                    }
+                });
+
+            Channel sc = null;
+            Channel cc = null;
+            try {
+                // Start server
+                sc = sb.bind(TEST_ADDRESS).sync().channel();
+
+                final CountDownLatch latch = new CountDownLatch(1);
+                // Connect to the server
+                cc = cb.connect(sc.localAddress()).sync().channel();
+                final Channel ccCpy = cc;
+                cc.eventLoop().execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        // Send a message event up the pipeline.
+                        ccCpy.pipeline().fireChannelRead("Hello, World");
+                        latch.countDown();
+                    }
+                });
+                assertTrue(latch.await(5, SECONDS));
+
+                // Close the channel
+                closeChannel(cc);
+                closeChannel(sc);
+                sc.closeFuture().sync();
+            } finally {
+                closeChannel(cc);
+                closeChannel(sc);
+            }
+        } finally {
+            Future<?> group1Future = group1.shutdownGracefully(0, 0, SECONDS);
+            Future<?> group2Future = group2.shutdownGracefully(0, 0, SECONDS);
+
+            group1Future.await();
+            group2Future.await();
+        }
+    }
+
+    @Test
+    public void testNioChannel() throws Exception {
+
+        EventLoopGroup group1 = new NioEventLoopGroup(2);
+        EventLoopGroup group2 = new NioEventLoopGroup(2);
+        try {
+            Bootstrap cb = new Bootstrap();
+            ServerBootstrap sb = new ServerBootstrap();
+
+            cb.group(group1)
+                .handler(new TestHandler());
+
+            sb.group(group2)
+                .childHandler(new ChannelInitializer<NioSocketChannel>() {
+                    @Override
+                    public void initChannel(NioSocketChannel ch) throws Exception {
+                        ch.pipeline().addLast(new TestHandler());
+                    }
+                });
+
+            Channel sc = null;
+            Channel cc = null;
+            try {
+                // Start server
+                sc = sb.bind(0).sync().channel();
+
+                final CountDownLatch latch = new CountDownLatch(1);
+                // Connect to the server
+                cc = cb.connect(sc.localAddress()).sync().channel();
+                final Channel ccCpy = cc;
+                cc.eventLoop().execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        // Send a message event up the pipeline.
+                        ccCpy.pipeline().fireChannelRead("Hello, World");
+                        latch.countDown();
+                    }
+                });
+                assertTrue(latch.await(5, SECONDS));
+
+                // Close the channel
+                closeChannel(cc);
+                closeChannel(sc);
+                sc.closeFuture().sync();
+            } finally {
+                closeChannel(cc);
+                closeChannel(sc);
+            }
+        } finally {
+            Future<?> group1Future = group1.shutdownGracefully(0, 0, SECONDS);
+            Future<?> group2Future = group2.shutdownGracefully(0, 0, SECONDS);
+
+            group1Future.await();
+            group2Future.await();
+        }
+    }
+
+    static class TestHandler extends ChannelInboundHandlerAdapter {
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            logger.info(String.format("Received message: %s", msg));
+            ReferenceCountUtil.safeRelease(msg);
+        }
+    }
+
+    private static void closeChannel(Channel cc) {
+        if (cc != null) {
+            cc.close().syncUninterruptibly();
+        }
+    }
+}

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -21,7 +21,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFactoriesRegistry;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -949,6 +948,7 @@ public class LocalChannelTest {
             closeChannel(sc);
         }
     }
+<<<<<<< HEAD
 
 <<<<<<< HEAD
     private static void writeAndFlushReadOnSuccess(final ChannelHandlerContext ctx, Object msg) {
@@ -1251,4 +1251,6 @@ public class LocalChannelTest {
         }
     }
 >>>>>>> address review comments and add test case
+=======
+>>>>>>> do not use Map but Class.isAssignableFrom and clean up test cases
 }

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -21,6 +21,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFactory;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;

--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -948,9 +948,7 @@ public class LocalChannelTest {
             closeChannel(sc);
         }
     }
-<<<<<<< HEAD
 
-<<<<<<< HEAD
     private static void writeAndFlushReadOnSuccess(final ChannelHandlerContext ctx, Object msg) {
         ctx.writeAndFlush(msg).addListener(new ChannelFutureListener() {
             @Override
@@ -1009,24 +1007,7 @@ public class LocalChannelTest {
                             writeAndFlushReadOnSuccess(ctx, msg);
                         }
                     }
-                })
-    }
-
-    @Test
-    public void testUseChannelFactoriesRegistry() throws Exception {
-        Bootstrap cb = new Bootstrap();
-        ServerBootstrap sb = new ServerBootstrap();
-
-        cb.group(group1)
-          .handler(new TestHandler());
-
-        sb.group(group2)
-          .childHandler(new ChannelInitializer<LocalChannel>() {
-              @Override
-              public void initChannel(LocalChannel ch) throws Exception {
-                  ch.pipeline().addLast(new TestHandler());
-              }
-          });
+                });
 
         Channel sc = null;
         Channel cc = null;
@@ -1221,36 +1202,33 @@ public class LocalChannelTest {
             ctx.close();
         }
     }
-=======
 
-            final CountDownLatch latch = new CountDownLatch(1);
-            // Connect to the server
-            cc = cb.connect(sc.localAddress()).sync().channel();
-            final Channel ccCpy = cc;
-            cc.eventLoop().execute(new Runnable() {
-                @Override
-                public void run() {
-                    // Send a message event up the pipeline.
-                    ccCpy.pipeline().fireChannelRead("Hello, World");
-                    latch.countDown();
-                }
-            });
-            assertTrue(latch.await(5, SECONDS));
+    @Test(timeout = 5000)
+    public void testUseChannelFactoriesRegistry() throws Exception {
+        Bootstrap cb = new Bootstrap();
+        ServerBootstrap sb = new ServerBootstrap();
 
-            // Close the channel
-            closeChannel(cc);
-            closeChannel(sc);
-            sc.closeFuture().sync();
+        cb.group(group1)
+          .handler(new TestHandler());
 
-            assertNull(String.format(
-                    "Expected null, got channel '%s' for local address '%s'",
-                    LocalChannelRegistry.get(TEST_ADDRESS), TEST_ADDRESS), LocalChannelRegistry.get(TEST_ADDRESS));
+        sb.group(group2)
+          .childHandler(new ChannelInitializer<LocalChannel>() {
+              @Override
+              public void initChannel(LocalChannel ch) throws Exception {
+                  ch.pipeline().addLast(new TestHandler());
+              }
+          });
+
+        Channel sc = null;
+        Channel cc = null;
+        try {
+            // Start server
+            sc = sb.bind(TEST_ADDRESS).sync().channel();
+            cc = cb.connect(TEST_ADDRESS).sync().channel();
         } finally {
             closeChannel(cc);
             closeChannel(sc);
         }
     }
->>>>>>> address review comments and add test case
-=======
->>>>>>> do not use Map but Class.isAssignableFrom and clean up test cases
+
 }


### PR DESCRIPTION
Introduce a EventLoopGroup#defaultChannelFactory as an hint to build a ChannelFactory if not configured.
This way the Channel type will be automatically discovered for simple use-cases

Motivation:

see issue #6839 

Modification:

I have added a EventLoopGroup#defaultChannelFactory(boolean serverSide) method to let the EventLoopGroup describe the usual type of Channel it handles.

This way code will be simpler:

before the change:
```
 ServerBootstrap b = new ServerBootstrap();
            b.group(bossGroup, workerGroup)
                .channel(NetworkUtils.isEnableEpoolNative() ? EpollServerSocketChannel.class : NioServerSocketChannel.class)
                .childHandler(channelInitialized)
                .option(ChannelOption.SO_BACKLOG, 128);

```
After the change:
```
 ServerBootstrap b = new ServerBootstrap();
            b.group(bossGroup, workerGroup)
                .childHandler(channelInitialized)
                .option(ChannelOption.SO_BACKLOG, 128);

```

Result:

Fixes #6839 

I have some questions:
- I needed to change the 'validate' method in order to create the channelFactory if not given, this is not very good for me but I did not find another way
- this PR does not include new test cases, I will add them as soon as the general approach to the problem wil be approved (at the moment I have tested all netty based projects and all is running as expected)

