### PR TITLE
Adding option to Http2MultiplexCodecBuilder to propagate SETTINGS fra…

### DIFF
--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/CleartextHttp2ServerUpgradeHandlerTest.java
@@ -231,7 +231,7 @@ public class CleartextHttp2ServerUpgradeHandlerTest {
 
         ByteBuf settingsFrame = settingsFrameBuf();
 
-        assertFalse(channel.writeInbound(settingsFrame));
+        assertTrue(channel.writeInbound(settingsFrame));
 
         assertEquals(1, userEvents.size());
         assertTrue(userEvents.get(0) instanceof PriorKnowledgeUpgradeEvent);


### PR DESCRIPTION

Motivation:

Allow the observation of SETTINGS frame by other handlers in the pipeline. For my particular use case this allows me to observe the value of MAX_CONCURRENT_STREAMS for a ChannelPool abstraction that supports HTTP/2 multiplexing. 

Modification:

Describe the modifications you've done.
Add a new option to the Http2MultiplexCodecBuilder to turn settings propagation off/on. The approach taken is similar to InboundHttp2ToHttpAdapter.

Result:

Settings can now be observed in the parent channel. Previously it was not possible (to my knowledge) to capture the settings when using Http2MultiplexCodec.

