### PR TITLE
Fix DN resolution when ndots is greater than 1

### DIFF
--- a/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/SearchDomainTest.java
@@ -104,8 +104,10 @@ public class SearchDomainTest {
         // "host2" not resolved
         assertNotResolve(resolver, "host2");
 
-        // "host3" does not contain a dot or is not absolute
-        assertNotResolve(resolver, "host3");
+        // "host3" does not contain a dot nor it's absolute but it should still be resolved after search list have
+        // been checked
+        resolved = assertResolve(resolver, "host3");
+        assertEquals(store.getAddress("host3"), resolved);
 
         // "host3." does not contain a dot but is absolute
         resolved = assertResolve(resolver, "host3.");
@@ -152,8 +154,10 @@ public class SearchDomainTest {
         // "host2" not resolved
         assertNotResolveAll(resolver, "host2");
 
-        // "host3" does not contain a dot or is not absolute
-        assertNotResolveAll(resolver, "host3");
+        // "host3" does not contain a dot nor it's absolute but it should still be resolved after search list have
+        // been checked
+        resolved = assertResolveAll(resolver, "host3");
+        assertEquals(store.getAddresses("host3"), resolved);
 
         // "host3." does not contain a dot but is absolute
         resolved = assertResolveAll(resolver, "host3.");
@@ -281,7 +285,7 @@ public class SearchDomainTest {
         dnsServer = new TestDnsServer(store);
         dnsServer.start();
 
-        resolver = newResolver().searchDomains(Collections.singletonList("foo.com")).ndots(2).build();
+        resolver = newResolver().searchDomains(Collections.singletonList("foo.com")).ndots(1).build();
 
         Future<InetAddress> fut = resolver.resolve("unknown.hostname");
         assertTrue(fut.await(10, TimeUnit.SECONDS));
@@ -293,12 +297,12 @@ public class SearchDomainTest {
     }
 
     @Test
-    public void testExceptionMsgDoesNotContainSearchDomainIfNdotsNotHighEnough() throws Exception {
+    public void testExceptionMsgDoesNotContainSearchDomainIfNdotsIsNotReached() throws Exception {
         TestDnsServer.MapRecordStoreA store = new TestDnsServer.MapRecordStoreA(Collections.<String>emptySet());
         dnsServer = new TestDnsServer(store);
         dnsServer.start();
 
-        resolver = newResolver().searchDomains(Collections.singletonList("foo.com")).ndots(1).build();
+        resolver = newResolver().searchDomains(Collections.singletonList("foo.com")).ndots(2).build();
 
         Future<InetAddress> fut = resolver.resolve("unknown.hostname");
         assertTrue(fut.await(10, TimeUnit.SECONDS));


### PR DESCRIPTION
Motivation:

DN resolution does not fall back to the "original name" lookup after search list is checked. This results in a failure to resolve any name (outside of search list) that has number of dots less than resolv.conf's ndots value (which, for example, is often the case in the context of Kubernetes where kubelet passes on resolv.conf containing "options ndots:5").

It also does not go through the search list in a situation described in resolv.conf man:
"The default for n[dots] is 1, meaning that if there are any dots in a name, the name will be tried first as an absolute name before any search list elements are appended to it."

Modifications:

DnsNameResolverContext::resolve was updated to match Go's https://github.com/golang/go/blob/release-branch.go1.9/src/net/dnsclient_unix.go#L338 logic.

Result:
DnsNameResolverContext::resolve will now try to resolve "original name" if search list yields no results when number of dots in the original name is less than resolv.conf's ndots value. It will also go through the search list in case "origin name" resolution fails and number of dots is equal or larger than resolv.conf's ndots value.

(ICLA signed)