### PR TITLE
Use Constructor for reflective class instantiation.

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoderNano.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufDecoderNano.java
@@ -82,7 +82,7 @@ public class ProtobufDecoderNano extends MessageToMessageDecoder<ByteBuf> {
             msg.getBytes(msg.readerIndex(), array, 0, length);
             offset = 0;
         }
-        MessageNano prototype = clazz.newInstance();
+        MessageNano prototype = clazz.getConstructor().newInstance();
         out.add(MessageNano.mergeFrom(prototype, array, offset, length));
     }
 }

--- a/transport-udt/src/test/java/io/netty/test/udt/util/CaliperRunner.java
+++ b/transport-udt/src/test/java/io/netty/test/udt/util/CaliperRunner.java
@@ -78,7 +78,7 @@ public final class CaliperRunner {
     public static Run execute(final String name,
             final Class<? extends CaliperBench> klaz) throws Exception {
 
-        final CaliperBench booter = klaz.newInstance();
+        final CaliperBench booter = klaz.getConstructor().newInstance();
 
         final List<Map<String, String>> varsSet = product(booter);
 

--- a/transport/src/main/java/io/netty/channel/ReflectiveChannelFactory.java
+++ b/transport/src/main/java/io/netty/channel/ReflectiveChannelFactory.java
@@ -35,7 +35,7 @@ public class ReflectiveChannelFactory<T extends Channel> implements ChannelFacto
     @Override
     public T newChannel() {
         try {
-            return clazz.newInstance();
+            return clazz.getConstructor().newInstance();
         } catch (Throwable t) {
             throw new ChannelException("Unable to create Channel from class " + clazz, t);
         }


### PR DESCRIPTION
Motivation:
Calling `newInstance()` on a Class object can bypass compile time
checked Exception propagation.  This is noted in Java Puzzlers,
as well as in ErrorProne:
http://errorprone.info/bugpattern/ClassNewInstance

Modifications:
Use the niladic constructor to create a new instance.

Result:
Compile time safety for checked exceptions
