### PR TITLE
HashedWheelTimer.newTimeout(...) may overflow

### DIFF
--- a/common/src/main/java/io/netty/util/HashedWheelTimer.java
+++ b/common/src/main/java/io/netty/util/HashedWheelTimer.java
@@ -419,6 +419,11 @@ public class HashedWheelTimer implements Timer {
         // Add the timeout to the timeout queue which will be processed on the next tick.
         // During processing all the queued HashedWheelTimeouts will be added to the correct HashedWheelBucket.
         long deadline = System.nanoTime() + unit.toNanos(delay) - startTime;
+
+        // Guard against overflow.
+        if (delay > 0 && deadline < 0) {
+            deadline = Long.MAX_VALUE;
+        }
         HashedWheelTimeout timeout = new HashedWheelTimeout(this, task, deadline);
         timeouts.add(timeout);
         return timeout;

--- a/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
+++ b/common/src/test/java/io/netty/util/HashedWheelTimerTest.java
@@ -230,6 +230,21 @@ public class HashedWheelTimerTest {
         timer.stop();
     }
 
+    @Test
+    public void testOverflow() throws InterruptedException  {
+        final HashedWheelTimer timer = new HashedWheelTimer();
+        final CountDownLatch latch = new CountDownLatch(1);
+        Timeout timeout = timer.newTimeout(new TimerTask() {
+            @Override
+            public void run(Timeout timeout) {
+                latch.countDown();
+            }
+        }, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+        assertFalse(latch.await(1, TimeUnit.SECONDS));
+        timeout.cancel();
+        timer.stop();
+    }
+
     private static TimerTask createNoOpTimerTask() {
         return new TimerTask() {
             @Override


### PR DESCRIPTION
Motivation:

We dont protect from overflow and so the timer may fire too early if a large timeout is used.

Modifications:

Add overflow guard and a test.

Result:

Fixes https://github.com/netty/netty/issues/7760.