### PR TITLE
Fix compiler warnings in netty Epoll and unix common

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -315,7 +315,9 @@ static jstring netty_epoll_native_kernelVersion(JNIEnv* env, jclass clazz) {
 }
 
 static jboolean netty_epoll_native_isSupportingSendmmsg(JNIEnv* env, jclass clazz) {
-    if (sendmmsg) {
+    // Use & to avoid warnings with -Wtautological-pointer-compare when sendmmsg is
+    // not weakly defined.
+    if (&sendmmsg != NULL) {
         return JNI_TRUE;
     }
     return JNI_FALSE;

--- a/transport-native-unix-common/src/main/c/netty_unix_socket.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_socket.c
@@ -581,7 +581,7 @@ static jint netty_unix_socket_connectDomainSocket(JNIEnv* env, jclass clazz, jin
 static jint netty_unix_socket_recvFd(JNIEnv* env, jclass clazz, jint fd) {
     int socketFd;
     struct msghdr descriptorMessage = { 0 };
-    struct iovec iov[1] = { 0 };
+    struct iovec iov[1] = { { 0 } };
     char control[CMSG_SPACE(sizeof(int))] = { 0 };
     char iovecData[1];
 
@@ -629,7 +629,7 @@ static jint netty_unix_socket_recvFd(JNIEnv* env, jclass clazz, jint fd) {
 
 static jint netty_unix_socket_sendFd(JNIEnv* env, jclass clazz, jint socketFd, jint fd) {
     struct msghdr descriptorMessage = { 0 };
-    struct iovec iov[1] = { 0 };
+    struct iovec iov[1] = { { 0 } };
     char control[CMSG_SPACE(sizeof(int))] = { 0 };
     char iovecData[1];
 


### PR DESCRIPTION
Motivation:
Google requires stricter compilation by adding `-Werror` and enabling many other warnings.   

Modification:
Fix compiler warnings.  the explanation for each change is in its commit.

Result:
Easier compilation.

cc: @Scottmitch 