### PR TITLE
UnixResolverDnsServerAddressStreamProvider should allow for empty /et…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProvider.java
@@ -87,11 +87,9 @@ public final class UnixResolverDnsServerAddressStreamProvider implements DnsServ
      * @throws IOException If an error occurs while parsing the input files.
      */
     public UnixResolverDnsServerAddressStreamProvider(File etcResolvConf, File... etcResolverFiles) throws IOException {
-        if (etcResolverFiles != null && etcResolverFiles.length == 0) {
-            throw new IllegalArgumentException("etcResolverFiles must either be null or non-empty");
-        }
         Map<String, DnsServerAddresses> etcResolvConfMap = parse(checkNotNull(etcResolvConf, "etcResolvConf"));
-        domainToNameServerStreamMap = etcResolverFiles != null ? parse(etcResolverFiles) : etcResolvConfMap;
+        final boolean useEtcResolverFiles = etcResolverFiles != null && etcResolverFiles.length != 0;
+        domainToNameServerStreamMap = useEtcResolverFiles ? parse(etcResolverFiles) : etcResolvConfMap;
 
         DnsServerAddresses defaultNameServerAddresses = etcResolvConfMap.get(etcResolvConf.getName());
         if (defaultNameServerAddresses == null) {
@@ -104,7 +102,7 @@ public final class UnixResolverDnsServerAddressStreamProvider implements DnsServ
             this.defaultNameServerAddresses = defaultNameServerAddresses;
         }
 
-        if (etcResolverFiles != null) {
+        if (useEtcResolverFiles) {
             domainToNameServerStreamMap.putAll(etcResolvConfMap);
         }
     }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/UnixResolverDnsServerAddressStreamProviderTest.java
@@ -99,6 +99,18 @@ public class UnixResolverDnsServerAddressStreamProviderTest {
         assertEquals(DEFAULT_NDOTS, parseEtcResolverFirstNdots(f));
     }
 
+    @Test
+    public void emptyEtcResolverDirectoryDoesNotThrow() throws IOException {
+        File f = buildFile("domain linecorp.local\n" +
+                           "nameserver 127.0.0.2\n" +
+                           "nameserver 127.0.0.3\n");
+        UnixResolverDnsServerAddressStreamProvider p =
+                new UnixResolverDnsServerAddressStreamProvider(f, folder.newFolder().listFiles());
+
+        DnsServerAddressStream stream = p.nameServerAddressStream("somehost");
+        assertHostNameEquals("127.0.0.2", stream.next());
+    }
+
     private File buildFile(String contents) throws IOException {
         File f = folder.newFile();
         OutputStream out = new FileOutputStream(f);


### PR DESCRIPTION
…c/resolver dir

Motivation:
UnixResolverDnsServerAddressStreamProvider currently throws an exception if /etc/resolver exists but it empty. This shouldn't be an exception and can be tolerated as if there is no contribution from /etc/resolver.

Modifications:
- Treat /etc/resolver as present and empty the same as not being present

Result:
UnixResolverDnsServerAddressStreamProvider initialization can tolerate empty /etc/resolver directory.