### PR TITLE
Close channels that are released to a closed FixedChannelPool.

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -258,6 +258,8 @@ public class FixedChannelPool extends SimpleChannelPool {
                 assert executor.inEventLoop();
 
                 if (closed) {
+                    // Since the pool is closed, we have no choice but to close the channel
+                    channel.close();
                     promise.setFailure(new IllegalStateException("FixedChannelPooled was closed"));
                     return;
                 }
@@ -366,6 +368,10 @@ public class FixedChannelPool extends SimpleChannelPool {
             assert executor.inEventLoop();
 
             if (closed) {
+                if (future.isSuccess()) {
+                    // Since the pool is closed, we have no choice but to close the channel
+                    future.getNow().close();
+                }
                 originalPromise.setFailure(new IllegalStateException("FixedChannelPooled was closed"));
                 return;
             }

--- a/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
@@ -299,8 +299,12 @@ public class FixedChannelPoolTest {
             }
         }).syncUninterruptibly();
         pool.release(channel).syncUninterruptibly();
+
+        // Since the pool is closed.. the release channel should have been closed
+        channel.closeFuture().syncUninterruptibly();
+        assertFalse("Unexpected open channel", channel.isOpen());
+
         sc.close().syncUninterruptibly();
-        channel.close().syncUninterruptibly();
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Channels returned to a FixedChannelPool after closing it remain active.

Since channels that where acquired from the pool are not closed during the close operation, they remain open even after releasing the channel back to the pool where they are then in accessible and become in-effect a connection leak.

Modification:

Close the released channel on releasing back to a closed pool.

Result:

Much harder to create a connection leak by closing an active
FixedChannelPool instance.