### PR TITLE
DefaultDnsCache should expire all records per hostname when one TTL i…

### DIFF
--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.NetUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+public class DefaultDnsCacheTest {
+
+    @Test
+    public void testExpire() throws Throwable {
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final DefaultDnsCache cache = new DefaultDnsCache();
+            cache.cache("netty.io", null, NetUtil.LOCALHOST, 1, loop);
+            cache.cache("netty.io", null, NetUtil.LOCALHOST6, 10000, loop);
+
+            Throwable error = loop.schedule(new Callable<Throwable>() {
+                @Override
+                public Throwable call() throws Exception {
+                    try {
+                        Assert.assertNull(cache.get("netty.io", null));
+                        return null;
+                    } catch (Throwable cause) {
+                        return cause;
+                    }
+                }
+            }, 1, TimeUnit.SECONDS).get();
+            if (error != null) {
+                throw error;
+            }
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+}


### PR DESCRIPTION
…s reached.

Motivation:

At the moment DefaultDnsCache will expire each record dependong on its own TTL. This may result in unexpected results for the end-user especially if the user for example uses IPV4_PREFERED but the cached AAAA records has a higher TTL then the A records and so the A record was removed. In this case we would only return the AAAA record and not even try to refresh.

Modifications:

Always expire all records for a hostname when one TTL is reached.

Result:

Fixes [#7329]