### PR TITLE
EventLoop.schedule with big delay fails

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -150,6 +150,8 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         if (delay < 0) {
             delay = 0;
         }
+        validateScheduled(delay, unit);
+
         return schedule(new ScheduledFutureTask<Void>(
                 this, command, null, ScheduledFutureTask.deadlineNanos(unit.toNanos(delay))));
     }
@@ -161,6 +163,8 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         if (delay < 0) {
             delay = 0;
         }
+        validateScheduled(delay, unit);
+
         return schedule(new ScheduledFutureTask<V>(
                 this, callable, ScheduledFutureTask.deadlineNanos(unit.toNanos(delay))));
     }
@@ -177,6 +181,8 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
             throw new IllegalArgumentException(
                     String.format("period: %d (expected: > 0)", period));
         }
+        validateScheduled(initialDelay, unit);
+        validateScheduled(period, unit);
 
         return schedule(new ScheduledFutureTask<Void>(
                 this, Executors.<Void>callable(command, null),
@@ -196,9 +202,19 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
                     String.format("delay: %d (expected: > 0)", delay));
         }
 
+        validateScheduled(initialDelay, unit);
+        validateScheduled(delay, unit);
+
         return schedule(new ScheduledFutureTask<Void>(
                 this, Executors.<Void>callable(command, null),
                 ScheduledFutureTask.deadlineNanos(unit.toNanos(initialDelay)), -unit.toNanos(delay)));
+    }
+
+    /**
+     * Sub-classes may override this to restrict the maximal amount of time someone can use to schedule a task.
+     */
+    protected void validateScheduled(long amount, TimeUnit unit) {
+        // NOOP
     }
 
     <V> ScheduledFuture<V> schedule(final ScheduledFutureTask<V> task) {

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.epoll;
+
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.Future;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class EpollEventLoopTest {
+
+    @Test(timeout = 5000L)
+    public void testScheduleBigDelayOverMax() {
+        EventLoopGroup group = new EpollEventLoopGroup(1);
+
+        final EventLoop el = group.next();
+        try {
+            el.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    // NOOP
+                }
+            }, Integer.MAX_VALUE, TimeUnit.DAYS);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+
+        group.shutdownGracefully();
+    }
+
+    @Test
+    public void testScheduleBigDelay() {
+        EventLoopGroup group = new EpollEventLoopGroup(1);
+
+        final EventLoop el = group.next();
+        Future<?> future = el.schedule(new Runnable() {
+            @Override
+            public void run() {
+                // NOOP
+            }
+        }, EpollEventLoop.MAX_SCHEDULED_DAYS, TimeUnit.DAYS);
+
+        assertFalse(future.awaitUninterruptibly(1000));
+        assertTrue(future.cancel(true));
+        group.shutdownGracefully();
+    }
+}

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.Queue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static io.netty.channel.kqueue.KQueueEventArray.deleteGlobalRefs;
@@ -75,6 +76,8 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
 
     private volatile int wakenUp;
     private volatile int ioRatio = 50;
+
+    static final long MAX_SCHEDULED_DAYS = 365 * 3;
 
     KQueueEventLoop(EventLoopGroup parent, Executor executor, int maxEvents,
                     SelectStrategy strategy, RejectedExecutionHandler rejectedExecutionHandler) {
@@ -365,6 +368,14 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
             Thread.sleep(1000);
         } catch (InterruptedException e) {
             // Ignore.
+        }
+    }
+
+    @Override
+    protected void validateScheduled(long amount, TimeUnit unit) {
+        long days = unit.toDays(amount);
+        if (days > MAX_SCHEDULED_DAYS) {
+            throw new IllegalArgumentException("days: " + days + " (expected: < " + MAX_SCHEDULED_DAYS + ')');
         }
     }
 }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueEventLoopTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueEventLoopTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.kqueue;
