### PR TITLE
Only enable validation of headers if original headers were validating…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
@@ -142,7 +142,10 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
 
     @Override
     public FullHttpRequest replace(ByteBuf content) {
-        return new DefaultFullHttpRequest(protocolVersion(), method(), uri(), content, headers(), trailingHeaders());
+        FullHttpRequest request = new DefaultFullHttpRequest(protocolVersion(), method(), uri(), content,
+                HttpHeaders.copy(headers()), HttpHeaders.copy(trailingHeaders()));
+        request.setDecoderResult(decoderResult());
+        return request;
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpRequest.java
@@ -143,7 +143,7 @@ public class DefaultFullHttpRequest extends DefaultHttpRequest implements FullHt
     @Override
     public FullHttpRequest replace(ByteBuf content) {
         FullHttpRequest request = new DefaultFullHttpRequest(protocolVersion(), method(), uri(), content,
-                HttpHeaders.copy(headers()), HttpHeaders.copy(trailingHeaders()));
+                headers().copy(), trailingHeaders().copy());
         request.setDecoderResult(decoderResult());
         return request;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
@@ -150,7 +150,7 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
     @Override
     public FullHttpResponse replace(ByteBuf content) {
         FullHttpResponse response = new DefaultFullHttpResponse(protocolVersion(), status(), content,
-                HttpHeaders.copy(headers()), HttpHeaders.copy(trailingHeaders()));
+                headers().copy(), trailingHeaders().copy());
         response.setDecoderResult(decoderResult());
         return response;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultFullHttpResponse.java
@@ -149,7 +149,10 @@ public class DefaultFullHttpResponse extends DefaultHttpResponse implements Full
 
     @Override
     public FullHttpResponse replace(ByteBuf content) {
-        return new DefaultFullHttpResponse(protocolVersion(), status(), content, headers(), trailingHeaders());
+        FullHttpResponse response = new DefaultFullHttpResponse(protocolVersion(), status(), content,
+                HttpHeaders.copy(headers()), HttpHeaders.copy(trailingHeaders()));
+        response.setDecoderResult(decoderResult());
+        return response;
     }
 
     @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -348,9 +348,7 @@ public class DefaultHttpHeaders extends HttpHeaders {
         return headers.hashCode(CASE_SENSITIVE_HASHER);
     }
 
-    /**
-     * Returns a deep copy of this instance.
-     */
+    @Override
     public HttpHeaders copy() {
         return new DefaultHttpHeaders(headers.copy());
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -42,7 +42,7 @@ import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
 /**
  * Default implementation of {@link HttpHeaders}.
  */
-public class DefaultHttpHeaders extends HttpHeaders {
+public class DefaultHttpHeaders extends HttpHeaders implements Cloneable {
     private static final int HIGHEST_INVALID_VALUE_CHAR_MASK = ~15;
     private static final ByteProcessor HEADER_NAME_VALIDATOR = new ByteProcessor() {
         @Override
@@ -346,6 +346,13 @@ public class DefaultHttpHeaders extends HttpHeaders {
     @Override
     public int hashCode() {
         return headers.hashCode(CASE_SENSITIVE_HASHER);
+    }
+
+    /**
+     * Returns a deep copy of this instance.
+     */
+    public HttpHeaders copy() {
+        return new DefaultHttpHeaders(headers.copy());
     }
 
     private static void validateHeaderNameElement(byte value) {

--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java
@@ -42,7 +42,7 @@ import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
 /**
  * Default implementation of {@link HttpHeaders}.
  */
-public class DefaultHttpHeaders extends HttpHeaders implements Cloneable {
+public class DefaultHttpHeaders extends HttpHeaders {
     private static final int HIGHEST_INVALID_VALUE_CHAR_MASK = ~15;
     private static final ByteProcessor HEADER_NAME_VALIDATOR = new ByteProcessor() {
         @Override

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -1698,13 +1698,7 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
      * Returns a deap copy of the passed in {@link HttpHeaders}.
      */
     public static HttpHeaders copy(HttpHeaders headers) {
-        final HttpHeaders copy;
-        if (headers instanceof DefaultHttpHeaders) {
-            copy = ((DefaultHttpHeaders) headers).copy();
-        } else {
-            copy = new DefaultHttpHeaders();
-            copy.set(headers);
-        }
-        return copy;
+        return (headers instanceof DefaultHttpHeaders) ? ((DefaultHttpHeaders) headers).copy()
+                : new DefaultHttpHeaders().set(headers);
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -1697,8 +1697,7 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     /**
      * Returns a deap copy of the passed in {@link HttpHeaders}.
      */
-    public static HttpHeaders copy(HttpHeaders headers) {
-        return (headers instanceof DefaultHttpHeaders) ? ((DefaultHttpHeaders) headers).copy()
-                : new DefaultHttpHeaders().set(headers);
+    public HttpHeaders copy() {
+        return new DefaultHttpHeaders().set(this);
     }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpHeaders.java
@@ -1693,4 +1693,18 @@ public abstract class HttpHeaders implements Iterable<Map.Entry<String, String>>
     public String toString() {
         return HeadersUtils.toString(getClass(), iteratorCharSequence(), size());
     }
+
+    /**
+     * Returns a deap copy of the passed in {@link HttpHeaders}.
+     */
+    public static HttpHeaders copy(HttpHeaders headers) {
+        final HttpHeaders copy;
+        if (headers instanceof DefaultHttpHeaders) {
+            copy = ((DefaultHttpHeaders) headers).copy();
+        } else {
+            copy = new DefaultHttpHeaders();
+            copy.set(headers);
+        }
+        return copy;
+    }
 }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -425,7 +425,7 @@ public class HttpObjectAggregator
         @Override
         public FullHttpRequest replace(ByteBuf content) {
             DefaultFullHttpRequest dup = new DefaultFullHttpRequest(protocolVersion(), method(), uri(), content,
-                    HttpHeaders.copy(headers()), HttpHeaders.copy(trailingHeaders()));
+                    headers().copy(), trailingHeaders().copy());
             dup.setDecoderResult(decoderResult());
             return dup;
         }
@@ -523,7 +523,7 @@ public class HttpObjectAggregator
         @Override
         public FullHttpResponse replace(ByteBuf content) {
             DefaultFullHttpResponse dup = new DefaultFullHttpResponse(getProtocolVersion(), getStatus(), content,
-                    HttpHeaders.copy(headers()), HttpHeaders.copy(trailingHeaders()));
+                    headers().copy(), trailingHeaders().copy());
             dup.setDecoderResult(decoderResult());
             return dup;
         }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectAggregator.java
@@ -424,9 +424,8 @@ public class HttpObjectAggregator
 
         @Override
         public FullHttpRequest replace(ByteBuf content) {
-            DefaultFullHttpRequest dup = new DefaultFullHttpRequest(protocolVersion(), method(), uri(), content);
-            dup.headers().set(headers());
-            dup.trailingHeaders().set(trailingHeaders());
+            DefaultFullHttpRequest dup = new DefaultFullHttpRequest(protocolVersion(), method(), uri(), content,
+                    HttpHeaders.copy(headers()), HttpHeaders.copy(trailingHeaders()));
             dup.setDecoderResult(decoderResult());
             return dup;
         }
@@ -523,9 +522,8 @@ public class HttpObjectAggregator
 
         @Override
         public FullHttpResponse replace(ByteBuf content) {
-            DefaultFullHttpResponse dup = new DefaultFullHttpResponse(getProtocolVersion(), getStatus(), content);
-            dup.headers().set(headers());
-            dup.trailingHeaders().set(trailingHeaders());
+            DefaultFullHttpResponse dup = new DefaultFullHttpResponse(getProtocolVersion(), getStatus(), content,
+                    HttpHeaders.copy(headers()), HttpHeaders.copy(trailingHeaders()));
             dup.setDecoderResult(decoderResult());
             return dup;
         }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -608,7 +608,7 @@ public class InboundHttp2ToHttpAdapterTest {
             verify(serverListener, times(2)).messageReceived(requestCaptor.capture());
             capturedRequests = requestCaptor.getAllValues();
             assertEquals(2, capturedRequests.size());
-            // We expect to not have this header i nthe captured request so remove it now.
+            // We do not expect to have this header in the captured request so remove it now.
             assertNotNull(request.headers().remove("x-http2-stream-weight"));
 
             assertEquals(request, capturedRequests.get(0));

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/InboundHttp2ToHttpAdapterTest.java
@@ -62,6 +62,7 @@ import static io.netty.handler.codec.http2.Http2TestUtil.of;
 import static io.netty.handler.codec.http2.Http2TestUtil.runInChannel;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -607,6 +608,9 @@ public class InboundHttp2ToHttpAdapterTest {
             verify(serverListener, times(2)).messageReceived(requestCaptor.capture());
             capturedRequests = requestCaptor.getAllValues();
             assertEquals(2, capturedRequests.size());
+            // We expect to not have this header i nthe captured request so remove it now.
+            assertNotNull(request.headers().remove("x-http2-stream-weight"));
+
             assertEquals(request, capturedRequests.get(0));
             assertEquals(request2, capturedRequests.get(1));
 

--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -952,6 +952,16 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
         return (T) this;
     }
 
+    /**
+     * Returns a deep copy of this instance.
+     */
+    public DefaultHeaders<K, V, T> copy() {
+        DefaultHeaders<K, V, T> copy = new DefaultHeaders<K, V, T>(
+                hashingStrategy, valueConverter, nameValidator, entries.length);
+        copy.set(this);
+        return copy;
+    }
+
     private final class HeaderIterator implements Iterator<Map.Entry<K, V>> {
         private HeaderEntry<K, V> current = head;
 

--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -958,7 +958,7 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     public DefaultHeaders<K, V, T> copy() {
         DefaultHeaders<K, V, T> copy = new DefaultHeaders<K, V, T>(
                 hashingStrategy, valueConverter, nameValidator, entries.length);
-        copy.set(this);
+        copy.addImpl(this);
         return copy;
     }
 


### PR DESCRIPTION
… as well.

Motiviation:

In our replace(...) methods we always used validation for the newly created headers while the original headers may not use validation at all.

Modifications:

- Only use validation if the original headers used validation as well.
- Ensure we create a copy of the headers in replace(...).

Result:

Fixes [#5226]