### PR TITLE
Don't use VM.maxDirectMemory() on IBM J9 / Eclipse OpenJ9 to retrieve…

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -993,10 +993,14 @@ public final class PlatformDependent {
         try {
             systemClassLoader = getSystemClassLoader();
 
-            // On z/OS we should not use VM.maxDirectMemory() as it not reflects the correct value.
+            // When using IBM J9 / Eclipse OpenJ9 we should not use VM.maxDirectMemory() as it not reflects the
+            // correct value.
             // See:
             //  - https://github.com/netty/netty/issues/7654
-            if (!SystemPropertyUtil.get("os.name", "").toLowerCase().contains("z/os")) {
+            String vmName = SystemPropertyUtil.get("java.vm.name", "").toLowerCase();
+            if (!vmName.startsWith("ibm j9") &&
+                    // https://github.com/eclipse/openj9/blob/openj9-0.8.0/runtime/include/vendor_version.h#L53
+                    !vmName.startsWith("eclipse openj9")) {
                 // Try to get from sun.misc.VM.maxDirectMemory() which should be most accurate.
                 Class<?> vmClass = Class.forName("sun.misc.VM", true, systemClassLoader);
                 Method m = vmClass.getDeclaredMethod("maxDirectMemory");


### PR DESCRIPTION
… direct memory limit

Motivation:

On J9 / OpenJ9 netty initializes this value with 64M, even the direct accessible memory is actually unbounded.

Modifications:

Skip usage of VM.maxDirectMemory() on J9 / OpenJ9

Result:

More correct direct memory limit detection. Fixes #7654.