### PR TITLE
Make DelegatingChannelPromiseNotifier use Vararg overload

### DIFF
--- a/transport/src/main/java/io/netty/channel/DelegatingChannelPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/DelegatingChannelPromiseNotifier.java
@@ -98,7 +98,7 @@ public final class DelegatingChannelPromiseNotifier implements ChannelPromise, C
     }
 
     @Override
-    public ChannelPromise addListeners(GenericFutureListener<? extends Future<? super Void>>[] listeners) {
+    public ChannelPromise addListeners(GenericFutureListener<? extends Future<? super Void>>... listeners) {
         delegate.addListeners(listeners);
         return this;
     }
@@ -110,7 +110,7 @@ public final class DelegatingChannelPromiseNotifier implements ChannelPromise, C
     }
 
     @Override
-    public ChannelPromise removeListeners(GenericFutureListener<? extends Future<? super Void>>[] listeners) {
+    public ChannelPromise removeListeners(GenericFutureListener<? extends Future<? super Void>>... listeners) {
         delegate.removeListeners(listeners);
         return this;
     }

--- a/transport/src/test/java/io/netty/channel/DelegatingChannelPromiseNotifierTest.java
+++ b/transport/src/test/java/io/netty/channel/DelegatingChannelPromiseNotifierTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.*;
+
+public class DelegatingChannelPromiseNotifierTest {
+    @Test
+    public void varargsNotifiersAllowed() {
+        ChannelPromise promise = Mockito.mock(ChannelPromise.class);
+        DelegatingChannelPromiseNotifier promiseNotifier = new DelegatingChannelPromiseNotifier(promise);
+
+        GenericFutureListener<? extends Future<? super Void>> gfl =
+                (GenericFutureListener<? extends Future<? super Void>>) Mockito.mock(GenericFutureListener.class);
+        promiseNotifier.addListeners(gfl);
+        promiseNotifier.removeListeners(gfl);
+
+        Mockito.verify(promise).addListeners(gfl);
+        Mockito.verify(promise).removeListeners(gfl);
+    }
+}


### PR DESCRIPTION
Motivation:
ErrorProne complains that the array override doesn't match the
vararg super call.  See http://errorprone.info/bugpattern/Overrides

Additionally, almost every other Future uses the vararg form, so
it would be stylistically consistent to keep it that way.

Modifications:
Use vararg override.

Result:
Cleaner, less naggy code.


cc: @Scottmitch