### PR TITLE
DNS Resolver should be more consistent with JDK resolution

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStream.java
@@ -29,4 +29,19 @@ public interface DnsServerAddressStream {
      * Retrieves the next DNS server address from the stream.
      */
     InetSocketAddress next();
+
+    /**
+     * Get the number of times {@link #next()} will return a distinct element before repeating or terminating.
+     * @return the number of times {@link #next()} will return a distinct element before repeating or terminating.
+     */
+    int size();
+
+    /**
+     * Duplicate this object. The result of this should be able to be independently iterated over via {@link #next()}.
+     * <p>
+     * Note that {@link #clone()} isn't used because it may make sense for some implementations to have the following
+     * relationship {@code x.duplicate() == x}.
+     * @return A clone of this object.
+     */
+    DnsServerAddressStream duplicate();
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/SequentialDnsServerAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/SequentialDnsServerAddressStream.java
@@ -41,6 +41,16 @@ final class SequentialDnsServerAddressStream implements DnsServerAddressStream {
     }
 
     @Override
+    public int size() {
+        return addresses.length;
+    }
+
+    @Override
+    public SequentialDnsServerAddressStream duplicate() {
+        return new SequentialDnsServerAddressStream(addresses, i);
+    }
+
+    @Override
     public String toString() {
         return toString("sequential", i, addresses);
     }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/SequentialDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/SequentialDnsServerAddressStreamProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.util.internal.UnstableApi;
+
+import java.net.InetSocketAddress;
+
+import static io.netty.resolver.dns.DnsServerAddresses.sequential;
+
+/**
+ * A {@link DnsServerAddressStreamProvider} which is backed by a sequential list of DNS servers.
+ */
+@UnstableApi
+public final class SequentialDnsServerAddressStreamProvider extends UniSequentialDnsServerAddressStreamProvider {
+    /**
+     * Create a new instance.
+     * @param addresses The addresses which will be be returned in sequential order via
+     * {@link #nameServerAddressStream(String)}
+     */
+    public SequentialDnsServerAddressStreamProvider(InetSocketAddress... addresses) {
+        super(sequential(addresses));
+    }
+
+    /**
+     * Create a new instance.
+     * @param addresses The addresses which will be be returned in sequential order via
+     * {@link #nameServerAddressStream(String)}
+     */
+    public SequentialDnsServerAddressStreamProvider(Iterable<? extends InetSocketAddress> addresses) {
+        super(sequential(addresses));
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/ShuffledDnsServerAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/ShuffledDnsServerAddressStream.java
@@ -27,9 +27,14 @@ final class ShuffledDnsServerAddressStream implements DnsServerAddressStream {
     private int i;
 
     ShuffledDnsServerAddressStream(InetSocketAddress[] addresses) {
-        this.addresses = addresses.clone();
+        this.addresses = addresses;
 
         shuffle();
+    }
+
+    private ShuffledDnsServerAddressStream(InetSocketAddress[] addresses, int startIdx) {
+        this.addresses = addresses;
+        i = startIdx;
     }
 
     private void shuffle() {
@@ -55,6 +60,16 @@ final class ShuffledDnsServerAddressStream implements DnsServerAddressStream {
             shuffle();
         }
         return next;
+    }
+
+    @Override
+    public int size() {
+        return addresses.length;
+    }
+
+    @Override
+    public ShuffledDnsServerAddressStream duplicate() {
+        return new ShuffledDnsServerAddressStream(addresses, i);
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/SingletonDnsServerAddresses.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/SingletonDnsServerAddresses.java
@@ -21,12 +21,21 @@ import java.net.InetSocketAddress;
 final class SingletonDnsServerAddresses extends DnsServerAddresses {
 
     private final InetSocketAddress address;
-    private final String strVal;
 
     private final DnsServerAddressStream stream = new DnsServerAddressStream() {
         @Override
         public InetSocketAddress next() {
             return address;
+        }
+
+        @Override
+        public int size() {
+            return 1;
+        }
+
+        @Override
+        public DnsServerAddressStream duplicate() {
+            return this;
         }
 
         @Override
@@ -37,7 +46,6 @@ final class SingletonDnsServerAddresses extends DnsServerAddresses {
 
     SingletonDnsServerAddresses(InetSocketAddress address) {
         this.address = address;
-        strVal = new StringBuilder(32).append("singleton(").append(address).append(')').toString();
     }
 
     @Override
@@ -47,6 +55,6 @@ final class SingletonDnsServerAddresses extends DnsServerAddresses {
 
     @Override
     public String toString() {
-        return strVal;
+        return "singleton(" + address + ")";
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/UniSequentialDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/UniSequentialDnsServerAddressStreamProvider.java
@@ -15,20 +15,20 @@
  */
 package io.netty.resolver.dns;
 
-import io.netty.util.internal.UnstableApi;
-
-import java.net.InetSocketAddress;
+import io.netty.util.internal.ObjectUtil;
 
 /**
- * A {@link DnsServerAddressStreamProvider} which always uses a single DNS server for resolution.
+ * A {@link DnsServerAddressStreamProvider} which is backed by a single {@link DnsServerAddresses}.
  */
-@UnstableApi
-public final class SingletonDnsServerAddressStreamProvider extends UniSequentialDnsServerAddressStreamProvider {
-    /**
-     * Create a new instance.
-     * @param address The singleton address to use for every DNS resolution.
-     */
-    public SingletonDnsServerAddressStreamProvider(final InetSocketAddress address) {
-        super(DnsServerAddresses.singleton(address));
+abstract class UniSequentialDnsServerAddressStreamProvider implements DnsServerAddressStreamProvider {
+    private final DnsServerAddresses addresses;
+
+    UniSequentialDnsServerAddressStreamProvider(DnsServerAddresses addresses) {
+        this.addresses = ObjectUtil.checkNotNull(addresses, "addresses");
+    }
+
+    @Override
+    public final DnsServerAddressStream nameServerAddressStream(String hostname) {
+        return addresses.stream();
     }
 }


### PR DESCRIPTION
Motivation:
If there are multiple DNS servers to query Java's DNS resolver will attempt to resolve A and AAAA records in sequential order and will terminate with a failure once all DNS servers have been exhausted. Netty's DNS server will share the same DnsServerAddressStream for the different record types which may send the A question to the first host and the AAAA question to the second host. Netty's DNS resolution also may not progress to the next DNS server in all situations and doesn't have a means to know when resolution has completed.

Modifications:
- DnsServerAddressStream should support new methods to allow the same stream to be used to issue multiple queries (e.g. A and AAAA) against the same host.
- DnsServerAddressStream should support a method to determine when the stream will start to repeat, and therefore a failure can be returned.
- Introduce SequentialDnsServerAddressStreamProvider for sequential use cases

Result:
Fixes https://github.com/netty/netty/issues/6926.