### PR TITLE
HTTP/2 enforce HTTP message flow

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpStatusClass.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpStatusClass.java
@@ -74,6 +74,27 @@ public enum HttpStatusClass {
         return UNKNOWN;
     }
 
+    /**
+     * Returns the class of the specified HTTP status code.
+     * @param code Just the numeric portion of the http status code.
+     */
+    public static HttpStatusClass valueOf(CharSequence code) {
+        if (code != null && code.length() == 3) {
+            char c0 = code.charAt(0);
+            return isDigit(c0) && isDigit(code.charAt(1)) && isDigit(code.charAt(2)) ? valueOf(digit(c0) * 100)
+                                                                                     : UNKNOWN;
+        }
+        return UNKNOWN;
+    }
+
+    private static int digit(char c) {
+        return c - '0';
+    }
+
+    private static boolean isDigit(char c) {
+        return c >= '0' && c <= '9';
+    }
+
     private final int min;
     private final int max;
     private final AsciiString defaultReasonPhrase;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Stream.java
@@ -130,14 +130,40 @@ public interface Http2Stream {
     <V> V removeProperty(Http2Connection.PropertyKey key);
 
     /**
-     * Indicates that headers has been sent to the remote on this stream.
+     * Indicates that headers have been sent to the remote endpoint on this stream. The first call to this method would
+     * be for the initial headers (see {@link #isHeadersSent()}} and the second call would indicate the trailers
+     * (see {@link #isTrailersReceived()}).
+     * @param isInformational {@code true} if the headers contain an informational status code (for responses only).
      */
-    Http2Stream headersSent();
+    Http2Stream headersSent(boolean isInformational);
 
     /**
-     * Indicates whether or not headers was sent to the remote endpoint.
+     * Indicates whether or not headers were sent to the remote endpoint.
      */
     boolean isHeadersSent();
+
+    /**
+     * Indicates whether or not trailers were sent to the remote endpoint.
+     */
+    boolean isTrailersSent();
+
+    /**
+     * Indicates that headers have been received. The first call to this method would be for the initial headers
+     * (see {@link #isHeadersReceived()}} and the second call would indicate the trailers
+     * (see {@link #isTrailersReceived()}).
+     * @param isInformational {@code true} if the headers contain an informational status code (for responses only).
+     */
+    Http2Stream headersReceived(boolean isInformational);
+
+    /**
+     * Indicates whether or not the initial headers have been received.
+     */
+    boolean isHeadersReceived();
+
+    /**
+     * Indicates whether or not the trailers have been received.
+     */
+    boolean isTrailersReceived();
 
     /**
      * Indicates that a push promise was sent to the remote endpoint.


### PR DESCRIPTION
Motivation:
codec-http2 currently does not strictly enforce the HTTP/1.x semantics with respect to the number of headers defined in RFC 7540 Section 8.1 [1]. We currently don't validate the number of headers nor do we validate that the trailing headers should indicate EOS.

[1] https://tools.ietf.org/html/rfc7540#section-8.1

Modifications:
- DefaultHttp2ConnectionDecoder should only allow decoding of a single headers and a single trailers
- DefaultHttp2ConnectionEncoder should only allow encoding of a single headers and optionally a single trailers

Result:
Constraints of RFC 7540 restricting the number of headers/trailers is enforced.