### PR TITLE
AutoClose behavior may infinite loop

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -24,6 +24,7 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.Socket;
+import io.netty.util.internal.UnstableApi;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -82,6 +83,16 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
     @Override
     protected Object filterOutboundMessage(Object msg) throws Exception {
         throw new UnsupportedOperationException();
+    }
+
+    @UnstableApi
+    @Override
+    protected final void doShutdownOutput(Throwable cause) throws Exception {
+        try {
+            super.doShutdownOutput(cause);
+        } finally {
+            close();
+        }
     }
 
     abstract Channel newChildChannel(int fd, byte[] remote, int offset, int len) throws Exception;

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -31,6 +31,7 @@ import io.netty.channel.unix.DatagramSocketAddress;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.Socket;
 import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -424,6 +425,16 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             return true;
         }
         return false;
+    }
+
+    @UnstableApi
+    @Override
+    protected void doShutdownOutput(Throwable cause) throws Exception {
+        // UDP sockets are not connected. A write failure may just be temporary or disconnect was called.
+        ChannelOutboundBuffer channelOutboundBuffer = unsafe().outboundBuffer();
+        if (channelOutboundBuffer != null) {
+            channelOutboundBuffer.remove(cause);
+        }
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -557,14 +557,27 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
             close(promise, CLOSE_CLOSED_CHANNEL_EXCEPTION, CLOSE_CLOSED_CHANNEL_EXCEPTION, false);
         }
 
+        /**
+         * Shutdown the output portion of the corresponding {@link Channel}.
+         * For example this will clean up the {@link ChannelOutboundBuffer} and not allow any more writes.
+         */
         @UnstableApi
