### PR TITLE
Record release when enable detailed leak detection

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareByteBuf.java
@@ -932,6 +932,18 @@ final class AdvancedLeakAwareByteBuf extends SimpleLeakAwareByteBuf {
     }
 
     @Override
+    public boolean release() {
+        leak.record();
+        return super.release();
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        leak.record();
+        return super.release(decrement);
+    }
+
+    @Override
     public ByteBuf touch() {
         leak.record();
         return this;

--- a/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AdvancedLeakAwareCompositeByteBuf.java
@@ -1018,6 +1018,18 @@ final class AdvancedLeakAwareCompositeByteBuf extends SimpleLeakAwareCompositeBy
     }
 
     @Override
+    public boolean release() {
+        leak.record();
+        return super.release();
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        leak.record();
+        return super.release(decrement);
+    }
+
+    @Override
     public CompositeByteBuf touch() {
         leak.record();
         return this;

--- a/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareByteBuf.java
@@ -98,7 +98,7 @@ class SimpleLeakAwareByteBuf extends WrappedByteBuf {
     }
 
     @Override
-    public final boolean release() {
+    public boolean release() {
         if (super.release()) {
             closeLeak();
             return true;
@@ -107,7 +107,7 @@ class SimpleLeakAwareByteBuf extends WrappedByteBuf {
     }
 
     @Override
-    public final boolean release(int decrement) {
+    public boolean release(int decrement) {
         if (super.release(decrement)) {
             closeLeak();
             return true;

--- a/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareCompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/SimpleLeakAwareCompositeByteBuf.java
@@ -31,7 +31,7 @@ class SimpleLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     }
 
     @Override
-    public final boolean release() {
+    public boolean release() {
         // Call unwrap() before just in case that super.release() will change the ByteBuf instance that is returned
         // by unwrap().
         ByteBuf unwrapped = unwrap();
@@ -43,7 +43,7 @@ class SimpleLeakAwareCompositeByteBuf extends WrappedCompositeByteBuf {
     }
 
     @Override
-    public final boolean release(int decrement) {
+    public boolean release(int decrement) {
         // Call unwrap() before just in case that super.release() will change the ByteBuf instance that is returned
         // by unwrap().
         ByteBuf unwrapped = unwrap();


### PR DESCRIPTION
Motivation:
It would be easier to find where is missing release call in several retain release calls on a ByteBuf

Modifications:
Remove final modifier on SimpleLeakAwareByteBuf release function and override it to record release in AdvancedLeakAwareByteBuf and AdvancedLeakAwareCompositeByteBuf

Result:
Release will be recorded when enable detailed leak detection