### PR TITLE
Remove unused variable in DefaultHttp2StreamChannel

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -441,7 +441,6 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
 
         // Keeps track of flush calls in channelReadComplete(...) and aggregate these.
         private boolean inFireChannelReadComplete;
-        private boolean flushPending;
 
         boolean fireChannelReadPending;
 
@@ -1083,13 +1082,11 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
                     return;
                 }
                 try {
-                    // If we are current channelReadComplete(...) call we should just mark this Channel with a flush
-                    // pending. We will ensure we trigger ctx.flush() after we processed all Channels later on and
+                    // If we are currently in the  channelReadComplete(...) call we should just ignore the flush.
+                    // We will ensure we trigger ctx.flush() after we processed all Channels later on and
                     // so aggregate the flushes. This is done as ctx.flush() is expensive when as it may trigger an
                     // write(...) or writev(...) operation on the socket.
-                    if (inFireChannelReadComplete) {
-                        flushPending = true;
-                    } else {
+                    if (!inFireChannelReadComplete) {
                         flush0(ctx);
                     }
                 } finally {


### PR DESCRIPTION
Motivation:

We should remove unused variable (was never read).

Modifications:

Remove unused variable (was never read).

Result:

Cleanup.