### PR TITLE
Ensure Channel.isWritable() works with SslHandlerCoalescingBufferQueue

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/SslHandlerCoalescingBufferQueueTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SslHandlerCoalescingBufferQueueTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.ssl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelException;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.ssl.SslHandler.SslHandlerCoalescingBufferQueue;
+import io.netty.util.CharsetUtil;
+
+public class SslHandlerCoalescingBufferQueueTest {
+
+    @Test
+    public void shouldFireChannelWritabilityChangedAfterAddFirstRemoveFirst() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(2);
+        final List<Boolean> notifications = new ArrayList<Boolean>();
+        doCheckFireChannelWritabilityChanged(new TestChannelHandler(latch, notifications) {
+
+            @Override
+            protected void doRemoveWork(ChannelHandlerContext ctx) {
+                final SslHandlerCoalescingBufferQueue queue = queueRef.get();
+                queue.removeFirst(ctx.newPromise());
+            }
+
+            @Override
+            protected void doAddWork(ByteBuf msg) {
+                final SslHandlerCoalescingBufferQueue queue = queueRef.get();
+                queue.addFirst(msg);
+            }
+        }, latch, notifications, true);
+    }
+
+    @Test
+    public void shouldFireChannelWritabilityChangedAfterAddRemove() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(2);
+        final List<Boolean> notifications = new ArrayList<Boolean>();
+        doCheckFireChannelWritabilityChanged(new TestChannelHandler(latch, notifications) {
+
+            @Override
+            protected void doRemoveWork(ChannelHandlerContext ctx) {
+                final SslHandlerCoalescingBufferQueue queue = queueRef.get();
+                queue.remove(ctx.alloc(), 16, ctx.newPromise());
+            }
+
+            @Override
+            protected void doAddWork(ByteBuf msg) {
+                final SslHandlerCoalescingBufferQueue queue = queueRef.get();
+                queue.add(msg);
+            }
+        }, latch, notifications, true);
+    }
+
+    @Test
+    public void shouldFireChannelWritabilityChangedAfterAddReleaseAndFailAll() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(2);
+        final List<Boolean> notifications = new ArrayList<Boolean>();
+        doCheckFireChannelWritabilityChanged(new TestChannelHandler(latch, notifications) {
+
+            @Override
+            protected void doRemoveWork(ChannelHandlerContext ctx) {
+                final SslHandlerCoalescingBufferQueue queue = queueRef.get();
+                queue.releaseAndFailAll(ctx, new ChannelException("Pending write on removal"));
+            }
+
+            @Override
+            protected void doAddWork(ByteBuf msg) {
+                final SslHandlerCoalescingBufferQueue queue = queueRef.get();
+                queue.add(msg);
+            }
+        }, latch, notifications, false);
+    }
+
+    private void doCheckFireChannelWritabilityChanged(TestChannelHandler handler, CountDownLatch latch,
+            List<Boolean> notifications, boolean releaseMessage) throws Exception {
+        final ByteBuf msg = Unpooled.copiedBuffer("test", CharsetUtil.US_ASCII);
+
+        final EmbeddedChannel channel = new EmbeddedChannel(handler);
+
+        channel.config().setWriteBufferLowWaterMark(1);
+        channel.config().setWriteBufferHighWaterMark(3);
+
+        handler.doAddWork(msg);
+        channel.runPendingTasks();
+
+        assertTrue(latch.await(100, TimeUnit.MILLISECONDS));
+        System.out.println(notifications);
+        assertEquals(2, notifications.size());
+        assertFalse(notifications.get(0));
+        assertTrue(notifications.get(1));
+
+        if (releaseMessage) {
+            msg.release();
+        }
+    }
+
+    private static class TestChannelHandler extends ChannelInboundHandlerAdapter {
+        final AtomicReference<ChannelHandlerContext> ctxRef = new AtomicReference<ChannelHandlerContext>();
+        final AtomicReference<SslHandlerCoalescingBufferQueue> queueRef =
+                new AtomicReference<SslHandlerCoalescingBufferQueue>();
+        private final CountDownLatch latch;
+        private final List<Boolean> notifications;
+
+        public TestChannelHandler(CountDownLatch latch, List<Boolean> notifications) {
+            this.latch = latch;
+            this.notifications = notifications;
+        }
+
+        @Override
+        public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
+            ctxRef.set(ctx);
+            queueRef.set(new SslHandlerCoalescingBufferQueue(16, ctx));
+        }
+
+        @Override
+        public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+            latch.countDown();
+            notifications.add(ctx.channel().isWritable());
+            if (!ctx.channel().isWritable()) {
+                doRemoveWork(ctx);
+                ((EmbeddedChannel) ctx.channel()).runPendingTasks();
+            }
+        }
+
+        protected void doRemoveWork(ChannelHandlerContext ctx) {
+        }
+
+        protected void doAddWork(ByteBuf msg) {
+        }
+    }
+}

