### PR TITLE
Make Comparators Serializable

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/WeightedFairQueueByteDistributor.java
@@ -25,6 +25,7 @@ import io.netty.util.internal.PriorityQueueNode;
 import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.UnstableApi;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -399,7 +400,9 @@ public final class WeightedFairQueueByteDistributor implements StreamByteDistrib
      *     <li>Stream ID (higher stream ID is higher priority - used for tie breaker)</li>
      * </ul>
      */
-    private static final class StateOnlyComparator implements Comparator<State> {
+    private static final class StateOnlyComparator implements Comparator<State>, Serializable {
+        private static final long serialVersionUID = -4806936913002105966L;
+
         static final StateOnlyComparator INSTANCE = new StateOnlyComparator();
 
         private StateOnlyComparator() {
@@ -426,7 +429,9 @@ public final class WeightedFairQueueByteDistributor implements StreamByteDistrib
         }
     }
 
-    private static final class StatePseudoTimeComparator implements Comparator<State> {
+    private static final class StatePseudoTimeComparator implements Comparator<State>, Serializable {
+        private static final long serialVersionUID = -1437548640227161828L;
+
         static final StatePseudoTimeComparator INSTANCE = new StatePseudoTimeComparator();
 
         private StatePseudoTimeComparator() {

--- a/common/src/test/java/io/netty/util/internal/DefaultPriorityQueueTest.java
+++ b/common/src/test/java/io/netty/util/internal/DefaultPriorityQueueTest.java
@@ -17,6 +17,7 @@ package io.netty.util.internal;
 
 import org.junit.Test;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -245,7 +246,9 @@ public class DefaultPriorityQueueTest {
         assertTrue(queue.isEmpty());
     }
 
-    private static final class TestElementComparator implements Comparator<TestElement> {
+    private static final class TestElementComparator implements Comparator<TestElement>, Serializable {
+        private static final long serialVersionUID = 7930368853384760103L;
+
         static final TestElementComparator INSTANCE = new TestElementComparator();
 
         private TestElementComparator() {


### PR DESCRIPTION
Motivation:

Objects of `java.util.TreeMap` or `java.util.TreeSet` will become non-Serializable if instantiated with Comparators, which are not also Serializable. This can result in unexpected and difficult-to-diagnose bugs.

Modifications:

Implements Serializable for all classes, which implements Comparator.

Result:

Proper Comparators which will not force collections to non-Serializable mode.