### PR TITLE
Update os-maven-plugin to 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -576,7 +576,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.5.0.Final</version>
+        <version>1.6.0</version>
       </extension>
     </extensions>
 


### PR DESCRIPTION
Motivation:

A new version of os-maven-plugin has been released.

Modifications:

- Update os-maven-plugin from 1.5.0 to 1.6.0

Result:

- No visible changes
- Feels good