### PR TITLE
Http2MultiplexCodec should propagate unhandled Http2Frames down the pipeline

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -227,6 +227,9 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
             if (settings.initialWindowSize() != null) {
                 initialOutboundStreamWindow = settings.initialWindowSize();
             }
+        } else {
+            // Send any other frames down the pipeline
+            ctx.fireChannelRead(frame);
         }
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
@@ -171,6 +171,17 @@ public class Http2MultiplexCodecTest {
     }
 
     @Test
+    public void unhandledHttp2FramesShouldBePropagated() {
+        ByteBuf content = UnpooledByteBufAllocator.DEFAULT.buffer(8).writeLong(0);
+        Http2PingFrame decodedFrame = new DefaultHttp2PingFrame(content);
+
+        codec.onHttp2Frame(decodedFrame);
+        Http2PingFrame receivedPing = parentChannel.readInbound();
+        assertSame(receivedPing, decodedFrame);
+        assertTrue(receivedPing.release());
+    }
+
+    @Test
     public void channelReadShouldRespectAutoRead() {
         LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(inboundStream);
         Channel childChannel = inboundHandler.channel();


### PR DESCRIPTION
Motivation:

`Http2MultiplexCodec` swallows `Http2PingFrame`s without releasing the payload, resulting in a memory leak.

Modification:

Send unhandled frames down the pipeline for consumption/disposal by another `InboundChannelHandler`.

Result:

Fixes #7607.
