### PR TITLE
Introduce an alternative IdentityCipherSuiteFilter that defaults to supportedCiphers, close #7655

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/IdentityCipherSuiteFilter.java
+++ b/handler/src/main/java/io/netty/handler/ssl/IdentityCipherSuiteFilter.java
@@ -23,15 +23,31 @@ import java.util.Set;
  * This class will not do any filtering of ciphers suites.
  */
 public final class IdentityCipherSuiteFilter implements CipherSuiteFilter {
-    public static final IdentityCipherSuiteFilter INSTANCE = new IdentityCipherSuiteFilter();
 
-    private IdentityCipherSuiteFilter() { }
+    /**
+     * Defaults to default ciphers when provided ciphers are null
+     */
+    public static final IdentityCipherSuiteFilter INSTANCE = new IdentityCipherSuiteFilter(true);
+
+    /**
+     * Defaults to supported ciphers when provided ciphers are null
+     */
+    public static final IdentityCipherSuiteFilter INSTANCE_DEFAULTING_TO_SUPPORTED_CIPHERS =
+            new IdentityCipherSuiteFilter(false);
+
+    private final boolean defaultToDefaultCiphers;
+
+    private IdentityCipherSuiteFilter(boolean defaultToDefaultCiphers) {
+        this.defaultToDefaultCiphers = defaultToDefaultCiphers;
+    }
 
     @Override
     public String[] filterCipherSuites(Iterable<String> ciphers, List<String> defaultCiphers,
             Set<String> supportedCiphers) {
         if (ciphers == null) {
-            return defaultCiphers.toArray(new String[defaultCiphers.size()]);
+            return defaultToDefaultCiphers ?
+                    defaultCiphers.toArray(new String[defaultCiphers.size()]) :
+                    supportedCiphers.toArray(new String[supportedCiphers.size()]);
         } else {
             List<String> newCiphers = new ArrayList<String>(supportedCiphers.size());
             for (String c : ciphers) {
@@ -43,5 +59,4 @@ public final class IdentityCipherSuiteFilter implements CipherSuiteFilter {
             return newCiphers.toArray(new String[newCiphers.size()]);
         }
     }
-
 }

--- a/handler/src/test/java/io/netty/handler/ssl/IdentityCipherSuiteFilterTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/IdentityCipherSuiteFilterTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class IdentityCipherSuiteFilterTest {
+
+    @Test
+    public void regularInstanceDefaultsToDefaultCiphers() {
+        List<String> defaultCiphers = Arrays.asList("FOO", "BAR");
+        Set<String> supportedCiphers = new HashSet<String>(Arrays.asList("BAZ", "QIX"));
+        String[] filtered = IdentityCipherSuiteFilter.INSTANCE
+                .filterCipherSuites(null, defaultCiphers, supportedCiphers);
+        assertArrayEquals(defaultCiphers.toArray(), filtered);
+    }
+
+    @Test
+    public void alternativeInstanceDefaultsToSupportedCiphers() {
+        List<String> defaultCiphers = Arrays.asList("FOO", "BAR");
+        Set<String> supportedCiphers = new HashSet<String>(Arrays.asList("BAZ", "QIX"));
+        String[] filtered = IdentityCipherSuiteFilter.INSTANCE_DEFAULTING_TO_SUPPORTED_CIPHERS
+                .filterCipherSuites(null, defaultCiphers, supportedCiphers);
+        assertArrayEquals(supportedCiphers.toArray(), filtered);
+    }
+}


### PR DESCRIPTION
Motivation:

Sometimes, it would be convenient to be able to easily enable all
supported cipher suites, regardless of security.

Currently, the only way it to retrieve all supported ciphers and pass
them explicitly.

Modification:

Introduce a new IdentityCipherSuiteFilter singleton that defaults to
supportedCiphers instead of defaultCiphers when ciphers are null.

Result:

Convenient way to enabled all supported cipher suites.