### PR TITLE
Skip NPN tests when libressl 2.6.1+ is used.

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -131,8 +131,37 @@ public class OpenSslEngineTest extends SSLEngineTest {
         super.testClientHostnameValidationFail();
     }
 
+    private static boolean isNpnSupported(String versionString) {
+        String[] versionStringParts = versionString.split(" ", -1);
+        if (versionStringParts.length == 2 && "LibreSSL".equals(versionStringParts[0])) {
+            String[] versionParts = versionStringParts[1].split("\\.", -1);
+            if (versionParts.length == 3) {
+                int major = Integer.parseInt(versionParts[0]);
+                if (major < 2) {
+                    return true;
+                }
+                if (major > 2) {
+                    return false;
+                }
+                int minor = Integer.parseInt(versionParts[1]);
+                if (minor < 6) {
+                    return true;
+                }
+                if (minor > 6) {
+                    return false;
+                }
+                int bugfix = Integer.parseInt(versionParts[2]);
+                if (bugfix > 0) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
     @Test
     public void testNpn() throws Exception {
+        String versionString = OpenSsl.versionString();
+        assumeTrue("LibreSSL 2.6.1 removed NPN support, detected " + versionString, isNpnSupported(versionString));
         ApplicationProtocolConfig apn = acceptingNegotiator(Protocol.NPN,
                 PREFERRED_APPLICATION_LEVEL_PROTOCOL);
         setupHandlers(apn);

--- a/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/SSLEngineTest.java
@@ -1009,7 +1009,7 @@ public abstract class SSLEngineTest {
         SslHandler handler = channel.pipeline().get(SslHandler.class);
         assertNotNull(handler);
         String appProto = handler.applicationProtocol();
-        assertEquals(appProto, expectedApplicationProtocol);
+        assertEquals(expectedApplicationProtocol, appProto);
 
         SSLEngine engine = handler.engine();
         if (engine instanceof Java9SslEngine) {


### PR DESCRIPTION
    Motivation:

    LibreSSL removed support for NPN in its 2.6.1+ releases.

    Modifications:

    Skip NPN tests in libressl 2.6.1+

    Result:

    Be able to run netty tests against libressl 2.6.1+ as well.