### PR TITLE
ObjectCleanerThread must be a deamon thread to ensure the JVM can alw…

### DIFF
--- a/common/src/test/java/io/netty/util/internal/ObjectCleanerTest.java
+++ b/common/src/test/java/io/netty/util/internal/ObjectCleanerTest.java
@@ -23,6 +23,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class ObjectCleanerTest {
 
@@ -109,5 +111,27 @@ public class ObjectCleanerTest {
             System.runFinalization();
             Thread.sleep(100);
         }
+    }
+
+    @Test(timeout = 5000)
+    public void testCleanerThreadIsDaemon() throws Exception {
+        temporaryObject = new Object();
+        ObjectCleaner.register(temporaryObject, new Runnable() {
+            @Override
+            public void run() {
+                // NOOP
+            }
+        });
+
+        Thread cleanerThread = null;
+
+        for (Thread thread : Thread.getAllStackTraces().keySet()) {
+            if (thread.getName().equals(ObjectCleaner.CLEANER_THREAD_NAME)) {
+                cleanerThread = thread;
+                break;
+            }
+        }
+        assertNotNull(cleanerThread);
+        assertTrue(cleanerThread.isDaemon());
     }
 }


### PR DESCRIPTION
…ays terminate.

Motivation:

The ObjectCleanerThread must be a daemon thread as otherwise we may block the JVM from exit. By using a daemon thread we basically give the same garantees as the JVM when it comes to cleanup of resources (as the GC threads are also daemon threads and the CleanerImpl uses a deamon thread as well in Java9+).

Modifications:

Change ObjectCleanThread to be a daemon thread.

Result:

JVM shutdown will always be able to complete. Fixed [#7617].