### PR TITLE
Make osgi testing work with java>=9 by updating to felix 5.6.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
         <!-- Not use alpn agent as Java9 supports alpn out of the box -->
         <argLine.alpnAgent />
         <!-- Skip as maven plugin not works with Java9 yet --> 
-        <skipOsgiTestsuite>true</skipOsgiTestsuite>
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- Needed because of https://issues.apache.org/jira/browse/MENFORCER-275 -->
         <enforcer.plugin.version>3.0.0-M1</enforcer.plugin.version>

--- a/testsuite-osgi/pom.xml
+++ b/testsuite-osgi/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <exam.version>4.9.1</exam.version>
-    <argLine.java9.extras>--add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED</argLine.java9.extras>
+    <argLine.java9.extras>--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED</argLine.java9.extras>
   </properties>
 
   <profiles>
@@ -209,7 +209,7 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.framework</artifactId>
-      <version>5.4.0</version>
+      <version>5.6.10</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Motivation:

Currently, the testing-osgi is set to skip if run with java>=9. That is not necessary when using a newer version of Felix.

Modification:

Update to Felix framework 5.6.10 (which has better jpms support), add some more --add-opens to not have WARN messages, and remove the skipOsgiTestsuite setting from the parent pom.

Result:

OSGi tests run and pass on java>=9.
