### PR TITLE
Use java.util.Base64 for SSL cert / key encoding when running on Java8+

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Java8SslUtils.java
@@ -15,10 +15,17 @@
  */
 package io.netty.handler.ssl;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.base64.Base64;
+import io.netty.handler.codec.base64.Base64Dialect;
+
 import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SNIMatcher;
 import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLParameters;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -83,5 +90,13 @@ final class Java8SslUtils {
             return false;
         }
         return true;
+    }
+
+    static ByteBuf toBase64(ByteBuf src) {
+        ByteBuffer srcBuffer = src.internalNioBuffer(src.readerIndex(), src.readableBytes());
+        int remaining = srcBuffer.remaining();
+        ByteBuffer encodedBuffer = java.util.Base64.getEncoder().encode(srcBuffer);
+        src.skipBytes(remaining - srcBuffer.remaining());
+        return Unpooled.wrappedBuffer(encodedBuffer);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -695,6 +695,8 @@
 
             <ignore>java.util.concurrent.ConcurrentLinkedDeque</ignore>
             <ignore>java.util.concurrent.ThreadLocalRandom</ignore>
+            <ignore>java.util.Base64</ignore>
+            <ignore>java.util.Base64$Encoder</ignore>
 
             <!-- Compression -->
             <ignore>java.util.zip.CRC32</ignore>


### PR DESCRIPTION
Motivation:

We need to encode certs and keys when creating *OpenSsl*Context instances. This is kind of "slow" when using a high leak-detector level and so slow down testing a lot where a lot of these are created and destroyed. We can speed this up by using the java.util.Base64.Encoder when we run on Java8+.

Modifications:

Use java.util.Base64.Encoder when possible.

Result:

Much faster test times when using Java8+. Fixes [#7029].

Before (when running tests in handler module):

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 20:23 min
[INFO] Finished at: 2017-07-28T09:26:57+02:00
[INFO] Final Memory: 48M/1301M
[INFO] ---

After (when running tests in handler module):

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 05:09 min
[INFO] Finished at: 2017-07-28T08:45:14+02:00
[INFO] Final Memory: 38M/820M
[INFO] ------------------------------------------------------------------------
