### PR TITLE
Addition of a new jSerialComm transport

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -116,6 +116,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport-jserialcomm</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>netty-transport-udt</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/example/src/main/java/io/netty/example/jserialcomm/rxtx/JSerialCommClient.java
+++ b/example/src/main/java/io/netty/example/jserialcomm/rxtx/JSerialCommClient.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.jserialcomm.rxtx;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.jsc.JSerialCommDeviceAddress;
+import io.netty.channel.jsc.JSerialCommChannel;
+import io.netty.channel.oio.OioEventLoopGroup;
+import io.netty.handler.codec.LineBasedFrameDecoder;
+import io.netty.handler.codec.string.StringDecoder;
+import io.netty.handler.codec.string.StringEncoder;
+
+/**
+ * Sends one message to a serial device
+ */
+public final class JSerialCommClient {
+
+    static final String PORT = System.getProperty("port", "COM7");
+
+    public static void main(String[] args) throws Exception {
+        EventLoopGroup group = new OioEventLoopGroup();
+        try {
+            Bootstrap b = new Bootstrap();
+            b.group(group)
+             .channel(JSerialCommChannel.class)
+             .handler(new ChannelInitializer<JSerialCommChannel>() {
+                 @Override
+                 public void initChannel(JSerialCommChannel ch) throws Exception {
+                     ch.pipeline().addLast(
+                         new LineBasedFrameDecoder(32768),
+                         new StringEncoder(),
+                         new StringDecoder(),
+                         new JSerialCommClientHandler()
+                     );
+                 }
+             });
+
+            ChannelFuture f = b.connect(new JSerialCommDeviceAddress(PORT)).sync();
+
+            f.channel().closeFuture().sync();
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+}

--- a/example/src/main/java/io/netty/example/jserialcomm/rxtx/JSerialCommClientHandler.java
+++ b/example/src/main/java/io/netty/example/jserialcomm/rxtx/JSerialCommClientHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.example.jserialcomm.rxtx;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+public class JSerialCommClientHandler extends SimpleChannelInboundHandler<String> {
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) {
+        ctx.writeAndFlush("AT\n");
+    }
+
+    @Override
+    public void channelRead0(ChannelHandlerContext ctx, String msg) throws Exception {
+        if ("OK".equals(msg)) {
+            System.out.println("Serial port responded to AT");
+        } else {
+            System.out.println("Serial port responded with not-OK: " + msg);
+        }
+        ctx.close();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,7 @@
     <module>resolver-dns</module>
     <module>tarball</module>
     <module>transport</module>
+    <module>transport-jserialcomm</module>
     <module>transport-native-unix-common-tests</module>
     <module>transport-native-unix-common</module>
     <module>transport-native-epoll</module>
@@ -371,6 +372,12 @@
         <groupId>org.jctools</groupId>
         <artifactId>jctools-core</artifactId>
         <version>2.0.1</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fazecast</groupId>
+        <artifactId>jSerialComm</artifactId>
+        <version>1.3.11</version>
       </dependency>
 
       <dependency>

--- a/transport-jserialcomm/pom.xml
+++ b/transport-jserialcomm/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2017 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<!--suppress MavenModelInspection -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-parent</artifactId>
+    <version>4.1.13.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>netty-transport-jserialcomm</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Netty/Transport/jSerialComm</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-buffer</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>netty-transport</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fazecast</groupId>
+      <artifactId>jSerialComm</artifactId>
+    </dependency>
+  </dependencies>
+</project>
+

--- a/transport-jserialcomm/src/main/java/io/netty/channel/jsc/DefaultJSerialCommChannelConfig.java
+++ b/transport-jserialcomm/src/main/java/io/netty/channel/jsc/DefaultJSerialCommChannelConfig.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.jsc;
+
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.DefaultChannelConfig;
+import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.RecvByteBufAllocator;
+
+import java.util.Map;
+
+import static io.netty.channel.jsc.JSerialCommChannelOption.*;
+
+/**
+ * Default configuration class for jSerialComm device connections.
+ */
+final class DefaultJSerialCommChannelConfig extends DefaultChannelConfig implements JSerialCommChannelConfig {
+
+    private volatile int baudrate = 115200;
+    private volatile Stopbits stopbits = Stopbits.STOPBITS_1;
+    private volatile int databits = 8;
+    private volatile Paritybit paritybit = Paritybit.NONE;
+    private volatile int waitTime;
+    private volatile int readTimeout = 1000;
+
+    DefaultJSerialCommChannelConfig(JSerialCommChannel channel) {
+        super(channel);
+    }
+
+    @Override
+    public Map<ChannelOption<?>, Object> getOptions() {
+        return getOptions(super.getOptions(), BAUD_RATE, STOP_BITS, DATA_BITS, PARITY_BIT, WAIT_TIME);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T getOption(ChannelOption<T> option) {
+        if (option == BAUD_RATE) {
+            return (T) Integer.valueOf(getBaudrate());
+        }
+        if (option == STOP_BITS) {
+            return (T) getStopbits();
+        }
+        if (option == DATA_BITS) {
+            return (T) Integer.valueOf(getDatabits());
+        }
+        if (option == PARITY_BIT) {
+            return (T) getParitybit();
+        }
+        if (option == WAIT_TIME) {
+            return (T) Integer.valueOf(getWaitTimeMillis());
+        }
+        if (option == READ_TIMEOUT) {
+            return (T) Integer.valueOf(getReadTimeout());
+        }
+        return super.getOption(option);
+    }
+
+    @Override
+    public <T> boolean setOption(ChannelOption<T> option, T value) {
+        validate(option, value);
+
+        if (option == BAUD_RATE) {
+            setBaudrate((Integer) value);
+        } else if (option == STOP_BITS) {
+            setStopbits((Stopbits) value);
+        } else if (option == DATA_BITS) {
+            setDatabits((Integer) value);
+        } else if (option == PARITY_BIT) {
+            setParitybit((Paritybit) value);
+        } else if (option == WAIT_TIME) {
+            setWaitTimeMillis((Integer) value);
+        } else if (option == READ_TIMEOUT) {
+            setReadTimeout((Integer) value);
+        } else {
+            return super.setOption(option, value);
+        }
+        return true;
+    }
+
+    @Override
+    public JSerialCommChannelConfig setBaudrate(final int baudrate) {
+        this.baudrate = baudrate;
+        return this;
+    }
+
+    @Override
+    public JSerialCommChannelConfig setStopbits(final Stopbits stopbits) {
+        this.stopbits = stopbits;
+        return this;
+    }
+
+    @Override
+    public JSerialCommChannelConfig setDatabits(final int databits) {
+        this.databits = databits;
+        return this;
+    }
+
+    @Override
+    public JSerialCommChannelConfig setParitybit(final Paritybit paritybit) {
+        this.paritybit = paritybit;
+        return  this;
+    }
+
+    @Override
+    public int getBaudrate() {
+        return baudrate;
+    }
+
+    @Override
+    public Stopbits getStopbits() {
+        return stopbits;
+    }
+
+    @Override
+    public int getDatabits() {
+        return databits;
+    }
+
+    @Override
+    public Paritybit getParitybit() {
+        return paritybit;
+    }
+
+
+    @Override
+    public int getWaitTimeMillis() {
+        return waitTime;
+    }
+
+    @Override
+    public JSerialCommChannelConfig setWaitTimeMillis(final int waitTimeMillis) {
+        if (waitTimeMillis < 0) {
+            throw new IllegalArgumentException("Wait time must be >= 0");
+        }
+        waitTime = waitTimeMillis;
+        return this;
+    }
+
+    @Override
+    public JSerialCommChannelConfig setReadTimeout(int readTimeout) {
+        if (readTimeout < 0) {
+            throw new IllegalArgumentException("readTime must be >= 0");
+        }
+        this.readTimeout = readTimeout;
+        return this;
+    }
+
+    @Override
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    @Override
+    public JSerialCommChannelConfig setConnectTimeoutMillis(int connectTimeoutMillis) {
+        super.setConnectTimeoutMillis(connectTimeoutMillis);
+        return this;
+    }
+
+    @Override
+    public JSerialCommChannelConfig setWriteSpinCount(int writeSpinCount) {
+        super.setWriteSpinCount(writeSpinCount);
+        return this;
+    }
+
+    @Override
+    public JSerialCommChannelConfig setAllocator(ByteBufAllocator allocator) {
+        super.setAllocator(allocator);
+        return this;
+    }
+
+    @Override
+    public JSerialCommChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator) {
+        super.setRecvByteBufAllocator(allocator);
+        return this;
+    }
+
+    @Override
+    public JSerialCommChannelConfig setAutoRead(boolean autoRead) {
+        super.setAutoRead(autoRead);
+        return this;
+    }
+
+    @Override
+    public JSerialCommChannelConfig setAutoClose(boolean autoClose) {
+        super.setAutoClose(autoClose);
+        return this;
+    }
+
+    @Override
+    public JSerialCommChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark) {
+        super.setWriteBufferHighWaterMark(writeBufferHighWaterMark);
+        return this;
+    }
+
+    @Override
+    public JSerialCommChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark) {
+        super.setWriteBufferLowWaterMark(writeBufferLowWaterMark);
+        return this;
+    }
+
+    @Override
+    public JSerialCommChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator) {
+        super.setMessageSizeEstimator(estimator);
+        return this;
+    }
+}

