### PR TITLE
Reflective setAccessible(true) will produce scary warnings on the con…

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -719,7 +719,7 @@ public class Http2FrameCodecTest {
                 UpgradeEvent.class.getDeclaredConstructor(CharSequence.class, FullHttpRequest.class);
 
         // Check if we could make it accessible which may fail on java9.
-        Assume.assumeTrue(ReflectionUtil.trySetAccessible(constructor) == null);
+        Assume.assumeTrue(ReflectionUtil.trySetAccessible(constructor, true) == null);
 
         HttpServerUpgradeHandler.UpgradeEvent upgradeEvent = constructor.newInstance(
                 "HTTP/2", new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"));
@@ -757,7 +757,7 @@ public class Http2FrameCodecTest {
                 UpgradeEvent.class.getDeclaredConstructor(CharSequence.class, FullHttpRequest.class);
 
         // Check if we could make it accessible which may fail on java9.
-        Assume.assumeTrue(ReflectionUtil.trySetAccessible(constructor) == null);
+        Assume.assumeTrue(ReflectionUtil.trySetAccessible(constructor, true) == null);
 
         String longString = new String(new char[70000]).replace("\0", "*");
         DefaultFullHttpRequest request =

--- a/common/src/main/java/io/netty/util/internal/ReflectionUtil.java
+++ b/common/src/main/java/io/netty/util/internal/ReflectionUtil.java
@@ -26,7 +26,10 @@ public final class ReflectionUtil {
      * {@link java.lang.reflect.InaccessibleObjectException} and return it.
      * The caller must check if it returns {@code null} and if not handle the returned exception.
      */
-    public static Throwable trySetAccessible(AccessibleObject object) {
+    public static Throwable trySetAccessible(AccessibleObject object, boolean checkAccessible) {
+        if (checkAccessible && !PlatformDependent0.isExplicitTryReflectionSetAccessible()) {
+            return new UnsupportedOperationException("Reflective setAccessible(true) disabled");
+        }
         try {
             object.setAccessible(true);
             return null;

--- a/common/src/test/java/io/netty/util/internal/logging/Log4J2LoggerTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/Log4J2LoggerTest.java
@@ -67,7 +67,7 @@ public class Log4J2LoggerTest extends AbstractInternalLoggerTest<Logger> {
         try {
             Field field = clazz.getDeclaredField(fieldName);
             if (!field.isAccessible()) {
-                Assume.assumeThat(ReflectionUtil.trySetAccessible(field), CoreMatchers.nullValue());
+                Assume.assumeThat(ReflectionUtil.trySetAccessible(field, true), CoreMatchers.nullValue());
             }
             return (T) field.get(AbstractInternalLogger.class);
         } catch (ReflectiveOperationException e) {
@@ -87,7 +87,7 @@ public class Log4J2LoggerTest extends AbstractInternalLoggerTest<Logger> {
 
         Method method = mockLog.getClass().getDeclaredMethod("setLevel", Level.class);
         if (!method.isAccessible()) {
-            Assume.assumeThat(ReflectionUtil.trySetAccessible(method), CoreMatchers.nullValue());
+            Assume.assumeThat(ReflectionUtil.trySetAccessible(method, true), CoreMatchers.nullValue());
         }
         method.invoke(mockLog, targetLevel);
     }

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -214,11 +214,11 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                     Field selectedKeysField = selectorImplClass.getDeclaredField("selectedKeys");
                     Field publicSelectedKeysField = selectorImplClass.getDeclaredField("publicSelectedKeys");
 
-                    Throwable cause = ReflectionUtil.trySetAccessible(selectedKeysField);
+                    Throwable cause = ReflectionUtil.trySetAccessible(selectedKeysField, true);
                     if (cause != null) {
                         return cause;
                     }
-                    cause = ReflectionUtil.trySetAccessible(publicSelectedKeysField);
+                    cause = ReflectionUtil.trySetAccessible(publicSelectedKeysField, true);
                     if (cause != null) {
                         return cause;
                     }


### PR DESCRIPTION
…sole when using java9+, dont do it

Motivation:

Reflective setAccessible(true) will produce scary warnings on the console when using java9+, while netty still works. That said users may feel uncomfortable with these warnings, we should not try to do it by default when using java9+.

Modifications:

Add io.netty.noReflectiveAccessible system property which controls if setAccessible(...) will be used. By default it will bet set to true when using java9+.

Result:

Fixes [#7254].