### PR TITLE
Set readPending to false when ever a read is done

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollStreamChannel.java
@@ -645,7 +645,6 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
         private boolean handleReadException(ChannelPipeline pipeline, ByteBuf byteBuf, Throwable cause, boolean close) {
             if (byteBuf != null) {
                 if (byteBuf.isReadable()) {
-                    readPending = false;
                     pipeline.fireChannelRead(byteBuf);
                 } else {
                     byteBuf.release();
@@ -710,6 +709,7 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
                     // to handle direct buffers.
                     byteBuf = allocHandle.allocate(allocator);
                     int writable = byteBuf.writableBytes();
+                    readPending = false;
                     int localReadAmount = doReadBytes(byteBuf);
                     if (localReadAmount <= 0) {
                         // not was read release the buffer
@@ -717,7 +717,6 @@ public abstract class AbstractEpollStreamChannel extends AbstractEpollChannel im
                         close = localReadAmount < 0;
                         break;
                     }
-                    readPending = false;
                     pipeline.fireChannelRead(byteBuf);
                     byteBuf = null;
 

--- a/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
+++ b/transport/src/main/java/io/netty/channel/nio/AbstractNioByteChannel.java
@@ -122,6 +122,16 @@ public abstract class AbstractNioByteChannel extends AbstractNioChannel {
                         byteBuf.release();
                         byteBuf = null;
                         close = localReadAmount < 0;
+                        if (close) {
+                            // Based upon the Javadocs it is possible that NIO may have spurious wake ups [1]. In this
+                            // case we should be more cautious and only set readPending to false if data was actually
+                            // read.
+                            // [1] https://docs.oracle.com/javase/7/docs/api/java/nio/channels/SelectionKey.html
+                            // That a selection key's ready set indicates that its channel is ready for some operation
+                            // category is a hint, but not a guarantee, that an operation in such a category may be
+                            // performed by a thread without causing the thread to block.
+                            setReadPending(false);
+                        }
                         break;
                     }
                     if (!readPendingReset) {


### PR DESCRIPTION
Motivation:
readPending is currently only set to false if data is delivered to the application, however this may result in duplicate events being received from the selector in the event that the socket was closed.

Modifications:
- We should set readPending to false before each read attempt for all
transports besides NIO.
- Based upon the Javadocs it is possible that NIO may have spurious
wakeups [1]. In this case we should be more cautious and only set
readPending to false if data was actually read.

[1] https://docs.oracle.com/javase/7/docs/api/java/nio/channels/SelectionKey.html
That a selection key's ready set indicates that its channel is ready for some operation category is a hint, but not a guarantee, that an operation in such a category may be performed by a thread without causing the thread to block.

Result:
Notification from the selector (or simulated events from kqueue/epoll ET) in the event of socket closure.
Fixes #7255