### PR TITLE
Fix IllegalReferenceCountException when using Http2MultiplexCodec and…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -337,9 +337,6 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
         } catch (Http2Exception e) {
             ctx.fireExceptionCaught(e);
             ctx.close();
-        } finally {
-            // We need to ensure we release the goAwayFrame.
-            goAwayFrame.release();
         }
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
@@ -183,9 +183,13 @@ public class Http2MultiplexCodecTest {
         codec.onHttp2Frame(pingFrame);
         assertSame(parentChannel.readInbound(), pingFrame);
 
-        DefaultHttp2GoAwayFrame goAwayFrame = new DefaultHttp2GoAwayFrame(1);
+        DefaultHttp2GoAwayFrame goAwayFrame =
+                new DefaultHttp2GoAwayFrame(1, parentChannel.alloc().buffer().writeLong(8));
         codec.onHttp2Frame(goAwayFrame);
-        assertSame(parentChannel.readInbound(), goAwayFrame);
+
+        Http2GoAwayFrame frame = parentChannel.readInbound();
+        assertSame(frame, goAwayFrame);
+        assertTrue(frame.release());
     }
 
     @Test


### PR DESCRIPTION
… a DefaultHttp2GoAwayFrame with a non empty ByteBuffer is received.

Motivation:

We incorrectly called frame.release() in onHttp2GoAwayFrame which could lead to IllegalReferenceCountExceptions.  The call of release() is inappropriate because the fireChannelRead() in onHttp2Frame() will handle it.

Modifications:

- Not call frame.release
- Add a unit test

Result:

Fxies https://github.com/netty/netty/issues/7892.