### PR TITLE
Improved error message in FixedChannelPool

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -194,7 +194,7 @@ public class FixedChannelPool extends SimpleChannelPool {
         } else if (action == null && acquireTimeoutMillis != -1) {
             throw new NullPointerException("action");
         } else if (action != null && acquireTimeoutMillis < 0) {
-            throw new IllegalArgumentException("acquireTimeoutMillis: " + acquireTimeoutMillis + " (expected: >= 1)");
+            throw new IllegalArgumentException("acquireTimeoutMillis: " + acquireTimeoutMillis + " (expected: >= 0)");
         } else {
             acquireTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(acquireTimeoutMillis);
             switch (action) {

--- a/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
+++ b/transport/src/test/java/io/netty/channel/pool/FixedChannelPoolTest.java
@@ -20,7 +20,6 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
-import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalChannel;
@@ -98,6 +97,15 @@ public class FixedChannelPoolTest {
 
     @Test(expected = TimeoutException.class)
     public void testAcquireTimeout() throws Exception {
+        testAcquireTimeout(500);
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void testAcquireWithZeroTimeout() throws Exception {
+        testAcquireTimeout(0);
+    }
+
+    private static void testAcquireTimeout(long timeoutMillis) throws Exception {
         LocalAddress addr = new LocalAddress(LOCAL_ADDR_ID);
         Bootstrap cb = new Bootstrap();
         cb.remoteAddress(addr);
@@ -118,7 +126,7 @@ public class FixedChannelPoolTest {
         Channel sc = sb.bind(addr).syncUninterruptibly().channel();
         ChannelPoolHandler handler = new TestChannelPoolHandler();
         ChannelPool pool = new FixedChannelPool(cb, handler, ChannelHealthChecker.ACTIVE,
-                                                 AcquireTimeoutAction.FAIL, 500, 1, Integer.MAX_VALUE);
+                                                AcquireTimeoutAction.FAIL, timeoutMillis, 1, Integer.MAX_VALUE);
 
         Channel channel = pool.acquire().syncUninterruptibly().getNow();
         Future<Channel> future = pool.acquire();


### PR DESCRIPTION
Motivation:

`FixedChannelPool` allows users to configure `acquireTimeoutMillis` and expects given value to be greater or equal to zero when timeout action is supplied. However, validation error message said that value is expected to be greater or equal to one. Code performs check against zero.

Modifications:

Changed error message to say that value greater or equal to zero is expected. Added test to check that zero is an acceptable value.

Result:

Exception with right error message is thrown.