### PR TITLE
Fix reference count issue when using Http2FrameCodec / Http2Multiplex…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -248,7 +248,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
                 upgrade.upgradeRequest().headers().setInt(
                         HttpConversionUtil.ExtensionHeaderNames.STREAM_ID.text(), HTTP_UPGRADE_STREAM_ID);
                 InboundHttpToHttp2Adapter.handle(
-                        ctx, connection(), decoder().frameListener(), upgrade.upgradeRequest());
+                        ctx, connection(), decoder().frameListener(), upgrade.upgradeRequest().retain());
             } finally {
                 upgrade.release();
             }

--- a/codec-http2/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/codec-http2/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
…Codec with HttpServerUpgradeHandler

Motivation:

When using  Http2FrameCodec / Http2MultiplexCodec with HttpServerUpgradeHandler reference count exception will be triggered.

Modifications:

- Correctly retain before calling InboundHttpToHttp2Adapter.handle
- Add unit test

Result:

Fixes [#7172].