### PR TITLE
Fix failing h2spec tests 8.1.2.1 related to pseudo-headers validation

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -16,6 +16,7 @@ package io.netty.handler.codec.http2;
 
 import static io.netty.handler.codec.http2.Http2Error.PROTOCOL_ERROR;
 import static io.netty.handler.codec.http2.Http2Exception.connectionError;
+import static io.netty.handler.codec.http2.Http2Headers.PseudoHeaderName.hasPseudoHeaderFormat;
 import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
 import static io.netty.util.AsciiString.isUpperCase;
 import io.netty.handler.codec.CharSequenceValueConverter;
@@ -30,7 +31,7 @@ public class DefaultHttp2Headers
         extends DefaultHeaders<CharSequence, CharSequence, Http2Headers> implements Http2Headers {
     private static final ByteProcessor HTTP2_NAME_VALIDATOR_PROCESSOR = new ByteProcessor() {
         @Override
-        public boolean process(byte value) throws Exception {
+        public boolean process(byte value) {
             return !isUpperCase(value);
         }
     };
@@ -197,7 +198,7 @@ public class DefaultHttp2Headers
             this.next = next;
 
             // Make sure the pseudo headers fields are first in iteration order
-            if (key.length() != 0 && key.charAt(0) == ':') {
+            if (hasPseudoHeaderFormat(key)) {
                 after = firstNonPseudo;
                 before = firstNonPseudo.before();
             } else {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2HeadersDecoder.java
@@ -115,7 +115,7 @@ public class DefaultHttp2HeadersDecoder implements Http2HeadersDecoder, Http2Hea
     public Http2Headers decodeHeaders(int streamId, ByteBuf headerBlock) throws Http2Exception {
         try {
             final Http2Headers headers = newHeaders();
-            hpackDecoder.decode(streamId, headerBlock, headers);
+            hpackDecoder.decode(streamId, headerBlock, headers, validateHeaders);
             headerArraySizeAccumulator = HEADERS_COUNT_WEIGHT_NEW * headers.size() +
                                          HEADERS_COUNT_WEIGHT_HISTORICAL * headerArraySizeAccumulator;
             return headers;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Headers.java
@@ -35,38 +35,44 @@ public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2H
         /**
          * {@code :method}.
          */
-        METHOD(":method"),
+        METHOD(":method", true),
 
         /**
          * {@code :scheme}.
          */
-        SCHEME(":scheme"),
+        SCHEME(":scheme", true),
 
         /**
          * {@code :authority}.
          */
-        AUTHORITY(":authority"),
+        AUTHORITY(":authority", true),
 
         /**
          * {@code :path}.
          */
-        PATH(":path"),
+        PATH(":path", true),
 
         /**
          * {@code :status}.
          */
-        STATUS(":status");
+        STATUS(":status", false);
+
+        private static final char PSEUDO_HEADER_PREFIX = ':';
+        private static final byte PSEUDO_HEADER_PREFIX_BYTE = (byte) PSEUDO_HEADER_PREFIX;
 
         private final AsciiString value;
-        private static final CharSequenceMap<AsciiString> PSEUDO_HEADERS = new CharSequenceMap<AsciiString>();
+        private final boolean requestOnly;
+        private static final CharSequenceMap<PseudoHeaderName> PSEUDO_HEADERS = new CharSequenceMap<PseudoHeaderName>();
+
         static {
             for (PseudoHeaderName pseudoHeader : PseudoHeaderName.values()) {
-                PSEUDO_HEADERS.add(pseudoHeader.value(), AsciiString.EMPTY_STRING);
+                PSEUDO_HEADERS.add(pseudoHeader.value(), pseudoHeader);
             }
         }
 
-        PseudoHeaderName(String value) {
+        PseudoHeaderName(String value, boolean requestOnly) {
             this.value = AsciiString.cached(value);
+            this.requestOnly = requestOnly;
         }
 
         public AsciiString value() {
@@ -75,10 +81,42 @@ public interface Http2Headers extends Headers<CharSequence, CharSequence, Http2H
         }
 
         /**
+         * Indicates whether the specified header follows the pseudo-header format (begins with ':' character)
+         *
+         * @return {@code true} if the header follow the pseudo-header format
+         */
+        public static boolean hasPseudoHeaderFormat(CharSequence headerName) {
+            if (headerName instanceof AsciiString) {
+                final AsciiString asciiHeaderName = (AsciiString) headerName;
+                return asciiHeaderName.length() > 0 && asciiHeaderName.byteAt(0) == PSEUDO_HEADER_PREFIX_BYTE;
+            } else {
+                return headerName.length() > 0 && headerName.charAt(0) == PSEUDO_HEADER_PREFIX;
+            }
+        }
+
+        /**
          * Indicates whether the given header name is a valid HTTP/2 pseudo header.
          */
         public static boolean isPseudoHeader(CharSequence header) {
             return PSEUDO_HEADERS.contains(header);
+        }
+
+        /**
+         * Returns the {@link PseudoHeaderName} corresponding to the specified header name.
+         *
+         * @return corresponding {@link PseudoHeaderName} if any, {@code null} otherwise.
+         */
+        public static PseudoHeaderName getPseudoHeader(CharSequence header) {
+            return PSEUDO_HEADERS.get(header);
+        }
+
+        /**
+         * Indicates whether the pseudo-header is to be used in a request context.
+         *
+         * @return {@code true} if the pseudo-header is to be used in a request context
+         */
+        public boolean isRequestOnly() {
+            return requestOnly;
         }
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackEncoderTest.java
@@ -31,7 +31,7 @@ public class HpackEncoderTest {
     private Http2Headers mockHeaders;
 
     @Before
-    public void setUp() throws Http2Exception {
+    public void setUp() {
         hpackEncoder = new HpackEncoder();
         hpackDecoder = new HpackDecoder(DEFAULT_HEADER_LIST_SIZE, 32);
         mockHeaders = mock(Http2Headers.class);
@@ -42,7 +42,7 @@ public class HpackEncoderTest {
         ByteBuf buf = Unpooled.buffer();
         hpackEncoder.setMaxHeaderTableSize(buf, MAX_HEADER_TABLE_SIZE);
         hpackDecoder.setMaxHeaderTableSize(MAX_HEADER_TABLE_SIZE);
-        hpackDecoder.decode(0, buf, mockHeaders);
+        hpackDecoder.decode(0, buf, mockHeaders, true);
         assertEquals(MAX_HEADER_TABLE_SIZE, hpackDecoder.getMaxHeaderTableSize());
         buf.release();
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTestCase.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackTestCase.java
@@ -214,7 +214,7 @@ final class HpackTestCase {
         try {
             List<HpackHeaderField> headers = new ArrayList<HpackHeaderField>();
             TestHeaderListener listener = new TestHeaderListener(headers);
-            hpackDecoder.decode(0, in, listener);
+            hpackDecoder.decode(0, in, listener, true);
             return headers;
         } finally {
             in.release();

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InOrderHttp2Headers.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InOrderHttp2Headers.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.http2;
+
+import io.netty.handler.codec.CharSequenceValueConverter;
+import io.netty.handler.codec.DefaultHeaders;
+
+import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
+
+/**
+ * Http2Headers implementation that preserves headers insertion order.
+ */
+public class InOrderHttp2Headers
+        extends DefaultHeaders<CharSequence, CharSequence, Http2Headers> implements Http2Headers {
+
+    InOrderHttp2Headers() {
+        super(CharSequenceValueConverter.INSTANCE);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof Http2Headers && equals((Http2Headers) o, CASE_SENSITIVE_HASHER);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode(CASE_SENSITIVE_HASHER);
+    }
+
+    @Override
+    public Http2Headers method(CharSequence value) {
+        set(PseudoHeaderName.METHOD.value(), value);
+        return this;
+    }
+
+    @Override
+    public Http2Headers scheme(CharSequence value) {
+        set(PseudoHeaderName.SCHEME.value(), value);
+        return this;
+    }
+
+    @Override
+    public Http2Headers authority(CharSequence value) {
+        set(PseudoHeaderName.AUTHORITY.value(), value);
+        return this;
+    }
+
+    @Override
+    public Http2Headers path(CharSequence value) {
+        set(PseudoHeaderName.PATH.value(), value);
+        return this;
+    }
+
+    @Override
+    public Http2Headers status(CharSequence value) {
+        set(PseudoHeaderName.STATUS.value(), value);
+        return this;
+    }
+
+    @Override
+    public CharSequence method() {
+        return get(PseudoHeaderName.METHOD.value());
+    }
+
+    @Override
+    public CharSequence scheme() {
+        return get(PseudoHeaderName.SCHEME.value());
+    }
+
+    @Override
+    public CharSequence authority() {
+        return get(PseudoHeaderName.AUTHORITY.value());
+    }
+
+    @Override
+    public CharSequence path() {
+        return get(PseudoHeaderName.PATH.value());
+    }
+
+    @Override
+    public CharSequence status() {
+        return get(PseudoHeaderName.STATUS.value());
+    }
+}

--- a/codec-http2/src/test/resources/io/netty/handler/codec/http2/testdata/testStaticTableEntries.json
+++ b/codec-http2/src/test/resources/io/netty/handler/codec/http2/testdata/testStaticTableEntries.json
@@ -10,13 +10,6 @@
         { ":path": "/index.html" },
         { ":scheme": "http" },
         { ":scheme": "https" },
-        { ":status": "200" },
-        { ":status": "204" },
-        { ":status": "206" },
-        { ":status": "304" },
-        { ":status": "400" },
-        { ":status": "404" },
-        { ":status": "500" },
         { "accept-charset": "" },
         { "accept-encoding": "gzip, deflate" },
         { "accept-language": "" },
@@ -66,7 +59,7 @@
         { "www-authenticate": "" }
       ],
       "encoded": [
-        "8182 8384 8586 8788 898a 8b8c 8d8e 8f90",
+        "8182 8384 8586 87 8f90",
         "9192 9394 9596 9798 999a 9b9c 9d9e 9fa0",
         "a1a2 a3a4 a5a6 a7a8 a9aa abac adae afb0",
         "b1b2 b3b4 b5b6 b7b8 b9ba bbbc bd"

--- a/codec-http2/src/test/resources/io/netty/handler/codec/http2/testdata/testStaticTableResponseEntries.json
+++ b/codec-http2/src/test/resources/io/netty/handler/codec/http2/testdata/testStaticTableResponseEntries.json
@@ -1,0 +1,23 @@
+{
+  "header_blocks":
+  [
+    {
+      "headers": [
+        { ":status": "200" },
+        { ":status": "204" },
+        { ":status": "206" },
+        { ":status": "304" },
+        { ":status": "400" },
+        { ":status": "404" },
+        { ":status": "500" }
+      ],
+      "encoded": [
+        "8889 8a8b 8c8d 8e"
+      ],
+      "dynamic_table": [
+      ],
+      "table_size": 0
+    }
+  ]
+}
+

--- a/microbench/src/main/java/io/netty/handler/codec/http2/HpackDecoderBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/http2/HpackDecoderBenchmark.java
@@ -82,7 +82,7 @@ public class HpackDecoderBenchmark extends AbstractMicrobenchmark {
                 return this;
             }
         };
-        hpackDecoder.decode(0, input.duplicate(), headers);
+        hpackDecoder.decode(0, input.duplicate(), headers, true);
     }
 
     private byte[] getSerializedHeaders(Http2Headers headers, boolean sensitive) throws Http2Exception {

--- a/testsuite-http2/pom.xml
+++ b/testsuite-http2/pom.xml
@@ -72,9 +72,6 @@
             <excludeSpec>5.1 - closed: Sends a HEADERS frame</excludeSpec>
             <excludeSpec>5.1.1 - Sends stream identifier that is numerically smaller than previous</excludeSpec>
             <excludeSpec>7 - Sends a GOAWAY frame with unknown error code</excludeSpec>
-            <excludeSpec>8.1.2.1 - Sends a HEADERS frame that contains a unknown pseudo-header field</excludeSpec>
-            <excludeSpec>8.1.2.1 - Sends a HEADERS frame that contains the pseudo-header field defined for response</excludeSpec>
-            <excludeSpec>8.1.2.1 - Sends a HEADERS frame that contains a pseudo-header field that appears in a header block after a regular header field</excludeSpec>
             <excludeSpec>8.1.2.2 - Sends a HEADERS frame that contains the connection-specific header field</excludeSpec>
             <excludeSpec>8.1.2.2 - Sends a HEADERS frame that contains the TE header field with any value other than "trailers"</excludeSpec>
             <excludeSpec>8.1.2.3 - Sends a HEADERS frame with empty ":path" pseudo-header field</excludeSpec>


### PR DESCRIPTION
**Motivation:**

According to the [spec](http://httpwg.org/specs/rfc7540.html#HttpHeaders):

> All pseudo-header fields MUST appear in the header block before regular
> header fields. Any request or response that contains a pseudo-header
> field that appears in a header block after
> a regular header field MUST be treated as malformed (Section 8.1.2.6).

> Pseudo-header fields are only valid in the context in which they are defined.
> Pseudo-header fields defined for requests MUST NOT appear in responses;
> pseudo-header fields defined for responses MUST NOT appear in requests.
> Pseudo-header fields MUST NOT appear in trailers.
> Endpoints MUST treat a request or response that contains undefined or
> invalid pseudo-header fields as malformed (Section 8.1.2.6).

> Clients MUST NOT accept a malformed response. Note that these requirements
> are intended to protect against several types of common attacks against HTTP;
> they are deliberately strict because being permissive can expose
> implementations to these vulnerabilities.

**Modifications:**

- Introduce new constructor to DefaultHttp2Headers allowing
  header insertion order to be preserved (useful for testing)
- Assign a PseudoHeaderType (REQUEST|RESPONSE) to PseudoHeaderName
- Group variables related to header decoding to the inner class
  HeadersDecodingState
- Add pseudo-header validation to DefaultHttp2HeaderDecoder

**Result:**

- Requests with unknown pseudo-field headers are rejected
- Requests with containing response specific pseudo-headers are rejected
- Requests where pseudo-header appear after regular header are rejected
- Fixes #5761 tests 8.1.2.1

