### PR TITLE
CorsHandler.write(...) should not cause a flush.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
@@ -205,7 +205,7 @@ public class CorsHandler extends ChannelDuplexHandler {
                 setExposeHeaders(response);
             }
         }
-        ctx.writeAndFlush(msg, promise);
+        ctx.write(msg, promise);
     }
 
     private static void forbidden(final ChannelHandlerContext ctx, final HttpRequest request) {


### PR DESCRIPTION
Motivation:

CorsHandler.write(...) should not cause a flush but just trigger a write(...)

Modifications:

Replace writeAndFlush(...) with write(...)

Result:

Fixes https://github.com/netty/netty/issues/7837.