### PR TITLE
Filter DNS results so they only contain the expected type when multip…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
@@ -19,6 +19,7 @@ import static io.netty.resolver.dns.DnsAddressDecoder.decodeAddress;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.List;
 
 import io.netty.channel.EventLoop;
@@ -59,6 +60,31 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
             }
         }
         return false;
+    }
+
+    @Override
+    List<InetAddress> filterResults(List<InetAddress> unfiltered) {
+        final Class<? extends InetAddress> inetAddressType = parent.preferredAddressType().addressType();
+        final int size = unfiltered.size();
+        int numExpected = 0;
+        for (int i = 0; i < size; i++) {
+            InetAddress address = unfiltered.get(i);
+            if (inetAddressType.isInstance(address)) {
+                numExpected++;
+            }
+        }
+        if (numExpected == size || numExpected == 0) {
+            // If all the results are the preferred type, or none of them are, then we don't need to do any filtering.
+            return unfiltered;
+        }
+        List<InetAddress> filtered = new ArrayList<InetAddress>(numExpected);
+        for (int i = 0; i < size; i++) {
+            InetAddress address = unfiltered.get(i);
+            if (inetAddressType.isInstance(address)) {
+                filtered.add(address);
+            }
+        }
+        return filtered;
     }
 
     @Override

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
@@ -62,6 +62,11 @@ final class DnsRecordResolveContext extends DnsResolveContext<DnsRecord> {
     }
 
     @Override
+    List<DnsRecord> filterResults(List<DnsRecord> unfiltered) {
+        return unfiltered;
+    }
+
+    @Override
     void cache(String hostname, DnsRecord[] additionals, DnsRecord result, DnsRecord convertedResult) {
         // Do not cache.
         // XXX: When we implement cache, we would need to retain the reference count of the result record.

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsResolveContext.java
@@ -31,6 +31,7 @@ import io.netty.handler.codec.dns.DnsRecordType;
 import io.netty.handler.codec.dns.DnsResponse;
 import io.netty.handler.codec.dns.DnsResponseCode;
 import io.netty.handler.codec.dns.DnsSection;
+import io.netty.util.NetUtil;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
@@ -141,6 +142,12 @@ abstract class DnsResolveContext<T> {
      * at least one element.
      */
     abstract boolean containsExpectedResult(List<T> finalResult);
+
+    /**
+     * Returns a filtered list of results which should be the final result of DNS resolution. This must take into
+     * account JDK semantics such as {@link NetUtil#isIpV6AddressesPreferred()}.
+     */
+    abstract List<T> filterResults(List<T> unfiltered);
 
     /**
      * Caches a successful resolution.
@@ -702,7 +709,7 @@ abstract class DnsResolveContext<T> {
 
         if (finalResult != null) {
             // Found at least one resolved record.
-            trySuccess(promise, finalResult);
+            trySuccess(promise, filterResults(finalResult));
             return;
         }
 

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
@@ -258,7 +258,7 @@ class TestDnsServer extends DnsServer {
 
         private final Set<String> domains;
 
-        public TestRecordStore(Set<String> domains) {
+        private TestRecordStore(Set<String> domains) {
             this.domains = domains;
         }
 


### PR DESCRIPTION
…le types are present.

Motivation:

Currently, if a DNS server returns a non-preferred address type before the preferred one, then both will be returned as the result, and when only taking a single one, this usually ends up being the non-preferred type. However, the JDK requires lookups to only return the preferred type when possible to allow for backwards compatibility.

Explain here the context, and why you're making that change.

To allow a client to be able to resolve the appropriate address when running on a machine that does not support IPv6 but the DNS server returns IPv6 addresses before IPv4 addresses when querying.

Modification:

Filter the returned records to the expected type when both types are present.

Result:

Allows a client to run on a machine with IPv6 disabled even when a server returns both IPv4 and IPv6 results. Netty-based code can be a drop-in replacement for JDK-based code in such circumstances.

This PR filters results before returning them to respect JDK expectations. 

The test is a bit whacky, let me know if you have any ideas on making it cleaner.