### PR TITLE
Close SSLEngine when connection fails.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
+++ b/handler/src/main/java/io/netty/handler/ssl/SslHandler.java
@@ -1510,6 +1510,7 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
         try {
             // Release all resources such as internal buffers that SSLEngine
             // is managing.
+            outboundClosed = true;
             engine.closeOutbound();
 
             if (closeInbound) {
@@ -1557,6 +1558,9 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
 
     private void closeOutboundAndChannel(
             final ChannelHandlerContext ctx, final ChannelPromise promise, boolean disconnect) throws Exception {
+        outboundClosed = true;
+        engine.closeOutbound();
+
         if (!ctx.channel().isActive()) {
             if (disconnect) {
                 ctx.disconnect(promise);
@@ -1565,9 +1569,6 @@ public class SslHandler extends ByteToMessageDecoder implements ChannelOutboundH
             }
             return;
         }
-
-        outboundClosed = true;
-        engine.closeOutbound();
 
         ChannelPromise closeNotifyPromise = ctx.newPromise();
         try {


### PR DESCRIPTION
Motivation:
When using the JdkSslEngine, the ALPN class is used keep a reference
to the engine.   In the event that the TCP connection fails, the
SSLEngine is not removed from the map, creating a memory leak.

Modification:
Always close the SSLEngine regardless of if the channel became
active.  Also, record the SSLEngine was closed in all places.

Result:
Fixes: https://github.com/grpc/grpc-java/issues/3080
