### PR TITLE
Only try to match SSLException message when debug logging is enabled.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1506,13 +1506,15 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
                 try {
                     engine.closeInbound();
                 } catch (SSLException e) {
-                    // only log in debug mode as it most likely harmless and latest chrome still trigger
-                    // this all the time.
-                    //
-                    // See https://github.com/netty/netty/issues/1340
-                    String msg = e.getMessage();
-                    if (msg == null || !msg.contains("possible truncation attack")) {
-                        logger.debug("{} SSLEngine.closeInbound() raised an exception.", ctx.channel(), e);
+                    if (logger.isDebugEnabled()) {
+                        // only log in debug mode as it most likely harmless and latest chrome still trigger
+                        // this all the time.
+                        //
+                        // See https://github.com/netty/netty/issues/1340
+                        String msg = e.getMessage();
+                        if (msg == null || !msg.contains("possible truncation attack")) {
+                            logger.debug("{} SSLEngine.closeInbound() raised an exception.", ctx.channel(), e);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Motivation:

We only want to log for the particular case when debug logging is enabled so we not need to try to match the message if this is not the case.

Modifications:

Guard with logger.isDebugEnabled()

Result:

Less overhead when debug logging is not enabled.