### PR TITLE
Only flush on channelReadComplete(...) in http2 hello world examples.

### DIFF
--- a/example/src/main/java/io/netty/example/http2/helloworld/frame/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/frame/server/HelloWorldHttp2Handler.java
@@ -61,10 +61,15 @@ public class HelloWorldHttp2Handler extends ChannelDuplexHandler {
         }
     }
 
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        ctx.flush();
+    }
+
     /**
      * If receive a frame with end-of-stream set, send a pre-canned response.
      */
-    public void onDataRead(ChannelHandlerContext ctx, Http2DataFrame data) throws Exception {
+    private static void onDataRead(ChannelHandlerContext ctx, Http2DataFrame data) throws Exception {
         int consumed = data.padding() + data.content().readableBytes();
         int streamId = data.streamId();
 
@@ -82,7 +87,7 @@ public class HelloWorldHttp2Handler extends ChannelDuplexHandler {
     /**
      * If receive a frame with end-of-stream set, send a pre-canned response.
      */
-    public void onHeadersRead(ChannelHandlerContext ctx, Http2HeadersFrame headers)
+    private static void onHeadersRead(ChannelHandlerContext ctx, Http2HeadersFrame headers)
             throws Exception {
         if (headers.isEndStream()) {
             ByteBuf content = ctx.alloc().buffer();
@@ -99,6 +104,6 @@ public class HelloWorldHttp2Handler extends ChannelDuplexHandler {
         // Send a frame for the response status
         Http2Headers headers = new DefaultHttp2Headers().status(OK.codeAsText());
         ctx.write(new DefaultHttp2HeadersFrame(headers).streamId(streamId));
-        ctx.writeAndFlush(new DefaultHttp2DataFrame(payload, true).streamId(streamId));
+        ctx.write(new DefaultHttp2DataFrame(payload, true).streamId(streamId));
     }
 }

--- a/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/multiplex/server/HelloWorldHttp2Handler.java
@@ -60,10 +60,15 @@ public class HelloWorldHttp2Handler extends ChannelDuplexHandler {
         }
     }
 
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        ctx.flush();
+    }
+
     /**
      * If receive a frame with end-of-stream set, send a pre-canned response.
      */
-    public void onDataRead(ChannelHandlerContext ctx, Http2DataFrame data) throws Exception {
+    private static void onDataRead(ChannelHandlerContext ctx, Http2DataFrame data) throws Exception {
         if (data.isEndStream()) {
             sendResponse(ctx, data.content());
         } else {
@@ -75,7 +80,7 @@ public class HelloWorldHttp2Handler extends ChannelDuplexHandler {
     /**
      * If receive a frame with end-of-stream set, send a pre-canned response.
      */
-    public void onHeadersRead(ChannelHandlerContext ctx, Http2HeadersFrame headers)
+    private static void onHeadersRead(ChannelHandlerContext ctx, Http2HeadersFrame headers)
             throws Exception {
         if (headers.isEndStream()) {
             ByteBuf content = ctx.alloc().buffer();
@@ -92,6 +97,6 @@ public class HelloWorldHttp2Handler extends ChannelDuplexHandler {
         // Send a frame for the response status
         Http2Headers headers = new DefaultHttp2Headers().status(OK.codeAsText());
         ctx.write(new DefaultHttp2HeadersFrame(headers));
-        ctx.writeAndFlush(new DefaultHttp2DataFrame(payload, true));
+        ctx.write(new DefaultHttp2DataFrame(payload, true));
     }
 }

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp1Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp1Handler.java
@@ -60,11 +60,16 @@ public class HelloWorldHttp1Handler extends SimpleChannelInboundHandler<FullHttp
         response.headers().setInt(CONTENT_LENGTH, response.content().readableBytes());
 
         if (!keepAlive) {
-            ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+            ctx.write(response).addListener(ChannelFutureListener.CLOSE);
         } else {
             response.headers().set(CONNECTION, HttpHeaderValues.KEEP_ALIVE);
-            ctx.writeAndFlush(response);
+            ctx.write(response);
         }
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+        ctx.flush();
     }
 
     @Override

--- a/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp2Handler.java
+++ b/example/src/main/java/io/netty/example/http2/helloworld/server/HelloWorldHttp2Handler.java
@@ -90,11 +90,8 @@ public final class HelloWorldHttp2Handler extends Http2ConnectionHandler impleme
         Http2Headers headers = new DefaultHttp2Headers().status(OK.codeAsText());
         encoder().writeHeaders(ctx, streamId, headers, 0, false, ctx.newPromise());
         encoder().writeData(ctx, streamId, payload, 0, true, ctx.newPromise());
-        try {
-            flush(ctx);
-        } catch (Throwable cause) {
-            onError(ctx, cause);
-        }
+
+        // no need to call flush as channelReadComplete(...) will take care of it.
     }
 
     @Override


### PR DESCRIPTION
Motivation:

In our http1 hello world example we only flush on channelReadComplete(...) to make better use of gathering writes. We should do the same in http2.

Modifications:

Only flush in channelReadComplete(...)

Result:

Better performance and more consistent examples.
