### PR TITLE
Deprecate ApplicationProtocolNegotiator and its implementation as peo…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ApplicationProtocolNegotiator.java
@@ -25,7 +25,10 @@ import java.util.List;
  * <li><a href="https://technotes.googlecode.com/git/nextprotoneg.html">Next Protocol Negotiation</a></li>
  * <li><a href="http://tools.ietf.org/html/rfc7301">Application-Layer Protocol Negotiation</a></li>
  * </ul>
+ *
+ * @deprecated use {@link ApplicationProtocolConfig}
  */
+@SuppressWarnings("deprecation")
 public interface ApplicationProtocolNegotiator {
     /**
      * Get the collection of application protocols supported by this application (in preference order).

--- a/handler/src/main/java/io/netty/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkAlpnApplicationProtocolNegotiator.java
@@ -20,7 +20,10 @@ import javax.net.ssl.SSLEngine;
 
 /**
  * The {@link JdkApplicationProtocolNegotiator} to use if you need ALPN and are using {@link SslProvider#JDK}.
+ *
+ * @deprecated use {@link ApplicationProtocolConfig}.
  */
+@Deprecated
 public final class JdkAlpnApplicationProtocolNegotiator extends JdkBaseApplicationProtocolNegotiator {
     private static final boolean AVAILABLE = Conscrypt.isAvailable() || JettyAlpnSslEngine.isAvailable();
     private static final SslEngineWrapperFactory ALPN_WRAPPER = AVAILABLE ? new AlpnWrapper() : new FailureWrapper();

--- a/handler/src/main/java/io/netty/handler/ssl/JdkApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkApplicationProtocolNegotiator.java
@@ -22,7 +22,10 @@ import java.util.Set;
 
 /**
  * JDK extension methods to support {@link ApplicationProtocolNegotiator}
+ *
+ * @deprecated use {@link ApplicationProtocolConfig}
  */
+@Deprecated
 public interface JdkApplicationProtocolNegotiator extends ApplicationProtocolNegotiator {
     /**
      * Abstract factory pattern for wrapping an {@link SSLEngine} object. This is useful for NPN/APLN JDK support.

--- a/handler/src/main/java/io/netty/handler/ssl/JdkDefaultApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkDefaultApplicationProtocolNegotiator.java
@@ -15,7 +15,6 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.buffer.ByteBufAllocator;
 import java.util.Collections;
 import java.util.List;
 

--- a/handler/src/main/java/io/netty/handler/ssl/JdkNpnApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkNpnApplicationProtocolNegotiator.java
@@ -15,12 +15,14 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.buffer.ByteBufAllocator;
 import javax.net.ssl.SSLEngine;
 
 /**
  * The {@link JdkApplicationProtocolNegotiator} to use if you need NPN and are using {@link SslProvider#JDK}.
+ *
+ * @deprecated use {@link ApplicationProtocolConfig}.
  */
+@Deprecated
 public final class JdkNpnApplicationProtocolNegotiator extends JdkBaseApplicationProtocolNegotiator {
     private static final SslEngineWrapperFactory NPN_WRAPPER = new SslEngineWrapperFactory() {
         {

--- a/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/JdkSslContext.java
@@ -122,6 +122,7 @@ public class JdkSslContext extends SslContext {
     private final String[] protocols;
     private final String[] cipherSuites;
     private final List<String> unmodifiableCipherSuites;
+    @SuppressWarnings("deprecation")
     private final JdkApplicationProtocolNegotiator apn;
     private final ClientAuth clientAuth;
     private final SSLContext sslContext;
@@ -156,6 +157,7 @@ public class JdkSslContext extends SslContext {
         this(sslContext, isClient, ciphers, cipherFilter, toNegotiator(apn, !isClient), clientAuth, null, false);
     }
 
+    @SuppressWarnings("deprecation")
     JdkSslContext(SSLContext sslContext, boolean isClient, Iterable<String> ciphers, CipherSuiteFilter cipherFilter,
                   JdkApplicationProtocolNegotiator apn, ClientAuth clientAuth, String[] protocols, boolean startTls) {
         super(startTls);
@@ -218,6 +220,7 @@ public class JdkSslContext extends SslContext {
         return configureAndWrapEngine(context().createSSLEngine(peerHost, peerPort), alloc);
     }
 
+    @SuppressWarnings("deprecation")
     private SSLEngine configureAndWrapEngine(SSLEngine engine, ByteBufAllocator alloc) {
         engine.setEnabledCipherSuites(cipherSuites);
         engine.setEnabledProtocols(protocols);
@@ -255,6 +258,7 @@ public class JdkSslContext extends SslContext {
      * @param isServer {@code true} if a server {@code false} otherwise.
      * @return The results of the translation
      */
+    @SuppressWarnings("deprecation")
     static JdkApplicationProtocolNegotiator toNegotiator(ApplicationProtocolConfig config, boolean isServer) {
         if (config == null) {
             return JdkDefaultApplicationProtocolNegotiator.INSTANCE;

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslApplicationProtocolNegotiator.java
@@ -17,7 +17,10 @@ package io.netty.handler.ssl;
 
 /**
  * OpenSSL version of {@link ApplicationProtocolNegotiator}.
+ *
+ * @deprecated use {@link ApplicationProtocolConfig}
  */
+@Deprecated
 public interface OpenSslApplicationProtocolNegotiator extends ApplicationProtocolNegotiator {
 
     /**

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslDefaultApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslDefaultApplicationProtocolNegotiator.java
@@ -21,7 +21,10 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * OpenSSL {@link ApplicationProtocolNegotiator} for ALPN and NPN.
+ *
+ * @deprecated use {@link ApplicationProtocolConfig}.
  */
+@Deprecated
 public final class OpenSslDefaultApplicationProtocolNegotiator implements OpenSslApplicationProtocolNegotiator {
     private final ApplicationProtocolConfig config;
     public OpenSslDefaultApplicationProtocolNegotiator(ApplicationProtocolConfig config) {

--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslNpnApplicationProtocolNegotiator.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslNpnApplicationProtocolNegotiator.java
@@ -23,7 +23,7 @@ import java.util.List;
 /**
  * OpenSSL {@link ApplicationProtocolNegotiator} for NPN.
  *
- * @deprecated use {@link OpenSslDefaultApplicationProtocolNegotiator}
+ * @deprecated use {@link ApplicationProtocolConfig}
  */
 @Deprecated
 public final class OpenSslNpnApplicationProtocolNegotiator implements OpenSslApplicationProtocolNegotiator {

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -40,7 +40,6 @@ import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.CertificateRevokedException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -153,6 +152,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
     private volatile boolean rejectRemoteInitiatedRenegotiation;
     private volatile int bioNonApplicationBufferSize = DEFAULT_BIO_NON_APPLICATION_BUFFER_SIZE;
 
+    @SuppressWarnings("deprecation")
     static final OpenSslApplicationProtocolNegotiator NONE_PROTOCOL_NEGOTIATOR =
             new OpenSslApplicationProtocolNegotiator() {
                 @Override
@@ -545,6 +545,7 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
      * @param config The configuration which defines the translation
      * @return The results of the translation
      */
+    @SuppressWarnings("deprecation")
     static OpenSslApplicationProtocolNegotiator toNegotiator(ApplicationProtocolConfig config) {
         if (config == null) {
             return NONE_PROTOCOL_NEGOTIATOR;


### PR DESCRIPTION
…ple should use ApplicationProtocolConfig

Motivation:

We should deprecate ApplicationProtocolNegotiator as the users should use ApplicationProtocolConfig these days.

Modifications:

Add deprecation annotations and javadocs.

Result:

Be able to make package-private in next major release.