### PR TITLE
pom.xml: adding suuport for AARCH64 architecture in Netty/Transport/N…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -637,10 +637,10 @@
                 </requireMavenVersion>
                 <requireProperty>
                   <regexMessage>
-                    x86_64 JDK must be used.
+                    x86_64/AARCH64 JDK must be used.
                   </regexMessage>
                   <property>os.detected.arch</property>
-                  <regex>^x86_64$</regex>
+                  <regex>^(x86_64)|(aarch_64)$</regex>
                 </requireProperty>
               </rules>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -640,7 +640,7 @@
                     x86_64/AARCH64 JDK must be used.
                   </regexMessage>
                   <property>os.detected.arch</property>
-                  <regex>^(x86_64)|(aarch_64)$</regex>
+                  <regex>^(x86_64|aarch_64)$</regex>
                 </requireProperty>
               </rules>
             </configuration>


### PR DESCRIPTION
…ative/Epoll

AARCH 64 architecture support was missing in the exiting Netty-epoll code.
Now the Netty/Transport/Native/Epoll project can be used in aarch64 platform as well.

Motivation: 
To provide the support for AARCH64 architecture

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.
Existing source code was not providing the support for AARCH64 arch. Not we have modified the pom.xml file and it is working fine.
Modification:
Modified the pom.xml file as attached in pull request.


Describe the modifications you've done.

Result:
It is working fine on AARCH64 architecture.

Fixes #<GitHub issue number>. 

If there is no issue then describe the changes introduced by this PR.
