### PR TITLE
Update netty-tcnative native library names to use underscores.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -410,14 +410,12 @@ public final class OpenSsl {
         Set<String> libNames = new LinkedHashSet<String>(4);
         // First, try loading the platform-specific library. Platform-specific
         // libraries will be available if using a tcnative uber jar.
-        libNames.add("netty-tcnative-" + os + '-' + arch);
+        libNames.add("netty_tcnative-" + os + '-' + arch);
         if (LINUX.equalsIgnoreCase(os)) {
             // Fedora SSL lib so naming (libssl.so.10 vs libssl.so.1.0.0)..
-            libNames.add("netty-tcnative-" + os + '-' + arch + "-fedora");
+            libNames.add("netty_tcnative-" + os + '-' + arch + "-fedora");
         }
         // finally the default library.
-        libNames.add("netty-tcnative");
-        // in Java 8, statically compiled JNI code is namespaced
         libNames.add("netty_tcnative");
 
         NativeLibraryLoader.loadFirstAvailable(SSL.class.getClassLoader(),

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
-    <tcnative.version>2.0.5.Final</tcnative.version>
+    <tcnative.version>2.0.6.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
Motivation:

We recently changed netty-tcnative to use underscores in its native library names.

Modifications:

Update code to use underscores when loading native library.

Result:

More consistent code.