### PR TITLE
Correctly record creation stacktrace in ResourceLeakDetector.

### DIFF
--- a/common/src/main/java/io/netty/util/ResourceLeakDetector.java
+++ b/common/src/main/java/io/netty/util/ResourceLeakDetector.java
@@ -369,7 +369,8 @@ public class ResourceLeakDetector<T> {
             // be collected via the WeakReference.
             trackedHash = System.identityHashCode(referent);
             allLeaks.put(this, LeakEntry.INSTANCE);
-            headUpdater.set(this, Record.BOTTOM);
+            // Create a new Record so we always have the creation stacktrace included.
+            headUpdater.set(this, new Record(Record.BOTTOM));
             this.allLeaks = allLeaks;
         }
 


### PR DESCRIPTION
Motivation:

We missed to correctly record the stacktrace of the creation of an ResourceLeak record. This could either have the effect to log the wrote stacktrace for creation or not log a stacktrace at all if the object was dropped on the floor after it was created.

Modifications:

Correctly create a Record on creation of the object.

Result:

Fixes https://github.com/netty/netty/issues/7781.