### PR TITLE
Don't disable HttpObjectDecoder on upgrade from HTTP/1.x to HTTP/1.x over TLS (Netty 4.0)

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
@@ -173,8 +173,8 @@ public final class HttpClientCodec
         @Override
         protected boolean isContentAlwaysEmpty(HttpMessage msg) {
             final int statusCode = ((HttpResponse) msg).getStatus().code();
-            if (statusCode == 100) {
-                // 100-continue response should be excluded from paired comparison.
+            if (statusCode == 100 || statusCode == 101) {
+                // 100-continue and 101 switching protocols response should be excluded from paired comparison.
                 return true;
             }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -487,6 +487,20 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
     }
 
     /**
+     * Returns true if the server switched to a different protocol than HTTP/1.0 or HTTP/1.1, e.g. HTTP/2 or Websocket.
+     * Returns false if the upgrade happened in a different layer, e.g. upgrade from HTTP/1.1 to HTTP/1.1 over TLS.
+     */
+    protected boolean isSwitchingToNonHttp1Protocol(HttpResponse msg) {
+        if (msg.getStatus().code() != HttpResponseStatus.SWITCHING_PROTOCOLS.code()) {
+            return false;
+        }
+        String newProtocol = msg.headers().get(HttpHeaders.Values.UPGRADE);
+        return newProtocol == null ||
+                !newProtocol.contains(HttpVersion.HTTP_1_0.text()) &&
+                !newProtocol.contains(HttpVersion.HTTP_1_1.text());
+    }
+
+    /**
      * Resets the state of the decoder so that it is ready to decode a new message.
      * This method is useful for handling a rejected request with {@code Expect: 100-continue} header.
      */
@@ -505,7 +519,7 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         trailer = null;
         if (!isDecodingRequest()) {
             HttpResponse res = (HttpResponse) message;
-            if (res != null && res.getStatus().code() == 101) {
+            if (res != null && isSwitchingToNonHttp1Protocol(res)) {
                 currentState = State.UPGRADED;
                 return;
             }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpClientCodecTest.java
@@ -233,4 +233,34 @@ public class HttpClientCodecTest {
             cb.group().shutdownGracefully();
         }
     }
+
+    @Test
+    public void testDecodesFinalResponseAfterSwitchingProtocols() {
+        String SWITCHING_PROTOCOLS_RESPONSE = "HTTP/1.1 101 Switching Protocols\r\n" +
+                "Connection: Upgrade\r\n" +
+                "Upgrade: TLS/1.2, HTTP/1.1\r\n\r\n";
+
+        HttpClientCodec codec = new HttpClientCodec(4096, 8192, 8192, true);
+        EmbeddedChannel ch = new EmbeddedChannel(codec, new HttpObjectAggregator(1024));
+
+        HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "http://localhost/");
+        request.headers().set(HttpHeaders.Names.CONNECTION, HttpHeaders.Values.UPGRADE);
+        request.headers().set(HttpHeaders.Names.UPGRADE, "TLS/1.2");
+        assertTrue("Channel outbound write failed.", ch.writeOutbound(request));
+
+        assertTrue("Channel inbound write failed.",
+                ch.writeInbound(Unpooled.copiedBuffer(SWITCHING_PROTOCOLS_RESPONSE, CharsetUtil.ISO_8859_1)));
+        Object switchingProtocolsResponse = ch.readInbound();
+        assertNotNull("No response received", switchingProtocolsResponse);
+        assertThat("Response was not decoded", switchingProtocolsResponse, instanceOf(FullHttpResponse.class));
+        ((FullHttpResponse) switchingProtocolsResponse).release();
+
+        assertTrue("Channel inbound write failed",
+                ch.writeInbound(Unpooled.copiedBuffer(RESPONSE, CharsetUtil.ISO_8859_1)));
+        Object finalResponse = ch.readInbound();
+        assertNotNull("No response received", finalResponse);
+        assertThat("Response was not decoded", finalResponse, instanceOf(FullHttpResponse.class));
+        ((FullHttpResponse) finalResponse).release();
+        assertTrue("Channel finish failed", ch.finishAndReleaseAll());
+    }
 }


### PR DESCRIPTION
Motivation:

Being able to upgrade plain HTTP 1.x connection to TLS according to RFC 2817.
Switching the transport layer to TLS should be possible without removing HttpClientCodec from the pipeline, because HTTP/1.x layer of the protocol remains untouched by the switch.

Modification:
Don't set HttpObjectDecoder into UPGRADED state if SWITCHING_PROTOCOLS response contains HTTP/1.0 or HTTP/1.1 in the protocol stack described by the Upgrade header.

Describe the modifications you've done.
Added a new method isSwitchingToNonHttp1Protocol and called it from resetNow.
Additionally I had to skip pairing comparison for HTTP 101, because otherwise it resulted with NPE during decoding. I can see no reason why HTTP 100 and 101 would be handled differently in terms of request-response pairing.

Result:

Fixes #7293.