### PR TITLE
Fix race in ChannelReadHandler used during LocalChannel testing.

### DIFF
--- a/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/local/LocalChannelTest.java
@@ -1190,8 +1190,16 @@ public class LocalChannelTest {
                 } else {
                     read = 0;
                 }
+            } else {
+                read = 0;
             }
             ctx.fireChannelReadComplete();
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            ctx.fireExceptionCaught(cause);
+            ctx.close();
         }
     }
 }


### PR DESCRIPTION
Motivation:

ChannelReadHandler is used in tests added via f4d7e8de140048047299808bb7e707c15342b826. In the handler we verify the number of messages we receive per read() call but missed to sometimes reset the counter which resulted in exceptions.

Modifications:

Correctly reset read counter in all cases.

Result:

No more unexpected exceptions when running LocalChannel tests.