### PR TITLE
Don't check accessible in UnpooledHeapByteBuf#capacity

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractByteBuf.java
@@ -1192,6 +1192,7 @@ public abstract class AbstractByteBuf extends ByteBuf {
 
     @Override
     public ByteBuf slice(int index, int length) {
+        ensureAccessible();
         return new UnpooledSlicedByteBuf(this, index, length);
     }
 

--- a/buffer/src/main/java/io/netty/buffer/AbstractUnsafeSwappedByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/AbstractUnsafeSwappedByteBuf.java
@@ -64,7 +64,7 @@ abstract class AbstractUnsafeSwappedByteBuf extends SwappedByteBuf {
 
     @Override
     public final int getInt(int index) {
-        wrapped.checkIndex0(index, 4);
+        wrapped.checkIndex(index, 4);
         int v = _getInt(wrapped, index);
         return nativeByteOrder ? v : Integer.reverseBytes(v);
     }
@@ -76,21 +76,21 @@ abstract class AbstractUnsafeSwappedByteBuf extends SwappedByteBuf {
 
     @Override
     public final short getShort(int index) {
-        wrapped.checkIndex0(index, 2);
+        wrapped.checkIndex(index, 2);
         short v = _getShort(wrapped, index);
         return nativeByteOrder ? v : Short.reverseBytes(v);
     }
 
     @Override
     public final ByteBuf setShort(int index, int value) {
-        wrapped.checkIndex0(index, 2);
+        wrapped.checkIndex(index, 2);
         _setShort(wrapped, index, nativeByteOrder ? (short) value : Short.reverseBytes((short) value));
         return this;
     }
 
     @Override
     public final ByteBuf setInt(int index, int value) {
-        wrapped.checkIndex0(index, 4);
+        wrapped.checkIndex(index, 4);
         _setInt(wrapped, index, nativeByteOrder ? value : Integer.reverseBytes(value));
         return this;
     }

--- a/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/UnpooledHeapByteBuf.java
@@ -15,6 +15,7 @@
  */
 package io.netty.buffer;
 
+import io.netty.util.internal.EmptyArrays;
 import io.netty.util.internal.PlatformDependent;
 
 import java.io.IOException;
@@ -113,7 +114,6 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public int capacity() {
-        ensureAccessible();
         return array.length;
     }
 
@@ -552,7 +552,7 @@ public class UnpooledHeapByteBuf extends AbstractReferenceCountedByteBuf {
     @Override
     protected void deallocate() {
         freeArray(array);
-        array = null;
+        array = EmptyArrays.EMPTY_BYTES;
     }
 
     @Override


### PR DESCRIPTION
Motivation:
The `#ensureAccessible` method in `UnpooledHeapByteBuf#capacity` used
to prevent NPE if buffer is released and `array` is `null`. In all
other implementations of `ByteBuf` the accessible is not checked by
`capacity` method. We can assign an empty array to `array`
in the `deallocate` and don't worry about NPE in the `#capacity`.
This will help reduce the number of repeated calls of the
`#ensureAccessible` in many operations with `UnpooledHeapByteBuf`.

Modifications:
1. Remove `#ensureAccessible` call from `UnpooledHeapByteBuf#capacity`.
Use the `EmptyArrays#EMPTY_BYTES` instead of `null` in `#deallocate`.

2. Fix access checks in `AbstractUnsafeSwappedByteBuf` and
`AbstractByteBuf#slice` that relied on `#ensureAccessible`
in `UnpooledHeapByteBuf#capacity`. This was found by unit tests.

Result:
Less double calls of `#ensureAccessible` for `UnpooledHeapByteBuf`.