### PR TITLE
Simplify DefaultChannelGroup.contains(...) and so remove one instance…

### DIFF
--- a/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
+++ b/transport/src/main/java/io/netty/channel/group/DefaultChannelGroup.java
@@ -126,16 +126,12 @@ public class DefaultChannelGroup extends AbstractSet<Channel> implements Channel
 
     @Override
     public boolean contains(Object o) {
-        if (o instanceof Channel) {
-            Channel c = (Channel) o;
-            if (o instanceof ServerChannel) {
-                return serverChannels.containsValue(c);
-            } else {
-                return nonServerChannels.containsValue(c);
-            }
-        } else {
-            return false;
+        if (o instanceof ServerChannel) {
+            return serverChannels.containsValue(o);
+        } else if (o instanceof Channel) {
+            return nonServerChannels.containsValue(o);
         }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
…of check.

Motivation:

DefaultChannelGroup.contains(...) did one more instanceof check then needed.

Modifications:

Simplify contains(...) and remove one instanceof check.

Result:

Simplier and cheaper implementation.