### PR TITLE
Correctly take status into account when compare DefaultHttpResponse

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpResponse.java
@@ -105,4 +105,23 @@ public class DefaultHttpResponse extends DefaultHttpMessage implements HttpRespo
     public String toString() {
         return HttpMessageUtil.appendResponse(new StringBuilder(256), this).toString();
     }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = 31 * result + status.hashCode();
+        result = 31 * result + super.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof DefaultHttpResponse)) {
+            return false;
+        }
+
+        DefaultHttpResponse other = (DefaultHttpResponse) o;
+
+        return status.equals(other.status()) && super.equals(o);
+    }
 }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpResponseTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/DefaultHttpResponseTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.codec.http;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class DefaultHttpResponseTest {
+
+   @Test
+    public void testNotEquals() {
+        HttpResponse ok = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        HttpResponse notFound = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.NOT_FOUND);
+        assertNotEquals(ok, notFound);
+        assertNotEquals(ok.hashCode(), notFound.hashCode());
+   }
+
+    @Test
+    public void testEquals() {
+        HttpResponse ok = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        HttpResponse ok2 = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        assertEquals(ok, ok2);
+        assertEquals(ok.hashCode(), ok2.hashCode());
+    }
+}


### PR DESCRIPTION
Motivation:

DefaultHttpResponse did not respect its status when compute the hashCode and check for equality.

Modifications:

Correctly implement hashCode and equals

Result:

Fixes https://github.com/netty/netty/issues/7964.