### PR TITLE
AbstractByteBuf.ensureWritable(...) should check if buffer was released

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractUnsafeSwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractUnsafeSwappedByteBuf.java
@@ -122,7 +122,7 @@ abstract class AbstractUnsafeSwappedByteBuf extends SwappedByteBuf {
 
     @Override
     public final ByteBuf writeShort(int value) {
-        wrapped.ensureWritable(2);
+        wrapped.ensureWritable0(2);
         _setShort(wrapped, wrapped.writerIndex, nativeByteOrder ? (short) value : Short.reverseBytes((short) value));
         wrapped.writerIndex += 2;
         return this;
@@ -130,7 +130,7 @@ abstract class AbstractUnsafeSwappedByteBuf extends SwappedByteBuf {
 
     @Override
     public final ByteBuf writeInt(int value) {
-        wrapped.ensureWritable(4);
+        wrapped.ensureWritable0(4);
         _setInt(wrapped, wrapped.writerIndex, nativeByteOrder ? value : Integer.reverseBytes(value));
         wrapped.writerIndex += 4;
         return this;
@@ -138,7 +138,7 @@ abstract class AbstractUnsafeSwappedByteBuf extends SwappedByteBuf {
 
     @Override
     public final ByteBuf writeLong(long value) {
-        wrapped.ensureWritable(8);
+        wrapped.ensureWritable0(8);
         _setLong(wrapped, wrapped.writerIndex, nativeByteOrder ? value : Long.reverseBytes(value));
         wrapped.writerIndex += 8;
         return this;

--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -482,7 +482,7 @@ public final class ByteBufUtil {
         for (;;) {
             if (buf instanceof AbstractByteBuf) {
                 AbstractByteBuf byteBuf = (AbstractByteBuf) buf;
-                byteBuf.ensureWritable(utf8MaxBytes(seq));
+                byteBuf.ensureWritable0(utf8MaxBytes(seq));
                 int written = writeUtf8(byteBuf, byteBuf.writerIndex, seq, seq.length());
                 byteBuf.writerIndex += written;
                 return written;
@@ -583,7 +583,7 @@ public final class ByteBufUtil {
             for (;;) {
                 if (buf instanceof AbstractByteBuf) {
                     AbstractByteBuf byteBuf = (AbstractByteBuf) buf;
-                    byteBuf.ensureWritable(len);
+                    byteBuf.ensureWritable0(len);
                     int written = writeAscii(byteBuf, byteBuf.writerIndex, seq, len);
                     byteBuf.writerIndex += written;
                     return written;

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeDirectByteBuf.java
@@ -374,7 +374,8 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
 
     @Override
     public ByteBuf setZero(int index, int length) {
-        UnsafeByteBufUtil.setZero(this, addr(index), index, length);
+        checkIndex(index, length);
+        UnsafeByteBufUtil.setZero(addr(index), length);
         return this;
     }
 
@@ -382,7 +383,7 @@ final class PooledUnsafeDirectByteBuf extends PooledByteBuf<ByteBuffer> {
     public ByteBuf writeZero(int length) {
         ensureWritable(length);
         int wIndex = writerIndex;
-        setZero(wIndex, length);
+        UnsafeByteBufUtil.setZero(addr(wIndex), length);
         writerIndex = wIndex + length;
         return this;
     }

--- a/buffer/src/main/java/io/netty/buffer/PooledUnsafeHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledUnsafeHeapByteBuf.java
@@ -131,8 +131,9 @@ final class PooledUnsafeHeapByteBuf extends PooledHeapByteBuf {
     @Override
     public ByteBuf setZero(int index, int length) {
         if (PlatformDependent.javaVersion() >= 7) {
+            checkIndex(index, length);
             // Only do on java7+ as the needed Unsafe call was only added there.
-            _setZero(index, length);
+            UnsafeByteBufUtil.setZero(memory, idx(index), length);
             return this;
         }
         return super.setZero(index, length);
@@ -144,16 +145,11 @@ final class PooledUnsafeHeapByteBuf extends PooledHeapByteBuf {
             // Only do on java7+ as the needed Unsafe call was only added there.
             ensureWritable(length);
             int wIndex = writerIndex;
-            _setZero(wIndex, length);
+            UnsafeByteBufUtil.setZero(memory, idx(wIndex), length);
             writerIndex = wIndex + length;
             return this;
         }
         return super.writeZero(length);
-    }
-
-    private void _setZero(int index, int length) {
-        checkIndex(index, length);
-        UnsafeByteBufUtil.setZero(memory, idx(index), length);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeDirectByteBuf.java
@@ -517,7 +517,8 @@ public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf
 
     @Override
     public ByteBuf setZero(int index, int length) {
-        UnsafeByteBufUtil.setZero(this, addr(index), index, length);
+        checkIndex(index, length);
+        UnsafeByteBufUtil.setZero(addr(index), length);
         return this;
     }
 
@@ -525,7 +526,7 @@ public class UnpooledUnsafeDirectByteBuf extends AbstractReferenceCountedByteBuf
     public ByteBuf writeZero(int length) {
         ensureWritable(length);
         int wIndex = writerIndex;
-        setZero(wIndex, length);
+        UnsafeByteBufUtil.setZero(addr(wIndex), length);
         writerIndex = wIndex + length;
         return this;
     }

--- a/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledUnsafeHeapByteBuf.java
@@ -245,7 +245,8 @@ class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
     public ByteBuf setZero(int index, int length) {
         if (PlatformDependent.javaVersion() >= 7) {
             // Only do on java7+ as the needed Unsafe call was only added there.
-            _setZero(index, length);
+            checkIndex(index, length);
+            UnsafeByteBufUtil.setZero(array, index, length);
             return this;
         }
         return super.setZero(index, length);
@@ -257,16 +258,11 @@ class UnpooledUnsafeHeapByteBuf extends UnpooledHeapByteBuf {
             // Only do on java7+ as the needed Unsafe call was only added there.
             ensureWritable(length);
             int wIndex = writerIndex;
-            _setZero(wIndex, length);
+            UnsafeByteBufUtil.setZero(array, wIndex, length);
             writerIndex = wIndex + length;
             return this;
         }
         return super.writeZero(length);
-    }
-
-    private void _setZero(int index, int length) {
-        checkIndex(index, length);
-        UnsafeByteBufUtil.setZero(array, index, length);
     }
 
     @Override

--- a/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/UnsafeByteBufUtil.java
@@ -581,12 +581,11 @@ final class UnsafeByteBufUtil {
         }
     }
 
-    static void setZero(AbstractByteBuf buf, long addr, int index, int length) {
+    static void setZero(long addr, int length) {
         if (length == 0) {
             return;
         }
 
-        buf.checkIndex(index, length);
         PlatformDependent.setMemory(addr, length, ZERO);
     }
 

--- a/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
@@ -96,18 +96,6 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
 
     @Test(expected = IndexOutOfBoundsException.class)
     @Override
-    public void testEnsureWritableAfterRelease() {
-        super.testEnsureWritableAfterRelease();
-    }
-
-    @Test(expected = IndexOutOfBoundsException.class)
-    @Override
-    public void testWriteZeroAfterRelease() throws IOException {
-        super.testWriteZeroAfterRelease();
-    }
-
-    @Test(expected = IndexOutOfBoundsException.class)
-    @Override
     public void testGetReadOnlyDirectDst() {
         super.testGetReadOnlyDirectDst();
     }

--- a/buffer/src/test/java/io/netty/buffer/WrappedUnpooledUnsafeByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/WrappedUnpooledUnsafeByteBufTest.java
@@ -90,18 +90,6 @@ public class WrappedUnpooledUnsafeByteBufTest extends BigEndianUnsafeDirectByteB
 
     @Test(expected = IndexOutOfBoundsException.class)
     @Override
-    public void testEnsureWritableAfterRelease() {
-        super.testEnsureWritableAfterRelease();
-    }
-
-    @Test(expected = IndexOutOfBoundsException.class)
-    @Override
-    public void testWriteZeroAfterRelease() throws IOException {
-        super.testWriteZeroAfterRelease();
-    }
-
-    @Test(expected = IndexOutOfBoundsException.class)
-    @Override
     public void testGetReadOnlyDirectDst() {
         super.testGetReadOnlyDirectDst();
     }


### PR DESCRIPTION
Motivation:

AbstractByteBuf.ensureWritable(...) should check if buffer was released and if so throw an IllegalReferenceCountException

Modifications:

Ensure we throw in all cases.

Result:

More consistent and correct behaviour