### PR TITLE
Implement isWritable and ensureWritable on ReadOnlyByteBufferBuf

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/ReadOnlyByteBufferBuf.java
@@ -52,6 +52,26 @@ class ReadOnlyByteBufferBuf extends AbstractReferenceCountedByteBuf {
     protected void deallocate() { }
 
     @Override
+    public boolean isWritable() {
+        return false;
+    }
+
+    @Override
+    public boolean isWritable(int numBytes) {
+        return false;
+    }
+
+    @Override
+    public ByteBuf ensureWritable(int minWritableBytes) {
+        throw new ReadOnlyBufferException();
+    }
+
+    @Override
+    public int ensureWritable(int minWritableBytes, boolean force) {
+        return 1;
+    }
+
+    @Override
     public byte getByte(int index) {
         ensureAccessible();
         return _getByte(index);

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -43,6 +43,38 @@ public class ReadOnlyDirectByteBufferBufTest {
         buffer(allocate(1));
     }
 
+    @Test
+    public void shouldIndicateNotWritable() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
+        Assert.assertFalse(buf.isWritable());
+    }
+
+    @Test
+    public void shouldIndicateNotWritableAnyNumber() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
+        Assert.assertFalse(buf.isWritable(1));
+    }
+
+    @Test
+    public void ensureWritableIntStatusShouldFailButNotThrow() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
+        int result = buf.ensureWritable(1, false);
+        Assert.assertEquals(1, result);
+    }
+
+    @Test
+    public void ensureWritableForceIntStatusShouldFailButNotThrow() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
+        int result = buf.ensureWritable(1, true);
+        Assert.assertEquals(1, result);
+    }
+
+    @Test(expected = ReadOnlyBufferException.class)
+    public void ensureWritableShouldThrow() {
+        ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
+        buf.ensureWritable(1);
+    }
+
     @Test(expected = ReadOnlyBufferException.class)
     public void testSetByte() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer());

--- a/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
+++ b/buffer/src/test/java/io/netty/buffer/ReadOnlyDirectByteBufferBufTest.java
@@ -46,33 +46,53 @@ public class ReadOnlyDirectByteBufferBufTest {
     @Test
     public void shouldIndicateNotWritable() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
-        Assert.assertFalse(buf.isWritable());
+        try {
+            Assert.assertFalse(buf.isWritable());
+        } finally {
+            buf.release();
+        }
     }
 
     @Test
     public void shouldIndicateNotWritableAnyNumber() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
-        Assert.assertFalse(buf.isWritable(1));
+        try {
+            Assert.assertFalse(buf.isWritable(1));
+        } finally {
+            buf.release();
+        }
     }
 
     @Test
     public void ensureWritableIntStatusShouldFailButNotThrow() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
-        int result = buf.ensureWritable(1, false);
-        Assert.assertEquals(1, result);
+        try {
+            int result = buf.ensureWritable(1, false);
+            Assert.assertEquals(1, result);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test
     public void ensureWritableForceIntStatusShouldFailButNotThrow() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
-        int result = buf.ensureWritable(1, true);
-        Assert.assertEquals(1, result);
+        try {
+            int result = buf.ensureWritable(1, true);
+            Assert.assertEquals(1, result);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)
     public void ensureWritableShouldThrow() {
         ByteBuf buf = buffer(allocate(8).asReadOnlyBuffer()).clear();
-        buf.ensureWritable(1);
+        try {
+            buf.ensureWritable(1);
+        } finally {
+            buf.release();
+        }
     }
 
     @Test(expected = ReadOnlyBufferException.class)


### PR DESCRIPTION
Motivation:

It should be possible to write a ReadOnlyByteBufferBuf to a channel without errors. However, ReadOnlyByteBufferBuf does not override isWritable and ensureWritable, which can cause some handlers to mistakenly [assume they can write to the ReadOnlyByteBufferBuf](https://github.com/netty/netty/tree/2e92a2f5cdadb1c5932a75d3a84b9b89e77bde30/handler/src/main/java/io/netty/handler/ssl/SslHandler.java#L1960), resulting in ReadOnlyBufferException.

Modification:

Added isWritable and ensureWritable method overrides on ReadOnlyByteBufferBuf to indicate that it is never writable. Added tests for these methods.

Result:

Can successfully write ReadOnlyByteBufferBuf to a channel with an SslHandler (or any other handler which may attempt to write to the ByteBuf it receives).
