### PR TITLE
Decouple DnsCache and DnsCacheEntry

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCache.java
@@ -49,17 +49,19 @@ public interface DnsCache {
      * @param additionals the additional records
      * @return the cached entries
      */
-    List<DnsCacheEntry> get(String hostname, DnsRecord[] additionals);
+    List<? extends DnsCacheEntry> get(String hostname, DnsRecord[] additionals);
 
     /**
-     * Cache a resolved address for a given hostname.
+     * Create a new {@link DnsCacheEntry} and cache a resolved address for a given hostname.
      * @param hostname the hostname
      * @param additionals the additional records
      * @param address the resolved address
      * @param originalTtl the TLL as returned by the DNS server
      * @param loop the {@link EventLoop} used to register the TTL timeout
+     * @return The {@link DnsCacheEntry} corresponding to this cache entry.
      */
-    void cache(String hostname, DnsRecord[] additionals, InetAddress address, long originalTtl, EventLoop loop);
+    DnsCacheEntry cache(String hostname, DnsRecord[] additionals, InetAddress address, long originalTtl,
+                        EventLoop loop);
 
     /**
      * Cache the resolution failure for a given hostname.
@@ -67,6 +69,8 @@ public interface DnsCache {
      * @param additionals the additional records
      * @param cause the resolution failure
      * @param loop the {@link EventLoop} used to register the TTL timeout
+     * @return The {@link DnsCacheEntry} corresponding to this cache entry, or {@code null} if this cache doesn't
+     * support caching failed responses.
      */
-    void cache(String hostname, DnsRecord[] additionals, Throwable cause, EventLoop loop);
+    DnsCacheEntry cache(String hostname, DnsRecord[] additionals, Throwable cause, EventLoop loop);
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCacheEntry.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCacheEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 The Netty Project
+ * Copyright 2017 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,71 +13,28 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package io.netty.resolver.dns;
 
-import static io.netty.util.internal.ObjectUtil.checkNotNull;
-
-import io.netty.channel.EventLoop;
-import io.netty.util.concurrent.ScheduledFuture;
 import io.netty.util.internal.UnstableApi;
 
 import java.net.InetAddress;
-import java.util.concurrent.TimeUnit;
 
 /**
- * Entry in {@link DnsCache}.
+ * Represents the results from a previous DNS query which can be cached.
  */
 @UnstableApi
-public final class DnsCacheEntry {
+public interface DnsCacheEntry {
+    /**
+     * Get the resolved address.
+     * <p>
+     * This may be null if the resolution failed, and in that case {@link #cause()} will describe the failure.
+     * @return the resolved address.
+     */
+    InetAddress address();
 
-    private final String hostname;
-    private final InetAddress address;
-    private final Throwable cause;
-    private volatile ScheduledFuture<?> expirationFuture;
-
-    public DnsCacheEntry(String hostname, InetAddress address) {
-        this.hostname = checkNotNull(hostname, "hostname");
-        this.address = checkNotNull(address, "address");
-        cause = null;
-    }
-
-    public DnsCacheEntry(String hostname, Throwable cause) {
-        this.hostname = checkNotNull(hostname, "hostname");
-        this.cause = checkNotNull(cause, "cause");
-        address = null;
-    }
-
-    public String hostname() {
-        return hostname;
-    }
-
-    public InetAddress address() {
-        return address;
-    }
-
-    public Throwable cause() {
-        return cause;
-    }
-
-    void scheduleExpiration(EventLoop loop, Runnable task, long delay, TimeUnit unit) {
-        assert expirationFuture == null: "expiration task scheduled already";
-        expirationFuture = loop.schedule(task, delay, unit);
-    }
-
-    void cancelExpiration() {
-        ScheduledFuture<?> expirationFuture = this.expirationFuture;
-        if (expirationFuture != null) {
-            expirationFuture.cancel(false);
-        }
-    }
-
-    @Override
-    public String toString() {
-        if (cause != null) {
-            return hostname + '/' + cause;
-        } else {
-            return address.toString();
-        }
-    }
+    /**
+     * If the DNS query failed this will provide the rational.
+     * @return the rational for why the DNS query failed, or {@code null} if the query hasn't failed.
+     */
+    Throwable cause();
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -599,7 +599,7 @@ public class DnsNameResolver extends InetNameResolver {
                                     DnsRecord[] additionals,
                                     Promise<InetAddress> promise,
                                     DnsCache resolveCache) {
-        final List<DnsCacheEntry> cachedEntries = resolveCache.get(hostname, additionals);
+        final List<? extends DnsCacheEntry> cachedEntries = resolveCache.get(hostname, additionals);
         if (cachedEntries == null || cachedEntries.isEmpty()) {
             return false;
         }
@@ -729,7 +729,7 @@ public class DnsNameResolver extends InetNameResolver {
                                        DnsRecord[] additionals,
                                        Promise<List<InetAddress>> promise,
                                        DnsCache resolveCache) {
-        final List<DnsCacheEntry> cachedEntries = resolveCache.get(hostname, additionals);
+        final List<? extends DnsCacheEntry> cachedEntries = resolveCache.get(hostname, additionals);
         if (cachedEntries == null || cachedEntries.isEmpty()) {
             return false;
         }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -236,7 +236,7 @@ abstract class DnsNameResolverContext<T> {
             }
             idx = idx2;
 
-            List<DnsCacheEntry> entries = parent.authoritativeDnsServerCache().get(hostname, additionals);
+            List<? extends DnsCacheEntry> entries = parent.authoritativeDnsServerCache().get(hostname, additionals);
             if (entries != null && !entries.isEmpty()) {
                 return DnsServerAddresses.sequential(new DnsCacheIterable(entries)).stream();
             }
@@ -244,16 +244,16 @@ abstract class DnsNameResolverContext<T> {
     }
 
     private final class DnsCacheIterable implements Iterable<InetSocketAddress> {
-        private final List<DnsCacheEntry> entries;
+        private final List<? extends DnsCacheEntry> entries;
 
-        DnsCacheIterable(List<DnsCacheEntry> entries) {
+        DnsCacheIterable(List<? extends DnsCacheEntry> entries) {
             this.entries = entries;
         }
 
         @Override
         public Iterator<InetSocketAddress> iterator() {
             return new Iterator<InetSocketAddress>() {
-                Iterator<DnsCacheEntry> entryIterator = entries.iterator();
+                Iterator<? extends DnsCacheEntry> entryIterator = entries.iterator();
 
                 @Override
                 public boolean hasNext() {
@@ -484,9 +484,8 @@ abstract class DnsNameResolverContext<T> {
                 resolvedEntries = new ArrayList<DnsCacheEntry>(8);
             }
 
-            final DnsCacheEntry e = new DnsCacheEntry(hostname, resolved);
-            resolveCache.cache(hostname, additionals, resolved, r.timeToLive(), parent.ch.eventLoop());
-            resolvedEntries.add(e);
+            resolvedEntries.add(
+                    resolveCache.cache(hostname, additionals, resolved, r.timeToLive(), parent.ch.eventLoop()));
             found = true;
 
             // Note that we do not break from the loop here, so we decode/cache all A/AAAA records.

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/NoopDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/NoopDnsCache.java
@@ -47,21 +47,46 @@ public final class NoopDnsCache implements DnsCache {
     }
 
     @Override
-    public List<DnsCacheEntry> get(String hostname, DnsRecord[] additionals) {
+    public List<? extends DnsCacheEntry> get(String hostname, DnsRecord[] additionals) {
         return Collections.emptyList();
     }
 
     @Override
-    public void cache(String hostname, DnsRecord[] additional,
-                      InetAddress address, long originalTtl, EventLoop loop) {
+    public DnsCacheEntry cache(String hostname, DnsRecord[] additional,
+                               InetAddress address, long originalTtl, EventLoop loop) {
+        return new NoopDnsCacheEntry(address);
     }
 
     @Override
-    public void cache(String hostname, DnsRecord[] additional, Throwable cause, EventLoop loop) {
+    public DnsCacheEntry cache(String hostname, DnsRecord[] additional, Throwable cause, EventLoop loop) {
+        return null;
     }
 
     @Override
     public String toString() {
         return NoopDnsCache.class.getSimpleName();
+    }
+
+    private static final class NoopDnsCacheEntry implements DnsCacheEntry {
+        private final InetAddress address;
+
+        NoopDnsCacheEntry(InetAddress address) {
+            this.address = address;
+        }
+
+        @Override
+        public InetAddress address() {
+            return address;
+        }
+
+        @Override
+        public Throwable cause() {
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return address.toString();
+        }
     }
 }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -971,7 +971,7 @@ public class DnsNameResolverTest {
             if (cache) {
                 assertNull(nsCache.cache.get("io.", null));
                 assertNull(nsCache.cache.get("netty.io.", null));
-                List<DnsCacheEntry> entries = nsCache.cache.get("record.netty.io.", null);
+                List<? extends DnsCacheEntry> entries = nsCache.cache.get("record.netty.io.", null);
                 assertEquals(1, entries.size());
 
                 assertNull(nsCache.cache.get(hostname, null));
@@ -1159,7 +1159,8 @@ public class DnsNameResolverTest {
 
     private static final class TestDnsCache implements DnsCache {
         private final DnsCache cache;
-        final Map<String, List<DnsCacheEntry>> cacheHits = new HashMap<String, List<DnsCacheEntry>>();
+        final Map<String, List<? extends DnsCacheEntry>> cacheHits = new HashMap<String,
+                                                                                  List<? extends DnsCacheEntry>>();
 
         TestDnsCache(DnsCache cache) {
             this.cache = cache;
@@ -1176,22 +1177,22 @@ public class DnsNameResolverTest {
         }
 
         @Override
-        public List<DnsCacheEntry> get(String hostname, DnsRecord[] additionals) {
-            List<DnsCacheEntry> cacheEntries = cache.get(hostname, additionals);
+        public List<? extends DnsCacheEntry> get(String hostname, DnsRecord[] additionals) {
+            List<? extends DnsCacheEntry> cacheEntries = cache.get(hostname, additionals);
             cacheHits.put(hostname, cacheEntries);
             return cacheEntries;
         }
 
         @Override
-        public void cache(
+        public DnsCacheEntry cache(
                 String hostname, DnsRecord[] additionals, InetAddress address, long originalTtl, EventLoop loop) {
-            cache.cache(hostname, additionals, address, originalTtl, loop);
+            return cache.cache(hostname, additionals, address, originalTtl, loop);
         }
 
         @Override
-        public void cache(
+        public DnsCacheEntry cache(
                 String hostname, DnsRecord[] additionals, Throwable cause, EventLoop loop) {
-            cache.cache(hostname, additionals, cause, loop);
+            return cache.cache(hostname, additionals, cause, loop);
         }
     }
 


### PR DESCRIPTION
Motivation:
DnsCache (an interface) is coupled to DnsCacheEntry (a final class). This means that DnsCache implementations can't implement their own DnsCacheEntry objects if the default behavior isn't appropriate.

Modifications:
- DnsCacheEntry should be moved to DefaultDnsCache as it is an implementation detail
- DnsCache#cache(..) should return a new DnsCacheEntry
- The methods which from DnsCacheEntry that were used outside the scope of DefaultDnsCache should be moved into an interface

Result:
DnsCache is more extensible and not tightly coupled to a default implementation of DnsCacheEntry.