### PR TITLE
Handle partially decoded elements while streaming Json array

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/json/JsonObjectDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/json/JsonObjectDecoder.java
@@ -92,6 +92,10 @@ public class JsonObjectDecoder extends ByteToMessageDecoder {
 
         if (this.idx > in.readerIndex() && lastReaderIndex != in.readerIndex()) {
             this.idx = in.readerIndex();
+            if (state == ST_DECODING_ARRAY_STREAM) {
+                insideString = false;
+                openBraces = 1;
+            }
         }
 
         // index of next byte to process.


### PR DESCRIPTION
Motivation:

`insideString` and `openBraces` need a proper handling when streaming
Json array over multiple writes and an element decoding was started but
not completed.
Related to #6969

Modifications:

If the `idx` is reset:
- `insideString` has to be reset to `false` in order to indicate that
  array element will be decoded from the beginning
- `openBraces` has to be reset to `1` to indicate that Json array
  decoding is in progress.

Result:
Json array is properly decoded when in streaming mode
