### PR TITLE
Http2FrameCodec WindowUpdate bug

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -305,10 +305,8 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
     }
 
     private void increaseInitialConnectionWindow(int deltaBytes) throws Http2Exception {
-        Http2LocalFlowController localFlow = connection().local().flowController();
-        int targetConnectionWindow = localFlow.initialWindowSize() + deltaBytes;
-        localFlow.incrementWindowSize(connection().connectionStream(), deltaBytes);
-        localFlow.initialWindowSize(targetConnectionWindow);
+        // The LocalFlowController is responsible for detecting over/under flow.
+        connection().local().flowController().incrementWindowSize(connection().connectionStream(), deltaBytes);
     }
 
     final boolean consumeBytes(int streamId, int bytes) throws Http2Exception {


### PR DESCRIPTION
Motivation:
Http2FrameCodec increases the initialWindowSize when the user attempts to increase the connection flow control window. The initialWindowSize should only be touched as a result of a SETTINGS frame, and otherwise may result in flow control getting out of sync with our peer.

Modifications:
- Http2FrameCodec shouldn't update the initialWindowSize when a WindowUpdateFrame is written on the connection channel

Result:
More correct WindowUpdate processing.