### PR TITLE
Enable PooledByteBufAllocator to work, even without a cache

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -78,6 +78,24 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
     }
 
     @Test
+    public void testWithoutUseCacheForAllThreads() {
+        assertFalse(Thread.currentThread() instanceof FastThreadLocalThread);
+
+        PooledByteBufAllocator pool = new PooledByteBufAllocator(
+                /*preferDirect=*/ false,
+                /*nHeapArena=*/ 1,
+                /*nDirectArena=*/ 1,
+                /*pageSize=*/8192,
+                /*maxOrder=*/ 11,
+                /*tinyCacheSize=*/ 0,
+                /*smallCacheSize=*/ 0,
+                /*normalCacheSize=*/ 0,
+                /*useCacheForAllThreads=*/ false);
+        ByteBuf buf = pool.buffer(1);
+        buf.release();
+    }
+
+    @Test
     public void testArenaMetricsNoCache() {
         testArenaMetrics0(new PooledByteBufAllocator(true, 2, 2, 8192, 11, 0, 0, 0), 100, 0, 100, 100);
     }


### PR DESCRIPTION
Motivation:
`useCacheForAllThreads` may be false which disables memory caching
on non netty threads.  Setting this argument or the system property
makes it impossible to use `PooledByteBufAllocator`.

Modifications:

Delayed the check of `freeSweepAllocationThreshold` in
`PoolThreadCache` to after it knows there will be any caches in
use.  Additionally, check if the caches will have any data in them
(rather than allocating a 0-length array).

A test case is also added that fails without this change.

Results:

Fixes #7194
