### PR TITLE
Workaround IBM's J9 JVM getSupportedCipherSuites() returning SSL_ prefix cipher names

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
@@ -49,27 +49,20 @@ public final class Http2SecurityUtil {
      */
     private static final List<String> CIPHERS_JAVA_MOZILLA_MODERN_SECURITY = Collections.unmodifiableList(Arrays
             .asList(
-            /* Java 8 */
             /* openssl = ECDHE-ECDSA-AES256-GCM-SHA384 */
             "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-            "SSL_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
             /* openssl = ECDHE-RSA-AES256-GCM-SHA384 */
             "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-            "SSL_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
             /* openssl = ECDHE-ECDSA-CHACHA20-POLY1305 */
             "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-            "SSL_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
             /* openssl = ECDHE-RSA-CHACHA20-POLY1305 */
             "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-            "SSL_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
             /* openssl = ECDHE-ECDSA-AES128-GCM-SHA256 */
             "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-            "SSL_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
 
             /* REQUIRED BY HTTP/2 SPEC */
             /* openssl = ECDHE-RSA-AES128-GCM-SHA256 */
-            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-            "SSL_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
             /* REQUIRED BY HTTP/2 SPEC */
             ));
 

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -89,7 +89,20 @@ public class JdkSslContext extends SslContext {
         final String[] supportedCiphers = engine.getSupportedCipherSuites();
         SUPPORTED_CIPHERS = new HashSet<String>(supportedCiphers.length);
         for (i = 0; i < supportedCiphers.length; ++i) {
-            SUPPORTED_CIPHERS.add(supportedCiphers[i]);
+            String supportedCipher = supportedCiphers[i];
+            SUPPORTED_CIPHERS.add(supportedCipher);
+            // IBM's J9 JVM utilizes a custom naming scheme for ciphers and only returns ciphers with the "SSL_"
+            // prefix instead of the "TLS_" prefix (as defined in the JSSE cipher suite names [1]). According to IBM's
+            // documentation [2] the "SSL_" prefix is "interchangeable" with the "TLS_" prefix.
+            // See the IBM forum discussion [3] and issue on IBM's JVM [4] for more details.
+            //[1] http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#ciphersuites
+            //[2] https://www.ibm.com/support/knowledgecenter/en/SSYKE2_8.0.0/com.ibm.java.security.component.80.doc/
+            // security-component/jsse2Docs/ciphersuites.html
+            //[3] https://www.ibm.com/developerworks/community/forums/html/topic?id=9b5a56a9-fa46-4031-b33b-df91e28d77c2
+            //[4] https://www.ibm.com/developerworks/rfe/execute?use_case=viewRfe&CR_ID=71770
+            if (supportedCipher.startsWith("SSL_")) {
+                SUPPORTED_CIPHERS.add("TLS_" + supportedCipher.substring("SSL_".length()));
+            }
         }
         List<String> ciphers = new ArrayList<String>();
         addIfSupported(


### PR DESCRIPTION
Motivation:
IBM's J9 JVM utilizes a custom cipher naming scheme with SSL_ prefix [1] instead of the TLS_ prefix defined by TLS RFCs and the JSSE cihper suite names [2]. IBM's documentation says that the SSL_ prefix are "interchangeable" with cipher names with the TLS_ prefix [1]. To work around this issue we parse the supported cipher list and see an SSL_ prefix we can also add the same cipher with the TLS_ prefix. For more details see a discussion on IBM's forums [3] and IBM's issue tracker [4].

[1] https://www.ibm.com/support/knowledgecenter/en/SSYKE2_8.0.0/com.ibm.java.security.component.80.doc/security-component/jsse2Docs/ciphersuites.html
[2] http://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#ciphersuites
[3] https://www.ibm.com/developerworks/community/forums/html/topic?id=9b5a56a9-fa46-4031-b33b-df91e28d77c2
[4] https://www.ibm.com/developerworks/rfe/execute?use_case=viewRfe&CR_ID=71770

Modifications:
- When parsing the supported cipher list to get the supported ciphers and we encounter a SSL_ prefix we should also add a TLS_ prefix cipher.
- Remove SSL_ prefix ciphers from Http2SecurityUtil.

Result:
Work around for IBM JVM's custom naming scheme covers more cases for supported cipher suites.