### PR TITLE
Use the index-based AsciiString constructor instead of substring() usage

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HttpConversionUtil.java
@@ -446,16 +446,19 @@ public final class HttpConversionUtil {
         return path.isEmpty() ? EMPTY_REQUEST_PATH : new AsciiString(path);
     }
 
-    private static void setHttp2Authority(String authority, Http2Headers out) {
+    // package-private for testing only
+    static void setHttp2Authority(String authority, Http2Headers out) {
         // The authority MUST NOT include the deprecated "userinfo" subcomponent
         if (authority != null) {
-            int endOfUserInfo = authority.indexOf('@');
-            if (endOfUserInfo < 0) {
-                out.authority(new AsciiString(authority));
-            } else if (endOfUserInfo + 1 < authority.length()) {
-                out.authority(new AsciiString(authority.substring(endOfUserInfo + 1)));
+            if (authority.isEmpty()) {
+                out.authority(EMPTY_STRING);
             } else {
-                throw new IllegalArgumentException("authority: " + authority);
+                int start = authority.indexOf('@') + 1;
+                int length = authority.length() - start;
+                if (length == 0) {
+                    throw new IllegalArgumentException("authority: " + authority);
+                }
+                out.authority(new AsciiString(authority, start, length));
             }
         }
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HttpConversionUtilTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.util.AsciiString;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class HttpConversionUtilTest {
+    @Test
+    public void setHttp2AuthorityWithoutUserInfo() {
+        Http2Headers headers = new DefaultHttp2Headers();
+
+        HttpConversionUtil.setHttp2Authority("foo", headers);
+        assertEquals(new AsciiString("foo"), headers.authority());
+    }
+
+    @Test
+    public void setHttp2AuthorityWithUserInfo() {
+        Http2Headers headers = new DefaultHttp2Headers();
+
+        HttpConversionUtil.setHttp2Authority("info@foo", headers);
+        assertEquals(new AsciiString("foo"), headers.authority());
+
+        HttpConversionUtil.setHttp2Authority("@foo.bar", headers);
+        assertEquals(new AsciiString("foo.bar"), headers.authority());
+    }
+
+    @Test
+    public void setHttp2AuthorityNullOrEmpty() {
+        Http2Headers headers = new DefaultHttp2Headers();
+
+        HttpConversionUtil.setHttp2Authority(null, headers);
+        assertNull(headers.authority());
+
+        HttpConversionUtil.setHttp2Authority("", headers);
+        assertSame(AsciiString.EMPTY_STRING, headers.authority());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setHttp2AuthorityWithEmptyAuthority() {
+        HttpConversionUtil.setHttp2Authority("info@", new DefaultHttp2Headers());
+    }
+}


### PR DESCRIPTION
Motivation:
The construction `new AsciiString(string.substring(...))` can be replaced with the `new AsciiString(string, start, length)` to avoid extra allocation.

Modifications:
Apply the described replacement in `HttpConversionUtil#setHttp2Authority`.

Result:
Less allocations.