### PR TITLE
Not use safeRelease(...) but release(...) to release non-readable hol…

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/AbstractEpollChannel.java
@@ -302,7 +302,7 @@ abstract class AbstractEpollChannel extends AbstractChannel implements UnixChann
     protected final ByteBuf newDirectBuffer(Object holder, ByteBuf buf) {
         final int readableBytes = buf.readableBytes();
         if (readableBytes == 0) {
-            ReferenceCountUtil.safeRelease(holder);
+            ReferenceCountUtil.release(holder);
             return Unpooled.EMPTY_BUFFER;
         }
 

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -248,7 +248,7 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     protected final ByteBuf newDirectBuffer(Object holder, ByteBuf buf) {
         final int readableBytes = buf.readableBytes();
         if (readableBytes == 0) {
-            ReferenceCountUtil.safeRelease(holder);
+            ReferenceCountUtil.release(holder);
             return Unpooled.EMPTY_BUFFER;
         }
 


### PR DESCRIPTION
…ders to ensure we not mask errors.

Motivation:

AbstractChannel attempts to "filter" messages which are written [1]. A goal of this process is to copy from heap to direct if necessary. However implementations of this method [2][3] may translate a buffer with 0 readable bytes to EMPTY_BUFFER. This may mask a user error where an empty buffer is written but already released.

Modifications:

Replace safeRelease(...) with release(...) to ensure we propagate reference count issues.

Result:

Fixes [#7383]