### PR TITLE
Use 198.51.100.254 as BAD_HOST for tests.

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketTestPermutation.java
@@ -44,7 +44,7 @@ import java.util.List;
 
 public class SocketTestPermutation {
 
-    static final String BAD_HOST = SystemPropertyUtil.get("io.netty.testsuite.badHost", "netty.io");
+    static final String BAD_HOST = SystemPropertyUtil.get("io.netty.testsuite.badHost", "198.51.100.254");
     static final int BAD_PORT = SystemPropertyUtil.getInt("io.netty.testsuite.badPort", 65535);
 
     static {


### PR DESCRIPTION
Motivation:

At the moment we use netty.io as BAD_HOST with an port that we know is timing out. This may change in the future so we should better use 198.51.100.254 which is specified as "for documentation only".

Modifications:

Replace netty.io with 198.51.100.254 in tests that depend on BAD_HOST.

Result:

More future proof code.