### PR TITLE
Fix incorrect javadocs in Http2RemoteFlowController

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2RemoteFlowController.java
@@ -67,11 +67,12 @@ public interface Http2RemoteFlowController extends Http2FlowController {
     /**
      * Determine if the {@code stream} has bytes remaining for use in the flow control window.
      * <p>
-     * Note that this only takes into account HTTP/2 flow control. It does <strong>not</strong> take into account
-     * the underlying {@link io.netty.channel.Channel#isWritable()}.
+     * Note that this method respects channel writability. The channel must be writable for this method to
+     * return {@code true}.
+     *
      * @param stream The stream to test.
-     * @return {@code true} if if the {@code stream} has bytes remaining for use in the flow control window.
-     * {@code false} otherwise.
+     * @return {@code true} if the {@code stream} has bytes remaining for use in the flow control window and the
+     * channel is writable, {@code false} otherwise.
      */
     boolean isWritable(Http2Stream stream);
 


### PR DESCRIPTION
Motivation:

The javadocs of Http2RemoteFlowController.isWritable(...) are incorrect.

Modifications:

Update javadocs to reflect reality.

Result:

Correct javadocs.