### PR TITLE
Only reset readIsPending if outboundBuffer is not empty.

### DIFF
--- a/transport/src/main/java/io/netty/channel/local/LocalChannel.java
+++ b/transport/src/main/java/io/netty/channel/local/LocalChannel.java
@@ -436,7 +436,9 @@ public class LocalChannel extends AbstractChannel {
             }
         }
         ChannelPipeline peerPipeline = peer.pipeline();
-        if (peer.readInProgress) {
+        // We should only set readInProgress to false if there is any data that was read as otherwise we may miss to
+        // forward data later on.
+        if (peer.readInProgress && !peer.inboundBuffer.isEmpty()) {
             peer.readInProgress = false;
             for (;;) {
                 Object received = peer.inboundBuffer.poll();


### PR DESCRIPTION
Motivation:

We need to ensure we only reset readInProgress if the outboundBuffer is not empty as otherwise we may miss to call fireChannelRead(...) later on when using the LocalChannel.

Modifications:

Also check if the outboundBuffer is not empty before setting readInProgress to false again

Result:

Fixes https://github.com/netty/netty/issues/7855