### PR TITLE
Correctly respect java and openssl ciphers when using *OpenSslContext*

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -237,7 +237,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
         this.keyCertChain = keyCertChain == null ? null : keyCertChain.clone();
 
         unmodifiableCiphers = Arrays.asList(checkNotNull(cipherFilter, "cipherFilter").filterCipherSuites(
-                ciphers, DEFAULT_CIPHERS, availableJavaCipherSuites()));
+                ciphers, DEFAULT_CIPHERS, OpenSsl.AVAILABLE_CIPHER_SUITES));
 
         this.apn = checkNotNull(apn, "apn");
 


### PR DESCRIPTION
Motivation:

43ae974 introduced a regression where openssl nmed ciphers were not correctly included anymore in the default ciphers.

Modifications:

Add java and openssl cipher names to default ciphers.

Result:

Fix [#7094].