### PR TITLE
Move "fallthrough" statement to where fall actually happens

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -284,8 +284,8 @@ final class EpollEventLoop extends SingleThreadEventLoop {
                         if (wakenUp == 1) {
                             Native.eventFdWrite(eventFd.intValue(), 1L);
                         }
-                    default:
                         // fallthrough
+                    default:
                 }
 
                 final int ioRatio = this.ioRatio;


### PR DESCRIPTION
Motivation:
Static analysis looks for error prone switch case statements.
Accidental fall through is one such case, but it is sometimes
intentional.  To indicate this, the "//fallthrough" comment can be
added before the fall.

The code in question has this comment, but it is *after* the fall
so the static analysis flags it.

This is described in http://errorprone.info/bugpattern/FallThrough

Modifications:
Move fall through comment to where the fall actually occurs

Result:
More compatible with Error Prone tools
