### PR TITLE
AUTO_CLOSE should not be marked as deprecated.

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelConfig.java
+++ b/transport/src/main/java/io/netty/channel/ChannelConfig.java
@@ -195,21 +195,15 @@ public interface ChannelConfig {
     ChannelConfig setAutoRead(boolean autoRead);
 
     /**
-     * @deprecated  Auto close will be removed in a future release.
-     *
      * Returns {@code true} if and only if the {@link Channel} will be closed automatically and immediately on
-     * write failure.  The default is {@code false}.
+     * write failure. The default is {@code true}.
      */
-    @Deprecated
     boolean isAutoClose();
 
     /**
-     * @deprecated  Auto close will be removed in a future release.
-     *
      * Sets whether the {@link Channel} should be closed automatically and immediately on write failure.
-     * The default is {@code false}.
+     * The default is {@code true}.
      */
-    @Deprecated
     ChannelConfig setAutoClose(boolean autoClose);
 
     /**

--- a/transport/src/main/java/io/netty/channel/ChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/ChannelOption.java
@@ -99,12 +99,9 @@ public class ChannelOption<T> extends AbstractConstant<ChannelOption<T>> {
     public static final ChannelOption<Boolean> AUTO_READ = valueOf("AUTO_READ");
 
     /**
-     * @deprecated  Auto close will be removed in a future release.
-     *
      * If {@code true} then the {@link Channel} is closed automatically and immediately on write failure.
      * The default value is {@code true}.
      */
-    @Deprecated
     public static final ChannelOption<Boolean> AUTO_CLOSE = valueOf("AUTO_CLOSE");
 
     public static final ChannelOption<Boolean> SO_BROADCAST = valueOf("SO_BROADCAST");


### PR DESCRIPTION
Motivation:

A long time ago we deprecated AUTO_CLOSE but it turned out this feature is still useful.

Modifications:

- Remove `@Deprecated` tag for AUTO_CLOSE, setAutoClose(...) and isAutoClose(...)
- Fix javadocs on ChannelConfig to correctly tell the default value of AUTO_CLOSE.

Result:

Less warnings.