### PR TITLE
Fix http server parsing post parameters

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -118,14 +118,14 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
             }
             FileOutputStream outputStream = new FileOutputStream(file);
             try {
-                FileChannel localfileChannel = outputStream.getChannel();
+                FileChannel localFileChannel = outputStream.getChannel();
                 ByteBuffer byteBuffer = buffer.nioBuffer();
                 int written = 0;
                 while (written < size) {
-                    written += localfileChannel.write(byteBuffer);
+                    written += localFileChannel.write(byteBuffer);
                 }
                 buffer.readerIndex(buffer.readerIndex() + written);
-                localfileChannel.force(false);
+                localFileChannel.force(false);
             } finally {
                 outputStream.close();
             }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -114,9 +114,6 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
             }
             if (buffer.readableBytes() == 0) {
                 // empty file
-                if (!file.createNewFile()) {
-                    throw new IOException("file exists already: " + file);
-                }
                 return;
             }
             FileOutputStream outputStream = new FileOutputStream(file);


### PR DESCRIPTION
Motivation:

Provide fix for issue https://github.com/netty/netty/issues/6418.

Modification:

In case of empty buffer there was attempt to create already created file, this should not be the case here, because sufficient is to just skip writing empty bits to disk, file is already created.

