### PR TITLE
Adding stable JDK9 automatic module names derived from main packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,40 @@ Note that this is build-time requirement.  JDK 5 (for 3.x) or 6 (for 4.0+) is en
 ## Branches to look
 
 Development of all versions takes place in each branch whose name is identical to `<majorVersion>.<minorVersion>`.  For example, the development of 3.9 and 4.0 resides in [the branch '3.9'](https://github.com/netty/netty/tree/3.9) and [the branch '4.0'](https://github.com/netty/netty/tree/4.0) respectively.
+
+## Usage with JDK 9
+
+Netty can be used in modular JDK9 applications as a collection of automatic modules. The module names follow the
+reverse-DNS style, and are derived from subproject names rather than root packages due to historical reasons. They
+are listed below:
+
+ * `io.netty.buffer`
+ * `io.netty.codec`
+ * `io.netty.codec.dns`
+ * `io.netty.codec.haproxy`
+ * `io.netty.codec.http`
+ * `io.netty.codec.http2`
+ * `io.netty.codec.memcache`
+ * `io.netty.codec.mqtt`
+ * `io.netty.codec.redis`
+ * `io.netty.codec.smtp`
+ * `io.netty.codec.socks`
+ * `io.netty.codec.stomp`
+ * `io.netty.codec.xml`
+ * `io.netty.common`
+ * `io.netty.handler`
+ * `io.netty.handler.proxy`
+ * `io.netty.resolver`
+ * `io.netty.resolver.dns`
+ * `io.netty.transport`
+ * `io.netty.transport.epoll` (`native` omitted - reserved keyword in Java)
+ * `io.netty.transport.kqueue` (`native` omitted - reserved keyword in Java)
+ * `io.netty.transport.unix.common` (`native` omitted - reserved keyword in Java)
+ * `io.netty.transport.rxtx`
+ * `io.netty.transport.sctp`
+ * `io.netty.transport.udt`
+
+
+
+Automatic modules do not provide any means to declare dependencies, so you need to list each used module separately
+in your `module-info` file.

--- a/buffer/pom.xml
+++ b/buffer/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Buffer</name>
 
+  <properties>
+    <javaModuleName>io.netty.buffer</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-dns/pom.xml
+++ b/codec-dns/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Codec/DNS</name>
 
+  <properties>
+    <javaModuleName>io.netty.codec.dns</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-haproxy/pom.xml
+++ b/codec-haproxy/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Codec/HAProxy</name>
 
+  <properties>
+    <javaModuleName>io.netty.codec.haproxy</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-http/pom.xml
+++ b/codec-http/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Codec/HTTP</name>
 
+  <properties>
+    <javaModuleName>io.netty.codec.http</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-http2/pom.xml
+++ b/codec-http2/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Codec/HTTP2</name>
 
+  <properties>
+    <javaModuleName>io.netty.codec.http2</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-memcache/pom.xml
+++ b/codec-memcache/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Codec/Memcache</name>
 
+  <properties>
+    <javaModuleName>io.netty.codec.memcache</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-mqtt/pom.xml
+++ b/codec-mqtt/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Codec/MQTT</name>
 
+  <properties>
+    <javaModuleName>io.netty.codec.mqtt</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-redis/pom.xml
+++ b/codec-redis/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Codec/Redis</name>
 
+  <properties>
+    <javaModuleName>io.netty.codec.redis</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-smtp/pom.xml
+++ b/codec-smtp/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Codec/SMTP</name>
 
+  <properties>
+    <javaModuleName>io.netty.codec.smtp</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-socks/pom.xml
+++ b/codec-socks/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Codec/Socks</name>
 
+  <properties>
+    <javaModuleName>io.netty.codec.socks</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-stomp/pom.xml
+++ b/codec-stomp/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Codec/Stomp</name>
 
+  <properties>
+    <javaModuleName>io.netty.codec.stomp</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec-xml/pom.xml
+++ b/codec-xml/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Codec/XML</name>
 
+  <properties>
+    <javaModuleName>io.netty.codec.xml</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/codec/pom.xml
+++ b/codec/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Codec</name>
 
+  <properties>
+    <javaModuleName>io.netty.codec</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -30,6 +30,7 @@
   <name>Netty/Common</name>
 
   <properties>
+    <javaModuleName>io.netty.common</javaModuleName>
     <collection.template.dir>${project.basedir}/src/main/templates</collection.template.dir>
     <collection.template.test.dir>${project.basedir}/src/test/templates</collection.template.test.dir>
     <collection.src.dir>${project.build.directory}/generated-sources/collections/java</collection.src.dir>

--- a/handler-proxy/pom.xml
+++ b/handler-proxy/pom.xml
@@ -27,6 +27,7 @@
   <packaging>jar</packaging>
 
   <properties>
+    <javaModuleName>io.netty.handler.proxy</javaModuleName>
     <!-- Needed for SelfSignedCertificate -->
     <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED</argLine.java9.extras>
   </properties>

--- a/handler/pom.xml
+++ b/handler/pom.xml
@@ -26,7 +26,8 @@
   <artifactId>netty-handler</artifactId>
   <packaging>jar</packaging>
 
-  <properties> 
+  <properties>
+    <javaModuleName>io.netty.handler</javaModuleName>
     <!-- Needed for SelfSignedCertificate -->
     <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED</argLine.java9.extras>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1105,6 +1105,9 @@
                   <manifest>
                     <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                   </manifest>
+                  <manifestEntries>
+                    <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                  </manifestEntries>
                   <index>true</index>
                   <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                 </archive>

--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Resolver/DNS</name>
 
+  <properties>
+    <javaModuleName>io.netty.resolver.dns</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/resolver/pom.xml
+++ b/resolver/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Resolver</name>
 
+  <properties>
+    <javaModuleName>io.netty.resolver</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -27,6 +27,7 @@
   <packaging>jar</packaging>
 
   <properties>
+    <javaModuleName>io.netty.transport.epoll</javaModuleName>
     <!-- Needed by the native transport as we need the memoryAddress of the ByteBuffer -->
     <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED</argLine.java9.extras>
     <unix.common.lib.name>netty-unix-common</unix.common.lib.name>

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -353,6 +353,7 @@
   </profiles>
 
   <properties>
+    <javaModuleName>io.netty.transport.kqueue</javaModuleName>
     <!-- Needed by the native transport as we need the memoryAddress of the ByteBuffer -->
     <argLine.java9.extras>--add-exports java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED</argLine.java9.extras>
     <unix.common.lib.name>netty-unix-common</unix.common.lib.name>

--- a/transport-native-unix-common/pom.xml
+++ b/transport-native-unix-common/pom.xml
@@ -30,6 +30,8 @@
   </description>
 
   <properties>
+    <javaModuleName>io.netty.transport.unix.common</javaModuleName>
+
     <exe.make>make</exe.make>
     <exe.compiler>gcc</exe.compiler>
     <exe.archiver>ar</exe.archiver>

--- a/transport-rxtx/pom.xml
+++ b/transport-rxtx/pom.xml
@@ -29,6 +29,10 @@
 
   <name>Netty/Transport/RXTX</name>
 
+  <properties>
+    <javaModuleName>io.netty.transport.rxtx</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/transport-sctp/pom.xml
+++ b/transport-sctp/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Transport/SCTP</name>
 
+  <properties>
+    <javaModuleName>io.netty.transport.sctp</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/transport-udt/pom.xml
+++ b/transport-udt/pom.xml
@@ -29,6 +29,10 @@
 
   <name>Netty/Transport/UDT</name>
 
+  <properties>
+    <javaModuleName>io.netty.transport.udt</javaModuleName>
+  </properties>
+
   <dependencies>
 
     <!-- MAIN -->

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -28,6 +28,10 @@
 
   <name>Netty/Transport</name>
 
+  <properties>
+    <javaModuleName>io.netty.transport</javaModuleName>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Motivation:

`Automatic-Module-Name` entry provides a stable JDK9 module name, when Netty is used in a modular JDK9 applications. More info: http://blog.joda.org/2017/05/java-se-9-jpms-automatic-modules.html

When Netty migrates to JDK9 in the future, the entry can be replaced by actual `module-info` descriptor.

Modification:

The POM-s are configured to put the correct module names to the manifest.

Result:

Fixes #7218.