### PR TITLE
ReadOnlyUnsafeDirectByteBuf.memoryAddress() should not throw

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBuf.java
@@ -125,6 +125,16 @@ final class ReadOnlyUnsafeDirectByteBuf extends ReadOnlyByteBufferBuf {
         return copy;
     }
 
+    @Override
+    public boolean hasMemoryAddress() {
+        return true;
+    }
+
+    @Override
+    public long memoryAddress() {
+        return memoryAddress;
+    }
+
     private long addr(int index) {
         return memoryAddress + index;
     }

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -274,4 +274,20 @@ public class ReadOnlyDirectByteBufferBufTest {
             file.delete();
         }
     }
+
+    @Test
+    public void testMemoryAddress() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        try {
+            Assert.assertFalse(buf.hasMemoryAddress());
+            try {
+                buf.memoryAddress();
+                Assert.fail();
+            } catch (UnsupportedOperationException expected) {
+                // expected
+            }
+        } finally {
+            buf.release();
+        }
+    }
 }

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyUnsafeDirectByteBufferBufTest.java
@@ -16,7 +16,9 @@
 package io.netty.buffer;
 
 import io.netty.util.internal.PlatformDependent;
+import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.nio.ByteBuffer;
 
@@ -35,5 +37,17 @@ public class ReadOnlyUnsafeDirectByteBufferBufTest extends ReadOnlyDirectByteBuf
     @Override
     protected ByteBuf buffer(ByteBuffer buffer) {
         return new ReadOnlyUnsafeDirectByteBuf(UnpooledByteBufAllocator.DEFAULT, buffer);
+    }
+
+    @Test
+    @Override
+    public void testMemoryAddress() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());
+        try {
+            Assert.assertTrue(buf.hasMemoryAddress());
+            buf.memoryAddress();
+        } finally {
+            buf.release();
+        }
     }
 }


### PR DESCRIPTION
Motivation:

We need the memoryAddress of a direct buffer when using our native transports. For this reason ReadOnlyUnsafeDirectByteBuf.memoryAddress() should not throw.

Modifications:

- Correctly override ReadOnlyUnsafeDirectByteBuf.memoryAddress() and hasMemoryAddress()
- Add test case

Result:

Fixes [#7672].