### PR TITLE
Http2FrameLogger avoid hex dump of the ByteBufs when log disabled

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
@@ -61,109 +61,81 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
 
     public void logData(Direction direction, ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
             boolean endStream) {
-        if (isEnable()) {
-            logger.log(level, "{} {} PRIORITY: streamId={} padding={} endStream={} length={} bytes={}",
-                    ctx.channel(), direction.name(), streamId, padding, endStream, data.readableBytes(),
-                    toString(data));
-        }
+        logger.log(level, "{} {} PRIORITY: streamId={} padding={} endStream={} length={} bytes={}", ctx.channel(),
+                direction.name(), streamId, padding, endStream, data.readableBytes(), toString(data));
     }
 
     public void logHeaders(Direction direction, ChannelHandlerContext ctx, int streamId, Http2Headers headers,
             int padding, boolean endStream) {
-        if (isEnable()) {
-            logger.log(level, "{} {} PRIORITY: streamId={} headers={} padding={} endStream={}", ctx.channel(),
-                    direction.name(), streamId, headers, padding, endStream);
-        }
+        logger.log(level, "{} {} PRIORITY: streamId={} headers={} padding={} endStream={}", ctx.channel(),
+                direction.name(), streamId, headers, padding, endStream);
     }
 
     public void logHeaders(Direction direction, ChannelHandlerContext ctx, int streamId, Http2Headers headers,
             int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) {
-        if (isEnable()) {
-            logger.log(level, "{} {} PRIORITY: streamId={} headers={} streamDependency={} weight={} " +
-                            "exclusive={} padding={} endStream={}", ctx.channel(),
-                    direction.name(), streamId, headers, streamDependency, weight, exclusive, padding, endStream);
-        }
+        logger.log(level, "{} {} PRIORITY: streamId={} headers={} streamDependency={} weight={} exclusive={} " +
+                        "padding={} endStream={}", ctx.channel(),
+                direction.name(), streamId, headers, streamDependency, weight, exclusive, padding, endStream);
     }
 
     public void logPriority(Direction direction, ChannelHandlerContext ctx, int streamId, int streamDependency,
             short weight, boolean exclusive) {
-        if (isEnable()) {
-            logger.log(level, "{} {} PRIORITY: streamId={} streamDependency={} weight={} exclusive={}",
-                    ctx.channel(), direction.name(), streamId, streamDependency, weight, exclusive);
-        }
+        logger.log(level, "{} {} PRIORITY: streamId={} streamDependency={} weight={} exclusive={}", ctx.channel(),
+                direction.name(), streamId, streamDependency, weight, exclusive);
     }
 
     public void logRstStream(Direction direction, ChannelHandlerContext ctx, int streamId, long errorCode) {
-        if (isEnable()) {
-            logger.log(level, "{} {} RST_STREAM: streamId={} errorCode={}", ctx.channel(),
-                    direction.name(), streamId, errorCode);
-        }
+        logger.log(level, "{} {} RST_STREAM: streamId={} errorCode={}", ctx.channel(),
+                direction.name(), streamId, errorCode);
     }
 
     public void logSettingsAck(Direction direction, ChannelHandlerContext ctx) {
-        if (isEnable()) {
-            logger.log(level, "{} {} SETTINGS: ack=true", ctx.channel(), direction.name());
-        }
+        logger.log(level, "{} {} SETTINGS: ack=true", ctx.channel(), direction.name());
     }
 
     public void logSettings(Direction direction, ChannelHandlerContext ctx, Http2Settings settings) {
-        if (isEnable()) {
-            logger.log(level, "{} {} SETTINGS: ack=false settings={}", ctx.channel(), direction.name(), settings);
-        }
+        logger.log(level, "{} {} SETTINGS: ack=false settings={}", ctx.channel(), direction.name(), settings);
     }
 
     public void logPing(Direction direction, ChannelHandlerContext ctx, ByteBuf data) {
-        if (isEnable()) {
-            logger.log(level, "{} {} PING: ack=false length={} bytes={}", ctx.channel(),
-                    direction.name(), data.readableBytes(), toString(data));
-        }
+        logger.log(level, "{} {} PING: ack=false length={} bytes={}", ctx.channel(),
+                direction.name(), data.readableBytes(), toString(data));
     }
 
     public void logPingAck(Direction direction, ChannelHandlerContext ctx, ByteBuf data) {
-        if (isEnable()) {
-            logger.log(level, "{} {} PING: ack=true length={} bytes={}", ctx.channel(),
-                    direction.name(), data.readableBytes(), toString(data));
-        }
+        logger.log(level, "{} {} PING: ack=true length={} bytes={}", ctx.channel(),
+                direction.name(), data.readableBytes(), toString(data));
     }
 
     public void logPushPromise(Direction direction, ChannelHandlerContext ctx, int streamId, int promisedStreamId,
             Http2Headers headers, int padding) {
-        if (isEnable()) {
-            logger.log(level, "{} {} PUSH_PROMISE: streamId={} promisedStreamId={} headers={} padding={}",
-                    ctx.channel(), direction.name(), streamId, promisedStreamId, headers, padding);
-        }
+        logger.log(level, "{} {} PUSH_PROMISE: streamId={} promisedStreamId={} headers={} padding={}", ctx.channel(),
+                direction.name(), streamId, promisedStreamId, headers, padding);
     }
 
     public void logGoAway(Direction direction, ChannelHandlerContext ctx, int lastStreamId, long errorCode,
             ByteBuf debugData) {
-        if (isEnable()) {
-            logger.log(level, "{} {} GO_AWAY: lastStreamId={} errorCode={} length={} bytes={}", ctx.channel(),
-                    direction.name(), lastStreamId, errorCode, debugData.readableBytes(), toString(debugData));
-        }
+        logger.log(level, "{} {} GO_AWAY: lastStreamId={} errorCode={} length={} bytes={}", ctx.channel(),
+                direction.name(), lastStreamId, errorCode, debugData.readableBytes(), toString(debugData));
     }
 
     public void logWindowsUpdate(Direction direction, ChannelHandlerContext ctx, int streamId,
             int windowSizeIncrement) {
-        if (isEnable()) {
-            logger.log(level, "{} {} WINDOW_UPDATE: streamId={} windowSizeIncrement={}", ctx.channel(),
-                    direction.name(), streamId, windowSizeIncrement);
-        }
+        logger.log(level, "{} {} WINDOW_UPDATE: streamId={} windowSizeIncrement={}", ctx.channel(),
+                direction.name(), streamId, windowSizeIncrement);
     }
 
     public void logUnknownFrame(Direction direction, ChannelHandlerContext ctx, byte frameType, int streamId,
             Http2Flags flags, ByteBuf data) {
-        if (isEnable()) {
-            logger.log(level, "{} {} UNKNOWN: frameType={} streamId={} flags={} length={} bytes={}",
-                    ctx.channel(), direction.name(), frameType & 0xFF, streamId, flags.value(),
-                    data.readableBytes(), toString(data));
-        }
-    }
-
-    private boolean isEnable() {
-        return logger.isEnabled(level);
+        logger.log(level, "{} {} UNKNOWN: frameType={} streamId={} flags={} length={} bytes={}", ctx.channel(),
+                direction.name(), frameType & 0xFF, streamId, flags.value(), data.readableBytes(), toString(data));
     }
 
     private String toString(ByteBuf buf) {
+        if (!logger.isEnabled(level)) {
+            return "";
+        }
+
         if (level == InternalLogLevel.TRACE || buf.readableBytes() <= BUFFER_LENGTH_THRESHOLD) {
             // Log the entire buffer.
             return ByteBufUtil.hexDump(buf);

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
@@ -61,74 +61,104 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
 
     public void logData(Direction direction, ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
             boolean endStream) {
-        logger.log(level, "{} {} PRIORITY: streamId={} padding={} endStream={} length={} bytes={}", ctx.channel(),
-                direction.name(), streamId, padding, endStream, data.readableBytes(), toString(data));
+        if (isEnable()) {
+            logger.log(level, "{} {} PRIORITY: streamId={} padding={} endStream={} length={} bytes={}", ctx.channel(),
+                    direction.name(), streamId, padding, endStream, data.readableBytes(), toString(data));
+        }
     }
 
     public void logHeaders(Direction direction, ChannelHandlerContext ctx, int streamId, Http2Headers headers,
             int padding, boolean endStream) {
-        logger.log(level, "{} {} PRIORITY: streamId={} headers={} padding={} endStream={}", ctx.channel(),
-                direction.name(), streamId, headers, padding, endStream);
+        if (isEnable()) {
+            logger.log(level, "{} {} PRIORITY: streamId={} headers={} padding={} endStream={}", ctx.channel(),
+                    direction.name(), streamId, headers, padding, endStream);
+        }
     }
 
     public void logHeaders(Direction direction, ChannelHandlerContext ctx, int streamId, Http2Headers headers,
             int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) {
-        logger.log(level, "{} {} PRIORITY: streamId={} headers={} streamDependency={} weight={} exclusive={} " +
-                        "padding={} endStream={}", ctx.channel(),
-                direction.name(), streamId, headers, streamDependency, weight, exclusive, padding, endStream);
+        if (isEnable()) {
+            logger.log(level, "{} {} PRIORITY: streamId={} headers={} streamDependency={} weight={} exclusive={} " +
+                            "padding={} endStream={}", ctx.channel(),
+                    direction.name(), streamId, headers, streamDependency, weight, exclusive, padding, endStream);
+        }
     }
 
     public void logPriority(Direction direction, ChannelHandlerContext ctx, int streamId, int streamDependency,
             short weight, boolean exclusive) {
-        logger.log(level, "{} {} PRIORITY: streamId={} streamDependency={} weight={} exclusive={}", ctx.channel(),
-                direction.name(), streamId, streamDependency, weight, exclusive);
+        if (isEnable()) {
+            logger.log(level, "{} {} PRIORITY: streamId={} streamDependency={} weight={} exclusive={}", ctx.channel(),
+                    direction.name(), streamId, streamDependency, weight, exclusive);
+        }
     }
 
     public void logRstStream(Direction direction, ChannelHandlerContext ctx, int streamId, long errorCode) {
-        logger.log(level, "{} {} RST_STREAM: streamId={} errorCode={}", ctx.channel(),
-                direction.name(), streamId, errorCode);
+        if (isEnable()) {
+            logger.log(level, "{} {} RST_STREAM: streamId={} errorCode={}", ctx.channel(),
+                    direction.name(), streamId, errorCode);
+        }
     }
 
     public void logSettingsAck(Direction direction, ChannelHandlerContext ctx) {
-        logger.log(level, "{} {} SETTINGS: ack=true", ctx.channel(), direction.name());
+        if (isEnable()) {
+            logger.log(level, "{} {} SETTINGS: ack=true", ctx.channel(), direction.name());
+        }
     }
 
     public void logSettings(Direction direction, ChannelHandlerContext ctx, Http2Settings settings) {
-        logger.log(level, "{} {} SETTINGS: ack=false settings={}", ctx.channel(), direction.name(), settings);
+        if (isEnable()) {
+            logger.log(level, "{} {} SETTINGS: ack=false settings={}", ctx.channel(), direction.name(), settings);
+        }
     }
 
     public void logPing(Direction direction, ChannelHandlerContext ctx, ByteBuf data) {
-        logger.log(level, "{} {} PING: ack=false length={} bytes={}", ctx.channel(),
-                direction.name(), data.readableBytes(), toString(data));
+        if (isEnable()) {
+            logger.log(level, "{} {} PING: ack=false length={} bytes={}", ctx.channel(),
+                    direction.name(), data.readableBytes(), toString(data));
+        }
     }
 
     public void logPingAck(Direction direction, ChannelHandlerContext ctx, ByteBuf data) {
-        logger.log(level, "{} {} PING: ack=true length={} bytes={}", ctx.channel(),
-                direction.name(), data.readableBytes(), toString(data));
+        if (isEnable()) {
+            logger.log(level, "{} {} PING: ack=true length={} bytes={}", ctx.channel(),
+                    direction.name(), data.readableBytes(), toString(data));
+        }
     }
 
     public void logPushPromise(Direction direction, ChannelHandlerContext ctx, int streamId, int promisedStreamId,
             Http2Headers headers, int padding) {
-        logger.log(level, "{} {} PUSH_PROMISE: streamId={} promisedStreamId={} headers={} padding={}", ctx.channel(),
-                direction.name(), streamId, promisedStreamId, headers, padding);
+        if (isEnable()) {
+            logger.log(level, "{} {} PUSH_PROMISE: streamId={} promisedStreamId={} headers={} padding={}", ctx.channel(),
+                    direction.name(), streamId, promisedStreamId, headers, padding);
+        }
     }
 
     public void logGoAway(Direction direction, ChannelHandlerContext ctx, int lastStreamId, long errorCode,
             ByteBuf debugData) {
-        logger.log(level, "{} {} GO_AWAY: lastStreamId={} errorCode={} length={} bytes={}", ctx.channel(),
-                direction.name(), lastStreamId, errorCode, debugData.readableBytes(), toString(debugData));
+        if (isEnable()) {
+            logger.log(level, "{} {} GO_AWAY: lastStreamId={} errorCode={} length={} bytes={}", ctx.channel(),
+                    direction.name(), lastStreamId, errorCode, debugData.readableBytes(), toString(debugData));
+        }
     }
 
     public void logWindowsUpdate(Direction direction, ChannelHandlerContext ctx, int streamId,
             int windowSizeIncrement) {
-        logger.log(level, "{} {} WINDOW_UPDATE: streamId={} windowSizeIncrement={}", ctx.channel(),
-                direction.name(), streamId, windowSizeIncrement);
+        if (isEnable()) {
+            logger.log(level, "{} {} WINDOW_UPDATE: streamId={} windowSizeIncrement={}", ctx.channel(),
+                    direction.name(), streamId, windowSizeIncrement);
+        }
     }
 
     public void logUnknownFrame(Direction direction, ChannelHandlerContext ctx, byte frameType, int streamId,
             Http2Flags flags, ByteBuf data) {
-        logger.log(level, "{} {} UNKNOWN: frameType={} streamId={} flags={} length={} bytes={}", ctx.channel(),
-                direction.name(), frameType & 0xFF, streamId, flags.value(), data.readableBytes(), toString(data));
+        if (isEnable()) {
+            logger.log(level, "{} {} UNKNOWN: frameType={} streamId={} flags={} length={} bytes={}", ctx.channel(),
+                    direction.name(), frameType & 0xFF, streamId, flags.value(), data.readableBytes(), toString(data));
+        }
+    }
+
+    private boolean isEnable() {
+        return logger.isEnabled(level);
     }
 
     private String toString(ByteBuf buf) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
@@ -62,8 +62,9 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
     public void logData(Direction direction, ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
             boolean endStream) {
         if (isEnable()) {
-            logger.log(level, "{} {} PRIORITY: streamId={} padding={} endStream={} length={} bytes={}", ctx.channel(),
-                    direction.name(), streamId, padding, endStream, data.readableBytes(), toString(data));
+            logger.log(level, "{} {} PRIORITY: streamId={} padding={} endStream={} length={} bytes={}",
+                    ctx.channel(), direction.name(), streamId, padding, endStream, data.readableBytes(),
+                    toString(data));
         }
     }
 
@@ -78,8 +79,8 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
     public void logHeaders(Direction direction, ChannelHandlerContext ctx, int streamId, Http2Headers headers,
             int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) {
         if (isEnable()) {
-            logger.log(level, "{} {} PRIORITY: streamId={} headers={} streamDependency={} weight={} exclusive={} " +
-                            "padding={} endStream={}", ctx.channel(),
+            logger.log(level, "{} {} PRIORITY: streamId={} headers={} streamDependency={} weight={} " +
+                            "exclusive={} padding={} endStream={}", ctx.channel(),
                     direction.name(), streamId, headers, streamDependency, weight, exclusive, padding, endStream);
         }
     }
@@ -87,8 +88,8 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
     public void logPriority(Direction direction, ChannelHandlerContext ctx, int streamId, int streamDependency,
             short weight, boolean exclusive) {
         if (isEnable()) {
-            logger.log(level, "{} {} PRIORITY: streamId={} streamDependency={} weight={} exclusive={}", ctx.channel(),
-                    direction.name(), streamId, streamDependency, weight, exclusive);
+            logger.log(level, "{} {} PRIORITY: streamId={} streamDependency={} weight={} exclusive={}",
+                    ctx.channel(), direction.name(), streamId, streamDependency, weight, exclusive);
         }
     }
 
@@ -128,8 +129,8 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
     public void logPushPromise(Direction direction, ChannelHandlerContext ctx, int streamId, int promisedStreamId,
             Http2Headers headers, int padding) {
         if (isEnable()) {
-            logger.log(level, "{} {} PUSH_PROMISE: streamId={} promisedStreamId={} headers={} padding={}", ctx.channel(),
-                    direction.name(), streamId, promisedStreamId, headers, padding);
+            logger.log(level, "{} {} PUSH_PROMISE: streamId={} promisedStreamId={} headers={} padding={}",
+                    ctx.channel(), direction.name(), streamId, promisedStreamId, headers, padding);
         }
     }
 
@@ -152,8 +153,9 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
     public void logUnknownFrame(Direction direction, ChannelHandlerContext ctx, byte frameType, int streamId,
             Http2Flags flags, ByteBuf data) {
         if (isEnable()) {
-            logger.log(level, "{} {} UNKNOWN: frameType={} streamId={} flags={} length={} bytes={}", ctx.channel(),
-                    direction.name(), frameType & 0xFF, streamId, flags.value(), data.readableBytes(), toString(data));
+            logger.log(level, "{} {} UNKNOWN: frameType={} streamId={} flags={} length={} bytes={}",
+                    ctx.channel(), direction.name(), frameType & 0xFF, streamId, flags.value(),
+                    data.readableBytes(), toString(data));
         }
     }
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
@@ -20,6 +20,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.logging.LogLevel;
+import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogLevel;
 import io.netty.util.internal.logging.InternalLogger;
@@ -133,7 +134,7 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
 
     private String toString(ByteBuf buf) {
         if (!logger.isEnabled(level)) {
-            return "";
+            return StringUtil.EMPTY_STRING;
         }
 
         if (level == InternalLogLevel.TRACE || buf.readableBytes() <= BUFFER_LENGTH_THRESHOLD) {


### PR DESCRIPTION
Currentry logger create hex dump even if log write will not apply.
It's unecessary GC overhead. Restore optiomization from #3492

Close #7025
