### PR TITLE
Revert SslEngineWrapperFactory api breakage introduced by 4448b8f42f59…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
@@ -107,7 +107,7 @@ public final class JdkAlpnApplicationProtocolNegotiator extends JdkBaseApplicati
         super(ALPN_WRAPPER, selectorFactory, listenerFactory, protocols);
     }
 
-    private static final class FailureWrapper implements SslEngineWrapperFactory {
+    private static final class FailureWrapper extends AllocatorAwareSslEngineWrapperFactory {
         @Override
         public SSLEngine wrapSslEngine(SSLEngine engine, ByteBufAllocator alloc,
                                        JdkApplicationProtocolNegotiator applicationNegotiator, boolean isServer) {
@@ -118,7 +118,7 @@ public final class JdkAlpnApplicationProtocolNegotiator extends JdkBaseApplicati
         }
     }
 
-    private static final class AlpnWrapper implements SslEngineWrapperFactory {
+    private static final class AlpnWrapper extends AllocatorAwareSslEngineWrapperFactory {
         @Override
         public SSLEngine wrapSslEngine(SSLEngine engine, ByteBufAllocator alloc,
                                        JdkApplicationProtocolNegotiator applicationNegotiator, boolean isServer) {

--- a/handler/src/main/java/io/netty/handler/ssl/JdkApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkApplicationProtocolNegotiator.java
@@ -32,6 +32,29 @@ public interface JdkApplicationProtocolNegotiator extends ApplicationProtocolNeg
          * Abstract factory pattern for wrapping an {@link SSLEngine} object. This is useful for NPN/APLN support.
          *
          * @param engine The engine to wrap.
+         * @param applicationNegotiator The application level protocol negotiator
+         * @param isServer <ul>
+         * <li>{@code true} if the engine is for server side of connections</li>
+         * <li>{@code false} if the engine is for client side of connections</li>
+         * </ul>
+         * @return The resulting wrapped engine. This may just be {@code engine}.
+         */
+        SSLEngine wrapSslEngine(
+                SSLEngine engine, JdkApplicationProtocolNegotiator applicationNegotiator, boolean isServer);
+    }
+
+    abstract class AllocatorAwareSslEngineWrapperFactory implements SslEngineWrapperFactory {
+
+        @Override
+        public final SSLEngine wrapSslEngine(SSLEngine engine,
+                                       JdkApplicationProtocolNegotiator applicationNegotiator, boolean isServer) {
+            return wrapSslEngine(engine, ByteBufAllocator.DEFAULT, applicationNegotiator, isServer);
+        }
+
+        /**
+         * Abstract factory pattern for wrapping an {@link SSLEngine} object. This is useful for NPN/APLN support.
+         *
+         * @param engine The engine to wrap.
          * @param alloc the buffer allocator.
          * @param applicationNegotiator The application level protocol negotiator
          * @param isServer <ul>
@@ -40,8 +63,8 @@ public interface JdkApplicationProtocolNegotiator extends ApplicationProtocolNeg
          * </ul>
          * @return The resulting wrapped engine. This may just be {@code engine}.
          */
-        SSLEngine wrapSslEngine(SSLEngine engine, ByteBufAllocator alloc,
-                JdkApplicationProtocolNegotiator applicationNegotiator, boolean isServer);
+        abstract SSLEngine wrapSslEngine(SSLEngine engine, ByteBufAllocator alloc,
+                                JdkApplicationProtocolNegotiator applicationNegotiator, boolean isServer);
     }
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/JdkDefaultApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkDefaultApplicationProtocolNegotiator.java
@@ -30,7 +30,7 @@ final class JdkDefaultApplicationProtocolNegotiator implements JdkApplicationPro
             new JdkDefaultApplicationProtocolNegotiator();
     private static final SslEngineWrapperFactory DEFAULT_SSL_ENGINE_WRAPPER_FACTORY = new SslEngineWrapperFactory() {
         @Override
-        public SSLEngine wrapSslEngine(SSLEngine engine, ByteBufAllocator alloc,
+        public SSLEngine wrapSslEngine(SSLEngine engine,
                                        JdkApplicationProtocolNegotiator applicationNegotiator, boolean isServer) {
             return engine;
         }

--- a/handler/src/main/java/io/netty/handler/ssl/JdkNpnApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkNpnApplicationProtocolNegotiator.java
@@ -31,7 +31,7 @@ public final class JdkNpnApplicationProtocolNegotiator extends JdkBaseApplicatio
         }
 
         @Override
-        public SSLEngine wrapSslEngine(SSLEngine engine, ByteBufAllocator alloc,
+        public SSLEngine wrapSslEngine(SSLEngine engine,
                                        JdkApplicationProtocolNegotiator applicationNegotiator, boolean isServer) {
             return new JettyNpnSslEngine(engine, applicationNegotiator, isServer);
         }

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -236,7 +236,12 @@ public class JdkSslContext extends SslContext {
                     throw new Error("Unknown auth " + clientAuth);
             }
         }
-        return apn.wrapperFactory().wrapSslEngine(engine, alloc, apn, isServer());
+        JdkApplicationProtocolNegotiator.SslEngineWrapperFactory factory = apn.wrapperFactory();
+        if (factory instanceof JdkApplicationProtocolNegotiator.AllocatorAwareSslEngineWrapperFactory) {
+            return ((JdkApplicationProtocolNegotiator.AllocatorAwareSslEngineWrapperFactory) factory)
+                    .wrapSslEngine(engine, alloc, apn, isServer());
+        }
+        return factory.wrapSslEngine(engine, apn, isServer());
     }
 
     @Override


### PR DESCRIPTION
…9e79db1744cd8f5fdfee702c195e.

Motivation:

Commit 4448b8f42f599e79db1744cd8f5fdfee702c195e introduced some API breakage which we need to revert before we release.

Modifications:

- Introduce an AllocatorAwareSslEngineWrapperFactory which expose an extra method that takes a ByteBufAllocator as well.
- Revert API changes to SslEngineWrapperFactory.

Result:

API breakage reverted.