### PR TITLE
Adapt to API changes in Conscrypt 1.0.0.RC11

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/Conscrypt.java
+++ b/handler/src/main/java/io/netty/handler/ssl/Conscrypt.java
@@ -26,44 +26,43 @@ import java.lang.reflect.Method;
 final class Conscrypt {
     // This class exists to avoid loading other conscrypt related classes using features only available in JDK8+,
     // because we need to maintain JDK6+ runtime compatibility.
-    private static final Class<?> ENGINES_CLASS = getEnginesClass();
+    private static final Class<?> CONSCRYPT_CLASS = getConscryptClass();
 
     /**
      * Indicates whether or not conscrypt is available on the current system.
      */
     static boolean isAvailable() {
-        return ENGINES_CLASS != null && PlatformDependent.javaVersion() >= 8;
+        return CONSCRYPT_CLASS != null && PlatformDependent.javaVersion() >= 8;
     }
 
     static boolean isEngineSupported(SSLEngine engine) {
-        return isAvailable() && isConscryptEngine(engine, ENGINES_CLASS);
+        return isAvailable() && isConscryptEngine(engine, CONSCRYPT_CLASS);
     }
 
-    private static Class<?> getEnginesClass() {
+    private static Class<?> getConscryptClass() {
         try {
-            // Always use bootstrap class loader.
-            Class<?> engineClass = Class.forName("org.conscrypt.Conscrypt$Engines", true,
+            Class<?> conscryptClass = Class.forName("org.conscrypt.Conscrypt", true,
                     ConscryptAlpnSslEngine.class.getClassLoader());
             // Ensure that it also has the isConscrypt method.
-            getIsConscryptMethod(engineClass);
-            return engineClass;
+            getIsConscryptMethod(conscryptClass);
+            return conscryptClass;
         } catch (Throwable ignore) {
             // Conscrypt was not loaded.
             return null;
         }
     }
 
-    private static boolean isConscryptEngine(SSLEngine engine, Class<?> enginesClass) {
+    private static boolean isConscryptEngine(SSLEngine engine, Class<?> conscryptClass) {
         try {
-            Method method = getIsConscryptMethod(enginesClass);
+            Method method = getIsConscryptMethod(conscryptClass);
             return (Boolean) method.invoke(null, engine);
         } catch (Throwable ignore) {
             return false;
         }
     }
 
-    private static Method getIsConscryptMethod(Class<?> enginesClass) throws NoSuchMethodException {
-        return enginesClass.getMethod("isConscrypt", SSLEngine.class);
+    private static Method getIsConscryptMethod(Class<?> conscryptClass) throws NoSuchMethodException {
+        return conscryptClass.getMethod("isConscrypt", SSLEngine.class);
     }
 
     private Conscrypt() { }


### PR DESCRIPTION
Motivation:

In google/conscrypt#313 the Conscrypt.Engines class was removed in favor
of methods directly on Conscrypt and overloading. The Conscrypt-using
code in Netty used reflection to access the old API, that doesn't exist
anymore. And thus recent versions of Conscrypt fail to enable things
like ALPN with Netty.

Modifications:

Instead of calling Conscrypt.Engines.isConscrypt, call
Conscrypt.isConscrypt.

Result:

Conscrypt detected properly at runtime.

------

It'd be nice to have a test for this, but we _already_ have such a thing. `ConscryptJdkSslEngineInteropTest` was kind enough to not run anything because `checkConscrypt()` failed:
```
-------------------------------------------------------------------------------
Test set: io.netty.handler.ssl.ConscryptJdkSslEngineInteropTest
-------------------------------------------------------------------------------
Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.055 sec - in io.netty.handler.ssl.ConscryptJdkSslEngineInteropTest
```

And now:
```
-------------------------------------------------------------------------------
Test set: io.netty.handler.ssl.ConscryptJdkSslEngineInteropTest
-------------------------------------------------------------------------------
Tests run: 93, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 4.404 sec - in io.netty.handler.ssl.ConscryptJdkSslEngineInteropTest
```

We have this same problem in gRPC and ALPN providers, where a test may silence itself in certain cases. We haven't really found a solution.