### PR TITLE
Fix tiny typo in FixedChannelPool error message

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/FixedChannelPool.java
@@ -43,10 +43,10 @@ public class FixedChannelPool extends SimpleChannelPool {
             new TimeoutException("Acquire operation took longer then configured maximum time"),
             FixedChannelPool.class, "<init>(...)");
     static final IllegalStateException POOL_CLOSED_ON_RELEASE_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new IllegalStateException("FixedChannelPooled was closed"),
+            new IllegalStateException("FixedChannelPool was closed"),
             FixedChannelPool.class, "release(...)");
     static final IllegalStateException POOL_CLOSED_ON_ACQUIRE_EXCEPTION = ThrowableUtil.unknownStackTrace(
-            new IllegalStateException("FixedChannelPooled was closed"),
+            new IllegalStateException("FixedChannelPool was closed"),
             FixedChannelPool.class, "acquire0(...)");
     public enum AcquireTimeoutAction {
         /**


### PR DESCRIPTION
Motivation:

Closed `FixedChannelPool` fails acquire and release operations with `IllegalStateException`s. These exceptions had message "FixedChannelPooled was closed". Here "FixedChannelPooled" looks like a typo and should probably be "FixedChannelPool".

Modifications:

Changed exception message to "FixedChannelPool was closed". Added test to assert that acquire operation on a closed pool fails.

Result:

A tiny bit cleaner exception message.