### PR TITLE
ByteBuf.toString(Charset) is not thread-safe

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
+++ b/buffer/src/main/java/io/netty/buffer/ByteBufUtil.java
@@ -682,8 +682,7 @@ public final class ByteBufUtil {
             dst.clear();
         }
         if (src.nioBufferCount() == 1) {
-            // Use internalNioBuffer(...) to reduce object creation.
-            decodeString(decoder, src.internalNioBuffer(readerIndex, len), dst);
+            decodeString(decoder, src.nioBuffer(readerIndex, len), dst);
         } else {
             // We use a heap buffer as CharsetDecoder is most likely able to use a fast-path if src and dst buffers
             // are both backed by a byte array.


### PR DESCRIPTION
Motivation:

Calling `ByteBuf#toString(Charset)` or `ByteBuf#toString(int, int, Charset)` on the same buffer from multiple threads at the same time produces unexpected results, such as various exceptions and/or corrupted output. This is because `ByteBufUtil#decodeString(...)` is taking the source ByteBuffer for `CharsetDecoder#decode()` from `ByteBuf#internalNioBuffer(int, int)`, which is not thread-safe.

Modification:

Call `ByteBuf#nioBuffer()` instead of `ByteBuf#internalNioBuffer()` to get the source buffer to pass to `CharsetDecoder#decode()`.

Result:

Fixes the possible race condition.
