### PR TITLE
Throw FileNotFoundException when connecting to a missing UDS path

### DIFF
--- a/transport-native-unix-common/src/main/c/netty_unix_errors.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_errors.c
@@ -78,6 +78,10 @@ void netty_unix_errors_throwOutOfMemoryError(JNIEnv* env) {
 }
 
 // JNI Registered Methods Begin
+static jint netty_unix_errors_errnoENOENT(JNIEnv* env, jclass clazz) {
+    return ENOENT;
+}
+
 static jint netty_unix_errors_errnoENOTCONN(JNIEnv* env, jclass clazz) {
     return ENOTCONN;
 }
@@ -129,6 +133,7 @@ static jstring netty_unix_errors_strError(JNIEnv* env, jclass clazz, jint error)
 
 // JNI Method Registration Table Begin
 static const JNINativeMethod statically_referenced_fixed_method_table[] = {
+  { "errnoENOENT", "()I", (void *) netty_unix_errors_errnoENOENT },
   { "errnoENOTCONN", "()I", (void *) netty_unix_errors_errnoENOTCONN },
   { "errnoEBADF", "()I", (void *) netty_unix_errors_errnoEBADF },
   { "errnoEPIPE", "()I", (void *) netty_unix_errors_errnoEPIPE },

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/Errors.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/Errors.java
@@ -17,6 +17,7 @@ package io.netty.channel.unix;
 
 import io.netty.util.internal.EmptyArrays;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.NoRouteToHostException;
@@ -33,6 +34,7 @@ import static io.netty.channel.unix.ErrorsStaticallyReferencedJniMethods.*;
  */
 public final class Errors {
     // As all our JNI methods return -errno on error we need to compare with the negative errno codes.
+    public static final int ERRNO_ENOENT_NEGATIVE = -errnoENOENT();
     public static final int ERRNO_ENOTCONN_NEGATIVE = -errnoENOTCONN();
     public static final int ERRNO_EBADF_NEGATIVE = -errnoEBADF();
     public static final int ERRNO_EPIPE_NEGATIVE = -errnoEPIPE();
@@ -104,6 +106,9 @@ public final class Errors {
         if (err == ERROR_EISCONN_NEGATIVE) {
             throw new AlreadyConnectedException();
         }
+        if (err == ERRNO_ENOENT_NEGATIVE) {
+            throw new FileNotFoundException();
+        }
         throw new ConnectException(method + "(..) failed: " + ERRORS[-err]);
     }
 
@@ -131,6 +136,9 @@ public final class Errors {
         }
         if (err == ERRNO_ENOTCONN_NEGATIVE) {
             throw new NotYetConnectedException();
+        }
+        if (err == ERRNO_ENOENT_NEGATIVE) {
+            throw new FileNotFoundException();
         }
 
         // TODO: We could even go further and use a pre-instantiated IOException for the other error codes, but for

--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/ErrorsStaticallyReferencedJniMethods.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/ErrorsStaticallyReferencedJniMethods.java
@@ -30,6 +30,7 @@ final class ErrorsStaticallyReferencedJniMethods {
 
     private ErrorsStaticallyReferencedJniMethods() { }
 
+    static native int errnoENOENT();
     static native int errnoEBADF();
     static native int errnoEPIPE();
     static native int errnoECONNRESET();


### PR DESCRIPTION
Motivation:
Exception handling is nicer when a more specific Exception is thrown

Modification:
Add a static reference for ENOENT, and throw FNFE if it is returned

Result:
More precise exception handling
