### PR TITLE
Immediate caching the wrapped string value in AsciiString

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderNames.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderNames.java
@@ -28,332 +28,332 @@ public final class HttpHeaderNames {
     /**
      * {@code "accept"}
      */
-    public static final AsciiString ACCEPT = new AsciiString("accept");
+    public static final AsciiString ACCEPT = AsciiString.cached("accept");
     /**
      * {@code "accept-charset"}
      */
-    public static final AsciiString ACCEPT_CHARSET = new AsciiString("accept-charset");
+    public static final AsciiString ACCEPT_CHARSET = AsciiString.cached("accept-charset");
     /**
      * {@code "accept-encoding"}
      */
-    public static final AsciiString ACCEPT_ENCODING = new AsciiString("accept-encoding");
+    public static final AsciiString ACCEPT_ENCODING = AsciiString.cached("accept-encoding");
     /**
      * {@code "accept-language"}
      */
-    public static final AsciiString ACCEPT_LANGUAGE = new AsciiString("accept-language");
+    public static final AsciiString ACCEPT_LANGUAGE = AsciiString.cached("accept-language");
     /**
      * {@code "accept-ranges"}
      */
-    public static final AsciiString ACCEPT_RANGES = new AsciiString("accept-ranges");
+    public static final AsciiString ACCEPT_RANGES = AsciiString.cached("accept-ranges");
     /**
      * {@code "accept-patch"}
      */
-    public static final AsciiString ACCEPT_PATCH = new AsciiString("accept-patch");
+    public static final AsciiString ACCEPT_PATCH = AsciiString.cached("accept-patch");
     /**
      * {@code "access-control-allow-credentials"}
      */
     public static final AsciiString ACCESS_CONTROL_ALLOW_CREDENTIALS =
-            new AsciiString("access-control-allow-credentials");
+            AsciiString.cached("access-control-allow-credentials");
     /**
      * {@code "access-control-allow-headers"}
      */
     public static final AsciiString ACCESS_CONTROL_ALLOW_HEADERS =
-            new AsciiString("access-control-allow-headers");
+            AsciiString.cached("access-control-allow-headers");
     /**
      * {@code "access-control-allow-methods"}
      */
     public static final AsciiString ACCESS_CONTROL_ALLOW_METHODS =
-            new AsciiString("access-control-allow-methods");
+            AsciiString.cached("access-control-allow-methods");
     /**
      * {@code "access-control-allow-origin"}
      */
     public static final AsciiString ACCESS_CONTROL_ALLOW_ORIGIN =
-            new AsciiString("access-control-allow-origin");
+            AsciiString.cached("access-control-allow-origin");
     /**
      * {@code "access-control-expose-headers"}
      */
     public static final AsciiString ACCESS_CONTROL_EXPOSE_HEADERS =
-            new AsciiString("access-control-expose-headers");
+            AsciiString.cached("access-control-expose-headers");
     /**
      * {@code "access-control-max-age"}
      */
-    public static final AsciiString ACCESS_CONTROL_MAX_AGE = new AsciiString("access-control-max-age");
+    public static final AsciiString ACCESS_CONTROL_MAX_AGE = AsciiString.cached("access-control-max-age");
     /**
      * {@code "access-control-request-headers"}
      */
     public static final AsciiString ACCESS_CONTROL_REQUEST_HEADERS =
-            new AsciiString("access-control-request-headers");
+            AsciiString.cached("access-control-request-headers");
     /**
      * {@code "access-control-request-method"}
      */
     public static final AsciiString ACCESS_CONTROL_REQUEST_METHOD =
-            new AsciiString("access-control-request-method");
+            AsciiString.cached("access-control-request-method");
     /**
      * {@code "age"}
      */
-    public static final AsciiString AGE = new AsciiString("age");
+    public static final AsciiString AGE = AsciiString.cached("age");
     /**
      * {@code "allow"}
      */
-    public static final AsciiString ALLOW = new AsciiString("allow");
+    public static final AsciiString ALLOW = AsciiString.cached("allow");
     /**
      * {@code "authorization"}
      */
-    public static final AsciiString AUTHORIZATION = new AsciiString("authorization");
+    public static final AsciiString AUTHORIZATION = AsciiString.cached("authorization");
     /**
      * {@code "cache-control"}
      */
-    public static final AsciiString CACHE_CONTROL = new AsciiString("cache-control");
+    public static final AsciiString CACHE_CONTROL = AsciiString.cached("cache-control");
     /**
      * {@code "connection"}
      */
-    public static final AsciiString CONNECTION = new AsciiString("connection");
+    public static final AsciiString CONNECTION = AsciiString.cached("connection");
     /**
      * {@code "content-base"}
      */
-    public static final AsciiString CONTENT_BASE = new AsciiString("content-base");
+    public static final AsciiString CONTENT_BASE = AsciiString.cached("content-base");
     /**
      * {@code "content-encoding"}
      */
-    public static final AsciiString CONTENT_ENCODING = new AsciiString("content-encoding");
+    public static final AsciiString CONTENT_ENCODING = AsciiString.cached("content-encoding");
     /**
      * {@code "content-language"}
      */
-    public static final AsciiString CONTENT_LANGUAGE = new AsciiString("content-language");
+    public static final AsciiString CONTENT_LANGUAGE = AsciiString.cached("content-language");
     /**
      * {@code "content-length"}
      */
-    public static final AsciiString CONTENT_LENGTH = new AsciiString("content-length");
+    public static final AsciiString CONTENT_LENGTH = AsciiString.cached("content-length");
     /**
      * {@code "content-location"}
      */
-    public static final AsciiString CONTENT_LOCATION = new AsciiString("content-location");
+    public static final AsciiString CONTENT_LOCATION = AsciiString.cached("content-location");
     /**
      * {@code "content-transfer-encoding"}
      */
-    public static final AsciiString CONTENT_TRANSFER_ENCODING = new AsciiString("content-transfer-encoding");
+    public static final AsciiString CONTENT_TRANSFER_ENCODING = AsciiString.cached("content-transfer-encoding");
     /**
      * {@code "content-disposition"}
      */
-    public static final AsciiString CONTENT_DISPOSITION = new AsciiString("content-disposition");
+    public static final AsciiString CONTENT_DISPOSITION = AsciiString.cached("content-disposition");
     /**
      * {@code "content-md5"}
      */
-    public static final AsciiString CONTENT_MD5 = new AsciiString("content-md5");
+    public static final AsciiString CONTENT_MD5 = AsciiString.cached("content-md5");
     /**
      * {@code "content-range"}
      */
-    public static final AsciiString CONTENT_RANGE = new AsciiString("content-range");
+    public static final AsciiString CONTENT_RANGE = AsciiString.cached("content-range");
     /**
      * {@code "content-security-policy"}
      */
-    public static final AsciiString CONTENT_SECURITY_POLICY = new AsciiString("content-security-policy");
+    public static final AsciiString CONTENT_SECURITY_POLICY = AsciiString.cached("content-security-policy");
     /**
      * {@code "content-type"}
      */
-    public static final AsciiString CONTENT_TYPE = new AsciiString("content-type");
+    public static final AsciiString CONTENT_TYPE = AsciiString.cached("content-type");
     /**
      * {@code "cookie"}
      */
-    public static final AsciiString COOKIE = new AsciiString("cookie");
+    public static final AsciiString COOKIE = AsciiString.cached("cookie");
     /**
      * {@code "date"}
      */
-    public static final AsciiString DATE = new AsciiString("date");
+    public static final AsciiString DATE = AsciiString.cached("date");
     /**
      * {@code "etag"}
      */
-    public static final AsciiString ETAG = new AsciiString("etag");
+    public static final AsciiString ETAG = AsciiString.cached("etag");
     /**
      * {@code "expect"}
      */
-    public static final AsciiString EXPECT = new AsciiString("expect");
+    public static final AsciiString EXPECT = AsciiString.cached("expect");
     /**
      * {@code "expires"}
      */
-    public static final AsciiString EXPIRES = new AsciiString("expires");
+    public static final AsciiString EXPIRES = AsciiString.cached("expires");
     /**
      * {@code "from"}
      */
-    public static final AsciiString FROM = new AsciiString("from");
+    public static final AsciiString FROM = AsciiString.cached("from");
     /**
      * {@code "host"}
      */
-    public static final AsciiString HOST = new AsciiString("host");
+    public static final AsciiString HOST = AsciiString.cached("host");
     /**
      * {@code "if-match"}
      */
-    public static final AsciiString IF_MATCH = new AsciiString("if-match");
+    public static final AsciiString IF_MATCH = AsciiString.cached("if-match");
     /**
      * {@code "if-modified-since"}
      */
-    public static final AsciiString IF_MODIFIED_SINCE = new AsciiString("if-modified-since");
+    public static final AsciiString IF_MODIFIED_SINCE = AsciiString.cached("if-modified-since");
     /**
      * {@code "if-none-match"}
      */
-    public static final AsciiString IF_NONE_MATCH = new AsciiString("if-none-match");
+    public static final AsciiString IF_NONE_MATCH = AsciiString.cached("if-none-match");
     /**
      * {@code "if-range"}
      */
-    public static final AsciiString IF_RANGE = new AsciiString("if-range");
+    public static final AsciiString IF_RANGE = AsciiString.cached("if-range");
     /**
      * {@code "if-unmodified-since"}
      */
-    public static final AsciiString IF_UNMODIFIED_SINCE = new AsciiString("if-unmodified-since");
+    public static final AsciiString IF_UNMODIFIED_SINCE = AsciiString.cached("if-unmodified-since");
     /**
      * @deprecated use {@link #CONNECTION}
      *
      * {@code "keep-alive"}
      */
     @Deprecated
-    public static final AsciiString KEEP_ALIVE = new AsciiString("keep-alive");
+    public static final AsciiString KEEP_ALIVE = AsciiString.cached("keep-alive");
     /**
      * {@code "last-modified"}
      */
-    public static final AsciiString LAST_MODIFIED = new AsciiString("last-modified");
+    public static final AsciiString LAST_MODIFIED = AsciiString.cached("last-modified");
     /**
      * {@code "location"}
      */
-    public static final AsciiString LOCATION = new AsciiString("location");
+    public static final AsciiString LOCATION = AsciiString.cached("location");
     /**
      * {@code "max-forwards"}
      */
-    public static final AsciiString MAX_FORWARDS = new AsciiString("max-forwards");
+    public static final AsciiString MAX_FORWARDS = AsciiString.cached("max-forwards");
     /**
      * {@code "origin"}
      */
-    public static final AsciiString ORIGIN = new AsciiString("origin");
+    public static final AsciiString ORIGIN = AsciiString.cached("origin");
     /**
      * {@code "pragma"}
      */
-    public static final AsciiString PRAGMA = new AsciiString("pragma");
+    public static final AsciiString PRAGMA = AsciiString.cached("pragma");
     /**
      * {@code "proxy-authenticate"}
      */
-    public static final AsciiString PROXY_AUTHENTICATE = new AsciiString("proxy-authenticate");
+    public static final AsciiString PROXY_AUTHENTICATE = AsciiString.cached("proxy-authenticate");
     /**
      * {@code "proxy-authorization"}
      */
-    public static final AsciiString PROXY_AUTHORIZATION = new AsciiString("proxy-authorization");
+    public static final AsciiString PROXY_AUTHORIZATION = AsciiString.cached("proxy-authorization");
     /**
      * @deprecated use {@link #CONNECTION}
      *
      * {@code "proxy-connection"}
      */
     @Deprecated
-    public static final AsciiString PROXY_CONNECTION = new AsciiString("proxy-connection");
+    public static final AsciiString PROXY_CONNECTION = AsciiString.cached("proxy-connection");
     /**
      * {@code "range"}
      */
-    public static final AsciiString RANGE = new AsciiString("range");
+    public static final AsciiString RANGE = AsciiString.cached("range");
     /**
      * {@code "referer"}
      */
-    public static final AsciiString REFERER = new AsciiString("referer");
+    public static final AsciiString REFERER = AsciiString.cached("referer");
     /**
      * {@code "retry-after"}
      */
-    public static final AsciiString RETRY_AFTER = new AsciiString("retry-after");
+    public static final AsciiString RETRY_AFTER = AsciiString.cached("retry-after");
     /**
      * {@code "sec-websocket-key1"}
      */
-    public static final AsciiString SEC_WEBSOCKET_KEY1 = new AsciiString("sec-websocket-key1");
+    public static final AsciiString SEC_WEBSOCKET_KEY1 = AsciiString.cached("sec-websocket-key1");
     /**
      * {@code "sec-websocket-key2"}
      */
-    public static final AsciiString SEC_WEBSOCKET_KEY2 = new AsciiString("sec-websocket-key2");
+    public static final AsciiString SEC_WEBSOCKET_KEY2 = AsciiString.cached("sec-websocket-key2");
     /**
      * {@code "sec-websocket-location"}
      */
-    public static final AsciiString SEC_WEBSOCKET_LOCATION = new AsciiString("sec-websocket-location");
+    public static final AsciiString SEC_WEBSOCKET_LOCATION = AsciiString.cached("sec-websocket-location");
     /**
      * {@code "sec-websocket-origin"}
      */
-    public static final AsciiString SEC_WEBSOCKET_ORIGIN = new AsciiString("sec-websocket-origin");
+    public static final AsciiString SEC_WEBSOCKET_ORIGIN = AsciiString.cached("sec-websocket-origin");
     /**
      * {@code "sec-websocket-protocol"}
      */
-    public static final AsciiString SEC_WEBSOCKET_PROTOCOL = new AsciiString("sec-websocket-protocol");
+    public static final AsciiString SEC_WEBSOCKET_PROTOCOL = AsciiString.cached("sec-websocket-protocol");
     /**
      * {@code "sec-websocket-version"}
      */
-    public static final AsciiString SEC_WEBSOCKET_VERSION = new AsciiString("sec-websocket-version");
+    public static final AsciiString SEC_WEBSOCKET_VERSION = AsciiString.cached("sec-websocket-version");
     /**
      * {@code "sec-websocket-key"}
      */
-    public static final AsciiString SEC_WEBSOCKET_KEY = new AsciiString("sec-websocket-key");
+    public static final AsciiString SEC_WEBSOCKET_KEY = AsciiString.cached("sec-websocket-key");
     /**
      * {@code "sec-websocket-accept"}
      */
-    public static final AsciiString SEC_WEBSOCKET_ACCEPT = new AsciiString("sec-websocket-accept");
+    public static final AsciiString SEC_WEBSOCKET_ACCEPT = AsciiString.cached("sec-websocket-accept");
     /**
      * {@code "sec-websocket-protocol"}
      */
-    public static final AsciiString SEC_WEBSOCKET_EXTENSIONS = new AsciiString("sec-websocket-extensions");
+    public static final AsciiString SEC_WEBSOCKET_EXTENSIONS = AsciiString.cached("sec-websocket-extensions");
     /**
      * {@code "server"}
      */
-    public static final AsciiString SERVER = new AsciiString("server");
+    public static final AsciiString SERVER = AsciiString.cached("server");
     /**
      * {@code "set-cookie"}
      */
-    public static final AsciiString SET_COOKIE = new AsciiString("set-cookie");
+    public static final AsciiString SET_COOKIE = AsciiString.cached("set-cookie");
     /**
      * {@code "set-cookie2"}
      */
-    public static final AsciiString SET_COOKIE2 = new AsciiString("set-cookie2");
+    public static final AsciiString SET_COOKIE2 = AsciiString.cached("set-cookie2");
     /**
      * {@code "te"}
      */
-    public static final AsciiString TE = new AsciiString("te");
+    public static final AsciiString TE = AsciiString.cached("te");
     /**
      * {@code "trailer"}
      */
-    public static final AsciiString TRAILER = new AsciiString("trailer");
+    public static final AsciiString TRAILER = AsciiString.cached("trailer");
     /**
      * {@code "transfer-encoding"}
      */
-    public static final AsciiString TRANSFER_ENCODING = new AsciiString("transfer-encoding");
+    public static final AsciiString TRANSFER_ENCODING = AsciiString.cached("transfer-encoding");
     /**
      * {@code "upgrade"}
      */
-    public static final AsciiString UPGRADE = new AsciiString("upgrade");
+    public static final AsciiString UPGRADE = AsciiString.cached("upgrade");
     /**
      * {@code "user-agent"}
      */
-    public static final AsciiString USER_AGENT = new AsciiString("user-agent");
+    public static final AsciiString USER_AGENT = AsciiString.cached("user-agent");
     /**
      * {@code "vary"}
      */
-    public static final AsciiString VARY = new AsciiString("vary");
+    public static final AsciiString VARY = AsciiString.cached("vary");
     /**
      * {@code "via"}
      */
-    public static final AsciiString VIA = new AsciiString("via");
+    public static final AsciiString VIA = AsciiString.cached("via");
     /**
      * {@code "warning"}
      */
-    public static final AsciiString WARNING = new AsciiString("warning");
+    public static final AsciiString WARNING = AsciiString.cached("warning");
     /**
      * {@code "websocket-location"}
      */
-    public static final AsciiString WEBSOCKET_LOCATION = new AsciiString("websocket-location");
+    public static final AsciiString WEBSOCKET_LOCATION = AsciiString.cached("websocket-location");
     /**
      * {@code "websocket-origin"}
      */
-    public static final AsciiString WEBSOCKET_ORIGIN = new AsciiString("websocket-origin");
+    public static final AsciiString WEBSOCKET_ORIGIN = AsciiString.cached("websocket-origin");
     /**
      * {@code "websocket-protocol"}
      */
-    public static final AsciiString WEBSOCKET_PROTOCOL = new AsciiString("websocket-protocol");
+    public static final AsciiString WEBSOCKET_PROTOCOL = AsciiString.cached("websocket-protocol");
     /**
      * {@code "www-authenticate"}
      */
-    public static final AsciiString WWW_AUTHENTICATE = new AsciiString("www-authenticate");
+    public static final AsciiString WWW_AUTHENTICATE = AsciiString.cached("www-authenticate");
     /**
      * {@code "x-frame-options"}
      */
-    public static final AsciiString X_FRAME_OPTIONS = new AsciiString("x-frame-options");
+    public static final AsciiString X_FRAME_OPTIONS = AsciiString.cached("x-frame-options");
 
     private HttpHeaderNames() { }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaderValues.java
@@ -25,189 +25,189 @@ public final class HttpHeaderValues {
     /**
      * {@code "application/json"}
      */
-    public static final AsciiString APPLICATION_JSON = new AsciiString("application/json");
+    public static final AsciiString APPLICATION_JSON = AsciiString.cached("application/json");
     /**
      * {@code "application/x-www-form-urlencoded"}
      */
     public static final AsciiString APPLICATION_X_WWW_FORM_URLENCODED =
-            new AsciiString("application/x-www-form-urlencoded");
+            AsciiString.cached("application/x-www-form-urlencoded");
     /**
      * {@code "application/octet-stream"}
      */
-    public static final AsciiString APPLICATION_OCTET_STREAM = new AsciiString("application/octet-stream");
+    public static final AsciiString APPLICATION_OCTET_STREAM = AsciiString.cached("application/octet-stream");
     /**
      * {@code "attachment"}
      * See {@link HttpHeaderNames#CONTENT_DISPOSITION}
      */
-    public static final AsciiString ATTACHMENT = new AsciiString("attachment");
+    public static final AsciiString ATTACHMENT = AsciiString.cached("attachment");
     /**
      * {@code "base64"}
      */
-    public static final AsciiString BASE64 = new AsciiString("base64");
+    public static final AsciiString BASE64 = AsciiString.cached("base64");
     /**
      * {@code "binary"}
      */
-    public static final AsciiString BINARY = new AsciiString("binary");
+    public static final AsciiString BINARY = AsciiString.cached("binary");
     /**
      * {@code "boundary"}
      */
-    public static final AsciiString BOUNDARY = new AsciiString("boundary");
+    public static final AsciiString BOUNDARY = AsciiString.cached("boundary");
     /**
      * {@code "bytes"}
      */
-    public static final AsciiString BYTES = new AsciiString("bytes");
+    public static final AsciiString BYTES = AsciiString.cached("bytes");
     /**
      * {@code "charset"}
      */
-    public static final AsciiString CHARSET = new AsciiString("charset");
+    public static final AsciiString CHARSET = AsciiString.cached("charset");
     /**
      * {@code "chunked"}
      */
-    public static final AsciiString CHUNKED = new AsciiString("chunked");
+    public static final AsciiString CHUNKED = AsciiString.cached("chunked");
     /**
      * {@code "close"}
      */
-    public static final AsciiString CLOSE = new AsciiString("close");
+    public static final AsciiString CLOSE = AsciiString.cached("close");
     /**
      * {@code "compress"}
      */
-    public static final AsciiString COMPRESS = new AsciiString("compress");
+    public static final AsciiString COMPRESS = AsciiString.cached("compress");
     /**
      * {@code "100-continue"}
      */
-    public static final AsciiString CONTINUE = new AsciiString("100-continue");
+    public static final AsciiString CONTINUE = AsciiString.cached("100-continue");
     /**
      * {@code "deflate"}
      */
-    public static final AsciiString DEFLATE = new AsciiString("deflate");
+    public static final AsciiString DEFLATE = AsciiString.cached("deflate");
     /**
      * {@code "x-deflate"}
      */
-    public static final AsciiString X_DEFLATE = new AsciiString("x-deflate");
+    public static final AsciiString X_DEFLATE = AsciiString.cached("x-deflate");
     /**
      * {@code "file"}
      * See {@link HttpHeaderNames#CONTENT_DISPOSITION}
      */
-    public static final AsciiString FILE = new AsciiString("file");
+    public static final AsciiString FILE = AsciiString.cached("file");
     /**
      * {@code "filename"}
      * See {@link HttpHeaderNames#CONTENT_DISPOSITION}
      */
-    public static final AsciiString FILENAME = new AsciiString("filename");
+    public static final AsciiString FILENAME = AsciiString.cached("filename");
     /**
      * {@code "form-data"}
      * See {@link HttpHeaderNames#CONTENT_DISPOSITION}
      */
-    public static final AsciiString FORM_DATA = new AsciiString("form-data");
+    public static final AsciiString FORM_DATA = AsciiString.cached("form-data");
     /**
      * {@code "gzip"}
      */
-    public static final AsciiString GZIP = new AsciiString("gzip");
+    public static final AsciiString GZIP = AsciiString.cached("gzip");
     /**
      * {@code "gzip,deflate"}
      */
-    public static final AsciiString GZIP_DEFLATE = new AsciiString("gzip,deflate");
+    public static final AsciiString GZIP_DEFLATE = AsciiString.cached("gzip,deflate");
     /**
      * {@code "x-gzip"}
      */
-    public static final AsciiString X_GZIP = new AsciiString("x-gzip");
+    public static final AsciiString X_GZIP = AsciiString.cached("x-gzip");
     /**
      * {@code "identity"}
      */
-    public static final AsciiString IDENTITY = new AsciiString("identity");
+    public static final AsciiString IDENTITY = AsciiString.cached("identity");
     /**
      * {@code "keep-alive"}
      */
-    public static final AsciiString KEEP_ALIVE = new AsciiString("keep-alive");
+    public static final AsciiString KEEP_ALIVE = AsciiString.cached("keep-alive");
     /**
      * {@code "max-age"}
      */
-    public static final AsciiString MAX_AGE = new AsciiString("max-age");
+    public static final AsciiString MAX_AGE = AsciiString.cached("max-age");
     /**
      * {@code "max-stale"}
      */
-    public static final AsciiString MAX_STALE = new AsciiString("max-stale");
+    public static final AsciiString MAX_STALE = AsciiString.cached("max-stale");
     /**
      * {@code "min-fresh"}
      */
-    public static final AsciiString MIN_FRESH = new AsciiString("min-fresh");
+    public static final AsciiString MIN_FRESH = AsciiString.cached("min-fresh");
     /**
      * {@code "multipart/form-data"}
      */
-    public static final AsciiString MULTIPART_FORM_DATA = new AsciiString("multipart/form-data");
+    public static final AsciiString MULTIPART_FORM_DATA = AsciiString.cached("multipart/form-data");
     /**
      * {@code "multipart/mixed"}
      */
-    public static final AsciiString MULTIPART_MIXED = new AsciiString("multipart/mixed");
+    public static final AsciiString MULTIPART_MIXED = AsciiString.cached("multipart/mixed");
     /**
      * {@code "must-revalidate"}
      */
-    public static final AsciiString MUST_REVALIDATE = new AsciiString("must-revalidate");
+    public static final AsciiString MUST_REVALIDATE = AsciiString.cached("must-revalidate");
     /**
      * {@code "name"}
      * See {@link HttpHeaderNames#CONTENT_DISPOSITION}
      */
-    public static final AsciiString NAME = new AsciiString("name");
+    public static final AsciiString NAME = AsciiString.cached("name");
     /**
      * {@code "no-cache"}
      */
-    public static final AsciiString NO_CACHE = new AsciiString("no-cache");
+    public static final AsciiString NO_CACHE = AsciiString.cached("no-cache");
     /**
      * {@code "no-store"}
      */
-    public static final AsciiString NO_STORE = new AsciiString("no-store");
+    public static final AsciiString NO_STORE = AsciiString.cached("no-store");
     /**
      * {@code "no-transform"}
      */
-    public static final AsciiString NO_TRANSFORM = new AsciiString("no-transform");
+    public static final AsciiString NO_TRANSFORM = AsciiString.cached("no-transform");
     /**
      * {@code "none"}
      */
-    public static final AsciiString NONE = new AsciiString("none");
+    public static final AsciiString NONE = AsciiString.cached("none");
     /**
      * {@code "0"}
      */
-    public static final AsciiString ZERO = new AsciiString("0");
+    public static final AsciiString ZERO = AsciiString.cached("0");
     /**
      * {@code "only-if-cached"}
      */
-    public static final AsciiString ONLY_IF_CACHED = new AsciiString("only-if-cached");
+    public static final AsciiString ONLY_IF_CACHED = AsciiString.cached("only-if-cached");
     /**
      * {@code "private"}
      */
-    public static final AsciiString PRIVATE = new AsciiString("private");
+    public static final AsciiString PRIVATE = AsciiString.cached("private");
     /**
      * {@code "proxy-revalidate"}
      */
-    public static final AsciiString PROXY_REVALIDATE = new AsciiString("proxy-revalidate");
+    public static final AsciiString PROXY_REVALIDATE = AsciiString.cached("proxy-revalidate");
     /**
      * {@code "public"}
      */
-    public static final AsciiString PUBLIC = new AsciiString("public");
+    public static final AsciiString PUBLIC = AsciiString.cached("public");
     /**
      * {@code "quoted-printable"}
      */
-    public static final AsciiString QUOTED_PRINTABLE = new AsciiString("quoted-printable");
+    public static final AsciiString QUOTED_PRINTABLE = AsciiString.cached("quoted-printable");
     /**
      * {@code "s-maxage"}
      */
-    public static final AsciiString S_MAXAGE = new AsciiString("s-maxage");
+    public static final AsciiString S_MAXAGE = AsciiString.cached("s-maxage");
     /**
      * {@code "text/plain"}
      */
-    public static final AsciiString TEXT_PLAIN = new AsciiString("text/plain");
+    public static final AsciiString TEXT_PLAIN = AsciiString.cached("text/plain");
     /**
      * {@code "trailers"}
      */
-    public static final AsciiString TRAILERS = new AsciiString("trailers");
+    public static final AsciiString TRAILERS = AsciiString.cached("trailers");
     /**
      * {@code "upgrade"}
      */
-    public static final AsciiString UPGRADE = new AsciiString("upgrade");
+    public static final AsciiString UPGRADE = AsciiString.cached("upgrade");
     /**
      * {@code "websocket"}
      */
-    public static final AsciiString WEBSOCKET = new AsciiString("websocket");
+    public static final AsciiString WEBSOCKET = AsciiString.cached("websocket");
 
     private HttpHeaderValues() { }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpMethod.java
@@ -132,7 +132,7 @@ public class HttpMethod implements Comparable<HttpMethod> {
             }
         }
 
-        this.name = new AsciiString(name);
+        this.name = AsciiString.cached(name);
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpScheme.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpScheme.java
@@ -38,7 +38,7 @@ public final class HttpScheme {
 
     private HttpScheme(int port, String name) {
         this.port = port;
-        this.name = new AsciiString(name);
+        this.name = AsciiString.cached(name);
     }
 
     public AsciiString name() {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpStatusClass.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpStatusClass.java
@@ -102,7 +102,7 @@ public enum HttpStatusClass {
     HttpStatusClass(int min, int max, String defaultReasonPhrase) {
         this.min = min;
         this.max = max;
-        this.defaultReasonPhrase = new AsciiString(defaultReasonPhrase);
+        this.defaultReasonPhrase = AsciiString.cached(defaultReasonPhrase);
     }
 
     /**

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpUtil.java
@@ -39,7 +39,7 @@ public final class HttpUtil {
     @Deprecated
     static final EmptyHttpHeaders EMPTY_HEADERS = new EmptyHttpHeaders();
     private static final AsciiString CHARSET_EQUALS = AsciiString.of(HttpHeaderValues.CHARSET + "=");
-    private static final AsciiString SEMICOLON = AsciiString.of(";");
+    private static final AsciiString SEMICOLON = AsciiString.cached(";");
 
     private HttpUtil() { }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker00.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientHandshaker00.java
@@ -43,7 +43,7 @@ import java.nio.ByteBuffer;
  */
 public class WebSocketClientHandshaker00 extends WebSocketClientHandshaker {
 
-    private static final AsciiString WEBSOCKET = new AsciiString("WebSocket");
+    private static final AsciiString WEBSOCKET = AsciiString.cached("WebSocket");
 
     private ByteBuf expectedChallengeResponseBytes;
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketScheme.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketScheme.java
@@ -37,7 +37,7 @@ public final class WebSocketScheme {
 
     private WebSocketScheme(int port, String name) {
         this.port = port;
-        this.name = new AsciiString(name);
+        this.name = AsciiString.cached(name);
     }
 
     public AsciiString name() {

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspHeaderNames.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspHeaderNames.java
@@ -41,7 +41,7 @@ public final class RtspHeaderNames {
     /**
      * {@code "allow"}
      */
-    public static final AsciiString ALLOW = new AsciiString("allow");
+    public static final AsciiString ALLOW = AsciiString.cached("allow");
     /**
      * {@code "authorization"}
      */
@@ -49,11 +49,11 @@ public final class RtspHeaderNames {
     /**
      * {@code "bandwidth"}
      */
-    public static final AsciiString BANDWIDTH = new AsciiString("bandwidth");
+    public static final AsciiString BANDWIDTH = AsciiString.cached("bandwidth");
     /**
      * {@code "blocksize"}
      */
-    public static final AsciiString BLOCKSIZE = new AsciiString("blocksize");
+    public static final AsciiString BLOCKSIZE = AsciiString.cached("blocksize");
     /**
      * {@code "cache-control"}
      */
@@ -61,7 +61,7 @@ public final class RtspHeaderNames {
     /**
      * {@code "conference"}
      */
-    public static final AsciiString CONFERENCE = new AsciiString("conference");
+    public static final AsciiString CONFERENCE = AsciiString.cached("conference");
     /**
      * {@code "connection"}
      */
@@ -93,7 +93,7 @@ public final class RtspHeaderNames {
     /**
      * {@code "cseq"}
      */
-    public static final AsciiString CSEQ = new AsciiString("cseq");
+    public static final AsciiString CSEQ = AsciiString.cached("cseq");
     /**
      * {@code "cate"}
      */
@@ -121,7 +121,7 @@ public final class RtspHeaderNames {
     /**
      * {@code "keymgmt"}
      */
-    public static final AsciiString KEYMGMT = new AsciiString("keymgmt");
+    public static final AsciiString KEYMGMT = AsciiString.cached("keymgmt");
     /**
      * {@code "last-modified"}
      */
@@ -133,11 +133,11 @@ public final class RtspHeaderNames {
     /**
      * {@code "proxy-require"}
      */
-    public static final AsciiString PROXY_REQUIRE = new AsciiString("proxy-require");
+    public static final AsciiString PROXY_REQUIRE = AsciiString.cached("proxy-require");
     /**
      * {@code "public"}
      */
-    public static final AsciiString PUBLIC = new AsciiString("public");
+    public static final AsciiString PUBLIC = AsciiString.cached("public");
     /**
      * {@code "range"}
      */
@@ -149,7 +149,7 @@ public final class RtspHeaderNames {
     /**
      * {@code "require"}
      */
-    public static final AsciiString REQUIRE = new AsciiString("require");
+    public static final AsciiString REQUIRE = AsciiString.cached("require");
     /**
      * {@code "retry-after"}
      */
@@ -157,15 +157,15 @@ public final class RtspHeaderNames {
     /**
      * {@code "rtp-info"}
      */
-    public static final AsciiString RTP_INFO = new AsciiString("rtp-info");
+    public static final AsciiString RTP_INFO = AsciiString.cached("rtp-info");
     /**
      * {@code "scale"}
      */
-    public static final AsciiString SCALE = new AsciiString("scale");
+    public static final AsciiString SCALE = AsciiString.cached("scale");
     /**
      * {@code "session"}
      */
-    public static final AsciiString SESSION = new AsciiString("session");
+    public static final AsciiString SESSION = AsciiString.cached("session");
     /**
      * {@code "server"}
      */
@@ -173,19 +173,19 @@ public final class RtspHeaderNames {
     /**
      * {@code "speed"}
      */
-    public static final AsciiString SPEED = new AsciiString("speed");
+    public static final AsciiString SPEED = AsciiString.cached("speed");
     /**
      * {@code "timestamp"}
      */
-    public static final AsciiString TIMESTAMP = new AsciiString("timestamp");
+    public static final AsciiString TIMESTAMP = AsciiString.cached("timestamp");
     /**
      * {@code "transport"}
      */
-    public static final AsciiString TRANSPORT = new AsciiString("transport");
+    public static final AsciiString TRANSPORT = AsciiString.cached("transport");
     /**
      * {@code "unsupported"}
      */
-    public static final AsciiString UNSUPPORTED = new AsciiString("unsupported");
+    public static final AsciiString UNSUPPORTED = AsciiString.cached("unsupported");
     /**
      * {@code "user-agent"}
      */

--- a/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspHeaderValues.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/rtsp/RtspHeaderValues.java
@@ -26,11 +26,11 @@ public final class RtspHeaderValues {
     /**
      * {@code "append"}
      */
-    public static final AsciiString APPEND = new AsciiString("append");
+    public static final AsciiString APPEND = AsciiString.cached("append");
     /**
      * {@code "AVP"}
      */
-    public static final AsciiString AVP = new AsciiString("AVP");
+    public static final AsciiString AVP = AsciiString.cached("AVP");
     /**
      * {@code "bytes"}
      */
@@ -42,11 +42,11 @@ public final class RtspHeaderValues {
     /**
      * {@code "client_port"}
      */
-    public static final AsciiString CLIENT_PORT = new AsciiString("client_port");
+    public static final AsciiString CLIENT_PORT = AsciiString.cached("client_port");
     /**
      * {@code "clock"}
      */
-    public static final AsciiString CLOCK = new AsciiString("clock");
+    public static final AsciiString CLOCK = AsciiString.cached("clock");
     /**
      * {@code "close"}
      */
@@ -66,7 +66,7 @@ public final class RtspHeaderValues {
     /**
      * {@code "destination"}
      */
-    public static final AsciiString DESTINATION = new AsciiString("destination");
+    public static final AsciiString DESTINATION = AsciiString.cached("destination");
     /**
      * {@code "gzip"}
      */
@@ -78,7 +78,7 @@ public final class RtspHeaderValues {
     /**
      * {@code "interleaved"}
      */
-    public static final AsciiString INTERLEAVED = new AsciiString("interleaved");
+    public static final AsciiString INTERLEAVED = AsciiString.cached("interleaved");
     /**
      * {@code "keep-alive"}
      */
@@ -86,7 +86,7 @@ public final class RtspHeaderValues {
     /**
      * {@code "layers"}
      */
-    public static final AsciiString LAYERS = new AsciiString("layers");
+    public static final AsciiString LAYERS = AsciiString.cached("layers");
     /**
      * {@code "max-age"}
      */
@@ -102,11 +102,11 @@ public final class RtspHeaderValues {
     /**
      * {@code "mode"}
      */
-    public static final AsciiString MODE = new AsciiString("mode");
+    public static final AsciiString MODE = AsciiString.cached("mode");
     /**
      * {@code "multicast"}
      */
-    public static final AsciiString MULTICAST = new AsciiString("multicast");
+    public static final AsciiString MULTICAST = AsciiString.cached("multicast");
     /**
      * {@code "must-revalidate"}
      */
@@ -130,7 +130,7 @@ public final class RtspHeaderValues {
     /**
      * {@code "port"}
      */
-    public static final AsciiString PORT = new AsciiString("port");
+    public static final AsciiString PORT = AsciiString.cached("port");
     /**
      * {@code "private"}
      */
@@ -146,51 +146,51 @@ public final class RtspHeaderValues {
     /**
      * {@code "RTP"}
      */
-    public static final AsciiString RTP = new AsciiString("RTP");
+    public static final AsciiString RTP = AsciiString.cached("RTP");
     /**
      * {@code "rtptime"}
      */
-    public static final AsciiString RTPTIME = new AsciiString("rtptime");
+    public static final AsciiString RTPTIME = AsciiString.cached("rtptime");
     /**
      * {@code "seq"}
      */
-    public static final AsciiString SEQ = new AsciiString("seq");
+    public static final AsciiString SEQ = AsciiString.cached("seq");
     /**
      * {@code "server_port"}
      */
-    public static final AsciiString SERVER_PORT = new AsciiString("server_port");
+    public static final AsciiString SERVER_PORT = AsciiString.cached("server_port");
     /**
      * {@code "ssrc"}
      */
-    public static final AsciiString SSRC = new AsciiString("ssrc");
+    public static final AsciiString SSRC = AsciiString.cached("ssrc");
     /**
      * {@code "TCP"}
      */
-    public static final AsciiString TCP = new AsciiString("TCP");
+    public static final AsciiString TCP = AsciiString.cached("TCP");
     /**
      * {@code "time"}
      */
-    public static final AsciiString TIME = new AsciiString("time");
+    public static final AsciiString TIME = AsciiString.cached("time");
     /**
      * {@code "timeout"}
      */
-    public static final AsciiString TIMEOUT = new AsciiString("timeout");
+    public static final AsciiString TIMEOUT = AsciiString.cached("timeout");
     /**
      * {@code "ttl"}
      */
-    public static final AsciiString TTL = new AsciiString("ttl");
+    public static final AsciiString TTL = AsciiString.cached("ttl");
     /**
      * {@code "UDP"}
      */
-    public static final AsciiString UDP = new AsciiString("UDP");
+    public static final AsciiString UDP = AsciiString.cached("UDP");
     /**
      * {@code "unicast"}
      */
-    public static final AsciiString UNICAST = new AsciiString("unicast");
+    public static final AsciiString UNICAST = AsciiString.cached("unicast");
     /**
      * {@code "url"}
      */
-    public static final AsciiString URL = new AsciiString("url");
+    public static final AsciiString URL = AsciiString.cached("url");
 
     private RtspHeaderValues() { }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHeaders.java
@@ -35,27 +35,27 @@ public interface SpdyHeaders extends Headers<CharSequence, CharSequence, SpdyHea
         /**
          * {@code ":host"}
          */
-        public static final AsciiString HOST = new AsciiString(":host");
+        public static final AsciiString HOST = AsciiString.cached(":host");
         /**
          * {@code ":method"}
          */
-        public static final AsciiString METHOD = new AsciiString(":method");
+        public static final AsciiString METHOD = AsciiString.cached(":method");
         /**
          * {@code ":path"}
          */
-        public static final AsciiString PATH = new AsciiString(":path");
+        public static final AsciiString PATH = AsciiString.cached(":path");
         /**
          * {@code ":scheme"}
          */
-        public static final AsciiString SCHEME = new AsciiString(":scheme");
+        public static final AsciiString SCHEME = AsciiString.cached(":scheme");
         /**
          * {@code ":status"}
          */
-        public static final AsciiString STATUS = new AsciiString(":status");
+        public static final AsciiString STATUS = AsciiString.cached(":status");
         /**
          * {@code ":version"}
          */
-        public static final AsciiString VERSION = new AsciiString(":version");
+        public static final AsciiString VERSION = AsciiString.cached(":version");
 
         private HttpNames() { }
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/spdy/SpdyHttpHeaders.java
@@ -30,19 +30,19 @@ public final class SpdyHttpHeaders {
         /**
          * {@code "x-spdy-stream-id"}
          */
-        public static final AsciiString STREAM_ID = new AsciiString("x-spdy-stream-id");
+        public static final AsciiString STREAM_ID = AsciiString.cached("x-spdy-stream-id");
         /**
          * {@code "x-spdy-associated-to-stream-id"}
          */
-        public static final AsciiString ASSOCIATED_TO_STREAM_ID = new AsciiString("x-spdy-associated-to-stream-id");
+        public static final AsciiString ASSOCIATED_TO_STREAM_ID = AsciiString.cached("x-spdy-associated-to-stream-id");
         /**
          * {@code "x-spdy-priority"}
          */
-        public static final AsciiString PRIORITY = new AsciiString("x-spdy-priority");
+        public static final AsciiString PRIORITY = AsciiString.cached("x-spdy-priority");
         /**
          * {@code "x-spdy-scheme"}
          */
-        public static final AsciiString SCHEME = new AsciiString("x-spdy-scheme");
+        public static final AsciiString SCHEME = AsciiString.cached("x-spdy-scheme");
 
         private Names() { }
     }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackStaticTable.java
@@ -107,12 +107,12 @@ final class HpackStaticTable {
     /* 61 */ newEmptyHeaderField("www-authenticate")
     );
 
-    private static HpackHeaderField newEmptyHeaderField(CharSequence name) {
-        return newHeaderField(name, AsciiString.EMPTY_STRING);
+    private static HpackHeaderField newEmptyHeaderField(String name) {
+        return new HpackHeaderField(AsciiString.cached(name), AsciiString.EMPTY_STRING);
     }
 
-    private static HpackHeaderField newHeaderField(CharSequence name, CharSequence value) {
-        return new HpackHeaderField(AsciiString.of(name), AsciiString.of(value));
+    private static HpackHeaderField newHeaderField(String name, String value) {
+        return new HpackHeaderField(AsciiString.cached(name), AsciiString.cached(value));
     }
 
     private static final CharSequenceMap<Integer> STATIC_INDEX_BY_NAME = createMap();

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2CodecUtil.java
@@ -43,7 +43,7 @@ import static java.lang.Math.min;
 public final class Http2CodecUtil {
     public static final int CONNECTION_STREAM_ID = 0;
     public static final int HTTP_UPGRADE_STREAM_ID = 1;
-    public static final CharSequence HTTP_UPGRADE_SETTINGS_HEADER = new AsciiString("HTTP2-Settings");
+    public static final CharSequence HTTP_UPGRADE_SETTINGS_HEADER = AsciiString.cached("HTTP2-Settings");
     public static final CharSequence HTTP_UPGRADE_PROTOCOL_NAME = "h2c";
     public static final CharSequence TLS_UPGRADE_PROTOCOL_NAME = ApplicationProtocolNames.HTTP_2;
 

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -66,7 +66,7 @@ public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2H
         }
 
         PseudoHeaderName(String value) {
-            this.value = new AsciiString(value);
+            this.value = AsciiString.cached(value);
         }
 
         public AsciiString value() {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -99,7 +99,7 @@ public final class HttpConversionUtil {
      * <a href="https://tools.ietf.org/html/rfc7540#section-8.1.2.3">rfc7540, 8.1.2.3</a> states the path must not
      * be empty, and instead should be {@code /}.
      */
-    private static final AsciiString EMPTY_REQUEST_PATH = new AsciiString("/");
+    private static final AsciiString EMPTY_REQUEST_PATH = AsciiString.cached("/");
 
     private HttpConversionUtil() {
     }
@@ -154,7 +154,7 @@ public final class HttpConversionUtil {
         private final AsciiString text;
 
         ExtensionHeaderNames(String text) {
-            this.text = new AsciiString(text);
+            this.text = AsciiString.cached(text);
         }
 
         public AsciiString text() {

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/SmtpCommand.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/SmtpCommand.java
@@ -29,19 +29,19 @@ import java.util.Map;
  */
 @UnstableApi
 public final class SmtpCommand {
-    public static final SmtpCommand EHLO = new SmtpCommand(new AsciiString("EHLO"), false);
-    public static final SmtpCommand HELO = new SmtpCommand(new AsciiString("HELO"), false);
-    public static final SmtpCommand MAIL = new SmtpCommand(new AsciiString("MAIL"), false);
-    public static final SmtpCommand RCPT = new SmtpCommand(new AsciiString("RCPT"), false);
-    public static final SmtpCommand DATA = new SmtpCommand(new AsciiString("DATA"), true);
-    public static final SmtpCommand NOOP = new SmtpCommand(new AsciiString("NOOP"), false);
-    public static final SmtpCommand RSET = new SmtpCommand(new AsciiString("RSET"), false);
-    public static final SmtpCommand EXPN = new SmtpCommand(new AsciiString("EXPN"), false);
-    public static final SmtpCommand VRFY = new SmtpCommand(new AsciiString("VRFY"), false);
-    public static final SmtpCommand HELP = new SmtpCommand(new AsciiString("HELP"), false);
-    public static final SmtpCommand QUIT = new SmtpCommand(new AsciiString("QUIT"), false);
+    public static final SmtpCommand EHLO = new SmtpCommand(AsciiString.cached("EHLO"), false);
+    public static final SmtpCommand HELO = new SmtpCommand(AsciiString.cached("HELO"), false);
+    public static final SmtpCommand MAIL = new SmtpCommand(AsciiString.cached("MAIL"), false);
+    public static final SmtpCommand RCPT = new SmtpCommand(AsciiString.cached("RCPT"), false);
+    public static final SmtpCommand DATA = new SmtpCommand(AsciiString.cached("DATA"), true);
+    public static final SmtpCommand NOOP = new SmtpCommand(AsciiString.cached("NOOP"), false);
+    public static final SmtpCommand RSET = new SmtpCommand(AsciiString.cached("RSET"), false);
+    public static final SmtpCommand EXPN = new SmtpCommand(AsciiString.cached("EXPN"), false);
+    public static final SmtpCommand VRFY = new SmtpCommand(AsciiString.cached("VRFY"), false);
+    public static final SmtpCommand HELP = new SmtpCommand(AsciiString.cached("HELP"), false);
+    public static final SmtpCommand QUIT = new SmtpCommand(AsciiString.cached("QUIT"), false);
 
-    private static final CharSequence DATA_CMD = new AsciiString("DATA");
+    private static final CharSequence DATA_CMD = AsciiString.cached("DATA");
     private static final Map<CharSequence, SmtpCommand> COMMANDS = new HashMap<CharSequence, SmtpCommand>();
     static {
         COMMANDS.put(EHLO.name(), EHLO);

--- a/codec-smtp/src/main/java/io/netty/handler/codec/smtp/SmtpRequests.java
+++ b/codec-smtp/src/main/java/io/netty/handler/codec/smtp/SmtpRequests.java
@@ -33,7 +33,7 @@ public final class SmtpRequests {
     private static final SmtpRequest RSET = new DefaultSmtpRequest(SmtpCommand.RSET);
     private static final SmtpRequest HELP_NO_ARG = new DefaultSmtpRequest(SmtpCommand.HELP);
     private static final SmtpRequest QUIT = new DefaultSmtpRequest(SmtpCommand.QUIT);
-    private static final AsciiString FROM_NULL_SENDER = new AsciiString("FROM:<>");
+    private static final AsciiString FROM_NULL_SENDER = AsciiString.cached("FROM:<>");
 
     /**
      * Creates a {@code HELO} request.

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompHeaders.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompHeaders.java
@@ -28,25 +28,25 @@ import java.util.Map.Entry;
  */
 public interface StompHeaders extends Headers<CharSequence, CharSequence, StompHeaders> {
 
-    AsciiString ACCEPT_VERSION = new AsciiString("accept-version");
-    AsciiString HOST = new AsciiString("host");
-    AsciiString LOGIN = new AsciiString("login");
-    AsciiString PASSCODE = new AsciiString("passcode");
-    AsciiString HEART_BEAT = new AsciiString("heart-beat");
-    AsciiString VERSION = new AsciiString("version");
-    AsciiString SESSION = new AsciiString("session");
-    AsciiString SERVER = new AsciiString("server");
-    AsciiString DESTINATION = new AsciiString("destination");
-    AsciiString ID = new AsciiString("id");
-    AsciiString ACK = new AsciiString("ack");
-    AsciiString TRANSACTION = new AsciiString("transaction");
-    AsciiString RECEIPT = new AsciiString("receipt");
-    AsciiString MESSAGE_ID = new AsciiString("message-id");
-    AsciiString SUBSCRIPTION = new AsciiString("subscription");
-    AsciiString RECEIPT_ID = new AsciiString("receipt-id");
-    AsciiString MESSAGE = new AsciiString("message");
-    AsciiString CONTENT_LENGTH = new AsciiString("content-length");
-    AsciiString CONTENT_TYPE = new AsciiString("content-type");
+    AsciiString ACCEPT_VERSION = AsciiString.cached("accept-version");
+    AsciiString HOST = AsciiString.cached("host");
+    AsciiString LOGIN = AsciiString.cached("login");
+    AsciiString PASSCODE = AsciiString.cached("passcode");
+    AsciiString HEART_BEAT = AsciiString.cached("heart-beat");
+    AsciiString VERSION = AsciiString.cached("version");
+    AsciiString SESSION = AsciiString.cached("session");
+    AsciiString SERVER = AsciiString.cached("server");
+    AsciiString DESTINATION = AsciiString.cached("destination");
+    AsciiString ID = AsciiString.cached("id");
+    AsciiString ACK = AsciiString.cached("ack");
+    AsciiString TRANSACTION = AsciiString.cached("transaction");
+    AsciiString RECEIPT = AsciiString.cached("receipt");
+    AsciiString MESSAGE_ID = AsciiString.cached("message-id");
+    AsciiString SUBSCRIPTION = AsciiString.cached("subscription");
+    AsciiString RECEIPT_ID = AsciiString.cached("receipt-id");
+    AsciiString MESSAGE = AsciiString.cached("message");
+    AsciiString CONTENT_LENGTH = AsciiString.cached("content-length");
+    AsciiString CONTENT_TYPE = AsciiString.cached("content-type");
 
     /**
      * {@link Headers#get(Object)} and convert the result to a {@link String}.

--- a/example/src/main/java/io/netty/example/http/helloworld/HttpHelloWorldServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/helloworld/HttpHelloWorldServerHandler.java
@@ -30,10 +30,10 @@ import static io.netty.handler.codec.http.HttpVersion.*;
 public class HttpHelloWorldServerHandler extends ChannelInboundHandlerAdapter {
     private static final byte[] CONTENT = { 'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd' };
 
-    private static final AsciiString CONTENT_TYPE = new AsciiString("Content-Type");
-    private static final AsciiString CONTENT_LENGTH = new AsciiString("Content-Length");
-    private static final AsciiString CONNECTION = new AsciiString("Connection");
-    private static final AsciiString KEEP_ALIVE = new AsciiString("keep-alive");
+    private static final AsciiString CONTENT_TYPE = AsciiString.cached("Content-Type");
+    private static final AsciiString CONTENT_LENGTH = AsciiString.cached("Content-Length");
+    private static final AsciiString CONNECTION = AsciiString.cached("Connection");
+    private static final AsciiString KEEP_ALIVE = AsciiString.cached("keep-alive");
 
     @Override
     public void channelReadComplete(ChannelHandlerContext ctx) {


### PR DESCRIPTION
Motivation:
The `AsciiString#toString` method calculate string value and cache it into field. If an `AsciiString` created from the `String` value, we can avoid rebuilding strings if we cache them immediately when creating `AsciiString`. It would be useful for constants strings, which already stored in the JVMs string table, or in cases where an unavoidable `#toString `method call is assumed.

Modifications:
- Add new static method `AsciiString#cache(String)` which save string value into cache field.
- Apply a "benign" data race in the `#hashCode` and `#toString` methods.

Result:
Less memory usage in some `AsciiString` use cases.