### PR TITLE
Friendly ProtobufDecoder for ProtobufLite

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoder.java
@@ -89,10 +89,6 @@ public class ProtobufDecoder extends MessageToMessageDecoder<ByteBuf> {
         this(prototype, null);
     }
 
-    public ProtobufDecoder(MessageLite prototype, ExtensionRegistry extensionRegistry) {
-        this(prototype, (ExtensionRegistryLite) extensionRegistry);
-    }
-
     public ProtobufDecoder(MessageLite prototype, ExtensionRegistryLite extensionRegistry) {
         if (prototype == null) {
             throw new NullPointerException("prototype");


### PR DESCRIPTION
Friendly ProtobufDecoder for ProtobufLite.

Motivation:
Impossible to use Netty with Protobuf Lite to run on Raspberry.
 
Modifications:
Removed constructor of ProtobufDecoder where used ExtensionRegistry, there are also constructor with ExtensionRegistryLite.
 
Result:
Fixes #6778
Protobuf lite version running successfully.