### PR TITLE
Ability to scoop up events that reach the tail of the ChannelPipeline

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -1165,6 +1165,20 @@ public class DefaultChannelPipeline implements ChannelPipeline {
     }
 
     /**
+     * Called once the {@link ChannelInboundHandler#channelActive(ChannelHandlerContext)}event hit
+     * the end of the {@link ChannelPipeline}.
+     */
+    protected void onUnhandledInboundChannelActive() {
+    }
+
+    /**
+     * Called once the {@link ChannelInboundHandler#channelInactive(ChannelHandlerContext)} event hit
+     * the end of the {@link ChannelPipeline}.
+     */
+    protected void onUnhandledInboundChannelInactive() {
+    }
+
+    /**
      * Called once a message hit the end of the {@link ChannelPipeline} without been handled by the user
      * in {@link ChannelInboundHandler#channelRead(ChannelHandlerContext, Object)}. This method is responsible
      * to call {@link ReferenceCountUtil#release(Object)} on the given msg at some point.
@@ -1177,6 +1191,31 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         } finally {
             ReferenceCountUtil.release(msg);
         }
+    }
+
+    /**
+     * Called once the {@link ChannelInboundHandler#channelReadComplete(ChannelHandlerContext)} event hit
+     * the end of the {@link ChannelPipeline}.
+     */
+    protected void onUnhandledInboundChannelReadComplete() {
+    }
+
+    /**
+     * Called once an user event hit the end of the {@link ChannelPipeline} without been handled by the user
+     * in {@link ChannelInboundHandler#userEventTriggered(ChannelHandlerContext, Object)}. This method is responsible
+     * to call {@link ReferenceCountUtil#release(Object)} on the given event at some point.
+     */
+    protected void onUnhandledInboundUserEventTriggered(Object evt) {
+        // This may not be a configuration error and so don't log anything.
+        // The event may be superfluous for the current pipeline configuration.
+        ReferenceCountUtil.release(evt);
+    }
+
+    /**
+     * Called once the {@link ChannelInboundHandler#channelWritabilityChanged(ChannelHandlerContext)} event hit
+     * the end of the {@link ChannelPipeline}.
+     */
+    protected void onUnhandledChannelWritabilityChanged() {
     }
 
     @UnstableApi
@@ -1215,13 +1254,19 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         public void channelUnregistered(ChannelHandlerContext ctx) throws Exception { }
 
         @Override
-        public void channelActive(ChannelHandlerContext ctx) throws Exception { }
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            onUnhandledInboundChannelActive();
+        }
 
         @Override
-        public void channelInactive(ChannelHandlerContext ctx) throws Exception { }
+        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+            onUnhandledInboundChannelInactive();
+        }
 
         @Override
-        public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception { }
+        public void channelWritabilityChanged(ChannelHandlerContext ctx) throws Exception {
+            onUnhandledChannelWritabilityChanged();
+        }
 
         @Override
         public void handlerAdded(ChannelHandlerContext ctx) throws Exception { }
@@ -1231,9 +1276,7 @@ public class DefaultChannelPipeline implements ChannelPipeline {
 
         @Override
         public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-            // This may not be a configuration error and so don't log anything.
-            // The event may be superfluous for the current pipeline configuration.
-            ReferenceCountUtil.release(evt);
+            onUnhandledInboundUserEventTriggered(evt);
         }
 
         @Override
@@ -1247,7 +1290,9 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         }
 
         @Override
-        public void channelReadComplete(ChannelHandlerContext ctx) throws Exception { }
+        public void channelReadComplete(ChannelHandlerContext ctx) throws Exception {
+            onUnhandledInboundChannelReadComplete();
+        }
     }
 
     final class HeadContext extends AbstractChannelHandlerContext

