### PR TITLE
Only load native transport if running architecture match the compiled…

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -92,6 +92,8 @@ public final class PlatformDependent {
     private static final File TMPDIR = tmpdir0();
 
     private static final int BIT_MODE = bitMode0();
+    private static final String NORMALIZED_ARCH = normalizeArch(SystemPropertyUtil.get("os.arch", ""));
+    private static final String NORMALIZED_OS = normalizeOs(SystemPropertyUtil.get("os.name", ""));
 
     private static final int ADDRESS_SIZE = addressSize0();
     private static final boolean USE_DIRECT_BUFFER_NO_CLEANER;
@@ -1224,6 +1226,99 @@ public final class PlatformDependent {
         default:
             return hash;
         }
+    }
+
+    public static String normalizedArch() {
+        return NORMALIZED_ARCH;
+    }
+
+    public static String normalizedOs() {
+        return NORMALIZED_OS;
+    }
+
+    private static String normalize(String value) {
+        return value.toLowerCase(Locale.US).replaceAll("[^a-z0-9]+", "");
+    }
+
+    private static String normalizeArch(String value) {
+        value = normalize(value);
+        if (value.matches("^(x8664|amd64|ia32e|em64t|x64)$")) {
+            return "x86_64";
+        }
+        if (value.matches("^(x8632|x86|i[3-6]86|ia32|x32)$")) {
+            return "x86_32";
+        }
+        if (value.matches("^(ia64|itanium64)$")) {
+            return "itanium_64";
+        }
+        if (value.matches("^(sparc|sparc32)$")) {
+            return "sparc_32";
+        }
+        if (value.matches("^(sparcv9|sparc64)$")) {
+            return "sparc_64";
+        }
+        if (value.matches("^(arm|arm32)$")) {
+            return "arm_32";
+        }
+        if ("aarch64".equals(value)) {
+            return "aarch_64";
+        }
+        if (value.matches("^(ppc|ppc32)$")) {
+            return "ppc_32";
+        }
+        if ("ppc64".equals(value)) {
+            return "ppc_64";
+        }
+        if ("ppc64le".equals(value)) {
+            return "ppcle_64";
+        }
+        if ("s390".equals(value)) {
+            return "s390_32";
+        }
+        if ("s390x".equals(value)) {
+            return "s390_64";
+        }
+
+        return "unknown";
+    }
+
+    private static String normalizeOs(String value) {
+        value = normalize(value);
+        if (value.startsWith("aix")) {
+            return "aix";
+        }
+        if (value.startsWith("hpux")) {
+            return "hpux";
+        }
+        if (value.startsWith("os400")) {
+            // Avoid the names such as os4000
+            if (value.length() <= 5 || !Character.isDigit(value.charAt(5))) {
+                return "os400";
+            }
+        }
+        if (value.startsWith("linux")) {
+            return "linux";
+        }
+        if (value.startsWith("macosx") || value.startsWith("osx")) {
+            return "osx";
+        }
+        if (value.startsWith("freebsd")) {
+            return "freebsd";
+        }
+        if (value.startsWith("openbsd")) {
+            return "openbsd";
+        }
+        if (value.startsWith("netbsd")) {
+            return "netbsd";
+        }
+        if (value.startsWith("solaris") || value.startsWith("sunos")) {
+            return "sunos";
+        }
+        if (value.startsWith("windows")) {
+            return "windows";
+        }
+
+        return "unknown";
     }
 
     private static final class AtomicLongCounter extends AtomicLong implements LongCounter {

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -144,7 +144,7 @@
               <execution>
                 <id>build-native-lib</id>
                 <configuration>
-                  <name>netty_transport_native_epoll</name>
+                  <name>netty_transport_native_epoll_${os.detected.arch}</name>
                   <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
                   <libDirectory>${project.build.outputDirectory}</libDirectory>
                   <!-- We use Maven's artifact classifier instead.
@@ -179,7 +179,7 @@
                       <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                     </manifest>
                     <manifestEntries>
-                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_epoll.so; osname=linux; processor=x86_64,*</Bundle-NativeCode>
+                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_epoll_${os.detected.arch}.so; osname=linux; processor=${os.detected.arch},*</Bundle-NativeCode>
                     </manifestEntries>
                     <index>true</index>
                     <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java
@@ -196,7 +196,8 @@ public final class Native {
         if (!name.startsWith("linux")) {
             throw new IllegalStateException("Only supported on Linux");
         }
-        NativeLibraryLoader.load("netty_transport_native_epoll", PlatformDependent.getClassLoader(Native.class));
+        NativeLibraryLoader.load("netty_transport_native_epoll_" + PlatformDependent.normalizedArch(),
+                PlatformDependent.getClassLoader(Native.class));
     }
 
     private Native() {

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -70,7 +70,7 @@
               <execution>
                 <id>build-native-lib</id>
                 <configuration>
-                  <name>netty_transport_native_kqueue</name>
+                  <name>netty_transport_native_kqueue_${os.detected.arch}</name>
                   <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
                   <libDirectory>${project.build.outputDirectory}</libDirectory>
                   <!-- We use Maven's artifact classifier instead.
@@ -110,7 +110,7 @@
                       <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                     </manifest>
                     <manifestEntries>
-                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue.jnilib; osname=darwin, processor=x86_64"</Bundle-NativeCode>
+                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue_${os.detected.arch}.jnilib; osname=darwin, processor=${os.detected.arch}"</Bundle-NativeCode>
                     </manifestEntries>
                     <index>true</index>
                     <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -179,7 +179,7 @@
               <execution>
                 <id>build-native-lib</id>
                 <configuration>
-                  <name>netty_transport_native_kqueue</name>
+                  <name>netty_transport_native_kqueue_${os.detected.arch}</name>
                   <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
                   <libDirectory>${project.build.outputDirectory}</libDirectory>
                   <!-- We use Maven's artifact classifier instead.
@@ -217,7 +217,7 @@
                       <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                     </manifest>
                     <manifestEntries>
-                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue.jnilib; osname=darwin, processor=x86_64"</Bundle-NativeCode>
+                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue_${os.detected.arch}.jnilib; osname=darwin, processor=${os.detected.arch}"</Bundle-NativeCode>
                     </manifestEntries>
                     <index>true</index>
                     <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -286,7 +286,7 @@
               <execution>
                 <id>build-native-lib</id>
                 <configuration>
-                  <name>netty_transport_native_kqueue</name>
+                  <name>netty_transport_native_kqueue_${os.detected.arch}</name>
                   <nativeSourceDirectory>${project.basedir}/src/main/c</nativeSourceDirectory>
                   <libDirectory>${project.build.outputDirectory}</libDirectory>
                   <!-- We use Maven's artifact classifier instead.
@@ -324,7 +324,7 @@
                       <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                     </manifest>
                     <manifestEntries>
-                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue.jnilib; osname=darwin, processor=x86_64"</Bundle-NativeCode>
+                      <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue_${os.detected.arch}.jnilib; osname=darwin, processor=${os.detected.arch}"</Bundle-NativeCode>
                     </manifestEntries>
                     <index>true</index>
                     <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/Native.java
@@ -111,7 +111,8 @@ final class Native {
         if (!name.startsWith("mac") && !name.contains("bsd") && !name.startsWith("darwin")) {
             throw new IllegalStateException("Only supported on BSD");
         }
-        NativeLibraryLoader.load("netty_transport_native_kqueue", PlatformDependent.getClassLoader(Native.class));
+        NativeLibraryLoader.load("netty_transport_native_kqueue_" + PlatformDependent.normalizedArch(),
+                PlatformDependent.getClassLoader(Native.class));
     }
 
     private Native() {


### PR DESCRIPTION
… library architecture.

Motivation:

We should only try to load the native artifacts if the architecture we are currently running on is the same as the one the native libraries were compiled for.

Modifications:

Include architecture in native lib name and append the current arch when trying to load these. This will fail then if its not the same as the arch of the compiled arch.

Result:

Fixes [#7150].