### PR TITLE
Fixes NPE in ClientCookieDecoder

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieDecoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/ClientCookieDecoder.java
@@ -140,7 +140,7 @@ public final class ClientCookieDecoder extends CookieDecoder {
                 cookieBuilder.appendAttribute(nameBegin, nameEnd, valueBegin, valueEnd);
             }
         }
-        return cookieBuilder.cookie();
+        return cookieBuilder != null ? cookieBuilder.cookie() : null;
     }
 
     private static class CookieBuilder {

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ClientCookieDecoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ClientCookieDecoderTest.java
@@ -204,6 +204,13 @@ public class ClientCookieDecoderTest {
     }
 
     @Test
+    public void testDecodingInvalidValuesWithCommaAtStart() {
+        assertNull(ClientCookieDecoder.STRICT.decode(","));
+        assertNull(ClientCookieDecoder.STRICT.decode(",a"));
+        assertNull(ClientCookieDecoder.STRICT.decode(",a=a"));
+    }
+
+    @Test
     public void testDecodingLongValue() {
         String longValue =
                 "b___$Q__$ha__<NC=MN(F__%#4__<NC=MN(F__2_d____#=IvZB__2_F____'=KqtH__2-9____" +


### PR DESCRIPTION
Motivation:
NPE occurs in `ClientCookieDecoder` if a cookie starts with comma.

Modifications:
Check `cookieBuilder` for `null` in the return.

Result:
No fails NPE on invalid cookies.