### PR TITLE
Fix possible stalls in SingleThreadEventExecutor

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -762,11 +762,9 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
         }
 
         boolean inEventLoop = inEventLoop();
-        if (inEventLoop) {
-            addTask(task);
-        } else {
+        addTask(task);
+        if (!inEventLoop) {
             startThread();
-            addTask(task);
             if (isShutdown() && removeTask(task)) {
                 reject();
             }

--- a/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/SingleThreadEventExecutor.java
@@ -856,14 +856,19 @@ public abstract class SingleThreadEventExecutor extends AbstractScheduledEventEx
     private static final long SCHEDULE_PURGE_INTERVAL = TimeUnit.SECONDS.toNanos(1);
 
     private void startThread() {
-        if (state == ST_NOT_STARTED) {
-            if (STATE_UPDATER.compareAndSet(this, ST_NOT_STARTED, ST_STARTED)) {
-                try {
-                    doStartThread();
-                } catch (Throwable cause) {
-                    STATE_UPDATER.set(this, ST_NOT_STARTED);
-                    PlatformDependent.throwException(cause);
+        for (;;) {
+            if (state == ST_NOT_STARTED) {
+                if (STATE_UPDATER.compareAndSet(this, ST_NOT_STARTED, ST_STARTED)) {
+                    try {
+                        doStartThread();
+                        break;
+                    } catch (Throwable cause) {
+                        STATE_UPDATER.set(this, ST_NOT_STARTED);
+                        PlatformDependent.throwException(cause);
+                    }
                 }
+            } else {
+                break;
             }
         }
     }


### PR DESCRIPTION
Motivation:

I was trying to implement backpressure (only calling `channel.read()` when there was demand) and under high concurrency (>100 threads) was reliably experiencing stalls. As a consequence had a quick look at underlying classes and noticed possible stalls in `SingleThreadEventExecutor`. This doesn't fix my problem but should be fixed anyway.

Two problems were noticed in `SingleThreadEventExecutor` where it is possible that 
* a call to `execute(Runnable)` adds a task to the queue but does not run that task (until `execute` gets called again).

Modification:

The first fix was simply to add a task to the queue *before* calling `startThread`. As it stood it was possible that a thread was started and stopped before the call to `addTask` was made. The consequence being that the task would not be executed till the next call to `execute`.

Similarly, in `startThread` itself the `compareAndSet` call should be in a loop to retry.

Result:

I haven't added unit tests for these as I suspect they would be difficult to induce. 