-        public void shutdownOutput() {
+        public final void shutdownOutput() {
+            shutdownOutput(null);
+        }
+
+        /**
+         * Shutdown the output portion of the corresponding {@link Channel}.
+         * For example this will clean up the {@link ChannelOutboundBuffer} and not allow any more writes.
+         * @param cause The cause which may provide rational for the shutdown.
+         */
+        final void shutdownOutput(Throwable cause) {
             final ChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
             if (outboundBuffer == null) {
                 return;
             }
             this.outboundBuffer = null; // Disallow adding any messages and flushes to outboundBuffer.
-            ChannelOutputShutdownException e = new ChannelOutputShutdownException("Channel output explicitly shutdown");
+            ChannelOutputShutdownException e = new ChannelOutputShutdownException("Channel output shutdown", cause);
             outboundBuffer.failFlushed(e, false);
             outboundBuffer.close(e, true);
             pipeline.fireUserEventTriggered(ChannelOutputShutdownEvent.INSTANCE);
@@ -830,7 +843,11 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                      */
                     close(voidPromise(), t, FLUSH0_CLOSED_CHANNEL_EXCEPTION, false);
                 } else {
-                    outboundBuffer.failFlushed(t, true);
+                    try {
+                        doShutdownOutput(t);
+                    } catch (Throwable t2) {
+                        close(voidPromise(), t2, FLUSH0_CLOSED_CHANNEL_EXCEPTION, false);
+                    }
                 }
             } finally {
                 inFlush0 = false;
@@ -963,6 +980,16 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
      * Close the {@link Channel}
      */
     protected abstract void doClose() throws Exception;
+
+    /**
+     * Called when conditions justify shutting down the output portion of the channel. This may happen if a write
+     * operation throws an exception.
+     * @param cause The cause for the shutdown.
+     */
+    @UnstableApi
+    protected void doShutdownOutput(Throwable cause) throws Exception {
+        ((AbstractUnsafe) unsafe).shutdownOutput(cause);
+    }
 
     /**
      * Deregister the {@link Channel} from its {@link EventLoop}.

--- a/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
@@ -15,7 +15,7 @@
  */
 package io.netty.channel;
 
-import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.UnstableApi;
 
 import java.net.SocketAddress;
 
@@ -59,6 +59,16 @@ public abstract class AbstractServerChannel extends AbstractChannel implements S
     @Override
     protected void doDisconnect() throws Exception {
         throw new UnsupportedOperationException();
+    }
+
+    @UnstableApi
+    @Override
+    protected final void doShutdownOutput(Throwable cause) throws Exception {
+        try {
+            super.doShutdownOutput(cause);
+        } finally {
+            close();
+        }
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -33,6 +33,7 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.RecyclableArrayList;
+import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -521,6 +522,13 @@ public class EmbeddedChannel extends AbstractChannel {
     @Override
     protected void doClose() throws Exception {
         state = 2;
+    }
+
+    @UnstableApi
+    @Override
+    protected final void doShutdownOutput(Throwable cause) throws Exception {
+        super.doShutdownOutput(cause);
+        close();
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -31,6 +31,7 @@ import io.netty.util.concurrent.SingleThreadEventExecutor;
 import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.ThrowableUtil;
+import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -287,6 +288,13 @@ public class LocalChannel extends AbstractChannel {
                 releaseInboundBuffers();
             }
         }
+    }
+
+    @UnstableApi
+    @Override
+    protected final void doShutdownOutput(Throwable cause) throws Exception {
+        super.doShutdownOutput(cause);
+        close();
     }
 
     private void tryClose(boolean isActive) {

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ServerChannel;
+import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.net.PortUnreachableException;
@@ -176,6 +177,13 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
         return cause instanceof IOException &&
                 !(cause instanceof PortUnreachableException) &&
                 !(this instanceof ServerChannel);
+    }
+
+    @UnstableApi
+    @Override
+    protected void doShutdownOutput(Throwable cause) throws Exception {
+        super.doShutdownOutput(cause);
+        close();
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/oio/AbstractOioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/AbstractOioMessageChannel.java
@@ -18,6 +18,7 @@ package io.netty.channel.oio;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelPipeline;
+import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -97,6 +98,13 @@ public abstract class AbstractOioMessageChannel extends AbstractOioChannel {
             // See https://github.com/netty/netty/issues/2404
             read();
         }
+    }
+
+    @UnstableApi
+    @Override
+    protected void doShutdownOutput(Throwable cause) throws Exception {
+        super.doShutdownOutput(cause);
+        close();
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/socket/ChannelOutputShutdownException.java
+++ b/transport/src/main/java/io/netty/channel/socket/ChannelOutputShutdownException.java
@@ -29,4 +29,8 @@ public final class ChannelOutputShutdownException extends IOException {
     public ChannelOutputShutdownException(String msg) {
         super(msg);
     }
+
+    public ChannelOutputShutdownException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
 }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -33,6 +33,7 @@ import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.util.internal.SocketUtils;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -233,6 +234,16 @@ public final class NioDatagramChannel
     @Override
     protected void doClose() throws Exception {
         javaChannel().close();
+    }
+
+    @UnstableApi
+    @Override
+    protected void doShutdownOutput(Throwable cause) throws Exception {
+        // UDP sockets are not connected. A write failure may just be temporary or doDisconnect() was called.
+        ChannelOutboundBuffer channelOutboundBuffer = unsafe().outboundBuffer();
+        if (channelOutboundBuffer != null) {
+            channelOutboundBuffer.remove(cause);
+        }
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioDatagramChannel.java
@@ -32,6 +32,7 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -198,6 +199,16 @@ public class OioDatagramChannel extends AbstractOioMessageChannel
     @Override
     protected void doDisconnect() throws Exception {
         socket.disconnect();
+    }
+
+    @UnstableApi
+    @Override
+    protected final void doShutdownOutput(Throwable cause) throws Exception {
+        // UDP sockets are not connected. A write failure may just be temporary or {@link #doDisconnect()} was called.
+        ChannelOutboundBuffer channelOutboundBuffer = unsafe().outboundBuffer();
+        if (channelOutboundBuffer != null) {
+            channelOutboundBuffer.remove(cause);
+        }
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannel.java
@@ -26,6 +26,7 @@ import io.netty.channel.oio.OioByteStreamChannel;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.util.internal.SocketUtils;
+import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -125,6 +126,13 @@ public class OioSocketChannel extends OioByteStreamChannel
         return socket.isOutputShutdown() || !isActive();
     }
 
+    @UnstableApi
+    @Override
+    protected final void doShutdownOutput(final Throwable cause) throws Exception {
+        shutdownOutput0(voidPromise());
+        super.doShutdownOutput(cause);
+    }
+
     @Override
     public ChannelFuture shutdownOutput() {
         return shutdownOutput(newPromise());
@@ -168,8 +176,11 @@ public class OioSocketChannel extends OioByteStreamChannel
     }
 
     private void shutdownOutput0() throws IOException {
-        socket.shutdownOutput();
-        ((AbstractUnsafe) unsafe()).shutdownOutput();
+        try {
+            socket.shutdownOutput();
+        } finally {
+            ((AbstractUnsafe) unsafe()).shutdownOutput();
+        }
     }
 
     private void shutdown0(ChannelPromise promise) {


### PR DESCRIPTION
Motivation:
If AutoClose is false and there is a IoException then AbstractChannel will not close the channel but instead just fail flushed element in the ChannelOutboundBuffer. AbstractChannel also notifies of writability changes, which may lead to an infinite loop if the peer has closed its read side of the socket because we will keep accepting more data but continuously fail because the peer isn't accepting writes.

Modifications:
- If the transport throws on a write we should acknowledge that the output side of the channel has been shutdown and cleanup. If the channel can't accept more data because it is full, and still healthy it is not expected to throw. However if the channel is not healthy it will throw and is not expected to accept any more writes. In this case we should shutdown the output for Channels that support this feature and otherwise just close.
- Connection-less protocols like UDP can remain the same because the channel may disconnected temporarily.
- Make sure AbstractUnsafe#shutdownOutput is called because the shutdown on the socket may throw an exception.

Result:
More correct handling of write failure when AutoClose is false.