### PR TITLE
Do not send Content-Length: 0 on 101 responses.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerUpgradeHandler.java
@@ -350,7 +350,6 @@ public class HttpServerUpgradeHandler extends HttpObjectAggregator {
                 Unpooled.EMPTY_BUFFER, false);
         res.headers().add(HttpHeaderNames.CONNECTION, HttpHeaderValues.UPGRADE);
         res.headers().add(HttpHeaderNames.UPGRADE, upgradeProtocol);
-        res.headers().add(HttpHeaderNames.CONTENT_LENGTH, HttpHeaderValues.ZERO);
         return res;
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
@@ -142,8 +142,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
 
         String expectedHttpResponse = "HTTP/1.1 101 Switching Protocols\r\n" +
                 "connection: upgrade\r\n" +
-                "upgrade: h2c\r\n" +
-                "content-length: 0\r\n\r\n";
+                "upgrade: h2c\r\n\r\n";
         ByteBuf responseBuffer = channel.readOutbound();
         assertEquals(expectedHttpResponse, responseBuffer.toString(CharsetUtil.UTF_8));
         responseBuffer.release();


### PR DESCRIPTION
Motivation:

During code read of the Netty codebase I noticed that the Netty `HttpServerUpgradeHandler` unconditionally sets a Content-Length: 0 header on 101 Switching Protocols responses. This explicitly contravenes RFC 7230 Section 3.3.2 (Content-Length), which notes that:

> A server MUST NOT send a Content-Length header field in any response with a status code of 1xx (Informational) or 204 (No Content).

While it is unlikely that any client will ever be confused by this behaviour, there is no reason to contravene this part of the specification.

Modifications:

Removed the line of code setting the header field and changed the only test that expected it to be there.

Result:

When performing the server portion of HTTP upgrade, the 101 Switching Protocols response will no longer contain a Content-Length: 0 header field.