### PR TITLE
UnixResolverDnsServerAddressStreamProviderTest failure

### DIFF
--- a/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
@@ -111,6 +111,6 @@ public class UnixResolverDnsServerAddressStreamProviderTest {
     }
 
     private static void assertHostNameEquals(String expectedHostname, InetSocketAddress next) {
-        assertEquals("unexpected hostname: " + next, expectedHostname, next.getHostName());
+        assertEquals("unexpected hostname: " + next, expectedHostname, next.getHostString());
     }
 }


### PR DESCRIPTION
Motivation:
InetSocketAddress#getHostName() may attempt a reverse lookup which may lead to test failures because the expected address will not match.

Modifications:
- Use InetSocketAddress#getHostString() which will not attempt any lookups and instead return the original String

Result:
UnixResolverDnsServerAddressStreamProviderTest is more reliable.