### PR TITLE
Http2MultiplexChannel close promise completion consistency with Abstr…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -856,7 +856,7 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
                     return;
                 }
                 if (closePromise.isDone()) {
-                    promise.setFailure(new ClosedChannelException());
+                    promise.setSuccess();
                     return;
                 }
                 if (pendingClosePromise != null) {
@@ -886,9 +886,10 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
                         }
                     }
 
-                    // The promise should be notified before we call fireChannelInactive().
-                    promise.setSuccess();
+                    // The promise should be notified before we call fireChannelInactive(), and the closePromise should
+                    // be notified first for consistency with AbstractChannel so listeners of
                     closePromise.setSuccess();
+                    promise.setSuccess();
 
                     pipeline().fireChannelInactive();
                     if (isRegistered()) {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -29,14 +30,13 @@ import io.netty.handler.codec.http.HttpScheme;
 import io.netty.handler.codec.http2.Http2Exception.StreamException;
 import io.netty.util.AsciiString;
 import io.netty.util.AttributeKey;
-
-import java.net.InetSocketAddress;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.netty.util.ReferenceCountUtil.release;
 import static org.junit.Assert.assertEquals;
@@ -365,6 +365,82 @@ public class Http2MultiplexCodecTest {
         inboundHandler.checkException();
 
         future.syncUninterruptibly();
+    }
+
+    @Test
+    public void channelClosedWhenCloseListenerCompletes() {
+        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(inboundStream);
+        Http2StreamChannel childChannel = (Http2StreamChannel) inboundHandler.channel();
+
+        assertTrue(childChannel.isOpen());
+        assertTrue(childChannel.isActive());
+
+        final AtomicBoolean channelOpen = new AtomicBoolean(true);
+        final AtomicBoolean channelActive = new AtomicBoolean(true);
+
+        childChannel.close().addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) {
+                channelOpen.set(future.channel().isOpen());
+                channelActive.set(future.channel().isActive());
+            }
+        }).syncUninterruptibly();
+
+        assertFalse(channelOpen.get());
+        assertFalse(childChannel.isActive());
+    }
+
+    @Test
+    public void channelClosedWhenChannelClosePromiseCompletes() {
+        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(inboundStream);
+        Http2StreamChannel childChannel = (Http2StreamChannel) inboundHandler.channel();
+
+        assertTrue(childChannel.isOpen());
+        assertTrue(childChannel.isActive());
+
+        final AtomicBoolean channelOpen = new AtomicBoolean(true);
+        final AtomicBoolean channelActive = new AtomicBoolean(true);
+
+        childChannel.closeFuture().addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(ChannelFuture future) {
+                channelOpen.set(future.channel().isOpen());
+                channelActive.set(future.channel().isActive());
+            }
+        });
+        childChannel.close().syncUninterruptibly();
+
+        assertFalse(channelOpen.get());
+        assertFalse(childChannel.isActive());
+    }
+
+    @Test
+    public void channelClosedTwiceMarksPromiseAsSuccessful() {
+        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(inboundStream);
+        Http2StreamChannel childChannel = (Http2StreamChannel) inboundHandler.channel();
+
+        assertTrue(childChannel.isOpen());
+        assertTrue(childChannel.isActive());
+        childChannel.close().syncUninterruptibly();
+        childChannel.close().syncUninterruptibly();
+
+        assertFalse(childChannel.isOpen());
+        assertFalse(childChannel.isActive());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void channelClosedTwiceWithVoidPromiseThrows() {
+        LastInboundHandler inboundHandler = streamActiveAndWriteHeaders(inboundStream);
+        Http2StreamChannel childChannel = (Http2StreamChannel) inboundHandler.channel();
+
+        assertTrue(childChannel.isOpen());
+        assertTrue(childChannel.isActive());
+        childChannel.close().syncUninterruptibly();
+
+        assertFalse(childChannel.isOpen());
+        assertFalse(childChannel.isActive());
+
+        childChannel.close(childChannel.voidPromise()).syncUninterruptibly();
     }
 
     @Test


### PR DESCRIPTION
…actChannel

Motivation:
The completion order of promises in Http2MultiplexChannel#close should be consistent with that of AbstractChannel. Otherwise this may result in Future listeners seeing incorrect channel state.

Modifications:
- Subsequent close operations should always result in successfully completing the close promise
- The channel's closePromise should be completed before the close(Promise) argument

Result:
More consistent behavior between Http2MultiplexChannel and AbstractChannel.