### PR TITLE
Provide an API for controlling and h2c upgrade response stream in Http2MultiplexCodec

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java
@@ -143,7 +143,7 @@ public class Http2FrameCodec extends Http2ConnectionHandler {
 
     private static final InternalLogger LOG = InternalLoggerFactory.getInstance(Http2FrameCodec.class);
 
-    private final PropertyKey streamKey;
+    protected final PropertyKey streamKey;
     private final PropertyKey upgradeKey;
 
     private final Integer initialFlowControlWindowSize;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodecBuilder.java
@@ -29,6 +29,7 @@ public class Http2MultiplexCodecBuilder
         extends AbstractHttp2ConnectionHandlerBuilder<Http2MultiplexCodec, Http2MultiplexCodecBuilder> {
 
     final ChannelHandler childHandler;
+    private ChannelHandler upgradeStreamHandler;
 
     Http2MultiplexCodecBuilder(boolean server, ChannelHandler childHandler) {
         server(server);
@@ -81,6 +82,14 @@ public class Http2MultiplexCodecBuilder
     @Override
     public Http2MultiplexCodecBuilder gracefulShutdownTimeoutMillis(long gracefulShutdownTimeoutMillis) {
         return super.gracefulShutdownTimeoutMillis(gracefulShutdownTimeoutMillis);
+    }
+
+    public Http2MultiplexCodecBuilder withUpgradeStreamHandler(ChannelHandler upgradeStreamHandler) {
+        if (this.isServer()) {
+            throw new IllegalArgumentException("Server codecs don't use an extra handler for the upgrade stream");
+        }
+        this.upgradeStreamHandler = upgradeStreamHandler;
+        return this;
     }
 
     @Override
@@ -157,6 +166,6 @@ public class Http2MultiplexCodecBuilder
     @Override
     protected Http2MultiplexCodec build(
             Http2ConnectionDecoder decoder, Http2ConnectionEncoder encoder, Http2Settings initialSettings) {
-        return new Http2MultiplexCodec(encoder, decoder, initialSettings, childHandler);
+        return new Http2MultiplexCodec(encoder, decoder, initialSettings, childHandler, upgradeStreamHandler);
     }
 }

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ClientUpgradeCodecTest.java
@@ -14,9 +14,11 @@
  */
 package io.netty.handler.codec.http2;
 
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -43,7 +45,8 @@ public class Http2ClientUpgradeCodecTest {
 
     @Test
     public void testUpgradeToHttp2MultiplexCodec() throws Exception {
-        testUpgrade(Http2MultiplexCodecBuilder.forClient(new HttpInboundHandler()).build());
+        testUpgrade(Http2MultiplexCodecBuilder.forClient(new HttpInboundHandler())
+            .withUpgradeStreamHandler(new ChannelInboundHandlerAdapter()).build());
     }
 
     private static void testUpgrade(Http2ConnectionHandler handler) throws Exception {

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecClientUpgradeTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecClientUpgradeTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.netty.handler.codec.http2;
+
+import org.junit.Test;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Http2MultiplexCodecClientUpgradeTest {
+
+    @ChannelHandler.Sharable
+    private final class NoopHandler extends ChannelInboundHandlerAdapter {
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) {
+            ctx.channel().close();
+        }
+    }
+
+    private final class UpgradeHandler extends ChannelInboundHandlerAdapter {
+        Http2Stream.State stateOnActive;
+        int streamId;
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            Http2StreamChannel ch = (Http2StreamChannel) ctx.channel();
+            stateOnActive = ch.stream().state();
+            streamId = ch.stream().id();
+            super.channelActive(ctx);
+        }
+    }
+
+    private Http2MultiplexCodec newCodec(ChannelHandler upgradeHandler) {
+        Http2MultiplexCodecBuilder builder = Http2MultiplexCodecBuilder.forClient(new NoopHandler());
+        builder.withUpgradeStreamHandler(upgradeHandler);
+        return builder.build();
+    }
+
+    @Test
+    public void upgradeHandlerGetsActivated() throws Exception {
+        UpgradeHandler upgradeHandler = new UpgradeHandler();
+        Http2MultiplexCodec codec = newCodec(upgradeHandler);
+        EmbeddedChannel ch = new EmbeddedChannel(codec);
+
+        codec.onHttpClientUpgrade();
+
+        assertFalse(upgradeHandler.stateOnActive.localSideOpen());
+        assertTrue(upgradeHandler.stateOnActive.remoteSideOpen());
+        assertEquals(1, upgradeHandler.streamId);
+        assertTrue(ch.finishAndReleaseAll());
+    }
+
+    @Test(expected = Http2Exception.class)
+    public void clientUpgradeWithoutUpgradeHandlerThrowsHttp2Exception() throws Http2Exception {
+        Http2MultiplexCodec codec = Http2MultiplexCodecBuilder.forClient(new NoopHandler()).build();
+        EmbeddedChannel ch = new EmbeddedChannel(codec);
+        try {
+            codec.onHttpClientUpgrade();
+        } finally {
+            assertTrue(ch.finishAndReleaseAll());
+        }
+    }
+}

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2MultiplexCodecTest.java
@@ -633,7 +633,7 @@ public class Http2MultiplexCodecTest {
                                            Http2ConnectionDecoder decoder,
                                            Http2Settings initialSettings,
                                            ChannelHandler inboundStreamHandler) {
-            super(encoder, decoder, initialSettings, inboundStreamHandler);
+            super(encoder, decoder, initialSettings, inboundStreamHandler, null);
         }
 
         void onHttp2Frame(Http2Frame frame) {


### PR DESCRIPTION
Motivation:

Http2MultiplexCodec doesn't currently have an API for using the response
of a h2c upgrade request.

Modifications:

Add a new API to the Http2MultiplexCodecBuilder which allows for setting
an upgrade handler and wire it into the Http2MultiplexCodec
implementation.

Result:

When using the Http2MultiplexCodec with h2c upgrades the upgrade handler
will get added to the Http2StreamChannel which represents the
half-closed (local) response of stream 1. It is then up to the user to
manage the transition from the IO channel pipeline configuration
necessary for making the h2c upgrade request to a form where it can read
the response from the new stream channel.

Fixes #7947.