### PR TITLE
Do not define JNI_OnLoad when not dynamic

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -595,7 +595,7 @@ jint JNI_OnLoad_netty_transport_native_epoll(JavaVM* vm, void* reserved) {
         return JNI_ERR;
     }
     char* packagePrefix = NULL;
-#ifndef NETTY_NOT_DYNAMIC
+#ifndef NETTY_BUILD_STATIC
     Dl_info dlinfo;
     jint status = 0;
     // We need to use an address of a function that is uniquely part of this library, so choose a static
@@ -609,7 +609,7 @@ jint JNI_OnLoad_netty_transport_native_epoll(JavaVM* vm, void* reserved) {
         fprintf(stderr, "FATAL: transport-native-epoll JNI encountered unexpected dlinfo.dli_fname: %s\n", dlinfo.dli_fname);
         return JNI_ERR;
     }
-#endif /* NETTY_NOT_DYNAMIC */
+#endif /* NETTY_BUILD_STATIC */
     jint ret = netty_epoll_native_JNI_OnLoad(env, packagePrefix);
 
     if (packagePrefix != NULL) {
@@ -620,9 +620,11 @@ jint JNI_OnLoad_netty_transport_native_epoll(JavaVM* vm, void* reserved) {
     return ret;
 }
 
+#ifndef NETTY_BUILD_STATIC
 jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     return JNI_OnLoad_netty_transport_native_epoll(vm, reserved);
 }
+#endif /* NETTY_BUILD_STATIC */
 
 // Invoked by the JVM when statically linked
 void JNI_OnUnload_netty_transport_native_epoll(JavaVM* vm, void* reserved) {
@@ -634,6 +636,8 @@ void JNI_OnUnload_netty_transport_native_epoll(JavaVM* vm, void* reserved) {
     netty_epoll_native_JNI_OnUnLoad(env);
 }
 
+#ifndef NETTY_BUILD_STATIC
 void JNI_OnUnload(JavaVM* vm, void* reserved) {
   JNI_OnUnload_netty_transport_native_epoll(vm, reserved);
 }
+#endif /* NETTY_BUILD_STATIC */

--- a/transport-native-kqueue/src/main/c/netty_kqueue_native.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_native.c
@@ -278,7 +278,7 @@ jint JNI_OnLoad_netty_transport_native_kqueue(JavaVM* vm, void* reserved) {
     }
 
     char* packagePrefix = NULL;
-#ifndef NETTY_NOT_DYNAMIC
+#ifndef NETTY_BUILD_STATIC
     Dl_info dlinfo;
     jint status = 0;
     // We need to use an address of a function that is uniquely part of this library, so choose a static
@@ -292,7 +292,7 @@ jint JNI_OnLoad_netty_transport_native_kqueue(JavaVM* vm, void* reserved) {
         fprintf(stderr, "FATAL: transport-native-kqueue JNI encountered unexpected dlinfo.dli_fname: %s\n", dlinfo.dli_fname);
         return JNI_ERR;
     }
-#endif /* NETTY_NOT_DYNAMIC */
+#endif /* NETTY_BUILD_STATIC */
     jint ret = netty_kqueue_native_JNI_OnLoad(env, packagePrefix);
 
     if (packagePrefix != NULL) {
@@ -303,9 +303,11 @@ jint JNI_OnLoad_netty_transport_native_kqueue(JavaVM* vm, void* reserved) {
     return ret;
 }
 
+#ifndef NETTY_BUILD_STATIC
 jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     return JNI_OnLoad_netty_transport_native_kqueue(vm, reserved);
 }
+#endif /* NETTY_BUILD_STATIC */
 
 // Invoked by the JVM when statically linked
 void JNI_OnUnload_netty_transport_native_kqueue(JavaVM* vm, void* reserved) {
@@ -317,6 +319,8 @@ void JNI_OnUnload_netty_transport_native_kqueue(JavaVM* vm, void* reserved) {
     netty_kqueue_native_JNI_OnUnLoad(env);
 }
 
+#ifndef NETTY_BUILD_STATIC
 void JNI_OnUnload(JavaVM* vm, void* reserved) {
     return JNI_OnUnload_netty_transport_native_kqueue(vm, reserved);
 }
+#endif /* NETTY_BUILD_STATIC */


### PR DESCRIPTION
Motivation:
Due to an oversight (by myself), linking two JNI modules with
duplicate symbols fails in linking.  This only seems to happen
some of the time (the behavior seems to be different between GCC
and Clang toolchains).  For instance, including both netty tcnative
and netty epoll fails to link because of duplicate JNI_OnLoad
symobols.

Modification:
Do not define the JNI_OnLoad and JNI_OnUnload symbols when
compiling for static linkage, as indicated by the NETTY_NOT_DYNAMIC
preprocessor define.  They are never directly called when
statically linked.

Result:
Able to statically compile epoll and tcnative code into a single
binary.
