### PR TITLE
Remove remote initiated renegotiation support

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslEngine.java
@@ -212,7 +212,6 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
     private final ByteBufAllocator alloc;
     private final OpenSslEngineMap engineMap;
     private final OpenSslApplicationProtocolNegotiator apn;
-    private final boolean rejectRemoteInitiatedRenegotiation;
     private final OpenSslSession session;
     private final Certificate[] localCerts;
     private final ByteBuffer[] singleSrcBuffer = new ByteBuffer[1];
@@ -247,7 +246,6 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         session = new OpenSslSession(context.sessionContext());
         clientMode = context.isClient();
         engineMap = context.engineMap;
-        rejectRemoteInitiatedRenegotiation = context.getRejectRemoteInitiatedRenegotiation();
         localCerts = context.keyCertChain;
         keyMaterialManager = context.keyMaterialManager();
         enableOcsp = context.enableOcsp;
@@ -1122,7 +1120,7 @@ public class ReferenceCountedOpenSslEngine extends SSLEngine implements Referenc
         // As rejectRemoteInitiatedRenegotiation() is called in a finally block we also need to check if we shutdown
         // the engine before as otherwise SSL.getHandshakeCount(ssl) will throw an NPE if the passed in ssl is 0.
         // See https://github.com/netty/netty/issues/7353
-        if (rejectRemoteInitiatedRenegotiation && !isDestroyed() && SSL.getHandshakeCount(ssl) > 1) {
+        if (!isDestroyed() && SSL.getHandshakeCount(ssl) > 1) {
             // TODO: In future versions me may also want to send a fatal_alert to the client and so notify it
             // that the renegotiation failed.
             shutdown();

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslRenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslRenegotiateTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import org.junit.BeforeClass;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.net.ssl.SSLException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assume.assumeTrue;
+
+public class OpenSslRenegotiateTest extends RenegotiateTest {
+
+    @BeforeClass
+    public static void checkOpenSsl() {
+        assumeTrue(OpenSsl.isAvailable());
+    }
+
+    @Override
+    protected SslProvider serverSslProvider() {
+        return SslProvider.OPENSSL;
+    }
+
+    protected void verifyResult(AtomicReference<Throwable> error) throws Throwable {
+        Throwable cause = error.get();
+        // Renegotation is not supported by the OpenSslEngine.
+        assertThat(cause, is(instanceOf(SSLException.class)));
+    }
+}

--- a/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/RenegotiateTest.java
@@ -47,7 +47,6 @@ public abstract class RenegotiateTest {
         try {
             final SslContext context = SslContextBuilder.forServer(cert.key(), cert.cert())
                     .sslProvider(serverSslProvider()).build();
-            initSslServerContext(context);
             ServerBootstrap sb = new ServerBootstrap();
             sb.group(group).channel(LocalServerChannel.class)
                     .childHandler(new ChannelInitializer<Channel>() {
@@ -125,10 +124,7 @@ public abstract class RenegotiateTest {
             latch.await();
             clientChannel.close().syncUninterruptibly();
             channel.close().syncUninterruptibly();
-            Throwable cause = error.get();
-            if (cause != null) {
-                throw cause;
-            }
+            verifyResult(error);
         } finally  {
             group.shutdownGracefully();
         }
@@ -136,6 +132,10 @@ public abstract class RenegotiateTest {
 
     protected abstract SslProvider serverSslProvider();
 
-    protected void initSslServerContext(SslContext context) {
+    protected void verifyResult(AtomicReference<Throwable> error) throws Throwable {
+        Throwable cause = error.get();
+        if (cause != null) {
+            throw cause;
+        }
     }
 }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSslClientRenegotiateTest.java
@@ -40,7 +40,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import javax.net.ssl.SSLHandshakeException;
 import java.io.File;
 import java.nio.channels.ClosedChannelException;
 import java.security.cert.CertificateException;
@@ -49,7 +48,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.*;
+import javax.net.ssl.SSLHandshakeException;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
 public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
@@ -79,7 +82,6 @@ public class SocketSslClientRenegotiateTest extends AbstractSocketTest {
         boolean hasOpenSsl = OpenSsl.isAvailable();
         if (hasOpenSsl) {
             OpenSslServerContext context = new OpenSslServerContext(CERT_FILE, KEY_FILE);
-            context.setRejectRemoteInitiatedRenegotiation(true);
             serverContexts.add(context);
         } else {
             logger.warn("OpenSSL is unavailable and thus will not be tested.", OpenSsl.unavailabilityCause());


### PR DESCRIPTION
Motivation:
We recently removed support for renegotiation, but there are still some hooks to attempt to allow remote initiated renegotiation to succeed. The remote initated renegotiation can be even more problematic from a security stand point and should also be removed.

Modifications:
- Remove state related to remote iniated renegotiation from OpenSslEngine

Result:
More renegotiation code removed from the OpenSslEngine code path.