### PR TITLE
Add FileRegionStream which can be used to provide a stream of FileReg…

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultFileRegionStream.java
+++ b/transport/src/main/java/io/netty/channel/DefaultFileRegionStream.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.IllegalReferenceCountException;
+import io.netty.util.internal.UnstableApi;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+import static io.netty.util.internal.ObjectUtil.*;
+
+/**
+ * {@link FileRegionStream} implementations which provides a stream of {@link FileRegion}s
+ * backed by a {@link FileChannel}.
+ */
+@UnstableApi
+public final class DefaultFileRegionStream extends AbstractReferenceCounted implements FileRegionStream {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultFileRegionStream.class);
+
+    private final FileChannel file;
+    private final long endPosition;
+    private long position;
+
+    /**
+     * Create a new instance
+     *
+     * @param file              the {@link FileChannel} which should be transfered
+     * @param position          the position from which the transfer should start
+     * @param count             the number of bytes to transfer
+     */
+    public DefaultFileRegionStream(FileChannel file, long position, long count) {
+        this.file = checkNotNull(file, "file");
+        this.position = checkPositiveOrZero(position, "position");
+        endPosition = position + checkPositiveOrZero(count, "count");
+    }
+
+    @Override
+    public FileRegion read(long bytes) {
+        if (refCnt() == 0) {
+            throw new IllegalReferenceCountException(0);
+        }
+
+        if (position + bytes > endPosition) {
+            throw new IllegalArgumentException();
+        }
+        FileRegion region = new DefaultFileRegion(file, position, bytes, false);
+        position += bytes;
+        return region;
+    }
+
+    @Override
+    public long readableBytes() {
+        return endPosition - position;
+    }
+
+    @Override
+    protected void deallocate() {
+        try {
+            file.close();
+        } catch (IOException e) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("Failed to close FileChannel.", e);
+            }
+        }
+    }
+
+    @Override
+    public DefaultFileRegionStream touch(Object hint) {
+        return this;
+    }
+
+    @Override
+    public DefaultFileRegionStream retain() {
+        super.retain();
+        return this;
+    }
+
+    @Override
+    public DefaultFileRegionStream retain(int increment) {
+        super.retain(increment);
+        return this;
+    }
+
+    @Override
+    public DefaultFileRegionStream touch() {
+        super.touch();
+        return this;
+    }
+}

--- a/transport/src/main/java/io/netty/channel/FileRegionStream.java
+++ b/transport/src/main/java/io/netty/channel/FileRegionStream.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import io.netty.util.ReferenceCounted;
+import io.netty.util.internal.UnstableApi;
+
+/**
+ * Provides a stream of {@link FileRegion}s.
+ */
+@UnstableApi
+public interface FileRegionStream extends ReferenceCounted {
+
+    /**
+     * Returns a {@link FileRegion} that contains the number of bytes.
+     */
+    FileRegion read(long bytes);
+
+    /**
+     * Returns the number of bytes that are still avaiable via {@link #read(long)}.
+     */
+    long readableBytes();
+}


### PR DESCRIPTION
…ion backed by some resource.

Motivation:

To support difference use-cases (like for example HTTP/2) we need the ability to dynamicly create FileRegion instances from a FileChannel in specific sizes.

Modifications:

- Add FileRegionStream and a DefaultFileRegionStream implementation which allows to create DefaultFileRegion instances using the same FileChannel instance.
- Allow to create DefaultFileRegion instances from a FileRegion and allow the user to take responsibility to close the FileChannel. This can be useful for users to write the same FileChannel multiple times without the overhead of calling
 open(...) all the times. This is important as open(...) may block and is also expensive.

Result:

Be able to create a stream of FileRegions.