### PR TITLE
Fix #6969: Do not reset the states while streaming Json array

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/json/JsonObjectDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/json/JsonObjectDecoder.java
@@ -92,7 +92,6 @@ public class JsonObjectDecoder extends ByteToMessageDecoder {
 
         if (this.idx > in.readerIndex() && lastReaderIndex != in.readerIndex()) {
             this.idx = in.readerIndex();
-            reset();
         }
 
         // index of next byte to process.


### PR DESCRIPTION
Motivation:

Calling JsonObjectDecoder#reset while streaming Json array over multiple
writes causes CorruptedFrameException to be thrown.

Modifications:

While streaming Json array and if the current readerIndex has been reset,
ensure that the states will not be reset.

Result:

Fixes #6969