### PR TITLE
Correctly handle multiple calls to DefaultHttp2StreamChannel.Unsafe.c…

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
@@ -464,6 +464,18 @@ public class Http2MultiplexCodecTest {
         assertSame(headers, headers2);
     }
 
+    @Test
+    public void callUnsafeCloseMultipleTimes() {
+        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(inboundStream);
+        Http2StreamChannel childChannel = (Http2StreamChannel) inboundHandler.channel();
+        childChannel.unsafe().close(childChannel.voidPromise());
+
+        ChannelPromise promise = childChannel.newPromise();
+        childChannel.unsafe().close(promise);
+        promise.syncUninterruptibly();
+        childChannel.closeFuture().syncUninterruptibly();
+    }
+
     private LastInboundHandler streamActiveAndWriteHeaders(Http2FrameStream stream) {
         LastInboundHandler inboundHandler = new LastInboundHandler();
         childChannelInitializer.handler = inboundHandler;


### PR DESCRIPTION
…lose(...)

Motivation:

Calling DefaultHttp2StreamChannel.Unsafe.close(...) multiple times should not fail.

Modification:

- Correctly handle multiple calls to DefaultHttp2StreamChannel.Unsafe.close(...)
- Add unit test

Result:

Fixes [#7628]