### PR TITLE
Update to netty-tcnative 2.0.8.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
     <!-- Fedora-"like" systems. This is currently only used for the netty-tcnative dependency -->
     <os.detection.classifierWithLikes>fedora</os.detection.classifierWithLikes>
     <tcnative.artifactId>netty-tcnative</tcnative.artifactId>
-    <tcnative.version>2.0.7.Final</tcnative.version>
+    <tcnative.version>2.0.8.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>


### PR DESCRIPTION
Motivation:

netty-tcnative 2.0.8.Final was released.

Modifications:

Update to latest netty-tcnative release.

Result:

Use latest release of tcnative