### PR TITLE
Allow to call AbstractDiskHttpData.setContent(Unpooled.EMPTY_BUFFER) …

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/multipart/AbstractDiskHttpData.java
@@ -115,7 +115,13 @@ public abstract class AbstractDiskHttpData extends AbstractHttpData {
             if (buffer.readableBytes() == 0) {
                 // empty file
                 if (!file.createNewFile()) {
-                    throw new IOException("file exists already: " + file);
+                    if (file.length() == 0) {
+                        return;
+                    } else {
+                        if (!file.delete() || !file.createNewFile()) {
+                            throw new IOException("file exists already: " + file);
+                        }
+                    }
                 }
                 return;
             }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/multipart/DiskFileUploadTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/multipart/DiskFileUploadTest.java
@@ -15,8 +15,13 @@
  */
 package io.netty.handler.codec.http.multipart;
 
-import org.junit.Assert;
+import io.netty.buffer.Unpooled;
 import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class DiskFileUploadTest {
 
@@ -24,6 +29,52 @@ public class DiskFileUploadTest {
     public final void testDiskFileUploadEquals() {
         DiskFileUpload f2 =
                 new DiskFileUpload("d1", "d1", "application/json", null, null, 100);
-        Assert.assertEquals(f2, f2);
+        assertEquals(f2, f2);
+        f2.delete();
+    }
+
+     @Test
+     public void testEmptyBufferSetMultipleTimes() throws IOException {
+         DiskFileUpload f =
+                 new DiskFileUpload("d1", "d1", "application/json", null, null, 100);
+
+         f.setContent(Unpooled.EMPTY_BUFFER);
+
+         assertTrue(f.getFile().exists());
+         assertEquals(0, f.getFile().length());
+         f.setContent(Unpooled.EMPTY_BUFFER);
+         assertTrue(f.getFile().exists());
+         assertEquals(0, f.getFile().length());
+         f.delete();
+     }
+
+    @Test
+    public void testEmptyBufferSetAfterNonEmptyBuffer() throws IOException {
+        DiskFileUpload f =
+                new DiskFileUpload("d1", "d1", "application/json", null, null, 100);
+
+        f.setContent(Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 }));
+
+        assertTrue(f.getFile().exists());
+        assertEquals(4, f.getFile().length());
+        f.setContent(Unpooled.EMPTY_BUFFER);
+        assertTrue(f.getFile().exists());
+        assertEquals(0, f.getFile().length());
+        f.delete();
+    }
+
+    @Test
+    public void testNonEmptyBufferSetMultipleTimes() throws IOException {
+        DiskFileUpload f =
+                new DiskFileUpload("d1", "d1", "application/json", null, null, 100);
+
+        f.setContent(Unpooled.wrappedBuffer(new byte[] { 1, 2, 3, 4 }));
+
+        assertTrue(f.getFile().exists());
+        assertEquals(4, f.getFile().length());
+        f.setContent(Unpooled.wrappedBuffer(new byte[] { 1, 2}));
+        assertTrue(f.getFile().exists());
+        assertEquals(2, f.getFile().length());
+        f.delete();
     }
 }


### PR DESCRIPTION
…multiple times.

Motivation:

It should be possible to call setContent(Unpooled.EMPTY_BUFFER) multiple times just like its possible to do the same with a non empty buffer.

Modifications:

- Correctly reset underlying storage if called multiple times.
- Add tests

Result:

Fixes https://github.com/netty/netty/issues/6418
