### PR TITLE
Always follow cnames even if a matching A or AAAA record was found.

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
@@ -50,19 +50,6 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     }
 
     @Override
-    boolean containsExpectedResult(List<InetAddress> finalResult) {
-        final int size = finalResult.size();
-        final Class<? extends InetAddress> inetAddressType = parent.preferredAddressType().addressType();
-        for (int i = 0; i < size; i++) {
-            InetAddress address = finalResult.get(i);
-            if (inetAddressType.isInstance(address)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @Override
     List<InetAddress> filterResults(List<InetAddress> unfiltered) {
         final Class<? extends InetAddress> inetAddressType = parent.preferredAddressType().addressType();
         final int size = unfiltered.size();

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsRecordResolveContext.java
@@ -15,9 +15,6 @@
  */
 package io.netty.resolver.dns;
 
-import static io.netty.resolver.dns.DnsAddressDecoder.decodeAddress;
-
-import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
 
@@ -54,11 +51,6 @@ final class DnsRecordResolveContext extends DnsResolveContext<DnsRecord> {
     @Override
     DnsRecord convertRecord(DnsRecord record, String hostname, DnsRecord[] additionals, EventLoop eventLoop) {
         return ReferenceCountUtil.retain(record);
-    }
-
-    @Override
-    boolean containsExpectedResult(List<DnsRecord> finalResult) {
-        return true;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

At the moment if you do a resolveAll and at least one A / AAAA record is present we will not follow any CNAMEs that are also present. This is different to how the JDK behaves.

Modifications:

- Allows follow CNAMEs.
- Add unit test.

Result:

Fixes https://github.com/netty/netty/issues/7915.