### PR TITLE
Update tests to not use TestUtils.getFreePort() and so ensure we not …

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/sctp/AbstractSctpTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/sctp/AbstractSctpTest.java
@@ -21,14 +21,12 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.testsuite.transport.AbstractComboTestsuiteTest;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.util.TestUtils;
 import io.netty.util.NetUtil;
 
 import java.net.InetSocketAddress;
 import java.util.List;
 
 public abstract class AbstractSctpTest extends AbstractComboTestsuiteTest<ServerBootstrap, Bootstrap> {
-    protected volatile InetSocketAddress addr;
 
     protected AbstractSctpTest() {
         super(ServerBootstrap.class, Bootstrap.class);
@@ -41,11 +39,9 @@ public abstract class AbstractSctpTest extends AbstractComboTestsuiteTest<Server
 
     @Override
     protected void configure(ServerBootstrap serverBootstrap, Bootstrap bootstrap, ByteBufAllocator allocator) {
-        addr = new InetSocketAddress(NetUtil.LOCALHOST, TestUtils.getFreePort());
-        serverBootstrap.localAddress(addr);
+        serverBootstrap.localAddress(new InetSocketAddress(NetUtil.LOCALHOST, 0));
         serverBootstrap.option(ChannelOption.ALLOCATOR, allocator);
         serverBootstrap.childOption(ChannelOption.ALLOCATOR, allocator);
-        bootstrap.remoteAddress(addr);
         bootstrap.option(ChannelOption.ALLOCATOR, allocator);
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/sctp/SctpEchoTest.java
@@ -92,7 +92,7 @@ public class SctpEchoTest extends AbstractSctpTest {
         });
 
         Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
 
         for (int i = 0; i < data.length;) {
             int length = Math.min(random.nextInt(1024 * 64), data.length - i);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractClientSocketTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractClientSocketTest.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.testsuite.transport.AbstractTestsuiteTest;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.util.TestUtils;
 import io.netty.util.NetUtil;
 
 import java.net.InetSocketAddress;
@@ -28,8 +27,6 @@ import java.net.SocketAddress;
 import java.util.List;
 
 public abstract class AbstractClientSocketTest extends AbstractTestsuiteTest<Bootstrap> {
-
-    protected volatile SocketAddress addr;
 
     protected AbstractClientSocketTest() {
         super(Bootstrap.class);
@@ -42,13 +39,10 @@ public abstract class AbstractClientSocketTest extends AbstractTestsuiteTest<Boo
 
     @Override
     protected void configure(Bootstrap bootstrap, ByteBufAllocator allocator) {
-        addr = newSocketAddress();
-        bootstrap.remoteAddress(addr);
         bootstrap.option(ChannelOption.ALLOCATOR, allocator);
     }
 
     protected SocketAddress newSocketAddress() {
-        return new InetSocketAddress(
-                NetUtil.LOCALHOST, TestUtils.getFreePort());
+        return new InetSocketAddress(NetUtil.LOCALHOST, 0);
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractDatagramTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractDatagramTest.java
@@ -20,15 +20,13 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.testsuite.transport.AbstractComboTestsuiteTest;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.util.TestUtils;
 import io.netty.util.NetUtil;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.util.List;
 
 public abstract class AbstractDatagramTest extends AbstractComboTestsuiteTest<Bootstrap, Bootstrap> {
-
-    protected volatile InetSocketAddress addr;
 
     protected AbstractDatagramTest() {
         super(Bootstrap.class, Bootstrap.class);
@@ -41,16 +39,16 @@ public abstract class AbstractDatagramTest extends AbstractComboTestsuiteTest<Bo
 
     @Override
     protected void configure(Bootstrap bootstrap, Bootstrap bootstrap2, ByteBufAllocator allocator) {
-        addr = new InetSocketAddress(
-                NetUtil.LOCALHOST4, TestUtils.getFreePort());
-        bootstrap.localAddress(addr);
         bootstrap.option(ChannelOption.ALLOCATOR, allocator);
-        bootstrap2.localAddress(0).remoteAddress(addr);
         bootstrap2.option(ChannelOption.ALLOCATOR, allocator);
     }
 
-    protected void refreshLocalAddress(Bootstrap bootstrap) {
-        addr = new InetSocketAddress(NetUtil.LOCALHOST4, TestUtils.getFreePort());
-        bootstrap.localAddress(addr);
+    protected SocketAddress newSocketAddress() {
+        // We use LOCALHOST4 as we use InternetProtocolFamily.IPv4 when creating the DatagramChannel and its
+        // not supported to bind to and IPV6 address in this case.
+        //
+        // See also http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/e74259b3eadc/
+        // src/share/classes/sun/nio/ch/DatagramChannelImpl.java#l684
+        return new InetSocketAddress(NetUtil.LOCALHOST4, 0);
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractServerSocketTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractServerSocketTest.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.testsuite.transport.AbstractTestsuiteTest;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.util.TestUtils;
 import io.netty.util.NetUtil;
 
 import java.net.InetSocketAddress;
@@ -28,8 +27,6 @@ import java.net.SocketAddress;
 import java.util.List;
 
 public abstract class AbstractServerSocketTest extends AbstractTestsuiteTest<ServerBootstrap> {
-
-    protected volatile SocketAddress addr;
 
     protected AbstractServerSocketTest() {
         super(ServerBootstrap.class);
@@ -42,14 +39,13 @@ public abstract class AbstractServerSocketTest extends AbstractTestsuiteTest<Ser
 
     @Override
     protected void configure(ServerBootstrap bootstrap, ByteBufAllocator allocator) {
-        addr = newSocketAddress();
-        bootstrap.localAddress(addr);
+        bootstrap.localAddress(newSocketAddress());
         bootstrap.option(ChannelOption.ALLOCATOR, allocator);
         bootstrap.childOption(ChannelOption.ALLOCATOR, allocator);
     }
 
     protected SocketAddress newSocketAddress() {
         return new InetSocketAddress(
-                NetUtil.LOCALHOST, TestUtils.getFreePort());
+                NetUtil.LOCALHOST, 0);
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/AbstractSocketTest.java
@@ -21,7 +21,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.testsuite.transport.AbstractComboTestsuiteTest;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.util.TestUtils;
 import io.netty.util.NetUtil;
 
 import java.net.InetSocketAddress;
@@ -29,8 +28,6 @@ import java.net.SocketAddress;
 import java.util.List;
 
 public abstract class AbstractSocketTest extends AbstractComboTestsuiteTest<ServerBootstrap, Bootstrap> {
-
-    protected volatile SocketAddress addr;
 
     protected AbstractSocketTest() {
         super(ServerBootstrap.class, Bootstrap.class);
@@ -43,16 +40,13 @@ public abstract class AbstractSocketTest extends AbstractComboTestsuiteTest<Serv
 
     @Override
     protected void configure(ServerBootstrap bootstrap, Bootstrap bootstrap2, ByteBufAllocator allocator) {
-        addr = newSocketAddress();
-        bootstrap.localAddress(addr);
+        bootstrap.localAddress(newSocketAddress());
         bootstrap.option(ChannelOption.ALLOCATOR, allocator);
         bootstrap.childOption(ChannelOption.ALLOCATOR, allocator);
-        bootstrap2.remoteAddress(addr);
         bootstrap2.option(ChannelOption.ALLOCATOR, allocator);
     }
 
     protected SocketAddress newSocketAddress() {
-        return new InetSocketAddress(
-                NetUtil.LOCALHOST, TestUtils.getFreePort());
+        return new InetSocketAddress(NetUtil.LOCALHOST, 0);
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramMulticastTest.java
@@ -57,9 +57,12 @@ public class DatagramMulticastTest extends AbstractDatagramTest {
         sb.option(ChannelOption.SO_REUSEADDR, true);
         cb.option(ChannelOption.IP_MULTICAST_IF, NetUtil.LOOPBACK_IF);
         cb.option(ChannelOption.SO_REUSEADDR, true);
+
+        Channel sc = sb.bind(newSocketAddress()).sync().channel();
+
+        InetSocketAddress addr = (InetSocketAddress) sc.localAddress();
         cb.localAddress(addr.getPort());
 
-        Channel sc = sb.bind().sync().channel();
         if (sc instanceof OioDatagramChannel) {
             // skip the test for OIO, as it fails because of
             // No route to host which makes no sense.

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/DatagramUnicastTest.java
@@ -27,7 +27,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.DatagramPacket;
 import org.junit.Test;
 
-import java.net.BindException;
+import java.net.InetSocketAddress;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -159,35 +159,16 @@ public class DatagramUnicastTest extends AbstractDatagramTest {
             }
         });
 
-        Channel sc = null;
-        BindException bindFailureCause = null;
-        for (int i = 0; i < 3; i ++) {
-            try {
-                sc = sb.bind().sync().channel();
-                break;
-            } catch (Exception e) {
-                if (e instanceof BindException) {
-                    logger.warn("Failed to bind to a free port; trying again", e);
-                    bindFailureCause = (BindException) e;
-                    refreshLocalAddress(sb);
-                } else {
-                    throw e;
-                }
-            }
-        }
-
-        if (sc == null) {
-            throw bindFailureCause;
-        }
-
+        Channel sc = sb.bind(newSocketAddress()).sync().channel();
         Channel cc;
         if (bindClient) {
-            cc = cb.bind().sync().channel();
+            cc = cb.bind(newSocketAddress()).sync().channel();
         } else {
             cb.option(ChannelOption.DATAGRAM_CHANNEL_ACTIVE_ON_REGISTRATION, true);
             cc = cb.register().sync().channel();
         }
 
+        InetSocketAddress addr = (InetSocketAddress) sc.localAddress();
         for (int i = 0; i < count; i++) {
             switch (wrapType) {
                 case DUP:

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/ServerSocketSuspendTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/ServerSocketSuspendTest.java
@@ -58,7 +58,7 @@ public class ServerSocketSuspendTest extends AbstractServerSocketTest {
             long startTime = System.nanoTime();
             for (int i = 0; i < NUM_CHANNELS; i ++) {
                 Socket s = new Socket();
-                SocketUtils.connect(s, addr, 10000);
+                SocketUtils.connect(s, sc.localAddress(), 10000);
                 sockets.add(s);
             }
 
@@ -80,7 +80,7 @@ public class ServerSocketSuspendTest extends AbstractServerSocketTest {
             long startTime = System.nanoTime();
             for (int i = 0; i < NUM_CHANNELS; i ++) {
                 Socket s = new Socket();
-                s.connect(addr, 10000);
+                s.connect(sc.localAddress(), 10000);
                 sockets.add(s);
             }
             long endTime = System.nanoTime();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketAutoReadTest.java
@@ -66,14 +66,13 @@ public class SocketAutoReadTest extends AbstractSocketTest {
 
             serverChannel = sb.bind().syncUninterruptibly().channel();
 
-            cb.remoteAddress(serverChannel.localAddress())
-                    .option(ChannelOption.AUTO_READ, true)
+            cb.option(ChannelOption.AUTO_READ, true)
                     // We want to ensure that we attempt multiple individual read operations per read loop so we can
                     // test the auto read feature being turned off when data is first read.
                     .option(ChannelOption.RCVBUF_ALLOCATOR, new TestRecvByteBufAllocator())
                     .handler(clientInitializer);
 
-            clientChannel = cb.connect().syncUninterruptibly().channel();
+            clientChannel = cb.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
 
             // 3 bytes means 3 independent reads for TestRecvByteBufAllocator
             clientChannel.writeAndFlush(Unpooled.wrappedBuffer(new byte[3]));

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketBufReleaseTest.java
@@ -53,7 +53,7 @@ public class SocketBufReleaseTest extends AbstractSocketTest {
         cb.handler(clientHandler);
 
         Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
 
         // Ensure the server socket accepted the client connection *and* initialized pipeline successfully.
         serverHandler.channelFuture.sync();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCancelWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCancelWriteTest.java
@@ -51,7 +51,7 @@ public class SocketCancelWriteTest extends AbstractSocketTest {
         sb.childHandler(sh);
 
         Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
 
         ChannelFuture f = cc.write(a);
         assertTrue(f.cancel(false));

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketChannelNotYetConnectedTest.java
@@ -20,7 +20,6 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.socket.SocketChannel;
 import org.junit.Test;
 
-import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.nio.channels.NotYetConnectedException;
 
@@ -34,7 +33,7 @@ public class SocketChannelNotYetConnectedTest extends AbstractClientSocketTest {
 
     public void testShutdownNotYetConnected(Bootstrap cb) throws Throwable {
         SocketChannel ch = (SocketChannel) cb.handler(new ChannelInboundHandlerAdapter())
-                .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+                .bind(newSocketAddress()).syncUninterruptibly().channel();
         try {
             try {
                 ch.shutdownInput().syncUninterruptibly();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCloseForciblyTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketCloseForciblyTest.java
@@ -44,7 +44,7 @@ public class SocketCloseForciblyTest extends AbstractSocketTest {
 
         Channel sc = sb.bind().sync().channel();
 
-        cb.connect().channel().closeFuture().syncUninterruptibly();
+        cb.connect(sc.localAddress()).channel().closeFuture().syncUninterruptibly();
         sc.close().sync();
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectTest.java
@@ -84,7 +84,7 @@ public class SocketConnectTest extends AbstractSocketTest {
         Channel cc = null;
         try {
             sb.childHandler(new ChannelInboundHandlerAdapter());
-            sc = sb.bind(NetUtil.LOCALHOST, TestUtils.getFreePort()).syncUninterruptibly().channel();
+            sc = sb.bind().syncUninterruptibly().channel();
 
             cb.handler(new ChannelInboundHandlerAdapter() {
                 @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketConnectionAttemptTest.java
@@ -23,7 +23,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelOption;
 import io.netty.util.internal.SocketUtils;
-import io.netty.testsuite.util.TestUtils;
 import io.netty.util.NetUtil;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.concurrent.Promise;
@@ -44,6 +43,9 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
 
     private static final String BAD_HOST = SystemPropertyUtil.get("io.netty.testsuite.badHost", "netty.io");
     private static final int BAD_PORT = SystemPropertyUtil.getInt("io.netty.testsuite.badPort", 65535);
+
+    // See /etc/services
+    private static final int UNASSIGNED_PORT = 4;
 
     static {
         InternalLogger logger = InternalLoggerFactory.getInstance(SocketConnectionAttemptTest.class);
@@ -89,14 +91,13 @@ public class SocketConnectionAttemptTest extends AbstractClientSocketTest {
         ChannelHandler handler = new ChannelInboundHandlerAdapter() {
             @Override
             public void channelActive(ChannelHandlerContext ctx) throws Exception {
-                Channel channel = ctx.channel();
                 errorPromise.setFailure(new AssertionError("should have never been called"));
             }
         };
 
         cb.handler(handler);
         cb.option(ChannelOption.ALLOW_HALF_CLOSURE, halfClosure);
-        ChannelFuture future = cb.connect(NetUtil.LOCALHOST, TestUtils.getFreePort()).awaitUninterruptibly();
+        ChannelFuture future = cb.connect(NetUtil.LOCALHOST, UNASSIGNED_PORT).awaitUninterruptibly();
         assertThat(future.cause(), is(instanceOf(ConnectException.class)));
         assertThat(errorPromise.cause(), is(nullValue()));
     }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketEchoTest.java
@@ -155,7 +155,7 @@ public class SocketEchoTest extends AbstractSocketTest {
         cb.option(ChannelOption.AUTO_READ, autoRead);
 
         Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
 
         for (int i = 0; i < data.length;) {
             int length = Math.min(random.nextInt(1024 * 64), data.length - i);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketExceptionHandlingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketExceptionHandlingTest.java
@@ -50,9 +50,8 @@ public class SocketExceptionHandlingTest extends AbstractSocketTest {
 
             serverChannel = sb.bind().syncUninterruptibly().channel();
 
-            cb.remoteAddress(serverChannel.localAddress())
-              .handler(new MyInitializer());
-            clientChannel = cb.connect().syncUninterruptibly().channel();
+            cb.handler(new MyInitializer());
+            clientChannel = cb.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
 
             clientChannel.writeAndFlush(Unpooled.wrappedBuffer(new byte[1024]));
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFileRegionTest.java
@@ -146,7 +146,7 @@ public class SocketFileRegionTest extends AbstractSocketTest {
 
         Channel sc = sb.bind().sync().channel();
 
-        Channel cc = cb.connect().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
         FileRegion region = new DefaultFileRegion(
                 new FileInputStream(file).getChannel(), startOffset, data.length - bufferSize);
         FileRegion emptyRegion = new DefaultFileRegion(new FileInputStream(file).getChannel(), 0, 0);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketFixedLengthEchoTest.java
@@ -83,7 +83,7 @@ public class SocketFixedLengthEchoTest extends AbstractSocketTest {
         });
 
         Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
         for (int i = 0; i < data.length;) {
             int length = Math.min(random.nextInt(1024 * 3), data.length - i);
             cc.writeAndFlush(Unpooled.wrappedBuffer(data, i, length));

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -115,7 +115,7 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
         sb.childHandler(sh);
 
         Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
 
         for (int i = 0; i < data.length;) {
             int length = Math.min(random.nextInt(1024 * 8), data.length - i);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketMultipleConnectTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketMultipleConnectTest.java
@@ -22,7 +22,6 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.testsuite.transport.TestsuitePermutation;
-import io.netty.testsuite.util.TestUtils;
 import io.netty.util.NetUtil;
 import org.junit.Test;
 
@@ -44,7 +43,7 @@ public class SocketMultipleConnectTest extends AbstractSocketTest {
         Channel cc = null;
         try {
             sb.childHandler(new ChannelInboundHandlerAdapter());
-            sc = sb.bind(NetUtil.LOCALHOST, TestUtils.getFreePort()).syncUninterruptibly().channel();
+            sc = sb.bind(NetUtil.LOCALHOST, 0).syncUninterruptibly().channel();
 
             cb.handler(new ChannelInboundHandlerAdapter());
             cc = cb.register().syncUninterruptibly().channel();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketObjectEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketObjectEchoTest.java
@@ -96,7 +96,7 @@ public class SocketObjectEchoTest extends AbstractSocketTest {
         });
 
         Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
         for (String element : data) {
             cc.writeAndFlush(element);
         }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketReadPendingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketReadPendingTest.java
@@ -60,12 +60,11 @@ public class SocketReadPendingTest extends AbstractSocketTest {
 
             serverChannel = sb.bind().syncUninterruptibly().channel();
 
-            cb.remoteAddress(serverChannel.localAddress())
-              .option(ChannelOption.AUTO_READ, false)
+            cb.option(ChannelOption.AUTO_READ, false)
               // We intend to do 2 reads per read loop wakeup
               .option(ChannelOption.RCVBUF_ALLOCATOR, new TestNumReadsRecvByteBufAllocator(2))
               .handler(clientInitializer);
-            clientChannel = cb.connect().syncUninterruptibly().channel();
+            clientChannel = cb.connect(serverChannel.localAddress()).syncUninterruptibly().channel();
 
             // 4 bytes means 2 read loops for TestNumReadsRecvByteBufAllocator
             clientChannel.writeAndFlush(Unpooled.wrappedBuffer(new byte[4]));

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketShutdownOutputByPeerTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketShutdownOutputByPeerTest.java
@@ -17,6 +17,7 @@ package io.netty.testsuite.transport.socket;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.SimpleChannelInboundHandler;
@@ -43,10 +44,11 @@ public class SocketShutdownOutputByPeerTest extends AbstractServerSocketTest {
     public void testShutdownOutput(ServerBootstrap sb) throws Throwable {
         TestHandler h = new TestHandler();
         Socket s = new Socket();
+        Channel sc = null;
         try {
-            sb.childHandler(h).childOption(ChannelOption.ALLOW_HALF_CLOSURE, true).bind().sync();
+            sc = sb.childHandler(h).childOption(ChannelOption.ALLOW_HALF_CLOSURE, true).bind().sync().channel();
 
-            SocketUtils.connect(s, addr, 10000);
+            SocketUtils.connect(s, sc.localAddress(), 10000);
             s.getOutputStream().write(1);
 
             assertEquals(1, (int) h.queue.take());
@@ -68,6 +70,9 @@ public class SocketShutdownOutputByPeerTest extends AbstractServerSocketTest {
             Thread.sleep(100);
             assertEquals(1, h.halfClosureCount.intValue());
         } finally {
+            if (sc != null) {
+                sc.close();
+            }
             s.close();
         }
     }
@@ -80,10 +85,11 @@ public class SocketShutdownOutputByPeerTest extends AbstractServerSocketTest {
     public void testShutdownOutputWithoutOption(ServerBootstrap sb) throws Throwable {
         TestHandler h = new TestHandler();
         Socket s = new Socket();
+        Channel sc = null;
         try {
-            sb.childHandler(h).bind().sync();
+            sc = sb.childHandler(h).bind().sync().channel();
 
-            SocketUtils.connect(s, addr, 10000);
+            SocketUtils.connect(s, sc.localAddress(), 10000);
             s.getOutputStream().write(1);
 
             assertEquals(1, (int) h.queue.take());
@@ -106,6 +112,9 @@ public class SocketShutdownOutputByPeerTest extends AbstractServerSocketTest {
             Thread.sleep(100);
             assertEquals(0, h.halfClosureCount.intValue());
         } finally {
+            if (sc != null) {
+                sc.close();
+            }
             s.close();
         }
     }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketShutdownOutputBySelfTest.java
@@ -48,8 +48,8 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         Socket s = null;
         SocketChannel ch = null;
         try {
-            ss.bind(addr);
-            ch = (SocketChannel) cb.handler(h).connect().sync().channel();
+            ss.bind(newSocketAddress());
+            ch = (SocketChannel) cb.handler(h).connect(ss.getLocalSocketAddress()).sync().channel();
             assertTrue(ch.isActive());
             assertFalse(ch.isOutputShutdown());
 
@@ -95,8 +95,8 @@ public class SocketShutdownOutputBySelfTest extends AbstractClientSocketTest {
         ServerSocket ss = new ServerSocket();
         Socket s = null;
         try {
-            ss.bind(addr);
-            SocketChannel ch = (SocketChannel) cb.handler(h).connect().sync().channel();
+            ss.bind(newSocketAddress());
+            SocketChannel ch = (SocketChannel) cb.handler(h).connect(ss.getLocalSocketAddress()).sync().channel();
             assertTrue(ch.isActive());
             s = ss.accept();
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSpdyEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSpdyEchoTest.java
@@ -194,10 +194,10 @@ public class SocketSpdyEchoTest extends AbstractSocketTest {
 
         cb.handler(ch);
 
-        Channel sc = sb.localAddress(0).bind().sync().channel();
+        Channel sc = sb.bind().sync().channel();
         int port = ((InetSocketAddress) sc.localAddress()).getPort();
 
-        Channel cc = cb.remoteAddress(NetUtil.LOCALHOST, port).connect().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
         cc.writeAndFlush(frames);
 
         while (ch.counter < frames.writerIndex() - ignoredBytes) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -155,7 +155,7 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
         });
 
         Channel sc = sb.bind().sync().channel();
-        cb.connect().sync();
+        cb.connect(sc.localAddress()).sync();
 
         Future<Channel> clientHandshakeFuture = clientSslHandler.handshakeFuture();
         clientHandshakeFuture.sync();

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslEchoTest.java
@@ -280,7 +280,7 @@ public class SocketSslEchoTest extends AbstractSocketTest {
         });
 
         final Channel sc = sb.bind().sync().channel();
-        cb.connect().sync();
+        cb.connect(sc.localAddress()).sync();
 
         final Future<Channel> clientHandshakeFuture = clientSslHandler.handshakeFuture();
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslGreetingTest.java
@@ -140,7 +140,7 @@ public class SocketSslGreetingTest extends AbstractSocketTest {
         });
 
         Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
 
         ch.latch.await();
 

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslSessionReuseTest.java
@@ -27,7 +27,6 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.ssl.JdkSslClientContext;
-import io.netty.handler.ssl.JdkSslContext;
 import io.netty.handler.ssl.JdkSslServerContext;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
@@ -128,16 +127,16 @@ public class SocketSslSessionReuseTest extends AbstractSocketTest {
         });
 
         try {
-            SSLSessionContext clientSessionCtx = ((JdkSslContext) clientCtx).sessionContext();
+            SSLSessionContext clientSessionCtx = clientCtx.sessionContext();
             ByteBuf msg = Unpooled.wrappedBuffer(new byte[] { 0xa, 0xb, 0xc, 0xd }, 0, 4);
-            Channel cc = cb.connect().sync().channel();
+            Channel cc = cb.connect(sc.localAddress()).sync().channel();
             cc.writeAndFlush(msg).sync();
             cc.closeFuture().sync();
             rethrowHandlerExceptions(sh, ch);
             Set<String> sessions = sessionIdSet(clientSessionCtx.getIds());
 
             msg = Unpooled.wrappedBuffer(new byte[] { 0xa, 0xb, 0xc, 0xd }, 0, 4);
-            cc = cb.connect().sync().channel();
+            cc = cb.connect(sc.localAddress()).sync().channel();
             cc.writeAndFlush(msg).sync();
             cc.closeFuture().sync();
             assertEquals("Expected no new sessions", sessions, sessionIdSet(clientSessionCtx.getIds()));

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStartTlsTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStartTlsTest.java
@@ -174,7 +174,7 @@ public class SocketStartTlsTest extends AbstractSocketTest {
         });
 
         Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
 
         while (cc.isActive()) {
             if (sh.exception.get() != null) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStringEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStringEchoTest.java
@@ -98,7 +98,7 @@ public class SocketStringEchoTest extends AbstractSocketTest {
         });
 
         Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
         for (String element : data) {
             String delimiter = random.nextBoolean() ? "\r\n" : "\n";
             cc.writeAndFlush(element + delimiter);

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/TrafficShapingHandlerTest.java
@@ -324,7 +324,7 @@ public class TrafficShapingHandlerTest extends AbstractSocketTest {
         });
 
         Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
 
         int totalNb = 0;
         for (int i = 1; i < multipleMessage.length; i++) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/WriteBeforeRegisteredTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/WriteBeforeRegisteredTest.java
@@ -33,7 +33,7 @@ public class WriteBeforeRegisteredTest extends AbstractClientSocketTest {
         TestHandler h = new TestHandler();
         SocketChannel ch = null;
         try {
-            ch = (SocketChannel) cb.handler(h).connect().channel();
+            ch = (SocketChannel) cb.handler(h).connect(newSocketAddress()).channel();
             ch.writeAndFlush(Unpooled.wrappedBuffer(new byte[] { 1 }));
         } finally {
             if (ch != null) {

--- a/testsuite/src/main/java/io/netty/testsuite/transport/udt/UDTClientServerConnectionTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/udt/UDTClientServerConnectionTest.java
@@ -32,12 +32,14 @@ import io.netty.handler.codec.Delimiters;
 import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.codec.string.StringEncoder;
 import io.netty.util.CharsetUtil;
+import io.netty.util.NetUtil;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetSocketAddress;
 import java.util.concurrent.ThreadFactory;
 
 import static org.junit.Assert.*;
@@ -51,16 +53,14 @@ public class UDTClientServerConnectionTest {
 
         static final Logger log = LoggerFactory.getLogger(Client.class);
 
-        final String host;
-        final int port;
+        private final InetSocketAddress address;
 
         volatile Channel channel;
         volatile boolean isRunning;
         volatile boolean isShutdown;
 
-        Client(final String host, final int port) {
-            this.host = host;
-            this.port = port;
+        Client(InetSocketAddress address) {
+            this.address = address;
         }
 
         @Override
@@ -88,7 +88,7 @@ public class UDTClientServerConnectionTest {
                                 pipeline.addLast("handler", new ClientHandler());
                             }
                         });
-                channel = boot.connect(host, port).sync().channel();
+                channel = boot.connect(address).sync().channel();
                 isRunning = true;
                 log.info("Client ready.");
                 waitForRunning(false);
@@ -178,16 +178,14 @@ public class UDTClientServerConnectionTest {
 
         final ChannelGroup group = new DefaultChannelGroup("server group", GlobalEventExecutor.INSTANCE);
 
-        final String host;
-        final int port;
+        private final InetSocketAddress address;
 
         volatile Channel channel;
         volatile boolean isRunning;
         volatile boolean isShutdown;
 
-        Server(final String host, final int port) {
-            this.host = host;
-            this.port = port;
+        Server(InetSocketAddress address) {
+            this.address = address;
         }
 
         @Override
@@ -218,7 +216,7 @@ public class UDTClientServerConnectionTest {
                                         group));
                             }
                         });
-                channel = boot.bind(port).sync().channel();
+                channel = boot.bind(address).sync().channel();
                 isRunning = true;
                 log.info("Server ready.");
                 waitForRunning(false);
@@ -340,19 +338,16 @@ public class UDTClientServerConnectionTest {
      */
     @Test
     public void connection() throws Exception {
-
-        final String host = "localhost";
-        final int port = 1234;
-
         log.info("Starting server.");
-        final Server server = new Server(host, port);
+        // Using LOCALHOST4 as UDT transport does not support IPV6 :(
+        final Server server = new Server(new InetSocketAddress(NetUtil.LOCALHOST4, 0));
         final Thread serverTread = new Thread(server, "server-*");
         serverTread.start();
         server.waitForRunning(true);
         assertTrue(server.isRunning);
 
         log.info("Starting client.");
-        final Client client = new Client(host, port);
+        final Client client = new Client((InetSocketAddress) server.channel.localAddress());
         final Thread clientThread = new Thread(client, "client-*");
         clientThread.start();
         client.waitForRunning(true);

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollDomainSocketFdTest.java
@@ -86,7 +86,7 @@ public class EpollDomainSocketFdTest extends AbstractSocketTest {
         cb.option(EpollChannelOption.DOMAIN_SOCKET_READ_MODE,
                 DomainSocketReadMode.FILE_DESCRIPTORS);
         Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
 
         Object received = queue.take();
         cc.close().sync();

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollReuseAddrTest.java
@@ -23,7 +23,6 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.testsuite.util.TestUtils;
 import io.netty.util.NetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ResourceLeakDetector;
@@ -82,7 +81,7 @@ public class EpollReuseAddrTest {
         bootstrap.handler(new DummyHandler());
         ChannelFuture future = bootstrap.bind().syncUninterruptibly();
         try {
-            bootstrap.bind().syncUninterruptibly();
+            bootstrap.bind(future.channel().localAddress()).syncUninterruptibly();
             Assert.fail();
         } catch (Exception e) {
             Assert.assertTrue(e instanceof IOException);
@@ -102,7 +101,7 @@ public class EpollReuseAddrTest {
 
         final AtomicBoolean accepted2 = new AtomicBoolean();
         bootstrap.childHandler(new ServerSocketTestHandler(accepted2));
-        ChannelFuture future2 = bootstrap.bind().syncUninterruptibly();
+        ChannelFuture future2 = bootstrap.bind(address1).syncUninterruptibly();
         InetSocketAddress address2 = (InetSocketAddress) future2.channel().localAddress();
 
         Assert.assertEquals(address1, address2);
@@ -129,7 +128,7 @@ public class EpollReuseAddrTest {
 
         final AtomicBoolean received2 = new AtomicBoolean();
         bootstrap.handler(new DatagramSocketTestHandler(received2));
-        ChannelFuture future2 = bootstrap.bind().syncUninterruptibly();
+        ChannelFuture future2 = bootstrap.bind(address1).syncUninterruptibly();
         final InetSocketAddress address2 = (InetSocketAddress) future2.channel().localAddress();
 
         Assert.assertEquals(address1, address2);
@@ -173,7 +172,7 @@ public class EpollReuseAddrTest {
         bootstrap.group(EpollSocketTestPermutation.EPOLL_BOSS_GROUP, EpollSocketTestPermutation.EPOLL_WORKER_GROUP);
         bootstrap.channel(EpollServerSocketChannel.class);
         bootstrap.childHandler(new DummyHandler());
-        InetSocketAddress address = new InetSocketAddress(NetUtil.LOCALHOST, TestUtils.getFreePort());
+        InetSocketAddress address = new InetSocketAddress(NetUtil.LOCALHOST, 0);
         bootstrap.localAddress(address);
         return bootstrap;
     }
@@ -182,7 +181,7 @@ public class EpollReuseAddrTest {
         Bootstrap bootstrap = new Bootstrap();
         bootstrap.group(EpollSocketTestPermutation.EPOLL_WORKER_GROUP);
         bootstrap.channel(EpollDatagramChannel.class);
-        InetSocketAddress address = new InetSocketAddress(NetUtil.LOCALHOST, TestUtils.getFreePort());
+        InetSocketAddress address = new InetSocketAddress(NetUtil.LOCALHOST, 0);
         bootstrap.localAddress(address);
         return bootstrap;
     }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSpliceTest.java
@@ -59,7 +59,7 @@ public class EpollSpliceTest {
         ServerBootstrap bs = new ServerBootstrap();
         bs.channel(EpollServerSocketChannel.class);
         bs.group(group).childHandler(sh);
-        final Channel sc = bs.bind(NetUtil.LOCALHOST, TestUtils.getFreePort()).syncUninterruptibly().channel();
+        final Channel sc = bs.bind(NetUtil.LOCALHOST, 0).syncUninterruptibly().channel();
 
         ServerBootstrap bs2 = new ServerBootstrap();
         bs2.channel(EpollServerSocketChannel.class);
@@ -125,7 +125,7 @@ public class EpollSpliceTest {
                 });
             }
         });
-        Channel pc = bs2.bind(NetUtil.LOCALHOST, TestUtils.getFreePort()).syncUninterruptibly().channel();
+        Channel pc = bs2.bind(NetUtil.LOCALHOST, 0).syncUninterruptibly().channel();
 
         Bootstrap cb = new Bootstrap();
         cb.group(group);
@@ -201,7 +201,7 @@ public class EpollSpliceTest {
         bs.channel(EpollServerSocketChannel.class);
         bs.group(group).childHandler(sh);
         bs.childOption(EpollChannelOption.EPOLL_MODE, EpollMode.LEVEL_TRIGGERED);
-        Channel sc = bs.bind(NetUtil.LOCALHOST, TestUtils.getFreePort()).syncUninterruptibly().channel();
+        Channel sc = bs.bind(NetUtil.LOCALHOST, 0).syncUninterruptibly().channel();
 
         Bootstrap cb = new Bootstrap();
         cb.group(group);

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueDomainSocketFdTest.java
@@ -85,7 +85,7 @@ public class KQueueDomainSocketFdTest extends AbstractSocketTest {
         cb.option(KQueueChannelOption.DOMAIN_SOCKET_READ_MODE,
                 DomainSocketReadMode.FILE_DESCRIPTORS);
         Channel sc = sb.bind().sync().channel();
-        Channel cc = cb.connect().sync().channel();
+        Channel cc = cb.connect(sc.localAddress()).sync().channel();
 
         Object received = queue.take();
         cc.close().sync();


### PR DESCRIPTION
…try to use a port that is used by the system in the meantime.

Motivation:

We should not try to detect a free port in tests put just use 0 when bind so there is no race in which the system my bind something to the port we choosen before.

Modifications:

- Remove the usage of TestUtils.getFreePort() in the testsuite
- Remove hack to workaround bind errors which will not happen anymore now

Result:

Less flacky tests.