### PR TITLE
Include JNIEXPORT on exported symbols

### DIFF
--- a/transport-native-epoll/src/main/c/netty_epoll_native.c
+++ b/transport-native-epoll/src/main/c/netty_epoll_native.c
@@ -621,7 +621,7 @@ jint JNI_OnLoad_netty_transport_native_epoll(JavaVM* vm, void* reserved) {
 }
 
 #ifndef NETTY_BUILD_STATIC
-jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     return JNI_OnLoad_netty_transport_native_epoll(vm, reserved);
 }
 #endif /* NETTY_BUILD_STATIC */
@@ -637,7 +637,7 @@ void JNI_OnUnload_netty_transport_native_epoll(JavaVM* vm, void* reserved) {
 }
 
 #ifndef NETTY_BUILD_STATIC
-void JNI_OnUnload(JavaVM* vm, void* reserved) {
+JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved) {
   JNI_OnUnload_netty_transport_native_epoll(vm, reserved);
 }
 #endif /* NETTY_BUILD_STATIC */

--- a/transport-native-kqueue/src/main/c/netty_kqueue_native.c
+++ b/transport-native-kqueue/src/main/c/netty_kqueue_native.c
@@ -353,7 +353,7 @@ jint JNI_OnLoad_netty_transport_native_kqueue(JavaVM* vm, void* reserved) {
 }
 
 #ifndef NETTY_BUILD_STATIC
-jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     return JNI_OnLoad_netty_transport_native_kqueue(vm, reserved);
 }
 #endif /* NETTY_BUILD_STATIC */
@@ -369,7 +369,7 @@ void JNI_OnUnload_netty_transport_native_kqueue(JavaVM* vm, void* reserved) {
 }
 
 #ifndef NETTY_BUILD_STATIC
-void JNI_OnUnload(JavaVM* vm, void* reserved) {
+JNIEXPORT void JNI_OnUnload(JavaVM* vm, void* reserved) {
     return JNI_OnUnload_netty_transport_native_kqueue(vm, reserved);
 }
 #endif /* NETTY_BUILD_STATIC */


### PR DESCRIPTION
Motivation:
As noticed in https://stackoverflow.com/questions/45700277/
compilation can fail if the definition of a method doesn't
match the declaration.  It's easy enough to add this in, and make
it easy to compile.

Modifications:
Add JNIEXPORT to the entry points.

* On Windows this adds: `__declspec(dllexport)`
* On Mac this adds: `__attribute__((visibility("default")))`
* On Linux (GCC 4.2+) this adds: ` __attribute__((visibility("default")))`
* On other it doesn't add anything.

Result:
Easier compilation