### PR TITLE
Allow to write Http2UnkownFrame when using Http2FrameCodec / Http2Mul…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -296,6 +296,10 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
             encoder().writeSettings(ctx, ((Http2SettingsFrame) msg).settings(), promise);
         } else if (msg instanceof Http2GoAwayFrame) {
             writeGoAwayFrame(ctx, (Http2GoAwayFrame) msg, promise);
+        } else if (msg instanceof Http2UnknownFrame) {
+            Http2UnknownFrame unknownFrame = (Http2UnknownFrame) msg;
+            encoder().writeFrame(ctx, unknownFrame.frameType(), unknownFrame.stream().id(),
+                    unknownFrame.flags(), unknownFrame.content(), promise);
         } else if (!(msg instanceof Http2Frame)) {
             ctx.write(msg, promise);
         } else {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2FrameCodecTest.java
@@ -535,6 +535,20 @@ public class Http2FrameCodecTest {
     }
 
     @Test
+    public void writeUnknownFrame() {
+        final Http2FrameStream stream = frameCodec.newStream();
+
+        ByteBuf buffer = Unpooled.buffer().writeByte(1);
+        DefaultHttp2UnknownFrame unknownFrame = new DefaultHttp2UnknownFrame(
+                (byte) 20, new Http2Flags().ack(true), buffer);
+        unknownFrame.stream(stream);
+        channel.write(unknownFrame);
+
+        verify(frameWriter).writeFrame(eq(http2HandlerCtx), eq(unknownFrame.frameType()),
+                eq(unknownFrame.stream().id()), eq(unknownFrame.flags()), eq(buffer), any(ChannelPromise.class));
+    }
+
+    @Test
     public void sendSettingsFrame() {
         Http2Settings settings = new Http2Settings();
         channel.write(new DefaultHttp2SettingsFrame(settings));


### PR DESCRIPTION
…tiplexCodec

Motivation:

We should allow to write Http2UnkownFrame to allow custom extensions.

Modifications:

Allow to write Http2UnkownFrame
Add unit test

Result:

Fixes https://github.com/netty/netty/issues/7860.