### PR TITLE
Add missed 'serialVersionUID' field for Serializable classes

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Exception.java
@@ -252,6 +252,8 @@ public class Http2Exception extends Exception {
     }
 
     public static final class HeaderListSizeException extends StreamException {
+        private static final long serialVersionUID = -8807603212183882637L;
+
         private final boolean decode;
 
         HeaderListSizeException(int streamId, Http2Error error, String message, boolean decode) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelId.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelId.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelId;
  * ChannelId implementation which is used by our {@link Http2StreamChannel} implementation.
  */
 final class Http2StreamChannelId implements ChannelId {
+    private static final long serialVersionUID = -6642338822166867585L;
 
     private final int id;
     private final ChannelId parentId;

--- a/codec/src/test/java/io/netty/handler/codec/serialization/CompatibleObjectEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/serialization/CompatibleObjectEncoderTest.java
@@ -53,6 +53,8 @@ public class CompatibleObjectEncoderTest {
     }
 
     private static final class TestSerializable implements Serializable {
+        private static final long serialVersionUID = 2235771472534930360L;
+
         public final int x;
         public final int y;
 

--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -507,8 +507,10 @@ public class ResourceLeakDetector<T> {
     }
 
     private static final class Record extends Throwable {
+        private static final long serialVersionUID = 6065153674892850720L;
 
         private static final Set<String> STACK_TRACE_ELEMENT_EXCLUSIONS = new HashSet<String>();
+
         static {
             STACK_TRACE_ELEMENT_EXCLUSIONS.add("io.netty.util.ReferenceCountUtil.touch");
             STACK_TRACE_ELEMENT_EXCLUSIONS.add("io.netty.buffer.AdvancedLeakAwareByteBuf.touch");

--- a/handler/src/main/java/io/netty/handler/ssl/PemPrivateKey.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemPrivateKey.java
@@ -41,6 +41,7 @@ import io.netty.util.internal.ObjectUtil;
  * @see #valueOf(ByteBuf)
  */
 public final class PemPrivateKey extends AbstractReferenceCounted implements PrivateKey, PemEncoded {
+    private static final long serialVersionUID = 7978017465645018936L;
 
     private static final byte[] BEGIN_PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----\n".getBytes(CharsetUtil.US_ASCII);
     private static final byte[] END_PRIVATE_KEY = "\n-----END PRIVATE KEY-----\n".getBytes(CharsetUtil.US_ASCII);

--- a/handler/src/test/java/io/netty/handler/ssl/JdkSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/JdkSslEngineTest.java
@@ -352,6 +352,8 @@ public class JdkSslEngineTest extends SSLEngineTest {
     }
 
     private static final class SkipTestException extends RuntimeException {
+        private static final long serialVersionUID = 9214869217774035223L;
+
         SkipTestException(String message) {
             super(message);
         }

--- a/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslErrorTest.java
@@ -247,6 +247,7 @@ public class SslErrorTest {
     }
 
     private static final class TestCertificateException extends CertificateException {
+        private static final long serialVersionUID = -5816338303868751410L;
 
         public TestCertificateException(Throwable cause) {
             super(cause);

--- a/handler/src/test/java/io/netty/handler/ssl/ocsp/OcspTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ocsp/OcspTest.java
@@ -494,6 +494,8 @@ public class OcspTest {
     }
 
     private static final class OcspTestException extends IllegalStateException {
+        private static final long serialVersionUID = 4516426833250228159L;
+
         public OcspTestException(String message) {
             super(message);
         }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -153,6 +153,8 @@ abstract class DnsNameResolverContext<T> {
     }
 
     private static final class SearchDomainUnknownHostException extends UnknownHostException {
+        private static final long serialVersionUID = -8573510133644997085L;
+
         SearchDomainUnknownHostException(Throwable cause, String originalHostname) {
             super("Search domain query failed. Original hostname: '" + originalHostname + "' " + cause.getMessage());
             setStackTrace(cause.getStackTrace());

--- a/transport/src/main/java/io/netty/channel/socket/ChannelOutputShutdownException.java
+++ b/transport/src/main/java/io/netty/channel/socket/ChannelOutputShutdownException.java
@@ -26,6 +26,8 @@ import java.io.IOException;
  */
 @UnstableApi
 public final class ChannelOutputShutdownException extends IOException {
+    private static final long serialVersionUID = 6712549938359321378L;
+
     public ChannelOutputShutdownException(String msg) {
         super(msg);
     }

--- a/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/PendingWriteQueueTest.java
@@ -377,5 +377,7 @@ public class PendingWriteQueueTest {
         }
     }
 
-    private static final class TestException extends Exception { }
+    private static final class TestException extends Exception {
+        private static final long serialVersionUID = -9018570103039458401L;
+    }
 }


### PR DESCRIPTION
Motivation:

Without a 'serialVersionUID' field, any change to a class will make previously serialized versions unreadable.

Modifications:

Add missed 'serialVersionUID' field for all Serializable classes.

Result:

Proper deserialization of previously serialized objects.
