### PR TITLE
Enforce sane upper limit for TTL in DefaultDnsCache.

### DIFF
--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
@@ -18,6 +18,7 @@ package io.netty.resolver.dns;
 import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.util.NetUtil;
 import org.junit.Assert;
 import org.junit.Test;
@@ -51,6 +52,25 @@ public class DefaultDnsCacheTest {
             if (error != null) {
                 throw error;
             }
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testExpireWithDifferentTTLs() {
+        testExpireWithTTL0(1);
+        testExpireWithTTL0(1000);
+        testExpireWithTTL0(1000000);
+    }
+
+    private static void testExpireWithTTL0(int days) {
+        EventLoopGroup group = new NioEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final DefaultDnsCache cache = new DefaultDnsCache();
+            Assert.assertNotNull(cache.cache("netty.io", null, NetUtil.LOCALHOST, days, loop));
         } finally {
             group.shutdownGracefully();
         }


### PR DESCRIPTION
Motivation:

In b47fb817991b42ec8808c7d26538f3f2464e1fa6 we limited the max supported delay to match what our internal implementat can support. Because of this it was possible that DefaultDnsCache produced an IllegalArgumentException when it tried to schedule a expiration > 3 years.

Modifications:

Limit the max supported TTL to 2 years which is safe for all our EventLoop implementations.

Result:

No more exceptions when adding records to the cache with a huge TTL.