### PR TITLE
Dont use the ThreadDeathWatcher to release memory back to PoolArena a…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -435,13 +435,19 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
             final PoolArena<byte[]> heapArena = leastUsedArena(heapArenas);
             final PoolArena<ByteBuffer> directArena = leastUsedArena(directArenas);
 
-            if (useCacheForAllThreads || Thread.currentThread() instanceof FastThreadLocalThread) {
+            Thread current = Thread.currentThread();
+            boolean fastThread = current instanceof FastThreadLocalThread;
+            if (useCacheForAllThreads || current instanceof FastThreadLocalThread) {
+                // If our FastThreadLocalThread will call FastThreadLocal.removeAll() we not need to use
+                // the ThreadDeathWatcher to release memory from the PoolThreadCache once the Thread dies.
+                boolean useTheadWatcher = fastThread ?
+                        !((FastThreadLocalThread) current).willCleanupFastThreadLocals() : true;
                 return new PoolThreadCache(
                         heapArena, directArena, tinyCacheSize, smallCacheSize, normalCacheSize,
-                        DEFAULT_MAX_CACHED_BUFFER_CAPACITY, DEFAULT_CACHE_TRIM_INTERVAL);
+                        DEFAULT_MAX_CACHED_BUFFER_CAPACITY, DEFAULT_CACHE_TRIM_INTERVAL, useTheadWatcher);
             }
             // No caching for non FastThreadLocalThreads.
-            return new PoolThreadCache(heapArena, directArena, 0, 0, 0, 0, 0);
+            return new PoolThreadCache(heapArena, directArena, 0, 0, 0, 0, 0, false);
         }
 
         @Override
@@ -594,7 +600,9 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
     }
 
     final PoolThreadCache threadCache() {
-        return threadCache.get();
+        PoolThreadCache cache =  threadCache.get();
+        assert cache != null;
+        return cache;
     }
 
     /**

--- a/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
+++ b/buffer/src/main/java/io/netty/buffer/PooledByteBufAllocator.java
@@ -439,12 +439,12 @@ public class PooledByteBufAllocator extends AbstractByteBufAllocator implements 
             boolean fastThread = current instanceof FastThreadLocalThread;
             if (useCacheForAllThreads || current instanceof FastThreadLocalThread) {
                 // If our FastThreadLocalThread will call FastThreadLocal.removeAll() we not need to use
-                // the ThreadDeathWatcher to release memory from the PoolThreadCache once the Thread dies.
-                boolean useTheadWatcher = fastThread ?
+                // a finalizer to release memory from the PoolThreadCache once the Thread dies.
+                boolean useFinalizer = fastThread ?
                         !((FastThreadLocalThread) current).willCleanupFastThreadLocals() : true;
                 return new PoolThreadCache(
                         heapArena, directArena, tinyCacheSize, smallCacheSize, normalCacheSize,
-                        DEFAULT_MAX_CACHED_BUFFER_CAPACITY, DEFAULT_CACHE_TRIM_INTERVAL, useTheadWatcher);
+                        DEFAULT_MAX_CACHED_BUFFER_CAPACITY, DEFAULT_CACHE_TRIM_INTERVAL, useFinalizer);
             }
             // No caching for non FastThreadLocalThreads.
             return new PoolThreadCache(heapArena, directArena, 0, 0, 0, 0, 0, false);

--- a/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
+++ b/buffer/src/test/java/io/netty/buffer/PooledByteBufAllocatorTest.java
@@ -290,8 +290,9 @@ public class PooledByteBufAllocatorTest extends AbstractByteBufAllocatorTest<Poo
             }
         }
 
-        // Wait for the ThreadDeathWatcher to have destroyed all thread caches
+        // Wait for the GC to have destroyed all thread caches
         while (allocator.metric().numThreadLocalCaches() > 0) {
+            System.gc();
             LockSupport.parkNanos(MILLISECONDS.toNanos(100));
         }
 

--- a/common/src/main/java/io/netty/util/ThreadDeathWatcher.java
+++ b/common/src/main/java/io/netty/util/ThreadDeathWatcher.java
@@ -37,7 +37,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * associated {@link Runnable}s.  When there is no thread to watch (i.e. all threads are dead), the daemon thread
  * will terminate itself, and a new daemon thread will be started again when a new watch is added.
  * </p>
+ * @deprecated this is not used within netty anymore and will be removed in the next major release.
  */
