### PR TITLE
Update links for actual Protobuf repo and documentation

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -90,7 +90,7 @@
         </dependency>
       </dependencies>
     </profile>
-    
+
     <!-- The linux profile will only include the native jar for epol to the all jar.
          If you want to also include the native jar for kqueue use -Puber.
     -->
@@ -213,7 +213,7 @@
                     <groupId>com.puppycrawl.tools</groupId>
                     <artifactId>checkstyle</artifactId>
                   </exclusion>
-                </exclusions> 
+                </exclusions>
               </dependency>
               <dependency>
                 <groupId>com.puppycrawl.tools</groupId>
@@ -245,7 +245,7 @@
               <detectJavaApiLink>false</detectJavaApiLink>
               <additionalparam>
                 -link http://docs.oracle.com/javase/7/docs/api/
-                -link http://code.google.com/apis/protocolbuffers/docs/reference/java/
+                -link https://developers.google.com/protocol-buffers/docs/reference/java/
                 -link http://docs.oracle.com/javaee/6/api/
                 -link http://www.slf4j.org/apidocs/
                 -link https://commons.apache.org/proper/commons-logging/apidocs/

--- a/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/ProtobufVarint32FrameDecoder.java
@@ -27,7 +27,7 @@ import java.util.List;
 /**
  * A decoder that splits the received {@link ByteBuf}s dynamically by the
  * value of the Google Protocol Buffers
- * <a href="http://code.google.com/apis/protocolbuffers/docs/encoding.html#varints">Base
+ * <a href="https://developers.google.com/protocol-buffers/docs/encoding#varints">Base
  * 128 Varints</a> integer length field in the message. For example:
  * <pre>
  * BEFORE DECODE (302 bytes)       AFTER DECODE (300 bytes)

--- a/codec/src/main/java/io/netty/handler/codec/protobuf/package-info.java
+++ b/codec/src/main/java/io/netty/handler/codec/protobuf/package-info.java
@@ -16,7 +16,7 @@
 
 /**
  * Encoder and decoder which transform a
- * <a href="http://code.google.com/p/protobuf/">Google Protocol Buffers</a>
+ * <a href="https://github.com/google/protobuf">Google Protocol Buffers</a>
  * {@link com.google.protobuf.Message} and {@link com.google.protobuf.nano.MessageNano} into a
  * {@link io.netty.buffer.ByteBuf} and vice versa.
  */


### PR DESCRIPTION
Motivation:

Use actual links to new locations of Protobuf repo and documentation to avoid problems when redirect will not work.

Modification:

Links in comments and all/pom.xml.

Result:

Correct links to Protobuf resources.