### PR TITLE
Test output should include GC details

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,12 @@
       </properties>
     </profile>
     <profile>
+      <id>noPrintGC</id>
+      <properties>
+        <argLine.printGC>-D_</argLine.printGC>
+      </properties>
+    </profile>
+    <profile>
       <id>noUnsafe</id>
       <properties>
         <argLine.noUnsafe>-Dio.netty.noUnsafe</argLine.noUnsafe>
@@ -180,6 +186,7 @@
     <argLine.leak>-D_</argLine.leak> <!-- Overridden when 'leak' profile is active -->
     <argLine.noUnsafe>-D_</argLine.noUnsafe> <!-- Overridden when 'noUnsafe' profile is active -->
     <argLine.coverage>-D_</argLine.coverage> <!-- Overridden when 'coverage' profile is active -->
+    <argLine.printGC>-XX:+PrintGCDetails</argLine.printGC>
     <argLine.java9 /> <!-- Overridden when 'java9' profile is active -->
     <argLine.javaProperties>-D_</argLine.javaProperties>
     <!-- Configure the os-maven-plugin extension to expand the classifier on                  -->
@@ -811,7 +818,7 @@
             <logback.configurationFile>${logging.config}</logback.configurationFile>
             <logLevel>${logging.logLevel}</logLevel>
           </systemPropertyVariables>
-          <argLine>${argLine.common} ${argLine.alpnAgent} ${argLine.leak} ${argLine.coverage} ${argLine.noUnsafe} ${argLine.java9} ${argLine.javaProperties}</argLine>
+          <argLine>${argLine.common} ${argLine.printGC} ${argLine.alpnAgent} ${argLine.leak} ${argLine.coverage} ${argLine.noUnsafe} ${argLine.java9} ${argLine.javaProperties}</argLine>
           <properties>
             <property>
               <name>listener</name>


### PR DESCRIPTION
Motivation:
Our tests are often asynchronous and have timeouts to avoid hanging indefinitely. However sometimes the timeouts maybe set to low for the CI servers. It would be helpful to confirm if the application was busy with GC and if that was a contributing factor to the test timing out.

Modifications:
- Unit tests should run with -XX:+PrintGCDetails by default

Result:
More visibility into GC behavior in unit tests.