### PR TITLE
We should prefer heap buffers when using the OIO transport to reduce …

### DIFF
--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/DefaultRxtxChannelConfig.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/DefaultRxtxChannelConfig.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.PreferHeapByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 
@@ -49,6 +50,7 @@ final class DefaultRxtxChannelConfig extends DefaultChannelConfig implements Rxt
 
     DefaultRxtxChannelConfig(RxtxChannel channel) {
         super(channel);
+        setAllocator(new PreferHeapByteBufAllocator(getAllocator()));
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/PreferHeapByteBufAllocator.java
+++ b/transport/src/main/java/io/netty/channel/PreferHeapByteBufAllocator.java
@@ -13,21 +13,24 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package io.netty.channel.local;
+package io.netty.channel;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.CompositeByteBuf;
+import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.UnstableApi;
 
 /**
  * Wraps another {@link ByteBufAllocator} and use heapbuffers everywhere except when a direct buffer is explicit
  * requested.
  */
-final class PreferHeapByteBufAllocator implements ByteBufAllocator {
+@UnstableApi
+public final class PreferHeapByteBufAllocator implements ByteBufAllocator {
     private final ByteBufAllocator allocator;
 
-    PreferHeapByteBufAllocator(ByteBufAllocator allocator) {
-        this.allocator = allocator;
+    public PreferHeapByteBufAllocator(ByteBufAllocator allocator) {
+        this.allocator = ObjectUtil.checkNotNull(allocator, "allocator");
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
+import io.netty.channel.PreferHeapByteBufAllocator;
 import io.netty.channel.SingleThreadEventLoop;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;

--- a/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalServerChannel.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
+import io.netty.channel.PreferHeapByteBufAllocator;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.SingleThreadEventLoop;
 import io.netty.util.concurrent.SingleThreadEventExecutor;

--- a/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioDatagramChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioDatagramChannelConfig.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.PreferHeapByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.DatagramChannel;
@@ -36,6 +37,7 @@ final class DefaultOioDatagramChannelConfig extends DefaultDatagramChannelConfig
 
     DefaultOioDatagramChannelConfig(DatagramChannel channel, DatagramSocket javaSocket) {
         super(channel, javaSocket);
+        setAllocator(new PreferHeapByteBufAllocator(getAllocator()));
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioServerSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioServerSocketChannelConfig.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.PreferHeapByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.DefaultServerSocketChannelConfig;
@@ -39,10 +40,12 @@ public class DefaultOioServerSocketChannelConfig extends DefaultServerSocketChan
     @Deprecated
     public DefaultOioServerSocketChannelConfig(ServerSocketChannel channel, ServerSocket javaSocket) {
         super(channel, javaSocket);
+        setAllocator(new PreferHeapByteBufAllocator(getAllocator()));
     }
 
     DefaultOioServerSocketChannelConfig(OioServerSocketChannel channel, ServerSocket javaSocket) {
         super(channel, javaSocket);
+        setAllocator(new PreferHeapByteBufAllocator(getAllocator()));
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioSocketChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/DefaultOioSocketChannelConfig.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.PreferHeapByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.socket.DefaultSocketChannelConfig;
@@ -37,10 +38,12 @@ public class DefaultOioSocketChannelConfig extends DefaultSocketChannelConfig im
     @Deprecated
     public DefaultOioSocketChannelConfig(SocketChannel channel, Socket javaSocket) {
         super(channel, javaSocket);
+        setAllocator(new PreferHeapByteBufAllocator(getAllocator()));
     }
 
     DefaultOioSocketChannelConfig(OioSocketChannel channel, Socket javaSocket) {
         super(channel, javaSocket);
+        setAllocator(new PreferHeapByteBufAllocator(getAllocator()));
     }
 
     @Override


### PR DESCRIPTION
…memory copies.

Motivation:

When using the OIO transport we need to act on byte[] when writing and reading from / to the underyling Socket. So we should ensure we use heap buffers by default to reduce memory copies.

Modifications:

Ensure we prefer heap buffers by default for the OIO transport.

Result:

Possible less memory copies.