### PR TITLE
HttpHeaders valuesIterator and contains improvements

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/CombinedHttpHeaders.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import static io.netty.util.AsciiString.CASE_INSENSITIVE_HASHER;
 import static io.netty.util.internal.StringUtil.COMMA;
+import static io.netty.util.internal.StringUtil.unescapeCsvFields;
 
 /**
  * Will add multiple values for the same header as single header with a comma separated list of values.
@@ -84,6 +85,19 @@ public class CombinedHttpHeaders extends DefaultHttpHeaders {
         }
 
         @Override
+        public Iterator<CharSequence> valueIterator(CharSequence name) {
+            Iterator<CharSequence> itr = super.valueIterator(name);
+            if (!itr.hasNext()) {
+                return itr;
+            }
+            Iterator<CharSequence> unescapedItr = unescapeCsvFields(itr.next()).iterator();
+            if (itr.hasNext()) {
+                throw new IllegalStateException("CombinedHttpHeaders should only have one value");
+            }
+            return unescapedItr;
+        }
+
+        @Override
         public List<CharSequence> getAll(CharSequence name) {
             List<CharSequence> values = super.getAll(name);
             if (values.isEmpty()) {
@@ -92,7 +106,7 @@ public class CombinedHttpHeaders extends DefaultHttpHeaders {
             if (values.size() != 1) {
                 throw new IllegalStateException("CombinedHttpHeaders should only have one value");
             }
-            return StringUtil.unescapeCsvFields(values.get(0));
+            return unescapeCsvFields(values.get(0));
         }
 
         @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -277,6 +277,32 @@ public class DefaultHttpHeaders extends HttpHeaders {
     }
 
     @Override
+    public Iterator<String> valueStringIterator(CharSequence name) {
+        final Iterator<CharSequence> itr = valueCharSequenceIterator(name);
+        return new Iterator<String>() {
+            @Override
+            public boolean hasNext() {
+                return itr.hasNext();
+            }
+
+            @Override
+            public String next() {
+                return itr.next().toString();
+            }
+
+            @Override
+            public void remove() {
+                itr.remove();
+            }
+        };
+    }
+
+    @Override
+    public Iterator<CharSequence> valueCharSequenceIterator(CharSequence name) {
+        return headers.valueIterator(name);
+    }
+
+    @Override
     public boolean contains(String name) {
         return contains((CharSequence) name);
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -31,6 +31,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import static io.netty.util.AsciiString.contentEquals;
+import static io.netty.util.AsciiString.contentEqualsIgnoreCase;
+import static io.netty.util.AsciiString.trim;
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
@@ -1146,7 +1149,7 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
      */
     @Deprecated
     public static boolean equalsIgnoreCase(CharSequence name1, CharSequence name2) {
-        return AsciiString.contentEqualsIgnoreCase(name1, name2);
+        return contentEqualsIgnoreCase(name1, name2);
     }
 
     @Deprecated
@@ -1308,6 +1311,24 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
      * @return Iterator over the name/value header pairs.
      */
     public abstract Iterator<Entry<CharSequence, CharSequence>> iteratorCharSequence();
