### PR TITLE
Return Iterable from DnsCache.get(...) to allow easier extensibility

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsCache.java
@@ -49,7 +49,7 @@ public interface DnsCache {
      * @param additionals the additional records
      * @return the cached entries
      */
-    List<? extends DnsCacheEntry> get(String hostname, DnsRecord[] additionals);
+    Iterable<? extends DnsCacheEntry> get(String hostname, DnsRecord[] additionals);
 
     /**
      * Create a new {@link DnsCacheEntry} and cache a resolved address for a given hostname.

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -45,6 +45,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
@@ -236,17 +237,20 @@ abstract class DnsNameResolverContext<T> {
             }
             idx = idx2;
 
-            List<? extends DnsCacheEntry> entries = parent.authoritativeDnsServerCache().get(hostname, additionals);
-            if (entries != null && !entries.isEmpty()) {
-                return DnsServerAddresses.sequential(new DnsCacheIterable(entries)).stream();
+            Iterable<? extends DnsCacheEntry> entries = parent.authoritativeDnsServerCache().get(hostname, additionals);
+            if (entries != null) {
+                if (((entries instanceof Collection) && !((Collection<?>) entries).isEmpty())
+                        || (entries.iterator().hasNext())) {
+                    return DnsServerAddresses.sequential(new DnsCacheIterable(entries)).stream();
+                }
             }
         }
     }
 
     private final class DnsCacheIterable implements Iterable<InetSocketAddress> {
-        private final List<? extends DnsCacheEntry> entries;
+        private final Iterable<? extends DnsCacheEntry> entries;
 
-        DnsCacheIterable(List<? extends DnsCacheEntry> entries) {
+        DnsCacheIterable(Iterable<? extends DnsCacheEntry> entries) {
             this.entries = entries;
         }
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -65,6 +65,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -83,13 +84,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class DnsNameResolverTest {
 
@@ -971,8 +966,10 @@ public class DnsNameResolverTest {
             if (cache) {
                 assertNull(nsCache.cache.get("io.", null));
                 assertNull(nsCache.cache.get("netty.io.", null));
-                List<? extends DnsCacheEntry> entries = nsCache.cache.get("record.netty.io.", null);
-                assertEquals(1, entries.size());
+                Iterator<? extends DnsCacheEntry> entries = nsCache.cache.get("record.netty.io.", null).iterator();
+                assertTrue(entries.hasNext());
+                entries.next();
+                assertFalse(entries.hasNext());
 
                 assertNull(nsCache.cache.get(hostname, null));
 
@@ -1159,8 +1156,8 @@ public class DnsNameResolverTest {
 
     private static final class TestDnsCache implements DnsCache {
         private final DnsCache cache;
-        final Map<String, List<? extends DnsCacheEntry>> cacheHits = new HashMap<String,
-                                                                                  List<? extends DnsCacheEntry>>();
+        final Map<String, Iterable<? extends DnsCacheEntry>> cacheHits = new HashMap<String,
+                Iterable<? extends DnsCacheEntry>>();
 
         TestDnsCache(DnsCache cache) {
             this.cache = cache;
@@ -1177,8 +1174,8 @@ public class DnsNameResolverTest {
         }
 
         @Override
-        public List<? extends DnsCacheEntry> get(String hostname, DnsRecord[] additionals) {
-            List<? extends DnsCacheEntry> cacheEntries = cache.get(hostname, additionals);
+        public Iterable<? extends DnsCacheEntry> get(String hostname, DnsRecord[] additionals) {
+            Iterable<? extends DnsCacheEntry> cacheEntries = cache.get(hostname, additionals);
             cacheHits.put(hostname, cacheEntries);
             return cacheEntries;
         }


### PR DESCRIPTION
Motiviation:

At the moment we return a List but to make it easier to write your own Cache which may lazy compute things we should just return Iterable.

Modification:

Change DnsCache.get(...) to return a Iterable

Result:

More flexible way to write your own DnsCache implementation or wrap an existing one to add extra functionality.