### PR TITLE
#7695 no need to manually release chunk during upload in HttpUploadServer

### DIFF
--- a/example/src/main/java/io/netty/example/http/upload/HttpUploadServerHandler.java
+++ b/example/src/main/java/io/netty/example/http/upload/HttpUploadServerHandler.java
@@ -225,12 +225,8 @@ public class HttpUploadServerHandler extends SimpleChannelInboundHandler<HttpObj
                         logger.info(" 100% (FinalSize: " + partialContent.length() + ")");
                         partialContent = null;
                     }
-                    try {
-                        // new value
-                        writeHttpData(data);
-                    } finally {
-                        data.release();
-                    }
+                    // new value
+                    writeHttpData(data);
                 }
             }
             // Check partial decoding for a FileUpload


### PR DESCRIPTION
Motivation:

After https://github.com/netty/netty/pull/7527 fix there is no need to manually release chunks (`HttpData`) during file upload as they will be released on `HttpPostRequestDecoder.destroy()`.

Modification:

`HttpUploadServer` example doesn't release chunks manually (doesn't call `data.release()`).

Result:
Fixes https://github.com/netty/netty/issues/7695 and https://github.com/netty/netty/issues/7689
