### PR TITLE
DefaultSocks5CommandRequest incorrectly rejects SOCKS5 commands with …

### DIFF
--- a/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandRequest.java
+++ b/codec-socks/src/main/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandRequest.java
@@ -59,8 +59,8 @@ public final class DefaultSocks5CommandRequest extends AbstractSocks5Message imp
             }
         }
 
-        if (dstPort <= 0 || dstPort >= 65536) {
-            throw new IllegalArgumentException("dstPort: " + dstPort + " (expected: 1~65535)");
+        if (dstPort < 0 || dstPort > 65535) {
+            throw new IllegalArgumentException("dstPort: " + dstPort + " (expected: 0~65535)");
         }
 
         this.type = type;

--- a/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandRequestTest.java
+++ b/codec-socks/src/test/java/io/netty/handler/codec/socksx/v5/DefaultSocks5CommandRequestTest.java
@@ -76,7 +76,7 @@ public class DefaultSocks5CommandRequestTest {
     public void testValidPortRange() {
         try {
             new DefaultSocks5CommandRequest(Socks5CommandType.BIND, Socks5AddressType.DOMAIN,
-                    "παράδειγμα.δοκιμήπαράδει", 0);
+                    "παράδειγμα.δοκιμήπαράδει", -1);
         } catch (Exception e) {
             assertTrue(e instanceof IllegalArgumentException);
         }
@@ -87,5 +87,10 @@ public class DefaultSocks5CommandRequestTest {
         } catch (Exception e) {
             assertTrue(e instanceof IllegalArgumentException);
         }
+
+        new DefaultSocks5CommandRequest(Socks5CommandType.BIND, Socks5AddressType.DOMAIN,
+                "παράδειγμα.δοκιμήπαράδει", 0);
+        new DefaultSocks5CommandRequest(Socks5CommandType.BIND, Socks5AddressType.DOMAIN,
+                "παράδειγμα.δοκιμήπαράδει", 65535);
     }
 }


### PR DESCRIPTION
…dstPort=0

Motivation:

According to SOCKS 5 spec, dstPort = 0 is a valid value in case of UDP ASSOCIATE.

Modifications:

- Allow 0 as port.
- Add unit tests.

Result:

Fixes [#7156].