### PR TITLE
Make methods 'static' where it possible

### DIFF
--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyByteBufTest.java
@@ -202,7 +202,7 @@ public class ReadOnlyByteBufTest {
         ensureWritableIntStatusShouldFailButNotThrow(true);
     }
 
-    private void ensureWritableIntStatusShouldFailButNotThrow(boolean force) {
+    private static void ensureWritableIntStatusShouldFailButNotThrow(boolean force) {
         ByteBuf buf = buffer(1);
         ByteBuf readOnly = buf.asReadOnly();
         int result = readOnly.ensureWritable(1, force);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -159,7 +159,7 @@ public class HttpObjectAggregator
         }
     }
 
-    private Object continueResponse(HttpMessage start, int maxContentLength, ChannelPipeline pipeline) {
+    private static Object continueResponse(HttpMessage start, int maxContentLength, ChannelPipeline pipeline) {
         if (HttpUtil.isUnsupportedExpectation(start)) {
             // if the request contains an unsupported expectation, we return 417
             pipeline.fireUserEventTriggered(HttpExpectationFailedEvent.INSTANCE);

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpUtilTest.java
@@ -215,7 +215,7 @@ public class HttpUtilTest {
         run100ContinueTest(message, false);
     }
 
-    private void run100ContinueTest(final HttpVersion version, final String expectations, boolean expect) {
+    private static void run100ContinueTest(final HttpVersion version, final String expectations, boolean expect) {
         final HttpMessage message = new DefaultFullHttpRequest(version, HttpMethod.GET, "/");
         if (expectations != null) {
             message.headers().set(HttpHeaderNames.EXPECT, expectations);
@@ -223,7 +223,7 @@ public class HttpUtilTest {
         run100ContinueTest(message, expect);
     }
 
-    private void run100ContinueTest(final HttpMessage message, final boolean expected) {
+    private static void run100ContinueTest(final HttpMessage message, final boolean expected) {
         assertEquals(expected, HttpUtil.is100ContinueExpected(message));
         ReferenceCountUtil.release(message);
     }
@@ -242,7 +242,8 @@ public class HttpUtilTest {
         runUnsupportedExpectationTest(message, false);
     }
 
-    private void runUnsupportedExpectationTest(final HttpVersion version, final String expectations, boolean expect) {
+    private static void runUnsupportedExpectationTest(final HttpVersion version,
+                                                      final String expectations, boolean expect) {
         final HttpMessage message = new DefaultFullHttpRequest(version, HttpMethod.GET, "/");
         if (expectations != null) {
             message.headers().set("Expect", expectations);
@@ -250,7 +251,7 @@ public class HttpUtilTest {
         runUnsupportedExpectationTest(message, expect);
     }
 
-    private void runUnsupportedExpectationTest(final HttpMessage message, final boolean expected) {
+    private static void runUnsupportedExpectationTest(final HttpMessage message, final boolean expected) {
         assertEquals(expected, HttpUtil.isUnsupportedExpectation(message));
         ReferenceCountUtil.release(message);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameReaderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameReaderTest.java
@@ -390,7 +390,7 @@ public class DefaultHttp2FrameReaderTest {
         }
     }
 
-    private void writePriorityFrame(
+    private static void writePriorityFrame(
             ByteBuf output, int streamId, int streamDependency, int weight) {
         writeFrameHeader(output, 5, PRIORITY, new Http2Flags(), streamId);
         output.writeInt(streamDependency);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2FrameWriterTest.java
@@ -265,7 +265,7 @@ public class DefaultHttp2FrameWriterTest {
         }
     }
 
-    private Http2Headers dummyHeaders(Http2Headers headers, int times) {
+    private static Http2Headers dummyHeaders(Http2Headers headers, int times) {
         final String largeValue = repeat("dummy-value", 100);
         for (int i = 0; i < times; i++) {
             headers.add(String.format("dummy-%d", i), largeValue);
@@ -273,7 +273,7 @@ public class DefaultHttp2FrameWriterTest {
         return headers;
     }
 
-    private String repeat(String str, int count) {
+    private static String repeat(String str, int count) {
         return String.format(String.format("%%%ds", count), " ").replace(" ", str);
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/ReadOnlyHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/ReadOnlyHttp2HeadersTest.java
@@ -198,39 +198,39 @@ public class ReadOnlyHttp2HeadersTest {
         assertFalse(itr.hasNext());
     }
 
-    private void testValueIteratorSingleValue(Http2Headers headers, CharSequence name, CharSequence value) {
+    private static void testValueIteratorSingleValue(Http2Headers headers, CharSequence name, CharSequence value) {
         Iterator<CharSequence> itr = headers.valueIterator(name);
         assertTrue(itr.hasNext());
         assertTrue(AsciiString.contentEqualsIgnoreCase(value, itr.next()));
         assertFalse(itr.hasNext());
     }
 
-    private void testIteratorReadOnly(Http2Headers headers) {
+    private static void testIteratorReadOnly(Http2Headers headers) {
         Iterator<Map.Entry<CharSequence, CharSequence>> itr = headers.iterator();
         assertTrue(itr.hasNext());
         itr.remove();
     }
 
-    private void testIteratorEntryReadOnly(Http2Headers headers) {
+    private static void testIteratorEntryReadOnly(Http2Headers headers) {
         Iterator<Map.Entry<CharSequence, CharSequence>> itr = headers.iterator();
         assertTrue(itr.hasNext());
         itr.next().setValue("foo");
     }
 
-    private ReadOnlyHttp2Headers newServerHeaders() {
+    private static ReadOnlyHttp2Headers newServerHeaders() {
         return ReadOnlyHttp2Headers.serverHeaders(false, new AsciiString("200"), otherHeaders());
     }
 
-    private ReadOnlyHttp2Headers newClientHeaders() {
+    private static ReadOnlyHttp2Headers newClientHeaders() {
         return ReadOnlyHttp2Headers.clientHeaders(false, new AsciiString("meth"), new AsciiString("/foo"),
                 new AsciiString("schemer"), new AsciiString("respect_my_authority"), otherHeaders());
     }
 
-    private ReadOnlyHttp2Headers newTrailers() {
+    private static ReadOnlyHttp2Headers newTrailers() {
         return ReadOnlyHttp2Headers.trailers(false, otherHeaders());
     }
 
-    private AsciiString[] otherHeaders() {
+    private static AsciiString[] otherHeaders() {
         return new AsciiString[] {
                 new AsciiString("name1"), new AsciiString("value1"),
                 new AsciiString("name2"), new AsciiString("value2"),

--- a/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
@@ -45,7 +45,7 @@ public class DefaultHeadersTest {
         }
     }
 
-    private TestDefaultHeaders newInstance() {
+    private static TestDefaultHeaders newInstance() {
         return new TestDefaultHeaders();
     }
 

--- a/codec/src/test/java/io/netty/handler/codec/string/LineEncoderTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/string/LineEncoderTest.java
@@ -33,7 +33,7 @@ public class LineEncoderTest {
         testLineEncode(LineSeparator.UNIX, "abc");
     }
 
-    private void testLineEncode(LineSeparator lineSeparator, String msg) {
+    private static void testLineEncode(LineSeparator lineSeparator, String msg) {
         EmbeddedChannel channel = new EmbeddedChannel(new LineEncoder(lineSeparator, CharsetUtil.UTF_8));
         assertTrue(channel.writeOutbound(msg));
         ByteBuf buf = channel.readOutbound();

--- a/common/src/test/java/io/netty/util/NettyRuntimeTests.java
+++ b/common/src/test/java/io/netty/util/NettyRuntimeTests.java
@@ -98,7 +98,7 @@ public class NettyRuntimeTests {
         assertNull(secondRefernce.get());
     }
 
-    private Runnable getRunnable(
+    private static Runnable getRunnable(
             final NettyRuntime.AvailableProcessorsHolder holder,
             final CyclicBarrier barrier,
             final AtomicReference<IllegalStateException> reference) {

--- a/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/DefaultPromiseTest.java
@@ -241,8 +241,8 @@ public class DefaultPromiseTest {
         }
     }
 
-    private void testStackOverFlowChainedFuturesA(int promiseChainLength, final EventExecutor executor,
-                                                  boolean runTestInExecutorThread)
+    private static void testStackOverFlowChainedFuturesA(int promiseChainLength, final EventExecutor executor,
+                                                         boolean runTestInExecutorThread)
             throws InterruptedException {
         final Promise<Void>[] p = new DefaultPromise[promiseChainLength];
         final CountDownLatch latch = new CountDownLatch(promiseChainLength);
@@ -264,8 +264,8 @@ public class DefaultPromiseTest {
         }
     }
 
-    private void testStackOverFlowChainedFuturesA(EventExecutor executor, final Promise<Void>[] p,
-                                                  final CountDownLatch latch) {
+    private static void testStackOverFlowChainedFuturesA(EventExecutor executor, final Promise<Void>[] p,
+                                                         final CountDownLatch latch) {
         for (int i = 0; i < p.length; i ++) {
             final int finalI = i;
             p[i] = new DefaultPromise<Void>(executor);
@@ -283,8 +283,8 @@ public class DefaultPromiseTest {
         p[0].setSuccess(null);
     }
 
-    private void testStackOverFlowChainedFuturesB(int promiseChainLength, final EventExecutor executor,
-                                                  boolean runTestInExecutorThread)
+    private static void testStackOverFlowChainedFuturesB(int promiseChainLength, final EventExecutor executor,
+                                                         boolean runTestInExecutorThread)
             throws InterruptedException {
         final Promise<Void>[] p = new DefaultPromise[promiseChainLength];
         final CountDownLatch latch = new CountDownLatch(promiseChainLength);
@@ -306,8 +306,8 @@ public class DefaultPromiseTest {
         }
     }
 
-    private void testStackOverFlowChainedFuturesB(EventExecutor executor, final Promise<Void>[] p,
-                                                  final CountDownLatch latch) {
+    private static void testStackOverFlowChainedFuturesB(EventExecutor executor, final Promise<Void>[] p,
+                                                         final CountDownLatch latch) {
         for (int i = 0; i < p.length; i ++) {
             final int finalI = i;
             p[i] = new DefaultPromise<Void>(executor);

--- a/common/src/test/java/io/netty/util/concurrent/DefaultThreadFactoryTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/DefaultThreadFactoryTest.java
@@ -186,7 +186,7 @@ public class DefaultThreadFactoryTest {
         }
     }
 
-    private void runStickyThreadGroupTest(
+    private static void runStickyThreadGroupTest(
             final Callable<DefaultThreadFactory> callable,
             final ThreadGroup expected) throws InterruptedException {
         final AtomicReference<ThreadGroup> captured = new AtomicReference<ThreadGroup>();

--- a/common/src/test/java/io/netty/util/internal/DefaultPriorityQueueTest.java
+++ b/common/src/test/java/io/netty/util/internal/DefaultPriorityQueueTest.java
@@ -116,7 +116,7 @@ public class DefaultPriorityQueueTest {
         testRemoval(true);
     }
 
-    private void testRemoval(boolean typed) {
+    private static void testRemoval(boolean typed) {
         PriorityQueue<TestElement> queue = new DefaultPriorityQueue<TestElement>(TestElementComparator.INSTANCE, 4);
         assertEmptyQueue(queue);
 

--- a/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
+++ b/common/src/test/java/io/netty/util/internal/PlatformDependentTest.java
@@ -66,7 +66,7 @@ public class PlatformDependentTest {
         boolean equals(byte[] bytes1, int startPos1, byte[] bytes2, int startPos2, int length);
     }
 
-    private void testEquals(EqualityChecker equalsChecker) {
+    private static void testEquals(EqualityChecker equalsChecker) {
         byte[] bytes1 = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd'};
         byte[] bytes2 = {'H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd'};
         assertNotSame(bytes1, bytes2);

--- a/common/src/test/java/io/netty/util/internal/StringUtilTest.java
+++ b/common/src/test/java/io/netty/util/internal/StringUtilTest.java
@@ -440,7 +440,7 @@ public class StringUtilTest {
         assertEscapeCsvAndUnEscapeCsv("\n");
     }
 
-    private void assertEscapeCsvAndUnEscapeCsv(String value) {
+    private static void assertEscapeCsvAndUnEscapeCsv(String value) {
         assertEquals(value, unescapeCsv(StringUtil.escapeCsv(value)));
     }
 

--- a/example/src/main/java/io/netty/example/http2/tiles/Http2RequestHandler.java
+++ b/example/src/main/java/io/netty/example/http2/tiles/Http2RequestHandler.java
@@ -69,7 +69,7 @@ public class Http2RequestHandler extends SimpleChannelInboundHandler<FullHttpReq
         }
     }
 
-    private void sendBadRequest(ChannelHandlerContext ctx, String streamId) {
+    private static void sendBadRequest(ChannelHandlerContext ctx, String streamId) {
         FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, BAD_REQUEST, EMPTY_BUFFER);
         streamId(response, streamId);
         ctx.writeAndFlush(response);

--- a/handler/src/test/java/io/netty/handler/ssl/CipherSuiteConverterTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/CipherSuiteConverterTest.java
@@ -307,14 +307,14 @@ public class CipherSuiteConverterTest {
         testUnknownJavaCiphersToOpenSSL("");
     }
 
-    private void testUnknownOpenSSLCiphersToJava(String openSslCipherSuite) {
+    private static void testUnknownOpenSSLCiphersToJava(String openSslCipherSuite) {
         CipherSuiteConverter.clearCache();
 
         assertNull(CipherSuiteConverter.toJava(openSslCipherSuite, "TLS"));
         assertNull(CipherSuiteConverter.toJava(openSslCipherSuite, "SSL"));
     }
 
-    private void testUnknownJavaCiphersToOpenSSL(String javaCipherSuite) {
+    private static void testUnknownJavaCiphersToOpenSSL(String javaCipherSuite) {
         CipherSuiteConverter.clearCache();
 
         assertNull(CipherSuiteConverter.toOpenSsl(javaCipherSuite));

--- a/handler/src/test/java/io/netty/handler/ssl/ocsp/OcspTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/ocsp/OcspTest.java
@@ -99,7 +99,7 @@ public class OcspTest {
         testClientOcspNotEnabled(SslProvider.OPENSSL_REFCNT);
     }
 
-    private void testClientOcspNotEnabled(SslProvider sslProvider) throws Exception {
+    private static void testClientOcspNotEnabled(SslProvider sslProvider) throws Exception {
         SslContext context = SslContextBuilder.forClient()
                 .sslProvider(sslProvider)
                 .build();
@@ -126,7 +126,7 @@ public class OcspTest {
         testServerOcspNotEnabled(SslProvider.OPENSSL_REFCNT);
     }
 
-    private void testServerOcspNotEnabled(SslProvider sslProvider) throws Exception {
+    private static void testServerOcspNotEnabled(SslProvider sslProvider) throws Exception {
         SelfSignedCertificate ssc = new SelfSignedCertificate();
         try {
             SslContext context = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey())
@@ -161,7 +161,7 @@ public class OcspTest {
     /**
      * The Server provides an OCSP staple and the Client accepts it.
      */
-    private void testClientAcceptingOcspStaple(SslProvider sslProvider) throws Exception {
+    private static void testClientAcceptingOcspStaple(SslProvider sslProvider) throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
         ChannelInboundHandlerAdapter serverHandler = new ChannelInboundHandlerAdapter() {
             @Override
@@ -207,7 +207,7 @@ public class OcspTest {
     /**
      * The Server provides an OCSP staple and the Client rejects it.
      */
-    private void testClientRejectingOcspStaple(SslProvider sslProvider) throws Exception {
+    private static void testClientRejectingOcspStaple(SslProvider sslProvider) throws Exception {
         final AtomicReference<Throwable> causeRef = new AtomicReference<Throwable>();
         final CountDownLatch latch = new CountDownLatch(1);
 
@@ -250,7 +250,7 @@ public class OcspTest {
     /**
      * The server has OCSP stapling enabled but doesn't provide a staple.
      */
-    private void testServerHasNoStaple(SslProvider sslProvider) throws Exception {
+    private static void testServerHasNoStaple(SslProvider sslProvider) throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
         ChannelInboundHandlerAdapter serverHandler = new ChannelInboundHandlerAdapter() {
             @Override
@@ -297,7 +297,7 @@ public class OcspTest {
      *
      * The exception should bubble up on the client side and the connection should get closed.
      */
-    private void testClientException(SslProvider sslProvider) throws Exception {
+    private static void testClientException(SslProvider sslProvider) throws Exception {
         final AtomicReference<Throwable> causeRef = new AtomicReference<Throwable>();
         final CountDownLatch latch = new CountDownLatch(1);
 

--- a/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
+++ b/handler/src/test/java/io/netty/handler/timeout/IdleStateHandlerTest.java
@@ -67,7 +67,7 @@ public class IdleStateHandlerTest {
                 IdleStateEvent.ALL_IDLE_STATE_EVENT, IdleStateEvent.ALL_IDLE_STATE_EVENT);
     }
 
-    private void anyIdle(TestableIdleStateHandler idleStateHandler, Object... expected) throws Exception {
+    private static void anyIdle(TestableIdleStateHandler idleStateHandler, Object... expected) throws Exception {
 
         assertTrue("The number of expected events must be >= 1", expected.length >= 1);
 
@@ -159,8 +159,8 @@ public class IdleStateHandlerTest {
         anyNotIdle(idleStateHandler, writer, IdleStateEvent.FIRST_ALL_IDLE_STATE_EVENT);
     }
 
-    private void anyNotIdle(TestableIdleStateHandler idleStateHandler,
-            Action action, Object expected) throws Exception {
+    private static void anyNotIdle(TestableIdleStateHandler idleStateHandler,
+                                   Action action, Object expected) throws Exception {
 
         final List<Object> events = new ArrayList<Object>();
         ChannelInboundHandlerAdapter handler = new ChannelInboundHandlerAdapter() {
@@ -205,7 +205,7 @@ public class IdleStateHandlerTest {
         observeOutputIdle(false);
     }
 
-    private void observeOutputIdle(boolean writer) throws Exception {
+    private static void observeOutputIdle(boolean writer) throws Exception {
 
         long writerIdleTime = 0L;
         long allIdleTime = 0L;

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -765,7 +765,7 @@ abstract class DnsNameResolverContext<T> {
         return true;
     }
 
-    private DnsQuestion newQuestion(String hostname, DnsRecordType type) {
+    private static DnsQuestion newQuestion(String hostname, DnsRecordType type) {
         try {
             return new DefaultDnsQuestion(hostname, type);
         } catch (IllegalArgumentException e) {

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
@@ -246,25 +246,26 @@ public class SearchDomainTest {
         assertNotResolve(resolver, "host2");
     }
 
-    private void assertNotResolve(DnsNameResolver resolver, String inetHost) throws InterruptedException {
+    private static void assertNotResolve(DnsNameResolver resolver, String inetHost) throws InterruptedException {
         Future<InetAddress> fut = resolver.resolve(inetHost);
         assertTrue(fut.await(10, TimeUnit.SECONDS));
         assertFalse(fut.isSuccess());
     }
 
-    private void assertNotResolveAll(DnsNameResolver resolver, String inetHost) throws InterruptedException {
+    private static void assertNotResolveAll(DnsNameResolver resolver, String inetHost) throws InterruptedException {
         Future<List<InetAddress>> fut = resolver.resolveAll(inetHost);
         assertTrue(fut.await(10, TimeUnit.SECONDS));
         assertFalse(fut.isSuccess());
     }
 
-    private String assertResolve(DnsNameResolver resolver, String inetHost) throws InterruptedException {
+    private static String assertResolve(DnsNameResolver resolver, String inetHost) throws InterruptedException {
         Future<InetAddress> fut = resolver.resolve(inetHost);
         assertTrue(fut.await(10, TimeUnit.SECONDS));
         return fut.getNow().getHostAddress();
     }
 
-    private List<String> assertResolveAll(DnsNameResolver resolver, String inetHost) throws InterruptedException {
+    private static List<String> assertResolveAll(DnsNameResolver resolver,
+                                                 String inetHost) throws InterruptedException {
         Future<List<InetAddress>> fut = resolver.resolveAll(inetHost);
         assertTrue(fut.await(10, TimeUnit.SECONDS));
         List<String> list = new ArrayList<String>();

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -238,7 +238,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
         return socket.isInputShutdown() && (inputClosedSeenErrorOnRead || !isAllowHalfClosure(config));
     }
 
-    final boolean isAllowHalfClosure(ChannelConfig config) {
+    private static boolean isAllowHalfClosure(ChannelConfig config) {
         return config instanceof EpollSocketChannelConfig &&
                 ((EpollSocketChannelConfig) config).isAllowHalfClosure();
     }

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollSocketChannelConfigTest.java
@@ -63,11 +63,11 @@ public class EpollSocketChannelConfigTest {
         ch.close().syncUninterruptibly();
     }
 
-    private long randLong(long min, long max) {
+    private static long randLong(long min, long max) {
         return min + nextLong(max - min + 1);
     }
 
-    private long nextLong(long n) {
+    private static long nextLong(long n) {
         long bits, val;
         do {
            bits = (rand.nextLong() << 1) >>> 1;

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -351,7 +351,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         return socket.isInputShutdown() && (inputClosedSeenErrorOnRead || !isAllowHalfClosure(config));
     }
 
-    final boolean isAllowHalfClosure(ChannelConfig config) {
+    private static boolean isAllowHalfClosure(ChannelConfig config) {
         return config instanceof KQueueSocketChannelConfig &&
                 ((KQueueSocketChannelConfig) config).isAllowHalfClosure();
     }


### PR DESCRIPTION
Motivation:

Even if it's a super micro-optimization (most JVM could optimize such cases in runtime), in theory (and according to some performance tests) it may help a bit. It also makes a code more clear and allows you to access such methods in the test scope directly, without an instance of the class.

Modifications:

Add 'static' modifier for all methods, where it possible. Mostly in test scope.

Result:

Cleaner code with proper 'static' modifiers.