### PR TITLE
Allow to disable native transport and native ssl support via system p…

### DIFF
--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueue.java
@@ -17,6 +17,7 @@ package io.netty.channel.kqueue;
 
 import io.netty.channel.unix.FileDescriptor;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.UnstableApi;
 
 /**
@@ -25,20 +26,24 @@ import io.netty.util.internal.UnstableApi;
 @UnstableApi
 public final class KQueue {
     private static final Throwable UNAVAILABILITY_CAUSE;
-
     static  {
         Throwable cause = null;
-        FileDescriptor kqueueFd = null;
-        try {
-            kqueueFd = Native.newKQueue();
-        } catch (Throwable t) {
-            cause = t;
-        } finally {
-            if (kqueueFd != null) {
-                try {
-                    kqueueFd.close();
-                } catch (Exception ignore) {
-                    // ignore
+        if (SystemPropertyUtil.getBoolean("io.netty.transport.noNative", false)) {
+            cause = new UnsupportedOperationException(
+                    "Native transport was explicit disabled with -Dio.netty.transport.noNative=true");
+        } else {
+            FileDescriptor kqueueFd = null;
+            try {
+                kqueueFd = Native.newKQueue();
+            } catch (Throwable t) {
+                cause = t;
+            } finally {
+                if (kqueueFd != null) {
+                    try {
+                        kqueueFd.close();
+                    } catch (Exception ignore) {
+                        // ignore
+                    }
                 }
             }
         }


### PR DESCRIPTION
…roperty.

Motivation:

Sometimes it's useful to disable native transports / native ssl to debug a problem. We should allow to do so with a system property so people not need to adjust code for this.

Modifications:

Add system properties which allow to disable native transport and native ssl.

Result:

Easier to disable native code usage without code changes.