### PR TITLE
#7285 Improved "Discarded inbound message" warning

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -1243,6 +1243,10 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Reached end of the pipeline for handlers : {}.",
+                        ctx.pipeline().names());
+            }
             onUnhandledInboundMessage(msg);
         }
 


### PR DESCRIPTION
Motivation:

On servers with many pipelines or dynamic pipelines, it is easy for end user to make mistake during pipeline configuration. Current message:

`Discarded inbound message PooledUnsafeDirectByteBuf(ridx: 0, widx: 2, cap: 2) that reached at the tail of the pipeline. Please check your pipeline configuration.`

Is not always meaningful and doesn't allow to find the wrong pipeline quickly.

Modification:

Added additional log message that identifies pipeline handlers. This will allow for the end users quickly find the problem pipeline.

Result:

Meaningful warning when the message reaches the end of the pipeline. Fixes https://github.com/netty/netty/issues/7285
