### PR TITLE
Propagate pong frames in WebSocketProtocolHandler

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketClientProtocolHandler.java
@@ -151,6 +151,23 @@ public class WebSocketClientProtocolHandler extends WebSocketProtocolHandler {
      *            {@code true} if close frames should not be forwarded and just close the channel
      */
     public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, boolean handleCloseFrames) {
+        this(handshaker, handleCloseFrames, true);
+    }
+
+    /**
+     * Base constructor
+     *
+     * @param handshaker
+     *            The {@link WebSocketClientHandshaker} which will be used to issue the handshake once the connection
+     *            was established to the remote peer.
+     * @param handleCloseFrames
+     *            {@code true} if close frames should not be forwarded and just close the channel
+     * @param dropPongFrames
+     *            {@code true} if pong frames should not be forwarded
+     */
+    public WebSocketClientProtocolHandler(WebSocketClientHandshaker handshaker, boolean handleCloseFrames,
+                                          boolean dropPongFrames) {
+        super(dropPongFrames);
         this.handshaker = handshaker;
         this.handleCloseFrames = handleCloseFrames;
     }

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandler.java
@@ -22,6 +22,27 @@ import io.netty.handler.codec.MessageToMessageDecoder;
 import java.util.List;
 
 abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocketFrame> {
+
+    private final boolean dropPongFrames;
+
+    /**
+     * Creates a new {@link WebSocketProtocolHandler} that will <i>drop</i> {@link PongWebSocketFrame}s.
+     */
+    WebSocketProtocolHandler() {
+        this(true);
+    }
+
+    /**
+     * Creates a new {@link WebSocketProtocolHandler}, given a parameter that determines whether or not to drop {@link
+     * PongWebSocketFrame}s.
+     *
+     * @param dropPongFrames
+     *            {@code true} if {@link PongWebSocketFrame}s should be dropped
+     */
+    WebSocketProtocolHandler(boolean dropPongFrames) {
+        this.dropPongFrames = dropPongFrames;
+    }
+
     @Override
     protected void decode(ChannelHandlerContext ctx, WebSocketFrame frame, List<Object> out) throws Exception {
         if (frame instanceof PingWebSocketFrame) {
@@ -29,8 +50,7 @@ abstract class WebSocketProtocolHandler extends MessageToMessageDecoder<WebSocke
             ctx.channel().writeAndFlush(new PongWebSocketFrame(frame.content()));
             return;
         }
-        if (frame instanceof PongWebSocketFrame) {
-            // Pong frames need to get ignored
+        if (frame instanceof PongWebSocketFrame && dropPongFrames) {
             return;
         }
 

--- a/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/websocketx/WebSocketServerProtocolHandler.java
@@ -132,6 +132,13 @@ public class WebSocketServerProtocolHandler extends WebSocketProtocolHandler {
 
     public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
             boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch, boolean checkStartsWith) {
+        this(websocketPath, subprotocols, allowExtensions, maxFrameSize, allowMaskMismatch, checkStartsWith, true);
+    }
+
+    public WebSocketServerProtocolHandler(String websocketPath, String subprotocols,
+                                          boolean allowExtensions, int maxFrameSize, boolean allowMaskMismatch,
+                                          boolean checkStartsWith, boolean dropPongFrames) {
+        super(dropPongFrames);
         this.websocketPath = websocketPath;
         this.subprotocols = subprotocols;
         this.allowExtensions = allowExtensions;

--- a/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandlerTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/websocketx/WebSocketProtocolHandlerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.netty.handler.codec.http.websocketx;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.CharsetUtil;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests common, abstract class functionality in {@link WebSocketClientProtocolHandler}.
+ */
+public class WebSocketProtocolHandlerTest {
+
+    @Test
+    public void testPingFrame() {
+        ByteBuf pingData = Unpooled.copiedBuffer("Hello, world", CharsetUtil.UTF_8);
+        EmbeddedChannel channel = new EmbeddedChannel(new WebSocketProtocolHandler() { });
+
+        PingWebSocketFrame inputMessage = new PingWebSocketFrame(pingData);
+        assertFalse(channel.writeInbound(inputMessage)); // the message was not propagated inbound
+
+        // a Pong frame was written to the channel
+        PongWebSocketFrame response = channel.readOutbound();
+        assertEquals(pingData, response.content());
+
+        pingData.release();
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testPongFrameDropFrameFalse() {
+        EmbeddedChannel channel = new EmbeddedChannel(new WebSocketProtocolHandler(false) { });
+
+        PongWebSocketFrame pingResponse = new PongWebSocketFrame();
+        assertTrue(channel.writeInbound(pingResponse));
+
+        assertPropagatedInbound(pingResponse, channel);
+
+        pingResponse.release();
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    public void testPongFrameDropFrameTrue() {
+        EmbeddedChannel channel = new EmbeddedChannel(new WebSocketProtocolHandler(true) { });
+
+        PongWebSocketFrame pingResponse = new PongWebSocketFrame();
+        assertFalse(channel.writeInbound(pingResponse)); // message was not propagated inbound
+    }
+
+    @Test
+    public void testTextFrame() {
+        EmbeddedChannel channel = new EmbeddedChannel(new WebSocketProtocolHandler() { });
+
+        TextWebSocketFrame textFrame = new TextWebSocketFrame();
+        assertTrue(channel.writeInbound(textFrame));
+
+        assertPropagatedInbound(textFrame, channel);
+
+        textFrame.release();
+        assertFalse(channel.finish());
+    }
+
+    /**
+     * Asserts that a message was propagated inbound through the channel.
+     */
+    private static <T extends WebSocketFrame> void assertPropagatedInbound(T message, EmbeddedChannel channel) {
+        T propagatedResponse = channel.readInbound();
+        assertEquals(message, propagatedResponse);
+    }
+}


### PR DESCRIPTION
Motivation:

Currently, on recipt of a PongWebSocketFrame, the
WebSocketProtocolHandler will drop the frame, rather than passing it
along so it can be referenced by other handlers.

Modifications:

Add boolean field to WebSocketProtocolHandler to indicate whether Pong
frames should be dropped or propagated, defaulting to "true" to preserve
existing functionality.

Add new constructors to the client and server implementations of
WebSocketProtocolHandler that allow for overriding the behavior for the
handling of Pong frames.

Result:

PongWebSocketFrames are passed along the channel, if specified.

Fixes #7954.