### PR TITLE
NPE in CorsHandler for unauthorized preflight request

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cors/CorsHandler.java
@@ -38,6 +38,7 @@ import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.util.ReferenceCountUtil.release;
 import static io.netty.util.internal.ObjectUtil.checkNonEmpty;
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
 
 /**
  * Handles <a href="http://www.w3.org/TR/cors/">Cross Origin Resource Sharing</a> (CORS) requests.
@@ -60,7 +61,7 @@ public class CorsHandler extends ChannelDuplexHandler {
      * Creates a new instance with a single {@link CorsConfig}.
      */
     public CorsHandler(final CorsConfig config) {
-        this(Collections.singletonList(config), config.isShortCircuit());
+        this(Collections.singletonList(checkNotNull(config, "config")), config.isShortCircuit());
     }
 
     /**
@@ -137,7 +138,7 @@ public class CorsHandler extends ChannelDuplexHandler {
 
     private boolean setOrigin(final HttpResponse response) {
         final String origin = request.headers().get(HttpHeaderNames.ORIGIN);
-        if (origin != null) {
+        if (origin != null && config != null) {
             if (NULL_ORIGIN.equals(origin) && config.isNullOriginAllowed()) {
                 setNullOrigin(response);
                 return true;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cors/CorsHandlerTest.java
@@ -150,6 +150,14 @@ public class CorsHandlerTest {
     }
 
     @Test
+    public void preflightRequestWithUnauthorizedOrigin() {
+        final String origin = "http://host";
+        final CorsConfig config = forOrigin("http://localhost").build();
+        final HttpResponse response = preflightRequest(config, origin, "xheader1");
+        assertThat(response.headers().contains(ACCESS_CONTROL_ALLOW_ORIGIN), is(false));
+    }
+
+    @Test
     public void preflightRequestWithCustomHeaders() {
         final String headerName = "CustomHeader";
         final String value1 = "value1";


### PR DESCRIPTION
**Motivation:**

NPE in `CorsHandler` if a pre-flight request is done using an Origin header which is
not allowed by any `CorsConfig` passed to the handler on creation.

**Modification:**

During the pre-flight, check the `CorsConfig` for `null` and handle it correctly by not returning
any access-control header

**Result:**

No more NPE for pre-flight requests with unauthorized origins.
