### PR TITLE
The constants calculation in compile-time

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/compression/FastLz.java
+++ b/codec/src/main/java/io/netty/handler/codec/compression/FastLz.java
@@ -168,7 +168,7 @@ final class FastLz {
                         readU16(input, inOffset + ip - 1) == readU16(input, inOffset + ip + 1)) {
                     distance = 1;
                     ip += 3;
-                    ref = anchor - 1 + 3;
+                    ref = anchor + (3 - 1);
 
                     /*
                      * goto match;

--- a/common/src/main/java/io/netty/util/internal/StringUtil.java
+++ b/common/src/main/java/io/netty/util/internal/StringUtil.java
@@ -48,19 +48,9 @@ public final class StringUtil {
 
     static {
         // Generate the lookup table that converts a byte into a 2-digit hexadecimal integer.
-        int i;
-        for (i = 0; i < 10; i++) {
-            BYTE2HEX_PAD[i] = "0" + i;
-            BYTE2HEX_NOPAD[i] = String.valueOf(i);
-        }
-        for (; i < 16; i++) {
-            char c = (char) ('a' + i - 10);
-            BYTE2HEX_PAD[i] = "0" + c;
-            BYTE2HEX_NOPAD[i] = String.valueOf(c);
-        }
-        for (; i < BYTE2HEX_PAD.length; i++) {
+        for (int i = 0; i < BYTE2HEX_PAD.length; i++) {
             String str = Integer.toHexString(i);
-            BYTE2HEX_PAD[i] = str;
+            BYTE2HEX_PAD[i] = i > 0xf ? str : ('0' + str);
             BYTE2HEX_NOPAD[i] = str;
         }
     }
@@ -226,10 +216,10 @@ public final class StringUtil {
             return c - '0';
         }
         if (c >= 'A' && c <= 'F') {
-            return c - 'A' + 0xA;
+            return c - ('A' - 0xA);
         }
         if (c >= 'a' && c <= 'f') {
-            return c - 'a' + 0xA;
+            return c - ('a' - 0xA);
         }
         return -1;
     }


### PR DESCRIPTION
Motivation:
Allow pre-computing calculation of the constants for compiler where it could be. Similar fix in OpenJDK: [1].

Modifications:
- Use parentheses.
- Simplify static initialization of `BYTE2HEX_*` arrays in `StringUtil`.

Result:
Less bytecode, possible faster calculations at runtime.

[1] https://bugs.openjdk.java.net/browse/JDK-4477961