### PR TITLE
Don't try to use UnixResolverDnsServerAddressStreamProvider when on W…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddressStreamProviders.java
@@ -15,6 +15,7 @@
  */
 package io.netty.resolver.dns;
 
+import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.UnstableApi;
 
 /**
@@ -25,7 +26,10 @@ public final class DnsServerAddressStreamProviders {
     // TODO(scott): how is this done on Windows? This may require a JNI call to GetNetworkParams
     // https://msdn.microsoft.com/en-us/library/aa365968(VS.85).aspx.
     private static final DnsServerAddressStreamProvider DEFAULT_DNS_SERVER_ADDRESS_STREAM_PROVIDER =
-            UnixResolverDnsServerAddressStreamProvider.parseSilently();
+            // If on windows just use the DefaultDnsServerAddressStreamProvider.INSTANCE as otherwise
+            // we will log some error which may be confusing.
+            PlatformDependent.isWindows() ? DefaultDnsServerAddressStreamProvider.INSTANCE :
+                    UnixResolverDnsServerAddressStreamProvider.parseSilently();
 
     private DnsServerAddressStreamProviders() {
     }


### PR DESCRIPTION
…indows.

Motivation:

We should not try to use UnixResolverDnsServerAddressStreamProvider when on Windows as it will log some error that will produce noise and may confuse users.

Modifications:

Just use DefaultDnsServerAddressStreamProvider if windows is used.

Result:

Less noise in the logs. This was reported in vert.x: https://github.com/eclipse/vert.x/issues/2204