### PR TITLE
Mark transport-rxtx as @deprecated

### DIFF
--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/DefaultRxtxChannelConfig.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/DefaultRxtxChannelConfig.java
@@ -36,7 +36,10 @@ import static io.netty.channel.rxtx.RxtxChannelOption.WAIT_TIME;
 
 /**
  * Default configuration class for RXTX device connections.
+ *
+ * @deprecated this transport will be removed in the next major version.
  */
+@Deprecated
 final class DefaultRxtxChannelConfig extends DefaultChannelConfig implements RxtxChannelConfig {
 
     private volatile int baudrate = 115200;

--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannel.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannel.java
@@ -36,7 +36,10 @@ import static io.netty.channel.rxtx.RxtxChannelOption.WAIT_TIME;
 
 /**
  * A channel to a serial device using the RXTX library.
+ *
+ * @deprecated this transport will be removed in the next major version.
  */
+@Deprecated
 public class RxtxChannel extends OioByteStreamChannel {
 
     private static final RxtxDeviceAddress LOCAL_ADDRESS = new RxtxDeviceAddress("localhost");

--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannelConfig.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannelConfig.java
@@ -49,7 +49,10 @@ import io.netty.channel.WriteBufferWaterMark;
  * <td>{@link RxtxChannelOption#WAIT_TIME}</td><td>{@link #setWaitTimeMillis(int)}</td>
  * </tr>
  * </table>
+ *
+ * @deprecated this transport will be removed in the next major version.
  */
+@Deprecated
 public interface RxtxChannelConfig extends ChannelConfig {
     enum Stopbits {
         /**

--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannelOption.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxChannelOption.java
@@ -22,7 +22,10 @@ import io.netty.channel.rxtx.RxtxChannelConfig.Stopbits;
 
 /**
  * Option for configuring a serial port connection
+ *
+ * @deprecated this transport will be removed in the next major version.
  */
+@Deprecated
 public final class RxtxChannelOption<T> extends ChannelOption<T> {
 
     public static final ChannelOption<Integer> BAUD_RATE = valueOf(RxtxChannelOption.class, "BAUD_RATE");

--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxDeviceAddress.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/RxtxDeviceAddress.java
@@ -20,7 +20,10 @@ import java.net.SocketAddress;
 /**
  * A {@link SocketAddress} subclass to wrap the serial port address of a RXTX
  * device (e.g. COM1, /dev/ttyUSB0).
+ *
+ * @deprecated this transport will be removed in the next major version.
  */
+@Deprecated
 public class RxtxDeviceAddress extends SocketAddress {
 
     private static final long serialVersionUID = -2907820090993709523L;

--- a/transport-rxtx/src/main/java/io/netty/channel/rxtx/package-info.java
+++ b/transport-rxtx/src/main/java/io/netty/channel/rxtx/package-info.java
@@ -16,5 +16,8 @@
 
 /**
  * A serial and parallel port communication transport based on <a href="http://rxtx.qbang.org/">RXTX</a>.
+ *
+ * @deprecated this transport will be removed in the next major version.
  */
+@Deprecated
 package io.netty.channel.rxtx;


### PR DESCRIPTION
Motivation:

transport-rxtx has no tests and there is really no easy way to add some. Beside this this transport is not really well maintained.

Modifications:

Mark transport-rxtx as @deprecated so we can drop it in next major version.

Result:

Notify users of plan to drop the transport.