### PR TITLE
Extract common parts from `if` statements

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectDecoder.java
@@ -534,12 +534,10 @@ public abstract class HttpObjectDecoder extends ByteToMessageDecoder {
         // when we produced an invalid message without consuming anything.
         in.skipBytes(in.readableBytes());
 
-        if (message != null) {
-            message.setDecoderResult(DecoderResult.failure(cause));
-        } else {
+        if (message == null) {
             message = createInvalidMessage();
-            message.setDecoderResult(DecoderResult.failure(cause));
         }
+        message.setDecoderResult(DecoderResult.failure(cause));
 
         HttpMessage ret = message;
         message = null;

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostRequestEncoder.java
@@ -93,6 +93,7 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
         HTML5
     }
 
+    @SuppressWarnings("rawtypes")
     private static final Map.Entry[] percentEncodings;
 
     static {
@@ -779,12 +780,11 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
         }
         // Now consider size for chunk or not
         long realSize = globalBodySize;
-        if (isMultipart) {
-            iterator = multipartHttpDatas.listIterator();
-        } else {
+        if (!isMultipart) {
             realSize -= 1; // last '&' removed
-            iterator = multipartHttpDatas.listIterator();
         }
+        iterator = multipartHttpDatas.listIterator();
+
         headers.set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(realSize));
         if (realSize > HttpPostBodyUtil.chunkSize || isMultipart) {
             isChunked = true;
@@ -948,13 +948,11 @@ public class HttpPostRequestEncoder implements ChunkedInput<HttpContent> {
             isKey = false;
             if (currentBuffer == null) {
                 currentBuffer = wrappedBuffer(buffer, wrappedBuffer("=".getBytes()));
-                // continue
-                size -= buffer.readableBytes() + 1;
             } else {
                 currentBuffer = wrappedBuffer(currentBuffer, buffer, wrappedBuffer("=".getBytes()));
-                // continue
-                size -= buffer.readableBytes() + 1;
             }
+            // continue
+            size -= buffer.readableBytes() + 1;
             if (currentBuffer.readableBytes() >= HttpPostBodyUtil.chunkSize) {
                 buffer = fillByteBuf();
                 return new DefaultHttpContent(buffer);

--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/HttpPostStandardRequestDecoder.java
@@ -466,21 +466,13 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                 }
                 firstpos = currentpos;
                 currentStatus = MultiPartStatus.EPILOGUE;
-                undecodedChunk.readerIndex(firstpos);
-                return;
-            }
-            if (contRead && currentAttribute != null) {
+            } else if (contRead && currentAttribute != null && currentStatus == MultiPartStatus.FIELD) {
                 // reset index except if to continue in case of FIELD getStatus
-                if (currentStatus == MultiPartStatus.FIELD) {
-                    currentAttribute.addContent(undecodedChunk.copy(firstpos, currentpos - firstpos),
-                                                false);
-                    firstpos = currentpos;
-                }
-                undecodedChunk.readerIndex(firstpos);
-            } else {
-                // end of line or end of block so keep index to last valid position
-                undecodedChunk.readerIndex(firstpos);
+                currentAttribute.addContent(undecodedChunk.copy(firstpos, currentpos - firstpos),
+                                            false);
+                firstpos = currentpos;
             }
+            undecodedChunk.readerIndex(firstpos);
         } catch (ErrorDataDecoderException e) {
             // error while decoding
             undecodedChunk.readerIndex(firstpos);
@@ -596,21 +588,13 @@ public class HttpPostStandardRequestDecoder implements InterfaceHttpPostRequestD
                 }
                 firstpos = currentpos;
                 currentStatus = MultiPartStatus.EPILOGUE;
-                undecodedChunk.readerIndex(firstpos);
-                return;
-            }
-            if (contRead && currentAttribute != null) {
+            } else if (contRead && currentAttribute != null && currentStatus == MultiPartStatus.FIELD) {
                 // reset index except if to continue in case of FIELD getStatus
-                if (currentStatus == MultiPartStatus.FIELD) {
-                    currentAttribute.addContent(undecodedChunk.copy(firstpos, currentpos - firstpos),
-                                                false);
-                    firstpos = currentpos;
-                }
-                undecodedChunk.readerIndex(firstpos);
-            } else {
-                // end of line or end of block so keep index to last valid position
-                undecodedChunk.readerIndex(firstpos);
+                currentAttribute.addContent(undecodedChunk.copy(firstpos, currentpos - firstpos),
+                                            false);
+                firstpos = currentpos;
             }
