### PR TITLE
ByteBufs which are not resizable should not throw in ensureWritable(i…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBuf.java
@@ -66,6 +66,16 @@ public class ReadOnlyByteBuf extends AbstractDerivedByteBuf {
     }
 
     @Override
+    public int ensureWritable(int minWritableBytes, boolean force) {
+        return 1;
+    }
+
+    @Override
+    public ByteBuf ensureWritable(int minWritableBytes) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
     public ByteBuf unwrap() {
         return buffer;
     }

--- a/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/AbstractPooledByteBufTest.java
@@ -15,7 +15,13 @@
  */
 package io.netty.buffer;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public abstract class AbstractPooledByteBufTest extends AbstractByteBufTest {
 
@@ -33,5 +39,24 @@ public abstract class AbstractPooledByteBufTest extends AbstractByteBufTest {
         assertEquals(0, buffer.writerIndex());
         assertEquals(0, buffer.readerIndex());
         return buffer;
+    }
+
+    @Test
+    public void ensureWritableWithEnoughSpaceShouldNotThrow() {
+        ByteBuf buf = newBuffer(1, 10);
+        buf.ensureWritable(3);
+        assertThat(buf.writableBytes(), is(greaterThanOrEqualTo(3)));
+        buf.release();
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void ensureWritableWithNotEnoughSpaceShouldThrow() {
+        ByteBuf buf = newBuffer(1, 10);
+        try {
+            buf.ensureWritable(11);
+            fail();
+        } finally {
+            buf.release();
+        }
     }
 }

--- a/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/SlicedByteBufTest.java
@@ -22,7 +22,10 @@ import org.junit.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests sliced channel buffers
@@ -226,5 +229,34 @@ public class SlicedByteBufTest extends AbstractByteBufTest {
     @Override
     public void testWriteUtf16CharSequenceExpand() {
         super.testWriteUtf16CharSequenceExpand();
+    }
+
+    @Test
+    public void ensureWritableWithEnoughSpaceShouldNotThrow() {
+        ByteBuf slice = newBuffer(10);
+        ByteBuf unwrapped = slice.unwrap();
+        slice.unwrap().writerIndex(unwrapped.writerIndex() + 5);
+        slice.writerIndex(slice.readerIndex());
+
+        // Run ensureWritable and verify this doesn't change any indexes.
+        int originalWriterIndex = slice.writerIndex();
+        int originalReadableBytes = slice.readableBytes();
+        slice.ensureWritable(originalWriterIndex - slice.writerIndex());
+        assertEquals(originalWriterIndex, slice.writerIndex());
+        assertEquals(originalReadableBytes, slice.readableBytes());
+        slice.release();
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void ensureWritableWithNotEnoughSpaceShouldThrow() {
+        ByteBuf slice = newBuffer(10);
+        ByteBuf unwrapped = slice.unwrap();
+        slice.unwrap().writerIndex(unwrapped.writerIndex() + 5);
+        try {
+            slice.ensureWritable(1);
+            fail();
+        } finally {
+            slice.release();
+        }
     }
 }


### PR DESCRIPTION
…nt,boolean)

Motivation:
ByteBuf#ensureWritable(int,boolean) returns an int indicating the status of the resize operation. For buffers that are unmodifiable or cannot be resized this method shouldn't throw but just return 1.
ByteBuf#ensureWriteable(int) should throw unmodifiable buffers.

Modifications:
- ReadOnlyByteBuf should be updated as described above.
- Add a unit test to SslHandler which verifies the read only buffer can be tolerated in the aggregation algorithm.

Result:
Fixes https://github.com/netty/netty/issues/7002.