### PR TITLE
Fix StompFrame.copy() does not copy headers, close #7561

### DIFF
--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
@@ -31,10 +31,16 @@ public class DefaultStompFrame extends DefaultStompHeadersSubframe implements St
     }
 
     public DefaultStompFrame(StompCommand command, ByteBuf content) {
-        super(command);
+        this(command, content, null);
+    }
+
+    public DefaultStompFrame(StompCommand command, ByteBuf content, StompHeaders headers) {
+        super(command, headers);
+
         if (content == null) {
             throw new NullPointerException("content");
         }
+
         this.content = content;
     }
 
@@ -60,7 +66,7 @@ public class DefaultStompFrame extends DefaultStompHeadersSubframe implements St
 
     @Override
     public StompFrame replace(ByteBuf content) {
-        return new DefaultStompFrame(command, content);
+        return new DefaultStompFrame(command, content, new DefaultStompHeaders().set(headers));
     }
 
     @Override

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompFrame.java
@@ -34,7 +34,7 @@ public class DefaultStompFrame extends DefaultStompHeadersSubframe implements St
         this(command, content, null);
     }
 
-    public DefaultStompFrame(StompCommand command, ByteBuf content, StompHeaders headers) {
+    DefaultStompFrame(StompCommand command, ByteBuf content, DefaultStompHeaders headers) {
         super(command, headers);
 
         if (content == null) {
@@ -66,7 +66,7 @@ public class DefaultStompFrame extends DefaultStompHeadersSubframe implements St
 
     @Override
     public StompFrame replace(ByteBuf content) {
-        return new DefaultStompFrame(command, content, new DefaultStompHeaders().set(headers));
+        return new DefaultStompFrame(command, content, headers.copy());
     }
 
     @Override

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeaders.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeaders.java
@@ -16,13 +16,13 @@
 
 package io.netty.handler.codec.stomp;
 
-import io.netty.handler.codec.CharSequenceValueConverter;
-import io.netty.handler.codec.DefaultHeaders;
-import io.netty.handler.codec.HeadersUtils;
-
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
+
+import io.netty.handler.codec.CharSequenceValueConverter;
+import io.netty.handler.codec.DefaultHeaders;
+import io.netty.handler.codec.HeadersUtils;
 
 import static io.netty.util.AsciiString.CASE_INSENSITIVE_HASHER;
 import static io.netty.util.AsciiString.CASE_SENSITIVE_HASHER;
@@ -57,5 +57,12 @@ public class DefaultStompHeaders
     public boolean contains(CharSequence name, CharSequence value, boolean ignoreCase) {
         return contains(name, value,
                 ignoreCase ? CASE_INSENSITIVE_HASHER : CASE_SENSITIVE_HASHER);
+    }
+
+    @Override
+    public DefaultStompHeaders copy() {
+        DefaultStompHeaders copyHeaders = new DefaultStompHeaders();
+        copyHeaders.addImpl(this);
+        return copyHeaders;
     }
 }

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeadersSubframe.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeadersSubframe.java
@@ -24,13 +24,19 @@ public class DefaultStompHeadersSubframe implements StompHeadersSubframe {
 
     protected final StompCommand command;
     protected DecoderResult decoderResult = DecoderResult.SUCCESS;
-    protected final StompHeaders headers = new DefaultStompHeaders();
+    protected final StompHeaders headers;
 
     public DefaultStompHeadersSubframe(StompCommand command) {
+        this(command, null);
+    }
+
+    public DefaultStompHeadersSubframe(StompCommand command, StompHeaders headers) {
         if (command == null) {
             throw new NullPointerException("command");
         }
+
         this.command = command;
+        this.headers = headers == null ? new DefaultStompHeaders() : headers;
     }
 
     @Override

--- a/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeadersSubframe.java
+++ b/codec-stomp/src/main/java/io/netty/handler/codec/stomp/DefaultStompHeadersSubframe.java
@@ -24,13 +24,13 @@ public class DefaultStompHeadersSubframe implements StompHeadersSubframe {
 
     protected final StompCommand command;
     protected DecoderResult decoderResult = DecoderResult.SUCCESS;
-    protected final StompHeaders headers;
+    protected final DefaultStompHeaders headers;
 
     public DefaultStompHeadersSubframe(StompCommand command) {
         this(command, null);
     }
 
-    public DefaultStompHeadersSubframe(StompCommand command, StompHeaders headers) {
+    DefaultStompHeadersSubframe(StompCommand command, DefaultStompHeaders headers) {
         if (command == null) {
             throw new NullPointerException("command");
         }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/DefaultStompFrameTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/DefaultStompFrameTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.stomp;
+
+import io.netty.util.AsciiString;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DefaultStompFrameTest {
+
+    @Test
+    public void testStompFrameCopy() {
+        StompFrame sourceframe = new DefaultStompFrame(StompCommand.CONNECT);
+
+        assertTrue(sourceframe.headers().isEmpty());
+
+        sourceframe.headers().set(StompHeaders.HOST, "localhost");
+
+        StompFrame copyFrame = sourceframe.copy();
+
+        assertEquals(sourceframe.headers(), copyFrame.headers());
+        assertEquals(sourceframe.content(), copyFrame.content());
+
+        AsciiString copyHeaderName = new AsciiString("foo");
+        AsciiString copyHeaderValue = new AsciiString("bar");
+        copyFrame.headers().set(copyHeaderName, copyHeaderName);
+
+        assertFalse(sourceframe.headers().contains(copyHeaderName, copyHeaderValue));
+
+        assertEquals(1, sourceframe.headers().size());
+        assertEquals(2, copyFrame.headers().size());
+    }
+}

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/DefaultStompFrameTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/DefaultStompFrameTest.java
@@ -48,5 +48,8 @@ public class DefaultStompFrameTest {
         assertEquals(1, sourceFrame.headers().size());
         assertEquals(2, copyFrame.headers().size());
         assertNotEquals(sourceFrame.headers(), copyFrame.headers());
+
+        assertTrue(sourceFrame.release());
+        assertTrue(copyFrame.release());
     }
 }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/DefaultStompFrameTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/DefaultStompFrameTest.java
@@ -20,31 +20,33 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class DefaultStompFrameTest {
 
     @Test
     public void testStompFrameCopy() {
-        StompFrame sourceframe = new DefaultStompFrame(StompCommand.CONNECT);
+        StompFrame sourceFrame = new DefaultStompFrame(StompCommand.CONNECT);
 
-        assertTrue(sourceframe.headers().isEmpty());
+        assertTrue(sourceFrame.headers().isEmpty());
 
-        sourceframe.headers().set(StompHeaders.HOST, "localhost");
+        sourceFrame.headers().set(StompHeaders.HOST, "localhost");
 
-        StompFrame copyFrame = sourceframe.copy();
+        StompFrame copyFrame = sourceFrame.copy();
 
-        assertEquals(sourceframe.headers(), copyFrame.headers());
-        assertEquals(sourceframe.content(), copyFrame.content());
+        assertEquals(sourceFrame.headers(), copyFrame.headers());
+        assertEquals(sourceFrame.content(), copyFrame.content());
 
         AsciiString copyHeaderName = new AsciiString("foo");
         AsciiString copyHeaderValue = new AsciiString("bar");
         copyFrame.headers().set(copyHeaderName, copyHeaderValue);
 
-        assertFalse(sourceframe.headers().contains(copyHeaderName, copyHeaderValue));
+        assertFalse(sourceFrame.headers().contains(copyHeaderName, copyHeaderValue));
         assertTrue(copyFrame.headers().contains(copyHeaderName, copyHeaderValue));
 
-        assertEquals(1, sourceframe.headers().size());
+        assertEquals(1, sourceFrame.headers().size());
         assertEquals(2, copyFrame.headers().size());
+        assertNotEquals(sourceFrame.headers(), copyFrame.headers());
     }
 }

--- a/codec-stomp/src/test/java/io/netty/handler/codec/stomp/DefaultStompFrameTest.java
+++ b/codec-stomp/src/test/java/io/netty/handler/codec/stomp/DefaultStompFrameTest.java
@@ -39,9 +39,10 @@ public class DefaultStompFrameTest {
 
         AsciiString copyHeaderName = new AsciiString("foo");
         AsciiString copyHeaderValue = new AsciiString("bar");
-        copyFrame.headers().set(copyHeaderName, copyHeaderName);
+        copyFrame.headers().set(copyHeaderName, copyHeaderValue);
 
         assertFalse(sourceframe.headers().contains(copyHeaderName, copyHeaderValue));
+        assertTrue(copyFrame.headers().contains(copyHeaderName, copyHeaderValue));
 
         assertEquals(1, sourceframe.headers().size());
         assertEquals(2, copyFrame.headers().size());


### PR DESCRIPTION
Motivation:
  Incorrect behavior for StompFrame.copy() method.

Modification:
 Added copying of frame headers

Result:
 When you call the StompFrame.copy() method, the headers are also copied.

Fixes [#7561]. 
  
  