### PR TITLE
Correctly copy existing elements when CodecOutputList.add(index, elem…

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/CodecOutputList.java
+++ b/codec/src/main/java/io/netty/handler/codec/CodecOutputList.java
@@ -148,7 +148,7 @@ final class CodecOutputList extends AbstractList<Object> implements RandomAccess
             expandArray();
         }
 
-        if (index != size - 1) {
+        if (index != size) {
             System.arraycopy(array, index, array, index + 1, size - index);
         }
 

--- a/codec/src/test/java/io/netty/handler/codec/CodecOutputListTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/CodecOutputListTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec;
+
+import org.junit.Test;
+
+
+import static org.junit.Assert.*;
+
+public class CodecOutputListTest {
+
+    @Test
+    public void testCodecOutputListAdd() {
+        CodecOutputList codecOutputList = CodecOutputList.newInstance();
+        try {
+            assertEquals(0, codecOutputList.size());
+            assertTrue(codecOutputList.isEmpty());
+
+            codecOutputList.add(1);
+            assertEquals(1, codecOutputList.size());
+            assertFalse(codecOutputList.isEmpty());
+            assertEquals(1, codecOutputList.get(0));
+
+            codecOutputList.add(0, 0);
+            assertEquals(2, codecOutputList.size());
+            assertFalse(codecOutputList.isEmpty());
+            assertEquals(0, codecOutputList.get(0));
+            assertEquals(1, codecOutputList.get(1));
+
+            codecOutputList.add(1, 2);
+            assertEquals(3, codecOutputList.size());
+            assertFalse(codecOutputList.isEmpty());
+            assertEquals(0, codecOutputList.get(0));
+            assertEquals(2, codecOutputList.get(1));
+            assertEquals(1, codecOutputList.get(2));
+        } finally {
+            codecOutputList.recycle();
+        }
+    }
+}


### PR DESCRIPTION
…ent) is called.

Motivation:

We did not correctly copy elements in some cases when add(index, element) was used.

Modifications:

- Correctly detect when copy is neede and when not.
- Add test case.

Result:

Fixes https://github.com/netty/netty/issues/7938.