### PR TITLE
Add explicit fall through comments for errorprone.info

### DIFF
--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -491,6 +491,7 @@ public final class StringUtil {
                         }
                         // double-quote appears without being enclosed with double-quotes
                     case LINE_FEED:
+                        // fall through
                     case CARRIAGE_RETURN:
                         // special characters appears without being enclosed with double-quotes
                         throw newInvalidEscapedCsvFieldException(value, i);

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -490,8 +490,8 @@ public final class StringUtil {
                             break;
                         }
                         // double-quote appears without being enclosed with double-quotes
+                    // fall through
                     case LINE_FEED:
-                        // fall through
                     case CARRIAGE_RETURN:
                         // special characters appears without being enclosed with double-quotes
                         throw newInvalidEscapedCsvFieldException(value, i);

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -490,7 +490,7 @@ public final class StringUtil {
                             break;
                         }
                         // double-quote appears without being enclosed with double-quotes
-                    // fall through
+                        // fall through
                     case LINE_FEED:
                     case CARRIAGE_RETURN:
                         // special characters appears without being enclosed with double-quotes

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -439,7 +439,7 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                         if (wakenUp.get()) {
                             selector.wakeup();
                         }
-                    // fall through
+                        // fall through
                     default:
                 }
 

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -439,8 +439,8 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                         if (wakenUp.get()) {
                             selector.wakeup();
                         }
+                    // fall through
                     default:
-                        // fallthrough
                 }
 
                 cancelledKeys = 0;


### PR DESCRIPTION
Motivation:

When compiling this code and running it through errorprone[1], this message appears:
```
StringUtil.java:493: error: [FallThrough] Switch case may fall through; add a `// fall through` comment if it was deliberate
                    case LINE_FEED:
                    ^
    (see http://errorprone.info/bugpattern/FallThrough)
```
By adding that comment, it silences the error and also makes clear the intention of that statement.

[1]http://errorprone.info/index

Modification:

Add simple comment.

Result:

Errorprone is happier with the code.

