### PR TITLE
Correctly handle WebSockets 00 when using HttpClientCodec.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpClientCodec.java
@@ -225,7 +225,8 @@ public final class HttpClientCodec extends CombinedChannelDuplexHandler<HttpResp
             final int statusCode = ((HttpResponse) msg).status().code();
             if (statusCode == 100 || statusCode == 101) {
                 // 100-continue and 101 switching protocols response should be excluded from paired comparison.
-                return true;
+                // Just delegate to super method which has all the needed handling.
+                return super.isContentAlwaysEmpty(msg);
             }
 
             // Get the getMethod of the HTTP request that corresponds to the
@@ -236,7 +237,7 @@ public final class HttpClientCodec extends CombinedChannelDuplexHandler<HttpResp
             switch (firstChar) {
             case 'H':
                 // According to 4.3, RFC2616:
-                // All responses to the HEAD request getMethod MUST NOT include a
+                // All responses to the HEAD request method MUST NOT include a
                 // message-body, even though the presence of entity-header fields
                 // might lead one to believe they do.
                 if (HttpMethod.HEAD.equals(method)) {


### PR DESCRIPTION
Motivation:

7995afee8f1cb9047709239321d84ccb279fe4d1 introduced a change that broke special handling of WebSockets 00.

Modifications:

Correctly delegate to super method which has special handling for WebSockets 00.

Result:

Fixes [#7362].