### PR TITLE
Correctly handle responses with status 205 and payload.

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpResponseEncoder.java
@@ -53,6 +53,14 @@ public class HttpResponseEncoder extends HttpObjectEncoder<HttpResponse> {
                 // Stripping Transfer-Encoding:
                 // See https://tools.ietf.org/html/rfc7230#section-3.3.1
                 msg.headers().remove(HttpHeaderNames.TRANSFER_ENCODING);
+            } else if (status.code() == HttpResponseStatus.RESET_CONTENT.code()) {
+
+                // Stripping Transfer-Encoding:
+                msg.headers().remove(HttpHeaderNames.TRANSFER_ENCODING);
+
+                // Set Content-Length: 0
+                // https://httpstatuses.com/205
+                msg.headers().setInt(HttpHeaderNames.CONTENT_LENGTH, 0);
             }
         }
     }
@@ -74,6 +82,7 @@ public class HttpResponseEncoder extends HttpObjectEncoder<HttpResponse> {
             return true;
         }
         return status.code() == HttpResponseStatus.NO_CONTENT.code() ||
-                status.code() == HttpResponseStatus.NOT_MODIFIED.code();
+                status.code() == HttpResponseStatus.NOT_MODIFIED.code() ||
+                status.code() == HttpResponseStatus.RESET_CONTENT.code();
     }
 }


### PR DESCRIPTION
Motivation:

HTTP responses with status of 205 should not contain a payload. We should enforce this.

Modifications:

Correctly handle responses with status 205 and payload by set Content-Length: 0 header and stripping out the content.

Result:

Fixes https://github.com/netty/netty/issues/7888