### PR TITLE
Unify KQueue and Epoll wait timeout approach

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -97,9 +97,15 @@ public final class Native {
         return new FileDescriptor(eventFd());
     }
 
+    public static FileDescriptor newTimerFd() {
+        return new FileDescriptor(timerFd());
+    }
+
     private static native int eventFd();
+    private static native int timerFd();
     public static native void eventFdWrite(int fd, long value);
     public static native void eventFdRead(int fd);
+    static native void timerFdRead(int fd);
 
     public static FileDescriptor newEpollCreate() {
         return new FileDescriptor(epollCreate());
@@ -107,14 +113,16 @@ public final class Native {
 
     private static native int epollCreate();
 
-    public static int epollWait(int efd, EpollEventArray events, int timeout) throws IOException {
-        int ready = epollWait0(efd, events.memoryAddress(), events.length(), timeout);
+    public static int epollWait(FileDescriptor epollFd, EpollEventArray events, FileDescriptor timerFd,
+                                int timeoutSec, int timeoutNs) throws IOException {
+        int ready = epollWait0(epollFd.intValue(), events.memoryAddress(), events.length(), timerFd.intValue(),
+                               timeoutSec, timeoutNs);
         if (ready < 0) {
             throw newIOException("epoll_wait", ready);
         }
         return ready;
     }
-    private static native int epollWait0(int efd, long address, int len, int timeout);
+    private static native int epollWait0(int efd, long address, int len, int timerFd, int timeoutSec, int timeoutNs);
 
     public static void epollCtlAdd(int efd, final int fd, final int flags) throws IOException {
         int res = epollCtlAdd0(efd, fd, flags);

--- a/transport-native-kqueue/src/main/c/netty_kqueue_native.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_native.c
@@ -80,11 +80,10 @@ static jint netty_kqueue_native_keventWait(JNIEnv* env, jclass clazz, jint kqueu
     timeoutTs.tv_sec = tvSec;
     timeoutTs.tv_nsec = tvNsec;
 
-    // Negatives = wait indefinitely, Zeros = poll (aka return immediately).
-    if ((tvSec == 0 && tvNsec == 0) || tvSec < 0 || tvNsec < 0) {
-        const struct timespec* fixedTs = (tvSec == 0 && tvNsec == 0) ? &timeoutTs : NULL;
+    if (tvSec == 0 && tvNsec == 0) {
+        // Zeros = poll (aka return immediately).
         for (;;) {
-            result = kevent(kqueueFd, changeList, changeListLength, eventList, eventListLength, fixedTs);
+            result = kevent(kqueueFd, changeList, changeListLength, eventList, eventListLength, &timeoutTs);
             if (result >= 0) {
                 return result;
             }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
@@ -133,12 +133,9 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
     }
 
     private int kqueueWait(boolean oldWakeup) throws IOException {
-        // TODO(scott): do we need to loop here ... we already loop in keventWait to ensure we wait the expected time.
-        // We also do the same thing in EPOLL ... do we need to loop there?
-
         // If a task was submitted when wakenUp value was 1, the task didn't get a chance to produce wakeup event.
-        // So we need to check task queue again before calling epoll_wait. If we don't, the task might be pended
-        // until epoll_wait was timed out. It might be pended until idle timeout if IdleStateHandler existed
+        // So we need to check task queue again before calling kqueueWait. If we don't, the task might be pended
+        // until kqueueWait was timed out. It might be pended until idle timeout if IdleStateHandler existed
         // in pipeline.
         if (oldWakeup && hasTasks()) {
             return kqueueWaitNow();


### PR DESCRIPTION
Motivation:
KQueueEventLoop and EpollEventLoop implement different approaches to applying a timeout of their respective poll calls. Epoll attempts to ensure the desired timeout is satisfied at the java layer and at the JNI layer, but it should be sufficient to account for spurious wakups at the JNI layer. Epoll timeout granularity is also limited to milliseconds which may be too large for some latency sensitive applications.

Modifications:
- Make EpollEventLoop wait method look like KQueueEventLoop
- Epoll should support a finer timeout granularity via timerfd_create. We can hide most of these details behind the epollWait0 JNI call to avoid crossing additional JNI boundaries.

Result:
More consistent timeout approach between KQueue and Epoll.