### PR TITLE
Added automatic module name to the jar manifest for native transports

### DIFF
--- a/transport-native-epoll/pom.xml
+++ b/transport-native-epoll/pom.xml
@@ -180,6 +180,7 @@
                     </manifest>
                     <manifestEntries>
                       <Bundle-NativeCode>META-INF/native/libnetty_transport_native_epoll_${os.detected.arch}.so; osname=Linux; processor=${os.detected.arch},*</Bundle-NativeCode>
+                      <Automatic-Module-Name>netty.transport.epoll</Automatic-Module-Name>
                     </manifestEntries>
                     <index>true</index>
                     <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/transport-native-kqueue/pom.xml
+++ b/transport-native-kqueue/pom.xml
@@ -111,6 +111,7 @@
                     </manifest>
                     <manifestEntries>
                       <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue_${os.detected.arch}.jnilib; osname=MacOSX, processor=${os.detected.arch}"</Bundle-NativeCode>
+                      <Automatic-Module-Name>netty.transport.kqueue</Automatic-Module-Name>
                     </manifestEntries>
                     <index>true</index>
                     <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -218,6 +219,7 @@
                     </manifest>
                     <manifestEntries>
                       <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue_${os.detected.arch}.jnilib; osname=OpenBSD, processor=${os.detected.arch}"</Bundle-NativeCode>
+                      <Automatic-Module-Name>netty.transport.kqueue</Automatic-Module-Name>
                     </manifestEntries>
                     <index>true</index>
                     <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -325,6 +327,7 @@
                     </manifest>
                     <manifestEntries>
                       <Bundle-NativeCode>META-INF/native/libnetty_transport_native_kqueue_${os.detected.arch}.jnilib; osname=FreeBSD, processor=${os.detected.arch}"</Bundle-NativeCode>
+                      <Automatic-Module-Name>netty.transport.kqueue</Automatic-Module-Name>
                     </manifestEntries>
                     <index>true</index>
                     <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>


### PR DESCRIPTION
Motivation:

Right now it is impossible to add native transports to modularized java 9 projects as the automatic generated name contains reserved keyword `native`.

Fix for #7266.

Modification:

Added predefined module names for native transports (without `native` keyword) to jar manifest to avoid automatic modules name:

```
netty.transport.epoll
netty.transport.kqueue
```

Result:

Now native transports could be added to modularized java 9 projects.
