### PR TITLE
DefaultHeaders value iterator

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -91,6 +91,13 @@ public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2H
     Iterator<Entry<CharSequence, CharSequence>> iterator();
 
     /**
+     * Equivalent to {@link #getAll(Object)} but no intermediate list is generated.
+     * @param name the name of the header to retrieve
+     * @return an {@link Iterator} of header values corresponding to {@code name}.
+     */
+    Iterator<CharSequence> valueIterator(CharSequence name);
+
+    /**
      * Sets the {@link PseudoHeaderName#METHOD} header or {@code null} if there is no such header
      */
     Http2Headers method(CharSequence value);

--- a/codec/src/main/java/io/netty/handler/codec/EmptyHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/EmptyHeaders.java
@@ -483,6 +483,16 @@ public class EmptyHeaders<K, V, T extends Headers<K, V, T>> implements Headers<K
         return thisT();
     }
 
+    /**
+     * Equivalent to {@link #getAll(Object)} but no intermediate list is generated.
+     * @param name the name of the header to retrieve
+     * @return an {@link Iterator} of header values corresponding to {@code name}.
+     */
+    public Iterator<V> valueIterator(@SuppressWarnings("unused") K name) {
+        List<V> empty = Collections.emptyList();
+        return empty.iterator();
+    }
+
     @Override
     public Iterator<Entry<K, V>> iterator() {
         List<Entry<K, V>> empty = Collections.emptyList();

--- a/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
@@ -16,6 +16,7 @@ package io.netty.handler.codec;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests for {@link DefaultHeaders}.
@@ -100,6 +102,41 @@ public class DefaultHeadersTest {
         List<CharSequence> values = headers.getAll(of("name"));
         assertEquals(3, values.size());
         assertTrue(values.containsAll(asList(of("value1"), of("value2"), of("value3"))));
+    }
+
+    @Test
+    public void multipleValuesPerNameIterator() {
+        TestDefaultHeaders headers = newInstance();
+        headers.add(of("name"), of("value1"));
+        headers.add(of("name"), of("value2"));
+        headers.add(of("name"), of("value3"));
+        assertEquals(3, headers.size());
+
+        List<CharSequence> values = new ArrayList<CharSequence>();
+        Iterator<CharSequence> itr = headers.valueIterator(of("name"));
+        while (itr.hasNext()) {
+            values.add(itr.next());
+        }
+        assertEquals(3, values.size());
+        assertTrue(values.containsAll(asList(of("value1"), of("value2"), of("value3"))));
+    }
+
+    @Test
+    public void multipleValuesPerNameIteratorEmpty() {
+        TestDefaultHeaders headers = newInstance();
+
+        List<CharSequence> values = new ArrayList<CharSequence>();
+        Iterator<CharSequence> itr = headers.valueIterator(of("name"));
+        while (itr.hasNext()) {
+            values.add(itr.next());
+        }
+        assertEquals(0, values.size());
+        try {
+            itr.next();
+            fail();
+        } catch (NoSuchElementException ignored) {
+            // ignored
+        }
     }
 
     @Test


### PR DESCRIPTION
Motivation:
The Headers interface supports an interface to get all the headers values corresponding to a particular name. This API returns a List which requires intermediate storage and increases GC pressure.

Modifications:
- Add a method which returns an iterator over all the values for a specific name

Result:
Ability to iterator over values for a specific name with no intermediate collection.