### PR TITLE
Include more detail why Unsafe is not available

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -247,6 +247,13 @@ public final class PlatformDependent {
     }
 
     /**
+     * Return the reason (if any) why {@code sun.misc.Unsafe} was not available.
+     */
+    public static Throwable getUnsafeUnavailabilityCause() {
+        return PlatformDependent0.getUnsafeUnavailabilityCause();
+    }
+
+    /**
      * {@code true} if and only if the platform supports unaligned access.
      *
      * @see <a href="http://en.wikipedia.org/wiki/Segmentation_fault#Bus_error">Wikipedia on segfault</a>
@@ -966,7 +973,8 @@ public final class PlatformDependent {
             boolean hasUnsafe = PlatformDependent0.hasUnsafe();
             logger.debug("sun.misc.Unsafe: {}", hasUnsafe ? "available" : "unavailable");
             return hasUnsafe;
-        } catch (Throwable ignored) {
+        } catch (Throwable t) {
+            logger.trace("Could not determine if Unsafe is available", t);
             // Probably failed to initialize PlatformDependent0.
             return false;
         }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Epoll.java
@@ -54,8 +54,11 @@ public final class Epoll {
         if (cause != null) {
             UNAVAILABILITY_CAUSE = cause;
         } else {
-            UNAVAILABILITY_CAUSE = PlatformDependent.hasUnsafe() ? null :
-                    new IllegalStateException("sun.misc.Unsafe not available");
+            UNAVAILABILITY_CAUSE = PlatformDependent.hasUnsafe()
+                    ? null
+                    : new IllegalStateException(
+                            "sun.misc.Unsafe not available",
+                            PlatformDependent.getUnsafeUnavailabilityCause());
         }
     }
 

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
@@ -46,8 +46,11 @@ public final class KQueue {
         if (cause != null) {
             UNAVAILABILITY_CAUSE = cause;
         } else {
-            UNAVAILABILITY_CAUSE = PlatformDependent.hasUnsafe() ? null :
-                    new IllegalStateException("sun.misc.Unsafe not available");
+            UNAVAILABILITY_CAUSE = PlatformDependent.hasUnsafe()
+                    ? null
+                    : new IllegalStateException(
+                            "sun.misc.Unsafe not available",
+                            PlatformDependent.getUnsafeUnavailabilityCause());
         }
     }
 


### PR DESCRIPTION
Motivation:
PD and PD0 Both try to find and use Unsafe.  If unavailable, they
try to log why and continue on.  However, it is not always easy to
enable this logging.  Chaining exceptions together is much easier
to reach, and the original exception is relevant when Unsafe is
needed.

Modifications:
* Make PD log why PD0 could not be loaded with a trace level log
* Make PD0 remember why Unsafe wasn't available
* Expose unavailability cause through PD for higher level use.
* Make Epoll and KQueue include the reason when failing

Result:
Easier debugging in hard to reconfigure environments
