### PR TITLE
ISSUE-7150 Add checks to load libs only in support environments.

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -73,6 +73,7 @@ public final class PlatformDependent {
 
     private static final boolean IS_WINDOWS = isWindows0();
     private static final boolean IS_OSX = isOsx0();
+    private static final boolean IS_LINUX = isLinux0();
 
     private static final boolean MAYBE_SUPER_USER;
 
@@ -214,6 +215,13 @@ public final class PlatformDependent {
      */
     public static boolean isOsx() {
         return IS_OSX;
+    }
+
+    /**
+     * Return {@code true} if the JVM is running on Linux
+     */
+    public static boolean isLinux() {
+        return IS_LINUX;
     }
 
     /**
@@ -941,6 +949,17 @@ public final class PlatformDependent {
             logger.debug("Platform: MacOS");
         }
         return osx;
+    }
+
+    private static boolean isLinux0() {
+        String osname = SystemPropertyUtil.get("os.name", "").toLowerCase(Locale.US)
+                                          .replaceAll("[^a-z0-9]+", "");
+        boolean linux = osname.startsWith("linux");
+
+        if (linux) {
+            logger.debug("Platform: Linux");
+        }
+        return linux;
     }
 
     private static boolean maybeSuperUser0() {

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
@@ -27,27 +27,31 @@ public final class KQueue {
     private static final Throwable UNAVAILABILITY_CAUSE;
 
     static  {
-        Throwable cause = null;
-        FileDescriptor kqueueFd = null;
-        try {
-            kqueueFd = Native.newKQueue();
-        } catch (Throwable t) {
-            cause = t;
-        } finally {
-            if (kqueueFd != null) {
-                try {
-                    kqueueFd.close();
-                } catch (Exception ignore) {
-                    // ignore
+        if (PlatformDependent.isOsx() && PlatformDependent.bitMode() == 64) {
+            Throwable cause = null;
+            FileDescriptor kqueueFd = null;
+            try {
+                kqueueFd = Native.newKQueue();
+            } catch (Throwable t) {
+                cause = t;
+            } finally {
+                if (kqueueFd != null) {
+                    try {
+                        kqueueFd.close();
+                    } catch (Exception ignore) {
+                        // ignore
+                    }
                 }
             }
-        }
 
-        if (cause != null) {
-            UNAVAILABILITY_CAUSE = cause;
+            if (cause != null) {
+                UNAVAILABILITY_CAUSE = cause;
+            } else {
+                UNAVAILABILITY_CAUSE = PlatformDependent.hasUnsafe() ? null :
+                                       new IllegalStateException("sun.misc.Unsafe not available");
+            }
         } else {
-            UNAVAILABILITY_CAUSE = PlatformDependent.hasUnsafe() ? null :
-                    new IllegalStateException("sun.misc.Unsafe not available");
+            UNAVAILABILITY_CAUSE = new IllegalStateException("jvm platform is not 64bit macOS / osx");
         }
     }
 


### PR DESCRIPTION
To avoid attempts of native lib loading, only load the libs in environments currently  the native libs are build/provided for.

Motivation:

Netty should only attempt to load native libs, for environments that the native libs are provided, this avoids un-needed jvm warnings on isAvailable checks.

Modification:

Add checks for epoll, to only load in 64bit linux jvm
Add checks for kqueue, to only load in 64bit osx jvm

Result:

Fixes #https://github.com/netty/netty/issues/7150

If there is no issue then describe the changes introduced by this PR.