### PR TITLE
Add DnsNameResolver.resolveAll(DnsQuestion)

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressDecoder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressDecoder.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import java.net.IDN;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
+import io.netty.handler.codec.dns.DnsRawRecord;
+import io.netty.handler.codec.dns.DnsRecord;
+
+/**
+ * Decodes an {@link InetAddress} from an A or AAAA {@link DnsRawRecord}.
+ */
+final class DnsAddressDecoder {
+
+    private static final int INADDRSZ4 = 4;
+    private static final int INADDRSZ6 = 16;
+
+    /**
+     * Decodes an {@link InetAddress} from an A or AAAA {@link DnsRawRecord}.
+     *
+     * @param record the {@link DnsRecord}, most likely a {@link DnsRawRecord}
+     * @param name the host name of the decoded address
+     * @param decodeIdn whether to convert {@code name} to a unicode host name
+     *
+     * @return the {@link InetAddress}, or {@code null} if {@code record} is not a {@link DnsRawRecord} or
+     *         its content is malformed
+     */
+    static InetAddress decodeAddress(DnsRecord record, String name, boolean decodeIdn) {
+        if (!(record instanceof DnsRawRecord)) {
+            return null;
+        }
+        final ByteBuf content = ((ByteBufHolder) record).content();
+        final int contentLen = content.readableBytes();
+        if (contentLen != INADDRSZ4 && contentLen != INADDRSZ6) {
+            return null;
+        }
+
+        final byte[] addrBytes = new byte[contentLen];
+        content.getBytes(content.readerIndex(), addrBytes);
+
+        try {
+            return InetAddress.getByAddress(decodeIdn ? IDN.toUnicode(name) : name, addrBytes);
+        } catch (UnknownHostException e) {
+            // Should never reach here.
+            throw new Error(e);
+        }
+    }
+
+    private DnsAddressDecoder() { }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressDecoder.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressDecoder.java
@@ -16,7 +16,6 @@
 package io.netty.resolver.dns;
 
 import java.net.IDN;
-import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import static io.netty.resolver.dns.DnsAddressDecoder.decodeAddress;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+
+import io.netty.channel.EventLoop;
+import io.netty.handler.codec.dns.DnsRecord;
+import io.netty.handler.codec.dns.DnsRecordType;
+
+final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
+
+    private final DnsCache resolveCache;
+
+    DnsAddressResolveContext(DnsNameResolver parent, String hostname, DnsRecord[] additionals,
+                             DnsServerAddressStream nameServerAddrs, DnsCache resolveCache) {
+        super(parent, hostname, DnsRecord.CLASS_IN, parent.resolveRecordTypes(), additionals, nameServerAddrs);
+        this.resolveCache = resolveCache;
+    }
+
+    @Override
+    DnsResolveContext<InetAddress> newResolverContext(DnsNameResolver parent, String hostname,
+                                                      int dnsClass, DnsRecordType[] expectedTypes,
+                                                      DnsRecord[] additionals,
+                                                      DnsServerAddressStream nameServerAddrs) {
+        return new DnsAddressResolveContext(parent, hostname, additionals, nameServerAddrs, resolveCache);
+    }
+
+    @Override
+    InetAddress convertRecord(DnsRecord record, String hostname, DnsRecord[] additionals, EventLoop eventLoop) {
+        return decodeAddress(record, hostname, parent.isDecodeIdn());
+    }
+
+    @Override
+    boolean gotResult(List<InetAddress> finalResult) {
+        final int size = finalResult.size();
+        final Class<? extends InetAddress> inetAddressType = parent.preferredAddressType().addressType();
+        for (int i = 0; i < size; i++) {
+            InetAddress address = finalResult.get(i);
+            if (inetAddressType.isInstance(address)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    void cache(String hostname, DnsRecord[] additionals,
+               DnsRecord result, InetAddress convertedResult) {
+        resolveCache.cache(hostname, additionals, convertedResult, result.timeToLive(), parent.ch.eventLoop());
+    }
+
+    @Override
+    void cache(String hostname, DnsRecord[] additionals, UnknownHostException cause) {
+        resolveCache.cache(hostname, additionals, cause, parent.ch.eventLoop());
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
@@ -49,7 +49,7 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     }
 
     @Override
-    boolean gotResult(List<InetAddress> finalResult) {
+    boolean containsExpectedResult(List<InetAddress> finalResult) {
         final int size = finalResult.size();
         final Class<? extends InetAddress> inetAddressType = parent.preferredAddressType().addressType();
         for (int i = 0; i < size; i++) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -608,6 +608,8 @@ public class DnsNameResolver extends InetNameResolver {
                 }
 
                 if (content != null) {
+                    // Our current implementation does not support reloading the hosts file,
+                    // so use a fairly large TTL (1 day, i.e. 86400 seconds).
                     trySuccess(promise, Collections.<DnsRecord>singletonList(
                             new DefaultDnsRawRecord(hostname, type, 86400, content)));
                     return promise;
@@ -739,7 +741,7 @@ public class DnsNameResolver extends InetNameResolver {
         doResolveAllUncached(hostname, additionals, allPromise, resolveCache);
         allPromise.addListener(new FutureListener<List<InetAddress>>() {
             @Override
-            public void operationComplete(Future<List<InetAddress>> future) throws Exception {
+            public void operationComplete(Future<List<InetAddress>> future) {
                 if (future.isSuccess()) {
                     trySuccess(promise, future.getNow().get(0));
                 } else {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -16,6 +16,8 @@
 package io.netty.resolver.dns;
 
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFactory;
@@ -33,11 +35,13 @@ import io.netty.channel.socket.InternetProtocolFamily;
 import io.netty.handler.codec.dns.DatagramDnsQueryEncoder;
 import io.netty.handler.codec.dns.DatagramDnsResponse;
 import io.netty.handler.codec.dns.DatagramDnsResponseDecoder;
+import io.netty.handler.codec.dns.DefaultDnsRawRecord;
 import io.netty.handler.codec.dns.DnsQuestion;
 import io.netty.handler.codec.dns.DnsRawRecord;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
 import io.netty.handler.codec.dns.DnsResponse;
+import io.netty.resolver.HostsFileEntries;
 import io.netty.resolver.HostsFileEntriesResolver;
 import io.netty.resolver.InetNameResolver;
 import io.netty.resolver.ResolvedAddressTypes;
@@ -45,6 +49,7 @@ import io.netty.util.NetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.FastThreadLocal;
 import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.FutureListener;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
@@ -55,6 +60,8 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.lang.reflect.Method;
 import java.net.IDN;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -527,6 +534,94 @@ public class DnsNameResolver extends InetNameResolver {
         doResolve(inetHost, EMPTY_ADDITIONALS, promise, resolveCache);
     }
 
+    /**
+     * Resolves the {@link DnsRecord}s that are matched by the specified {@link DnsQuestion}. Unlike
+     * {@link #query(DnsQuestion)}, this method handles redirection, CNAMEs and multiple name servers.
+     * If the specified {@link DnsQuestion} is {@code A} or {@code AAAA}, this method looks up the configured
+     * {@link HostsFileEntries} before sending a query to the name servers. If a match is found in the
+     * {@link HostsFileEntries}, a synthetic {@code A} or {@code AAAA} record will be returned.
+     *
+     * @param question the question
+     *
+     * @return the list of the {@link DnsRecord}s as the result of the resolution
+     */
+    public final Future<List<DnsRecord>> resolveAll(DnsQuestion question) {
+        return resolveAll(question, EMPTY_ADDITIONALS, executor().<List<DnsRecord>>newPromise());
+    }
+
+    /**
+     * Resolves the {@link DnsRecord}s that are matched by the specified {@link DnsQuestion}. Unlike
+     * {@link #query(DnsQuestion)}, this method handles redirection, CNAMEs and multiple name servers.
+     * If the specified {@link DnsQuestion} is {@code A} or {@code AAAA}, this method looks up the configured
+     * {@link HostsFileEntries} before sending a query to the name servers. If a match is found in the
+     * {@link HostsFileEntries}, a synthetic {@code A} or {@code AAAA} record will be returned.
+     *
+     * @param question the question
+     * @param additionals additional records ({@code OPT})
+     *
+     * @return the list of the {@link DnsRecord}s as the result of the resolution
+     */
+    public final Future<List<DnsRecord>> resolveAll(DnsQuestion question, Iterable<DnsRecord> additionals) {
+        return resolveAll(question, additionals, executor().<List<DnsRecord>>newPromise());
+    }
+
+    /**
+     * Resolves the {@link DnsRecord}s that are matched by the specified {@link DnsQuestion}. Unlike
+     * {@link #query(DnsQuestion)}, this method handles redirection, CNAMEs and multiple name servers.
+     * If the specified {@link DnsQuestion} is {@code A} or {@code AAAA}, this method looks up the configured
+     * {@link HostsFileEntries} before sending a query to the name servers. If a match is found in the
+     * {@link HostsFileEntries}, a synthetic {@code A} or {@code AAAA} record will be returned.
+     *
+     * @param question the question
+     * @param additionals additional records ({@code OPT})
+     * @param promise the {@link Promise} which will be fulfilled when the resolution is finished
+     *
+     * @return the list of the {@link DnsRecord}s as the result of the resolution
+     */
+    public final Future<List<DnsRecord>> resolveAll(DnsQuestion question, Iterable<DnsRecord> additionals,
+                                                    Promise<List<DnsRecord>> promise) {
+        final DnsRecord[] additionalsArray = toArray(additionals, true);
+        return resolveAll(question, additionalsArray, promise);
+    }
+
+    private Future<List<DnsRecord>> resolveAll(DnsQuestion question, DnsRecord[] additionals,
+                                               Promise<List<DnsRecord>> promise) {
+        checkNotNull(question, "question");
+        checkNotNull(promise, "promise");
+
+        // Respect /etc/hosts as well if the record type is A or AAAA.
+        final DnsRecordType type = question.type();
+        final String hostname = question.name();
+
+        if (type == DnsRecordType.A || type == DnsRecordType.AAAA) {
+            final InetAddress hostsFileEntry = resolveHostsFileEntry(hostname);
+            if (hostsFileEntry != null) {
+                ByteBuf content = null;
+                if (hostsFileEntry instanceof Inet4Address) {
+                    if (type == DnsRecordType.A) {
+                        content = Unpooled.wrappedBuffer(hostsFileEntry.getAddress());
+                    }
+                } else if (hostsFileEntry instanceof Inet6Address) {
+                    if (type == DnsRecordType.AAAA) {
+                        content = Unpooled.wrappedBuffer(hostsFileEntry.getAddress());
+                    }
+                }
+
+                if (content != null) {
+                    trySuccess(promise, Collections.<DnsRecord>singletonList(
+                            new DefaultDnsRawRecord(hostname, type, 86400, content)));
+                    return promise;
+                }
+            }
+        }
+
+        // It was not A/AAAA question or there was no entry in /etc/hosts.
+        final DnsServerAddressStream nameServerAddrs =
+                dnsServerAddressStreamProvider.nameServerAddressStream(hostname);
+        new DnsRecordResolveContext(this, question, additionals, nameServerAddrs).resolve(promise);
+        return promise;
+    }
+
     private static DnsRecord[] toArray(Iterable<DnsRecord> additionals, boolean validateType) {
         checkNotNull(additionals, "additionals");
         if (additionals instanceof Collection) {
@@ -624,7 +719,7 @@ public class DnsNameResolver extends InetNameResolver {
         }
     }
 
-    private static <T> void trySuccess(Promise<T> promise, T result) {
+    static <T> void trySuccess(Promise<T> promise, T result) {
         if (!promise.trySuccess(result)) {
             logger.warn("Failed to notify success ({}) to a promise: {}", result, promise);
         }
@@ -638,40 +733,20 @@ public class DnsNameResolver extends InetNameResolver {
 
     private void doResolveUncached(String hostname,
                                    DnsRecord[] additionals,
-                                   Promise<InetAddress> promise,
+                                   final Promise<InetAddress> promise,
                                    DnsCache resolveCache) {
-        new SingleResolverContext(this, hostname, additionals, resolveCache,
-                                  dnsServerAddressStreamProvider.nameServerAddressStream(hostname)).resolve(promise);
-    }
-
-    static final class SingleResolverContext extends DnsNameResolverContext<InetAddress> {
-        SingleResolverContext(DnsNameResolver parent, String hostname,
-                              DnsRecord[] additionals, DnsCache resolveCache, DnsServerAddressStream nameServerAddrs) {
-            super(parent, hostname, additionals, resolveCache, nameServerAddrs);
-        }
-
-        @Override
-        DnsNameResolverContext<InetAddress> newResolverContext(DnsNameResolver parent, String hostname,
-                                                               DnsRecord[] additionals, DnsCache resolveCache,
-                                                               DnsServerAddressStream nameServerAddrs) {
-            return new SingleResolverContext(parent, hostname, additionals, resolveCache, nameServerAddrs);
-        }
-
-        @Override
-        boolean finishResolve(
-            Class<? extends InetAddress> addressType, List<DnsCacheEntry> resolvedEntries,
-            Promise<InetAddress> promise) {
-
-            final int numEntries = resolvedEntries.size();
-            for (int i = 0; i < numEntries; i++) {
-                final InetAddress a = resolvedEntries.get(i).address();
-                if (addressType.isInstance(a)) {
-                    trySuccess(promise, a);
-                    return true;
+        final Promise<List<InetAddress>> allPromise = executor().newPromise();
+        doResolveAllUncached(hostname, additionals, allPromise, resolveCache);
+        allPromise.addListener(new FutureListener<List<InetAddress>>() {
+            @Override
+            public void operationComplete(Future<List<InetAddress>> future) throws Exception {
+                if (future.isSuccess()) {
+                    trySuccess(promise, future.getNow().get(0));
+                } else {
+                    tryFailure(promise, future.cause());
                 }
             }
-            return false;
-        }
+        });
     }
 
     @Override
@@ -747,50 +822,13 @@ public class DnsNameResolver extends InetNameResolver {
         }
     }
 
-    static final class ListResolverContext extends DnsNameResolverContext<List<InetAddress>> {
-        ListResolverContext(DnsNameResolver parent, String hostname,
-                            DnsRecord[] additionals, DnsCache resolveCache, DnsServerAddressStream nameServerAddrs) {
-            super(parent, hostname, additionals, resolveCache, nameServerAddrs);
-        }
-
-        @Override
-        DnsNameResolverContext<List<InetAddress>> newResolverContext(
-                DnsNameResolver parent, String hostname,  DnsRecord[] additionals, DnsCache resolveCache,
-                DnsServerAddressStream nameServerAddrs) {
-            return new ListResolverContext(parent, hostname, additionals, resolveCache, nameServerAddrs);
-        }
-
-        @Override
-        boolean finishResolve(
-            Class<? extends InetAddress> addressType, List<DnsCacheEntry> resolvedEntries,
-            Promise<List<InetAddress>> promise) {
-
-            List<InetAddress> result = null;
-            final int numEntries = resolvedEntries.size();
-            for (int i = 0; i < numEntries; i++) {
-                final InetAddress a = resolvedEntries.get(i).address();
-                if (addressType.isInstance(a)) {
-                    if (result == null) {
-                        result = new ArrayList<InetAddress>(numEntries);
-                    }
-                    result.add(a);
-                }
-            }
-
-            if (result != null) {
-                promise.trySuccess(result);
-                return true;
-            }
-            return false;
-        }
-    }
-
     private void doResolveAllUncached(String hostname,
                                       DnsRecord[] additionals,
                                       Promise<List<InetAddress>> promise,
                                       DnsCache resolveCache) {
-        new ListResolverContext(this, hostname, additionals, resolveCache,
-                                dnsServerAddressStreamProvider.nameServerAddressStream(hostname)).resolve(promise);
+        final DnsServerAddressStream nameServerAddrs =
+                dnsServerAddressStreamProvider.nameServerAddressStream(hostname);
+        new DnsAddressResolveContext(this, hostname, additionals, nameServerAddrs, resolveCache).resolve(promise);
     }
 
     private static String hostname(String inetHost) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import static io.netty.resolver.dns.DnsAddressDecoder.decodeAddress;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+
+import io.netty.channel.EventLoop;
+import io.netty.handler.codec.dns.DnsQuestion;
+import io.netty.handler.codec.dns.DnsRecord;
+import io.netty.handler.codec.dns.DnsRecordType;
+import io.netty.util.ReferenceCountUtil;
+
+final class DnsRecordResolveContext extends DnsResolveContext<DnsRecord> {
+
+    DnsRecordResolveContext(DnsNameResolver parent, DnsQuestion question, DnsRecord[] additionals,
+                            DnsServerAddressStream nameServerAddrs) {
+        this(parent, question.name(), question.dnsClass(),
+             new DnsRecordType[] { question.type() },
+             additionals, nameServerAddrs);
+    }
+
+    private DnsRecordResolveContext(DnsNameResolver parent, String hostname,
+                                    int dnsClass, DnsRecordType[] expectedTypes,
+                                    DnsRecord[] additionals,
+                                    DnsServerAddressStream nameServerAddrs) {
+        super(parent, hostname, dnsClass, expectedTypes, additionals, nameServerAddrs);
+    }
+
+    @Override
+    DnsResolveContext<DnsRecord> newResolverContext(DnsNameResolver parent, String hostname,
+                                                    int dnsClass, DnsRecordType[] expectedTypes,
+                                                    DnsRecord[] additionals,
+                                                    DnsServerAddressStream nameServerAddrs) {
+        return new DnsRecordResolveContext(parent, hostname, dnsClass, expectedTypes, additionals, nameServerAddrs);
+    }
+
+    @Override
+    DnsRecord convertRecord(DnsRecord record, String hostname, DnsRecord[] additionals, EventLoop eventLoop) {
+        return ReferenceCountUtil.retain(record);
+    }
+
+    @Override
+    boolean gotResult(List<DnsRecord> finalResult) {
+        return true;
+    }
+
+    @Override
+    void cache(String hostname, DnsRecord[] additionals, DnsRecord result, DnsRecord convertedResult) {
+        // Do not cache.
+    }
+
+    @Override
+    void cache(String hostname, DnsRecord[] additionals, UnknownHostException cause) {
+        // Do not cache.
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
@@ -57,17 +57,19 @@ final class DnsRecordResolveContext extends DnsResolveContext<DnsRecord> {
     }
 
     @Override
-    boolean gotResult(List<DnsRecord> finalResult) {
+    boolean containsExpectedResult(List<DnsRecord> finalResult) {
         return true;
     }
 
     @Override
     void cache(String hostname, DnsRecord[] additionals, DnsRecord result, DnsRecord convertedResult) {
         // Do not cache.
+        // XXX: When we implement cache, we would need to retain the reference count of the result record.
     }
 
     @Override
     void cache(String hostname, DnsRecord[] additionals, UnknownHostException cause) {
         // Do not cache.
+        // XXX: When we implement cache, we would need to retain the reference count of the result record.
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -137,9 +137,10 @@ abstract class DnsResolveContext<T> {
     abstract T convertRecord(DnsRecord record, String hostname, DnsRecord[] additionals, EventLoop eventLoop);
 
     /**
-     * Returns {@code true} if the given list contains any expected records.
+     * Returns {@code true} if the given list contains any expected records. {@code finalResult} always contains
+     * at least one element.
      */
-    abstract boolean gotResult(List<T> finalResult);
+    abstract boolean containsExpectedResult(List<T> finalResult);
 
     /**
      * Caches a successful resolution.
@@ -444,8 +445,7 @@ abstract class DnsResolveContext<T> {
                 for (int i = 0; i < additionalCount; i++) {
                     final DnsRecord r = res.recordAt(DnsSection.ADDITIONAL, i);
 
-                    if (r.type() != question.type() ||
-                        r.type() == DnsRecordType.A && !parent.supportsARecords() ||
+                    if (r.type() == DnsRecordType.A && !parent.supportsARecords() ||
                         r.type() == DnsRecordType.AAAA && !parent.supportsAAAARecords()) {
                         continue;
                     }
@@ -547,9 +547,9 @@ abstract class DnsResolveContext<T> {
             if (finalResult == null) {
                 finalResult = new ArrayList<T>(8);
             }
+            finalResult.add(converted);
 
             cache(hostname, additionals, r, converted);
-            finalResult.add(converted);
             found = true;
 
             // Note that we do not break from the loop here, so we decode/cache all A/AAAA records.
@@ -641,12 +641,12 @@ abstract class DnsResolveContext<T> {
             queryLifecycleObserver.queryCancelled(allowedQueries);
 
             // There are still some queries we did not receive responses for.
-            if (finalResult != null && gotResult(finalResult)) {
+            if (finalResult != null && containsExpectedResult(finalResult)) {
                 // But it's OK to finish the resolution process if we got something expected.
                 finishResolve(promise, cause);
             }
 
-            // We did not get any thing interesting, so we can't finish the resolution process.
+            // We did not get an expected result yet, so we can't finish the resolution process.
             return;
         }
 


### PR DESCRIPTION
Motivation:

A user is currently expected to use DnsNameResolver.query() when he or
she wants to look up the full DNS records rather than just InetAddres.

However, query() only performs a single query. It does not handle
/etc/hosts file, redirection, CNAMEs or multiple name servers.

As a result, such a user has to duplicate all the logic in
DnsNameResolverContext.

Modifications:

- Refactor DnsNameResolverContext so that it can send queries for
  arbitrary record types.
  - Rename DnsNameResolverContext to DnsResolveContext
  - Add DnsAddressResolveContext which extends DnsResolveContext for
    A/AAAA lookup
  - Add DnsRecordResolveContext which extends DnsResolveContext for
    arbitrary lookup
- Add DnsNameResolverContext.resolveAll(DnsQuestion) and its variants
- Change DnsNameResolverContext.resolve() delegates the resolve request
  to resolveAll() for simplicity
- Move the code that decodes A/AAAA record content to DnsAddressDecoder

Result:

- Fixes #7795
- A user does not have to duplicate DnsNameResolverContext in his or her
  own code to implement the usual DNS resolver behavior.