### PR TITLE
change default max message size in MqttDecoder

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -39,7 +39,7 @@ import static io.netty.handler.codec.mqtt.MqttCodecUtil.validateFixedHeader;
  */
 public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
 
-    private static final int DEFAULT_MAX_BYTES_IN_MESSAGE = 8092;
+    private static final int DEFAULT_MAX_BYTES_IN_MESSAGE = 268435455;
 
     /**
      * States of the decoder.


### PR DESCRIPTION
### Motivation:
I think that default max message size in MqttDecoder should be equal to the maximum suggested by the protocol.

### Modification:
changed default max message size in MqttDecoder from 8 092 to 268 435 455.

Result:

Fixes #7012
