### PR TITLE
Don't calculate max direct memory twice in PlatformDependent

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -158,7 +158,7 @@ public final class PlatformDependent {
         } else {
             USE_DIRECT_BUFFER_NO_CLEANER = true;
             if (maxDirectMemory < 0) {
-                maxDirectMemory = maxDirectMemory0();
+                maxDirectMemory = MAX_DIRECT_MEMORY;
                 if (maxDirectMemory <= 0) {
                     DIRECT_MEMORY_COUNTER = null;
                 } else {

--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -81,7 +81,6 @@ public final class PlatformDependent {
     private static final Throwable UNSAFE_UNAVAILABILITY_CAUSE = unsafeUnavailabilityCause0();
     private static final boolean DIRECT_BUFFER_PREFERRED =
             UNSAFE_UNAVAILABILITY_CAUSE == null && !SystemPropertyUtil.getBoolean("io.netty.noPreferDirect", false);
-    private static final long MAX_DIRECT_MEMORY = maxDirectMemory0();
 
     private static final int MPSC_CHUNK_SIZE =  1024;
     private static final int MIN_MAX_MPSC_CAPACITY =  MPSC_CHUNK_SIZE * 2;
@@ -158,7 +157,7 @@ public final class PlatformDependent {
         } else {
             USE_DIRECT_BUFFER_NO_CLEANER = true;
             if (maxDirectMemory < 0) {
-                maxDirectMemory = MAX_DIRECT_MEMORY;
+                maxDirectMemory = maxDirectMemory0();
                 if (maxDirectMemory <= 0) {
                     DIRECT_MEMORY_COUNTER = null;
                 } else {
@@ -280,7 +279,7 @@ public final class PlatformDependent {
      * Returns the maximum memory reserved for direct buffer allocation.
      */
     public static long maxDirectMemory() {
-        return MAX_DIRECT_MEMORY;
+        return DIRECT_MEMORY_LIMIT;
     }
 
     /**


### PR DESCRIPTION
Motivation:

I'm not sure if trivial changes like this are interesting :-) But I noticed that the `PlatformDependent.maxDirectMemory0()` method is called twice unnecessarily during static initialization (on the default path at least).

Modifications:

Use constant `MAX_DIRECT_MEMORY` already set to the same value instead of calling `maxDirectMemory0()` again.

Result:

A surely imperceivable reduction in operations performed at startup.