### PR TITLE
Fix ArrayIndexOutOfBoundsException in AsciiString indexOf(...) and la…

### DIFF
--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -689,7 +689,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
         }
         final byte firstCharAsByte = c2b0(firstChar);
         final int len = offset + start + length - subCount;
-        for (int i = start + offset; i <= len; ++i) {
+        for (int i = start + offset; i <= len && i < length; ++i) {
             if (value[i] == firstCharAsByte) {
                 int o1 = i, o2 = 0;
                 while (++o2 < subCount && b2c(value[++o1]) == subString.charAt(o2)) {
@@ -773,7 +773,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
         }
         final byte firstCharAsByte = c2b0(firstChar);
         final int end = offset + start;
-        for (int i = offset + start + length - subCount; i >= end; --i) {
+        for (int i = length - subCount; i >= end; --i) {
             if (value[i] == firstCharAsByte) {
                 int o1 = i, o2 = 0;
                 while (++o2 < subCount && b2c(value[++o1]) == subString.charAt(o2)) {

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -385,4 +385,26 @@ public class AsciiStringCharacterTest {
         //two "123"s
         assertEquals(AsciiString.hashCode("123"), AsciiString.hashCode("a123".substring(1)));
     }
+
+    @Test
+    public void testIndexOf() {
+        Assert.assertEquals(3, new AsciiString("012345").indexOf("345", 3));
+        Assert.assertEquals(3, new AsciiString("012345").indexOf("345", 0));
+        Assert.assertEquals(-1, new AsciiString("012345").indexOf("345", 4));
+        Assert.assertEquals(-1, new AsciiString("012345").indexOf("abc", 3));
+        Assert.assertEquals(-1, new AsciiString("012345").indexOf("abc", 0));
+        Assert.assertEquals(-1, new AsciiString("012345").indexOf("abcdefghi", 0));
+        Assert.assertEquals(-1, new AsciiString("012345").indexOf("abcdefghi", 4));
+    }
+
+    @Test
+    public void testLastIndexOf() {
+        Assert.assertEquals(3, new AsciiString("012345").lastIndexOf("345", 3));
+        Assert.assertEquals(3, new AsciiString("012345").lastIndexOf("345", 0));
+        Assert.assertEquals(-1, new AsciiString("012345").lastIndexOf("345", 4));
+        Assert.assertEquals(-1, new AsciiString("012345").lastIndexOf("abc", 3));
+        Assert.assertEquals(-1, new AsciiString("012345").lastIndexOf("abc", 0));
+        Assert.assertEquals(-1, new AsciiString("012345").lastIndexOf("abcdefghi", 0));
+        Assert.assertEquals(-1, new AsciiString("012345").lastIndexOf("abcdefghi", 4));
+    }
 }


### PR DESCRIPTION
…stIndexOf(...)

Motivation:

AsciiString did not correctly calculate the bounds and so it was possible to see an ArrayIndexOutOfBoundsException.

Modifications:

Correctly calculate bounds.

Result:

Fixes https://github.com/netty/netty/issues/7863