### PR TITLE
Update Http2SecurityUtil cipher suites

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
@@ -31,7 +31,7 @@ public final class Http2SecurityUtil {
      * The following list is derived from <a
      * href="http://docs.oracle.com/javase/8/docs/technotes/guides/security/SunProviders.html">SunJSSE Supported
      * Ciphers</a> and <a
-     * href="https://wiki.mozilla.org/Security/Server_Side_TLS#Non-Backward_Compatible_Ciphersuite">Mozilla Cipher
+     * href="https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility">Mozilla Modern Cipher
      * Suites</a> in accordance with the <a
      * href="https://tools.ietf.org/html/draft-ietf-httpbis-http2-16#section-9.2.2">HTTP/2 Specification</a>.
      *
@@ -42,50 +42,39 @@ public final class Http2SecurityUtil {
      */
     public static final List<String> CIPHERS;
 
-    private static final List<String> CIPHERS_JAVA_MOZILLA_INCREASED_SECURITY = Collections.unmodifiableList(Arrays
+    /**
+     * <a href="https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility">Mozilla Modern Cipher
+     * Suites</a> minus the following cipher suites that are black listed by the
+     * <a href="https://tools.ietf.org/html/rfc7540#appendix-A">HTTP/2 RFC</a>.
+     */
+    private static final List<String> CIPHERS_JAVA_MOZILLA_MODERN_SECURITY = Collections.unmodifiableList(Arrays
             .asList(
             /* Java 8 */
             /* openssl = ECDHE-ECDSA-AES256-GCM-SHA384 */
             "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
             "SSL_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-            /* openssl = ECDHE-ECDSA-AES128-GCM-SHA256 */
-            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-            "SSL_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
             /* openssl = ECDHE-RSA-AES256-GCM-SHA384 */
             "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
             "SSL_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            /* openssl = ECDHE-ECDSA-CHACHA20-POLY1305 */
+            "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+            "SSL_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+            /* openssl = ECDHE-RSA-CHACHA20-POLY1305 */
+            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+            "SSL_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+            /* openssl = ECDHE-ECDSA-AES128-GCM-SHA256 */
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            "SSL_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 
             /* REQUIRED BY HTTP/2 SPEC */
             /* openssl = ECDHE-RSA-AES128-GCM-SHA256 */
             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-            "SSL_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-
+            "SSL_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
             /* REQUIRED BY HTTP/2 SPEC */
-            /* openssl = DHE-RSA-AES128-GCM-SHA256 */
-            "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
-            "SSL_DHE_RSA_WITH_AES_128_GCM_SHA256",
-            /* openssl = DHE-DSS-AES128-GCM-SHA256 */
-            "TLS_DHE_DSS_WITH_AES_128_GCM_SHA256",
-            "SSL_DHE_DSS_WITH_AES_128_GCM_SHA256"
-            ));
-
-    private static final List<String> CIPHERS_JAVA_NO_MOZILLA_INCREASED_SECURITY = Collections.unmodifiableList(Arrays
-            .asList(
-            /* Java 8 */
-            /* openssl = DHE-RSA-AES256-GCM-SHA384 */
-            "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
-            "SSL_DHE_RSA_WITH_AES_256_GCM_SHA384",
-            /* openssl = DHE-DSS-AES256-GCM-SHA384 */
-            "TLS_DHE_DSS_WITH_AES_256_GCM_SHA384",
-            "SSL_DHE_DSS_WITH_AES_256_GCM_SHA384"
             ));
 
     static {
-        List<String> ciphers = new ArrayList<String>(CIPHERS_JAVA_MOZILLA_INCREASED_SECURITY.size()
-                + CIPHERS_JAVA_NO_MOZILLA_INCREASED_SECURITY.size());
-        ciphers.addAll(CIPHERS_JAVA_MOZILLA_INCREASED_SECURITY);
-        ciphers.addAll(CIPHERS_JAVA_NO_MOZILLA_INCREASED_SECURITY);
-        CIPHERS = Collections.unmodifiableList(ciphers);
+        CIPHERS = Collections.unmodifiableList(new ArrayList<String>(CIPHERS_JAVA_MOZILLA_MODERN_SECURITY));
     }
 
     private Http2SecurityUtil() { }


### PR DESCRIPTION
Motivation:
Mozilla's Server Side cipher suite recommendations have been updated [1].

[1] https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility

Modifications:
- Update Http2SecurityUtil to exclude older ciphers.
- Remove support for DHE ciphersuites because they are now Intermediate and BoringSSL dropped support for these ciphers [2]

[2] https://boringssl.googlesource.com/boringssl/+/7e06de5d2d1b53c57c0c81e8d6ba4122b64cf626

Result:
Updated default ciphers for HTTP/2.