### PR TITLE
Fix NPE when using Http2ServerUpgradeCodec with Http2FrameCodec and H…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -156,8 +156,13 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         if (connection().isServer()) {
             throw connectionError(PROTOCOL_ERROR, "Client-side HTTP upgrade requested for a server");
         }
-        if (prefaceSent() || decoder.prefaceReceived()) {
-            throw connectionError(PROTOCOL_ERROR, "HTTP upgrade must occur before HTTP/2 preface is sent or received");
+        if (!prefaceSent()) {
+            // If the preface was not sent yet it most likely means the handler was not added to the pipeline before
+            // calling this method.
+            throw connectionError(INTERNAL_ERROR, "HTTP upgrade must occur after preface was sent");
+        }
+        if (decoder.prefaceReceived()) {
+            throw connectionError(PROTOCOL_ERROR, "HTTP upgrade must occur before HTTP/2 preface is received");
         }
 
         // Create a local stream used for the HTTP cleartext upgrade.
@@ -172,8 +177,13 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
         if (!connection().isServer()) {
             throw connectionError(PROTOCOL_ERROR, "Server-side HTTP upgrade requested for a client");
         }
-        if (prefaceSent() || decoder.prefaceReceived()) {
-            throw connectionError(PROTOCOL_ERROR, "HTTP upgrade must occur before HTTP/2 preface is sent or received");
+        if (!prefaceSent()) {
+            // If the preface was not sent yet it most likely means the handler was not added to the pipeline before
+            // calling this method.
+            throw connectionError(INTERNAL_ERROR, "HTTP upgrade must occur after preface was sent");
+        }
+        if (decoder.prefaceReceived()) {
+            throw connectionError(PROTOCOL_ERROR, "HTTP upgrade must occur before HTTP/2 preface is received");
         }
 
         // Apply the settings but no ACK is necessary.

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -57,6 +57,7 @@ import static io.netty.util.CharsetUtil.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
@@ -214,6 +215,28 @@ public class Http2ConnectionHandlerTest {
     public void tearDown() throws Exception {
         if (handler != null) {
             handler.handlerRemoved(ctx);
+        }
+    }
+
+    @Test
+    public void onHttpServerUpgradeWithoutHandlerAdded() throws Exception {
+        handler = new Http2ConnectionHandlerBuilder().frameListener(new Http2FrameAdapter()).server(true).build();
+        try {
+            handler.onHttpServerUpgrade(new Http2Settings());
+            fail();
+        } catch (Http2Exception e) {
+            assertEquals(Http2Error.INTERNAL_ERROR, e.error());
+        }
+    }
+
+    @Test
+    public void onHttpClientUpgradeWithoutHandlerAdded() throws Exception {
+        handler = new Http2ConnectionHandlerBuilder().frameListener(new Http2FrameAdapter()).server(false).build();
+        try {
+            handler.onHttpClientUpgrade();
+            fail();
+        } catch (Http2Exception e) {
+            assertEquals(Http2Error.INTERNAL_ERROR, e.error());
         }
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ServerUpgradeCodecTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class Http2ServerUpgradeCodecTest {
+
+    @Test
+    public void testUpgradeToHttp2ConnectionHandler() {
+        testUpgrade(new Http2ConnectionHandlerBuilder().frameListener(new Http2FrameAdapter()).build());
+    }
+
+    @Test
+    public void testUpgradeToHttp2FrameCodec() {
+        testUpgrade(new Http2FrameCodecBuilder(true).build());
+    }
+
+    @Test
+    public void testUpgradeToHttp2MultiplexCodec() {
+        testUpgrade(new Http2MultiplexCodecBuilder(true, new HttpInboundHandler()).build());
+    }
+
+    private static void testUpgrade(Http2ConnectionHandler handler) {
+        FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.OPTIONS, "*");
+        request.headers().set(HttpHeaderNames.HOST, "netty.io");
+        request.headers().set(HttpHeaderNames.CONNECTION, "Upgrade, HTTP2-Settings");
+        request.headers().set(HttpHeaderNames.UPGRADE, "h2c");
+        request.headers().set("HTTP2-Settings", "AAMAAABkAAQAAP__");
+
+        EmbeddedChannel channel = new EmbeddedChannel(new ChannelInboundHandlerAdapter());
+        ChannelHandlerContext ctx = channel.pipeline().firstContext();
+        Http2ServerUpgradeCodec codec = new Http2ServerUpgradeCodec("connectionHandler", handler);
+        assertTrue(codec.prepareUpgradeResponse(ctx, request, new DefaultHttpHeaders()));
+        codec.upgradeTo(ctx, request);
+        // Flush the channel to ensure we write out all buffered data
+        channel.flush();
+
+        assertSame(handler, channel.pipeline().remove("connectionHandler"));
+        assertNull(channel.pipeline().get(handler.getClass()));
+        assertTrue(channel.finish());
+
+        // Check that the preface was send (a.k.a the settings frame)
+        ByteBuf settingsBuffer = channel.readOutbound();
+        assertNotNull(settingsBuffer);
+        settingsBuffer.release();
+
+        assertNull(channel.readOutbound());
+    }
+
+    @ChannelHandler.Sharable
+    private static final class HttpInboundHandler extends ChannelInboundHandlerAdapter { }
+}


### PR DESCRIPTION
Motiviation:

At the moment an NPE is thrown if someone tries to use the Http2ServerUpgradeCodec with Http2FrameCodec and Http2MultiplexCodec.

Modifications:

- Ensure the handler was added to the pipeline before calling on*Upgrade(...) methods.
- Add tests
- Fix adding of handlers after upgrade.

Result:

Fixes [#7173].
