### PR TITLE
Minor improvements in ByteBufOutputStream

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufOutputStream.java
@@ -15,6 +15,8 @@
  */
 package io.netty.buffer;
 
+import io.netty.util.CharsetUtil;
+
 import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -73,48 +75,45 @@ public class ByteBufOutputStream extends OutputStream implements DataOutput {
 
     @Override
     public void write(int b) throws IOException {
-        buffer.writeByte((byte) b);
+        buffer.writeByte(b);
     }
 
     @Override
     public void writeBoolean(boolean v) throws IOException {
-        write(v? (byte) 1 : (byte) 0);
+        buffer.writeBoolean(v);
     }
 
     @Override
     public void writeByte(int v) throws IOException {
-        write(v);
+        buffer.writeByte(v);
     }
 
     @Override
     public void writeBytes(String s) throws IOException {
-        int len = s.length();
-        for (int i = 0; i < len; i ++) {
-            write((byte) s.charAt(i));
-        }
+        buffer.writeCharSequence(s, CharsetUtil.US_ASCII);
     }
 
     @Override
     public void writeChar(int v) throws IOException {
-        writeShort((short) v);
+        buffer.writeChar(v);
     }
 
     @Override
     public void writeChars(String s) throws IOException {
         int len = s.length();
         for (int i = 0 ; i < len ; i ++) {
-            writeChar(s.charAt(i));
+            buffer.writeChar(s.charAt(i));
         }
     }
 
     @Override
     public void writeDouble(double v) throws IOException {
-        writeLong(Double.doubleToLongBits(v));
+        buffer.writeDouble(v);
     }
 
     @Override
     public void writeFloat(float v) throws IOException {
-        writeInt(Float.floatToIntBits(v));
+        buffer.writeFloat(v);
     }
 
     @Override


### PR DESCRIPTION
Motivation:
In the `ByteBufOutputStream` we can use an appropriate methods of `ByteBuf`
to reduce calls of virtual methods and do not copying converting logic.

Modifications:
- Use an appropriate methods of `ByteBuf`
- Remove redundant conversions (int -> byte, int -> char).
- Use `ByteBuf#writeCharSequence` in the `writeBytes(String)'.

Result:
Less code duplication. A `writeBytes(String)` method is faster.
No unnecessary conversions. More consistent and cleaner code.