### PR TITLE
HTTP/2 Remove Http2FrameStream#CONNECTION_STREAM

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameStream.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameStream.java
@@ -24,23 +24,6 @@ import io.netty.util.internal.UnstableApi;
  */
 @UnstableApi
 public interface Http2FrameStream {
-
-    /**
-     * The stream with identifier 0, representing the HTTP/2 connection.
-     */
-    Http2FrameStream CONNECTION_STREAM = new Http2FrameStream() {
-
-        @Override
-        public int id() {
-            return 0;
-        }
-
-        @Override
-        public State state() {
-            return State.IDLE;
-        }
-    };
-
     /**
      * Returns the stream identifier.
      *

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrame.java
@@ -20,8 +20,7 @@ import io.netty.util.internal.UnstableApi;
 /**
  * A frame whose meaning <em>may</em> apply to a particular stream, instead of the entire connection. It is still
  * possible for this frame type to apply to the entire connection. In such cases, the {@link #stream()} must return
- * {@link Http2FrameStream#CONNECTION_STREAM}. If the frame applies to a stream, the {@link Http2FrameStream#id()} must
- * be greater than zero.
+ * {@code null}. If the frame applies to a stream, the {@link Http2FrameStream#id()} must be greater than zero.
  */
 @UnstableApi
 public interface Http2StreamFrame extends Http2Frame {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -57,10 +57,25 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.handler.codec.http2.Http2CodecUtil.isStreamIdValid;
-import static io.netty.handler.codec.http2.Http2FrameStream.CONNECTION_STREAM;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyShort;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
  * Unit tests for {@link Http2FrameCodec}.
@@ -470,7 +485,7 @@ public class Http2FrameCodecTest {
 
         int windowUpdate = 1024;
 
-        channel.write(new DefaultHttp2WindowUpdateFrame(windowUpdate).stream(CONNECTION_STREAM));
+        channel.write(new DefaultHttp2WindowUpdateFrame(windowUpdate));
 
         assertEquals(initialWindowSizeBefore + windowUpdate, localFlow.initialWindowSize());
     }


### PR DESCRIPTION
Motivation:
Http2FrameStream#CONNECTION_STREAM is required to identify the
connection stream. However this leads to inconsistent usage from a user
perspective. When a user creates a Http2Frame for a non-connection
stream, the Http2MultiplexCodec automatically sets the stream, and the
user is never exposed to the Http2FrameStream object. However when the
user writes a Http2Frame for a connection stream they are required to
set the Http2FrameStream object. We can remove the Http2FrameStream#CONNECTION_STREAM
and keep the Http2FrameStream object internal, and therefore consistent
between the connection and non-connection use cases.

Modifications:
- Remove Http2FrameStream#CONNECTION_STREAM
- Update Http2FrameCodec to handle Http2Frame#stream() which returns
null

Result:
More consistent usage on http2 parent channel and http2 child channel.