### PR TITLE
Add slice support for FileRegion.

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultFileRegion.java
+++ b/transport/src/main/java/io/netty/channel/DefaultFileRegion.java
@@ -17,6 +17,7 @@ package io.netty.channel;
 
 import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.IllegalReferenceCountException;
+import io.netty.util.ReferenceCounted;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -32,7 +33,7 @@ import java.nio.channels.WritableByteChannel;
  * Be aware that the {@link FileChannel} will be automatically closed once {@link #refCnt()} returns
  * {@code 0}.
  */
-public class DefaultFileRegion extends AbstractReferenceCounted implements FileRegion {
+public class DefaultFileRegion extends FileChannelBasedFileRegion implements FileRegion {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultFileRegion.class);
     private final File f;
@@ -87,16 +88,12 @@ public class DefaultFileRegion extends AbstractReferenceCounted implements FileR
         this.f = f;
     }
 
-    /**
-     * Returns {@code true} if the {@link FileRegion} has a open file-descriptor
-     */
+    @Override
     public boolean isOpen() {
         return file != null;
     }
 
-    /**
-     * Explicitly open the underlying file-descriptor if not done yet.
-     */
+    @Override
     public void open() throws IOException {
         if (!isOpen() && refCnt() > 0) {
             // Only open if this DefaultFileRegion was not released yet.
@@ -120,26 +117,27 @@ public class DefaultFileRegion extends AbstractReferenceCounted implements FileR
         return transferred;
     }
 
+    @Deprecated
     @Override
     public long transferred() {
         return transferred;
     }
 
+    @Deprecated
     @Override
     public long transferTo(WritableByteChannel target, long position) throws IOException {
         long count = this.count - position;
         if (count < 0 || position < 0) {
-            throw new IllegalArgumentException(
-                    "position out of range: " + position +
-                    " (expected: 0 - " + (this.count - 1) + ')');
+            throw new IllegalArgumentException(String.format(
+                    "position out of range: %d (expected: 0 - %d)", position, this.count - 1));
         }
         if (count == 0) {
-            return 0L;
+            return 0;
         }
         if (refCnt() == 0) {
             throw new IllegalReferenceCountException(0);
         }
-        // Call open to make sure fc is initialized. This is a no-oop if we called it before.
+        // Call open to make sure fc is initialized. This is a no-op if we called it before.
         open();
 
         long written = file.transferTo(this.position + position, count, target);
@@ -149,8 +147,20 @@ public class DefaultFileRegion extends AbstractReferenceCounted implements FileR
         return written;
     }
 
-    @Override
-    protected void deallocate() {
+    private final AbstractReferenceCounted refCnt = new AbstractReferenceCounted() {
+
+        @Override
+        public ReferenceCounted touch(Object hint) {
+            return DefaultFileRegion.this;
+        }
+
+        @Override
+        protected void deallocate() {
+            close();
+        }
+    };
+
+    private void close() {
         FileChannel file = this.file;
 
         if (file == null) {
@@ -168,24 +178,51 @@ public class DefaultFileRegion extends AbstractReferenceCounted implements FileR
     }
 
     @Override
+    public int refCnt() {
+        return refCnt.refCnt();
+    }
+
+    @Override
+    public boolean release() {
+        return refCnt.release();
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        return refCnt.release(decrement);
+    }
+
+    @Override
     public FileRegion retain() {
-        super.retain();
+        refCnt.retain();
         return this;
     }
 
     @Override
     public FileRegion retain(int increment) {
-        super.retain(increment);
+        refCnt.retain(increment);
         return this;
     }
 
     @Override
     public FileRegion touch() {
+        refCnt.touch();
         return this;
     }
 
     @Override
     public FileRegion touch(Object hint) {
+        refCnt.touch(hint);
         return this;
+    }
+
+    @Override
+    public SliceableFileRegion unwrap() {
+        return null;
+    }
+
+    @Override
+    protected FileChannel channel() {
+        return file;
     }
 }

--- a/transport/src/main/java/io/netty/channel/FileChannelBasedFileRegion.java
+++ b/transport/src/main/java/io/netty/channel/FileChannelBasedFileRegion.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import io.netty.util.IllegalReferenceCountException;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * Base class for {@link FileRegion} implementations which based on a {@link FileChannel}.
+ */
+public abstract class FileChannelBasedFileRegion implements SliceableFileRegion {
+
+    private long transferIndex;
+    private long transferred;
+
+    @Override
+    public long transferBytesTo(WritableByteChannel target, long length) throws IOException {
+        long written = transferBytesTo(target, transferIndex, length);
+        if (written > 0) {
+            transferIndex += written;
+        }
+        return written;
+    }
+
+    @Override
+    public long transferIndex() {
+        return transferIndex;
+    }
+
+    @Override
+    public FileChannelBasedFileRegion transferIndex(long index) {
+        if (index < 0 || index > count()) {
+            throw new IndexOutOfBoundsException(
+                    String.format("transferIndex: %d (expected: 0 <= transferIndex <= count(%d))",
+                            index, count()));
+        }
+        this.transferIndex = index;
+        return this;
+    }
+
+    @Override
+    public boolean isTransferable() {
+        return transferIndex < count();
+    }
+
+    @Override
+    public long transferableBytes() {
+        return count() - transferIndex;
+    }
+
+    @Override
+    public long transferBytesTo(WritableByteChannel target, long position, long length) throws IOException {
+        if (position < 0 || position > count()) {
+            throw new IllegalArgumentException(String
+                    .format("position out of range: %d (expected: 0 - %d)", position, count() - 1));
+        }
+        if (length < 0) {
+            throw new IllegalArgumentException("negative length " + length);
+        }
+        length = Math.min(count() - position, length);
+        if (length == 0) {
+            return 0;
+        }
+        if (refCnt() == 0) {
+            throw new IllegalReferenceCountException(0);
+        }
+        // Call open to make sure fc is initialized. This is a no-op if we called it before.
+        open();
+        return channel().transferTo(position() + position, length, target);
+    }
+
+    @Override
+    public SliceableFileRegion slice(long index, long length) {
+        return new FileChannelBasedSlicedFileRegion(this, index, length);
+    }
+
+    @Override
+    public SliceableFileRegion retainedSlice(long index, long length) {
+        SliceableFileRegion sliced = slice(index, length);
+        sliced.retain();
+        return sliced;
+    }
+
+    @Override
+    public SliceableFileRegion transferSlice(long length) {
+        SliceableFileRegion sliced = slice(transferIndex(), length);
+        transferIndex += length;
+        return sliced;
+    }
+
+    @Override
+    public SliceableFileRegion transferRetainedSlice(long length) {
+        SliceableFileRegion sliced = transferSlice(length);
+        sliced.retain();
+        return sliced;
+    }
+
+    /**
+     * Explicitly open the underlying file-descriptor if not done yet.
+     * <p>
+     * The implementation should be idempotent.
+     */
+    public abstract void open() throws IOException;
+
+    /**
+     * Returns {@code true} if the {@link FileChannelBasedFileRegion} has a open file-descriptor
+     */
+    public abstract boolean isOpen();
+
+    /**
+     * Return the underlying file channel instance of this file region. Will return {@code null} if
+     * the underlying file channel has not been opened yet.
+     */
+    protected abstract FileChannel channel();
+
+    // The methods below are only used to keep compatible with old APIs.
+    @Override
+    public long transfered() {
+        return transferred;
+    }
+
+    @Override
+    public long transferred() {
+        return transferred;
+    }
+
+    @Override
+    public long transferTo(WritableByteChannel target, long position) throws IOException {
+        // pass Long.MAX_VALUE to indicate that transfer as much as possible.
+        long written = transferBytesTo(target, position, Long.MAX_VALUE);
+        if (written > 0) {
+            transferred += written;
+        }
+        return written;
+    }
+}

--- a/transport/src/main/java/io/netty/channel/FileChannelBasedSlicedFileRegion.java
+++ b/transport/src/main/java/io/netty/channel/FileChannelBasedSlicedFileRegion.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+/**
+ * A derived {@link FileChannelBasedFileRegion} which shares reference counting with its parent.
+ */
+final class FileChannelBasedSlicedFileRegion extends FileChannelBasedFileRegion {
+
+    private final FileChannelBasedFileRegion parent;
+    private final long offset;
+    private final long count;
+
+    FileChannelBasedSlicedFileRegion(FileChannelBasedFileRegion parent, long index, long count) {
+        if (index < 0 || index > parent.count() - count) {
+            throw new IndexOutOfBoundsException(parent + ".slice(" + index + ", " + count + ')');
+        }
+
+        if (parent instanceof FileChannelBasedSlicedFileRegion) {
+            FileChannelBasedSlicedFileRegion sliced = (FileChannelBasedSlicedFileRegion) parent;
+            this.parent = sliced.parent;
+            this.offset = sliced.offset + index;
+        } else {
+            this.parent = parent;
+            this.offset = index;
+        }
+        this.count = count;
+    }
+
+    @Override
+    public long position() {
+        return parent.position() + offset;
+    }
+
+    @Override
+    public long count() {
+        return count;
+    }
+
+    @Override
+    public FileChannelBasedSlicedFileRegion retain() {
+        parent.retain();
+        return this;
+    }
+
+    @Override
+    public FileChannelBasedSlicedFileRegion retain(int increment) {
+        parent.retain(increment);
+        return this;
+    }
+
+    @Override
+    public FileChannelBasedSlicedFileRegion touch() {
+        parent.touch();
+        return this;
+    }
+
+    @Override
+    public FileChannelBasedSlicedFileRegion touch(Object hint) {
+        parent.touch(hint);
+        return this;
+    }
+
+    @Override
+    public int refCnt() {
+        return parent.refCnt();
+    }
+
+    @Override
+    public boolean release() {
+        return parent.release();
+    }
+
+    @Override
+    public boolean release(int decrement) {
+        return parent.release(decrement);
+    }
+
+    @Override
+    public FileChannelBasedFileRegion unwrap() {
+        return parent;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return parent.isOpen();
+    }
+
+    @Override
+    public void open() throws IOException {
+        parent.open();
+    }
+
+    @Override
+    protected FileChannel channel() {
+        return parent.channel();
+    }
+}

--- a/transport/src/main/java/io/netty/channel/FileRegion.java
+++ b/transport/src/main/java/io/netty/channel/FileRegion.java
@@ -67,7 +67,12 @@ public interface FileRegion extends ReferenceCounted {
 
     /**
      * Returns the bytes which was transfered already.
+     *
+     * @deprecated Will be removed in the next minor release of netty. Please use the new methods added in
+     *             {@link FileChannelBasedFileRegion} instead and they will be moved to this interface in the next minor
+     *             release.
      */
+    @Deprecated
     long transferred();
 
     /**
@@ -84,7 +89,11 @@ public interface FileRegion extends ReferenceCounted {
      *                  transfer start from {@link #position()}th byte and
      *                  <tt>{@link #count()} - 1</tt> will make the last
      *                  byte of the region transferred.
+     * @deprecated Will be removed in the next minor release of netty. Please use the new methods added in
+     *             {@link FileChannelBasedFileRegion} instead and they will be moved to this interface in the next minor
+     *             release.
      */
+    @Deprecated
     long transferTo(WritableByteChannel target, long position) throws IOException;
 
     @Override

--- a/transport/src/main/java/io/netty/channel/SliceableFileRegion.java
+++ b/transport/src/main/java/io/netty/channel/SliceableFileRegion.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import java.io.IOException;
+import java.nio.channels.WritableByteChannel;
+
+/**
+ * A {@link FileRegion} which supports slice.
+ * <p>
+ * We introduce this interface because we can not add new methods to an interface until next
+ * minor release. All the methods here will be moved to FileRegion when we release netty 4.2.
+ */
+public interface SliceableFileRegion extends FileRegion {
+
+    /**
+     * Returns the {@code transferIndex} of this file region.
+     */
+    long transferIndex();
+
+    /**
+     * Sets the {@code transferIndex} of file region.
+     *
+     * @throws IndexOutOfBoundsException
+     *             if the specified {@code transferIndex} is less than {@code 0} or greater than
+     *             {@link #count()}
+     */
+    SliceableFileRegion transferIndex(long index);
+
+    /**
+     * Returns {@code true} if and only if {@code (this.count - this.transferIndex)} is greater than
+     * {@code 0}.
+     */
+    boolean isTransferable();
+
+    /**
+     * Returns the number of readable bytes which is equal to {@code (count - transferIndex)}.
+     */
+    long transferableBytes();
+
+    /**
+     * Transfers the content of this file region to the specified channel.
+     *
+     * @param target
+     *            the destination of the transfer
+     * @param length
+     *            the maximum number of bytes to transfer
+     */
+    long transferBytesTo(WritableByteChannel target, long length) throws IOException;
+
+    /**
+     * Transfers the content of this file region to the specified channel.
+     * <p>
+     * This method does not modify {@link #transferIndex()}.
+     *
+     * @param target
+     *            the destination of the transfer
+     * @param position
+     *            the relative offset of the file where the transfer begins from. For example,
+     *            <tt>0</tt> will make the transfer start from {@link #position()}th byte and
+     *            <tt>{@link #count()} - 1</tt> will make the last byte of the region transferred.
+     * @param length
+     *            the maximum number of bytes to transfer
+     */
+    long transferBytesTo(WritableByteChannel target, long position, long length) throws IOException;
+
+    /**
+     * Returns a slice of this file region's sub-region. This method does not modify
+     * {@code transferIndex} of this buffer.
+     * <p>
+     * Also be aware that this method will NOT call {@link #retain()} and so the reference count
+     * will NOT be increased.
+     */
+    SliceableFileRegion slice(long index, long length);
+
+    /**
+     * Returns a slice of this file region's sub-region. This method does not modify
+     * {@code transferIndex} of this buffer.
+     * <p>
+     * Note that this method returns a {@linkplain #retain() retained} file region unlike
+     * {@link #slice(long, long)}.
+     */
+    SliceableFileRegion retainedSlice(long index, long length);
+
+    /**
+     * Returns a new slice of this file region's sub-region starting at the current
+     * {@code transferIndex} and increases the {@code transferIndex} by the size of the new slice (=
+     * {@code length}).
+     * <p>
+     * Also be aware that this method will NOT call {@link #retain()} and so the reference count
+     * will NOT be increased.
+     *
+     * @param length
+     *            the size of the new slice
+     */
+    SliceableFileRegion transferSlice(long length);
+
+    /**
+     * Returns a new slice of this file region's sub-region starting at the current
+     * {@code transferIndex} and increases the {@code transferIndex} by the size of the new slice (=
+     * {@code length}).
+     * <p>
+     * Note that this method returns a {@linkplain #retain() retained} file region unlike
+     * {@link #transferSlice(long)}.
+     *
+     * @param length
+     *            the size of the new slice
+     */
+    SliceableFileRegion transferRetainedSlice(long length);
+
+    /**
+     * Return the underlying file region instance if this file region is a wrapper of another file
+     * region.
+     *
+     * @return {@code null} if this file region is not a wrapper
+     */
+    SliceableFileRegion unwrap();
+}

--- a/transport/src/test/java/io/netty/channel/FileChannelBasedSlicedFileRegionTest.java
+++ b/transport/src/test/java/io/netty/channel/FileChannelBasedSlicedFileRegionTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.channel;
+
+import io.netty.util.IllegalReferenceCountException;
+import io.netty.util.internal.ThreadLocalRandom;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.util.Arrays;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test for {@link FileChannelBasedSlicedFileRegion}.
+ */
+public final class FileChannelBasedSlicedFileRegionTest {
+
+    private static byte[] TEST_DATA = new byte[1024 * 64];
+
+    private static File TEST_FILE;
+
+    @BeforeClass
+    public static void setUp() throws IOException {
+        ThreadLocalRandom.current().nextBytes(TEST_DATA);
+        TEST_FILE = File.createTempFile("netty-", ".tmp");
+        TEST_FILE.deleteOnExit();
+        FileOutputStream out = new FileOutputStream(TEST_FILE);
+        try {
+            out.write(TEST_DATA);
+        } finally {
+            out.close();
+        }
+    }
+
+    private byte[] transferBytesTo(SliceableFileRegion region, int length) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        WritableByteChannel ch = Channels.newChannel(bos);
+        try {
+            while (bos.size() < length && region.isTransferable()) {
+                region.transferBytesTo(ch, length - bos.size());
+            }
+        } finally {
+            ch.close();
+        }
+        return bos.toByteArray();
+    }
+
+    private byte[] transferTo(FileRegion region) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        WritableByteChannel ch = Channels.newChannel(bos);
+        try {
+            while (region.transferred() < region.count()) {
+                region.transferTo(ch, region.transferred());
+            }
+        } finally {
+            ch.close();
+        }
+        return bos.toByteArray();
+    }
+
+    @Test
+    public void testSlice() throws IOException {
+        DefaultFileRegion region = new DefaultFileRegion(TEST_FILE, 0, TEST_DATA.length);
+
+        SliceableFileRegion subRegion1 = region.retainedSlice(TEST_DATA.length / 2,
+                TEST_DATA.length / 2);
+
+        assertEquals(0, region.position());
+        assertTrue(region.isTransferable());
+        assertEquals(TEST_DATA.length, region.transferableBytes());
+        assertEquals(0, region.transferIndex());
+
+        assertEquals(TEST_DATA.length / 2, subRegion1.position());
+        assertTrue(subRegion1.isTransferable());
+        assertEquals(TEST_DATA.length / 2, subRegion1.transferableBytes());
+        assertEquals(0, subRegion1.transferIndex());
+
+        assertArrayEquals(TEST_DATA, transferBytesTo(region, Integer.MAX_VALUE));
+        assertEquals(TEST_DATA.length, region.transferIndex());
+        assertFalse(region.isTransferable());
+        region.release();
+
+        SliceableFileRegion subRegion2 = subRegion1.retainedSlice(TEST_DATA.length / 4,
+                TEST_DATA.length / 4);
+
+        assertEquals(TEST_DATA.length / 4 * 3, subRegion2.position());
+        assertTrue(subRegion2.isTransferable());
+        assertEquals(TEST_DATA.length / 4, subRegion2.transferableBytes());
+        assertEquals(0, subRegion2.transferIndex());
+
+        assertArrayEquals(Arrays.copyOfRange(TEST_DATA, TEST_DATA.length / 2, TEST_DATA.length),
+                transferBytesTo(subRegion1, Integer.MAX_VALUE));
+        assertEquals(TEST_DATA.length / 2, subRegion1.transferIndex());
+        assertFalse(subRegion1.isTransferable());
+        subRegion1.release();
+
+        assertArrayEquals(Arrays.copyOfRange(TEST_DATA, TEST_DATA.length / 4 * 3, TEST_DATA.length),
+                transferBytesTo(subRegion2, Integer.MAX_VALUE));
+        assertEquals(TEST_DATA.length / 4, subRegion2.transferIndex());
+        assertFalse(subRegion2.isTransferable());
+        subRegion2.release();
+    }
+
+    @Test
+    public void testTransferSlice() throws IOException {
+        DefaultFileRegion region = new DefaultFileRegion(TEST_FILE, 0, TEST_DATA.length);
+        assertEquals(0, region.position());
+        assertTrue(region.isTransferable());
+        assertEquals(TEST_DATA.length, region.transferableBytes());
+        assertEquals(0, region.transferIndex());
+
+        assertArrayEquals(Arrays.copyOf(TEST_DATA, TEST_DATA.length / 2),
+                transferBytesTo(region, TEST_DATA.length / 2));
+
+        SliceableFileRegion subRegion1 = region.transferRetainedSlice(TEST_DATA.length / 2);
+        assertFalse(region.isTransferable());
+        assertEquals(0, region.transferableBytes());
+        assertEquals(TEST_DATA.length, region.transferIndex());
+        region.release();
+
+        assertEquals(TEST_DATA.length / 2, subRegion1.position());
+        assertTrue(subRegion1.isTransferable());
+        assertEquals(TEST_DATA.length / 2, subRegion1.transferableBytes());
+        assertEquals(0, subRegion1.transferIndex());
+
+        assertArrayEquals(
+                Arrays.copyOfRange(TEST_DATA, TEST_DATA.length / 2,
+                        TEST_DATA.length - TEST_DATA.length / 4),
+                transferBytesTo(subRegion1, TEST_DATA.length / 4));
+
+        SliceableFileRegion subRegion2 = subRegion1.transferRetainedSlice(TEST_DATA.length / 4);
+        assertFalse(subRegion1.isTransferable());
+        assertEquals(0, subRegion1.transferableBytes());
+        assertEquals(TEST_DATA.length / 2, subRegion1.transferIndex());
+        subRegion1.release();
+
+        assertEquals(TEST_DATA.length - TEST_DATA.length / 4, subRegion2.position());
+        assertArrayEquals(Arrays.copyOfRange(TEST_DATA, TEST_DATA.length - TEST_DATA.length / 4,
+                TEST_DATA.length), transferBytesTo(subRegion2, TEST_DATA.length / 4));
+        subRegion2.release();
+    }
+
+    @Test
+    public void testOldTransferTo() throws IOException {
+        DefaultFileRegion region = new DefaultFileRegion(TEST_FILE, 0, TEST_DATA.length);
+
+        SliceableFileRegion subRegion1 = region.transferRetainedSlice(TEST_DATA.length / 2);
+        assertArrayEquals(Arrays.copyOf(TEST_DATA, TEST_DATA.length / 2), transferTo(subRegion1));
+        assertEquals(subRegion1.count(), subRegion1.transferred());
+
+        SliceableFileRegion subRegion2 = region.transferRetainedSlice(TEST_DATA.length / 2);
+        assertArrayEquals(Arrays.copyOfRange(TEST_DATA, TEST_DATA.length / 2, TEST_DATA.length),
+                transferTo(subRegion2));
+        assertEquals(subRegion2.count(), subRegion2.transferred());
+
+        subRegion1.release();
+        subRegion2.release();
+        region.release();
+    }
+
+    @Test(expected = IllegalReferenceCountException.class)
+    public void testReferenceCountError() throws IOException {
+        DefaultFileRegion region = new DefaultFileRegion(TEST_FILE, 0, TEST_DATA.length);
+        region.release();
+        transferBytesTo(region, TEST_DATA.length);
+    }
+}


### PR DESCRIPTION
Motivation:
Let codec such as HTTP/2 can write FileRegion chunk by chunk.

Modifications:
Add a transferIndex which is similar to readerIndex in ByteBuf for FileRegion.
Add two transferBytesTo methods which are similar to readBytes in ByteBuf for FileRegion.
Add slice and transferSlice methods which are similar to slice and readSlice in ByteBuf for FileRegion.
Make the return value of position to be the offset related to the FileChannel returned by channel method. And for DefaultFileRegion, the return value of the original position method is the offset related to the underlying FileChannel, so this does not break compatibility.
The new methods are added to a SliceableFileRegion interface which extends the old FileRegion interface, will move the new methods to FileRegion at the next minor release.
Add a FileChannelBasedFileRegion which makes it easier for implementation file channel related file regions.
Add a FileChannelBasedSlicedFileRegion which is package private.
Add FileChannelBasedSlicedFileRegionTest.
The native transport has not been modified yet so it can not accept the FileChannelBasedSlicedFileRegion right now, will address it in another PR.

Result:
Passed all FileRegion related testsuites.

Fixes
The first step of #3927 
