### PR TITLE
Http2FrameLogger frame labels incorrect

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameLogger.java
@@ -62,19 +62,19 @@ public class Http2FrameLogger extends ChannelHandlerAdapter {
 
     public void logData(Direction direction, ChannelHandlerContext ctx, int streamId, ByteBuf data, int padding,
             boolean endStream) {
-        logger.log(level, "{} {} PRIORITY: streamId={} padding={} endStream={} length={} bytes={}", ctx.channel(),
+        logger.log(level, "{} {} DATA: streamId={} padding={} endStream={} length={} bytes={}", ctx.channel(),
                 direction.name(), streamId, padding, endStream, data.readableBytes(), toString(data));
     }
 
     public void logHeaders(Direction direction, ChannelHandlerContext ctx, int streamId, Http2Headers headers,
             int padding, boolean endStream) {
-        logger.log(level, "{} {} PRIORITY: streamId={} headers={} padding={} endStream={}", ctx.channel(),
+        logger.log(level, "{} {} HEADERS: streamId={} headers={} padding={} endStream={}", ctx.channel(),
                 direction.name(), streamId, headers, padding, endStream);
     }
 
     public void logHeaders(Direction direction, ChannelHandlerContext ctx, int streamId, Http2Headers headers,
             int streamDependency, short weight, boolean exclusive, int padding, boolean endStream) {
-        logger.log(level, "{} {} PRIORITY: streamId={} headers={} streamDependency={} weight={} exclusive={} " +
+        logger.log(level, "{} {} HEADERS: streamId={} headers={} streamDependency={} weight={} exclusive={} " +
                         "padding={} endStream={}", ctx.channel(),
                 direction.name(), streamId, headers, streamDependency, weight, exclusive, padding, endStream);
     }


### PR DESCRIPTION
Motivation:
The labels identifying the frame types in Http2FrameLogger are not always correct.

Modification:
- Correct the string labels to indicate the right frame type in Http2FrameLogger

Result:
Logs are more correct.