### PR TITLE
Correctly include the stream id when convert from Http2HeadersFrame t…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2StreamFrameToHttpObjectCodec.java
@@ -81,9 +81,10 @@ public class Http2StreamFrameToHttpObjectCodec extends MessageToMessageCodec<Htt
     @Override
     protected void decode(ChannelHandlerContext ctx, Http2StreamFrame frame, List<Object> out) throws Exception {
         if (frame instanceof Http2HeadersFrame) {
-            int id = 0; // not really the id
             Http2HeadersFrame headersFrame = (Http2HeadersFrame) frame;
             Http2Headers headers = headersFrame.headers();
+            Http2FrameStream stream = headersFrame.stream();
+            int id = stream == null ? 0 : stream.id();
 
             final CharSequence status = headers.status();
 


### PR DESCRIPTION
…o HttpMessage

Motivation:

We did not correctly set the stream id in the headers of HttpMessage when converting a Http2HeadersFrame. This is based on https://github.com/netty/netty/pull/7778 so thanks to @jprante.

Modifications:

- Correctly set the id when possible in the header.
- Add test case

Result:

Correctly include stream id.