### PR TITLE
Guard against NoClassDefFoundError when trying to load Unsafe.

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -96,6 +96,10 @@ final class PlatformDependent0 {
                         return e;
                     } catch (IllegalAccessException e) {
                         return e;
+                    } catch (NoClassDefFoundError e) {
+                        // Also catch NoClassDefFoundError in case someone uses for example OSGI and it made
+                        // Unsafe unloadable.
+                        return e;
                     }
                 }
             });


### PR DESCRIPTION
Motivation:

OSGI and other enviroments may not allow to even load Unsafe which will lead to an NoClassDefFoundError when trying to access it. We should guard against this.

Modifications:

Catch NoClassDefFoundError when trying to load Unsafe.

Result:

Be able to use netty with a strict OSGI config.