### PR TITLE
Fixed JMH ByteBuf benchmark to avoid dead code elimination

### DIFF
--- a/microbench/src/main/java/io/netty/microbench/buffer/ByteBufBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/buffer/ByteBufBenchmark.java
@@ -54,27 +54,27 @@ public class ByteBufBenchmark extends AbstractMicrobenchmark {
     }
 
     @Benchmark
-    public void setByteBufferHeap() {
-        byteBuffer.put(0, BYTE);
+    public ByteBuffer setByteBufferHeap() {
+        return byteBuffer.put(0, BYTE);
     }
 
     @Benchmark
-    public void setByteBufferDirect() {
-        directByteBuffer.put(0, BYTE);
+    public ByteBuffer setByteBufferDirect() {
+        return directByteBuffer.put(0, BYTE);
     }
 
     @Benchmark
-    public void setByteBufHeap() {
-        buffer.setByte(0, BYTE);
+    public ByteBuf setByteBufHeap() {
+        return buffer.setByte(0, BYTE);
     }
 
     @Benchmark
-    public void setByteBufDirect() {
-        directBuffer.setByte(0, BYTE);
+    public ByteBuf setByteBufDirect() {
+        return directBuffer.setByte(0, BYTE);
     }
 
     @Benchmark
-    public void setByteBufDirectPooled() {
-        directBufferPooled.setByte(0, BYTE);
+    public ByteBuf setByteBufDirectPooled() {
+        return directBufferPooled.setByte(0, BYTE);
     }
 }


### PR DESCRIPTION
Motivation:

The JMH doc suggests to use BlackHoles to avoid dead code elimination hence would be better to follow this best practice.

Modifications:

Each benchmark method is returning the ByteBuf/ByteBuffer to avoid the JVM to perform any dead code elimination.

Result:

The results are more reliable and comparable to the others provided by other ByteBuf benchmarks (eg HeapByteBufBenchmark)