### PR TITLE
Expose all defaults on PooledByteBufAllocator

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -360,6 +360,20 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     }
 
     /**
+     * Default thread caching behavior - System Property: io.netty.allocator.useCacheForAllThreads - default true
+     */
+    public static boolean defaultUseCacheForAllThreads() {
+        return DEFAULT_USE_CACHE_FOR_ALL_THREADS;
+    }
+
+    /**
+     * Default prefer direct - System Property: io.netty.noPreferDirect - default false
+     */
+    public static boolean defaultPreferDirect() {
+        return PlatformDependent.directBufferPreferred();
+    }
+
+    /**
      * Default tiny cache size - System Property: io.netty.allocator.tinyCacheSize - default 512
      */
     public static int defaultTinyCacheSize() {


### PR DESCRIPTION
Motivation:
Most, but not all defaults are statically exposed on
PooledByteBufAllocator.  This makes it cumbersome to make a custom
allocator where most of the defaults remain the same.

Modification:
Expose useCacheForAllThreads, and Direct preferred.  The latter is
needed because it is under the internal package, and public code
should probably not depend on it.

Result:
More customizeable allocators