+@Deprecated
 public final class ThreadDeathWatcher {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(ThreadDeathWatcher.class);

--- a/common/src/main/java/io/netty/util/concurrent/DefaultThreadFactory.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultThreadFactory.java
@@ -105,7 +105,7 @@ public class DefaultThreadFactory implements ThreadFactory {
 
     @Override
     public Thread newThread(Runnable r) {
-        Thread t = newThread(new DefaultRunnableDecorator(r), prefix + nextId.incrementAndGet());
+        Thread t = newThread(FastThreadLocalRunnable.wrap(r), prefix + nextId.incrementAndGet());
         try {
             if (t.isDaemon() != daemon) {
                 t.setDaemon(daemon);
@@ -122,23 +122,5 @@ public class DefaultThreadFactory implements ThreadFactory {
 
     protected Thread newThread(Runnable r, String name) {
         return new FastThreadLocalThread(threadGroup, r, name);
-    }
-
-    private static final class DefaultRunnableDecorator implements Runnable {
-
-        private final Runnable r;
-
-        DefaultRunnableDecorator(Runnable r) {
-            this.r = r;
-        }
-
-        @Override
-        public void run() {
-            try {
-                r.run();
-            } finally {
-                FastThreadLocal.removeAll();
-            }
-        }
     }
 }

--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocalRunnable.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocalRunnable.java
@@ -1,0 +1,39 @@
+/*
+* Copyright 2014 The Netty Project
+*
+* The Netty Project licenses this file to you under the Apache License,
+* version 2.0 (the "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at:
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+package io.netty.util.concurrent;
+
+import io.netty.util.internal.ObjectUtil;
+
+final class FastThreadLocalRunnable implements Runnable {
+    private final Runnable runnable;
+
+    private FastThreadLocalRunnable(Runnable runnable) {
+        this.runnable = ObjectUtil.checkNotNull(runnable, "runnable");
+    }
+
+    @Override
+    public void run() {
+        try {
+            runnable.run();
+        } finally {
+            FastThreadLocal.removeAll();
+        }
+    }
+
+    static Runnable wrap(Runnable runnable) {
+        return runnable instanceof FastThreadLocalRunnable ? runnable : new FastThreadLocalRunnable(runnable);
+    }
+}

--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocalThread.java
@@ -16,42 +16,54 @@
 package io.netty.util.concurrent;
 
 import io.netty.util.internal.InternalThreadLocalMap;
+import io.netty.util.internal.UnstableApi;
 
 /**
  * A special {@link Thread} that provides fast access to {@link FastThreadLocal} variables.
  */
 public class FastThreadLocalThread extends Thread {
+    // This will be set to true if we have a chance to wrap the Runnable.
+    private final boolean cleanupFastThreadLocals;
 
     private InternalThreadLocalMap threadLocalMap;
 
-    public FastThreadLocalThread() { }
+    public FastThreadLocalThread() {
+        cleanupFastThreadLocals = false;
+    }
 
     public FastThreadLocalThread(Runnable target) {
-        super(target);
+        super(FastThreadLocalRunnable.wrap(target));
+        cleanupFastThreadLocals = true;
     }
 
     public FastThreadLocalThread(ThreadGroup group, Runnable target) {
-        super(group, target);
+        super(group, FastThreadLocalRunnable.wrap(target));
+        cleanupFastThreadLocals = true;
     }
 
     public FastThreadLocalThread(String name) {
         super(name);
+        cleanupFastThreadLocals = false;
     }
 
     public FastThreadLocalThread(ThreadGroup group, String name) {
         super(group, name);
+        cleanupFastThreadLocals = false;
     }
 
     public FastThreadLocalThread(Runnable target, String name) {
-        super(target, name);
+        super(FastThreadLocalRunnable.wrap(target), name);
+        cleanupFastThreadLocals = true;
     }
 
     public FastThreadLocalThread(ThreadGroup group, Runnable target, String name) {
-        super(group, target, name);
+        super(group, FastThreadLocalRunnable.wrap(target), name);
+        cleanupFastThreadLocals = true;
     }
 
     public FastThreadLocalThread(ThreadGroup group, Runnable target, String name, long stackSize) {
-        super(group, target, name, stackSize);
+        super(group, FastThreadLocalRunnable.wrap(target), name, stackSize);
+        cleanupFastThreadLocals = true;
     }
 
     /**
@@ -68,5 +80,13 @@ public class FastThreadLocalThread extends Thread {
      */
     public final void setThreadLocalMap(InternalThreadLocalMap threadLocalMap) {
         this.threadLocalMap = threadLocalMap;
+    }
+
+    /**
+     * Returns {@code true} if {@link FastThreadLocal#removeAll()} will be called once {@link #run()} completes.
+     */
+    @UnstableApi
+    public boolean willCleanupFastThreadLocals() {
+        return cleanupFastThreadLocals;
     }
 }


### PR DESCRIPTION
…fter PoolThreadCache is not used anymore

Motivation:

At the moment we use the ThreadDeathWatcher to release memory back to the PoolArena after the PoolThreadCache is not used anymore if the cache is used by a non-FastThreadLocalThread. This will need to spawn on extra thread and iterate over all the Threads each second.

Modifications:

Better just use a finalizer to return the memory back to the PoolArena after the cache is not used anymore and the cache belonged to a non-FastThreadLocalThread.

Result:

Less running threads / overhead.