### PR TITLE
Adjust tests to also pass when using BoringSSL

### DIFF
--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslEngineTest.java
@@ -558,9 +558,7 @@ public class OpenSslEngineTest extends SSLEngineTest {
                 .build();
 
         testWrapWithDifferentSizes(PROTOCOL_SSL_V3, "ADH-AES128-SHA");
-        testWrapWithDifferentSizes(PROTOCOL_SSL_V3, "AES128-SHA");
         testWrapWithDifferentSizes(PROTOCOL_SSL_V3, "ADH-CAMELLIA128-SHA");
-        testWrapWithDifferentSizes(PROTOCOL_SSL_V3, "DES-CBC3-SHA");
         testWrapWithDifferentSizes(PROTOCOL_SSL_V3, "AECDH-AES128-SHA");
         testWrapWithDifferentSizes(PROTOCOL_SSL_V3, "AECDH-DES-CBC3-SHA");
         testWrapWithDifferentSizes(PROTOCOL_SSL_V3, "CAMELLIA128-SHA");
@@ -568,7 +566,6 @@ public class OpenSslEngineTest extends SSLEngineTest {
         testWrapWithDifferentSizes(PROTOCOL_SSL_V3, "SEED-SHA");
         testWrapWithDifferentSizes(PROTOCOL_SSL_V3, "RC4-MD5");
         testWrapWithDifferentSizes(PROTOCOL_SSL_V3, "ADH-AES256-SHA");
-        testWrapWithDifferentSizes(PROTOCOL_SSL_V3, "AES256-SHA");
         testWrapWithDifferentSizes(PROTOCOL_SSL_V3, "ADH-SEED-SHA");
         testWrapWithDifferentSizes(PROTOCOL_SSL_V3, "ADH-DES-CBC3-SHA");
         testWrapWithDifferentSizes(PROTOCOL_SSL_V3, "EDH-RSA-DES-CBC3-SHA");


### PR DESCRIPTION
Motivation:

Some of the tests failed when using BoringSSL as some protocol / cipher combinations are not supported and it uses a different alert when the cert is not valid yet.

Modification:

- Remove protocol / cipher combos that are not supported by BoringSSL
- Test for different alert when using BoringSSL

Result:

Not test failures when using BoringSSL.