### PR TITLE
FIX endless loop in ByteBufUtil#writeAscii

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -591,7 +591,9 @@ public final class ByteBufUtil {
                     // Unwrap as the wrapped buffer may be an AbstractByteBuf and so we can use fast-path.
                     buf = buf.unwrap();
                 } else {
-                    buf.writeBytes(seq.toString().getBytes(CharsetUtil.US_ASCII));
+                    byte[] bytes = seq.toString().getBytes(CharsetUtil.US_ASCII);
+                    buf.writeBytes(bytes);
+                    return bytes.length;
                 }
             }
         }

--- a/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ByteBufUtilTest.java
@@ -205,6 +205,20 @@ public class ByteBufUtilTest {
     }
 
     @Test
+    public void testWriteUsAsciiSwapped() {
+        String usAscii = "NettyRocks";
+        ByteBuf buf = Unpooled.buffer(16);
+        buf.writeBytes(usAscii.getBytes(CharsetUtil.US_ASCII));
+        SwappedByteBuf buf2 = new SwappedByteBuf(Unpooled.buffer(16));
+        ByteBufUtil.writeAscii(buf2, usAscii);
+
+        assertEquals(buf, buf2);
+
+        buf.release();
+        buf2.release();
+    }
+
+    @Test
     public void testWriteUsAsciiWrapped() {
         String usAscii = "NettyRocks";
         ByteBuf buf = unreleasableBuffer(Unpooled.buffer(16));


### PR DESCRIPTION
Motivation:

Missing return in ByteBufUtil#writeAscii causes endless loop

Modifications:

Add return after write finished

Result:

ByteBufUtil#writeAscii is ok