--- a/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTailTest.java
+++ b/transport/src/test/java/io/netty/channel/DefaultChannelPipelineTailTest.java
@@ -1,0 +1,408 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.netty.bootstrap.Bootstrap;
+
+public class DefaultChannelPipelineTailTest {
+
+    private static EventLoopGroup GROUP;
+
+    @BeforeClass
+    public static void init() {
+        GROUP = new DefaultEventLoopGroup(1);
+    }
+
+    @AfterClass
+    public static void destroy() {
+        GROUP.shutdownGracefully();
+    }
+
+    @Test
+    public void testOnUnhandledInboundChannelActive() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        MyChannel myChannel = new MyChannel() {
+            @Override
+            protected void onUnhandledInboundChannelActive() {
+                latch.countDown();
+            }
+        };
+
+        Bootstrap bootstrap = new Bootstrap()
+                .channelFactory(new MyChannelFactory(myChannel))
+                .group(GROUP)
+                .handler(new ChannelInboundHandlerAdapter())
+                .remoteAddress(new InetSocketAddress(0));
+
+        Channel channel = bootstrap.connect()
+                .sync().channel();
+
+        try {
+            assertTrue(latch.await(1L, TimeUnit.SECONDS));
+        } finally {
+            channel.close();
+        }
+    }
+
+    @Test
+    public void testOnUnhandledInboundChannelInactive() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        MyChannel myChannel = new MyChannel() {
+            @Override
+            protected void onUnhandledInboundChannelInactive() {
+                latch.countDown();
+            }
+        };
+
+        Bootstrap bootstrap = new Bootstrap()
+                .channelFactory(new MyChannelFactory(myChannel))
+                .group(GROUP)
+                .handler(new ChannelInboundHandlerAdapter())
+                .remoteAddress(new InetSocketAddress(0));
+
+        Channel channel = bootstrap.connect()
+                .sync().channel();
+
+        channel.close().syncUninterruptibly();
+
+        assertTrue(latch.await(1L, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testOnUnhandledInboundException() throws Exception {
+        final AtomicReference<Throwable> causeRef = new AtomicReference<Throwable>();
+        final CountDownLatch latch = new CountDownLatch(1);
+        MyChannel myChannel = new MyChannel() {
+            @Override
+            protected void onUnhandledInboundException(Throwable cause) {
+                causeRef.set(cause);
+                latch.countDown();
+            }
+        };
+
+        Bootstrap bootstrap = new Bootstrap()
+                .channelFactory(new MyChannelFactory(myChannel))
+                .group(GROUP)
+                .handler(new ChannelInboundHandlerAdapter())
+                .remoteAddress(new InetSocketAddress(0));
+
+        Channel channel = bootstrap.connect()
+                .sync().channel();
+
+        try {
+            IOException ex = new IOException("testOnUnhandledInboundException");
+            channel.pipeline().fireExceptionCaught(ex);
+            assertTrue(latch.await(1L, TimeUnit.SECONDS));
+            assertSame(ex, causeRef.get());
+        } finally {
+            channel.close();
+        }
+    }
+
+    @Test
+    public void testOnUnhandledInboundMessage() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        MyChannel myChannel = new MyChannel() {
+            @Override
+            protected void onUnhandledInboundMessage(Object msg) {
+                latch.countDown();
+            }
+        };
+
+        Bootstrap bootstrap = new Bootstrap()
+                .channelFactory(new MyChannelFactory(myChannel))
+                .group(GROUP)
+                .handler(new ChannelInboundHandlerAdapter())
+                .remoteAddress(new InetSocketAddress(0));
+
+        Channel channel = bootstrap.connect()
+                .sync().channel();
+
+        try {
+            channel.pipeline().fireChannelRead("testOnUnhandledInboundMessage");
+            assertTrue(latch.await(1L, TimeUnit.SECONDS));
+        } finally {
+            channel.close();
+        }
+    }
+
+    @Test
+    public void testOnUnhandledInboundReadComplete() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        MyChannel myChannel = new MyChannel() {
+            @Override
+            protected void onUnhandledInboundReadComplete() {
+                latch.countDown();
+            }
+        };
+
+        Bootstrap bootstrap = new Bootstrap()
+                .channelFactory(new MyChannelFactory(myChannel))
+                .group(GROUP)
+                .handler(new ChannelInboundHandlerAdapter())
+                .remoteAddress(new InetSocketAddress(0));
+
+        Channel channel = bootstrap.connect()
+                .sync().channel();
+
+        try {
+            channel.pipeline().fireChannelReadComplete();
+            assertTrue(latch.await(1L, TimeUnit.SECONDS));
+        } finally {
+            channel.close();
+        }
+    }
+
+    @Test
+    public void testOnUnhandledInboundUserEventTriggered() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        MyChannel myChannel = new MyChannel() {
+            @Override
+            protected void onUnhandledInboundUserEventTriggered(Object evt) {
+                latch.countDown();
+            }
+        };
+
+        Bootstrap bootstrap = new Bootstrap()
+                .channelFactory(new MyChannelFactory(myChannel))
+                .group(GROUP)
+                .handler(new ChannelInboundHandlerAdapter())
+                .remoteAddress(new InetSocketAddress(0));
+
+        Channel channel = bootstrap.connect()
+                .sync().channel();
+
+        try {
+            channel.pipeline().fireUserEventTriggered("testOnUnhandledInboundUserEventTriggered");
+            assertTrue(latch.await(1L, TimeUnit.SECONDS));
+        } finally {
+            channel.close();
+        }
+    }
+
+    @Test
+    public void testOnUnhandledInboundWritabilityChanged() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        MyChannel myChannel = new MyChannel() {
+            @Override
+            protected void onUnhandledInboundWritabilityChanged() {
+                latch.countDown();
+            }
+        };
+
+        Bootstrap bootstrap = new Bootstrap()
+                .channelFactory(new MyChannelFactory(myChannel))
+                .group(GROUP)
+                .handler(new ChannelInboundHandlerAdapter())
+                .remoteAddress(new InetSocketAddress(0));
+
+        Channel channel = bootstrap.connect()
+                .sync().channel();
+
+        try {
+            channel.pipeline().fireChannelWritabilityChanged();
+            assertTrue(latch.await(1L, TimeUnit.SECONDS));
+        } finally {
+            channel.close();
+        }
+    }
+
+    private static class MyChannelFactory implements ChannelFactory<MyChannel> {
+        private final MyChannel channel;
+
+        public MyChannelFactory(MyChannel channel) {
+            this.channel = channel;
+        }
+
+        @Override
+        public MyChannel newChannel() {
+            return channel;
+        }
+    }
+
+    private abstract static class MyChannel extends AbstractChannel {
+        private static final ChannelMetadata METADATA = new ChannelMetadata(false);
+
+        private final ChannelConfig config = new DefaultChannelConfig(this);
+
+        private boolean active;
+        private boolean closed;
+
+        protected MyChannel() {
+            super(null);
+        }
+
+        @Override
+        protected DefaultChannelPipeline newChannelPipeline() {
+            return new MyChannelPipeline(this);
+        }
+
+        @Override
+        public ChannelConfig config() {
+            return config;
+        }
+
+        @Override
+        public boolean isOpen() {
+            return !closed;
+        }
+
+        @Override
+        public boolean isActive() {
+            return isOpen() && active;
+        }
+
+        @Override
+        public ChannelMetadata metadata() {
+            return METADATA;
+        }
+
+        @Override
+        protected AbstractUnsafe newUnsafe() {
+            return new MyUnsafe();
+        }
+
+        @Override
+        protected boolean isCompatible(EventLoop loop) {
+            return true;
+        }
+
+        @Override
+        protected SocketAddress localAddress0() {
+            return null;
+        }
+
+        @Override
+        protected SocketAddress remoteAddress0() {
+            return null;
+        }
+
+        @Override
+        protected void doBind(SocketAddress localAddress) throws Exception {
+        }
+
+        @Override
+        protected void doDisconnect() throws Exception {
+        }
+
+        @Override
+        protected void doClose() throws Exception {
+            closed = true;
+        }
+
+        @Override
+        protected void doBeginRead() throws Exception {
+        }
+
+        @Override
+        protected void doWrite(ChannelOutboundBuffer in) throws Exception {
+            throw new IOException();
+        }
+
+        protected void onUnhandledInboundChannelActive() {
+        }
+
+        protected void onUnhandledInboundChannelInactive() {
+        }
+
+        protected void onUnhandledInboundException(Throwable cause) {
+        }
+
+        protected void onUnhandledInboundMessage(Object msg) {
+        }
+
+        protected void onUnhandledInboundReadComplete() {
+        }
+
+        protected void onUnhandledInboundUserEventTriggered(Object evt) {
+        }
+
+        protected void onUnhandledInboundWritabilityChanged() {
+        }
+
+        private class MyUnsafe extends AbstractUnsafe {
+            @Override
+            public void connect(SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) {
+                if (!ensureOpen(promise)) {
+                    return;
+                }
+
+                if (!active) {
+                    active = true;
+                    pipeline().fireChannelActive();
+                }
+
+                promise.setSuccess();
+            }
+        }
+
+        private class MyChannelPipeline extends DefaultChannelPipeline {
+
+            public MyChannelPipeline(Channel channel) {
+                super(channel);
+            }
+
+            @Override
+            protected void onUnhandledInboundChannelActive() {
+                MyChannel.this.onUnhandledInboundChannelActive();
+            }
+
+            @Override
+            protected void onUnhandledInboundChannelInactive() {
+                MyChannel.this.onUnhandledInboundChannelInactive();
+            }
+
+            @Override
+            protected void onUnhandledInboundException(Throwable cause) {
+                MyChannel.this.onUnhandledInboundException(cause);
+            }
+
+            @Override
+            protected void onUnhandledInboundMessage(Object msg) {
+                MyChannel.this.onUnhandledInboundMessage(msg);
+            }
+
+            @Override
+            protected void onUnhandledInboundChannelReadComplete() {
+                MyChannel.this.onUnhandledInboundReadComplete();
+            }
+
+            @Override
+            protected void onUnhandledInboundUserEventTriggered(Object evt) {
+                MyChannel.this.onUnhandledInboundUserEventTriggered(evt);
+            }
+
+            @Override
+            protected void onUnhandledChannelWritabilityChanged() {
+                MyChannel.this.onUnhandledInboundWritabilityChanged();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation

There is currently no way to enforce the position of a handler in a ChannelPipeline and assume you wanted to write something like a custom Channel type that acts as a proxy between two other Channels.

ProxyChannel(Channel client, Channel server) {
  client calls write(msg) -> server.write(msg)
  client calls flush() -> server.flush()
  server calls fireChannelRead(msg) -> client.write(msg)
  server calls fireChannelReadComplete() -> client.flush()
}

In order to make it work reliably one needs to be able to scoop up the various events at the head and tail of the pipeline. The head side of the pipeline is covered by Unsafe and it's also relatively safe to count on the user to not use the addFirst() method to manipulate the pipeline. The tail side is always at a risk of getting broken because addLast() is the goto method to add handlers.

Modifications

Adding a few extra methods to DefaultChannelPipeline that expose some of the events that reach the pipeline's TailContext.

Result

Fixes #7484
