### PR TITLE
Use array initializer expression

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -98,7 +98,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     private static final int OPENSSL_OP_NO_PROTOCOL_INDEX_TLSv1 = 2;
     private static final int OPENSSL_OP_NO_PROTOCOL_INDEX_TLSv1_1 = 3;
     private static final int OPENSSL_OP_NO_PROTOCOL_INDEX_TLSv1_2 = 4;
-    private static final int[] OPENSSL_OP_NO_PROTOCOLS = new int[] {
+    private static final int[] OPENSSL_OP_NO_PROTOCOLS = {
             SSL.SSL_OP_NO_SSLv2,
             SSL.SSL_OP_NO_SSLv3,
             SSL.SSL_OP_NO_TLSv1,

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -907,7 +907,7 @@ public abstract class SslContext {
 
     /**
      * Create a new SslHandler.
-     * @see #newHandler(io.netty.buffer.ByteBufAllocator)
+     * @see #newHandler(ByteBufAllocator)
      */
     SslHandler newHandler(ByteBufAllocator alloc, boolean startTls) {
         return new SslHandler(newEngine(alloc), startTls);
@@ -945,7 +945,7 @@ public abstract class SslContext {
 
     /**
      * Create a new SslHandler.
-     * @see #newHandler(io.netty.buffer.ByteBufAllocator, String, int, boolean)
+     * @see #newHandler(ByteBufAllocator, String, int, boolean)
      */
     SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort, boolean startTls) {
         return new SslHandler(newEngine(alloc, peerHost, peerPort), startTls);

--- a/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslUtils.java
@@ -76,7 +76,7 @@ final class SslUtils {
      */
     static final int NOT_ENCRYPTED = -2;
 
-    static final String[] DEFAULT_CIPHER_SUITES = new String[] {
+    static final String[] DEFAULT_CIPHER_SUITES = {
         // GCM (Galois/Counter Mode) requires JDK 8.
         "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",


### PR DESCRIPTION
Motivation:

Code introduced in 6152990073607602b2263109139cf829f3d2f7e4 can be cleaned up and use array initializer expressions.

Modifications:

Use array initializer expressions.

Result:

Cleaner code.