### PR TITLE
Add testcases to prove HttpResponseEncoder correctly handles empty co…

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpResponseEncoderTest.java
@@ -150,4 +150,49 @@ public class HttpResponseEncoderTest {
 
         assertFalse(channel.finish());
     }
+
+    @Test
+    public void testEmptyContentChunked() throws Exception {
+        testEmptyContent(true);
+    }
+
+    @Test
+    public void testEmptyContentNotChunked() throws Exception {
+        testEmptyContent(false);
+    }
+
+    private static void testEmptyContent(boolean chunked) throws Exception {
+        String content = "netty rocks";
+        ByteBuf contentBuffer = Unpooled.copiedBuffer(content, CharsetUtil.US_ASCII);
+        int length = contentBuffer.readableBytes();
+
+        EmbeddedChannel channel = new EmbeddedChannel(new HttpResponseEncoder());
+        HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        if (!chunked) {
+            HttpUtil.setContentLength(response, length);
+        }
+        assertTrue(channel.writeOutbound(response));
+        assertTrue(channel.writeOutbound(new DefaultHttpContent(Unpooled.EMPTY_BUFFER)));
+        assertTrue(channel.writeOutbound(new DefaultLastHttpContent(contentBuffer)));
+
+        ByteBuf buffer = channel.readOutbound();
+        if (!chunked) {
+            assertEquals("HTTP/1.1 200 OK\r\ncontent-length: " + length + "\r\n\r\n",
+                    buffer.toString(CharsetUtil.US_ASCII));
+        } else {
+            assertEquals("HTTP/1.1 200 OK\r\n\r\n", buffer.toString(CharsetUtil.US_ASCII));
+        }
+        buffer.release();
+
+        // Test writing an empty buffer works when the encoder is not at ST_INIT.
+        buffer = channel.readOutbound();
+        assertEquals(0, buffer.readableBytes());
+        buffer.release();
+
+        buffer = channel.readOutbound();
+        assertEquals(length, buffer.readableBytes());
+        buffer.release();
+
+        assertFalse(channel.finish());
+    }
 }


### PR DESCRIPTION
…ntent

Motivation:

Issue #6695 states that there is an issue when writing empty content via HttpResponseEncoder.

Modifications:

Add two test-cases.

Result:

Verified that all works as expected.