### PR TITLE
Update JCTools version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
       <dependency>
         <groupId>org.jctools</groupId>
         <artifactId>jctools-core</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Motivation:

JCTools 2.1.0 contains package-info.class which doesn't load on JRE 6.

Modifications:

Change pom JCTools version.

Result:

Really fixes https://github.com/netty/netty/issues/7117