### PR TITLE
Change the encoded buffer of the published message to CompositeByteBuf

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttEncoder.java
@@ -317,7 +317,7 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
         int variablePartSize = variableHeaderBufferSize + payloadBufferSize;
         int fixedHeaderBufferSize = 1 + getVariableLengthInt(variablePartSize);
 
-        ByteBuf buf = byteBufAllocator.buffer(fixedHeaderBufferSize + variablePartSize);
+        ByteBuf buf = byteBufAllocator.buffer(fixedHeaderBufferSize + variableHeaderBufferSize);
         buf.writeByte(getFixedHeaderByte1(mqttFixedHeader));
         writeVariableLengthInt(buf, variablePartSize);
         buf.writeShort(topicNameBytes.length);
@@ -325,9 +325,8 @@ public final class MqttEncoder extends MessageToMessageEncoder<MqttMessage> {
         if (mqttFixedHeader.qosLevel().value() > 0) {
             buf.writeShort(variableHeader.messageId());
         }
-        buf.writeBytes(payload);
 
-        return buf;
+        return byteBufAllocator.compositeBuffer(2).addComponents(true, buf, payload.retain());
     }
 
     private static ByteBuf encodeMessageWithOnlySingleByteFixedHeaderAndMessageId(


### PR DESCRIPTION
Motivation:

Reduce the memory copy of the payload.

Modification:

Using the CompositeByteBuf.

Result:

Memory usage and performance may improve slightly.