### PR TITLE
Remove @deprecation keyword on AbstractUnsafe.ensureOpen(...)

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -880,7 +880,6 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             return unsafeVoidPromise;
         }
 
-        @Deprecated
         protected final boolean ensureOpen(ChannelPromise promise) {
             if (isOpen()) {
                 return true;


### PR DESCRIPTION
Motivation:

e84567004324c0bfd04b0ca9e1e182ed89394b16 marked AbstractUnsafe.ensureOpen(...) as deprecated for no reason.

Modifications:

Remove `@deprecation`

Result:

Remove incorrect annotation