### PR TITLE
Correctly convert empty HttpContent to ByteBuf

### DIFF
--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestEncoderTest.java
@@ -28,9 +28,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  */
@@ -146,12 +144,49 @@ public class HttpRequestEncoderTest {
     }
 
     @Test
-    public void testEmptydBufferShouldPassThrough() throws Exception {
+    public void testEmptyBufferShouldPassThrough() throws Exception {
         HttpRequestEncoder encoder = new HttpRequestEncoder();
         EmbeddedChannel channel = new EmbeddedChannel(encoder);
         ByteBuf buffer = Unpooled.buffer();
         channel.writeAndFlush(buffer).get();
         channel.finishAndReleaseAll();
         assertEquals(0, buffer.refCnt());
+    }
+
+    @Test
+    public void testEmptyContentChunked() throws Exception {
+        testEmptyContent(true);
+    }
+
+    @Test
+    public void testEmptyContentNotChunked() throws Exception {
+        testEmptyContent(false);
+    }
+
+    private void testEmptyContent(boolean chunked) throws Exception {
+        HttpRequestEncoder encoder = new HttpRequestEncoder();
+        EmbeddedChannel channel = new EmbeddedChannel(encoder);
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
+        if (chunked) {
+            HttpUtil.setTransferEncodingChunked(request, true);
+        }
+        assertTrue(channel.writeOutbound(request));
+
+        ByteBuf contentBuffer = Unpooled.buffer();
+        assertTrue(channel.writeOutbound(new DefaultHttpContent(contentBuffer)));
+
+        ByteBuf lastContentBuffer = Unpooled.buffer();
+        assertTrue(channel.writeOutbound(new DefaultHttpContent(lastContentBuffer)));
+
+        // Ensure we only produce ByteBuf instances.
+        ByteBuf head = channel.readOutbound();
+        assertTrue(head.release());
+
+        ByteBuf content = channel.readOutbound();
+        content.release();
+
+        ByteBuf lastContent = channel.readOutbound();
+        lastContent.release();
+        assertFalse(channel.finish());
     }
 }


### PR DESCRIPTION
Motivation:

93130b172a61815354267f0f3d8f5af52de39754 introduced a regression where we not "converted" an empty HttpContent to ByteBuf and just passed it on in the pipeline. This can lead to the situation that other handlers in the pipeline will see HttpContent instances which is not expected.

Modifications:

- Correctly convert HttpContent to ByteBuf when empty
- Add unit test.

Result:

Handlers in the pipeline will see the expected message type.
