### PR TITLE
DNS Resolver Search Domain Bugs

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverBuilder.java
@@ -55,7 +55,7 @@ public final class DnsNameResolverBuilder {
     private DnsQueryLifecycleObserverFactory dnsQueryLifecycleObserverFactory =
             NoopDnsQueryLifecycleObserverFactory.INSTANCE;
     private String[] searchDomains;
-    private int ndots = 1;
+    private int ndots = -1;
     private boolean decodeIdn = true;
 
     /**

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 
+import static io.netty.resolver.dns.UnixResolverDnsServerAddressStreamProvider.DEFAULT_NDOTS;
+import static io.netty.resolver.dns.UnixResolverDnsServerAddressStreamProvider.parseEtcResolverFirstNdots;
 import static org.junit.Assert.assertEquals;
 
 public class UnixResolverDnsServerAddressStreamProviderTest {
@@ -75,6 +77,26 @@ public class UnixResolverDnsServerAddressStreamProviderTest {
         DnsServerAddressStream stream = p.nameServerAddressStream("myhost.dc1.linecorp.local");
         assertHostNameEquals("127.0.0.4", stream.next());
         assertHostNameEquals("127.0.0.5", stream.next());
+    }
+
+    @Test
+    public void ndotsIsParsedIfPresent() throws IOException {
+        File f = buildFile("search localdomain\n" +
+                           "nameserver 127.0.0.11\n" +
+                           "options ndots:0\n");
+        assertEquals(0, parseEtcResolverFirstNdots(f));
+
+        f = buildFile("search localdomain\n" +
+                      "nameserver 127.0.0.11\n" +
+                      "options ndots:123 foo:goo\n");
+        assertEquals(123, parseEtcResolverFirstNdots(f));
+    }
+
+    @Test
+    public void defaultValueReturnedIfNdotsNotPresent() throws IOException {
+        File f = buildFile("search localdomain\n" +
+                           "nameserver 127.0.0.11\n");
+        assertEquals(DEFAULT_NDOTS, parseEtcResolverFirstNdots(f));
     }
 
     private File buildFile(String contents) throws IOException {


### PR DESCRIPTION
Motivation:
The DNS resolver supports search domains. However the ndots are not correctly enforced. The search domain should only be appended under the following scenario [1]:

> Resolver queries having fewer than ndots dots (default is 1) in them will be attempted using each component of the search path in turn until a match is found.

The DNS resolver current appends the search domains if ndots is 0 which should never happen (because no domain can have less than 0 dots).

[1] https://linux.die.net/man/5/resolv.conf

Modifications:
- Parse /etc/resolv.conf to get the default value for ndots on Unix platforms
- The search domain shouldn't be used if ndots is 0
- Avoid failing a promise to trigger the search domain queries in DnsNameResolverContext#resolve

Result:
More correct usage of search domains in the DNS resolver.
Fixes https://github.com/netty/netty/issues/6844.