### PR TITLE
Ensure netty builds with java9 (build 9+181)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,8 @@
         <!-- Skip as maven plugin not works with Java9 yet --> 
         <skipOsgiTestsuite>true</skipOsgiTestsuite>
         <forbiddenapis.skip>true</forbiddenapis.skip>
+        <!-- Needed because of https://issues.apache.org/jira/browse/MENFORCER-275 -->
+        <enforcer.plugin.version>3.0.0-M1</enforcer.plugin.version>
       </properties>
       <activation>
         <jdk>9</jdk>
@@ -199,6 +201,7 @@
     <logging.logLevel>debug</logging.logLevel>
     <log4j2.version>2.6.2</log4j2.version>
     <asm.version>5.1</asm.version>
+    <enforcer.plugin.version>1.4.1</enforcer.plugin.version>
     <testJavaHome>${env.JAVA_HOME}</testJavaHome>
     <skipOsgiTestsuite>false</skipOsgiTestsuite>
     <skipAutobahnTestsuite>false</skipAutobahnTestsuite>
@@ -576,6 +579,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${enforcer.plugin.version}</version>
         <executions>
           <execution>
             <id>enforce-tools</id>

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -48,6 +48,22 @@
       <groupId>org.apache.directory.server</groupId>
       <artifactId>apacheds-protocol-dns</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <!--
+          We need to use commons-lang 2.6 to be able to run the tests with java9
+          See https://github.com/apache/bookkeeper/issues/385
+        -->
+        <exclusion>
+          <groupId>commons-lang</groupId>
+          <artifactId>commons-lang</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Motivation:

To be able to build with latest java9 release we need to adjust commons-lang version and maven-enforcer-plugin.

Modifications:

- Use commons-lang 2.6.0
- Use maven-enforcer-plugin 3.0.0.M1 when building with java9

Result:

Netty builds again with latest java9 release