### PR TITLE
Reduce conditionals in DnsNameResovlerContext

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -141,12 +141,10 @@ abstract class DnsNameResolverContext<T> {
                         promise.trySuccess(future.getNow());
                     } else if (searchDomainIdx < searchDomains.length) {
                         doSearchDomainQuery(hostname + '.' + searchDomains[searchDomainIdx++], this);
+                    } else if (!startWithoutSearchDomain) {
+                        internalResolve(promise);
                     } else {
-                        if (!startWithoutSearchDomain) {
-                            internalResolve(promise);
-                        } else {
-                            promise.tryFailure(new SearchDomainUnknownHostException(future.cause(), hostname));
-                        }
+                        promise.tryFailure(new SearchDomainUnknownHostException(future.cause(), hostname));
                     }
                 }
             });


### PR DESCRIPTION
Motivation:
Minor cleanup from 844d804 just to reduce the conditional statements and indentation level.

Modifications:
- combine the else + if into an else if statement

Result:
Code cleaned up.