### PR TITLE
Revert workaround in test for Java 11 as it produces a connection-res…

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketRstTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketRstTest.java
@@ -22,8 +22,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.util.internal.PlatformDependent;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -91,13 +89,6 @@ public class SocketRstTest extends AbstractSocketTest {
 
         // Verify the client received a RST.
         Throwable cause = throwableRef.get();
-        if (PlatformDependent.javaVersion() >= 11 && sb.config().group() instanceof NioEventLoopGroup) {
-            // In Java11 calling SocketChannel.close() will also call shutdown(..,SHUT_WR) before actual closing the
-            // fd which means we may not see the ECONNRESET at all :(
-            if (cause == null) {
-                return;
-            }
-        }
         assertTrue("actual [type, message]: [" + cause.getClass() + ", " + cause.getMessage() + "]",
                 cause instanceof IOException);
 


### PR DESCRIPTION
…et as expected now.

Motivation:

We added a workaround for Java 11 as it not produced a connect-reset when SO_LINGER with 0 was set and NIO was used. This was fixed in the latest ea release of Java 11:

 - http://hg.openjdk.java.net/jdk/jdk/rev/ea54197f4fe4
 - https://bugs.openjdk.java.net/browse/JDK-8203059

Modifications:

Revert workaround.

Result:

Test that Java 11 behave the same way as earlier Java versions again.