### PR TITLE
Increase test timeout for SocketStringEchoTest

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStringEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketStringEchoTest.java
@@ -52,7 +52,7 @@ public class SocketStringEchoTest extends AbstractSocketTest {
         }
     }
 
-    @Test(timeout = 30000)
+    @Test(timeout = 60000)
     public void testStringEcho() throws Throwable {
         run();
     }
@@ -61,7 +61,7 @@ public class SocketStringEchoTest extends AbstractSocketTest {
         testStringEcho(sb, cb, true);
     }
 
-    @Test(timeout = 30000)
+    @Test(timeout = 60000)
     public void testStringEchoNotAutoRead() throws Throwable {
         run();
     }


### PR DESCRIPTION
Motivation:
SocketStringEchoTest has been observed to fail on CI servers, but the stack traces still indicate work was being done.

Modifications:
- Increase the test timeout

Result:
Tests have more time to complete, and hopefully less false positive test failures.