### PR TITLE
Do not treat errors as decoder exception

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ByteToMessageDecoder.java
@@ -265,8 +265,8 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
                 callDecode(ctx, cumulation, out);
             } catch (DecoderException e) {
                 throw e;
-            } catch (Throwable t) {
-                throw new DecoderException(t);
+            } catch (Exception e) {
+                throw new DecoderException(e);
             } finally {
                 if (cumulation != null && !cumulation.isReadable()) {
                     numReads = 0;
@@ -455,7 +455,7 @@ public abstract class ByteToMessageDecoder extends ChannelInboundHandlerAdapter 
             }
         } catch (DecoderException e) {
             throw e;
-        } catch (Throwable cause) {
+        } catch (Exception cause) {
             throw new DecoderException(cause);
         }
     }


### PR DESCRIPTION
Motivation: Today when Netty encounters a general error while decoding it treats this as a decoder exception. However, for fatal causes this should not be treated as such, instead the fatal error should be carried up the stack without the callee having to unwind causes.

Modifications: Instead of translating any error to a decoder exception, we let those unwind out the stack (note that finally blocks still execute).

Result: Fatal errors will not be treated as innocent decoder exceptions.

Relates #6096