### PR TITLE
Improvement : added overloaded method in order to avoid unnecessary allocation

### DIFF
--- a/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
+++ b/transport/src/main/java/io/netty/channel/DefaultChannelPipeline.java
@@ -354,6 +354,10 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         ctx.next = newCtx;
     }
 
+    public final ChannelPipeline addFirst(ChannelHandler handler) {
+        return addFirst(null, handler);
+    }
+
     @Override
     public final ChannelPipeline addFirst(ChannelHandler... handlers) {
         return addFirst(null, handlers);
@@ -381,6 +385,10 @@ public class DefaultChannelPipeline implements ChannelPipeline {
         }
 
         return this;
+    }
+
+    public final ChannelPipeline addLast(ChannelHandler handler) {
+        return addLast(null, handler);
     }
 
     @Override


### PR DESCRIPTION
Motivation : 

Avoid unnecessary array allocation when using the function with varargs in the `DefaultChannelPipeline` class.

Modifications : 

Added `addLast` and `addFirst` overloaded methods with 1 handler instead of varargs.

Result : 

No array allocation when using simple construction like `pipeline.addLast(new Handler());`
