### PR TITLE
Add SniCompletionEvent which allows to easily retrieve the hostname t…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/AbstractSniHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/AbstractSniHandler.java
@@ -257,7 +257,7 @@ public abstract class AbstractSniHandler<T> extends ByteToMessageDecoder impleme
         if (cause == null) {
             ctx.fireUserEventTriggered(new SniCompletionEvent(hostname));
         } else {
-            ctx.fireUserEventTriggered(new SniCompletionEvent(cause));
+            ctx.fireUserEventTriggered(new SniCompletionEvent(hostname, cause));
         }
     }
 

--- a/handler/src/main/java/io/netty/handler/ssl/SniCompletionEvent.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SniCompletionEvent.java
@@ -29,21 +29,24 @@ public final class SniCompletionEvent extends SslCompletionEvent {
         this.hostname = hostname;
     }
 
-    SniCompletionEvent(Throwable cause) {
+    SniCompletionEvent(String hostname, Throwable cause) {
         super(cause);
-        hostname = null;
+        this.hostname = hostname;
+    }
+
+    SniCompletionEvent(Throwable cause) {
+        this(null, cause);
     }
 
     /**
-     * Returns the SNI hostname send by the client of {@link #isSuccess()} is {@code true} otherwise
-     * it returns {@code null}.
+     * Returns the SNI hostname send by the client if we were able to parse it, {@code null} otherwise.
      */
     public String hostname() {
         return hostname;
     }
 
     @Override
-    public  String toString() {
+    public String toString() {
         final Throwable cause = cause();
         return cause == null ? getClass().getSimpleName() + "(SUCCESS='"  + hostname + "'\")":
                 getClass().getSimpleName() +  '(' + cause + ')';

--- a/handler/src/main/java/io/netty/handler/ssl/SniCompletionEvent.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SniCompletionEvent.java
@@ -15,39 +15,37 @@
  */
 package io.netty.handler.ssl;
 
-import io.netty.util.internal.ObjectUtil;
+import io.netty.util.internal.UnstableApi;
 
-public abstract class SslCompletionEvent {
+/**
+ * Event that is fired once we did a selection of a {@link SslContext} based on the {@code SNI hostname},
+ * which may be because it was successful or there was an error.
+ */
+@UnstableApi
+public final class SniCompletionEvent extends SslCompletionEvent {
+    private final String hostname;
 
-    private final Throwable cause;
-
-    SslCompletionEvent() {
-        cause = null;
+    SniCompletionEvent(String hostname) {
+        this.hostname = hostname;
     }
 
-    SslCompletionEvent(Throwable cause) {
-        this.cause = ObjectUtil.checkNotNull(cause, "cause");
+    SniCompletionEvent(Throwable cause) {
+        super(cause);
+        hostname = null;
     }
 
     /**
-     * Return {@code true} if the completion was successful
+     * Returns the SNI hostname send by the client of {@link #isSuccess()} is {@code true} otherwise
+     * it returns {@code null}.
      */
-    public final boolean isSuccess() {
-        return cause == null;
-    }
-
-    /**
-     * Return the {@link Throwable} if {@link #isSuccess()} returns {@code false}
-     * and so the completion failed.
-     */
-    public final Throwable cause() {
-        return cause;
+    public String hostname() {
+        return hostname;
     }
 
     @Override
     public  String toString() {
         final Throwable cause = cause();
-        return cause == null? getClass().getSimpleName() + "(SUCCESS)" :
+        return cause == null ? getClass().getSimpleName() + "(SUCCESS='"  + hostname + "'\")":
                 getClass().getSimpleName() +  '(' + cause + ')';
     }
 }


### PR DESCRIPTION
…hat was used to select the SslContext.

Motivation:

At the moment its a bit "hacky" to retrieve the hostname that was used during SNI as you need to hold a reference to SniHandler and then call hostname() once the selection is done. It would be better to fire an event to let the user know we did the selection.

Modifications:

Add a SniCompletionEvent that can be used to get the hostname that was used to do the selection and was included in the SNI extension.

Result:

Easier usage of SNI.
