### PR TITLE
Update JCTools version, fixes #7117

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
       <dependency>
         <groupId>org.jctools</groupId>
         <artifactId>jctools-core</artifactId>
-        <version>2.0.2</version>
+        <version>2.1.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Motivation:

Remove Unsafe dependency for Atomic queues in JCTools, resolved in version 2.1.0

Modification:

Change pom JCTools version

Result:

Fixes #7117 

