### PR TITLE
Avoid register multiple cleaner task for same thread's FastThreadLoca…

### DIFF
--- a/common/src/main/java/io/netty/util/internal/ObjectCleaner.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectCleaner.java
@@ -123,6 +123,10 @@ public final class ObjectCleaner {
         }
     }
 
+    public static int getLiveSetCount() {
+        return LIVE_SET.size();
+    }
+
     private ObjectCleaner() {
         // Only contains a static method.
     }


### PR DESCRIPTION
…l index

Motivation:

Currently if user call set/remove/set/remove many times, it will create multiple cleaner task for same index. It may cause OOM due to long live thread will have more and more task in LIVE_SET.

Modification:

Add flag to avoid recreating tasks.

Result:
Only create 1 clean task. But use more space of indexedVariables.
