### PR TITLE
Outputs the line number from where the logging request was issued

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -61,7 +61,7 @@ public abstract class InternalLoggerFactory {
     static {
         boolean lineNumber = SystemPropertyUtil.getBoolean(LINE_NUMBER, false);
         LOGGER_LINE_NUMBER = lineNumber;
-        getDefaultFactory().newInstance(InternalLoggerFactory.class.getName()).debug("-Dio.netty.maxThreadLocalCharBufferSize: {}", lineNumber);
+        getDefaultFactory().newInstance(InternalLoggerFactory.class.getName()).debug("-D{}: {}", LINE_NUMBER, lineNumber);
     }
 
     /**

--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -57,7 +57,6 @@ public abstract class InternalLoggerFactory {
         return f;
     }
 
-
     static {
         boolean lineNumber = SystemPropertyUtil.getBoolean(LINE_NUMBER, false);
         LOGGER_LINE_NUMBER = lineNumber;

--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -61,7 +61,8 @@ public abstract class InternalLoggerFactory {
     static {
         boolean lineNumber = SystemPropertyUtil.getBoolean(LINE_NUMBER, false);
         LOGGER_LINE_NUMBER = lineNumber;
-        getDefaultFactory().newInstance(InternalLoggerFactory.class.getName()).debug("-D{}: {}", LINE_NUMBER, lineNumber);
+        getDefaultFactory().newInstance(InternalLoggerFactory.class.getName())
+            .debug("-D{}: {}", LINE_NUMBER, lineNumber);
     }
 
     /**

--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -16,6 +16,8 @@
 
 package io.netty.util.internal.logging;
 
+import io.netty.util.internal.SystemPropertyUtil;
+
 /**
  * Creates an {@link InternalLogger} or changes the default factory
  * implementation.  This factory allows you to choose what logging framework
@@ -34,6 +36,8 @@ package io.netty.util.internal.logging;
 public abstract class InternalLoggerFactory {
 
     private static volatile InternalLoggerFactory defaultFactory;
+    static final String LINE_NUMBER = "io.netty.loggerLineNumber";
+    static final boolean LOGGER_LINE_NUMBER;
 
     @SuppressWarnings("UnusedCatchParameter")
     private static InternalLoggerFactory newDefaultFactory(String name) {
@@ -51,6 +55,13 @@ public abstract class InternalLoggerFactory {
             }
         }
         return f;
+    }
+
+
+    static {
+        boolean lineNumber = SystemPropertyUtil.getBoolean(LINE_NUMBER, false);
+        LOGGER_LINE_NUMBER = lineNumber;
+        getDefaultFactory().newInstance(InternalLoggerFactory.class.getName()).debug("-Dio.netty.maxThreadLocalCharBufferSize: {}", lineNumber);
     }
 
     /**

--- a/common/src/main/java/io/netty/util/internal/logging/LocationAwareSlf4JLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/LocationAwareSlf4JLogger.java
@@ -22,7 +22,7 @@ import static org.slf4j.spi.LocationAwareLogger.*;
 
 /**
  * <a href="http://www.slf4j.org/">SLF4J</a> logger.
- * similar to <a href="https://github.com/qos-ch/slf4j/blob/v_1.7.25/jcl-over-slf4j/src/main/java/org/apache/commons/logging/impl/SLF4JLocationAwareLog.java">SLF4JLocationAwareLog</a>
+ * similar to jcl-over-slf4j/SLF4JLocationAwareLog.java
  */
 class LocationAwareSlf4JLogger extends AbstractInternalLogger {
     public static final String FQCN = LocationAwareSlf4JLogger.class.getName();
@@ -42,7 +42,8 @@ class LocationAwareSlf4JLogger extends AbstractInternalLogger {
         logger.log(null, FQCN, level, message, params, throwable);
     }
 
-    public void log(final Marker marker, final int level, final String message, Throwable throwable, final Object... params) {
+    public void log(final Marker marker, final int level, final String message, Throwable throwable,
+                    final Object... params) {
         logger.log(marker, FQCN, level, message, params, throwable);
     }
 

--- a/common/src/main/java/io/netty/util/internal/logging/LocationAwareSlf4JLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/LocationAwareSlf4JLogger.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal.logging;
+
+import org.slf4j.Marker;
+import org.slf4j.spi.LocationAwareLogger;
+
+import static org.slf4j.spi.LocationAwareLogger.*;
+
+/**
+ * <a href="http://www.slf4j.org/">SLF4J</a> logger.
+ * similar to <a href="https://github.com/qos-ch/slf4j/blob/v_1.7.25/jcl-over-slf4j/src/main/java/org/apache/commons/logging/impl/SLF4JLocationAwareLog.java">SLF4JLocationAwareLog</a>
+ */
+class LocationAwareSlf4JLogger extends AbstractInternalLogger {
+    public static final String FQCN = LocationAwareSlf4JLogger.class.getName();
+
+    private final transient LocationAwareLogger logger;
+
+    LocationAwareSlf4JLogger(LocationAwareLogger logger) {
+        super(logger.getName());
+        this.logger = logger;
+    }
+
+    public void log(final int level, final String message, final Object... params) {
+        logger.log(null, FQCN, level, message, params, null);
+    }
+
+    public void log(final int level, final String message, Throwable throwable, final Object... params) {
+        logger.log(null, FQCN, level, message, params, throwable);
+    }
+
+    public void log(final Marker marker, final int level, final String message, Throwable throwable, final Object... params) {
+        logger.log(marker, FQCN, level, message, params, throwable);
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return logger.isTraceEnabled();
+    }
+
+    @Override
+    public void trace(String msg) {
+        log(TRACE_INT, msg, null);
+    }
+
+    @Override
+    public void trace(String format, Object arg) {
+        log(TRACE_INT, format, arg);
+    }
+
+    @Override
+    public void trace(String format, Object argA, Object argB) {
+        log(TRACE_INT, format, argA, argB);
+    }
+
+    @Override
+    public void trace(String format, Object... argArray) {
+        log(TRACE_INT, format, argArray);
+    }
+
+    @Override
+    public void trace(String msg, Throwable t) {
+        log(TRACE_INT, msg, t);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    @Override
+    public void debug(String msg) {
+        log(DEBUG_INT, msg);
+    }
+
+    @Override
+    public void debug(String format, Object arg) {
+        log(DEBUG_INT, format, arg);
+    }
+
+    @Override
+    public void debug(String format, Object argA, Object argB) {
+        log(DEBUG_INT, format, argA, argB);
+    }
+
+    @Override
+    public void debug(String format, Object... argArray) {
+        log(DEBUG_INT, format, argArray);
+    }
+
+    @Override
+    public void debug(String msg, Throwable t) {
+        log(DEBUG_INT, msg, t);
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return logger.isInfoEnabled();
+    }
+
+    @Override
+    public void info(String msg) {
+        log(INFO_INT, msg);
+    }
+
+    @Override
+    public void info(String format, Object arg) {
+        log(INFO_INT, format, arg);
+    }
+
+    @Override
+    public void info(String format, Object argA, Object argB) {
+        log(INFO_INT, format, argA, argB);
+    }
+
+    @Override
+    public void info(String format, Object... argArray) {
+        log(INFO_INT, format, argArray);
+    }
+
+    @Override
+    public void info(String msg, Throwable t) {
+        log(INFO_INT, msg, t);
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return logger.isWarnEnabled();
+    }
+
+    @Override
+    public void warn(String msg) {
+        log(WARN_INT, msg);
+    }
+
+    @Override
+    public void warn(String format, Object arg) {
+        log(WARN_INT, format, arg);
+    }
+
+    @Override
+    public void warn(String format, Object... argArray) {
+        log(WARN_INT, format, argArray);
+    }
+
+    @Override
+    public void warn(String format, Object argA, Object argB) {
+        log(WARN_INT, format, argA, argB);
+    }
+
+    @Override
+    public void warn(String msg, Throwable t) {
+        log(WARN_INT, msg, t);
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return logger.isErrorEnabled();
+    }
+
+    @Override
+    public void error(String msg) {
+        log(ERROR_INT, msg);
+    }
+
+    @Override
+    public void error(String format, Object arg) {
+        log(ERROR_INT, format, arg);
+    }
+
+    @Override
+    public void error(String format, Object argA, Object argB) {
+        log(ERROR_INT, format, argA, argB);
+    }
+
+    @Override
+    public void error(String format, Object... argArray) {
+        log(ERROR_INT, format, argArray);
+    }
+
+    @Override
+    public void error(String msg, Throwable t) {
+        log(ERROR_INT, msg, t);
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/logging/LocationAwareSlf4JLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/LocationAwareSlf4JLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 The Netty Project
+ * Copyright 2017 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
@@ -16,8 +16,10 @@
 package io.netty.util.internal.logging;
 
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.NOPLoggerFactory;
+import org.slf4j.spi.LocationAwareLogger;
 
 /**
  * Logger factory which creates a <a href="http://www.slf4j.org/">SLF4J</a>
@@ -44,6 +46,10 @@ public class Slf4JLoggerFactory extends InternalLoggerFactory {
 
     @Override
     public InternalLogger newInstance(String name) {
-        return new Slf4JLogger(LoggerFactory.getLogger(name));
+        Logger logger = LoggerFactory.getLogger(name);
+        if (LOGGER_LINE_NUMBER && logger instanceof LocationAwareLogger) {
+            return new LocationAwareSlf4JLogger((LocationAwareLogger) logger);
+        }
+        return new Slf4JLogger(logger);
     }
 }


### PR DESCRIPTION
Motivation:

Outputs the line number from where the logging request was issued when debugging netty

Modification:

Add LocationAwareSlf4JLogger can output the correct line number

Result:

Users of this library can correctly output the line number of the log when using slf4j