### PR TITLE
Add dev-tools dependency for commons

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -75,6 +75,15 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
+    <!-- Add dependency on dev-tools as otherwise the build will fail if not installed first manually -->
+    <!-- See https://github.com/netty/netty/issues/7842 -->
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-dev-tools</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Motivation:

We need to add a dev-tools dependecy for commons as otherwise we may fail to fetch it before we try to use it.

Modifications:

Add dependency.

Result:

Fixes https://github.com/netty/netty/issues/7842