--- a/transport-jserialcomm/src/main/java/io/netty/channel/jsc/JSerialCommChannel.java
+++ b/transport-jserialcomm/src/main/java/io/netty/channel/jsc/JSerialCommChannel.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.jsc;
+
+import com.fazecast.jSerialComm.SerialPort;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.oio.OioByteStreamChannel;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.util.concurrent.TimeUnit;
+
+import static io.netty.channel.jsc.JSerialCommChannelOption.*;
+
+
+/**
+ * A channel to a serial device using the jSerialComm library.
+ */
+public class JSerialCommChannel extends OioByteStreamChannel {
+
+    private static final JSerialCommDeviceAddress LOCAL_ADDRESS = new JSerialCommDeviceAddress("localhost");
+
+    private final JSerialCommChannelConfig config;
+
+    private boolean open = true;
+    private JSerialCommDeviceAddress deviceAddress;
+    private SerialPort serialPort;
+
+    public JSerialCommChannel() {
+        super(null);
+
+        config = new DefaultJSerialCommChannelConfig(this);
+    }
+
+    @Override
+    public JSerialCommChannelConfig config() {
+        return config;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return open;
+    }
+
+    @Override
+    protected AbstractUnsafe newUnsafe() {
+        return new JSCUnsafe();
+    }
+
+    @Override
+    protected void doConnect(SocketAddress remoteAddress, SocketAddress localAddress) throws Exception {
+        JSerialCommDeviceAddress remote = (JSerialCommDeviceAddress) remoteAddress;
+        SerialPort commPort = SerialPort.getCommPort(remote.value());
+        if (!commPort.openPort()) {
+            throw new IOException("Could not open port: " + remote.value());
+        }
+
+        commPort.setComPortTimeouts(
+                SerialPort.TIMEOUT_READ_BLOCKING, config().getOption(READ_TIMEOUT), 0);
+
+        deviceAddress = remote;
+        serialPort = commPort;
+    }
+
+    protected void doInit() throws Exception {
+        serialPort.setComPortParameters(
+            config().getOption(BAUD_RATE),
+            config().getOption(DATA_BITS),
+            config().getOption(STOP_BITS).value(),
+            config().getOption(PARITY_BIT).value()
+        );
+
+        activate(serialPort.getInputStream(), serialPort.getOutputStream());
+    }
+
+    @Override
+    public JSerialCommDeviceAddress localAddress() {
+        return (JSerialCommDeviceAddress) super.localAddress();
+    }
+
+    @Override
+    public JSerialCommDeviceAddress remoteAddress() {
+        return (JSerialCommDeviceAddress) super.remoteAddress();
+    }
+
+    @Override
+    protected JSerialCommDeviceAddress localAddress0() {
+        return LOCAL_ADDRESS;
+    }
+
+    @Override
+    protected JSerialCommDeviceAddress remoteAddress0() {
+        return deviceAddress;
+    }
+
+    @Override
+    protected void doBind(SocketAddress localAddress) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void doDisconnect() throws Exception {
+        doClose();
+    }
+
+    @Override
+    protected void doClose() throws Exception {
+        open = false;
+        try {
+           super.doClose();
+        } finally {
+            if (serialPort != null) {
+                serialPort.closePort();
+                serialPort = null;
+            }
+        }
+    }
+
+    @Override
+    protected boolean isInputShutdown() {
+        return !open;
+    }
+
+    @Override
+    protected ChannelFuture shutdownInput() {
+        return newFailedFuture(new UnsupportedOperationException("shutdownInput"));
+    }
+
+
+    private final class JSCUnsafe extends AbstractUnsafe {
+        @Override
+        public void connect(
+                final SocketAddress remoteAddress,
+                final SocketAddress localAddress, final ChannelPromise promise) {
+            if (!promise.setUncancellable() || !isOpen()) {
+                return;
+            }
+
+            try {
+                final boolean wasActive = isActive();
+                doConnect(remoteAddress, localAddress);
+
+                int waitTime = config().getOption(WAIT_TIME);
+                if (waitTime > 0) {
+                    eventLoop().schedule(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                doInit();
+                                safeSetSuccess(promise);
+                                if (!wasActive && isActive()) {
+                                    pipeline().fireChannelActive();
+                                }
+                            } catch (Throwable t) {
+                                safeSetFailure(promise, t);
+                                closeIfClosed();
+                            }
+                        }
+                   }, waitTime, TimeUnit.MILLISECONDS);
+                } else {
+                    doInit();
+                    safeSetSuccess(promise);
+                    if (!wasActive && isActive()) {
+                        pipeline().fireChannelActive();
+                    }
+                }
+            } catch (Throwable t) {
+                safeSetFailure(promise, t);
+                closeIfClosed();
+            }
+        }
+    }
+}

