### PR TITLE
Fix hashCode() in Http2StreamChannelId

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelId.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelId.java
@@ -56,7 +56,7 @@ final class Http2StreamChannelId implements ChannelId {
 
     @Override
     public int hashCode() {
-        return parentId.hashCode();
+        return id * 31 + parentId.hashCode();
     }
 
     @Override


### PR DESCRIPTION
Motivation:
In `Http2StreamChannelId` a `hashCode()` is not consistent with `equals()`.

Modifications:
Make a `Http2StreamChannelId.hashCode()` consistent with `equals()`.

Result:
Faster hash map's operations where the `Http2StreamChannelId` as keys.