+
+    /**
+     * Equivalent to {@link #getAll(String)} but it is possible that no intermediate list is generated.
+     * @param name the name of the header to retrieve
+     * @return an {@link Iterator} of header values corresponding to {@code name}.
+     */
+    public Iterator<String> valueStringIterator(CharSequence name) {
+        return getAll(name).iterator();
+    }
+
+    /**
+     * Equivalent to {@link #getAll(String)} but it is possible that no intermediate list is generated.
+     * @param name the name of the header to retrieve
+     * @return an {@link Iterator} of header values corresponding to {@code name}.
+     */
+    public Iterator<? extends CharSequence> valueCharSequenceIterator(CharSequence name) {
+        return valueStringIterator(name);
+    }
 
     /**
      * Checks to see if there is a header with the specified name
@@ -1546,18 +1567,16 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
      * @see #contains(CharSequence, CharSequence, boolean)
      */
     public boolean contains(String name, String value, boolean ignoreCase) {
-        List<String> values = getAll(name);
-        if (values.isEmpty()) {
-            return false;
-        }
-
-        for (String v: values) {
-            if (ignoreCase) {
-                if (v.equalsIgnoreCase(value)) {
+        Iterator<String> valueIterator = valueStringIterator(name);
+        if (ignoreCase) {
+            while (valueIterator.hasNext()) {
+                if (valueIterator.next().equalsIgnoreCase(value)) {
                     return true;
                 }
-            } else {
-                if (v.equals(value)) {
+            }
+        } else {
+            while (valueIterator.hasNext()) {
+                if (valueIterator.next().equals(value)) {
                     return true;
                 }
             }
@@ -1576,31 +1595,55 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
      * otherwise a case sensitive compare is run to compare values.
      */
     public boolean containsValue(CharSequence name, CharSequence value, boolean ignoreCase) {
-        List<String> values = getAll(name);
-        if (values.isEmpty()) {
-            return false;
-        }
-
-        for (String v: values) {
-            if (contains(v, value, ignoreCase)) {
+        Iterator<? extends CharSequence> itr = valueCharSequenceIterator(name);
+        while (itr.hasNext()) {
+            if (containsCommaSeparatedTrimmed(itr.next(), value, ignoreCase)) {
                 return true;
             }
         }
         return false;
     }
 
-    private static boolean contains(String value, CharSequence expected, boolean ignoreCase) {
-        String[] parts = value.split(",");
+    private static boolean containsCommaSeparatedTrimmed(CharSequence rawNext, CharSequence expected,
+                                                         boolean ignoreCase) {
+        int begin = 0;
+        int end;
         if (ignoreCase) {
-            for (String s: parts) {
-                if (AsciiString.contentEqualsIgnoreCase(expected, s.trim())) {
+            if ((end = AsciiString.indexOf(rawNext, ',', begin)) == -1) {
+                if (contentEqualsIgnoreCase(trim(rawNext), expected)) {
                     return true;
+                }
+            } else {
+                do {
+                    if (contentEqualsIgnoreCase(trim(rawNext.subSequence(begin, end)), expected)) {
+                        return true;
+                    }
+                    begin = end + 1;
+                } while ((end = AsciiString.indexOf(rawNext, ',', begin)) != -1);
+
+                if (begin < rawNext.length()) {
+                    if (contentEqualsIgnoreCase(trim(rawNext.subSequence(begin, rawNext.length())), expected)) {
+                        return true;
+                    }
                 }
             }
         } else {
-            for (String s: parts) {
-                if (AsciiString.contentEquals(expected, s.trim())) {
+            if ((end = AsciiString.indexOf(rawNext, ',', begin)) == -1) {
+                if (contentEquals(trim(rawNext), expected)) {
                     return true;
+                }
+            } else {
+                do {
+                    if (contentEquals(trim(rawNext.subSequence(begin, end)), expected)) {
+                        return true;
+                    }
+                    begin = end + 1;
+                } while ((end = AsciiString.indexOf(rawNext, ',', begin)) != -1);
+
+                if (begin < rawNext.length()) {
+                    if (contentEquals(trim(rawNext.subSequence(begin, rawNext.length())), expected)) {
+                        return true;
+                    }
                 }
             }
         }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/CombinedHttpHeadersTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/CombinedHttpHeadersTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 
 import static io.netty.util.AsciiString.contentEquals;
 import static org.junit.Assert.assertEquals;
@@ -299,5 +300,31 @@ public class CombinedHttpHeadersTest {
 
         HttpHeaders copiedHeaders = newCombinedHttpHeaders().add(headers);
         assertEquals(Arrays.asList("a", "", "b", "", "c, d"), copiedHeaders.getAll(HEADER_NAME));
+    }
+
+    @Test
+    public void valueIterator() {
+        final CombinedHttpHeaders headers = newCombinedHttpHeaders();
+        headers.set(HEADER_NAME, Arrays.asList("\ta", "   ", "  b ", "\t \t"));
+        headers.add(HEADER_NAME, " c, d \t");
+
+        assertFalse(headers.valueStringIterator("foo").hasNext());
+        assertValueIterator(headers.valueStringIterator(HEADER_NAME));
+        assertFalse(headers.valueCharSequenceIterator("foo").hasNext());
+        assertValueIterator(headers.valueCharSequenceIterator(HEADER_NAME));
+    }
+
+    private static void assertValueIterator(Iterator<? extends CharSequence> strItr) {
+        assertTrue(strItr.hasNext());
+        assertEquals("a", strItr.next());
+        assertTrue(strItr.hasNext());
+        assertEquals("", strItr.next());
+        assertTrue(strItr.hasNext());
+        assertEquals("b", strItr.next());
+        assertTrue(strItr.hasNext());
+        assertEquals("", strItr.next());
+        assertTrue(strItr.hasNext());
+        assertEquals("c, d", strItr.next());
+        assertFalse(strItr.hasNext());
     }
 }

--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -1006,6 +1006,34 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
     }
 
     /**
+     * Copies this string removing white space characters from the beginning and end of the string, and tries not to
+     * copy if possible.
+     *
+     * @param c The {@link CharSequence} to trim.
+     * @return a new string with characters {@code <= \\u0020} removed from the beginning and the end.
+     */
+    public static CharSequence trim(CharSequence c) {
+        if (c.getClass() == AsciiString.class) {
+            return ((AsciiString) c).trim();
+        }
+        if (c instanceof String) {
+            return ((String) c).trim();
+        }
+        int start = 0, last = c.length() - 1;
+        int end = last;
+        while (start <= end && c.charAt(start) <= ' ') {
+            start++;
+        }
+        while (end >= start && c.charAt(end) <= ' ') {
+            end--;
+        }
+        if (start == 0 && end == last) {
+            return c;
+        }
+        return c.subSequence(start, end);
+    }
+
+    /**
      * Duplicates this string removing white space characters from the beginning and end of the
      * string, without copying.
      *


### PR DESCRIPTION
Motivation:
In order to determine if a header contains a value we currently rely
upon getAll(..) and regular expressions. This operation is commonly used
during the encode and decode stage to determine the transfer encoding
(e.g. HttpUtil#isTransferEncodingChunked). This operation requires an
intermediate collection and possibly regular expressions for the
CombinedHttpHeaders use case which can be expensive.

Modifications:
- Add a valuesIterator to HttpHeaders and specializations of this method
for DefaultHttpHeaders, ReadOnlyHttpHeaders, and CombinedHttpHeaders.

Result:
Less intermediate collections and allocation overhead when determining
if HttpHeaders contains a name/value pair.