### PR TITLE
Correct typo in artifactId of dependency in bom pom.xml

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -198,14 +198,14 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty-transport-unix-common</artifactId>
-        <version>4.1.13.Final-SNAPSHOT</version>
+        <artifactId>netty-transport-native-unix-common</artifactId>
+        <version>4.1.14.Final-SNAPSHOT</version>
         <classifier>linux-x86_64</classifier>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty-transport-unix-common</artifactId>
-        <version>4.1.13.Final-SNAPSHOT</version>
+        <artifactId>netty-transport-native-unix-common</artifactId>
+        <version>4.1.14.Final-SNAPSHOT</version>
         <classifier>osx-x86_64</classifier>
       </dependency>
       <dependency>


### PR DESCRIPTION

    Motivation:

    There was a typo in a dependency in the bom pom.xml which lead to have it specify a non-existing artifact and also so not have the maven release plugin update the version correctly.

    Modifications:

    Rename netty-transport-unix-common to netty-transport-native-unix-common and also fix the version.

    Result:

    Fixes [#6979]