--- a/transport-jserialcomm/src/main/java/io/netty/channel/jsc/JSerialCommChannelConfig.java
+++ b/transport-jserialcomm/src/main/java/io/netty/channel/jsc/JSerialCommChannelConfig.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.jsc;
+
+import com.fazecast.jSerialComm.SerialPort;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.MessageSizeEstimator;
+import io.netty.channel.RecvByteBufAllocator;
+
+/**
+ * A configuration class for JSerialComm device connections.
+ *
+ * <h3>Available options</h3>
+ *
+ * In addition to the options provided by {@link ChannelConfig},
+ * {@link DefaultJSerialCommChannelConfig} allows the following options in the option map:
+ *
+ * <table border="1" cellspacing="0" cellpadding="6">
+ * <tr>
+ * <th>Name</th><th>Associated setter method</th>
+ * </tr><tr>
+ * <td>{@link JSerialCommChannelOption#BAUD_RATE}</td><td>{@link #setBaudrate(int)}</td>
+ * </tr><tr>
+ * <td>{@link JSerialCommChannelOption#STOP_BITS}</td><td>{@link #setStopbits(Stopbits)}</td>
+ * </tr><tr>
+ * <td>{@link JSerialCommChannelOption#DATA_BITS}</td><td>{@link #setDatabits(int)}</td>
+ * </tr><tr>
+ * <td>{@link JSerialCommChannelOption#PARITY_BIT}</td><td>{@link #setParitybit(Paritybit)}</td>
+ * </tr><tr>
+ * <td>{@link JSerialCommChannelOption#WAIT_TIME}</td><td>{@link #setWaitTimeMillis(int)}</td>
+ * </tr>
+ * </table>
+ */
+public interface JSerialCommChannelConfig extends ChannelConfig {
+    enum Stopbits {
+        /**
+         * 1 stop bit will be sent at the end of every character
+         */
+        STOPBITS_1(SerialPort.ONE_STOP_BIT),
+        /**
+         * 2 stop bits will be sent at the end of every character
+         */
+        STOPBITS_2(SerialPort.TWO_STOP_BITS),
+        /**
+         * 1.5 stop bits will be sent at the end of every character
+         */
+        STOPBITS_1_5(SerialPort.ONE_POINT_FIVE_STOP_BITS);
+
+        private final int value;
+
+        Stopbits(int value) {
+            this.value = value;
+        }
+
+        public int value() {
+            return value;
+        }
+
+        public static Stopbits valueOf(int value) {
+            for (Stopbits stopbit : Stopbits.values()) {
+                if (stopbit.value == value) {
+                    return stopbit;
+                }
+            }
+            throw new IllegalArgumentException("unknown " + Stopbits.class.getSimpleName() + " value: " + value);
+        }
+    }
+
+    enum Paritybit {
+        /**
+         * No parity bit will be sent with each data character at all
+         */
+        NONE(SerialPort.NO_PARITY),
+        /**
+         * An odd parity bit will be sent with each data character, ie. will be set
+         * to 1 if the data character contains an even number of bits set to 1.
+         */
+        ODD(SerialPort.ODD_PARITY),
+        /**
+         * An even parity bit will be sent with each data character, ie. will be set
+         * to 1 if the data character contains an odd number of bits set to 1.
+         */
+        EVEN(SerialPort.EVEN_PARITY),
+        /**
+         * A mark parity bit (ie. always 1) will be sent with each data character
+         */
+        MARK(SerialPort.MARK_PARITY),
+        /**
+         * A space parity bit (ie. always 0) will be sent with each data character
+         */
+        SPACE(SerialPort.SPACE_PARITY);
+
+        private final int value;
+
+        Paritybit(int value) {
+            this.value = value;
+        }
+
+        public int value() {
+            return value;
+        }
+
+        public static Paritybit valueOf(int value) {
+            for (Paritybit paritybit : Paritybit.values()) {
+                if (paritybit.value == value) {
+                    return paritybit;
+                }
+            }
+            throw new IllegalArgumentException("unknown " + Paritybit.class.getSimpleName() + " value: " + value);
+        }
+    }
+
+    /**
+     * Sets the baud rate (ie. bits per second) for communication with the serial device.
+     * The baud rate will include bits for framing (in the form of stop bits and parity),
+     * such that the effective data rate will be lower than this value.
+     *
+     * @param baudrate The baud rate (in bits per second)
+     */
+    JSerialCommChannelConfig setBaudrate(int baudrate);
+
+    /**
+     * Sets the number of stop bits to include at the end of every character to aid the
+     * serial device in synchronising with the data.
+     *
+     * @param stopbits The number of stop bits to use
+     */
+    JSerialCommChannelConfig setStopbits(Stopbits stopbits);
+
+    /**
+     * Sets the number of data bits to use to make up each character sent to the serial
+     * device.
+     *
+     * @param databits The number of data bits to use
+     */
+    JSerialCommChannelConfig setDatabits(int databits);
+
+    /**
+     * Sets the type of parity bit to be used when communicating with the serial device.
+     *
+     * @param paritybit The type of parity bit to be used
+     */
+    JSerialCommChannelConfig setParitybit(Paritybit paritybit);
+
+    /**
+     * @return The configured baud rate, defaulting to 115200 if unset
+     */
+    int getBaudrate();
+
+    /**
+     * @return The configured stop bits, defaulting to {@link Stopbits#STOPBITS_1} if unset
+     */
+    Stopbits getStopbits();
+
+    /**
+     * @return The configured data bits, defaulting to 8 if unset
+     */
+    int getDatabits();
+
+    /**
+     * @return The configured parity bit, defaulting to {@link Paritybit#NONE} if unset
+     */
+    Paritybit getParitybit();
+
+    /**
+     * @return The number of milliseconds to wait between opening the serial port and
+     *     initialising.
+     */
+    int getWaitTimeMillis();
+
+    /**
+     * Sets the time to wait after opening the serial port and before sending it any
+     * configuration information or data. A value of 0 indicates that no waiting should
+     * occur.
+     *
+     * @param waitTimeMillis The number of milliseconds to wait, defaulting to 0 (no
+     *     wait) if unset
+     * @throws IllegalArgumentException if the supplied value is &lt; 0
+     */
+    JSerialCommChannelConfig setWaitTimeMillis(int waitTimeMillis);
+
+    /**
+     * Sets the maximal time (in ms) to block while try to read from the serial port. Default is 1000ms
+     */
+    JSerialCommChannelConfig setReadTimeout(int readTimeout);
+
+    /**
+     * Return the maximal time (in ms) to block and wait for something to be ready to read.
+     */
+    int getReadTimeout();
+
+    @Override
+    JSerialCommChannelConfig setConnectTimeoutMillis(int connectTimeoutMillis);
+
+    @Override
+    JSerialCommChannelConfig setWriteSpinCount(int writeSpinCount);
+
+    @Override
+    JSerialCommChannelConfig setAllocator(ByteBufAllocator allocator);
+
+    @Override
+    JSerialCommChannelConfig setRecvByteBufAllocator(RecvByteBufAllocator allocator);
+
+    @Override
+    JSerialCommChannelConfig setAutoRead(boolean autoRead);
+
+    @Override
+    JSerialCommChannelConfig setWriteBufferHighWaterMark(int writeBufferHighWaterMark);
+
+    @Override
+    JSerialCommChannelConfig setWriteBufferLowWaterMark(int writeBufferLowWaterMark);
+
+    @Override
+    JSerialCommChannelConfig setMessageSizeEstimator(MessageSizeEstimator estimator);
+}

