### PR TITLE
DefaultHttp2Headers#contains(CharSequence, CharSequence) does not work with String

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Headers.java
@@ -184,6 +184,11 @@ public class DefaultHttp2Headers
     }
 
     @Override
+    public boolean contains(CharSequence name, CharSequence value) {
+        return contains(name, value, false);
+    }
+
+    @Override
     public boolean contains(CharSequence name, CharSequence value, boolean caseInsensitive) {
         return contains(name, value, caseInsensitive? CASE_INSENSITIVE_HASHER : CASE_SENSITIVE_HASHER);
     }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2HeadersTest.java
@@ -146,8 +146,10 @@ public class DefaultHttp2HeadersTest {
     @Test
     public void testContainsNameAndValue() {
         Http2Headers headers = newHeaders();
-        assertFalse(headers.contains("name1", "Value2", false));
-        assertTrue(headers.contains("name1", "Value2", true));
+        assertTrue(headers.contains("name1", "value2"));
+        assertFalse(headers.contains("name1", "Value2"));
+        assertTrue(headers.contains("2name", "Value3", true));
+        assertFalse(headers.contains("2name", "Value3", false));
     }
 
     private static void verifyAllPseudoHeadersPresent(Http2Headers headers) {


### PR DESCRIPTION
Motivation:

If you test a header value providing a String, contains() returns false.
This is due to the implementation inherited from DefaultHeaders using
the JAVA_HASHER.

JAVA_HASHER.equals returns false because a is a String and b an
AsciiString.

Modifications:

DefaultHttp2Headers overrides contains and uses CASE_SENSITIVE_HASHER.

Result:

You can test a header value with any CharSequence implementation.