### PR TITLE
Bump Conscrypt version to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>
-    <conscrypt.version>1.0.0.RC13</conscrypt.version>
+    <conscrypt.version>1.0.0</conscrypt.version>
     <conscrypt.classifier />
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>


### PR DESCRIPTION
Motivation:

Conscrypt is now 1.0. No more need to depend on release candidates.

Modifications:

Just the version bump. Things seemed compatible.

Result:

Depending on first guaranteed-api-stable release of Conscrypt.