### PR TITLE
Fix assertion error when closing / shutdown native channel and SO_LIN…

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -163,7 +163,25 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
             }
 
             if (isRegistered()) {
-                doDeregister();
+                // Need to check if we are on the EventLoop as doClose() may be triggered by the GlobalEventExecutor
+                // if SO_LINGER is used.
+                //
+                // See https://github.com/netty/netty/issues/7159
+                EventLoop loop = eventLoop();
+                if (loop.inEventLoop()) {
+                    doDeregister();
+                } else {
+                    loop.execute(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                doDeregister();
+                            } catch (Throwable cause) {
+                                pipeline().fireExceptionCaught(cause);
+                            }
+                        }
+                    });
+                }
             }
         } finally {
             socket.close();

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollServerChannel.java
@@ -24,7 +24,6 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.Socket;
-import io.netty.util.internal.UnstableApi;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -83,16 +82,6 @@ public abstract class AbstractEpollServerChannel extends AbstractEpollChannel im
     @Override
     protected Object filterOutboundMessage(Object msg) throws Exception {
         throw new UnsupportedOperationException();
-    }
-
-    @UnstableApi
-    @Override
-    protected final void doShutdownOutput(Throwable cause) throws Exception {
-        try {
-            super.doShutdownOutput(cause);
-        } finally {
-            close();
-        }
     }
 
     abstract Channel newChildChannel(int fd, byte[] remote, int offset, int len) throws Exception;

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollDatagramChannel.java
@@ -31,7 +31,6 @@ import io.netty.channel.unix.DatagramSocketAddress;
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.channel.unix.Socket;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -425,16 +424,6 @@ public final class EpollDatagramChannel extends AbstractEpollChannel implements 
             return true;
         }
         return false;
-    }
-
-    @UnstableApi
-    @Override
-    protected void doShutdownOutput(Throwable cause) throws Exception {
-        // UDP sockets are not connected. A write failure may just be temporary or disconnect was called.
-        ChannelOutboundBuffer channelOutboundBuffer = unsafe().outboundBuffer();
-        if (channelOutboundBuffer != null) {
-            channelOutboundBuffer.remove(cause);
-        }
     }
 
     @Override

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelTest.java
@@ -204,4 +204,22 @@ public class EpollSocketChannelTest {
             ctx.close();
         }
     }
+
+    // See https://github.com/netty/netty/issues/7159
+    @Test
+    public void testSoLingerNoAssertError() throws Exception {
+        EventLoopGroup group = new EpollEventLoopGroup(1);
+
+        try {
+            Bootstrap bootstrap = new Bootstrap();
+            EpollSocketChannel ch = (EpollSocketChannel) bootstrap.group(group)
+                    .channel(EpollSocketChannel.class)
+                    .option(ChannelOption.SO_LINGER, 10)
+                    .handler(new ChannelInboundHandlerAdapter())
+                    .bind(new InetSocketAddress(0)).syncUninterruptibly().channel();
+            ch.close().syncUninterruptibly();
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
 }

--- a/transport/src/main/java/io/netty/channel/AbstractChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractChannel.java
@@ -562,8 +562,9 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
          * For example this will clean up the {@link ChannelOutboundBuffer} and not allow any more writes.
          */
         @UnstableApi
-        public final void shutdownOutput() {
-            shutdownOutput(null);
+        public final void shutdownOutput(final ChannelPromise promise) {
+            assertEventLoop();
+            shutdownOutput(promise, null);
         }
 
         /**
@@ -571,15 +572,60 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
          * For example this will clean up the {@link ChannelOutboundBuffer} and not allow any more writes.
          * @param cause The cause which may provide rational for the shutdown.
          */
-        final void shutdownOutput(Throwable cause) {
+        private void shutdownOutput(final ChannelPromise promise, Throwable cause) {
+            if (!promise.setUncancellable()) {
+                return;
+            }
+
             final ChannelOutboundBuffer outboundBuffer = this.outboundBuffer;
             if (outboundBuffer == null) {
+                promise.setFailure(CLOSE_CLOSED_CHANNEL_EXCEPTION);
                 return;
             }
             this.outboundBuffer = null; // Disallow adding any messages and flushes to outboundBuffer.
-            ChannelOutputShutdownException e = new ChannelOutputShutdownException("Channel output shutdown", cause);
-            outboundBuffer.failFlushed(e, false);
-            outboundBuffer.close(e, true);
+
+            final Throwable shutdownCause = cause == null ?
+                    new ChannelOutputShutdownException("Channel output shutdown") :
+                    new ChannelOutputShutdownException("Channel output shutdown", cause);
+            Executor closeExecutor = prepareToClose();
+            if (closeExecutor != null) {
+                closeExecutor.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            // Execute the shutdown.
+                            doShutdownOutput();
+                            promise.setSuccess();
+                        } catch (Throwable err) {
+                            promise.setFailure(err);
+                        } finally {
+                            // Dispatch to the EventLoop
+                            eventLoop().execute(new Runnable() {
+                                @Override
+                                public void run() {
+                                    closeOutboundBufferForShutdown(pipeline, outboundBuffer, shutdownCause);
+                                }
+                            });
+                        }
+                    }
+                });
+            } else {
+                try {
+                    // Execute the shutdown.
+                    doShutdownOutput();
+                    promise.setSuccess();
+                } catch (Throwable err) {
+                    promise.setFailure(err);
+                } finally {
+                    closeOutboundBufferForShutdown(pipeline, outboundBuffer, shutdownCause);
+                }
+            }
+        }
+
+        private void closeOutboundBufferForShutdown(
+                ChannelPipeline pipeline, ChannelOutboundBuffer buffer, Throwable cause) {
+            buffer.failFlushed(cause, false);
+            buffer.close(cause, true);
             pipeline.fireUserEventTriggered(ChannelOutputShutdownEvent.INSTANCE);
         }
 
