### PR TITLE
Correctly update Channel writability when queueing data in SslHandler.

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -19,10 +19,13 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http2.Http2RemoteFlowController.FlowControlled;
@@ -87,6 +90,9 @@ public class DefaultHttp2ConnectionEncoderTest {
     private Channel channel;
 
     @Mock
+    private Channel.Unsafe unsafe;
+
+    @Mock
     private ChannelPipeline pipeline;
 
     @Mock
@@ -112,8 +118,13 @@ public class DefaultHttp2ConnectionEncoderTest {
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
 
+        ChannelMetadata metadata = new ChannelMetadata(false, 16);
         when(channel.isActive()).thenReturn(true);
         when(channel.pipeline()).thenReturn(pipeline);
+        when(channel.metadata()).thenReturn(metadata);
+        when(channel.unsafe()).thenReturn(unsafe);
+        ChannelConfig config = new DefaultChannelConfig(channel);
+        when(channel.config()).thenReturn(config);
         when(writer.configuration()).thenReturn(writerConfig);
         when(writerConfig.frameSizePolicy()).thenReturn(frameSizePolicy);
         when(frameSizePolicy.maxFrameSize()).thenReturn(64);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -45,8 +45,10 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
+import io.netty.channel.DefaultMessageSizeEstimator;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.ImmediateEventExecutor;
@@ -80,6 +82,9 @@ public class StreamBufferingEncoderTest {
 
     @Mock
     private Channel channel;
+
+    @Mock
+    private Channel.Unsafe unsafe;
 
     @Mock
     private ChannelConfig config;
@@ -137,6 +142,10 @@ public class StreamBufferingEncoderTest {
         when(channel.isWritable()).thenReturn(true);
         when(channel.bytesBeforeUnwritable()).thenReturn(Long.MAX_VALUE);
         when(config.getWriteBufferHighWaterMark()).thenReturn(Integer.MAX_VALUE);
+        when(config.getMessageSizeEstimator()).thenReturn(DefaultMessageSizeEstimator.DEFAULT);
+        ChannelMetadata metadata = new ChannelMetadata(false, 16);
+        when(channel.metadata()).thenReturn(metadata);
+        when(channel.unsafe()).thenReturn(unsafe);
         handler.handlerAdded(ctx);
     }
 

--- a/transport/src/main/java/io/netty/channel/CoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty/channel/CoalescingBufferQueue.java
@@ -40,7 +40,11 @@ public final class CoalescingBufferQueue extends AbstractCoalescingBufferQueue {
     }
 
     public CoalescingBufferQueue(Channel channel, int initSize) {
-        super(initSize);
+        this(channel, initSize, false);
+    }
+
+    public CoalescingBufferQueue(Channel channel, int initSize, boolean updateWritability) {
+        super(updateWritability ? channel : null, initSize);
         this.channel = ObjectUtil.checkNotNull(channel, "channel");
     }
 

--- a/transport/src/main/java/io/netty/channel/PendingBytesTracker.java
+++ b/transport/src/main/java/io/netty/channel/PendingBytesTracker.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import io.netty.util.internal.ObjectUtil;
+
+abstract class PendingBytesTracker implements MessageSizeEstimator.Handle {
+    private final MessageSizeEstimator.Handle estimatorHandle;
+
+    private PendingBytesTracker(MessageSizeEstimator.Handle estimatorHandle) {
+        this.estimatorHandle = ObjectUtil.checkNotNull(estimatorHandle, "estimatorHandle");
+    }
+
+    @Override
+    public final int size(Object msg) {
+        return estimatorHandle.size(msg);
+    }
+
+    public abstract void incrementPendingOutboundBytes(long bytes);
+    public abstract void decrementPendingOutboundBytes(long bytes);
+
+    static PendingBytesTracker newTracker(Channel channel) {
+        if (channel.pipeline() instanceof DefaultChannelPipeline) {
+            return new DefaultChannelPipelinePendingBytesTracker((DefaultChannelPipeline) channel.pipeline());
+        } else {
+            ChannelOutboundBuffer buffer = channel.unsafe().outboundBuffer();
+            MessageSizeEstimator.Handle handle = channel.config().getMessageSizeEstimator().newHandle();
+            // We need to guard against null as channel.unsafe().outboundBuffer() may returned null
+            // if the channel was already closed when constructing the PendingBytesTracker.
+            // See https://github.com/netty/netty/issues/3967
+            return buffer == null ?
+                    new NoopPendingBytesTracker(handle) : new ChannelOutboundBufferPendingBytesTracker(buffer, handle);
+        }
+    }
+
+    private static final class DefaultChannelPipelinePendingBytesTracker extends PendingBytesTracker {
+        private final DefaultChannelPipeline pipeline;
+
+        DefaultChannelPipelinePendingBytesTracker(DefaultChannelPipeline pipeline) {
+            super(pipeline.estimatorHandle());
+            this.pipeline = pipeline;
+        }
+
+        @Override
+        public void incrementPendingOutboundBytes(long bytes) {
+            pipeline.incrementPendingOutboundBytes(bytes);
+        }
+
+        @Override
+        public void decrementPendingOutboundBytes(long bytes) {
+            pipeline.decrementPendingOutboundBytes(bytes);
+        }
+    }
+
+    private static final class ChannelOutboundBufferPendingBytesTracker extends PendingBytesTracker {
+        private final ChannelOutboundBuffer buffer;
+
+        ChannelOutboundBufferPendingBytesTracker(
+                ChannelOutboundBuffer buffer, MessageSizeEstimator.Handle estimatorHandle) {
+            super(estimatorHandle);
+            this.buffer = buffer;
+        }
+
+        @Override
+        public void incrementPendingOutboundBytes(long bytes) {
+            buffer.incrementPendingOutboundBytes(bytes);
+        }
+
+        @Override
+        public void decrementPendingOutboundBytes(long bytes) {
+            buffer.decrementPendingOutboundBytes(bytes);
+        }
+    }
+
+    private static final class NoopPendingBytesTracker extends PendingBytesTracker {
+
+        NoopPendingBytesTracker(MessageSizeEstimator.Handle estimatorHandle) {
+            super(estimatorHandle);
+        }
+
+        @Override
+        public void incrementPendingOutboundBytes(long bytes) {
+            // Noop
+        }
+
+        @Override
+        public void decrementPendingOutboundBytes(long bytes) {
+            // Noop
+        }
+    }
+}

--- a/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
+++ b/transport/src/main/java/io/netty/channel/PendingWriteQueue.java
@@ -38,7 +38,7 @@ public final class PendingWriteQueue {
             SystemPropertyUtil.getInt("io.netty.transport.pendingWriteSizeOverhead", 64);
 
     private final ChannelHandlerContext ctx;
-    private final PendingTracker tracker;
+    private final PendingBytesTracker tracker;
 
     // head and tail pointers for the linked-list structure. If empty head and tail are null.
     private PendingWrite head;
@@ -46,80 +46,9 @@ public final class PendingWriteQueue {
     private int size;
     private long bytes;
 
-    private interface PendingTracker extends MessageSizeEstimator.Handle {
-        void incrementPendingOutboundBytes(long bytes);
-        void decrementPendingOutboundBytes(long bytes);
-    }
-
     public PendingWriteQueue(ChannelHandlerContext ctx) {
-        this.ctx = ObjectUtil.checkNotNull(ctx, "ctx");
-        if (ctx.pipeline() instanceof DefaultChannelPipeline) {
-            final DefaultChannelPipeline pipeline = (DefaultChannelPipeline) ctx.pipeline();
-            tracker = new PendingTracker() {
-                @Override
-                public void incrementPendingOutboundBytes(long bytes) {
-                    pipeline.incrementPendingOutboundBytes(bytes);
-                }
-
-                @Override
-                public void decrementPendingOutboundBytes(long bytes) {
-                    pipeline.decrementPendingOutboundBytes(bytes);
-                }
-
-                @Override
-                public int size(Object msg) {
-                    return pipeline.estimatorHandle().size(msg);
-                }
-            };
-        } else {
-            final MessageSizeEstimator.Handle estimator = ctx.channel().config().getMessageSizeEstimator().newHandle();
-            final ChannelOutboundBuffer buffer = ctx.channel().unsafe().outboundBuffer();
-            if (buffer == null) {
-                tracker = new PendingTracker() {
-                    @Override
-                    public void incrementPendingOutboundBytes(long bytes) {
-                        // noop
-                    }
-
-                    @Override
-                    public void decrementPendingOutboundBytes(long bytes) {
-                        // noop
-                    }
-
-                    @Override
-                    public int size(Object msg) {
-                        return estimator.size(msg);
-                    }
-                };
-            } else {
-                tracker = new PendingTracker() {
-                    @Override
-                    public void incrementPendingOutboundBytes(long bytes) {
-                        // We need to guard against null as channel.unsafe().outboundBuffer() may returned null
-                        // if the channel was already closed when constructing the PendingWriteQueue.
-                        // See https://github.com/netty/netty/issues/3967
-                        if (buffer != null) {
-                            buffer.incrementPendingOutboundBytes(bytes);
-                        }
-                    }
-
-                    @Override
-                    public void decrementPendingOutboundBytes(long bytes) {
-                        // We need to guard against null as channel.unsafe().outboundBuffer() may returned null
-                        // if the channel was already closed when constructing the PendingWriteQueue.
-                        // See https://github.com/netty/netty/issues/3967
-                        if (buffer != null) {
-                            buffer.decrementPendingOutboundBytes(bytes);
-                        }
-                    }
-
-                    @Override
-                    public int size(Object msg) {
-                        return estimator.size(msg);
-                    }
-                };
-            }
-        }
+        tracker = PendingBytesTracker.newTracker(ctx.channel());
+        this.ctx = ctx;
     }
 
     /**

--- a/transport/src/test/java/io/netty/channel/CoalescingBufferQueueTest.java
+++ b/transport/src/test/java/io/netty/channel/CoalescingBufferQueueTest.java
@@ -19,10 +19,9 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.CharsetUtil;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.ImmediateEventExecutor;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.MockitoAnnotations;
 
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertEquals;
@@ -44,13 +43,15 @@ public class CoalescingBufferQueueTest {
     private boolean mouseDone;
     private boolean mouseSuccess;
 
-    private Channel channel = new EmbeddedChannel();
-
-    private CoalescingBufferQueue writeQueue = new CoalescingBufferQueue(channel);
+    private EmbeddedChannel channel;
+    private CoalescingBufferQueue writeQueue;
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
+        mouseDone = false;
+        mouseSuccess = false;
+        channel = new EmbeddedChannel();
+        writeQueue = new CoalescingBufferQueue(channel, 16, true);
         catPromise = newPromise();
         mouseListener = new ChannelFutureListener() {
             @Override
@@ -66,13 +67,18 @@ public class CoalescingBufferQueueTest {
         mouse = Unpooled.wrappedBuffer("mouse".getBytes(CharsetUtil.US_ASCII));
     }
 
+    @After
+    public void finish() {
+        assertFalse(channel.finish());
+    }
+
     @Test
     public void testAggregateWithFullRead() {
         writeQueue.add(cat, catPromise);
         assertQueueSize(3, false);
         writeQueue.add(mouse, mouseListener);
         assertQueueSize(8, false);
-        DefaultChannelPromise aggregatePromise = newPromise();
+        ChannelPromise aggregatePromise = newPromise();
         assertEquals("catmouse", dequeue(8, aggregatePromise));
         assertQueueSize(0, true);
         assertFalse(catPromise.isSuccess());
@@ -101,7 +107,7 @@ public class CoalescingBufferQueueTest {
     public void testAggregateWithPartialRead() {
         writeQueue.add(cat, catPromise);
         writeQueue.add(mouse, mouseListener);
-        DefaultChannelPromise aggregatePromise = newPromise();
+        ChannelPromise aggregatePromise = newPromise();
         assertEquals("catm", dequeue(4, aggregatePromise));
         assertQueueSize(4, false);
         assertFalse(catPromise.isSuccess());
@@ -125,7 +131,7 @@ public class CoalescingBufferQueueTest {
         writeQueue.add(cat, catPromise);
         writeQueue.add(mouse, mouseListener);
 
-        DefaultChannelPromise aggregatePromise = newPromise();
+        ChannelPromise aggregatePromise = newPromise();
         assertSame(cat, writeQueue.remove(3, aggregatePromise));
         assertFalse(catPromise.isSuccess());
         aggregatePromise.setSuccess();
@@ -149,7 +155,7 @@ public class CoalescingBufferQueueTest {
         mouse.release();
 
         assertQueueSize(0, true);
-        DefaultChannelPromise aggregatePromise = newPromise();
+        ChannelPromise aggregatePromise = newPromise();
         assertEquals("", dequeue(Integer.MAX_VALUE, aggregatePromise));
         assertQueueSize(0, true);
     }
@@ -160,7 +166,7 @@ public class CoalescingBufferQueueTest {
         writeQueue.add(mouse, mouseListener);
         RuntimeException cause = new RuntimeException("ooops");
         writeQueue.releaseAndFailAll(cause);
-        DefaultChannelPromise aggregatePromise = newPromise();
+        ChannelPromise aggregatePromise = newPromise();
         assertQueueSize(0, true);
         assertEquals(0, cat.refCnt());
         assertEquals(0, mouse.refCnt());
@@ -176,7 +182,7 @@ public class CoalescingBufferQueueTest {
         writeQueue.add(cat, catPromise);
         writeQueue.add(empty, emptyPromise);
         assertQueueSize(3, false);
-        DefaultChannelPromise aggregatePromise = newPromise();
+        ChannelPromise aggregatePromise = newPromise();
         assertEquals("cat", dequeue(3, aggregatePromise));
         assertQueueSize(0, true);
         assertFalse(catPromise.isSuccess());
@@ -195,7 +201,7 @@ public class CoalescingBufferQueueTest {
         otherQueue.add(mouse, mouseListener);
         otherQueue.copyTo(writeQueue);
         assertQueueSize(8, false);
-        DefaultChannelPromise aggregatePromise = newPromise();
+        ChannelPromise aggregatePromise = newPromise();
         assertEquals("catmouse", dequeue(8, aggregatePromise));
         assertQueueSize(0, true);
         assertFalse(catPromise.isSuccess());
@@ -207,8 +213,49 @@ public class CoalescingBufferQueueTest {
         assertEquals(0, mouse.refCnt());
     }
 
-    private DefaultChannelPromise newPromise() {
-        return new DefaultChannelPromise(channel, ImmediateEventExecutor.INSTANCE);
+    @Test
+    public void testWritabilityChanged() {
+        testWritabilityChanged0(false);
+    }
+
+    @Test
+    public void testWritabilityChangedFailAll() {
+        testWritabilityChanged0(true);
+    }
+
+    private void testWritabilityChanged0(boolean fail) {
+        channel.config().setWriteBufferWaterMark(new WriteBufferWaterMark(3, 4));
+        assertTrue(channel.isWritable());
+        writeQueue.add(Unpooled.wrappedBuffer(new byte[] {1 , 2, 3}));
+        assertTrue(channel.isWritable());
+        writeQueue.add(Unpooled.wrappedBuffer(new byte[] {4, 5}));
+        assertFalse(channel.isWritable());
+        assertEquals(5, writeQueue.readableBytes());
+
+        if (fail) {
+            writeQueue.releaseAndFailAll(new IllegalStateException());
+        } else {
+            ByteBuf buffer = writeQueue.removeFirst(voidPromise);
+            assertEquals(1, buffer.readByte());
+            assertEquals(2, buffer.readByte());
+            assertEquals(3, buffer.readByte());
+            assertFalse(buffer.isReadable());
+            buffer.release();
+            assertTrue(channel.isWritable());
+
+            buffer = writeQueue.removeFirst(voidPromise);
+            assertEquals(4, buffer.readByte());
+            assertEquals(5, buffer.readByte());
+            assertFalse(buffer.isReadable());
+            buffer.release();
+        }
+
+        assertTrue(channel.isWritable());
+        assertTrue(writeQueue.isEmpty());
+    }
+
+    private ChannelPromise newPromise() {
+        return channel.newPromise();
     }
 
     private void assertQueueSize(int size, boolean isEmpty) {


### PR DESCRIPTION
Motivation:

A regression was introduced in 86e653e which had the effect that the writability was not updated for a Channel while queueing data in the SslHandler.

Modifications:

- Factor out code that will increment / decrement pending bytes and use it in AbstractCoalescingBufferQueue and PendingWriteQueue
- Add test-case

Result:

Channel writability changes are triggered again.