### PR TITLE
Add content-security-policy and x-frame-options to HttpHeaderNames

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderNames.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderNames.java
@@ -145,6 +145,10 @@ public final class HttpHeaderNames {
      */
     public static final AsciiString CONTENT_RANGE = new AsciiString("content-range");
     /**
+     * {@code "content-security-policy"}
+     */
+    public static final CharSequence CONTENT_SECURITY_POLICY = new AsciiString("content-security-policy");
+    /**
      * {@code "content-type"}
      */
     public static final AsciiString CONTENT_TYPE = new AsciiString("content-type");
@@ -346,6 +350,10 @@ public final class HttpHeaderNames {
      * {@code "www-authenticate"}
      */
     public static final AsciiString WWW_AUTHENTICATE = new AsciiString("www-authenticate");
+    /**
+     * {@code "x-frame-options"}
+     */
+    public static final CharSequence X_FRAME_OPTIONS = new AsciiString("x-frame-options");
 
     private HttpHeaderNames() { }
 }


### PR DESCRIPTION
Motivation:

These headers can be used to prevent clickjacking.

Modifications:

Add static fields for content-security-policy and x-frame-options

Result:

Expose general useful names