### PR TITLE
#7665 SUBACK can now indicate failure

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -392,7 +392,10 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
         final List<Integer> grantedQos = new ArrayList<Integer>();
         int numberOfBytesConsumed = 0;
         while (numberOfBytesConsumed < bytesRemainingInVariablePart) {
-            int qos = buffer.readUnsignedByte() & 0x03;
+            int qos = buffer.readUnsignedByte();
+            if (qos != MqttQoS.FAILURE.value()) {
+                qos &= 0x03;
+            }
             numberOfBytesConsumed++;
             grantedQos.add(qos);
         }


### PR DESCRIPTION
Motivation:

Since 3.1.1 mqtt protocol version SUBACK message can now indicate the failure in payload.

Modification:

Do not erase failure payload in for SUBACK message.

Result:

Fixes https://github.com/netty/netty/issues/7665
