### PR TITLE
First call channelReadComplete(...) before flush(...) for better perf…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -484,9 +484,10 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         // Trigger flush after read on the assumption that flush is cheap if there is nothing to write and that
         // for flow-control the read may release window that causes data to be written that can now be flushed.
         try {
-            flush(ctx);
-        } finally {
+            // First call channelReadComplete(...) as this may produce more data that we want to flush
             super.channelReadComplete(ctx);
+        } finally {
+            flush(ctx);
         }
     }
 


### PR DESCRIPTION
…ormance

Motivation:

In Http2ConnectionHandler we call flush(...) in channelReadComplete(...) to ensure we update the flow-controller and write stuff to the remote peer. We should better flip the order and so may be able to pick up more bytes.

Modifications:

Change order of calls.

Result:

Better performance