### PR TITLE
Correctly handle the case when converting of value fails and return n…

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/DefaultHeaders.java
@@ -603,7 +603,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Boolean getBoolean(K name) {
         V v = get(name);
-        return v != null ? valueConverter.convertToBoolean(v) : null;
+        try {
+            return v != null ? valueConverter.convertToBoolean(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -615,7 +619,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Byte getByte(K name) {
         V v = get(name);
-        return v != null ? valueConverter.convertToByte(v) : null;
+        try {
+            return v != null ? valueConverter.convertToByte(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -627,7 +635,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Character getChar(K name) {
         V v = get(name);
-        return v != null ? valueConverter.convertToChar(v) : null;
+        try {
+            return v != null ? valueConverter.convertToChar(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -639,7 +651,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Short getShort(K name) {
         V v = get(name);
-        return v != null ? valueConverter.convertToShort(v) : null;
+        try {
+            return v != null ? valueConverter.convertToShort(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -651,7 +667,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Integer getInt(K name) {
         V v = get(name);
-        return v != null ? valueConverter.convertToInt(v) : null;
+        try {
+            return v != null ? valueConverter.convertToInt(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -663,7 +683,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Long getLong(K name) {
         V v = get(name);
-        return v != null ? valueConverter.convertToLong(v) : null;
+        try {
+            return v != null ? valueConverter.convertToLong(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -675,7 +699,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Float getFloat(K name) {
         V v = get(name);
-        return v != null ? valueConverter.convertToFloat(v) : null;
+        try {
+            return v != null ? valueConverter.convertToFloat(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -687,7 +715,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Double getDouble(K name) {
         V v = get(name);
-        return v != null ? valueConverter.convertToDouble(v) : null;
+        try {
+            return v != null ? valueConverter.convertToDouble(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -699,7 +731,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Long getTimeMillis(K name) {
         V v = get(name);
-        return v != null ? valueConverter.convertToTimeMillis(v) : null;
+        try {
+            return v != null ? valueConverter.convertToTimeMillis(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -711,7 +747,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Boolean getBooleanAndRemove(K name) {
         V v = getAndRemove(name);
-        return v != null ? valueConverter.convertToBoolean(v) : null;
+        try {
+            return v != null ? valueConverter.convertToBoolean(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -723,7 +763,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Byte getByteAndRemove(K name) {
         V v = getAndRemove(name);
-        return v != null ? valueConverter.convertToByte(v) : null;
+        try {
+            return v != null ? valueConverter.convertToByte(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -735,12 +779,9 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Character getCharAndRemove(K name) {
         V v = getAndRemove(name);
-        if (v == null) {
-            return null;
-        }
         try {
-            return valueConverter.convertToChar(v);
-        } catch (Throwable ignored) {
+            return v != null ? valueConverter.convertToChar(v) : null;
+        } catch (RuntimeException ignore) {
             return null;
         }
     }
@@ -754,7 +795,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Short getShortAndRemove(K name) {
         V v = getAndRemove(name);
-        return v != null ? valueConverter.convertToShort(v) : null;
+        try {
+            return v != null ? valueConverter.convertToShort(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -766,7 +811,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Integer getIntAndRemove(K name) {
         V v = getAndRemove(name);
-        return v != null ? valueConverter.convertToInt(v) : null;
+        try {
+            return v != null ? valueConverter.convertToInt(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -778,7 +827,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Long getLongAndRemove(K name) {
         V v = getAndRemove(name);
-        return v != null ? valueConverter.convertToLong(v) : null;
+        try {
+            return v != null ? valueConverter.convertToLong(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -790,7 +843,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Float getFloatAndRemove(K name) {
         V v = getAndRemove(name);
-        return v != null ? valueConverter.convertToFloat(v) : null;
+        try {
+            return v != null ? valueConverter.convertToFloat(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -802,7 +859,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Double getDoubleAndRemove(K name) {
         V v = getAndRemove(name);
-        return v != null ? valueConverter.convertToDouble(v) : null;
+        try {
+            return v != null ? valueConverter.convertToDouble(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override
@@ -814,7 +875,11 @@ public class DefaultHeaders<K, V, T extends Headers<K, V, T>> implements Headers
     @Override
     public Long getTimeMillisAndRemove(K name) {
         V v = getAndRemove(name);
-        return v != null ? valueConverter.convertToTimeMillis(v) : null;
+        try {
+            return v != null ? valueConverter.convertToTimeMillis(v) : null;
+        } catch (RuntimeException ignore) {
+            return null;
+        }
     }
 
     @Override

--- a/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/DefaultHeadersTest.java
@@ -41,7 +41,11 @@ public class DefaultHeadersTest {
     private static final class TestDefaultHeaders extends
             DefaultHeaders<CharSequence, CharSequence, TestDefaultHeaders> {
         public TestDefaultHeaders() {
-            super(CharSequenceValueConverter.INSTANCE);
+            this(CharSequenceValueConverter.INSTANCE);
+        }
+
+        public TestDefaultHeaders(ValueConverter<CharSequence> converter) {
+            super(converter);
         }
     }
 
@@ -508,5 +512,132 @@ public class DefaultHeadersTest {
 
         headers = newInstance();
         assertEquals("TestDefaultHeaders[]", headers.toString());
+    }
+
+    @Test
+    public void testNotThrowWhenConvertFails() {
+        TestDefaultHeaders headers = new TestDefaultHeaders(new ValueConverter<CharSequence>() {
+            @Override
+            public CharSequence convertObject(Object value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public CharSequence convertBoolean(boolean value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public boolean convertToBoolean(CharSequence value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public CharSequence convertByte(byte value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public byte convertToByte(CharSequence value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public CharSequence convertChar(char value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public char convertToChar(CharSequence value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public CharSequence convertShort(short value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public short convertToShort(CharSequence value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public CharSequence convertInt(int value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public int convertToInt(CharSequence value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public CharSequence convertLong(long value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public long convertToLong(CharSequence value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public CharSequence convertTimeMillis(long value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public long convertToTimeMillis(CharSequence value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public CharSequence convertFloat(float value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public float convertToFloat(CharSequence value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public CharSequence convertDouble(double value) {
+                throw new IllegalArgumentException();
+            }
+
+            @Override
+            public double convertToDouble(CharSequence value) {
+                throw new IllegalArgumentException();
+            }
+        });
+        headers.set("name1", "");
+        assertNull(headers.getInt("name1"));
+        assertEquals(1, headers.getInt("name1", 1));
+
+        assertNull(headers.getBoolean(""));
+        assertFalse(headers.getBoolean("name1", false));
+
+        assertNull(headers.getByte("name1"));
+        assertEquals(1, headers.getByte("name1", (byte) 1));
+
+        assertNull(headers.getChar("name"));
+        assertEquals('n', headers.getChar("name1", 'n'));
+
+        assertNull(headers.getDouble("name"));
+        assertEquals(1, headers.getDouble("name1", 1), 0);
+
+        assertNull(headers.getFloat("name"));
+        assertEquals(Float.MAX_VALUE, headers.getFloat("name1", Float.MAX_VALUE), 0);
+
+        assertNull(headers.getLong("name"));
+        assertEquals(Long.MAX_VALUE, headers.getLong("name1", Long.MAX_VALUE));
+
+        assertNull(headers.getShort("name"));
+        assertEquals(Short.MAX_VALUE, headers.getShort("name1", Short.MAX_VALUE));
+
+        assertNull(headers.getTimeMillis("name"));
+        assertEquals(Long.MAX_VALUE, headers.getTimeMillis("name1", Long.MAX_VALUE));
     }
 }


### PR DESCRIPTION
…ull or default value.

Motivation:

Headers.get* methods should not throw an exception but return null or the default value if converting of the value fails.

Modifications:

- Correctly handle the case when ValueConverter throws an Exception.
- Add testcase.

Result:

Fixes [#7710].