### PR TITLE
ChunkedWriteHandler: avoid writing two times the same message

### DIFF
--- a/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
+++ b/handler/src/main/java/io/netty/handler/stream/ChunkedWriteHandler.java
@@ -299,8 +299,8 @@ public class ChunkedWriteHandler extends ChannelDuplexHandler {
                 ctx.flush();
                 requiresFlush = false;
             } else {
-                ctx.write(pendingMessage, currentWrite.promise);
                 this.currentWrite = null;
+                ctx.write(pendingMessage, currentWrite.promise);
                 requiresFlush = true;
             }
 


### PR DESCRIPTION
Motivation:

ChunkedWriteHandler.doFlush is called twice from the same write if the channelWritabilityChanged event is invoked during the write. The buffer is already written so no extra data is sent on the socket but it causes the "promise already done" exception to be thrown. 
This error happens only when the message is not ChunkedInput.

Modification:
Clear out the currentWrite reference before the ctx.write call, such that next time when the method is invoked the same object is not used twice.

Result:

Fixes #7819 


