### PR TITLE
Fix regression in reporting leaks introduced by 3c8c7fc7e9c27f87e64aa…

### DIFF
--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -266,7 +266,7 @@ public class ResourceLeakDetector<T> {
             if (ref == null) {
                 break;
             }
-            ref.close();
+            ref.dispose();
         }
     }
 
@@ -284,9 +284,7 @@ public class ResourceLeakDetector<T> {
                 break;
             }
 
-            ref.clear();
-
-            if (!ref.close()) {
+            if (!ref.dispose()) {
                 continue;
             }
 
@@ -392,6 +390,11 @@ public class ResourceLeakDetector<T> {
                     }
                 }
             }
+        }
+
+        boolean dispose() {
+            clear();
+            return allLeaks.remove(this, LeakEntry.INSTANCE);
         }
 
         @Override


### PR DESCRIPTION
…d5bd1df6c58ed8ef36e.

Motivation:

3c8c7fc7e9c27f87e64aad5bd1df6c58ed8ef36e introduced some changes to the ResourceLeakDetector that introduced a regression and so would always log that paranoid leak detection should be enabled even it was already.

Modifications:

Correctly not clear the recorded stacktraces when we process the reference queue so we can log these.

Result:

ResourceLeakDetector works again as expected.