### PR TITLE
Ensure we always release the AddressEnvelope when doing DNS queries.

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolverContext.java
@@ -325,6 +325,13 @@ abstract class DnsNameResolverContext<T> {
 
                 if (promise.isDone() || future.isCancelled()) {
                     queryLifecycleObserver.queryCancelled(allowedQueries);
+
+                    // Check if we need to release the envelope itself. If the query was cancelled the getNow() will
+                    // return null as well as the Future will be failed with a CancellationException.
+                    AddressedEnvelope<DnsResponse, InetSocketAddress> result = future.getNow();
+                    if (result != null) {
+                        result.release();
+                    }
                     return;
                 }
 


### PR DESCRIPTION
Motivation:

When we do DNS queries we need to ensure we always release the AddressEnvelope.

Modifications:

Also release the AddressEnvelope if the original resolution was done in the meantime and we did not cancel the extra query yet.

Result:

Should fix [#7713]