### PR TITLE
EmptyHeaders get with default value returns null

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/EmptyHeaders.java
+++ b/codec/src/main/java/io/netty/handler/codec/EmptyHeaders.java
@@ -30,7 +30,7 @@ public class EmptyHeaders<K, V, T extends Headers<K, V, T>> implements Headers<K
 
     @Override
     public V get(K name, V defaultValue) {
-        return null;
+        return defaultValue;
     }
 
     @Override
@@ -40,7 +40,7 @@ public class EmptyHeaders<K, V, T extends Headers<K, V, T>> implements Headers<K
 
     @Override
     public V getAndRemove(K name, V defaultValue) {
-        return null;
+        return defaultValue;
     }
 
     @Override


### PR DESCRIPTION
Motivation:
EmptyHeaders#get with a default value argument returns null. It should never return null, and instead it should return the default value.

Modifications:
- EmptyHeaders#get with a default value should return that default value

Result:
More correct implementation of the Headers API.