### PR TITLE
Fix ServerCookieEncoder javadoc, close #7115

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/ServerCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/ServerCookieEncoder.java
@@ -26,12 +26,12 @@ import java.util.List;
  *
  * As Netty's Cookie merges Expires and MaxAge into one single field, only Max-Age field is sent.
  *
- * Note that multiple cookies are supposed to be sent at once in a single "Set-Cookie" header.
+ * Note that multiple cookies must be sent as separate "Set-Cookie" headers.
  *
  * <pre>
  * // Example
- * {@link HttpRequest} req = ...;
- * res.setHeader("Cookie", {@link ServerCookieEncoder}.encode("JSESSIONID", "1234"));
+ * {@link HttpResponse} res = ...;
+ * res.setHeader("Set-Cookie", {@link ServerCookieEncoder}.encode("JSESSIONID", "1234"));
  * </pre>
  *
  * @see ServerCookieDecoder

--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ServerCookieEncoder.java
@@ -23,7 +23,7 @@ import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 import io.netty.handler.codec.DateFormatter;
 import io.netty.handler.codec.http.HttpConstants;
-import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,12 +40,12 @@ import java.util.Map;
  *
  * As Netty's Cookie merges Expires and MaxAge into one single field, only Max-Age field is sent.
  *
- * Note that multiple cookies are supposed to be sent at once in a single "Set-Cookie" header.
+ * Note that multiple cookies must be sent as separate "Set-Cookie" headers.
  *
  * <pre>
  * // Example
- * {@link HttpRequest} req = ...;
- * res.setHeader("Cookie", {@link ServerCookieEncoder}.encode("JSESSIONID", "1234"));
+ * {@link HttpResponse} res = ...;
+ * res.setHeader("Set-Cookie", {@link ServerCookieEncoder}.encode("JSESSIONID", "1234"));
  * </pre>
  *
  * @see ServerCookieDecoder


### PR DESCRIPTION
Motivation:

ServerCookieEncoder’s javadoc contains some invalid copy-pasting from
ClientCookieEncoder.

Modifications:
* As per RFC6265, multiple cookies are sent as separate Set-Cookie
response headers.
* Fix code sample

Result:

Proper javadoc