### PR TITLE
Correctly take position into account when wrap a ByteBuffer via ReadO…

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
@@ -27,8 +27,10 @@ import java.nio.ByteBuffer;
 final class ReadOnlyUnsafeDirectByteBuf extends ReadOnlyByteBufferBuf {
     private final long memoryAddress;
 
-    ReadOnlyUnsafeDirectByteBuf(ByteBufAllocator allocator, ByteBuffer buffer) {
-        super(allocator, buffer);
+    ReadOnlyUnsafeDirectByteBuf(ByteBufAllocator allocator, ByteBuffer byteBuffer) {
+        super(allocator, byteBuffer);
+        // Use buffer as the super class will slice the passed in ByteBuffer which means the memoryAddress
+        // may be different if the position != 0.
         memoryAddress = PlatformDependent.directBufferAddress(buffer);
     }
 

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBufferBufTest.java
@@ -16,7 +16,6 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
-import org.junit.Assume;
 import org.junit.BeforeClass;
 
 import java.nio.ByteBuffer;


### PR DESCRIPTION
…nlyUnsafeDirectByteBuf

Motivation:

We did not correctly take the position into account when wrapping a ByteBuffer via ReadOnlyUnsafeDirectByteBuf as we obtained the memory address from the original ByteBuffer and not the slice we take.

Modifications:

- Correctly use the slice to obtain memory address.
- Add test case.

Result:

Fixes [#7565].