### PR TITLE
SocksCommonUtils cleanup

### DIFF
--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequestDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdRequestDecoder.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.handler.codec.socks.SocksCmdRequestDecoder.State;
+import io.netty.util.NetUtil;
 
 import java.util.List;
 
@@ -54,7 +55,7 @@ public class SocksCmdRequestDecoder extends ReplayingDecoder<State> {
             case READ_CMD_ADDRESS: {
                 switch (addressType) {
                     case IPv4: {
-                        String host = SocksCommonUtils.intToIp(byteBuf.readInt());
+                        String host = NetUtil.intToIpAddress(byteBuf.readInt());
                         int port = byteBuf.readUnsignedShort();
                         out.add(new SocksCmdRequest(cmdType, addressType, host, port));
                         break;

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponseDecoder.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCmdResponseDecoder.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.handler.codec.socks.SocksCmdResponseDecoder.State;
+import io.netty.util.NetUtil;
 
 import java.util.List;
 
@@ -54,7 +55,7 @@ public class SocksCmdResponseDecoder extends ReplayingDecoder<State> {
             case READ_CMD_ADDRESS: {
                 switch (addressType) {
                     case IPv4: {
-                        String host = SocksCommonUtils.intToIp(byteBuf.readInt());
+                        String host = NetUtil.intToIpAddress(byteBuf.readInt());
                         int port = byteBuf.readUnsignedShort();
                         out.add(new SocksCmdResponse(cmdStatus, addressType, host, port));
                         break;

--- a/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCommonUtils.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socks/SocksCommonUtils.java
@@ -23,11 +23,6 @@ final class SocksCommonUtils {
     public static final SocksRequest UNKNOWN_SOCKS_REQUEST = new UnknownSocksRequest();
     public static final SocksResponse UNKNOWN_SOCKS_RESPONSE = new UnknownSocksResponse();
 
-    private static final int SECOND_ADDRESS_OCTET_SHIFT = 16;
-    private static final int FIRST_ADDRESS_OCTET_SHIFT = 24;
-    private static final int THIRD_ADDRESS_OCTET_SHIFT = 8;
-    private static final int XOR_DEFAULT_VALUE = 0xff;
-
     /**
      * A constructor to stop this class being constructed.
      */
@@ -35,51 +30,7 @@ final class SocksCommonUtils {
         // NOOP
     }
 
-    public static String intToIp(int i) {
-        return String.valueOf(i >> FIRST_ADDRESS_OCTET_SHIFT & XOR_DEFAULT_VALUE) + '.' +
-               (i >> SECOND_ADDRESS_OCTET_SHIFT & XOR_DEFAULT_VALUE) + '.' +
-               (i >> THIRD_ADDRESS_OCTET_SHIFT & XOR_DEFAULT_VALUE) + '.' +
-               (i & XOR_DEFAULT_VALUE);
-    }
-
-    private static final char[] ipv6conseqZeroFiller = {':', ':'};
     private static final char ipv6hextetSeparator = ':';
-
-    /**
-     * Convert numeric IPv6 to compressed format, where
-     * the longest sequence of 0's (with 2 or more 0's) is replaced with "::"
-     */
-    public static String ipv6toCompressedForm(byte[] src) {
-        assert src.length == 16;
-        //Find the longest sequence of 0's
-        //start of compressed region (hextet index)
-        int cmprHextet = -1;
-        //length of compressed region
-        int cmprSize = 0;
-        for (int hextet = 0; hextet < 8;) {
-            int curByte = hextet * 2;
-            int size = 0;
-            while (curByte < src.length && src[curByte] == 0
-                    && src[curByte + 1] == 0) {
-                curByte += 2;
-                size++;
-            }
-            if (size > cmprSize) {
-                cmprHextet = hextet;
-                cmprSize = size;
-            }
-            hextet = curByte / 2 + 1;
-        }
-        if (cmprHextet == -1 || cmprSize < 2) {
-            //No compression can be applied
-            return ipv6toStr(src);
-        }
-        StringBuilder sb = new StringBuilder(39);
-        ipv6toStr(sb, src, 0, cmprHextet);
-        sb.append(ipv6conseqZeroFiller);
-        ipv6toStr(sb, src, cmprHextet + cmprSize, 8);
-        return sb.toString();
-    }
 
     /**
      * Converts numeric IPv6 to standard (non-compressed) format.


### PR DESCRIPTION
Motivation:

1. Internal class `SocksCommonUtils` contains a method `intToIp` that also exists in the `NetUtil`.
2. A `SocksCommonUtils#ipv6toCompressedForm` is never used.

Modifications:

1. Replace `intToIp` method usage with `NetUtil#intToIpAddress`.
2. Remove unused methods from `SocksCommonUtils`.

Result:

Less code for supports.