### PR TITLE
Explicit specify hostaddress during tests to ensure testsuite pass on…

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectTest.java
@@ -21,6 +21,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.testsuite.util.TestUtils;
+import io.netty.util.NetUtil;
 import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import org.junit.Test;
@@ -82,7 +84,7 @@ public class SocketConnectTest extends AbstractSocketTest {
         Channel cc = null;
         try {
             sb.childHandler(new ChannelInboundHandlerAdapter());
-            sc = sb.bind(0).syncUninterruptibly().channel();
+            sc = sb.bind(NetUtil.LOCALHOST, TestUtils.getFreePort()).syncUninterruptibly().channel();
 
             cb.handler(new ChannelInboundHandlerAdapter() {
                 @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketMultipleConnectTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketMultipleConnectTest.java
@@ -22,6 +22,8 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.util.TestUtils;
+import io.netty.util.NetUtil;
 import org.junit.Test;
 
 import java.nio.channels.AlreadyConnectedException;
@@ -42,7 +44,7 @@ public class SocketMultipleConnectTest extends AbstractSocketTest {
         Channel cc = null;
         try {
             sb.childHandler(new ChannelInboundHandlerAdapter());
-            sc = sb.bind(0).syncUninterruptibly().channel();
+            sc = sb.bind(NetUtil.LOCALHOST, TestUtils.getFreePort()).syncUninterruptibly().channel();
 
             cb.handler(new ChannelInboundHandlerAdapter());
             cc = cb.register().syncUninterruptibly().channel();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
@@ -27,13 +27,14 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.unix.FileDescriptor;
+import io.netty.testsuite.util.TestUtils;
+import io.netty.util.NetUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -58,7 +59,7 @@ public class EpollSpliceTest {
         ServerBootstrap bs = new ServerBootstrap();
         bs.channel(EpollServerSocketChannel.class);
         bs.group(group).childHandler(sh);
-        final Channel sc = bs.bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+        final Channel sc = bs.bind(NetUtil.LOCALHOST, TestUtils.getFreePort()).syncUninterruptibly().channel();
 
         ServerBootstrap bs2 = new ServerBootstrap();
         bs2.channel(EpollServerSocketChannel.class);
@@ -124,7 +125,7 @@ public class EpollSpliceTest {
                 });
             }
         });
-        Channel pc = bs2.bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+        Channel pc = bs2.bind(NetUtil.LOCALHOST, TestUtils.getFreePort()).syncUninterruptibly().channel();
 
         Bootstrap cb = new Bootstrap();
         cb.group(group);
@@ -200,7 +201,7 @@ public class EpollSpliceTest {
         bs.channel(EpollServerSocketChannel.class);
         bs.group(group).childHandler(sh);
         bs.childOption(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED);
-        Channel sc = bs.bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+        Channel sc = bs.bind(NetUtil.LOCALHOST, TestUtils.getFreePort()).syncUninterruptibly().channel();
 
         Bootstrap cb = new Bootstrap();
         cb.group(group);


### PR DESCRIPTION
… docker (mac)

Motivation:

When run the current testsuite on docker (mac) it will fail a few tests with:

io.netty.channel.AbstractChannel$AnnotatedConnectException: connect(..) failed: Cannot assign requested address: /0:0:0:0:0:0:0:0%0:46607
Caused by: java.net.ConnectException: connect(..) failed: Cannot assign requested address

Modifications:

Specify host explicit as done in other tests to only use ipv6 when really supported.

Result:

Build pass on docker as well