### PR TITLE
ReadOnlyHttp2Headers.contains always ignores case for values

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/ReadOnlyHttp2Headers.java
@@ -430,29 +430,7 @@ public final class ReadOnlyHttp2Headers implements Http2Headers {
 
     @Override
     public boolean contains(CharSequence name, CharSequence value) {
-        final int nameHash = AsciiString.hashCode(name);
-        final int valueHash = AsciiString.hashCode(value);
-
-        final int pseudoHeadersEnd = pseudoHeaders.length - 1;
-        for (int i = 0; i < pseudoHeadersEnd; i += 2) {
-            AsciiString roName = pseudoHeaders[i];
-            AsciiString roValue = pseudoHeaders[i + 1];
-            if (roName.hashCode() == nameHash && roValue.hashCode() == valueHash &&
-                roName.contentEqualsIgnoreCase(name) && roValue.contentEqualsIgnoreCase(value)) {
-                return true;
-            }
-        }
-
-        final int otherHeadersEnd = otherHeaders.length - 1;
-        for (int i = 0; i < otherHeadersEnd; i += 2) {
-            AsciiString roName = otherHeaders[i];
-            AsciiString roValue = otherHeaders[i + 1];
-            if (roName.hashCode() == nameHash && roValue.hashCode() == valueHash &&
-                roName.contentEqualsIgnoreCase(name) && roValue.contentEqualsIgnoreCase(value)) {
-                return true;
-            }
-        }
-        return false;
+        return contains(name, value, false);
     }
 
     @Override

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/ReadOnlyHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/ReadOnlyHttp2HeadersTest.java
@@ -136,8 +136,9 @@ public class ReadOnlyHttp2HeadersTest {
     public void testContainsNameAndValue() {
         Http2Headers headers = newClientHeaders();
         assertTrue(headers.contains("Name1", "value1"));
-        assertFalse(headers.contains("Name1", "Value1", false));
-        assertTrue(headers.contains("Name1", "Value1", true));
+        assertFalse(headers.contains("Name1", "Value1"));
+        assertTrue(headers.contains("name2", "Value2", true));
+        assertFalse(headers.contains("name2", "Value2", false));
         assertTrue(headers.contains(Http2Headers.PseudoHeaderName.PATH.value(), "/foo"));
         assertFalse(headers.contains(Http2Headers.PseudoHeaderName.STATUS.value(), "200"));
         assertFalse(headers.contains("a missing header", "a missing value"));


### PR DESCRIPTION
Motivation:

When checking if a value is present, ReadOnlyHttp2Headers always ignores
case for values.

RFC 7540 says: https://tools.ietf.org/html/rfc7540#section-8.1.2
"header field names are strings of ASCII characters that are compared in a case-insensitive fashion"

But there is no such constraint on header values

Modifications:

Updated ReadOnlyHttp2Headers.contains to compare header value in a
case-sensitive way.

Result:

ReadOnlyHttp2Headers compares header names in a case-insensitive way,
values in a case-sensitive way.