### PR TITLE
Fixed|SimpleChannelPool.close() should only return after complete.

### DIFF
--- a/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
+++ b/transport/src/main/java/io/netty/channel/pool/SimpleChannelPool.java
@@ -394,7 +394,8 @@ public class SimpleChannelPool implements ChannelPool {
             if (channel == null) {
                 break;
             }
-            channel.close();
+            // Just ignore any errors that are reported back from close().
+            channel.close().awaitUninterruptibly();
         }
     }
 }


### PR DESCRIPTION
Motivation:

We need to ensure we only return from close() after all work is done as otherwise we may close the EventExecutor before we dispatched everything.

Modifications:

Correctly wait on operations to complete before return.

Result:

Fixes https://github.com/netty/netty/issues/7901.