### PR TITLE
Also use realloc when shrink the buffer.

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeNoCleanerDirectByteBuf.java
@@ -43,31 +43,23 @@ class UnpooledUnsafeNoCleanerDirectByteBuf extends UnpooledUnsafeDirectByteBuf {
     public ByteBuf capacity(int newCapacity) {
         checkNewCapacity(newCapacity);
 
-        int readerIndex = readerIndex();
-        int writerIndex = writerIndex();
         int oldCapacity = capacity();
+        if (newCapacity == oldCapacity) {
+            return this;
+        }
 
-        if (newCapacity > oldCapacity) {
-            ByteBuffer oldBuffer = buffer;
-            ByteBuffer newBuffer = reallocateDirect(oldBuffer, newCapacity);
-            setByteBuffer(newBuffer, false);
-        } else if (newCapacity < oldCapacity) {
-            ByteBuffer oldBuffer = buffer;
-            ByteBuffer newBuffer = allocateDirect(newCapacity);
-            if (readerIndex < newCapacity) {
-                if (writerIndex > newCapacity) {
-                    writerIndex = newCapacity;
-                    writerIndex(writerIndex);
+        ByteBuffer newBuffer = reallocateDirect(buffer, newCapacity);
+
+        if (newCapacity < oldCapacity) {
+            if (readerIndex() < newCapacity) {
+                if (writerIndex() > newCapacity) {
+                    writerIndex(newCapacity);
                 }
-                oldBuffer.position(readerIndex).limit(writerIndex);
-                newBuffer.position(readerIndex).limit(writerIndex);
-                newBuffer.put(oldBuffer);
-                newBuffer.clear();
             } else {
                 setIndex(newCapacity, newCapacity);
             }
-            setByteBuffer(newBuffer, true);
         }
+        setByteBuffer(newBuffer, false);
         return this;
     }
 }


### PR DESCRIPTION
Motivation:

We should also use realloc when shrink the buffer to eliminate extra allocations / memory copies when possible.

Modifications:

Use realloc for expanding and shrinking when possible.

Result:

Less memory copies and allocations
