### PR TITLE
OpenSsl should use _ instead of -

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -410,10 +410,10 @@ public final class OpenSsl {
         Set<String> libNames = new LinkedHashSet<String>(4);
         // First, try loading the platform-specific library. Platform-specific
         // libraries will be available if using a tcnative uber jar.
-        libNames.add("netty_tcnative-" + os + '-' + arch);
+        libNames.add("netty_tcnative_" + os + '_' + arch);
         if (LINUX.equalsIgnoreCase(os)) {
             // Fedora SSL lib so naming (libssl.so.10 vs libssl.so.1.0.0)..
-            libNames.add("netty_tcnative-" + os + '-' + arch + "-fedora");
+            libNames.add("netty_tcnative_" + os + '_' + arch + "_fedora");
         }
         // finally the default library.
         libNames.add("netty_tcnative");


### PR DESCRIPTION
Motivation:
netty-tcnative recently change the name of the native libraries from using - to _.

Modifications:
- OpenSsl should use _ instead of - even for the classifiers to be consistent with netty-tcnative

Result:
Loading netty-tcnative works.