### PR TITLE
Http2MultiplexCodec.DefaultHttpStreamChannel.isOpen() / isActive() sh…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -886,12 +886,14 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
                         }
                     }
 
+                    // The promise should be notified before we call fireChannelInactive().
+                    promise.setSuccess();
+                    closePromise.setSuccess();
+
                     pipeline().fireChannelInactive();
                     if (isRegistered()) {
                         deregister(unsafe().voidPromise());
                     }
-                    promise.setSuccess();
-                    closePromise.setSuccess();
                 } finally {
                     pendingClosePromise = null;
                 }


### PR DESCRIPTION
…oule be false when fireChannelActive() is called.

Motivation:

When part of a HTTP/2 StreamChannel the Http2StreamChannel.isOpen() / isActive() should report false within a call to a ChannelInboundHandlers channelInactive() method.

Modifications:

Fullfill promise before call fireChannelInactive()

Result:

Correctly update state / promise before notify handlers. Fixes [#7638]