### PR TITLE
Replace DnsNameResolverContext#trace special code with an implementat…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/BiDnsQueryLifecycleObserver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/BiDnsQueryLifecycleObserver.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.handler.codec.dns.DnsQuestion;
+import io.netty.handler.codec.dns.DnsResponseCode;
+import io.netty.util.internal.UnstableApi;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * Combines two {@link DnsQueryLifecycleObserver} into a single {@link DnsQueryLifecycleObserver}.
+ */
+@UnstableApi
+public final class BiDnsQueryLifecycleObserver implements DnsQueryLifecycleObserver {
+    private final DnsQueryLifecycleObserver a;
+    private final DnsQueryLifecycleObserver b;
+
+    /**
+     * Create a new instance.
+     * @param a The {@link DnsQueryLifecycleObserver} that will receive events first.
+     * @param b The {@link DnsQueryLifecycleObserver} that will receive events second.
+     */
+    public BiDnsQueryLifecycleObserver(DnsQueryLifecycleObserver a, DnsQueryLifecycleObserver b) {
+        this.a = checkNotNull(a, "a");
+        this.b = checkNotNull(b, "b");
+    }
+
+    @Override
+    public void queryWritten(InetSocketAddress dnsServerAddress, ChannelFuture future) {
+        try {
+            a.queryWritten(dnsServerAddress, future);
+        } finally {
+            b.queryWritten(dnsServerAddress, future);
+        }
+    }
+
+    @Override
+    public void queryCancelled(int queriesRemaining) {
+        try {
+            a.queryCancelled(queriesRemaining);
+        } finally {
+            b.queryCancelled(queriesRemaining);
+        }
+    }
+
+    @Override
+    public DnsQueryLifecycleObserver queryRedirected(List<InetSocketAddress> nameServers) {
+        try {
+            a.queryRedirected(nameServers);
+        } finally {
+            b.queryRedirected(nameServers);
+        }
+        return this;
+    }
+
+    @Override
+    public DnsQueryLifecycleObserver queryCNAMEd(DnsQuestion cnameQuestion) {
+        try {
+            a.queryCNAMEd(cnameQuestion);
+        } finally {
+            b.queryCNAMEd(cnameQuestion);
+        }
+        return this;
+    }
+
+    @Override
+    public DnsQueryLifecycleObserver queryNoAnswer(DnsResponseCode code) {
+        try {
+            a.queryNoAnswer(code);
+        } finally {
+            b.queryNoAnswer(code);
+        }
+        return this;
+    }
+
+    @Override
+    public void queryFailed(Throwable cause) {
+        try {
+            a.queryFailed(cause);
+        } finally {
+            b.queryFailed(cause);
+        }
+    }
+
+    @Override
+    public void querySucceed() {
+        try {
+            a.querySucceed();
+        } finally {
+            b.querySucceed();
+        }
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/BiDnsQueryLifecycleObserverFactory.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/BiDnsQueryLifecycleObserverFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.handler.codec.dns.DnsQuestion;
+import io.netty.util.internal.UnstableApi;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * Combines two {@link DnsQueryLifecycleObserverFactory} into a single {@link DnsQueryLifecycleObserverFactory}.
+ */
+@UnstableApi
+public final class BiDnsQueryLifecycleObserverFactory implements DnsQueryLifecycleObserverFactory {
+    private final DnsQueryLifecycleObserverFactory a;
+    private final DnsQueryLifecycleObserverFactory b;
+
+    /**
+     * Create a new instance.
+     * @param a The {@link DnsQueryLifecycleObserverFactory} that will receive events first.
+     * @param b The {@link DnsQueryLifecycleObserverFactory} that will receive events second.
+     */
+    public BiDnsQueryLifecycleObserverFactory(DnsQueryLifecycleObserverFactory a, DnsQueryLifecycleObserverFactory b) {
+        this.a = checkNotNull(a, "a");
+        this.b = checkNotNull(b, "b");
+    }
+
+    @Override
+    public DnsQueryLifecycleObserver newDnsQueryLifecycleObserver(DnsQuestion question) {
+        return new BiDnsQueryLifecycleObserver(a.newDnsQueryLifecycleObserver(question),
+                                               b.newDnsQueryLifecycleObserver(question));
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -167,7 +167,6 @@ public class DnsNameResolver extends InetNameResolver {
 
     private final long queryTimeoutMillis;
     private final int maxQueriesPerResolve;
-    private final boolean traceEnabled;
     private final ResolvedAddressTypes resolvedAddressTypes;
     private final InternetProtocolFamily[] resolvedInternetProtocolFamilies;
     private final boolean recursionDesired;
@@ -232,7 +231,6 @@ public class DnsNameResolver extends InetNameResolver {
         this.resolvedAddressTypes = resolvedAddressTypes != null ? resolvedAddressTypes : DEFAULT_RESOLVE_ADDRESS_TYPES;
         this.recursionDesired = recursionDesired;
         this.maxQueriesPerResolve = checkPositive(maxQueriesPerResolve, "maxQueriesPerResolve");
-        this.traceEnabled = traceEnabled;
         this.maxPayloadSize = checkPositive(maxPayloadSize, "maxPayloadSize");
         this.optResourceEnabled = optResourceEnabled;
         this.hostsFileEntriesResolver = checkNotNull(hostsFileEntriesResolver, "hostsFileEntriesResolver");
@@ -240,7 +238,11 @@ public class DnsNameResolver extends InetNameResolver {
                 checkNotNull(dnsServerAddressStreamProvider, "dnsServerAddressStreamProvider");
         this.resolveCache = checkNotNull(resolveCache, "resolveCache");
         this.authoritativeDnsServerCache = checkNotNull(authoritativeDnsServerCache, "authoritativeDnsServerCache");
-        this.dnsQueryLifecycleObserverFactory =
+        this.dnsQueryLifecycleObserverFactory = traceEnabled ?
+                    dnsQueryLifecycleObserverFactory instanceof NoopDnsQueryLifecycleObserverFactory ?
+                    new TraceDnsQueryLifeCycleObserverFactory() :
+                new BiDnsQueryLifecycleObserverFactory(new TraceDnsQueryLifeCycleObserverFactory(),
+                                                       dnsQueryLifecycleObserverFactory) :
                 checkNotNull(dnsQueryLifecycleObserverFactory, "dnsQueryLifecycleObserverFactory");
         this.searchDomains = searchDomains != null ? searchDomains.clone() : DEFAULT_SEARCH_DOMAINS;
         this.ndots = ndots >= 0 ? ndots : DEFAULT_NDOTS;
@@ -397,14 +399,6 @@ public class DnsNameResolver extends InetNameResolver {
      */
     public int maxQueriesPerResolve() {
         return maxQueriesPerResolve;
-    }
-
-    /**
-     * Returns if this resolver should generate the detailed trace information in an exception message so that
-     * it is easier to understand the cause of resolution failure. The default value if {@code true}.
-     */
-    public boolean isTraceEnabled() {
-        return traceEnabled;
     }
 
     /**

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/TraceDnsQueryLifeCycleObserverFactory.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/TraceDnsQueryLifeCycleObserverFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.handler.codec.dns.DnsQuestion;
+import io.netty.util.internal.logging.InternalLogLevel;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+final class TraceDnsQueryLifeCycleObserverFactory implements DnsQueryLifecycleObserverFactory {
+    private static final InternalLogger DEFAULT_LOGGER =
+            InternalLoggerFactory.getInstance(TraceDnsQueryLifeCycleObserverFactory.class);
+    private static final InternalLogLevel DEFAULT_LEVEL = InternalLogLevel.DEBUG;
+    private final InternalLogger logger;
+    private final InternalLogLevel level;
+
+    TraceDnsQueryLifeCycleObserverFactory() {
+        this(DEFAULT_LOGGER, DEFAULT_LEVEL);
+    }
+
+    TraceDnsQueryLifeCycleObserverFactory(InternalLogger logger, InternalLogLevel level) {
+        this.logger = checkNotNull(logger, "logger");
+        this.level = checkNotNull(level, "level");
+    }
+
+    @Override
+    public DnsQueryLifecycleObserver newDnsQueryLifecycleObserver(DnsQuestion question) {
+        return new TraceDnsQueryLifecycleObserver(question, logger, level);
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/TraceDnsQueryLifecycleObserver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/TraceDnsQueryLifecycleObserver.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.handler.codec.dns.DnsQuestion;
+import io.netty.handler.codec.dns.DnsResponseCode;
+import io.netty.util.internal.logging.InternalLogLevel;
+import io.netty.util.internal.logging.InternalLogger;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+final class TraceDnsQueryLifecycleObserver implements DnsQueryLifecycleObserver {
+    private final InternalLogger logger;
+    private final InternalLogLevel level;
+    private final DnsQuestion question;
+    private InetSocketAddress dnsServerAddress;
+
+    TraceDnsQueryLifecycleObserver(DnsQuestion question, InternalLogger logger, InternalLogLevel level) {
+        this.question = checkNotNull(question, "question");
+        this.logger = checkNotNull(logger, "logger");
+        this.level = checkNotNull(level, "level");
+    }
+
+    @Override
+    public void queryWritten(InetSocketAddress dnsServerAddress, ChannelFuture future) {
+        this.dnsServerAddress = dnsServerAddress;
+    }
+
+    @Override
+    public void queryCancelled(int queriesRemaining) {
+        if (dnsServerAddress != null) {
+            logger.log(level, "from {} : {} cancelled with {} queries remaining", dnsServerAddress, question,
+                        queriesRemaining);
+        } else {
+            logger.log(level, "{} query never written and cancelled with {} queries remaining", question,
+                        queriesRemaining);
+        }
+    }
+
+    @Override
+    public DnsQueryLifecycleObserver queryRedirected(List<InetSocketAddress> nameServers) {
+        logger.log(level, "from {} : {} redirected", dnsServerAddress, question);
+        return this;
+    }
+
+    @Override
+    public DnsQueryLifecycleObserver queryCNAMEd(DnsQuestion cnameQuestion) {
+        logger.log(level, "from {} : {} CNAME question {}", dnsServerAddress, question, cnameQuestion);
+        return this;
+    }
+
+    @Override
+    public DnsQueryLifecycleObserver queryNoAnswer(DnsResponseCode code) {
+        logger.log(level, "from {} : {} no answer {}", dnsServerAddress, question, code);
+        return this;
+    }
+
+    @Override
+    public void queryFailed(Throwable cause) {
+        if (dnsServerAddress != null) {
+            logger.log(level, "from {} : {} failure", dnsServerAddress, question, cause);
+        } else {
+            logger.log(level, "{} query never written and failed", question, cause);
+        }
+    }
+
+    @Override
+    public void querySucceed() {
+    }
+}


### PR DESCRIPTION
…ion of DnsQueryLifecycleObserver

Motivation:
DnsQueryLifecycleObserver is designed to capture the life cycle of every query. DnsNameResolverContext has a custom trace mechanism which consists of a StringBuilder and manual calls throughout the class. We can remove some special case code in DnsNameResolverContext and instead use a special implementation of DnsQueryLifecycleObserver when trace is enabled.

Modifications:
- Remove all references to the boolean trace variables in DnsNameResolverContext and DnsNameResolver
- Introduce TraceDnsQueryLifecycleObserver which will be used when trace is enabled and will log similar data as what trace currently provides

Result:
Less special case code in DnsNameResolverContext and instead delegate to TraceDnsQueryLifecycleObserver to capture trace information.