### PR TITLE
Ensure the tests complete on java7 and java9 as well.

### DIFF
--- a/codec-http2/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/codec-http2/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline


### PR DESCRIPTION
Motivation:

379ac890f4dbec15d19714711f85455a12112c3f introduced the usage of the inline mock maker. This unfortunally not work on java7 and java9.

Modifications:

Just use reflection to create the event for now.

Result:

Netty tests pass again on java7 and java9 as well.