### PR TITLE
Http2FrameCodecTest increase timeout

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -483,7 +483,7 @@ public class Http2FrameCodecTest {
         verify(frameWriter).writeSettings(eq(http2HandlerCtx), same(settings), any(ChannelPromise.class));
     }
 
-    @Test(timeout = 1000)
+    @Test(timeout = 5000)
     public void newOutboundStream() {
         final Http2FrameStream stream = frameCodec.newStream();
 


### PR DESCRIPTION
Motivation:
Http2FrameCodecTest#newOutboundStream has a timeout of 1 second and has been observed to timeout on CI servers.

Modifications:
- Increase the timeout to 5 seconds

Result:
Less false positive test failures on CI servers.