### PR TITLE
Use addAfter in Http2Codec.handlerAdded(....) to ensure we not end up…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Codec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Codec.java
@@ -40,8 +40,11 @@ public final class Http2Codec extends ChannelDuplexHandler {
 
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-        ctx.pipeline().addBefore(ctx.executor(), ctx.name(), null, frameCodec);
-        ctx.pipeline().addBefore(ctx.executor(), ctx.name(), null, multiplexCodec);
+        // We use addAfter(...) because if we would use addBefore(...) we could end up with an incorrect
+        // order of handlers in the pipeline when replace(...) is used with the Http2Codec.
+        // See https://github.com/netty/netty/issues/6881.
+        ctx.pipeline().addAfter(ctx.executor(), ctx.name(), null, multiplexCodec);
+        ctx.pipeline().addAfter(ctx.executor(), ctx.name(), null, frameCodec);
 
         ctx.pipeline().remove(this);
     }


### PR DESCRIPTION
… with incorrect handler order

Motivation:

When pipeline.replace(...) is used with the Http2Codec we will end up with an incorrect pipeline view for the handler that was replaced because the Http2Codec will add handler in front of itselv but the handler that will be replaced thinks that the Http2Codec is the handler that will be "next" in the pipeline.

Modifications:

- Use addAfter(...) in Http2Codec.handlerAdded(....) and so ensure correct ordering.
- Port tests written by @chhsiao90 in [#6952] to verify the fix.

Result:

Fixes [#6881]


If there is no issue then describe the changes introduced by this PR.
