### PR TITLE
Epoll and KQueue to use static initializers

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoopGroup.java
@@ -33,8 +33,8 @@ import java.util.concurrent.ThreadFactory;
  * it only works on linux.
  */
 public final class EpollEventLoopGroup extends MultithreadEventLoopGroup {
-    {
-        // Ensure JNI is initialized by the time this class is loaded.
+    static {
+        // Ensure JNI is initialized by the time this class is loaded by this time!
         Epoll.ensureAvailability();
     }
 

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoopGroup.java
@@ -30,10 +30,11 @@ import java.util.concurrent.ThreadFactory;
 
 @UnstableApi
 public final class KQueueEventLoopGroup extends MultithreadEventLoopGroup {
-    {
+    static {
         // Ensure JNI is initialized by the time this class is loaded by this time!
         KQueue.ensureAvailability();
     }
+
     /**
      * Create a new instance using the default number of threads and the default {@link ThreadFactory}.
      */


### PR DESCRIPTION
Motivation:
Epoll and KQueue transports use an instance initializer instead of a static initializer to ensure the JNI libraries are loaded before use. However the availability of the JNI libraries will not change after class load time so static initializers should be sufficient.

Modifications:
- Change the instance initializer to a static initializer for Epoll and KQueue initialization in their respective EventLoops

Result:
Less initialization required at instance creation time.