### PR TITLE
System property util might return null

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -794,7 +794,7 @@ final class PlatformDependent0 {
 
         // Android sets this property to Dalvik, regardless of whether it actually is.
         String vmName = SystemPropertyUtil.get("java.vm.name");
-        boolean isAndroid = vmName.equals("Dalvik");
+        boolean isAndroid = "Dalvik".equals(vmName);
         if (isAndroid) {
             logger.debug("Platform: Android");
         }


### PR DESCRIPTION
Motivation:

isAndroid0 should be robust.

Modifications:

yoda equals for string comparison.

Result:

No NPE.