### PR TITLE
Don't disable HttpObjectDecoder on upgrade from HTTP/1.x to HTTP/1.x over TLS

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -485,6 +485,21 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     }
 
     /**
+     * Returns true if the server switched to a different protocol than HTTP/1.0 or HTTP/1.1, e.g. HTTP/2.
+     * Returns false if the upgrade happened in a different layer, e.g. upgrade from HTTP/1.1 to HTTP/1.1 over TLS.
+     */
+    private boolean isSwitchingToNonHttp1Protocol(HttpResponse msg) {
+        if (msg == null)
+            return false;
+        if (msg.status() != HttpResponseStatus.SWITCHING_PROTOCOLS)
+            return false;
+        String newProtocol = msg.headers().get(HttpHeaderNames.UPGRADE);
+        return newProtocol != null &&
+                !newProtocol.contains(HttpVersion.HTTP_1_0.text()) &&
+                !newProtocol.contains(HttpVersion.HTTP_1_1.text());
+    }
+
+    /**
      * Resets the state of the decoder so that it is ready to decode a new message.
      * This method is useful for handling a rejected request with {@code Expect: 100-continue} header.
      */
@@ -501,12 +516,9 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         lineParser.reset();
         headerParser.reset();
         trailer = null;
-        if (!isDecodingRequest()) {
-            HttpResponse res = (HttpResponse) message;
-            if (res != null && res.status().code() == 101) {
-                currentState = State.UPGRADED;
-                return;
-            }
+        if (!isDecodingRequest() && isSwitchingToNonHttp1Protocol((HttpResponse) message)) {
+            currentState = State.UPGRADED;
+            return;
         }
 
         resetRequested = false;


### PR DESCRIPTION
Motivation:

Being able to upgrade to TLS according to RFC 2817, within HTTP/1.x. 
Switching the transport layer to TLS should be possible without removing `HttpClientCodec` from the pipeline, because HTTP/1.x layer of the protocol remains untouched by the switch. 

Modification:
Don't set `HttpObjectDecoder` into `UPGRADED` state if `SWITCHING_PROTOCOLS` response contains `HTTP/1.0` or `HTTP/1.1` in the protocol stack described by the `Upgrade` header.

Describe the modifications you've done.
Added a new method  `isSwitchingToNonHttp1Protocol` and called it from `resetNow`.

Result:

Should fix #7293. 
This is not fully tested yet - just asking if such a fix would be acceptable.

