### PR TITLE
DNS Resovler tests should be more explicit about ndots

### DIFF
--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverClientSubnetTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverClientSubnetTest.java
@@ -63,6 +63,7 @@ public class DnsNameResolverClientSubnetTest {
                 .nameServerProvider(
                         new SingletonDnsServerAddressStreamProvider(SocketUtils.socketAddress("8.8.8.8", 53)))
                 .maxQueriesPerResolve(1)
-                .optResourceEnabled(false);
+                .optResourceEnabled(false)
+                .ndots(1);
     }
 }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -298,7 +298,8 @@ public class DnsNameResolverTest {
                 .channelType(NioDatagramChannel.class)
                 .maxQueriesPerResolve(1)
                 .decodeIdn(decodeToUnicode)
-                .optResourceEnabled(false);
+                .optResourceEnabled(false)
+                .ndots(1);
 
         if (dnsServerAddressStreamProvider == null) {
             builder.nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer.localAddress()));
@@ -821,7 +822,8 @@ public class DnsNameResolverTest {
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV4_ONLY)
                     .channelType(NioDatagramChannel.class)
                     .queryTimeoutMillis(1000) // We expect timeouts if startDnsServer1 is false
-                    .optResourceEnabled(false);
+                    .optResourceEnabled(false)
+                    .ndots(1);
 
             builder.nameServerProvider(new SequentialDnsServerAddressStreamProvider(dnsServer1Address,
                     dnsServer2.localAddress()));
@@ -867,7 +869,8 @@ public class DnsNameResolverTest {
                     .resolvedAddressTypes(ResolvedAddressTypes.IPV6_PREFERRED)
                     .dnsQueryLifecycleObserverFactory(lifecycleObserverFactory)
                     .channelType(NioDatagramChannel.class)
-                    .optResourceEnabled(false);
+                    .optResourceEnabled(false)
+                    .ndots(1);
 
             builder.nameServerProvider(new SequentialDnsServerAddressStreamProvider(dnsServer1.localAddress(),
                     dnsServer2.localAddress()));

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
@@ -48,7 +48,8 @@ public class SearchDomainTest {
             .channelType(NioDatagramChannel.class)
             .nameServerProvider(new SingletonDnsServerAddressStreamProvider(dnsServer.localAddress()))
             .maxQueriesPerResolve(1)
-            .optResourceEnabled(false);
+            .optResourceEnabled(false)
+            .ndots(1);
     }
 
     private TestDnsServer dnsServer;


### PR DESCRIPTION
Motivation:
The DNS resolver may use default configuration inherited from the environment. This means the ndots value may change and result in test failure if the tests don't explicitly set the assumed value.

Modifications:
- Explicitly set ndots in resolver-dns unit tests so we don't fail if the environment overrides the search domain and ndots

Result:
Unit tests are less dependent upon the enviroment they run in.
Fixes https://github.com/netty/netty/issues/6966.