--- a/transport-jserialcomm/src/main/java/io/netty/channel/jsc/JSerialCommChannelOption.java
+++ b/transport-jserialcomm/src/main/java/io/netty/channel/jsc/JSerialCommChannelOption.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.jsc;
+
+import io.netty.channel.ChannelOption;
+import io.netty.channel.jsc.JSerialCommChannelConfig.Paritybit;
+import io.netty.channel.jsc.JSerialCommChannelConfig.Stopbits;
+
+/**
+ * Option for configuring a serial port connection
+ */
+public final class JSerialCommChannelOption<T> extends ChannelOption<T> {
+
+    public static final ChannelOption<Integer> BAUD_RATE = valueOf("BAUD_RATE");
+    public static final ChannelOption<Stopbits> STOP_BITS = valueOf("STOP_BITS");
+    public static final ChannelOption<Integer> DATA_BITS = valueOf("DATA_BITS");
+    public static final ChannelOption<Paritybit> PARITY_BIT = valueOf("PARITY_BIT");
+    public static final ChannelOption<Integer> WAIT_TIME = valueOf("WAIT_TIME");
+    public static final ChannelOption<Integer> READ_TIMEOUT = valueOf("READ_TIMEOUT");
+
+    @SuppressWarnings({ "unused", "deprecation" })
+    private JSerialCommChannelOption() {
+        super(null);
+    }
+}

