### PR TITLE
ISSUE-7076 Fix NPE in MQTT Connect

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnectPayload.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttConnectPayload.java
@@ -74,7 +74,7 @@ public final class MqttConnectPayload {
      */
     @Deprecated
     public String willMessage() {
-        return new String(willMessage, CharsetUtil.UTF_8);
+        return willMessage == null ? null : new String(willMessage, CharsetUtil.UTF_8);
     }
 
     public byte[] willMessageInBytes() {
@@ -90,7 +90,7 @@ public final class MqttConnectPayload {
      */
     @Deprecated
     public String password() {
-        return new String(password, CharsetUtil.UTF_8);
+        return password == null ? null : new String(password, CharsetUtil.UTF_8);
     }
 
     public byte[] passwordInBytes() {

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
@@ -125,7 +125,7 @@ public final class MqttMessageBuilders {
          */
         @Deprecated
         public ConnectBuilder willMessage(String willMessage) {
-            willMessage(willMessage.getBytes(CharsetUtil.UTF_8));
+            willMessage(willMessage == null ? null : willMessage.getBytes(CharsetUtil.UTF_8));
             return this;
         }
 
@@ -160,7 +160,7 @@ public final class MqttMessageBuilders {
          */
         @Deprecated
         public ConnectBuilder password(String password) {
-            password(password.getBytes(CharsetUtil.UTF_8));
+            password(password == null ? null : password.getBytes(CharsetUtil.UTF_8));
             return this;
         }
 

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttConnectPayloadTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttConnectPayloadTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.mqtt;
+
+import static org.junit.Assert.assertNull;
+
+import io.netty.util.CharsetUtil;
+import org.junit.Test;
+
+public class MqttConnectPayloadTest {
+
+    @Test
+    public void testNullWillMessage() throws Exception {
+        String clientIdentifier = "clientIdentifier";
+        String willTopic = "willTopic";
+        byte[] willMessage = null;
+        String userName = "userName";
+        byte[] password = "password".getBytes(CharsetUtil.UTF_8);
+        MqttConnectPayload mqttConnectPayload =
+            new MqttConnectPayload(clientIdentifier, willTopic, willMessage, userName, password);
+
+        assertNull(mqttConnectPayload.willMessageInBytes());
+        assertNull(mqttConnectPayload.willMessage());
+    }
+
+    @Test
+    public void testNullPassword() throws Exception {
+        String clientIdentifier = "clientIdentifier";
+        String willTopic = "willTopic";
+        byte[] willMessage = "willMessage".getBytes(CharsetUtil.UTF_8);
+        String userName = "userName";
+        byte[] password = null;
+        MqttConnectPayload mqttConnectPayload =
+            new MqttConnectPayload(clientIdentifier, willTopic, willMessage, userName, password);
+
+        assertNull(mqttConnectPayload.passwordInBytes());
+        assertNull(mqttConnectPayload.password());
+    }
+
+    @Test
+    public void testBuilderNullPassword() throws Exception {
+        MqttMessageBuilders.ConnectBuilder builder = new MqttMessageBuilders.ConnectBuilder();
+        builder.password((String) null);
+
+        MqttConnectPayload mqttConnectPayload = builder.build().payload();
+
+        assertNull(mqttConnectPayload.passwordInBytes());
+        assertNull(mqttConnectPayload.password());
+
+        builder = new MqttMessageBuilders.ConnectBuilder();
+        builder.password((byte[]) null);
+
+        mqttConnectPayload = builder.build().payload();
+
+        assertNull(mqttConnectPayload.passwordInBytes());
+        assertNull(mqttConnectPayload.password());
+    }
+
+    @Test
+    public void testBuilderNullWillMessage() throws Exception {
+        MqttMessageBuilders.ConnectBuilder builder = new MqttMessageBuilders.ConnectBuilder();
+        builder.willMessage((String) null);
+
+        MqttConnectPayload mqttConnectPayload = builder.build().payload();
+
+        assertNull(mqttConnectPayload.willMessageInBytes());
+        assertNull(mqttConnectPayload.willMessage());
+
+        builder = new MqttMessageBuilders.ConnectBuilder();
+        builder.willMessage((byte[]) null);
+
+        mqttConnectPayload = builder.build().payload();
+
+        assertNull(mqttConnectPayload.willMessageInBytes());
+        assertNull(mqttConnectPayload.willMessage());
+    }
+}


### PR DESCRIPTION
Add null checks before converting to string to avoid NPE.

Motivation:

Fixing an introduced NPE by #6817

Modification:

Add null checks.

Result:

Fixes #7076 . 
