### PR TITLE
Fix h2spec test 4.3 about invalid header block

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/HpackDecoder.java
@@ -303,6 +303,10 @@ final class HpackDecoder {
         if (headersLength > maxHeaderListSize) {
             headerListSizeExceeded(streamId, maxHeaderListSize, true);
         }
+
+        if (state != READ_HEADER_REPRESENTATION) {
+            throw connectionError(COMPRESSION_ERROR, "Incomplete header block fragment.");
+        }
     }
 
     /**

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/HpackDecoderTest.java
@@ -512,4 +512,17 @@ public class HpackDecoderTest {
             in.release();
         }
     }
+
+    @Test
+    public void testIncompleteHeaderFieldRepresentation() throws Http2Exception {
+        // Incomplete Literal Header Field with Incremental Indexing
+        byte[] input = {(byte) 0x40};
+        ByteBuf in = Unpooled.wrappedBuffer(input);
+        try {
+            expectedException.expect(Http2Exception.class);
+            hpackDecoder.decode(0, in, mockHeaders);
+        } finally {
+            in.release();
+        }
+    }
 }

--- a/testsuite-http2/pom.xml
+++ b/testsuite-http2/pom.xml
@@ -67,7 +67,6 @@
           <excludeSpecs>
             <excludeSpec>3.8 - Sends a GOAWAY frame</excludeSpec>
             <excludeSpec>4.2 - Sends a dynamic table size update at the end of header block</excludeSpec>
-            <excludeSpec>4.3 - Sends invalid header block fragment</excludeSpec>
             <excludeSpec>5.1 - idle: Sends a DATA frame</excludeSpec>
             <excludeSpec>5.1 - closed: Sends a DATA frame</excludeSpec>
             <excludeSpec>5.1 - closed: Sends a HEADERS frame</excludeSpec>


### PR DESCRIPTION
**Motivation**:

HPackDecoder works on entire header block, we shouldn't encounter
incomplete header fields. If we do we should treat it as
a decoding error and according to the specification:

> A decoding error in a header block MUST be treated as
> a connection error (Section 5.4.1) of type COMPRESSION_ERROR.

**Modifications**:

* Check final state in HpackDecoder once we've decoded all the data.

**Result**:

* Throw a connection error if we receive incomplete header fields
* H2spec 4.3 tests all passes ( #5761 )
