### PR TITLE
Cleanup: replaced deprecated ctx.attr() and ctx.hasAttr() methods usa…

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/marshalling/ContextBoundUnmarshallerProvider.java
+++ b/codec/src/main/java/io/netty/handler/codec/marshalling/ContextBoundUnmarshallerProvider.java
@@ -43,7 +43,7 @@ public class ContextBoundUnmarshallerProvider extends DefaultUnmarshallerProvide
 
     @Override
     public Unmarshaller getUnmarshaller(ChannelHandlerContext ctx) throws Exception {
-        Attribute<Unmarshaller> attr = ctx.attr(UNMARSHALLER);
+        Attribute<Unmarshaller> attr = ctx.channel().attr(UNMARSHALLER);
         Unmarshaller unmarshaller = attr.get();
         if (unmarshaller == null) {
             unmarshaller = super.getUnmarshaller(ctx);

--- a/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/AbstractTrafficShapingHandler.java
@@ -17,6 +17,7 @@ package io.netty.handler.traffic;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelHandlerContext;
@@ -426,7 +427,8 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
 
         @Override
         public void run() {
-            ChannelConfig config = ctx.channel().config();
+            Channel channel = ctx.channel();
+            ChannelConfig config = channel.config();
             if (!config.isAutoRead() && isHandlerActive(ctx)) {
                 // If AutoRead is False and Active is True, user make a direct setAutoRead(false)
                 // Then Just reset the status
@@ -434,7 +436,7 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
                     logger.debug("Not unsuspend: " + config.isAutoRead() + ':' +
                             isHandlerActive(ctx));
                 }
-                ctx.attr(READ_SUSPENDED).set(false);
+                channel.attr(READ_SUSPENDED).set(false);
             } else {
                 // Anything else allows the handler to reset the AutoRead
                 if (logger.isDebugEnabled()) {
@@ -446,9 +448,9 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
                                 + isHandlerActive(ctx));
                     }
                 }
-                ctx.attr(READ_SUSPENDED).set(false);
+                channel.attr(READ_SUSPENDED).set(false);
                 config.setAutoRead(true);
-                ctx.channel().read();
+                channel.read();
             }
             if (logger.isDebugEnabled()) {
                 logger.debug("Unsuspend final status => " + config.isAutoRead() + ':'
@@ -461,8 +463,9 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
      * Release the Read suspension
      */
     void releaseReadSuspended(ChannelHandlerContext ctx) {
-        ctx.attr(READ_SUSPENDED).set(false);
-        ctx.channel().config().setAutoRead(true);
+        Channel channel = ctx.channel();
+        channel.attr(READ_SUSPENDED).set(false);
+        channel.config().setAutoRead(true);
     }
 
     @Override
@@ -476,17 +479,18 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
             if (wait >= MINIMAL_WAIT) { // At least 10ms seems a minimal
                 // time in order to try to limit the traffic
                 // Only AutoRead AND HandlerActive True means Context Active
-                ChannelConfig config = ctx.channel().config();
+                Channel channel = ctx.channel();
+                ChannelConfig config = channel.config();
                 if (logger.isDebugEnabled()) {
                     logger.debug("Read suspend: " + wait + ':' + config.isAutoRead() + ':'
                             + isHandlerActive(ctx));
                 }
                 if (config.isAutoRead() && isHandlerActive(ctx)) {
                     config.setAutoRead(false);
-                    ctx.attr(READ_SUSPENDED).set(true);
+                    channel.attr(READ_SUSPENDED).set(true);
                     // Create a Runnable to reactive the read if needed. If one was create before it will just be
                     // reused to limit object creation
-                    Attribute<Runnable> attr = ctx.attr(REOPEN_TASK);
+                    Attribute<Runnable> attr = channel.attr(REOPEN_TASK);
                     Runnable reopenTask = attr.get();
                     if (reopenTask == null) {
                         reopenTask = new ReopenReadTimerTask(ctx);
@@ -524,7 +528,7 @@ public abstract class AbstractTrafficShapingHandler extends ChannelDuplexHandler
     }
 
     protected static boolean isHandlerActive(ChannelHandlerContext ctx) {
-        Boolean suspended = ctx.attr(READ_SUSPENDED).get();
+        Boolean suspended = ctx.channel().attr(READ_SUSPENDED).get();
         return suspended == null || Boolean.FALSE.equals(suspended);
     }
 

--- a/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
+++ b/handler/src/main/java/io/netty/handler/traffic/GlobalChannelTrafficShapingHandler.java
@@ -547,17 +547,18 @@ public class GlobalChannelTrafficShapingHandler extends AbstractTrafficShapingHa
             if (wait >= MINIMAL_WAIT) { // At least 10ms seems a minimal
                 // time in order to try to limit the traffic
                 // Only AutoRead AND HandlerActive True means Context Active
-                ChannelConfig config = ctx.channel().config();
+                Channel channel = ctx.channel();
+                ChannelConfig config = channel.config();
                 if (logger.isDebugEnabled()) {
                     logger.debug("Read Suspend: " + wait + ':' + config.isAutoRead() + ':'
                             + isHandlerActive(ctx));
                 }
                 if (config.isAutoRead() && isHandlerActive(ctx)) {
                     config.setAutoRead(false);
-                    ctx.attr(READ_SUSPENDED).set(true);
+                    channel.attr(READ_SUSPENDED).set(true);
                     // Create a Runnable to reactive the read if needed. If one was create before it will just be
                     // reused to limit object creation
-                    Attribute<Runnable> attr = ctx.attr(REOPEN_TASK);
+                    Attribute<Runnable> attr = channel.attr(REOPEN_TASK);
                     Runnable reopenTask = attr.get();
                     if (reopenTask == null) {
                         reopenTask = new ReopenReadTimerTask(ctx);

--- a/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
+++ b/transport/src/main/java/io/netty/channel/CombinedChannelDuplexHandler.java
@@ -581,12 +581,12 @@ public class CombinedChannelDuplexHandler<I extends ChannelInboundHandler, O ext
 
         @Override
         public <T> Attribute<T> attr(AttributeKey<T> key) {
-            return ctx.attr(key);
+            return ctx.channel().attr(key);
         }
 
         @Override
         public <T> boolean hasAttr(AttributeKey<T> key) {
-            return ctx.hasAttr(key);
+            return ctx.channel().hasAttr(key);
         }
 
         final void remove() {


### PR DESCRIPTION
…ge with ch.attr() and ch.hasAttr().

Motivation:

Will allow easy removal of deprecated methods in future.

Modification:

Replaced `ctx.attr()`, `ctx.hasAttr()` with `ctx.channel().attr()`, `ctx.channel().hasAttr()`.

Result:

No deprecated `ctx.attr()`, `ctx.hasAttr()` methods usage.