### PR TITLE
Update to conscrypt 1.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>
-    <conscrypt.version>1.0.1</conscrypt.version>
+    <conscrypt.version>1.1.2</conscrypt.version>
     <conscrypt.classifier />
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>


### PR DESCRIPTION
Motivation:

We use latest conscrypt to test against.

Modifications:

Update to conscrypt 1.1.2

Result:

Use latest conscrypt release.