### PR TITLE
Don't disable HttpObjectDecoder on upgrade from HTTP/1.x to HTTP/1.x over TLS

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
@@ -223,8 +223,8 @@ public final class HttpClientCodec extends CombinedChannelDuplexHandler<HttpResp
         @Override
         protected boolean isContentAlwaysEmpty(HttpMessage msg) {
             final int statusCode = ((HttpResponse) msg).status().code();
-            if (statusCode == 100) {
-                // 100-continue response should be excluded from paired comparison.
+            if (statusCode == 100 || statusCode == 101) {
+                // 100-continue and 101 switching protocols response should be excluded from paired comparison.
                 return true;
             }
 


### PR DESCRIPTION
Motivation:

Being able to upgrade plain HTTP 1.x connection to TLS according to RFC 2817.
Switching the transport layer to TLS should be possible without removing `HttpClientCodec` from the pipeline, because HTTP/1.x layer of the protocol remains untouched by the switch.

Modification:
Don't set HttpObjectDecoder into UPGRADED state if SWITCHING_PROTOCOLS response contains HTTP/1.0 or HTTP/1.1 in the protocol stack described by the Upgrade header. 

Describe the modifications you've done.
Added a new method isSwitchingToNonHttp1Protocol and called it from resetNow.
Additionally I had to skip pairing comparison for HTTP 101, because otherwise it resulted with NPE during decoding. I can see no reason why HTTP 100 and 101 would be handled differently in terms of request-response pairing. 

Result:

Fixes #7293.