### PR TITLE
OpenSSL CHACHA20 CipherSuiteConverter updates

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/CipherSuiteConverter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/CipherSuiteConverter.java
@@ -69,7 +69,7 @@ final class CipherSuiteConverter {
                     "^(?:(" + // BEGIN handshake algorithm
                         "(?:(?:EXP-)?" +
                             "(?:" +
-                                "(?:DHE|EDH|ECDH|ECDHE|SRP)-(?:DSS|RSA|ECDSA)|" +
+                                "(?:DHE|EDH|ECDH|ECDHE|SRP|RSA)-(?:DSS|RSA|ECDSA|PSK)|" +
                                 "(?:ADH|AECDH|KRB5|PSK|SRP)" +
                             ')' +
                         ")|" +
@@ -196,6 +196,8 @@ final class CipherSuiteConverter {
         String hmacAlgo = toOpenSslHmacAlgo(m.group(3));
         if (handshakeAlgo.isEmpty()) {
             return bulkCipher + '-' + hmacAlgo;
+        } else if (bulkCipher.contains("CHACHA20")) {
+            return handshakeAlgo + '-' + bulkCipher;
         } else {
             return handshakeAlgo + '-' + bulkCipher + '-' + hmacAlgo;
         }
@@ -342,7 +344,12 @@ final class CipherSuiteConverter {
         String bulkCipher = toJavaBulkCipher(m.group(2), export);
         String hmacAlgo = toJavaHmacAlgo(m.group(3));
 
-        return handshakeAlgo + "_WITH_" + bulkCipher + '_' + hmacAlgo;
+        String javaCipherSuite = handshakeAlgo + "_WITH_" + bulkCipher + '_' + hmacAlgo;
+        // For historical reasons the CHACHA20 ciphers do not follow OpenSSL's custom naming convention and omits the
+        // HMAC algorithm portion of the name. There is currently no way to derive this information because it is
+        // omitted from the OpenSSL cipher name, but they currently all use SHA256 for HMAC [1].
+        // [1] https://www.openssl.org/docs/man1.1.0/apps/ciphers.html
+        return bulkCipher.contains("CHACHA20") ? javaCipherSuite + "_SHA256" : javaCipherSuite;
     }
 
     private static String toJavaHandshakeAlgo(String handshakeAlgo, boolean export) {

--- a/handler/src/test/java/io/netty/handler/ssl/CipherSuiteConverterTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/CipherSuiteConverterTest.java
@@ -113,6 +113,16 @@ public class CipherSuiteConverterTest {
         testJ2OMapping("TLS_KRB5_EXPORT_WITH_RC2_CBC_40_MD5", "EXP-KRB5-RC2-CBC-MD5");
         testJ2OMapping("TLS_KRB5_EXPORT_WITH_RC2_CBC_40_SHA", "EXP-KRB5-RC2-CBC-SHA");
         testJ2OMapping("TLS_RSA_WITH_AES_256_CBC_SHA", "AES256-SHA");
+
+        // For historical reasons the CHACHA20 ciphers do not follow OpenSSL's custom naming
+        // convention and omits the HMAC algorithm portion of the name.
+        testJ2OMapping("TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256", "ECDHE-RSA-CHACHA20-POLY1305");
+        testJ2OMapping("TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256", "ECDHE-ECDSA-CHACHA20-POLY1305");
+        testJ2OMapping("TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256", "DHE-RSA-CHACHA20-POLY1305");
+        testJ2OMapping("TLS_PSK_WITH_CHACHA20_POLY1305_SHA256", "PSK-CHACHA20-POLY1305");
+        testJ2OMapping("TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256", "ECDHE-PSK-CHACHA20-POLY1305");
+        testJ2OMapping("TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256", "DHE-PSK-CHACHA20-POLY1305");
+        testJ2OMapping("TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256", "RSA-PSK-CHACHA20-POLY1305");
     }
 
     private static void testJ2OMapping(String javaCipherSuite, String openSslCipherSuite) {
@@ -260,6 +270,16 @@ public class CipherSuiteConverterTest {
         testO2JMapping("RSA_WITH_DES_CBC_MD5", "DES-CBC-MD5");
         testO2JMapping("EDH_RSA_EXPORT_WITH_DES_CBC_40_SHA", "EXP-EDH-RSA-DES-CBC-SHA");
         testO2JMapping("EDH_DSS_EXPORT_WITH_DES_CBC_40_SHA", "EXP-EDH-DSS-DES-CBC-SHA");
+
+        // For historical reasons the CHACHA20 ciphers do not follow OpenSSL's custom naming
+        // convention and omits the HMAC algorithm portion of the name.
+        testO2JMapping("ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256", "ECDHE-RSA-CHACHA20-POLY1305");
+        testO2JMapping("ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256", "ECDHE-ECDSA-CHACHA20-POLY1305");
+        testO2JMapping("DHE_RSA_WITH_CHACHA20_POLY1305_SHA256", "DHE-RSA-CHACHA20-POLY1305");
+        testO2JMapping("PSK_WITH_CHACHA20_POLY1305_SHA256", "PSK-CHACHA20-POLY1305");
+        testO2JMapping("ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256", "ECDHE-PSK-CHACHA20-POLY1305");
+        testO2JMapping("DHE_PSK_WITH_CHACHA20_POLY1305_SHA256", "DHE-PSK-CHACHA20-POLY1305");
+        testO2JMapping("RSA_PSK_WITH_CHACHA20_POLY1305_SHA256", "RSA-PSK-CHACHA20-POLY1305");
     }
 
     private static void testO2JMapping(String javaCipherSuite, String openSslCipherSuite) {


### PR DESCRIPTION
Motivation:
For historical reasons OpenSSL's internal naming convention for CHACHA20 based cipher suites does not include the HMAC algorithm in the cipher name. This will prevent the CHACHA20 cipher suites from being used if the RFC cipher names are specified.

Modifications:
- Add a special case for CHACHA20 cipher name conversions in CipherSuiteConverter
- Update OPENSSL_CIPHERSUITE_PATTERN to accommodate the new naming scheme for CHACHA20 cipher suites

Result:
CipherSuiteConverter now works with CHACHA20 cipher suites.