### PR TITLE
Make WebSocketServerHandshaker injectable in WebSocketServerProtocolH…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -103,6 +103,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
     private final int maxFramePayloadLength;
     private final boolean allowMaskMismatch;
     private final boolean checkStartsWith;
+    private WebSocketServerHandshaker handshaker;
 
     public WebSocketServerProtocolHandler(String websocketPath) {
         this(websocketPath, null, false);
@@ -132,12 +133,19 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
             boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch, boolean checkStartsWith) {
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, false, null);
+    }
+
+    public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
+            boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch, boolean checkStartsWith,
+            WebSocketServerHandshaker handshaker) {
         this.websocketPath = websocketPath;
         this.subprotocols = subprotocols;
         this.allowExtensions = allowExtensions;
         maxFramePayloadLength = maxFrameSize;
         this.allowMaskMismatch = allowMaskMismatch;
         this.checkStartsWith = checkStartsWith;
+        this.handshaker = handshaker;
     }
 
     @Override
@@ -147,7 +155,7 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
             // Add the WebSocketHandshakeHandler before this one.
             ctx.pipeline().addBefore(ctx.name(), WebSocketServerProtocolHandshakeHandler.class.getName(),
                     new WebSocketServerProtocolHandshakeHandler(websocketPath, subprotocols,
-                            allowExtensions, maxFramePayloadLength, allowMaskMismatch, checkStartsWith));
+                            allowExtensions, maxFramePayloadLength, allowMaskMismatch, checkStartsWith, handshaker));
         }
         if (cp.get(Utf8FrameValidator.class) == null) {
             // Add the UFT8 checking before this one.


### PR DESCRIPTION
…andler and WebSocketServerProtocolHandshakeHandler.

Motivation:
See also #7742.
At present, WebSocketServerHandshaker is not injectable in WebSocketServerProtocolHandler and WebSocketServerProtocolHandshakeHandler.
When we want to implement an original WebSocketServerHandshaker, we need heavy lifting or copy-and-paste work.
This PR enables us to use easily our own websocket server handshakers.

Modification:
- Add constractors to WebSocketServerProtocolHandler and WebSocketServerProtocolHandshakeHandler that are passed a WebSocketServerHandshaker object.
- Due to the above modification, some final fields may not be initialized at constractors. Therefore I make them non-final variables.

Result:
Fixes #7742 . 