--- a/transport-jserialcomm/src/main/java/io/netty/channel/jsc/JSerialCommDeviceAddress.java
+++ b/transport-jserialcomm/src/main/java/io/netty/channel/jsc/JSerialCommDeviceAddress.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.jsc;
+
+import java.net.SocketAddress;
+
+/**
+ * A {@link SocketAddress} subclass to wrap the serial port address of a jSerialComm
+ * device (e.g. COM1, /dev/ttyUSB0).
+ */
+public class JSerialCommDeviceAddress extends SocketAddress {
+
+    private static final long serialVersionUID = -2907820090993709523L;
+
+    private final String value;
+
+    /**
+     * Creates a JSerialCommDeviceAddress representing the address of the serial port.
+     *
+     * @param value the address of the device (e.g. COM1, /dev/ttyUSB0, ...)
+     */
+    public JSerialCommDeviceAddress(String value) {
+        this.value = value;
+    }
+
+    /**
+     * @return The serial port address of the device (e.g. COM1, /dev/ttyUSB0, ...)
+     */
+    public String value() {
+        return value;
+    }
+}

--- a/transport-jserialcomm/src/main/java/io/netty/channel/jsc/package-info.java
+++ b/transport-jserialcomm/src/main/java/io/netty/channel/jsc/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A serial port communication transport based on
+ * <a href="http://fazecast.github.io/jSerialComm/">jSerialComm</a>.
+ */
+package io.netty.channel.jsc;


### PR DESCRIPTION
Motivation:

This is an alternative to the Rxtx transport.
One of the main difference is that there is no
native lib installation requirement with jSerialComm
as it handles the native dependencies automatically.
Which makes the deployment/installation less complicated.

Modifications:

Addition of a new transport and associated example code.
A new depndency to jSerialComm

Result:

A new transport is available.