### PR TITLE
Fix NPEs in HttpPostRequestEncoder#nextChunk

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoderTest.java
@@ -19,16 +19,20 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpConstants;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.handler.codec.http.multipart.HttpPostRequestEncoder.EncoderMode;
 import io.netty.handler.codec.http.multipart.HttpPostRequestEncoder.ErrorDataEncoderException;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.StringUtil;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
 
@@ -37,6 +41,7 @@ import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TRANSFER_ENCODING;
 import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -357,5 +362,65 @@ public class HttpPostRequestEncoderTest {
         String contentStr = content.toString(CharsetUtil.UTF_8);
         content.release();
         return contentStr;
+    }
+
+    @Test
+    public void testDataIsMultipleOfChunkSize1() throws Exception {
+        DefaultHttpDataFactory factory = new DefaultHttpDataFactory(DefaultHttpDataFactory.MINSIZE);
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
+                HttpMethod.POST, "http://localhost");
+        HttpPostRequestEncoder encoder = new HttpPostRequestEncoder(factory, request, true,
+                HttpConstants.DEFAULT_CHARSET, HttpPostRequestEncoder.EncoderMode.RFC1738);
+
+        MemoryFileUpload first = new MemoryFileUpload("resources", "", "application/json", null,
+                Charset.forName("UTF-8"), -1);
+        first.setMaxSize(-1);
+        first.setContent(new ByteArrayInputStream(new byte[7955]));
+        encoder.addBodyHttpData(first);
+
+        MemoryFileUpload second = new MemoryFileUpload("resources2", "", "application/json", null,
+                Charset.forName("UTF-8"), -1);
+        second.setMaxSize(-1);
+        second.setContent(new ByteArrayInputStream(new byte[7928]));
+        encoder.addBodyHttpData(second);
+
+        assertNotNull(encoder.finalizeRequest());
+
+        checkNextChunkSize(encoder, 8096);
+        checkNextChunkSize(encoder, 8096);
+
+        HttpContent httpContent = encoder.readChunk((ByteBufAllocator) null);
+        assertTrue("Expected LastHttpContent is not received", httpContent instanceof LastHttpContent);
+        httpContent.release();
+
+        assertTrue("Expected end of input is not receive", encoder.isEndOfInput());
+    }
+
+    @Test
+    public void testDataIsMultipleOfChunkSize2() throws Exception {
+        DefaultFullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1,
+                HttpMethod.POST, "http://localhost");
+        HttpPostRequestEncoder encoder = new HttpPostRequestEncoder(request, true);
+        int length = 7943;
+        char[] array = new char[length];
+        Arrays.fill(array, 'a');
+        String longText = new String(array);
+        encoder.addBodyAttribute("foo", longText);
+
+        assertNotNull(encoder.finalizeRequest());
+
+        checkNextChunkSize(encoder, 8096);
+
+        HttpContent httpContent = encoder.readChunk((ByteBufAllocator) null);
+        assertTrue("Expected LastHttpContent is not received", httpContent instanceof LastHttpContent);
+        httpContent.release();
+
+        assertTrue("Expected end of input is not receive", encoder.isEndOfInput());
+    }
+
+    private static void checkNextChunkSize(HttpPostRequestEncoder encoder, int expectedSize) throws Exception {
+        HttpContent httpContent = encoder.readChunk((ByteBufAllocator) null);
+        assertEquals("Chunk is not " + expectedSize + " bytes", expectedSize, httpContent.content().readableBytes());
+        httpContent.release();
     }
 }


### PR DESCRIPTION
Motivation:

`HttpPostRequestEncoder `maintains an internal buffer that holds the
current encoded data. There are use cases when this internal buffer
becomes null, the next chunk processing implementation should take
this into consideration.

Modifications:

- When preparing the last chunk if `currentBuffer` is null, mark
`isLastChunkSent=true` and send `LastHttpContent.EMPTY_LAST_CONTENT`
- When calculating the remaining size take into consideration that the
`currentBuffer` might be null
- Tests are based on those provided in the issue by @nebhale and @bfiorini

Result:

Fixes #5478