### PR TITLE
Enfore upper limit for minTtl when using DefaultCacheEntry.

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
@@ -65,8 +65,8 @@ public class DefaultDnsCache implements DnsCache {
      * @param negativeTtl the TTL for failed queries
      */
     public DefaultDnsCache(int minTtl, int maxTtl, int negativeTtl) {
-        this.minTtl = checkPositiveOrZero(minTtl, "minTtl");
-        this.maxTtl = checkPositiveOrZero(maxTtl, "maxTtl");
+        this.minTtl = Math.min(MAX_SUPPORTED_TTL_SECS, checkPositiveOrZero(minTtl, "minTtl"));
+        this.maxTtl = Math.min(MAX_SUPPORTED_TTL_SECS, checkPositiveOrZero(maxTtl, "maxTtl"));
         if (minTtl > maxTtl) {
             throw new IllegalArgumentException(
                     "minTtl: " + minTtl + ", maxTtl: " + maxTtl + " (expected: 0 <= minTtl <= maxTtl)");

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
@@ -87,6 +87,19 @@ public class DefaultDnsCacheTest {
     }
 
     @Test
+    public void testExpireWithToBigMinTTL() {
+        EventLoopGroup group = new NioEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final DefaultDnsCache cache = new DefaultDnsCache(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE);
+            assertNotNull(cache.cache("netty.io", null, NetUtil.LOCALHOST, 100, loop));
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
     public void testAddMultipleAddressesForSameHostname() throws Exception {
         InetAddress addr1 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 1 });
         InetAddress addr2 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 2 });


### PR DESCRIPTION
Motivation:

a598c3b69b55f930b91a8265f42d1a3cceb75ddd added a upper limit for ttl but missed to also do the same for minTtl.

Modifications:

- Add upper limit for minTtl
- Add testcase.

Result:

No more IllegalArgumentException possible.