@@ -844,7 +890,7 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
                     close(voidPromise(), t, FLUSH0_CLOSED_CHANNEL_EXCEPTION, false);
                 } else {
                     try {
-                        doShutdownOutput(t);
+                        shutdownOutput(voidPromise(), t);
                     } catch (Throwable t2) {
                         close(voidPromise(), t2, FLUSH0_CLOSED_CHANNEL_EXCEPTION, false);
                     }
@@ -984,11 +1030,10 @@ public abstract class AbstractChannel extends DefaultAttributeMap implements Cha
     /**
      * Called when conditions justify shutting down the output portion of the channel. This may happen if a write
      * operation throws an exception.
-     * @param cause The cause for the shutdown.
      */
     @UnstableApi
-    protected void doShutdownOutput(Throwable cause) throws Exception {
-        ((AbstractUnsafe) unsafe).shutdownOutput(cause);
+    protected void doShutdownOutput() throws Exception {
+        doClose();
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
+++ b/transport/src/main/java/io/netty/channel/AbstractServerChannel.java
@@ -15,8 +15,6 @@
  */
 package io.netty.channel;
 
-import io.netty.util.internal.UnstableApi;
-
 import java.net.SocketAddress;
 
 /**
@@ -59,16 +57,6 @@ public abstract class AbstractServerChannel extends AbstractChannel implements S
     @Override
     protected void doDisconnect() throws Exception {
         throw new UnsupportedOperationException();
-    }
-
-    @UnstableApi
-    @Override
-    protected final void doShutdownOutput(Throwable cause) throws Exception {
-        try {
-            super.doShutdownOutput(cause);
-        } finally {
-            close();
-        }
     }
 
     @Override

--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -524,13 +524,6 @@ public class EmbeddedChannel extends AbstractChannel {
         state = 2;
     }
 
-    @UnstableApi
-    @Override
-    protected final void doShutdownOutput(Throwable cause) throws Exception {
-        super.doShutdownOutput(cause);
-        close();
-    }
-
     @Override
     protected void doBeginRead() throws Exception {
         // NOOP

--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -31,7 +31,6 @@ import io.netty.util.concurrent.SingleThreadEventExecutor;
 import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.ThrowableUtil;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -288,13 +287,6 @@ public class LocalChannel extends AbstractChannel {
                 releaseInboundBuffers();
             }
         }
-    }
-
-    @UnstableApi
-    @Override
-    protected final void doShutdownOutput(Throwable cause) throws Exception {
-        super.doShutdownOutput(cause);
-        close();
     }
 
     private void tryClose(boolean isActive) {

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioMessageChannel.java
@@ -20,7 +20,6 @@ import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ServerChannel;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.net.PortUnreachableException;
@@ -154,7 +153,7 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
                     }
                     break;
                 }
-            } catch (IOException e) {
+            } catch (Exception e) {
                 if (continueOnWriteError()) {
                     in.remove(e);
                 } else {
@@ -177,13 +176,6 @@ public abstract class AbstractNioMessageChannel extends AbstractNioChannel {
         return cause instanceof IOException &&
                 !(cause instanceof PortUnreachableException) &&
                 !(this instanceof ServerChannel);
-    }
-
-    @UnstableApi
-    @Override
-    protected void doShutdownOutput(Throwable cause) throws Exception {
-        super.doShutdownOutput(cause);
-        close();
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/oio/AbstractOioMessageChannel.java
+++ b/transport/src/main/java/io/netty/channel/oio/AbstractOioMessageChannel.java
@@ -18,7 +18,6 @@ package io.netty.channel.oio;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelPipeline;
-import io.netty.util.internal.UnstableApi;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -98,13 +97,6 @@ public abstract class AbstractOioMessageChannel extends AbstractOioChannel {
             // See https://github.com/netty/netty/issues/2404
             read();
         }
-    }
-
-    @UnstableApi
-    @Override
-    protected void doShutdownOutput(Throwable cause) throws Exception {
-        super.doShutdownOutput(cause);
-        close();
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannel.java
@@ -236,16 +236,6 @@ public final class NioDatagramChannel
         javaChannel().close();
     }
 
-    @UnstableApi
-    @Override
-    protected void doShutdownOutput(Throwable cause) throws Exception {
-        // UDP sockets are not connected. A write failure may just be temporary or doDisconnect() was called.
-        ChannelOutboundBuffer channelOutboundBuffer = unsafe().outboundBuffer();
-        if (channelOutboundBuffer != null) {
-            channelOutboundBuffer.remove(cause);
-        }
-    }
-
     @Override
     protected int doReadMessages(List<Object> buf) throws Exception {
         DatagramChannel ch = javaChannel();

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioDatagramChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioDatagramChannel.java
@@ -32,7 +32,6 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -201,16 +200,6 @@ public class OioDatagramChannel extends AbstractOioMessageChannel
         socket.disconnect();
     }
 
-    @UnstableApi
-    @Override
-    protected final void doShutdownOutput(Throwable cause) throws Exception {
-        // UDP sockets are not connected. A write failure may just be temporary or {@link #doDisconnect()} was called.
-        ChannelOutboundBuffer channelOutboundBuffer = unsafe().outboundBuffer();
-        if (channelOutboundBuffer != null) {
-            channelOutboundBuffer.remove(cause);
-        }
-    }
-
     @Override
     protected void doClose() throws Exception {
         socket.close();
@@ -299,7 +288,7 @@ public class OioDatagramChannel extends AbstractOioMessageChannel
                 }
                 socket.send(tmpPacket);
                 in.remove();
-            } catch (IOException e) {
+            } catch (Exception e) {
                 // Continue on write error as a DatagramChannel can write to multiple remote peers
                 //
                 // See https://github.com/netty/netty/issues/2665

--- a/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannel.java
+++ b/transport/src/main/java/io/netty/channel/socket/oio/OioSocketChannel.java
@@ -128,9 +128,8 @@ public class OioSocketChannel extends OioByteStreamChannel
 
     @UnstableApi
     @Override
-    protected final void doShutdownOutput(final Throwable cause) throws Exception {
-        shutdownOutput0(voidPromise());
-        super.doShutdownOutput(cause);
+    protected final void doShutdownOutput() throws Exception {
+        shutdownOutput0();
     }
 
     @Override
@@ -176,36 +175,7 @@ public class OioSocketChannel extends OioByteStreamChannel
     }
 
     private void shutdownOutput0() throws IOException {
-        try {
-            socket.shutdownOutput();
-        } finally {
-            ((AbstractUnsafe) unsafe()).shutdownOutput();
-        }
-    }
-
-    private void shutdown0(ChannelPromise promise) {
-        Throwable cause = null;
-        try {
-            shutdownOutput0();
-        } catch (Throwable t) {
-            cause = t;
-        }
-        try {
-            socket.shutdownInput();
-        } catch (Throwable t) {
-            if (cause == null) {
-                promise.setFailure(t);
-            } else {
-                logger.debug("Exception suppressed because a previous exception occurred.", t);
-                promise.setFailure(cause);
-            }
-            return;
-        }
-        if (cause == null) {
-            promise.setSuccess();
-        } else {
-            promise.setFailure(cause);
-        }
+        socket.shutdownOutput();
     }
 
     @Override


### PR DESCRIPTION
…GER is set.

Motivation:

When SO_LINGER is used we run doClose() on the GlobalEventExecutor by default so we need to ensure we schedule all code that needs to be run on the EventLoop on the EventLoop in doClose. Beside this there are also threading issues when calling shutdownOutput(...)

Modifications:

- Schedule removal from EventLoop to the EventLoop
- Correctly handle shutdownOutput and shutdown in respect with threading-model
- Add unit tests

Result:

Fixes [#7159].