### PR TITLE
Allow to delay registration when creating a EmbeddedChannel

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerTest.java
@@ -160,27 +160,32 @@ public class SslHandlerTest {
         }
 
         public void test(final boolean dropChannelActive) throws Exception {
-          SSLEngine engine = SSLContext.getDefault().createSSLEngine();
-          engine.setUseClientMode(true);
+            SSLEngine engine = SSLContext.getDefault().createSSLEngine();
+            engine.setUseClientMode(true);
 
-          EmbeddedChannel ch = new EmbeddedChannel(
-              this,
-              new SslHandler(engine),
-              new ChannelInboundHandlerAdapter() {
-                @Override
-                public void channelActive(ChannelHandlerContext ctx) throws Exception {
-                  if (!dropChannelActive) {
-                    ctx.fireChannelActive();
-                  }
-                }
-              }
-          );
-          ch.config().setAutoRead(false);
-          assertFalse(ch.config().isAutoRead());
+            EmbeddedChannel ch = new EmbeddedChannel(false, false,
+                    this,
+                    new SslHandler(engine),
+                    new ChannelInboundHandlerAdapter() {
+                        @Override
+                        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                            if (!dropChannelActive) {
+                                ctx.fireChannelActive();
+                            }
+                        }
+                    }
+            );
+            ch.config().setAutoRead(false);
+            assertFalse(ch.config().isAutoRead());
 
-          assertTrue(ch.writeOutbound(Unpooled.EMPTY_BUFFER));
-          assertTrue(readIssued);
-          assertTrue(ch.finishAndReleaseAll());
+            ch.register();
+
+            assertTrue(readIssued);
+            readIssued = false;
+
+            assertTrue(ch.writeOutbound(Unpooled.EMPTY_BUFFER));
+            assertTrue(readIssued);
+            assertTrue(ch.finishAndReleaseAll());
        }
     }
 

--- a/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/embedded/EmbeddedChannelTest.java
@@ -53,6 +53,28 @@ import io.netty.util.concurrent.ScheduledFuture;
 
 public class EmbeddedChannelTest {
 
+    @Test
+    public void testNotRegistered() throws Exception {
+        EmbeddedChannel channel = new EmbeddedChannel(false, false);
+        assertFalse(channel.isRegistered());
+        channel.register();
+        assertTrue(channel.isRegistered());
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testRegistered() throws Exception {
+        EmbeddedChannel channel = new EmbeddedChannel(true, false);
+        assertTrue(channel.isRegistered());
+        try {
+            channel.register();
+            fail();
+        } catch (IllegalStateException expected) {
+            // This is expected the channel is registered already on an EventLoop.
+        }
+        assertFalse(channel.finish());
+    }
+
     @Test(timeout = 2000)
     public void promiseDoesNotInfiniteLoop() throws InterruptedException {
         EmbeddedChannel channel = new EmbeddedChannel();


### PR DESCRIPTION

    Motivation:

    Some ChannelOptions must be set before the Channel is really registered to have the desired effect.

    Modifications:

    Add another constructor argument which allows to not register the EmbeddedChannel to its EventLoop until the user calls register().

    Result:

    More flexible usage of EmbeddedChannel. Also Fixes [#6968].