+
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.Future;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class KQueueEventLoopTest {
+
+    @Test(timeout = 5000L)
+    public void testScheduleBigDelayOverMax() {
+        EventLoopGroup group = new KQueueEventLoopGroup(1);
+
+        final EventLoop el = group.next();
+        try {
+            el.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    // NOOP
+                }
+            }, Integer.MAX_VALUE, TimeUnit.DAYS);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+
+        group.shutdownGracefully();
+    }
+
+    @Test
+    public void testScheduleBigDelay() {
+        EventLoopGroup group = new KQueueEventLoopGroup(1);
+
+        final EventLoop el = group.next();
+        Future<?> future = el.schedule(new Runnable() {
+            @Override
+            public void run() {
+                // NOOP
+            }
+        }, KQueueEventLoop.MAX_SCHEDULED_DAYS, TimeUnit.DAYS);
+
+        assertFalse(future.awaitUninterruptibly(1000));
+        assertTrue(future.cancel(true));
+        group.shutdownGracefully();
+    }
+}

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -113,6 +113,8 @@ public final class NioEventLoop extends SingleThreadEventLoop {
         }
     }
 
+    static final long MAX_SCHEDULED_DAYS = 365 * 3;
+
     /**
      * The NIO {@link Selector}.
      */
@@ -730,6 +732,7 @@ public final class NioEventLoop extends SingleThreadEventLoop {
             int selectCnt = 0;
             long currentTimeNanos = System.nanoTime();
             long selectDeadLineNanos = currentTimeNanos + delayNanos(currentTimeNanos);
+
             for (;;) {
                 long timeoutMillis = (selectDeadLineNanos - currentTimeNanos + 500000L) / 1000000L;
                 if (timeoutMillis <= 0) {
@@ -820,6 +823,14 @@ public final class NioEventLoop extends SingleThreadEventLoop {
             selector.selectNow();
         } catch (Throwable t) {
             logger.warn("Failed to update SelectionKeys.", t);
+        }
+    }
+
+    @Override
+    protected void validateScheduled(long amount, TimeUnit unit) {
+        long days = unit.toDays(amount);
+        if (days > MAX_SCHEDULED_DAYS) {
+            throw new IllegalArgumentException("days: " + days + " (expected: < " + MAX_SCHEDULED_DAYS + ')');
         }
     }
 }

--- a/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
@@ -17,12 +17,15 @@ package io.netty.channel.nio;
 
 import io.netty.channel.AbstractEventLoopTest;
 import io.netty.channel.Channel;
+import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.util.concurrent.Future;
 import org.junit.Test;
 
 import java.nio.channels.Selector;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.*;
 
@@ -67,5 +70,41 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
         } finally {
             group.shutdownGracefully();
         }
+    }
+
+    @Test(timeout = 5000L)
+    public void testScheduleBigDelayOverMax() {
+        EventLoopGroup group = new NioEventLoopGroup(1);
+        final EventLoop el = group.next();
+        try {
+            el.schedule(new Runnable() {
+                @Override
+                public void run() {
+                    // NOOP
+                }
+            }, Integer.MAX_VALUE, TimeUnit.DAYS);
+            fail();
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+
+        group.shutdownGracefully();
+    }
+
+    @Test
+    public void testScheduleBigDelay() {
+        EventLoopGroup group = new NioEventLoopGroup(1);
+
+        final EventLoop el = group.next();
+        Future<?> future = el.schedule(new Runnable() {
+            @Override
+            public void run() {
+                // NOOP
+            }
+        }, NioEventLoop.MAX_SCHEDULED_DAYS, TimeUnit.DAYS);
+
+        assertFalse(future.awaitUninterruptibly(1000));
+        assertTrue(future.cancel(true));
+        group.shutdownGracefully();
     }
 }


### PR DESCRIPTION
Motivation:

Using a very huge delay when calling schedule(...) may cause an Selector error when calling select(...) later on. We should gaurd against such a big value.

Modifications:

- Add guard against a very huge value.
- Added tests.

Result:

Fixes [#7365]