### PR TITLE
Unify default cipher suites betweek JDK and OpenSSL

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -45,10 +45,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
@@ -59,6 +59,8 @@ import javax.net.ssl.X509ExtendedTrustManager;
 import javax.net.ssl.X509KeyManager;
 import javax.net.ssl.X509TrustManager;
 
+import static io.netty.handler.ssl.OpenSsl.DEFAULT_CIPHERS;
+import static io.netty.handler.ssl.OpenSsl.availableJavaCipherSuites;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
 
@@ -100,7 +102,6 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
                 }
             });
 
-    private static final List<String> DEFAULT_CIPHERS;
     private static final Integer DH_KEY_LENGTH;
     private static final ResourceLeakDetector<ReferenceCountedOpenSslContext> leakDetector =
             ResourceLeakDetectorFactory.instance().newResourceLeakDetector(ReferenceCountedOpenSslContext.class);
@@ -176,24 +177,6 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             };
 
     static {
-        List<String> ciphers = new ArrayList<String>();
-        // XXX: Make sure to sync this list with JdkSslEngineFactory.
-        Collections.addAll(
-                ciphers,
-                "ECDHE-ECDSA-AES256-GCM-SHA384",
-                "ECDHE-ECDSA-AES128-GCM-SHA256",
-                "ECDHE-RSA-AES128-GCM-SHA256",
-                "ECDHE-RSA-AES128-SHA",
-                "ECDHE-RSA-AES256-SHA",
-                "AES128-GCM-SHA256",
-                "AES128-SHA",
-                "AES256-SHA");
-        DEFAULT_CIPHERS = Collections.unmodifiableList(ciphers);
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("Default cipher suite (OpenSSL): " + ciphers);
-        }
-
         Integer dhLen = null;
 
         try {
@@ -271,7 +254,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         }
 
         unmodifiableCiphers = Arrays.asList(checkNotNull(cipherFilter, "cipherFilter").filterCipherSuites(
-                convertedCiphers, DEFAULT_CIPHERS, OpenSsl.availableOpenSslCipherSuites()));
+                convertedCiphers, DEFAULT_CIPHERS, availableJavaCipherSuites()));
 
         this.apn = checkNotNull(apn, "apn");
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -24,7 +24,12 @@ import io.netty.handler.codec.base64.Base64Dialect;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.List;
+import java.util.Set;
+
 import javax.net.ssl.SSLHandshakeException;
+
+import static java.util.Arrays.asList;
 
 /**
  * Constants for SSL packets.
@@ -70,6 +75,47 @@ final class SslUtils {
      * data is not encrypted
      */
     static final int NOT_ENCRYPTED = -2;
+
+    static final String[] DEFAULT_CIPHER_SUITES = new String[] {
+        // GCM (Galois/Counter Mode) requires JDK 8.
+        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+        // AES256 requires JCE unlimited strength jurisdiction policy files.
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+        // GCM (Galois/Counter Mode) requires JDK 8.
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_RSA_WITH_AES_128_CBC_SHA",
+        // AES256 requires JCE unlimited strength jurisdiction policy files.
+        "TLS_RSA_WITH_AES_256_CBC_SHA"
+    };
+
+    /**
+     * Add elements from {@code names} into {@code enabled} if they are in {@code supported}.
+     */
+    static void addIfSupported(Set<String> supported, List<String> enabled, String... names) {
+        for (String n: names) {
+            if (supported.contains(n)) {
+                enabled.add(n);
+            }
+        }
+    }
+
+    static void useFallbackCiphersIfDefaultIsEmpty(List<String> defaultCiphers, Iterable<String> fallbackCiphers) {
+        if (defaultCiphers.isEmpty()) {
+            for (String cipher : fallbackCiphers) {
+                if (cipher.startsWith("SSL_") || cipher.contains("_RC4_")) {
+                    continue;
+                }
+                defaultCiphers.add(cipher);
+            }
+        }
+    }
+
+    static void useFallbackCiphersIfDefaultIsEmpty(List<String> defaultCiphers, String... fallbackCiphers) {
+        useFallbackCiphersIfDefaultIsEmpty(defaultCiphers, asList(fallbackCiphers));
+    }
 
     /**
      * Converts the given exception to a {@link SSLHandshakeException}, if it isn't already.


### PR DESCRIPTION
Motivation:
Currently the default cipher suites are set independently between JDK and OpenSSL. We should use a common approach to setting the default ciphers. Also the OpenSsl default ciphers are expressed in terms of the OpenSSL cipher name conventions, which is not correct and may be exposed to the end user. OpenSSL should also use the RFC cipher names like the JDK defaults.

Modifications:
- Move the default cipher definition to a common location and use it in JDK and OpenSSL initialization
- OpenSSL should not expose OpenSSL cipher names externally

Result:
Common initialization and OpenSSL doesn't expose custom cipher names.