### PR TITLE
Optimize space usage of FastThreadLocal

### DIFF
--- a/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
+++ b/common/src/main/java/io/netty/util/internal/InternalThreadLocalMap.java
@@ -26,6 +26,7 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -44,6 +45,8 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
     private static final int STRING_BUILDER_MAX_SIZE;
 
     public static final Object UNSET = new Object();
+
+    private BitSet cleanerFlags;
 
     static {
         STRING_BUILDER_INITIAL_SIZE =
@@ -330,5 +333,16 @@ public final class InternalThreadLocalMap extends UnpaddedInternalThreadLocalMap
     public boolean isIndexedVariableSet(int index) {
         Object[] lookup = indexedVariables;
         return index < lookup.length && lookup[index] != UNSET;
+    }
+
+    public boolean isCleanerFlagSet(int index) {
+        return cleanerFlags != null && cleanerFlags.get(index);
+    }
+
+    public void setCleanerFlag(int index) {
+        if (cleanerFlags == null) {
+            cleanerFlags = new BitSet();
+        }
+        cleanerFlags.set(index);
     }
 }

--- a/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
@@ -47,7 +47,7 @@ public class FastThreadLocalTest {
 
         // Initialize a thread-local variable.
         assertThat(var.get(), is(nullValue()));
-        assertThat(FastThreadLocal.size(), is(2));
+        assertThat(FastThreadLocal.size(), is(1));
 
         // And then remove it.
         FastThreadLocal.removeAll();


### PR DESCRIPTION
Motivation:
A FastThreadLocal instance currently occupies 2 slots of InternalThreadLocalMap of every thread. Actually for a FastThreadLocalThread, it does not need to store cleaner flags of FastThreadLocal instances. Besides, using BitSet to store cleaner flags is also better for space usage.

Modification:
Use BitSet to optimize space usage of FastThreadLocal.

Result:
Avoid unnecessary slot occupancy. Cleaner flags are now stored into a BitSet.

