### PR TITLE
UnknownHostException should mention search domain if used

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -101,7 +101,6 @@ abstract class DnsNameResolverContext<T> {
             Collections.newSetFromMap(
                     new IdentityHashMap<Future<AddressedEnvelope<DnsResponse, InetSocketAddress>>, Boolean>());
 
-    private String pristineHostname;
     private List<DnsCacheEntry> resolvedEntries;
     private StringBuilder trace;
     private int allowedQueries;
@@ -145,10 +144,22 @@ abstract class DnsNameResolverContext<T> {
                     } else if (count < parent.searchDomains().length) {
                         doSearchDomainQuery(count++, this);
                     } else {
-                        promise.tryFailure(future.cause());
+                        promise.tryFailure(new SearchDomainUnknownHostException(future.cause(), hostname));
                     }
                 }
             });
+        }
+    }
+
+    private static final class SearchDomainUnknownHostException extends UnknownHostException {
+        SearchDomainUnknownHostException(Throwable cause, String originalHostname) {
+            super("Search domain query failed. Original hostname: '" + originalHostname + "' " + cause.getMessage());
+            setStackTrace(cause.getStackTrace());
+        }
+
+        @Override
+        public Throwable fillInStackTrace() {
+            return this;
         }
     }
 
@@ -158,7 +169,6 @@ abstract class DnsNameResolverContext<T> {
                                                                    additionals,
                                                                    resolveCache,
                                                                    nameServerAddrs);
-        nextContext.pristineHostname = hostname;
         Promise<T> nextPromise = parent.executor().newPromise();
         nextContext.internalResolve(nextPromise);
         nextPromise.addListener(listener);
@@ -661,13 +671,7 @@ abstract class DnsNameResolverContext<T> {
         final int tries = maxAllowedQueries - allowedQueries;
         final StringBuilder buf = new StringBuilder(64);
 
-        buf.append("failed to resolve '");
-        if (pristineHostname != null) {
-          buf.append(pristineHostname);
-        } else {
-          buf.append(hostname);
-        }
-        buf.append('\'');
+        buf.append("failed to resolve '").append(hostname).append('\'');
         if (tries > 1) {
             if (tries < maxAllowedQueries) {
                 buf.append(" after ")

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
@@ -273,7 +274,7 @@ public class SearchDomainTest {
     }
 
     @Test
-    public void testExceptionMsgNoSearchDomain() throws Exception {
+    public void testExceptionMsgContainsSearchDomain() throws Exception {
         Set<String> domains = new HashSet<String>();
 
         TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains);
@@ -286,8 +287,27 @@ public class SearchDomainTest {
         assertTrue(fut.await(10, TimeUnit.SECONDS));
         assertFalse(fut.isSuccess());
         final Throwable cause = fut.cause();
-        assertEquals(UnknownHostException.class, cause.getClass());
+        assertThat(cause, instanceOf(UnknownHostException.class));
         assertThat("search domain is included in UnknownHostException", cause.getMessage(),
-            not(containsString("foo.com")));
+            containsString("foo.com"));
+    }
+
+    @Test
+    public void testExceptionMsgDoesNotContainSearchDomainIfNdotsNotHighEnough() throws Exception {
+        Set<String> domains = new HashSet<String>();
+
+        TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(domains);
+        dnsServer = new TestDnsServer(store);
+        dnsServer.start();
+
+        resolver = newResolver().searchDomains(Collections.singletonList("foo.com")).ndots(1).build();
+
+        Future<InetAddress> fut = resolver.resolve("unknown.hostname");
+        assertTrue(fut.await(10, TimeUnit.SECONDS));
+        assertFalse(fut.isSuccess());
+        final Throwable cause = fut.cause();
+        assertThat(cause, instanceOf(UnknownHostException.class));
+        assertThat("search domain is included in UnknownHostException", cause.getMessage(),
+                not(containsString("foo.com")));
     }
 }


### PR DESCRIPTION
Motivation:
ba80fbbe05489227d64dcbd4f5e91bef68072c37 modified the UnknownHostException to not include the search domain if the DNS query failed, but this masks what DNS query actually failed. Have the full hostname (including the search domain) provides more visibility and may help diagnose a configuration error if queries are unexpectedly failing.

Modifications:
- Remove DnsNameResolverContext#pristineHostname

Result:
UnknownHostException is more accurate and reflect what hostname actually resulted in failure.