### PR TITLE
Add the NOTICE of the forked portion of Apache Harmony

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -61,6 +61,8 @@ facade for Java, which can be obtained at:
 This product contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
+  * NOTICE:
+    * license/NOTICE.harmony.txt
   * LICENSE:
     * license/LICENSE.harmony.txt (Apache License 2.0)
   * HOMEPAGE:

--- a/license/NOTICE.harmony.txt
+++ b/license/NOTICE.harmony.txt
@@ -1,0 +1,6 @@
+Apache Harmony
+
+Copyright 2006, 2010 The Apache Software Foundation.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
Motivation:

According to the section 4d of ASLv2:

If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.

Modifications:

- Add a subset of NOTICE.txt of Apache Harmony.

Result:

- Fixes #7588
