### PR TITLE
HTTP/2 Child Channel reading and flushing

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -310,9 +310,9 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
         localFlow.initialWindowSize(targetConnectionWindow);
     }
 
-    final void consumeBytes(int streamId, int bytes) throws Http2Exception {
+    final boolean consumeBytes(int streamId, int bytes) throws Http2Exception {
         Http2Stream stream = connection().stream(streamId);
-        connection().local().flowController().consumeBytes(stream, bytes);
+        return connection().local().flowController().consumeBytes(stream, bytes);
     }
 
     private void writeGoAwayFrame(ChannelHandlerContext ctx, Http2GoAwayFrame frame, ChannelPromise promise) {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelId.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamChannelId.java
@@ -68,4 +68,9 @@ final class Http2StreamChannelId implements ChannelId {
         Http2StreamChannelId otherId = (Http2StreamChannelId) obj;
         return id == otherId.id && parentId.equals(otherId.parentId);
     }
+
+    @Override
+    public String toString() {
+        return asShortText();
+    }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
@@ -506,8 +506,9 @@ public class Http2MultiplexCodecTest {
         }
 
         @Override
-        void onBytesConsumed(ChannelHandlerContext ctx, Http2FrameStream stream, int bytes) {
+        boolean onBytesConsumed(ChannelHandlerContext ctx, Http2FrameStream stream, int bytes) {
             writer.write(new DefaultHttp2WindowUpdateFrame(bytes).stream(stream), ctx.newPromise());
+            return true;
         }
 
         @Override


### PR DESCRIPTION
Motivation:
If a child channel's read is triggered outside the parent channel's read
loop then it is possible a WINDOW_UPDATE will be written, but not
flushed.
If a child channel's beginRead processes data from the inboundBuffer and
then readPending is set to false, which will result in data not being
delivered if in the parent's read loop and more data is attempted to be
delievered to that child channel.

Modifications:
- The child channel must force a flush if a frame is written as a result
of reading a frame, and this is not in the parent channel's read loop
- The child channel must allow a transition from dequeueing from
beginRead into the parent channel's read loop to deliver more data

Result:
The child channel flushes data when reading outside the parent's read
loop, and has frames delivered more reliably.