### PR TITLE
Fixing CorsHandler response Content-Length

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
@@ -80,6 +81,9 @@ public class CorsHandler extends ChannelDuplexHandler {
             setAllowCredentials(response);
             setMaxAge(response);
             setPreflightHeaders(response);
+        }
+        if (!response.headers().contains(HttpHeaderNames.CONTENT_LENGTH)) {
+            response.headers().set(HttpHeaderNames.CONTENT_LENGTH, HttpHeaderValues.ZERO);
         }
         release(request);
         respond(ctx, request, response);
@@ -205,8 +209,10 @@ public class CorsHandler extends ChannelDuplexHandler {
     }
 
     private static void forbidden(final ChannelHandlerContext ctx, final HttpRequest request) {
+        HttpResponse response = new DefaultFullHttpResponse(request.protocolVersion(), FORBIDDEN);
+        response.headers().set(HttpHeaderNames.CONTENT_LENGTH, HttpHeaderValues.ZERO);
         release(request);
-        respond(ctx, request, new DefaultFullHttpResponse(request.protocolVersion(), FORBIDDEN));
+        respond(ctx, request, response);
     }
 
     private static void respond(

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
@@ -161,6 +161,7 @@ public class CorsHandlerTest {
         final HttpResponse response = preflightRequest(config, "http://localhost:8888", "content-type, xheader1");
         assertThat(response.headers().get(of("CustomHeader")), equalTo("somevalue"));
         assertThat(response.headers().get(VARY), equalTo(ORIGIN.toString()));
+        assertThat(response.headers().get(CONTENT_LENGTH), is("0"));
     }
 
     @Test
@@ -276,6 +277,7 @@ public class CorsHandlerTest {
         final CorsConfig config = forOrigin("http://localhost:8080").shortCircuit().build();
         final HttpResponse response = simpleRequest(config, "http://localhost:7777");
         assertThat(response.status(), is(FORBIDDEN));
+        assertThat(response.headers().get(CONTENT_LENGTH), is("0"));
     }
 
     @Test


### PR DESCRIPTION
**Motivation:**

Issue https://github.com/netty/netty/issues/7253

**Modifications:**

Adding `Content-Length: 0` to `CorsHandler.forbidden()` and `CorsHandler.handlePreflight()`

**Result:**

Contexts that are terminated by the CorsHandler will always include a Content-Length header