### PR TITLE
Simplify CharSequenceValueConverter#convertToBoolean

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/CharSequenceValueConverter.java
+++ b/codec/src/main/java/io/netty/handler/codec/CharSequenceValueConverter.java
@@ -25,6 +25,7 @@ import java.util.Date;
  */
 public class CharSequenceValueConverter implements ValueConverter<CharSequence> {
     public static final CharSequenceValueConverter INSTANCE = new CharSequenceValueConverter();
+    private static final AsciiString TRUE_ASCII = new AsciiString("true");
 
     @Override
     public CharSequence convertObject(Object value) {
@@ -66,14 +67,7 @@ public class CharSequenceValueConverter implements ValueConverter<CharSequence> 
 
     @Override
     public boolean convertToBoolean(CharSequence value) {
-        if (value instanceof AsciiString) {
-            AsciiString asciiString = (AsciiString) value;
-            return asciiString.contentEqualsIgnoreCase("true");
-        }
-        if (value.length() != 4) {
-            return false;
-        }
-        return Boolean.parseBoolean(value.toString());
+        return AsciiString.contentEqualsIgnoreCase(value, TRUE_ASCII);
     }
 
     @Override


### PR DESCRIPTION
Motivation:
CharSequenceValueConverter#convertToBoolean has a few manual conditionals which can be removed if we use AsciiString.contentEqualsIgnoreCase. Also by comparing an AsciiString to a String we will incur conversions to char that can be avoided if we compare against AsciiString.

Modifications:
- Use AsciiString.contentEqualsIgnoreCase
- Compare against a AsciiString

Result:
Simplified CharSequenceValueConverter#convertToBoolean which favors AsciiString comparison.