### PR TITLE
Performance improvement: Character.isWhitespace replaced with naive ==.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
@@ -127,7 +127,7 @@ public class HttpMethod implements Comparable<HttpMethod> {
 
         for (int i = 0; i < name.length(); i ++) {
             char c = name.charAt(i);
-            if (Character.isISOControl(c) || Character.isWhitespace(c)) {
+            if (Character.isISOControl(c) || c == ' ') {
                 throw new IllegalArgumentException("invalid character in name");
             }
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -681,7 +681,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         hex = hex.trim();
         for (int i = 0; i < hex.length(); i ++) {
             char c = hex.charAt(i);
-            if (c == ';' || Character.isWhitespace(c) || Character.isISOControl(c)) {
+            if (c == ';' || c == ' ' || Character.isISOControl(c)) {
                 hex = hex.substring(0, i);
                 break;
             }
@@ -724,7 +724,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         nameStart = findNonWhitespace(sb, 0);
         for (nameEnd = nameStart; nameEnd < length; nameEnd ++) {
             char ch = sb.charAt(nameEnd);
-            if (ch == ':' || Character.isWhitespace(ch)) {
+            if (ch == ':' || ch == ' ') {
                 break;
             }
         }
@@ -748,7 +748,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
     private static int findNonWhitespace(AppendableCharSequence sb, int offset) {
         for (int result = offset; result < sb.length(); ++result) {
-            if (!Character.isWhitespace(sb.charAtUnsafe(result))) {
+            if (sb.charAtUnsafe(result) != ' ') {
                 return result;
             }
         }
@@ -757,7 +757,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
     private static int findWhitespace(AppendableCharSequence sb, int offset) {
         for (int result = offset; result < sb.length(); ++result) {
-            if (Character.isWhitespace(sb.charAtUnsafe(result))) {
+            if (sb.charAtUnsafe(result) == ' ') {
                 return result;
             }
         }
@@ -766,7 +766,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
 
     private static int findEndOfString(AppendableCharSequence sb) {
         for (int result = sb.length() - 1; result > 0; --result) {
-            if (!Character.isWhitespace(sb.charAtUnsafe(result))) {
+            if (sb.charAtUnsafe(result) != ' ') {
                 return result + 1;
             }
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
@@ -363,7 +363,7 @@ public class HttpServerUpgradeHandler extends HttpObjectAggregator {
         final List<CharSequence> protocols = new ArrayList<CharSequence>(4);
         for (int i = 0; i < header.length(); ++i) {
             char c = header.charAt(i);
-            if (Character.isWhitespace(c)) {
+            if (c == ' ') {
                 // Don't include any whitespace.
                 continue;
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpVersion.java
@@ -160,7 +160,7 @@ public class HttpVersion implements Comparable<HttpVersion> {
 
         for (int i = 0; i < protocolName.length(); i ++) {
             if (Character.isISOControl(protocolName.charAt(i)) ||
-                    Character.isWhitespace(protocolName.charAt(i))) {
+                    protocolName.charAt(i) == ' ') {
                 throw new IllegalArgumentException("invalid character in protocolName");
             }
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostBodyUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostBodyUtil.java
@@ -129,7 +129,7 @@ final class HttpPostBodyUtil {
     static int findNonWhitespace(String sb, int offset) {
         int result;
         for (result = offset; result < sb.length(); result ++) {
-            if (!Character.isWhitespace(sb.charAt(result))) {
+            if (sb.charAt(result) != ' ') {
                 break;
             }
         }
@@ -143,7 +143,7 @@ final class HttpPostBodyUtil {
     static int findEndOfString(String sb) {
         int result;
         for (result = sb.length(); result > 0; result --) {
-            if (!Character.isWhitespace(sb.charAt(result - 1))) {
+            if (sb.charAt(result - 1) != ' ') {
                 break;
             }
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostMultipartRequestDecoder.java
@@ -589,7 +589,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
         SeekAheadOptimize sao = new SeekAheadOptimize(undecodedChunk);
         while (sao.pos < sao.limit) {
             char c = (char) (sao.bytes[sao.pos++] & 0xFF);
-            if (!Character.isISOControl(c) && !Character.isWhitespace(c)) {
+            if (!Character.isISOControl(c) && c != ' ') {
                 sao.setReadPosition(1);
                 return;
             }
@@ -600,7 +600,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
     private static void skipControlCharactersStandard(ByteBuf undecodedChunk) {
         for (;;) {
             char c = (char) undecodedChunk.readUnsignedByte();
-            if (!Character.isISOControl(c) && !Character.isWhitespace(c)) {
+            if (!Character.isISOControl(c) && c != ' ') {
                 undecodedChunk.readerIndex(undecodedChunk.readerIndex() - 1);
                 break;
             }
@@ -1783,7 +1783,7 @@ public class HttpPostMultipartRequestDecoder implements InterfaceHttpPostRequest
         nameStart = HttpPostBodyUtil.findNonWhitespace(sb, 0);
         for (nameEnd = nameStart; nameEnd < sb.length(); nameEnd++) {
             char ch = sb.charAt(nameEnd);
-            if (ch == ':' || Character.isWhitespace(ch)) {
+            if (ch == ':' || ch == ' ') {
                 break;
             }
         }

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -553,7 +553,7 @@ public final class StringUtil {
      */
     public static int indexOfNonWhiteSpace(CharSequence seq, int offset) {
         for (; offset < seq.length(); ++offset) {
-            if (!Character.isWhitespace(seq.charAt(offset))) {
+            if (seq.charAt(offset) != ' ') {
                 return offset;
             }
         }


### PR DESCRIPTION
Motivation:

Right now netty uses `Character.isWhitespace` check for whitespaces in some places of `HttpObjectDecoder` and few others http classes. However, this method is not intrinsic and slower than naive comparing with equal operator `==` (as it uses table lookup).

Modification:

`Character.isWhitespace` repalced with `==`. `!Character.isWhitespace` replaced with `!=`.

Result:

Tests show that `splitHeader` method of `HttpRequestDecoder` is 30% faster.

Benchmark for `Character.isWhitespace` vs `==` :

```
@BenchmarkMode(Mode.Throughput)
@Fork(1)
@State(Scope.Thread)
@Warmup(iterations = 10, time = 1, batchSize = 1000)
@Measurement(iterations = 20, time = 1, batchSize = 1000)
public class CharacterCompare {

    private char c = 'c';

    @Benchmark
    public boolean characterIsWhitespaceChar() {
        return Character.isWhitespace(c);
    }

    @Benchmark
    public boolean naiveCheckChar() {
        return c == ' ';
    }
}
```

Result: 
```
Benchmark                                    Mode  Cnt       Score       Error  Units
CharacterCompare.characterIsWhitespaceChar  thrpt   20  287834.304 ± 16050.006  ops/s
CharacterCompare.naiveCheckChar             thrpt   20  355577.043 ± 39929.517  ops/s
```

Benchmark for `splitHeader` of `HttpRequestDecoder` (you need to make fields and method public to make it work) :

```
@State(Scope.Benchmark)
@Warmup(iterations = 10)
@Measurement(iterations = 20)
public class HttpObjectDecoderSplitHeadersBenchmark extends AbstractMicrobenchmark {

    private HttpRequestDecoder httpRequestDecoder = new HttpRequestDecoder();
    private AppendableCharSequence header = new AppendableCharSequence(23).append("Content-Type: text/html");

    @Benchmark
    public CharSequence oldDecoder() throws Exception {
        httpRequestDecoder.splitHeader(header);
        return httpRequestDecoder.name;
    }

    @Benchmark
    public CharSequence newDecoder() throws Exception {
        httpRequestDecoder.splitHeaderNew(header);
        return httpRequestDecoder.name;
    }

}
```

Result:

```
Benchmark                                           Mode  Cnt         Score         Error  Units
HttpObjectDecoderSplitHeadersBenchmark.newDecoder  thrpt   40  21289487.337 ±  986998.323  ops/s
HttpObjectDecoderSplitHeadersBenchmark.oldDecoder  thrpt   40  14586426.110 ± 1328832.579  ops/s
```
