### PR TITLE
HTTP/2 HelloWorld clear text NPE

### DIFF
--- a/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp2Handler.java
@@ -19,22 +19,22 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http.HttpServerUpgradeHandler;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
 import io.netty.handler.codec.http2.Http2ConnectionEncoder;
 import io.netty.handler.codec.http2.Http2ConnectionHandler;
-import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Flags;
 import io.netty.handler.codec.http2.Http2FrameListener;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.Http2Settings;
-import io.netty.util.AsciiString;
 import io.netty.util.CharsetUtil;
 
 import static io.netty.buffer.Unpooled.copiedBuffer;
 import static io.netty.buffer.Unpooled.unreleasableBuffer;
-import static io.netty.example.http2.Http2ExampleUtil.UPGRADE_RESPONSE_HEADER;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 
 /**
@@ -50,11 +50,15 @@ public final class HelloWorldHttp2Handler extends Http2ConnectionHandler impleme
     }
 
     private static Http2Headers http1HeadersToHttp2Headers(FullHttpRequest request) {
-        return new DefaultHttp2Headers()
-                .authority(request.headers().get("Host"))
-                .method("GET")
+        CharSequence host = request.headers().get(HttpHeaderNames.HOST);
+        Http2Headers http2Headers = new DefaultHttp2Headers()
+                .method(HttpMethod.GET.asciiName())
                 .path(request.uri())
-                .scheme("http");
+                .scheme(HttpScheme.HTTP.name());
+        if (host != null) {
+            http2Headers.authority(host);
+        }
+        return http2Headers;
     }
 
     /**


### PR DESCRIPTION
Motivation:
HelloWorldHttp2Handler throws a NPE when converting from HTTP/1.x headers to HTTP/2 headers because there is no Host header.

Modifications:
- HelloWorldHttp2Handler should check if the Host header is present before setting it in the HTTP/2 headers

Result:
No more NPE in HelloWorldHttp2Handler.