### PR TITLE
Fix check logic in Http2MultiplexCodecBuilder

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
@@ -36,7 +36,7 @@ public class Http2MultiplexCodecBuilder
     }
 
     private static ChannelHandler checkSharable(ChannelHandler handler) {
-        if ((handler instanceof ChannelHandlerAdapter && !((ChannelHandlerAdapter) handler).isSharable()) ||
+        if ((handler instanceof ChannelHandlerAdapter && !((ChannelHandlerAdapter) handler).isSharable()) &&
                 !handler.getClass().isAnnotationPresent(ChannelHandler.Sharable.class)) {
             throw new IllegalArgumentException("The handler must be Sharable");
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilderTest.java
@@ -23,6 +23,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
@@ -224,5 +225,34 @@ public class Http2MultiplexCodecBuilderTest {
         public void channelInactive(ChannelHandlerContext ctx) throws Exception {
             ctx.fireChannelInactive();
         }
+    }
+
+    private static class SharableChannelHandler1 extends ChannelHandlerAdapter {
+        @Override
+        public boolean isSharable() {
+            return true;
+        }
+    }
+
+    @Sharable
+    private static class SharableChannelHandler2 extends ChannelHandlerAdapter {
+    }
+
+    private static class UnsharableChannelHandler extends ChannelHandlerAdapter {
+        @Override
+        public boolean isSharable() {
+            return false;
+        }
+    }
+
+    @Test
+    public void testSharableCheck() {
+        assertNotNull(Http2MultiplexCodecBuilder.forServer(new SharableChannelHandler1()));
+        assertNotNull(Http2MultiplexCodecBuilder.forServer(new SharableChannelHandler2()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnsharableHandler() {
+        Http2MultiplexCodecBuilder.forServer(new UnsharableChannelHandler());
     }
 }


### PR DESCRIPTION
Motivation:

There is an logic issue when checking if ChannelHandler is sharable.

Modification:

Corrected `||` to `&&`. Added test cases to reproduce this issue. 

