### PR TITLE
NativeLibraryLoader should check the result of ClassLoader#getResourc…

### DIFF
--- a/common/src/test/java/io/netty/util/internal/NativeLibraryLoaderTest.java
+++ b/common/src/test/java/io/netty/util/internal/NativeLibraryLoaderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal;
+
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.util.UUID;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class NativeLibraryLoaderTest {
+
+    @Test
+    public void testFileNotFound() {
+        try {
+            NativeLibraryLoader.load(UUID.randomUUID().toString(), NativeLibraryLoaderTest.class.getClassLoader());
+            fail();
+        } catch (UnsatisfiedLinkError error) {
+            assertTrue(error.getCause() instanceof FileNotFoundException);
+        }
+    }
+}


### PR DESCRIPTION
…e method

Motivation:

NativeLibraryLoader uses ClassLoader#getResource method that can return nulls when the resource cannot be found. The returned url variable should be checked for nullity and fail in a more usable manner than a NullPointerException

Modifications:

Fail with a FileNotFoundException

Result:

Fixes [#7222].
