### PR TITLE
[#7205] Check on wrong CONNECT packet with password but without username

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
@@ -20,6 +20,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.MessageToMessageEncoder;
 import io.netty.util.CharsetUtil;
 import io.netty.util.internal.EmptyArrays;
@@ -101,6 +102,11 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
         MqttConnectPayload payload = message.payload();
         MqttVersion mqttVersion = MqttVersion.fromProtocolNameAndLevel(variableHeader.name(),
                 (byte) variableHeader.version());
+
+        // as MQTT 3.1 & 3.1.1 spec, If the User Name Flag is set to 0, the Password Flag MUST be set to 0
+        if (!variableHeader.hasUserName() && variableHeader.hasPassword()) {
+            throw new DecoderException("Without a username, the password MUST be not set");
+        }
 
         // Client id
         String clientIdentifier = payload.clientIdentifier();

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageBuilders.java
@@ -150,7 +150,7 @@ public final class MqttMessageBuilders {
         }
 
         public ConnectBuilder username(String username) {
-            this.hasUser = true;
+            this.hasUser = username != null;
             this.username = username;
             return this;
         }
@@ -165,7 +165,7 @@ public final class MqttMessageBuilders {
         }
 
         public ConnectBuilder password(byte[] password) {
-            this.hasPassword = true;
+            this.hasPassword = password != null;
             this.password = password;
             return this;
         }

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -126,7 +126,7 @@ public class MqttCodecTest {
 
         try {
             ByteBuf byteBuf = MqttEncoder.doEncode(ALLOCATOR, message);
-        } catch(Exception cause) {
+        } catch (Exception cause) {
             assertTrue(cause instanceof DecoderException);
         }
     }

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -121,6 +121,17 @@ public class MqttCodecTest {
     }
 
     @Test
+    public void testConnectMessageNoPassword() throws Exception {
+        final MqttConnectMessage message = createConnectMessage(MqttVersion.MQTT_3_1_1, null, PASSWORD);
+
+        try {
+            ByteBuf byteBuf = MqttEncoder.doEncode(ALLOCATOR, message);
+        } catch(Exception cause) {
+            assertTrue(cause instanceof DecoderException);
+        }
+    }
+
+    @Test
     public void testConnAckMessage() throws Exception {
         final MqttConnAckMessage message = createConnAckMessage();
         ByteBuf byteBuf = MqttEncoder.doEncode(ALLOCATOR, message);
@@ -313,11 +324,15 @@ public class MqttCodecTest {
     }
 
     private static MqttConnectMessage createConnectMessage(MqttVersion mqttVersion) {
+        return createConnectMessage(mqttVersion, USER_NAME, PASSWORD);
+    }
+
+    private static MqttConnectMessage createConnectMessage(MqttVersion mqttVersion, String username, String password) {
         return MqttMessageBuilders.connect()
                 .clientId(CLIENT_ID)
                 .protocolVersion(mqttVersion)
-                .username(USER_NAME)
-                .password(PASSWORD)
+                .username(username)
+                .password(password)
                 .willRetain(true)
                 .willQoS(MqttQoS.AT_LEAST_ONCE)
                 .willFlag(true)


### PR DESCRIPTION
Added checking on password set but username not in the CONNECT encoding method

Changed the way how hasUsername and hasPassword are set in the CONNECT packet
Added unit test with a wrong CONNECT packet having password set but not username

Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
