### PR TITLE
Always start with the assumption that the writefilter is not enabled.

### DIFF
--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -64,6 +64,9 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
 
     final BsdSocket socket;
     private boolean readFilterEnabled = true;
+
+    // We always start with the assumption that the writefilter is not enabled as otherwise flush0 may return before
+    // we were even able to try to flush one time at all.
     private boolean writeFilterEnabled;
     boolean readReadyRunnablePending;
     boolean inputClosedSeenErrorOnRead;
@@ -81,14 +84,9 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
     private volatile SocketAddress remote;
 
     AbstractKQueueChannel(Channel parent, BsdSocket fd, boolean active) {
-        this(parent, fd, active, false);
-    }
-
-    AbstractKQueueChannel(Channel parent, BsdSocket fd, boolean active, boolean writeFilterEnabled) {
         super(parent);
         socket = checkNotNull(fd, "fd");
         this.active = active;
-        this.writeFilterEnabled = writeFilterEnabled;
         if (active) {
             // Directly cache the remote and local addresses
             // See https://github.com/netty/netty/issues/2359

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueChannel.java
@@ -217,10 +217,10 @@ abstract class AbstractKQueueChannel extends AbstractChannel implements UnixChan
         // make sure the readReadyRunnablePending variable is reset so we will be able to execute the Runnable on the
         // new EventLoop.
         readReadyRunnablePending = false;
-        // Add the write event first so we get notified of connection refused on the client side!
-        if (writeFilterEnabled) {
-            evSet0(Native.EVFILT_WRITE, Native.EV_ADD_CLEAR_ENABLE);
-        }
+
+        // Always start with the write filter enabled to ensure we are notified about connection refused.
+        evSet0(Native.EVFILT_WRITE, Native.EV_ADD_CLEAR_ENABLE);
+
         if (readFilterEnabled) {
             evSet0(Native.EVFILT_READ, Native.EV_ADD_CLEAR_ENABLE);
         }

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/AbstractKQueueStreamChannel.java
@@ -64,7 +64,7 @@ public abstract class AbstractKQueueStreamChannel extends AbstractKQueueChannel 
     };
 
     AbstractKQueueStreamChannel(Channel parent, BsdSocket fd, boolean active) {
-        super(parent, fd, active, true);
+        super(parent, fd, active);
     }
 
     AbstractKQueueStreamChannel(Channel parent, BsdSocket fd, SocketAddress remote) {


### PR DESCRIPTION
Motivation:

ce241bd11ec26008a692b87391b94d8efe69069d introduced code to not try flushing data to the socket when the writefilter is enabled. The problem with this was that we sometimes created an AbstractKqueueChannel that started with the writeFilter enabled and so we never had the chance to at least try to flush one time.

Modifications:

- Always start with the assumption that the write filter is not enabled. At worse we will try to write one time and then enable it if we can not flush out everything.
- Remove now unused constructor.

Result:

Fixes test timeout on macOS.