### PR TITLE
DelegatingSslContext should also be able to configure the SslHandler

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/DelegatingSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/DelegatingSslContext.java
@@ -73,6 +73,20 @@ public abstract class DelegatingSslContext extends SslContext {
     }
 
     @Override
+    protected final SslHandler newHandler(ByteBufAllocator alloc, boolean startTls) {
+        SslHandler handler = ctx.newHandler(alloc, startTls);
+        initHandler(handler);
+        return handler;
+    }
+
+    @Override
+    protected final SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort, boolean startTls) {
+        SslHandler handler = ctx.newHandler(alloc, peerHost, peerPort, startTls);
+        initHandler(handler);
+        return handler;
+    }
+
+    @Override
     public final SSLSessionContext sessionContext() {
         return ctx.sessionContext();
     }
@@ -81,4 +95,12 @@ public abstract class DelegatingSslContext extends SslContext {
      * Init the {@link SSLEngine}.
      */
     protected abstract void initEngine(SSLEngine engine);
+
+    /**
+     * Init the {@link SslHandler}. This will by default call {@link #initEngine(SSLEngine)}, sub-classes may override
+     * this.
+     */
+    protected void initHandler(SslHandler handler) {
+        initEngine(handler.engine());
+    }
 }

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -379,12 +379,12 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     }
 
     @Override
-    final SslHandler newHandler(ByteBufAllocator alloc, boolean startTls) {
+    protected final SslHandler newHandler(ByteBufAllocator alloc, boolean startTls) {
         return new SslHandler(newEngine0(alloc, null, -1, false), startTls, false);
     }
 
     @Override
-    final SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort, boolean startTls) {
+    protected final SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort, boolean startTls) {
         return new SslHandler(newEngine0(alloc, peerHost, peerPort, false), startTls, false);
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/SslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslContext.java
@@ -909,7 +909,7 @@ public abstract class SslContext {
      * Create a new SslHandler.
      * @see #newHandler(ByteBufAllocator)
      */
-    SslHandler newHandler(ByteBufAllocator alloc, boolean startTls) {
+    protected SslHandler newHandler(ByteBufAllocator alloc, boolean startTls) {
         return new SslHandler(newEngine(alloc), startTls);
     }
 
@@ -947,7 +947,7 @@ public abstract class SslContext {
      * Create a new SslHandler.
      * @see #newHandler(ByteBufAllocator, String, int, boolean)
      */
-    SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort, boolean startTls) {
+    protected SslHandler newHandler(ByteBufAllocator alloc, String peerHost, int peerPort, boolean startTls) {
         return new SslHandler(newEngine(alloc, peerHost, peerPort), startTls);
     }
 

--- a/handler/src/test/java/io/netty/handler/ssl/DelegatingSslContextTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/DelegatingSslContextTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.ssl;
+
+import io.netty.buffer.UnpooledByteBufAllocator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+
+public class DelegatingSslContextTest {
+    private static final String[] EXPECTED_PROTOCOLS = { SslUtils.PROTOCOL_TLS_V1_1 };
+
+    @Test
+    public void testInitEngineOnNewEngine() throws Exception {
+        SslContext delegating = newDelegatingSslContext();
+
+        SSLEngine engine = delegating.newEngine(UnpooledByteBufAllocator.DEFAULT);
+        Assert.assertArrayEquals(EXPECTED_PROTOCOLS, engine.getEnabledProtocols());
+
+        engine = delegating.newEngine(UnpooledByteBufAllocator.DEFAULT, "localhost", 9090);
+        Assert.assertArrayEquals(EXPECTED_PROTOCOLS, engine.getEnabledProtocols());
+    }
+
+    @Test
+    public void testInitEngineOnNewSslHandler() throws Exception {
+        SslContext delegating = newDelegatingSslContext();
+
+        SslHandler handler = delegating.newHandler(UnpooledByteBufAllocator.DEFAULT);
+        Assert.assertArrayEquals(EXPECTED_PROTOCOLS, handler.engine().getEnabledProtocols());
+
+        handler = delegating.newHandler(UnpooledByteBufAllocator.DEFAULT, "localhost", 9090);
+        Assert.assertArrayEquals(EXPECTED_PROTOCOLS, handler.engine().getEnabledProtocols());
+    }
+
+    private static SslContext newDelegatingSslContext() throws Exception {
+        return new DelegatingSslContext(new JdkSslContext(SSLContext.getDefault(), false, ClientAuth.NONE)) {
+            @Override
+            protected void initEngine(SSLEngine engine) {
+                engine.setEnabledProtocols(EXPECTED_PROTOCOLS);
+            }
+        };
+    }
+}


### PR DESCRIPTION
Motivation:

DelegatingSslContext at the moment intercept newEngine calls and allow to init the SslEngine after it is created. The problem here is that this may not work the SSLEngine that is wrapped in the SslHandler when calling newHandler(...). This is because some SslContext implementations not delegate to newEngine(...) when creating the SslHandler to allow some optimizations. For this we should also allow to init the SslHandler after its creation and by default just delegate to initEngine(...).

Modifications:

Allow the user to also init the SslHandler after creation while by default init its SSLEngine after creation.

Result:

More flexible and correct code.