### PR TITLE
Fail the connectPromise with the correct exception if the connection …

### DIFF
--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -468,6 +468,14 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
          * Shutdown the input side of the channel.
          */
         void shutdownInput(boolean readEOF) {
+            // We need to take special care of calling finishConnect() if readEOF is true and we not
+            // fullfilled the connectPromise yet. If we fail to do so the connectPromise will be failed
+            // with a ClosedChannelException as a close() will happen and so the FD is closed before we
+            // have a chance to call finishConnect() later on. Calling finishConnect() here will ensure
+            // we observe the correct exception in case of a connect failure.
+            if (readEOF && connectPromise != null) {
+                finishConnect();
+            }
             if (!socket.isInputShutdown()) {
                 if (isAllowHalfClosure(config())) {
                     try {


### PR DESCRIPTION
…is refused when using the native kqueue transport.

Motivation:

Due a bug we happen to sometimes fail the connectPromise with a ClosedChannelException when using the kqueue transport and the remote peer refuses the connection. We need to ensure we fail it with the correct exception.

Modifications:

Call finishConnect() before calling close() to ensure we preserve the correct exception.

Result:

KQueueSocketConnectionAttemptTest.testConnectionRefused will pass always on macOS.