### PR TITLE
Add RetryingInetNameResolver which can wrap a DnsNameResolver and implements retries

### DIFF
--- a/resolver-dns/pom.xml
+++ b/resolver-dns/pom.xml
@@ -69,6 +69,10 @@
       <version>2.6</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 </project>
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/RetryingInetNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/RetryingInetNameResolver.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.resolver.InetNameResolver;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
+import io.netty.util.concurrent.Promise;
+import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.UnstableApi;
+
+import java.net.InetAddress;
+import java.util.List;
+
+/**
+ * {@link InetNameResolver} implementation which allows to add retry cababilities to a {@link DnsNameResolver}.
+ */
+@UnstableApi
+public final class RetryingInetNameResolver extends InetNameResolver {
+
+    private final DnsNameResolver resolver;
+    private final int retries;
+
+    /**
+     * Create a new instance.
+     *
+     * @param resolver the {@link DnsNameResolver} which will be used for the queries.
+     * @param retries the number of retries that should be used for timeouts / IO errors.
+     */
+    public RetryingInetNameResolver(DnsNameResolver resolver, int retries) {
+        super(resolver.executor());
+        this.resolver = resolver;
+        this.retries = ObjectUtil.checkPositiveOrZero(retries, "retries");
+    }
+
+    @Override
+    protected void doResolve(final String inetHost, final Promise<InetAddress> promise) throws Exception {
+        resolver.resolve(inetHost).addListener(new RetryFutureListener<InetAddress>(retries, inetHost, promise) {
+            @Override
+            protected Future<InetAddress> resolveAgain(String inetHost) {
+                return resolver.resolve(inetHost);
+            }
+        });
+    }
+
+    @Override
+    protected void doResolveAll(String inetHost, Promise<List<InetAddress>> promise) throws Exception {
+        resolver.resolveAll(inetHost).addListener(
+                new RetryFutureListener<List<InetAddress>>(retries, inetHost, promise) {
+            @Override
+            protected Future<List<InetAddress>> resolveAgain(String inetHost) {
+                return resolver.resolveAll(inetHost);
+            }
+        });
+    }
+
+    private abstract static class RetryFutureListener<T> implements FutureListener<T> {
+
+        private final String inetHost;
+        private final Promise<T> promise;
+        private int retries;
+
+        RetryFutureListener(int retries, String inetHost, Promise<T> promise) {
+            this.retries = retries;
+            this.inetHost = inetHost;
+            this.promise = promise;
+        }
+
+        @Override
+        public void operationComplete(Future<T> future) throws Exception {
+            Throwable cause = future.cause();
+            if (cause == null) {
+                promise.setSuccess(future.getNow());
+            } else if (DnsNameResolver.isTransportOrTimeoutError(cause) && --retries >= 0) {
+                resolveAgain(inetHost).addListener(this);
+            } else {
+                promise.setFailure(cause);
+            }
+        }
+
+        protected abstract Future<T> resolveAgain(String inetHost);
+    }
+}

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/RetryingInetNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/RetryingInetNameResolverTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoop;
+import io.netty.handler.codec.dns.DnsQuestion;
+import io.netty.util.NetUtil;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.Promise;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class RetryingInetNameResolverTest {
+
+    @Test
+    public void testRetryOnTimeout() {
+        final DnsQuestion question = mock(DnsQuestion.class);
+        testRetryOnTimeout(new DnsNameResolverTimeoutException(
+                new InetSocketAddress(NetUtil.LOCALHOST, 0), question, "timeout"));
+        verifyNoMoreInteractions(question);
+    }
+
+    @Test
+    public void testRetryOnTransportError() {
+        final DnsQuestion question = mock(DnsQuestion.class);
+        testRetryOnTimeout(new DnsNameResolverException(
+                new InetSocketAddress(NetUtil.LOCALHOST, 0), question, "I/O", new IOException("I/O")));
+        verifyNoMoreInteractions(question);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void testRetryOnTimeout(final DnsNameResolverException cause) {
+        final int retries = 2;
+        final String hostname = "netty.io";
+        DefaultEventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            DnsNameResolver resolver = mock(DnsNameResolver.class);
+            when(resolver.executor()).thenReturn(loop);
+
+            when(resolver.resolve(eq(hostname), any(Promise.class))).then(new Answer<Future<InetAddress>>() {
+                private int called;
+                @Override
+                public Future<InetAddress> answer(InvocationOnMock invocationOnMock) throws Throwable {
+                    String host = invocationOnMock.getArgument(0);
+                    Promise<InetAddress> promise = invocationOnMock.getArgument(1);
+                    if (called++ == retries) {
+                        promise.setSuccess(NetUtil.LOCALHOST);
+                    } else {
+                        UnknownHostException ex = new UnknownHostException(host);
+                        ex.initCause(cause);
+                        promise.setFailure(ex);
+                    }
+                    return promise;
+                }
+            });
+            RetryingInetNameResolver retryingInetNameResolver = new RetryingInetNameResolver(resolver, retries);
+            retryingInetNameResolver.resolve(hostname).syncUninterruptibly();
+
+            verify(resolver, times(3)).resolve(eq(hostname), any(Promise.class));
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testNotRetryOnPlainUnkownHostException() {
+        final DnsQuestion question = mock(DnsQuestion.class);
+        testRetryOnTimeout(new DnsNameResolverException(
+                new InetSocketAddress(NetUtil.LOCALHOST, 0), question, "I/O", new IOException("I/O")));
+        verifyNoMoreInteractions(question);
+
+        final int retries = 2;
+        final String hostname = "netty.io";
+        DefaultEventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            DnsNameResolver resolver = mock(DnsNameResolver.class);
+            when(resolver.executor()).thenReturn(loop);
+
+            when(resolver.resolve(eq(hostname), any(Promise.class))).then(new Answer<Future<InetAddress>>() {
+                @Override
+                public Future<InetAddress> answer(InvocationOnMock invocationOnMock) throws Throwable {
+                    String host = invocationOnMock.getArgument(0);
+                    Promise<InetAddress> promise = invocationOnMock.getArgument(1);
+                    promise.setFailure(new UnknownHostException(host));
+                    return promise;
+                }
+            });
+            RetryingInetNameResolver retryingInetNameResolver = new RetryingInetNameResolver(resolver, retries);
+            Throwable cause = retryingInetNameResolver.resolve(hostname).awaitUninterruptibly().cause();
+            assertTrue(cause instanceof UnknownHostException);
+            verify(resolver, times(1)).resolve(eq(hostname), any(Promise.class));
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+}


### PR DESCRIPTION
Add RetryingInetNameResolver which can wrap a DnsNameResolver and implements retries

Motivation:

If a resolution fails because of a timeout or IO error its often useful to retry it as the Nameserver may just be overloaded or empower some kind of rate limiting.

Modifications:

- Add RetryingInetNameResolver which can be used to handle retries
- Add unit tests

Result:

More robust resolver handling.