### PR TITLE
IovArray.add(...) should check if buffer has memory address.

### DIFF
--- a/transport-native-unix-common/src/main/java/io/netty/channel/unix/IovArray.java
+++ b/transport-native-unix-common/src/main/java/io/netty/channel/unix/IovArray.java
@@ -91,7 +91,7 @@ public final class IovArray implements MessageProcessor {
         if (count == IOV_MAX) {
             // No more room!
             return false;
-        } else if (buf.nioBufferCount() == 1) {
+        } else if (buf.hasMemoryAddress() && buf.nioBufferCount() == 1) {
             final int len = buf.readableBytes();
             return len == 0 || add(buf.memoryAddress(), buf.readerIndex(), len);
         } else {


### PR DESCRIPTION
Motivation:

We currently not check if the buffer has a memory address and just assume this is the case if the nioBufferCount() == 1.

Modifications:

- Check hasMemoryAddress() before trying to access it.
- Add unit case.

Result:

More correct and robust code. Related to [#7752].