### PR TITLE
Automatically detect shaded packagePrefix

### DIFF
--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -181,11 +181,31 @@ public final class NativeLibraryLoader {
     }
 
     /**
+     * The shading prefix added to this class's full name.
+     *
+     * @throws UnsatisfiedLinkError if the shader used something other than a prefix
+     */
+    private static String calculatePackagePrefix() {
+        String maybeShaded = NativeLibraryLoader.class.getName();
+        // Use ! instead of . to avoid shading utilities from modifying the string
+        String expected = "io!netty!util!internal!NativeLibraryLoader".replace('!', '.');
+        if (!maybeShaded.endsWith(expected)) {
+            throw new UnsatisfiedLinkError(String.format(
+                    "Could not find prefix added to %s to get %s. When shading, only adding a "
+                    + "package prefix is supported", expected, maybeShaded));
+        }
+        return maybeShaded.substring(0, maybeShaded.length() - expected.length());
+    }
+
+    /**
      * Load the given library with the specified {@link ClassLoader}
      */
     public static void load(String originalName, ClassLoader loader) {
         // Adjust expected name to support shading of native libraries.
-        String name = SystemPropertyUtil.get("io.netty.packagePrefix", "").replace('.', '-') + originalName;
+        String implicitPackagePrefix = calculatePackagePrefix();
+        // The system property should not be necessary; it can be removed in the future.
+        String packagePrefix = SystemPropertyUtil.get("io.netty.packagePrefix", implicitPackagePrefix);
+        String name = packagePrefix.replace('.', '-') + originalName;
 
         String libname = System.mapLibraryName(name);
         String path = NATIVE_RESOURCE_HOME + libname;


### PR DESCRIPTION
Motivation:

Shading requires renaming binary components (.so, .dll; for tcnative,
epoll, etc). But the rename then requires setting the
io.netty.packagePrefix system property on the command line or runtime,
which is either a burden or not feasible.

If you don't rename the binary components everything appears to
work, until a dependency on a second version of the binary component is
added. At that point, only one version of the binary will be loaded...
which is what shading is supposed to prevent. So for valid shading, the
binaries must be renamed.

Modifications:

Automatically detect the package prefix by comparing the actual class
name to the non-shaded expected class name. The expected class name must
be obfuscated to prevent shading utilities from changing it.

Result:

When shading and using binary components, runtime configuration is no
longer necessary.

Pre-existing shading users that were not renaming the binary components
will break, because the packagePrefix previously defaulted to "". Since
these pre-existing users had broken configurations that only _appeared_
to work, this breakage is considered a Good Thing. Users may workaround
this breakage temporarily by setting -Dio.netty.packagePrefix= to
restore packagePrefix to "".

Fixes #6963

----

I have manually tested this with my in-progress shading in gRPC. The default was detected and behaved the same as specifying `io.netty.packagePrefix` before and after this change. Specifying `-Dio.netty.packagePrefix=` overrode the default. My shading config is still a bit broken, so I'm getting some cipher suite failures, but those were pre-existing and unrelated to defaulting the packagePrefix.

I could have returned `""` instead of throwing `UnsatisfiedLinkError` when the prefix is un-detected, but felt it was better to fail early instead of letting the binary component's linking to fail.