### PR TITLE
Use underscores in our native library names to allow loading on restr…

### DIFF
--- a/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
+++ b/common/src/main/java/io/netty/util/internal/NativeLibraryLoader.java
@@ -111,7 +111,7 @@ public final class NativeLibraryLoader {
      */
     public static void load(String originalName, ClassLoader loader) {
         // Adjust expected name to support shading of native libraries.
-        String name = calculatePackagePrefix().replace('.', '-') + originalName;
+        String name = calculatePackagePrefix().replace('.', '_') + originalName;
 
         String libname = System.mapLibraryName(name);
         String path = NATIVE_RESOURCE_HOME + libname;

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -144,6 +144,7 @@
               <execution>
                 <id>build-native-lib</id>
                 <configuration>
+                  <name>netty_transport_native_epoll</name>
                   <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
                   <libDirectory>${project.build.outputDirectory}</libDirectory>
                   <!-- We use Maven's artifact classifier instead.
@@ -178,7 +179,7 @@
                       <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                     </manifest>
                     <manifestEntries>
-                      <Bundle-NativeCode>META-INF/native/libnetty-transport-native-epoll.so; osname=linux; processor=x86_64,*</Bundle-NativeCode>
+                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_epoll.so; osname=linux; processor=x86_64,*</Bundle-NativeCode>
                     </manifestEntries>
                     <index>true</index>
                     <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -604,7 +604,7 @@ jint JNI_OnLoad_netty_transport_native_epoll(JavaVM* vm, void* reserved) {
         fprintf(stderr, "FATAL: transport-native-epoll JNI call to dladdr failed!\n");
         return JNI_ERR;
     }
-    packagePrefix = netty_unix_util_parse_package_prefix(dlinfo.dli_fname, "netty-transport-native-epoll", &status);
+    packagePrefix = netty_unix_util_parse_package_prefix(dlinfo.dli_fname, "netty_transport_native_epoll", &status);
     if (status == JNI_ERR) {
         fprintf(stderr, "FATAL: transport-native-epoll JNI encountered unexpected dlinfo.dli_fname: %s\n", dlinfo.dli_fname);
         return JNI_ERR;

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -188,11 +188,7 @@ public final class Native {
         if (!name.startsWith("linux")) {
             throw new IllegalStateException("Only supported on Linux");
         }
-        String []libraryNames = new String[] {
-          "netty-transport-native-epoll",
-          "netty_transport_native_epoll"
-        };
-        NativeLibraryLoader.loadFirstAvailable(PlatformDependent.getClassLoader(Native.class), libraryNames);
+        NativeLibraryLoader.load("netty_transport_native_epoll", PlatformDependent.getClassLoader(Native.class));
     }
 
     private Native() {

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -70,6 +70,7 @@
               <execution>
                 <id>build-native-lib</id>
                 <configuration>
+                  <name>netty_transport_native_kqueue</name>
                   <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
                   <libDirectory>${project.build.outputDirectory}</libDirectory>
                   <!-- We use Maven's artifact classifier instead.
@@ -109,7 +110,7 @@
                       <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                     </manifest>
                     <manifestEntries>
-                      <Bundle-NativeCode>META-INF/native/libnetty-transport-native-kqueue.jnilib; osname=darwin, processor=x86_64"</Bundle-NativeCode>
+                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue.jnilib; osname=darwin, processor=x86_64"</Bundle-NativeCode>
                     </manifestEntries>
                     <index>true</index>
                     <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -178,6 +179,7 @@
               <execution>
                 <id>build-native-lib</id>
                 <configuration>
+                  <name>netty_transport_native_kqueue</name>
                   <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
                   <libDirectory>${project.build.outputDirectory}</libDirectory>
                   <!-- We use Maven's artifact classifier instead.
@@ -215,7 +217,7 @@
                       <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                     </manifest>
                     <manifestEntries>
-                      <Bundle-NativeCode>META-INF/native/libnetty-transport-native-kqueue.jnilib; osname=darwin, processor=x86_64"</Bundle-NativeCode>
+                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue.jnilib; osname=darwin, processor=x86_64"</Bundle-NativeCode>
                     </manifestEntries>
                     <index>true</index>
                     <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -284,6 +286,7 @@
               <execution>
                 <id>build-native-lib</id>
                 <configuration>
+                  <name>netty_transport_native_kqueue</name>
                   <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
                   <libDirectory>${project.build.outputDirectory}</libDirectory>
                   <!-- We use Maven's artifact classifier instead.
@@ -321,7 +324,7 @@
                       <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                     </manifest>
                     <manifestEntries>
-                      <Bundle-NativeCode>META-INF/native/libnetty-transport-native-kqueue.jnilib; osname=darwin, processor=x86_64"</Bundle-NativeCode>
+                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue.jnilib; osname=darwin, processor=x86_64"</Bundle-NativeCode>
                     </manifestEntries>
                     <index>true</index>
                     <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/transport-native-kqueue/src/main/c/netty_kqueue_native.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_native.c
@@ -287,7 +287,7 @@ jint JNI_OnLoad_netty_transport_native_kqueue(JavaVM* vm, void* reserved) {
         fprintf(stderr, "FATAL: transport-native-kqueue JNI call to dladdr failed!\n");
         return JNI_ERR;
     }
-    packagePrefix = netty_unix_util_parse_package_prefix(dlinfo.dli_fname, "netty-transport-native-kqueue", &status);
+    packagePrefix = netty_unix_util_parse_package_prefix(dlinfo.dli_fname, "netty_transport_native_kqueue", &status);
     if (status == JNI_ERR) {
         fprintf(stderr, "FATAL: transport-native-kqueue JNI encountered unexpected dlinfo.dli_fname: %s\n", dlinfo.dli_fname);
         return JNI_ERR;

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
@@ -100,11 +100,7 @@ final class Native {
         if (!name.startsWith("mac") && !name.contains("bsd") && !name.startsWith("darwin")) {
             throw new IllegalStateException("Only supported on BSD");
         }
-        String []libraryNames = new String[] {
-            "netty-transport-native-kqueue",
-            "netty_transport_native_kqueue"
-        };
-        NativeLibraryLoader.loadFirstAvailable(PlatformDependent.getClassLoader(Native.class), libraryNames);
+        NativeLibraryLoader.load("netty_transport_native_kqueue", PlatformDependent.getClassLoader(Native.class));
     }
 
     private Native() {

--- a/transport-native-unix-common/src/main/c/netty_unix_util.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_util.c
@@ -87,7 +87,7 @@ char* netty_unix_util_parse_package_prefix(const char* libraryPathName, const ch
     packageNameEnd = packagePrefix + packagePrefixLen;
     // Package names must be sanitized, in JNI packages names are separated by '/' characters.
     for (; temp != packageNameEnd; ++temp) {
-        if (*temp == '-') {
+        if (*temp == '_') {
             *temp = '/';
         }
     }


### PR DESCRIPTION
Motivation:

At the moment we try to load the library using multiple names which includes names using - but also _ . We should just use _ all the time.

Modifications:

Replace - with _

Result:

Fixes [#7069]