### PR TITLE
SslHandler promise completion incorrect if write doesn't immediately

### DIFF
--- a/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
+++ b/transport/src/main/java/io/netty/channel/AbstractCoalescingBufferQueue.java
@@ -50,10 +50,11 @@ public abstract class AbstractCoalescingBufferQueue {
     /**
      * Add a buffer to the front of the queue.
      */
-    public final void addFirst(ByteBuf buf) {
+    public final void addFirst(ByteBuf buf, ChannelPromise promise) {
         // Listener would be added here, but since it is null there is no need. The assumption is there is already a
         // listener at the front of the queue, or there is a buffer at the front of the queue, which was spliced from
         // buf via remove().
+        bufAndListenerPairs.addFirst(new DelegatingChannelPromiseNotifier(promise));
         bufAndListenerPairs.addFirst(buf);
 
         incrementReadableBytes(buf.readableBytes());


### PR DESCRIPTION
complete

Motivation:
SslHandler removes a Buffer/Promise pair from
AbstractCoalescingBufferQueue when wrapping data. However it is possible
the SSLEngine will not consume the entire buffer. In this case
SslHandler adds the Buffer back to the queue, but doesn't add the
Promise back to the queue. This may result in the promise completing
immediately in finishFlush, and generally not correlating to the
completion of writing the corresponding Buffer

Modifications:
- AbstractCoalescingBufferQueue#addFirst should also support adding the
ChannelPromise
- In the event of a handshake timeout we should immediately fail pending
writes immediately to get a more accurate exception

Result:
Fixes https://github.com/netty/netty/issues/7378.