### PR TITLE
Fix StompSubframeDecoder.redHeaders no any notification when parsed l…

### DIFF
--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
@@ -80,7 +80,7 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
         this(DEFAULT_MAX_LINE_LENGTH, DEFAULT_CHUNK_SIZE);
     }
 
-    public StompSubframeDecoder(final boolean validateHeaders) {
+    public StompSubframeDecoder(boolean validateHeaders) {
         this(DEFAULT_MAX_LINE_LENGTH, DEFAULT_CHUNK_SIZE, validateHeaders);
     }
 
@@ -88,7 +88,7 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
         this(maxLineLength, maxChunkSize, false);
     }
 
-    public StompSubframeDecoder(int maxLineLength, int maxChunkSize, final boolean validateHeaders) {
+    public StompSubframeDecoder(int maxLineLength, int maxChunkSize, boolean validateHeaders) {
         super(State.SKIP_CONTROL_CHARACTERS);
         if (maxLineLength <= 0) {
             throw new IllegalArgumentException(

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
@@ -71,10 +71,10 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
 
     private final int maxLineLength;
     private final int maxChunkSize;
+    private final boolean validateHeaders;
     private int alreadyReadChunkSize;
     private LastStompContentSubframe lastContent;
     private long contentLength = -1;
-    private final boolean validateHeaders;
 
     public StompSubframeDecoder() {
         this(DEFAULT_MAX_LINE_LENGTH, DEFAULT_CHUNK_SIZE);

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
@@ -17,7 +17,6 @@ package io.netty.handler.codec.stomp;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.regex.Pattern;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -60,7 +59,6 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
 
     private static final int DEFAULT_CHUNK_SIZE = 8132;
     private static final int DEFAULT_MAX_LINE_LENGTH = 1024;
-    private static final Pattern HEADER_DELIMITER_PATTERN = Pattern.compile(":");
 
     enum State {
         SKIP_CONTROL_CHARACTERS,
@@ -223,7 +221,7 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
         for (;;) {
             String line = readLine(buffer, maxLineLength);
             if (!line.isEmpty()) {
-                String[] split = HEADER_DELIMITER_PATTERN.split(line);
+                String[] split = line.split(":");
                 if (split.length == 2) {
                     headers.add(split[0], split[1]);
                 } else if (validateHeaders) {

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/StompSubframeDecoder.java
@@ -15,6 +15,10 @@
  */
 package io.netty.handler.codec.stomp;
 
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -24,9 +28,6 @@ import io.netty.handler.codec.ReplayingDecoder;
 import io.netty.handler.codec.TooLongFrameException;
 import io.netty.handler.codec.stomp.StompSubframeDecoder.State;
 import io.netty.util.internal.AppendableCharSequence;
-
-import java.util.List;
-import java.util.Locale;
 
 import static io.netty.buffer.ByteBufUtil.indexOf;
 import static io.netty.buffer.ByteBufUtil.readBytes;
@@ -59,6 +60,7 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
 
     private static final int DEFAULT_CHUNK_SIZE = 8132;
     private static final int DEFAULT_MAX_LINE_LENGTH = 1024;
+    private static final Pattern HEADER_DELIMITER_PATTERN = Pattern.compile(":");
 
     enum State {
         SKIP_CONTROL_CHARACTERS,
@@ -74,12 +76,21 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
     private int alreadyReadChunkSize;
     private LastStompContentSubframe lastContent;
     private long contentLength = -1;
+    private final boolean validateHeaders;
 
     public StompSubframeDecoder() {
         this(DEFAULT_MAX_LINE_LENGTH, DEFAULT_CHUNK_SIZE);
     }
 
+    public StompSubframeDecoder(final boolean validateHeaders) {
+        this(DEFAULT_MAX_LINE_LENGTH, DEFAULT_CHUNK_SIZE, validateHeaders);
+    }
+
     public StompSubframeDecoder(int maxLineLength, int maxChunkSize) {
+        this(maxLineLength, maxChunkSize, false);
+    }
+
+    public StompSubframeDecoder(int maxLineLength, int maxChunkSize, final boolean validateHeaders) {
         super(State.SKIP_CONTROL_CHARACTERS);
         if (maxLineLength <= 0) {
             throw new IllegalArgumentException(
@@ -93,6 +104,7 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
         }
         this.maxChunkSize = maxChunkSize;
         this.maxLineLength = maxLineLength;
+        this.validateHeaders = validateHeaders;
     }
 
     @Override
@@ -134,7 +146,7 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
                     if (toRead > maxChunkSize) {
                         toRead = maxChunkSize;
                     }
-                    if (this.contentLength >= 0) {
+                    if (contentLength >= 0) {
                         int remainingLength = (int) (contentLength - alreadyReadChunkSize);
                         if (toRead > remainingLength) {
                             toRead = remainingLength;
@@ -211,14 +223,17 @@ public class StompSubframeDecoder extends ReplayingDecoder<State> {
         for (;;) {
             String line = readLine(buffer, maxLineLength);
             if (!line.isEmpty()) {
-                String[] split = line.split(":");
+                String[] split = HEADER_DELIMITER_PATTERN.split(line);
                 if (split.length == 2) {
                     headers.add(split[0], split[1]);
+                } else if (validateHeaders) {
+                    throw new IllegalArgumentException("a header value or name contains a prohibited character ':'" +
+                            ", " + line);
                 }
             } else {
                 if (headers.contains(StompHeaders.CONTENT_LENGTH))  {
-                    this.contentLength = getContentLength(headers, 0);
-                    if (this.contentLength == 0) {
+                    contentLength = getContentLength(headers, 0);
+                    if (contentLength == 0) {
                         return State.FINALIZE_FRAME_READ;
                     }
                 }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
@@ -18,11 +18,13 @@ package io.netty.handler.codec.stomp;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.util.CharsetUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import static io.netty.handler.codec.stomp.StompTestConstants.FRAME_WITH_INVALID_HEADER;
+import static io.netty.util.CharsetUtil.US_ASCII;
+import static io.netty.util.CharsetUtil.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -74,7 +76,7 @@ public class StompSubframeDecoderTest {
 
         StompContentSubframe content = channel.readInbound();
         assertTrue(content instanceof LastStompContentSubframe);
-        String s = content.content().toString(CharsetUtil.UTF_8);
+        String s = content.content().toString(UTF_8);
         assertEquals("hello, queue a!!!", s);
         content.release();
 
@@ -93,7 +95,7 @@ public class StompSubframeDecoderTest {
 
         StompContentSubframe content = channel.readInbound();
         assertTrue(content instanceof LastStompContentSubframe);
-        String s = content.content().toString(CharsetUtil.UTF_8);
+        String s = content.content().toString(UTF_8);
         assertEquals("hello, queue a!", s);
         content.release();
 
@@ -113,22 +115,22 @@ public class StompSubframeDecoderTest {
         assertEquals(StompCommand.SEND, frame.command());
 
         StompContentSubframe content = channel.readInbound();
-        String s = content.content().toString(CharsetUtil.UTF_8);
+        String s = content.content().toString(UTF_8);
         assertEquals("hello", s);
         content.release();
 
         content = channel.readInbound();
-        s = content.content().toString(CharsetUtil.UTF_8);
+        s = content.content().toString(UTF_8);
         assertEquals(", que", s);
         content.release();
 
         content = channel.readInbound();
-        s = content.content().toString(CharsetUtil.UTF_8);
+        s = content.content().toString(UTF_8);
         assertEquals("ue a!", s);
         content.release();
 
         content = channel.readInbound();
-        s = content.content().toString(CharsetUtil.UTF_8);
+        s = content.content().toString(UTF_8);
         assertEquals("!!", s);
         content.release();
 
@@ -163,7 +165,7 @@ public class StompSubframeDecoderTest {
 
     @Test
     public void testValidateHeadersDecodingDisabled() {
-        ByteBuf invalidIncoming = Unpooled.copiedBuffer(StompTestConstants.FRAME_WITH_INVALID_HEADER.getBytes(CharsetUtil.US_ASCII));
+        ByteBuf invalidIncoming = Unpooled.copiedBuffer(FRAME_WITH_INVALID_HEADER.getBytes(US_ASCII));
         assertTrue(channel.writeInbound(invalidIncoming));
 
         StompHeadersSubframe frame = channel.readInbound();
@@ -174,7 +176,7 @@ public class StompSubframeDecoderTest {
         assertFalse(frame.headers().contains("current-time"));
 
         StompContentSubframe content = channel.readInbound();
-        String s = content.content().toString(CharsetUtil.UTF_8);
+        String s = content.content().toString(UTF_8);
         assertEquals("some body", s);
         content.release();
     }
@@ -183,7 +185,7 @@ public class StompSubframeDecoderTest {
     public void testValidateHeadersDecodingEnabled() {
         channel = new EmbeddedChannel(new StompSubframeDecoder(true));
 
-        ByteBuf invalidIncoming = Unpooled.copiedBuffer(StompTestConstants.FRAME_WITH_INVALID_HEADER.getBytes(CharsetUtil.US_ASCII));
+        ByteBuf invalidIncoming = Unpooled.copiedBuffer(FRAME_WITH_INVALID_HEADER.getBytes(US_ASCII));
         assertTrue(channel.writeInbound(invalidIncoming));
 
         StompHeadersSubframe frame = channel.readInbound();

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
@@ -164,8 +164,9 @@ public class StompSubframeDecoderTest {
     @Test
     public void testValidateHeadersDecodingDisabled() {
         ByteBuf invalidIncoming = Unpooled.buffer();
-        invalidIncoming.writeBytes(StompTestConstants.FRAME_WITH_INVALID_HEADER.getBytes());
-        channel.writeInbound(invalidIncoming);
+        invalidIncoming.writeBytes(StompTestConstants.FRAME_WITH_INVALID_HEADER.getBytes(CharsetUtil.US_ASCII));
+        boolean bufAdded = channel.writeInbound(invalidIncoming);
+        assertTrue(bufAdded);
 
         StompHeadersSubframe frame = channel.readInbound();
         assertNotNull(frame);
@@ -185,8 +186,9 @@ public class StompSubframeDecoderTest {
         EmbeddedChannel channel = new EmbeddedChannel(new StompSubframeDecoder(true));
 
         ByteBuf invalidIncoming = Unpooled.buffer();
-        invalidIncoming.writeBytes(StompTestConstants.FRAME_WITH_INVALID_HEADER.getBytes());
-        channel.writeInbound(invalidIncoming);
+        invalidIncoming.writeBytes(StompTestConstants.FRAME_WITH_INVALID_HEADER.getBytes(CharsetUtil.US_ASCII));
+        boolean bufAdded = channel.writeInbound(invalidIncoming);
+        assertTrue(bufAdded);
 
         StompHeadersSubframe frame = channel.readInbound();
         assertNotNull(frame);

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompSubframeDecoderTest.java
@@ -163,10 +163,8 @@ public class StompSubframeDecoderTest {
 
     @Test
     public void testValidateHeadersDecodingDisabled() {
-        ByteBuf invalidIncoming = Unpooled.buffer();
-        invalidIncoming.writeBytes(StompTestConstants.FRAME_WITH_INVALID_HEADER.getBytes(CharsetUtil.US_ASCII));
-        boolean bufAdded = channel.writeInbound(invalidIncoming);
-        assertTrue(bufAdded);
+        ByteBuf invalidIncoming = Unpooled.copiedBuffer(StompTestConstants.FRAME_WITH_INVALID_HEADER.getBytes(CharsetUtil.US_ASCII));
+        assertTrue(channel.writeInbound(invalidIncoming));
 
         StompHeadersSubframe frame = channel.readInbound();
         assertNotNull(frame);
@@ -183,12 +181,10 @@ public class StompSubframeDecoderTest {
 
     @Test
     public void testValidateHeadersDecodingEnabled() {
-        EmbeddedChannel channel = new EmbeddedChannel(new StompSubframeDecoder(true));
+        channel = new EmbeddedChannel(new StompSubframeDecoder(true));
 
-        ByteBuf invalidIncoming = Unpooled.buffer();
-        invalidIncoming.writeBytes(StompTestConstants.FRAME_WITH_INVALID_HEADER.getBytes(CharsetUtil.US_ASCII));
-        boolean bufAdded = channel.writeInbound(invalidIncoming);
-        assertTrue(bufAdded);
+        ByteBuf invalidIncoming = Unpooled.copiedBuffer(StompTestConstants.FRAME_WITH_INVALID_HEADER.getBytes(CharsetUtil.US_ASCII));
+        assertTrue(channel.writeInbound(invalidIncoming));
 
         StompHeadersSubframe frame = channel.readInbound();
         assertNotNull(frame);

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompTestConstants.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/StompTestConstants.java
@@ -57,6 +57,12 @@ public final class StompTestConstants {
             '\n' +
             "body\0";
 
-    private StompTestConstants() { }
+    public static final String FRAME_WITH_INVALID_HEADER = "SEND\n" +
+            "destination:/some-destination\n" +
+            "content-type:text/plain\n" +
+            "current-time:2000-01-01T00:00:00\n" +
+            '\n' +
+            "some body\0";
 
+    private StompTestConstants() { }
 }


### PR DESCRIPTION
…ine that contains multiple colon, close #7083

Added validateHeaders flag, removed unnecessary code.