### PR TITLE
Fix writing of empty LastHttpContent with trailers

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
@@ -206,6 +206,7 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
                 buf.writeBytes(CRLF);
                 trailersEncodedSizeAccumulator = TRAILERS_WEIGHT_NEW * padSizeForAccumulation(buf.readableBytes()) +
                                                  TRAILERS_WEIGHT_HISTORICAL * trailersEncodedSizeAccumulator;
+                out.add(buf);
             }
         } else if (contentLength == 0) {
             // Need to produce some output otherwise an

--- a/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/HttpRequestEncoderTest.java
@@ -135,16 +135,26 @@ public class HttpRequestEncoderTest {
     }
 
     @Test
-    public void testEmptyContentChunked() throws Exception {
-        testEmptyContent(true);
+    public void testEmptyContentsChunked() throws Exception {
+        testEmptyContents(true, false);
     }
 
     @Test
-    public void testEmptyContentNotChunked() throws Exception {
-        testEmptyContent(false);
+    public void testEmptyContentsChunkedWithTrailers() throws Exception {
+        testEmptyContents(true, true);
     }
 
-    private void testEmptyContent(boolean chunked) throws Exception {
+    @Test
+    public void testEmptyContentsNotChunked() throws Exception {
+        testEmptyContents(false, false);
+    }
+
+    @Test
+    public void testEmptyContentNotsChunkedWithTrailers() throws Exception {
+        testEmptyContents(false, true);
+    }
+
+    private void testEmptyContents(boolean chunked, boolean trailers) throws Exception {
         HttpRequestEncoder encoder = new HttpRequestEncoder();
         EmbeddedChannel channel = new EmbeddedChannel(encoder);
         HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/");
@@ -157,7 +167,11 @@ public class HttpRequestEncoderTest {
         assertTrue(channel.writeOutbound(new DefaultHttpContent(contentBuffer)));
 
         ByteBuf lastContentBuffer = Unpooled.buffer();
-        assertTrue(channel.writeOutbound(new DefaultHttpContent(lastContentBuffer)));
+        LastHttpContent last = new DefaultLastHttpContent(lastContentBuffer);
+        if (trailers) {
+            last.trailingHeaders().set("X-Netty-Test", "true");
+        }
+        assertTrue(channel.writeOutbound(last));
 
         // Ensure we only produce ByteBuf instances.
         ByteBuf head = (ByteBuf) channel.readOutbound();


### PR DESCRIPTION
Motivation:

4732fabb1664acae0a545b6496066acb8d39ecb7 introduced a regression in HttpObjectEncoder which will lead to buffer leak and IllegalStateException when a LastHttpContent with trailers is written.

Modifications:

- Correctly add the buffer to the encoded list.
- Add testcases

Result:

Fixes [#7418]