### PR TITLE
Not log notify failure for DelegatingChannelPromiseNotifier when prom…

### DIFF
--- a/transport/src/main/java/io/netty/channel/DelegatingChannelPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/DelegatingChannelPromiseNotifier.java
@@ -36,7 +36,7 @@ public final class DelegatingChannelPromiseNotifier implements ChannelPromise, C
     private final boolean logNotifyFailure;
 
     public DelegatingChannelPromiseNotifier(ChannelPromise delegate) {
-        this(delegate, true);
+        this(delegate, !(delegate instanceof VoidChannelPromise));
     }
 
     public DelegatingChannelPromiseNotifier(ChannelPromise delegate, boolean logNotifyFailure) {


### PR DESCRIPTION
…ise is VoidChannelPromise

Motivation:

We should not log by default if the promise is a VoidChannelPromise as its try* methods will always return false.

Modifications:

Do an instanceof check to determine if we should log or not by default

Result:

No more noise in the logs when using a VoidChannelPromise.