+            undecodedChunk.readerIndex(firstpos);
         } catch (ErrorDataDecoderException e) {
             // error while decoding
             undecodedChunk.readerIndex(firstpos);

--- a/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
+++ b/codec/src/main/java/io/netty/handler/codec/ReplayingDecoder.java
@@ -327,11 +327,10 @@ public abstract class ReplayingDecoder<S> extends ByteToMessageDecoder {
             replayable.terminate();
             if (cumulation != null) {
                 callDecode(ctx, internalBuffer(), out);
-                decodeLast(ctx, replayable, out);
             } else {
                 replayable.setCumulation(Unpooled.EMPTY_BUFFER);
-                decodeLast(ctx, replayable, out);
             }
+            decodeLast(ctx, replayable, out);
         } catch (Signal replay) {
             // Ignore
             replay.expect(REPLAY);

--- a/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
+++ b/handler/src/main/java/io/netty/handler/ssl/ReferenceCountedOpenSslContext.java
@@ -285,26 +285,20 @@ public abstract class ReferenceCountedOpenSslContext extends SslContext implemen
             }
 
             /* Set session cache size, if specified */
-            if (sessionCacheSize > 0) {
-                this.sessionCacheSize = sessionCacheSize;
-                SSLContext.setSessionCacheSize(ctx, sessionCacheSize);
-            } else {
+            if (sessionCacheSize <= 0) {
                 // Get the default session cache size using SSLContext.setSessionCacheSize()
-                this.sessionCacheSize = sessionCacheSize = SSLContext.setSessionCacheSize(ctx, 20480);
-                // Revert the session cache size to the default value.
-                SSLContext.setSessionCacheSize(ctx, sessionCacheSize);
+                sessionCacheSize = SSLContext.setSessionCacheSize(ctx, 20480);
             }
+            this.sessionCacheSize = sessionCacheSize;
+            SSLContext.setSessionCacheSize(ctx, sessionCacheSize);
 
             /* Set session timeout, if specified */
-            if (sessionTimeout > 0) {
-                this.sessionTimeout = sessionTimeout;
-                SSLContext.setSessionCacheTimeout(ctx, sessionTimeout);
-            } else {
+            if (sessionTimeout <= 0) {
                 // Get the default session timeout using SSLContext.setSessionCacheTimeout()
-                this.sessionTimeout = sessionTimeout = SSLContext.setSessionCacheTimeout(ctx, 300);
-                // Revert the session timeout to the default value.
-                SSLContext.setSessionCacheTimeout(ctx, sessionTimeout);
+                sessionTimeout = SSLContext.setSessionCacheTimeout(ctx, 300);
             }
+            this.sessionTimeout = sessionTimeout;
+            SSLContext.setSessionCacheTimeout(ctx, sessionTimeout);
 
             if (enableOcsp) {
                 SSLContext.enableOcsp(ctx, isClient());

--- a/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutHandler.java
+++ b/handler/src/main/java/io/netty/handler/timeout/WriteTimeoutHandler.java
@@ -140,13 +140,11 @@ public class WriteTimeoutHandler extends ChannelOutboundHandlerAdapter {
     }
 
     private void addWriteTimeoutTask(WriteTimeoutTask task) {
-        if (lastTask == null) {
-            lastTask = task;
-        } else {
+        if (lastTask != null) {
             lastTask.next = task;
             task.prev = lastTask;
-            lastTask = task;
         }
+        lastTask = task;
     }
 
     private void removeWriteTimeoutTask(WriteTimeoutTask task) {

--- a/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
+++ b/transport-sctp/src/main/java/io/netty/channel/sctp/nio/NioSctpChannel.java
@@ -307,12 +307,10 @@ public class NioSctpChannel extends AbstractNioMessageChannel implements io.nett
             }
         }
         ByteBuffer nioData;
-        if (!needsCopy) {
-            nioData = data.nioBuffer();
-        } else {
+        if (needsCopy) {
             data = alloc.directBuffer(dataLen).writeBytes(data);
-            nioData = data.nioBuffer();
         }
+        nioData = data.nioBuffer();
         final MessageInfo mi = MessageInfo.createOutgoing(association(), null, packet.streamIdentifier());
         mi.payloadProtocolID(packet.protocolIdentifier());
         mi.streamNumber(packet.streamIdentifier());

--- a/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOutboundBuffer.java
@@ -113,12 +113,11 @@ public final class ChannelOutboundBuffer {
         Entry entry = Entry.newInstance(msg, size, total(msg), promise);
         if (tailEntry == null) {
             flushedEntry = null;
-            tailEntry = entry;
         } else {
             Entry tail = tailEntry;
             tail.next = entry;
-            tailEntry = entry;
         }
+        tailEntry = entry;
         if (unflushedEntry == null) {
             unflushedEntry = entry;
         }

--- a/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioDatagramChannelConfig.java
@@ -130,15 +130,13 @@ class NioDatagramChannelConfig extends DefaultDatagramChannelConfig {
     @Override
     public InetAddress getInterface() {
         NetworkInterface inf = getNetworkInterface();
-        if (inf == null) {
-            return null;
-        } else {
+        if (inf != null) {
             Enumeration<InetAddress> addresses = SocketUtils.addressesFromNetworkInterface(inf);
             if (addresses.hasMoreElements()) {
                 return addresses.nextElement();
             }
-            return null;
         }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Motivation:
Some `if` statements contains common parts that can be extracted.

Modifications:
Extract common parts from `if` statements.

Result:
Less code and bytecode. The code is simpler and more clear.