--- a/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
@@ -161,7 +161,7 @@ public abstract class AbstractCoalescingBufferQueue {
         readableBytes -= originalBytes - bytes;
         assert readableBytes >= 0;
 
-        decrementPendingOutboundBytes(originalBytes - bytes);
+        decrementPendingOutboundBytes((long) originalBytes - bytes);
 
         return toReturn;
     }
@@ -201,9 +201,9 @@ public abstract class AbstractCoalescingBufferQueue {
      * @param ctx The context to write all elements to.
      */
     public final void writeAndRemoveAll(ChannelHandlerContext ctx) {
-        readableBytes = 0;
-
         decrementPendingOutboundBytes(readableBytes);
+
+        readableBytes = 0;
 
         Throwable pending = null;
         ByteBuf previousBuf = null;
@@ -270,9 +270,9 @@ public abstract class AbstractCoalescingBufferQueue {
     }
 
     private void releaseAndCompleteAll(ChannelFuture future) {
-        readableBytes = 0;
-
         decrementPendingOutboundBytes(readableBytes);
+
+        readableBytes = 0;
 
         Throwable pending = null;
         for (;;) {

--- a/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
+++ b/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
@@ -15,6 +15,7 @@
  */
 package io.netty.channel;
 
+import io.netty.channel.PendingWritesTrackerFactory.PendingWritesTracker;
 import io.netty.util.Recycler;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.PromiseCombiner;
@@ -38,7 +39,7 @@ public final class PendingWriteQueue {
             SystemPropertyUtil.getInt("io.netty.transport.pendingWriteSizeOverhead", 64);
 
     private final ChannelHandlerContext ctx;
-    private final PendingTracker tracker;
+    private final PendingWritesTracker tracker;
 
     // head and tail pointers for the linked-list structure. If empty head and tail are null.
     private PendingWrite head;
@@ -46,80 +47,9 @@ public final class PendingWriteQueue {
     private int size;
     private long bytes;
 
-    private interface PendingTracker extends MessageSizeEstimator.Handle {
-        void incrementPendingOutboundBytes(long bytes);
-        void decrementPendingOutboundBytes(long bytes);
-    }
-
     public PendingWriteQueue(ChannelHandlerContext ctx) {
         this.ctx = ObjectUtil.checkNotNull(ctx, "ctx");
-        if (ctx.pipeline() instanceof DefaultChannelPipeline) {
-            final DefaultChannelPipeline pipeline = (DefaultChannelPipeline) ctx.pipeline();
-            tracker = new PendingTracker() {
-                @Override
-                public void incrementPendingOutboundBytes(long bytes) {
-                    pipeline.incrementPendingOutboundBytes(bytes);
-                }
-
-                @Override
-                public void decrementPendingOutboundBytes(long bytes) {
-                    pipeline.decrementPendingOutboundBytes(bytes);
-                }
-
-                @Override
-                public int size(Object msg) {
-                    return pipeline.estimatorHandle().size(msg);
-                }
-            };
-        } else {
-            final MessageSizeEstimator.Handle estimator = ctx.channel().config().getMessageSizeEstimator().newHandle();
-            final ChannelOutboundBuffer buffer = ctx.channel().unsafe().outboundBuffer();
-            if (buffer == null) {
-                tracker = new PendingTracker() {
-                    @Override
-                    public void incrementPendingOutboundBytes(long bytes) {
-                        // noop
-                    }
-
-                    @Override
-                    public void decrementPendingOutboundBytes(long bytes) {
-                        // noop
-                    }
-
-                    @Override
-                    public int size(Object msg) {
-                        return estimator.size(msg);
-                    }
-                };
-            } else {
-                tracker = new PendingTracker() {
-                    @Override
-                    public void incrementPendingOutboundBytes(long bytes) {
-                        // We need to guard against null as channel.unsafe().outboundBuffer() may returned null
-                        // if the channel was already closed when constructing the PendingWriteQueue.
-                        // See https://github.com/netty/netty/issues/3967
-                        if (buffer != null) {
-                            buffer.incrementPendingOutboundBytes(bytes);
-                        }
-                    }
-
-                    @Override
-                    public void decrementPendingOutboundBytes(long bytes) {
-                        // We need to guard against null as channel.unsafe().outboundBuffer() may returned null
-                        // if the channel was already closed when constructing the PendingWriteQueue.
-                        // See https://github.com/netty/netty/issues/3967
-                        if (buffer != null) {
-                            buffer.decrementPendingOutboundBytes(bytes);
-                        }
-                    }
-
-                    @Override
-                    public int size(Object msg) {
-                        return estimator.size(msg);
-                    }
-                };
-            }
-        }
+        this.tracker = PendingWritesTrackerFactory.newPendingWritesTracker(ctx);
     }
 
     /**

--- a/transport/src/main/java/io/netty/channel/PendingWritesTrackerFactory.java
+++ b/transport/src/main/java/io/netty/channel/PendingWritesTrackerFactory.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.channel;
+
+public final class PendingWritesTrackerFactory {
+
+    private PendingWritesTrackerFactory() {
+    }
+
+    public static PendingWritesTracker newPendingWritesTracker(ChannelHandlerContext ctx) {
+        if (ctx.pipeline() instanceof DefaultChannelPipeline) {
+            final DefaultChannelPipeline pipeline = (DefaultChannelPipeline) ctx.pipeline();
+            return new PendingWritesTracker() {
+                @Override
+                public void incrementPendingOutboundBytes(long bytes) {
+                    pipeline.incrementPendingOutboundBytes(bytes);
+                }
+
+                @Override
+                public void decrementPendingOutboundBytes(long bytes) {
+                    pipeline.decrementPendingOutboundBytes(bytes);
+                }
+
+                @Override
+                public int size(Object msg) {
+                    return pipeline.estimatorHandle().size(msg);
+                }
+            };
+        } else {
+            final MessageSizeEstimator.Handle estimator = ctx.channel().config().getMessageSizeEstimator().newHandle();
+            final ChannelOutboundBuffer buffer = ctx.channel().unsafe().outboundBuffer();
+            if (buffer == null) {
+                return new PendingWritesTracker() {
+                    @Override
+                    public void incrementPendingOutboundBytes(long bytes) {
+                        // noop
+                    }
+
+                    @Override
+                    public void decrementPendingOutboundBytes(long bytes) {
+                        // noop
+                    }
+
+                    @Override
+                    public int size(Object msg) {
+                        return estimator.size(msg);
+                    }
+                };
+            } else {
+                return new PendingWritesTracker() {
+                    @Override
+                    public void incrementPendingOutboundBytes(long bytes) {
+                        // We need to guard against null as channel.unsafe().outboundBuffer() may returned null
+                        // if the channel was already closed when constructing the PendingWriteQueue.
+                        // See https://github.com/netty/netty/issues/3967
+                        if (buffer != null) {
+                            buffer.incrementPendingOutboundBytes(bytes);
+                        }
+                    }
+
+                    @Override
+                    public void decrementPendingOutboundBytes(long bytes) {
+                        // We need to guard against null as channel.unsafe().outboundBuffer() may returned null
+                        // if the channel was already closed when constructing the PendingWriteQueue.
+                        // See https://github.com/netty/netty/issues/3967
+                        if (buffer != null) {
+                            buffer.decrementPendingOutboundBytes(bytes);
+                        }
+                    }
+
+                    @Override
+                    public int size(Object msg) {
+                        return estimator.size(msg);
+                    }
+                };
+            }
+        }
+    }
+
+    public interface PendingWritesTracker extends MessageSizeEstimator.Handle {
+        void incrementPendingOutboundBytes(long bytes);
+        void decrementPendingOutboundBytes(long bytes);
+    }
+
+}

--- a/transport/src/main/java/io/netty/channel/PendingWritesTrackerFactory.java
+++ b/transport/src/main/java/io/netty/channel/PendingWritesTrackerFactory.java
@@ -14,6 +14,9 @@
  */
 package io.netty.channel;
 
+import io.netty.util.internal.UnstableApi;
+
+@UnstableApi
 public final class PendingWritesTrackerFactory {
 
     private PendingWritesTrackerFactory() {
@@ -89,6 +92,7 @@ public final class PendingWritesTrackerFactory {
         }
     }
 
+    @UnstableApi
     public interface PendingWritesTracker extends MessageSizeEstimator.Handle {
         void incrementPendingOutboundBytes(long bytes);
         void decrementPendingOutboundBytes(long bytes);


### PR DESCRIPTION
Motivation:

A regression is introduced by commit 86e653e04fb452c92154e39cd7189615dc0ec323.
The new SslHandlerCoalescingBufferQueue does not update the pending outbound bytes.
Thus the Channel.isWritable() does not work anymore. External implementations that
rely on the ChannelInboundHandlerAdapter.channelWritabilityChanged do not receive
this event anymore if SslHandler in the pipeline.
This is related to issues #2752 and #7264

Modifications:

- Introduce PendingWritesTrackerFactory extracted from PendingWriteQueue
- increment/decrement the pending outbound bytes when adding/removing
  content via AbstractCoalescingBufferQueue methods

Result:

Channel.isWritable() works as expected. External implementations receive
the event ChannelInboundHandlerAdapter.channelWritabilityChanged
