### PR TITLE
Prevent a critical failure when Unsafe is not available

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -90,12 +90,10 @@ final class PlatformDependent0 {
                         }
                         // the unsafe instance
                         return unsafeField.get(null);
-                    } catch (NoSuchFieldException e) {
-                        return e;
-                    } catch (SecurityException e) {
-                        return e;
-                    } catch (IllegalAccessException e) {
-                        return e;
+                        // There are many non-obvious things that can go wrong,
+                        // including NoClassDefFoundError, so be ready for anything
+                    } catch (Throwable t) {
+                        return t;
                     }
                 }
             });


### PR DESCRIPTION
Fixes #6548

Signed-off-by: Tim Ward <timothyjward@apache.org>

Motivation:

The bug #6548 prevents netty from starting up when Unsafe is unavailable. This should not prevent netty starting.

Modification:

Catch the Throwable that might occur

Result:

Fixes #6548 

If there is no issue then describe the changes introduced by this PR.