### PR TITLE
Fix NPE in InboundHttp2ToHttpAdapter 

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -29,7 +29,7 @@ import io.netty.util.internal.UnstableApi;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
-import static io.netty.handler.codec.http.HttpResponseStatus.CREATED;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -298,7 +298,12 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
         // A push promise should not be allowed to add headers to an existing stream
         Http2Stream promisedStream = connection.stream(promisedStreamId);
         if (headers.status() == null) {
-            headers.status(CREATED.codeAsText());
+            // A PUSH_PROMISE frame has no Http response status.
+            // https://tools.ietf.org/html/rfc7540#section-8.2.1
+            // Server push is semantically equivalent to a server responding to a
+            // request; however, in this case, that request is also sent by the
+            // server, as a PUSH_PROMISE frame.
+            headers.status(OK.codeAsText());
         }
         FullHttpMessage msg = processHeadersBegin(ctx, promisedStream, headers, false, false, false);
         if (msg == null) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -26,7 +26,6 @@ import io.netty.handler.codec.http.HttpStatusClass;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.util.internal.UnstableApi;
 
-import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapter.java
@@ -29,6 +29,7 @@ import io.netty.util.internal.UnstableApi;
 import static io.netty.handler.codec.http2.Http2Error.INTERNAL_ERROR;
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
+import static io.netty.handler.codec.http.HttpResponseStatus.CREATED;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -296,6 +297,9 @@ public class InboundHttp2ToHttpAdapter extends Http2EventAdapter {
             Http2Headers headers, int padding) throws Http2Exception {
         // A push promise should not be allowed to add headers to an existing stream
         Http2Stream promisedStream = connection.stream(promisedStreamId);
+        if (headers.status() == null) {
+            headers.status(CREATED.codeAsText());
+        }
         FullHttpMessage msg = processHeadersBegin(ctx, promisedStream, headers, false, false, false);
         if (msg == null) {
             throw connectionError(PROTOCOL_ERROR, "Push Promise Frame received for pre-existing stream id %d",

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -498,7 +498,11 @@ public class InboundHttp2ToHttpAdapterTest {
             assertEquals(request, capturedRequests.get(0));
 
             final Http2Headers http2Headers = new DefaultHttp2Headers().status(new AsciiString("200"));
-            final Http2Headers http2Headers2 = new DefaultHttp2Headers().status(new AsciiString("201"))
+            // complete set of request header fields that the server attributes to
+            // the request.
+            // https://tools.ietf.org/html/rfc7540#section-8.2.1
+            // Therefore, we should consider the case where there is no Http response status.
+            final Http2Headers http2Headers2 = new DefaultHttp2Headers()
                     .scheme(new AsciiString("https"))
                     .authority(new AsciiString("example.org"));
             runInChannel(serverConnectedChannel, new Http2Runnable() {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -498,6 +498,7 @@ public class InboundHttp2ToHttpAdapterTest {
             assertEquals(request, capturedRequests.get(0));
 
             final Http2Headers http2Headers = new DefaultHttp2Headers().status(new AsciiString("200"));
+            // The PUSH_PROMISE frame includes a header block that contains a
             // complete set of request header fields that the server attributes to
             // the request.
             // https://tools.ietf.org/html/rfc7540#section-8.2.1


### PR DESCRIPTION
**Motivation**:
- When a HTTP/2 PUSH_PROMISE comes in, we call onPushPromiseRead in InboundHttp2ToHttpAdapter. This makes us create a FullHttpMessage, which eventually calls "HttpConversionUtil.parseStatus", which occurs always NPE because status is null.

**Modifications**:
- Fix setting status code to 200 to prevent NPE in "InboundHttp2ToHttpAdapter::onPushPromiseRead".

**Result**:
- Fixes [#7214].


According to the rfc7540 specification,
> https://tools.ietf.org/html/rfc7540#section-8.2.1
> Server push is semantically equivalent to a server responding to a
> request; however, in this case, that request is also sent by the
> server, as a PUSH_PROMISE frame.
> https://tools.ietf.org/html/rfc7540#section-8.2.2
> After sending the PUSH_PROMISE frame, the server can begin delivering
> the pushed response as a response (Section 8.1.2.4) on a server-
> initiated stream that uses the promised stream identifier.