### PR TITLE
Calculate correct lastRecords size

### DIFF
--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -364,17 +364,18 @@ public class ResourceLeakDetector<T> {
         }
 
         private void record0(Object hint, int recordsToSkip) {
-            if (creationRecord != null) {
+            // Check MAX_RECORDS > 0 here to avoid similar check before remove from and add to lastRecords
+            if (creationRecord != null && MAX_RECORDS > 0) {
                 String value = newRecord(hint, recordsToSkip);
 
                 synchronized (lastRecords) {
                     int size = lastRecords.size();
                     if (size == 0 || !lastRecords.getLast().equals(value)) {
+                        if (size >= MAX_RECORDS) {
+                            lastRecords.removeFirst();
+                            ++removedRecords;
+                        }
                         lastRecords.add(value);
-                    }
-                    if (size > MAX_RECORDS) {
-                        lastRecords.removeFirst();
-                        ++removedRecords;
                     }
                 }
             }


### PR DESCRIPTION
Motivation:
ResourceLeakDetector records at most MAX_RECORDS+1 records

Modifications:
Increase records size after add to lastRecords

Result:
ResourceLeakDetector will record at most MAX_RECORDS records
