### PR TITLE
Add java-doc for implemented methods of io.netty.util.concurrent.Future#cancel(boolean mayInterruptIfRunning) 

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/CompleteFuture.java
+++ b/common/src/main/java/io/netty/util/concurrent/CompleteFuture.java
@@ -140,6 +140,9 @@ public abstract class CompleteFuture<V> extends AbstractFuture<V> {
         return false;
     }
 
+    /**
+     * @param mayInterruptIfRunning this value has no effect in this implementation.
+     */
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         return false;

--- a/common/src/main/java/io/netty/util/concurrent/CompleteFuture.java
+++ b/common/src/main/java/io/netty/util/concurrent/CompleteFuture.java
@@ -141,6 +141,8 @@ public abstract class CompleteFuture<V> extends AbstractFuture<V> {
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @param mayInterruptIfRunning this value has no effect in this implementation.
      */
     @Override

--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -308,6 +308,9 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
         return (V) result;
     }
 
+    /**
+     * @param mayInterruptIfRunning this value has no effect in this implementation.
+     */
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         if (RESULT_UPDATER.compareAndSet(this, null, CANCELLATION_CAUSE_HOLDER)) {

--- a/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
+++ b/common/src/main/java/io/netty/util/concurrent/DefaultPromise.java
@@ -309,6 +309,8 @@ public class DefaultPromise<V> extends AbstractFuture<V> implements Promise<V> {
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @param mayInterruptIfRunning this value has no effect in this implementation.
      */
     @Override

--- a/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
+++ b/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
@@ -152,6 +152,8 @@ final class ScheduledFutureTask<V> extends PromiseTask<V> implements ScheduledFu
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @param mayInterruptIfRunning this value has no effect in this implementation.
      */
     @Override

--- a/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
+++ b/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
@@ -151,6 +151,9 @@ final class ScheduledFutureTask<V> extends PromiseTask<V> implements ScheduledFu
         }
     }
 
+    /**
+     * @param mayInterruptIfRunning this value has no effect in this implementation.
+     */
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         boolean canceled = super.cancel(mayInterruptIfRunning);

--- a/transport/src/main/java/io/netty/channel/DelegatingChannelPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/DelegatingChannelPromiseNotifier.java
@@ -172,11 +172,6 @@ public final class DelegatingChannelPromiseNotifier implements ChannelPromise, C
         return delegate.getNow();
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @param mayInterruptIfRunning this value has no effect in this implementation.
-     */
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         return delegate.cancel(mayInterruptIfRunning);

--- a/transport/src/main/java/io/netty/channel/DelegatingChannelPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/DelegatingChannelPromiseNotifier.java
@@ -172,6 +172,9 @@ public final class DelegatingChannelPromiseNotifier implements ChannelPromise, C
         return delegate.getNow();
     }
 
+    /**
+     * @param mayInterruptIfRunning this value has no effect in this implementation.
+     */
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         return delegate.cancel(mayInterruptIfRunning);

--- a/transport/src/main/java/io/netty/channel/DelegatingChannelPromiseNotifier.java
+++ b/transport/src/main/java/io/netty/channel/DelegatingChannelPromiseNotifier.java
@@ -173,6 +173,8 @@ public final class DelegatingChannelPromiseNotifier implements ChannelPromise, C
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @param mayInterruptIfRunning this value has no effect in this implementation.
      */
     @Override

--- a/transport/src/main/java/io/netty/channel/VoidChannelPromise.java
+++ b/transport/src/main/java/io/netty/channel/VoidChannelPromise.java
@@ -167,6 +167,8 @@ public final class VoidChannelPromise extends AbstractFuture<Void> implements Ch
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @param mayInterruptIfRunning this value has no effect in this implementation.
      */
     @Override

--- a/transport/src/main/java/io/netty/channel/VoidChannelPromise.java
+++ b/transport/src/main/java/io/netty/channel/VoidChannelPromise.java
@@ -166,6 +166,9 @@ public final class VoidChannelPromise extends AbstractFuture<Void> implements Ch
         return false;
     }
 
+    /**
+     * @param mayInterruptIfRunning this value has no effect in this implementation.
+     */
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         return false;

--- a/transport/src/main/java/io/netty/channel/group/VoidChannelGroupFuture.java
+++ b/transport/src/main/java/io/netty/channel/group/VoidChannelGroupFuture.java
@@ -138,6 +138,9 @@ final class VoidChannelGroupFuture implements ChannelGroupFuture {
         return null;
     }
 
+    /**
+     * @param mayInterruptIfRunning this value has no effect in this implementation.
+     */
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         return false;

--- a/transport/src/main/java/io/netty/channel/group/VoidChannelGroupFuture.java
+++ b/transport/src/main/java/io/netty/channel/group/VoidChannelGroupFuture.java
@@ -139,6 +139,8 @@ final class VoidChannelGroupFuture implements ChannelGroupFuture {
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @param mayInterruptIfRunning this value has no effect in this implementation.
      */
     @Override


### PR DESCRIPTION
Motivation:

The methods implement `io.netty.util.concurrent.Future#cancel(boolean mayInterruptIfRunning)` which actually ignored the param mayInterruptIfRunning.We need to add comments for the `mayInterruptIfRunning` param.

Modifications:

Add comments for the `mayInterruptIfRunning` param.

Result:

People who call the `cancel` method will be more clear about the effect of `mayInterruptIfRunning` param.
Fixes #7609 