### PR TITLE
Optimize DefaultChannelId.equals

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelId.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelId.java
@@ -274,7 +274,14 @@ public final class DefaultChannelId implements ChannelId {
 
     @Override
     public boolean equals(Object obj) {
-        return this == obj || (obj instanceof DefaultChannelId && Arrays.equals(data, ((DefaultChannelId) obj).data));
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof DefaultChannelId)) {
+            return false;
+        }
+        DefaultChannelId other = (DefaultChannelId) obj;
+        return hashCode == other.hashCode && Arrays.equals(data, other.data);
     }
 
     @Override


### PR DESCRIPTION
Motivation:
A `DefaultChannelId` has final `hashCode` field calculated in the constructor. We can use it in `equals` to the fast return for different objects.

Modifications:
Use `hashCode` field in `DefaultChannelId.equals()`.

Result:
Fast `equals` on negative scenarios.