### PR TITLE
Add a hint of ownership transfer when calling EmbeddedChannel.read*()…

### DIFF
--- a/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
+++ b/transport/src/main/java/io/netty/channel/embedded/EmbeddedChannel.java
@@ -40,7 +40,6 @@ import io.netty.util.ReferenceCountUtil;
 import io.netty.util.internal.ObjectUtil;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.RecyclableArrayList;
-import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -289,7 +288,11 @@ public class EmbeddedChannel extends AbstractChannel {
      */
     @SuppressWarnings("unchecked")
     public <T> T readInbound() {
-        return (T) poll(inboundMessages);
+        T message = (T) poll(inboundMessages);
+        if (message != null) {
+            ReferenceCountUtil.touch(message, "Caller of readInbound() will handle the message from this point");
+        }
+        return message;
     }
 
     /**
@@ -297,7 +300,11 @@ public class EmbeddedChannel extends AbstractChannel {
      */
     @SuppressWarnings("unchecked")
     public <T> T readOutbound() {
-        return (T) poll(outboundMessages);
+        T message =  (T) poll(outboundMessages);
+        if (message != null) {
+            ReferenceCountUtil.touch(message, "Caller of readOutbound() will handle the message from this point.");
+        }
+        return message;
     }
 
     /**


### PR DESCRIPTION
… methods.

Motivation:

As shown in issues it is sometimes hard to understand why a leak was reported when the user just calles EmbeddedChannel.readInbound() / EmbeddedChannel.readOutbound() and drop the message on the floor.

Modifications:

Add a hint before handover the message to the user and transfer the ownership.

Result:

Easier debugging of leaks caused by EmbeddedChannel.read*().