### PR TITLE
Use the correct murmur3 C1 value

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -49,7 +49,7 @@ final class PlatformDependent0 {
 
     // constants borrowed from murmur3
     static final int HASH_CODE_ASCII_SEED = 0xc2b2ae35;
-    static final int HASH_CODE_C1 = 0x1b873593;
+    static final int HASH_CODE_C1 = 0xcc9e2d51;
     static final int HASH_CODE_C2 = 0x1b873593;
 
     /**


### PR DESCRIPTION
Introduced in a7f7d9c8e004aa13801424e6e665b1ec525a822f (#5465).

This fixes a (what I presume to be) typo, using the same value for both `C1` and `C2`.

https://en.wikipedia.org/wiki/MurmurHash
https://github.com/google/guava/blob/master/guava/src/com/google/common/hash/Murmur3_32HashFunction.java#L60