### PR TITLE
Set stream ID to the real value in Http2StreamFrameToHttpObjectCodec

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
@@ -81,7 +81,7 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
     @Override
     protected void decode(ChannelHandlerContext ctx, Http2StreamFrame frame, List<Object> out) throws Exception {
         if (frame instanceof Http2HeadersFrame) {
-            int id = 0; // not really the id
+            int id = frame.stream().id();
             Http2HeadersFrame headersFrame = (Http2HeadersFrame) frame;
             Http2Headers headers = headersFrame.headers();
 


### PR DESCRIPTION
Motivation:

Http2StreamFrameToHttpObjectCodec is useful to convert HTTP/2 streams to Netty's HTTP requests/responses. But the HTTP/2 stream ID is always 0 after conversion.

Modification:

Instead of always using 0 for the stream ID,  the stream ID from frame.stream().id() is used.

Result:

The stream ID is set from the HTTP/2 stream and retained after conversion. This can be useful for users who wants to track HTTP/2 requests/responses, for example via header x-http2-stream-id.

This is a single line change. I think the contribution is so trivial that I did not sign the CLA yet.