### PR TITLE
Exhaust non-exhaustive switch cases

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -244,6 +244,10 @@ public class JdkSslContext extends SslContext {
                 case REQUIRE:
                     engine.setNeedClientAuth(true);
                     break;
+                case NONE:
+                    break; // exhaustive cases
+                default:
+                    throw new Error("Unknown auth " + clientAuth);
             }
         }
         return apn.wrapperFactory().wrapSslEngine(engine, apn, isServer());


### PR DESCRIPTION
Motivation:
ErrorProne warns about missing cases in switch statements that
appear as an oversight.

Modifcation:
Add the last case to statement to ensure all cases are covered.

Result:
Able to enable Error Prone static analysis

Note:  Sorry about sending so many tiny PRs.  Each compilation failure gets fixed and rolled into a commit.  Trying to compile a single package at a time takes a lot of work, so some fixes are not obvious until later.