### PR TITLE
Call correct super methods in test.

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -219,7 +219,7 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
             if (!autoRead) {
                 ctx.read();
             }
-            super.channelInactive(ctx);
+            super.channelActive(ctx);
         }
 
         @Override

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSpdyEchoTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketSpdyEchoTest.java
@@ -28,11 +28,9 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.spdy.SpdyFrameCodec;
 import io.netty.handler.codec.spdy.SpdyVersion;
-import io.netty.util.NetUtil;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -195,7 +193,6 @@ public class SocketSpdyEchoTest extends AbstractSocketTest {
         cb.handler(ch);
 
         Channel sc = sb.bind().sync().channel();
-        int port = ((InetSocketAddress) sc.localAddress()).getPort();
 
         Channel cc = cb.connect(sc.localAddress()).sync().channel();
         cc.writeAndFlush(frames);


### PR DESCRIPTION
Motivation:

We called the wrong super method in the test and also had a few unused imports.

Modifications:

Fix super method call and cleanup.

Result:

More correct test and cleanup.