### PR TITLE
Only use jboss-marshalling when using Java 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,8 @@
         <forbiddenapis.skip>true</forbiddenapis.skip>
         <!-- Needed because of https://issues.apache.org/jira/browse/MENFORCER-275 -->
         <enforcer.plugin.version>3.0.0-M1</enforcer.plugin.version>
+        <!-- 1.4.x does not work in Java10+ -->
+        <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
       </properties>
     </profile>
 
@@ -182,7 +184,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <netty.build.version>22</netty.build.version>
-    <jboss.marshalling.version>2.0.5.Final</jboss.marshalling.version>
+    <jboss.marshalling.version>1.4.11.Final</jboss.marshalling.version>
     <jetty.alpnAgent.version>2.0.7</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>"${settings.localRepository}"/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
     <argLine.common>


### PR DESCRIPTION
Motivation:

cff87de44cfaa4544360715dc83e5ad1aa2c0bd7 updated jboss-marshalling to 2.0.5.Final but this broke the ability to run tests with Java 7.

Modifications:

Only use 2.0.5.Final if compiled against Java 10 (as before 1.4.x works fine).

Result:

Be able to run tests with Java 7 on the CI.