### PR TITLE
Allow to schedule tasks up to Long.MAX_VALUE

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
+++ b/common/src/main/java/io/netty/util/concurrent/AbstractScheduledEventExecutor.java
@@ -150,7 +150,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         if (delay < 0) {
             delay = 0;
         }
-        validateScheduled(delay, unit);
+        validateScheduled0(delay, unit);
 
         return schedule(new ScheduledFutureTask<Void>(
                 this, command, null, ScheduledFutureTask.deadlineNanos(unit.toNanos(delay))));
@@ -163,7 +163,7 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
         if (delay < 0) {
             delay = 0;
         }
-        validateScheduled(delay, unit);
+        validateScheduled0(delay, unit);
 
         return schedule(new ScheduledFutureTask<V>(
                 this, callable, ScheduledFutureTask.deadlineNanos(unit.toNanos(delay))));
@@ -181,8 +181,8 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
             throw new IllegalArgumentException(
                     String.format("period: %d (expected: > 0)", period));
         }
-        validateScheduled(initialDelay, unit);
-        validateScheduled(period, unit);
+        validateScheduled0(initialDelay, unit);
+        validateScheduled0(period, unit);
 
         return schedule(new ScheduledFutureTask<Void>(
                 this, Executors.<Void>callable(command, null),
@@ -202,17 +202,25 @@ public abstract class AbstractScheduledEventExecutor extends AbstractEventExecut
                     String.format("delay: %d (expected: > 0)", delay));
         }
 
-        validateScheduled(initialDelay, unit);
-        validateScheduled(delay, unit);
+        validateScheduled0(initialDelay, unit);
+        validateScheduled0(delay, unit);
 
         return schedule(new ScheduledFutureTask<Void>(
                 this, Executors.<Void>callable(command, null),
                 ScheduledFutureTask.deadlineNanos(unit.toNanos(initialDelay)), -unit.toNanos(delay)));
     }
 
+    @SuppressWarnings("deprecation")
+    private void validateScheduled0(long amount, TimeUnit unit) {
+        validateScheduled(amount, unit);
+    }
+
     /**
      * Sub-classes may override this to restrict the maximal amount of time someone can use to schedule a task.
+     *
+     * @deprecated will be removed in the future.
      */
+    @Deprecated
     protected void validateScheduled(long amount, TimeUnit unit) {
         // NOOP
     }

--- a/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
+++ b/common/src/main/java/io/netty/util/concurrent/ScheduledFutureTask.java
@@ -35,7 +35,9 @@ final class ScheduledFutureTask<V> extends PromiseTask<V> implements ScheduledFu
     }
 
     static long deadlineNanos(long delay) {
-        return nanoTime() + delay;
+        long deadlineNanos = nanoTime() + delay;
+        // Guard against overflow
+        return deadlineNanos < 0 ? Long.MAX_VALUE : deadlineNanos;
     }
 
     private final long id = nextTaskId.getAndIncrement();

--- a/common/src/test/java/io/netty/util/concurrent/ScheduledFutureTaskTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/ScheduledFutureTaskTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.concurrent;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ScheduledFutureTaskTest {
+
+    @Test
+    public void testDeadlineNanosNotOverflow() {
+        Assert.assertEquals(Long.MAX_VALUE, ScheduledFutureTask.deadlineNanos(Long.MAX_VALUE));
+    }
+}

--- a/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
+++ b/transport-native-epoll/src/test/java/io/netty/channel/epoll/EpollEventLoopTest.java
@@ -24,32 +24,11 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class EpollEventLoopTest {
 
-    @Test(timeout = 5000L)
-    public void testScheduleBigDelayOverMax() {
-        EventLoopGroup group = new EpollEventLoopGroup(1);
-
-        final EventLoop el = group.next();
-        try {
-            el.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    // NOOP
-                }
-            }, Integer.MAX_VALUE, TimeUnit.DAYS);
-            fail();
-        } catch (IllegalArgumentException expected) {
-            // expected
-        }
-
-        group.shutdownGracefully();
-    }
-
     @Test
-    public void testScheduleBigDelay() {
+    public void testScheduleBigDelayNotOverflow() {
         EventLoopGroup group = new EpollEventLoopGroup(1);
 
         final EventLoop el = group.next();
@@ -58,7 +37,7 @@ public class EpollEventLoopTest {
             public void run() {
                 // NOOP
             }
-        }, EpollEventLoop.MAX_SCHEDULED_DAYS, TimeUnit.DAYS);
+        }, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
         assertFalse(future.awaitUninterruptibly(1000));
         assertTrue(future.cancel(true));

--- a/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
+++ b/transport-native-kqueue/src/main/java/io/netty/channel/kqueue/KQueueEventLoop.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.util.Queue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static io.netty.channel.kqueue.KQueueEventArray.deleteGlobalRefs;
@@ -76,8 +75,6 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
 
     private volatile int wakenUp;
     private volatile int ioRatio = 50;
-
-    static final long MAX_SCHEDULED_DAYS = 365 * 3;
 
     KQueueEventLoop(EventLoopGroup parent, Executor executor, int maxEvents,
                     SelectStrategy strategy, RejectedExecutionHandler rejectedExecutionHandler) {
@@ -368,14 +365,6 @@ final class KQueueEventLoop extends SingleThreadEventLoop {
             Thread.sleep(1000);
         } catch (InterruptedException e) {
             // Ignore.
-        }
-    }
-
-    @Override
-    protected void validateScheduled(long amount, TimeUnit unit) {
-        long days = unit.toDays(amount);
-        if (days > MAX_SCHEDULED_DAYS) {
-            throw new IllegalArgumentException("days: " + days + " (expected: < " + MAX_SCHEDULED_DAYS + ')');
         }
     }
 }

--- a/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueEventLoopTest.java
+++ b/transport-native-kqueue/src/test/java/io/netty/channel/kqueue/KQueueEventLoopTest.java
@@ -24,32 +24,11 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class KQueueEventLoopTest {
 
-    @Test(timeout = 5000L)
-    public void testScheduleBigDelayOverMax() {
-        EventLoopGroup group = new KQueueEventLoopGroup(1);
-
-        final EventLoop el = group.next();
-        try {
-            el.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    // NOOP
-                }
-            }, Integer.MAX_VALUE, TimeUnit.DAYS);
-            fail();
-        } catch (IllegalArgumentException expected) {
-            // expected
-        }
-
-        group.shutdownGracefully();
-    }
-
     @Test
-    public void testScheduleBigDelay() {
+    public void testScheduleBigDelayNotOverflow() {
         EventLoopGroup group = new KQueueEventLoopGroup(1);
 
         final EventLoop el = group.next();
@@ -58,7 +37,7 @@ public class KQueueEventLoopTest {
             public void run() {
                 // NOOP
             }
-        }, KQueueEventLoop.MAX_SCHEDULED_DAYS, TimeUnit.DAYS);
+        }, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
         assertFalse(future.awaitUninterruptibly(1000));
         assertTrue(future.cancel(true));

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -113,8 +113,6 @@ public final class NioEventLoop extends SingleThreadEventLoop {
         }
     }
 
-    static final long MAX_SCHEDULED_DAYS = 365 * 3;
-
     /**
      * The NIO {@link Selector}.
      */
@@ -823,14 +821,6 @@ public final class NioEventLoop extends SingleThreadEventLoop {
             selector.selectNow();
         } catch (Throwable t) {
             logger.warn("Failed to update SelectionKeys.", t);
-        }
-    }
-
-    @Override
-    protected void validateScheduled(long amount, TimeUnit unit) {
-        long days = unit.toDays(amount);
-        if (days > MAX_SCHEDULED_DAYS) {
-            throw new IllegalArgumentException("days: " + days + " (expected: < " + MAX_SCHEDULED_DAYS + ')');
         }
     }
 }

--- a/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/NioEventLoopTest.java
@@ -73,27 +73,8 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
         }
     }
 
-    @Test(timeout = 5000L)
-    public void testScheduleBigDelayOverMax() {
-        EventLoopGroup group = new NioEventLoopGroup(1);
-        final EventLoop el = group.next();
-        try {
-            el.schedule(new Runnable() {
-                @Override
-                public void run() {
-                    // NOOP
-                }
-            }, Integer.MAX_VALUE, TimeUnit.DAYS);
-            fail();
-        } catch (IllegalArgumentException expected) {
-            // expected
-        }
-
-        group.shutdownGracefully();
-    }
-
     @Test
-    public void testScheduleBigDelay() {
+    public void testScheduleBigDelayNotOverflow() {
         EventLoopGroup group = new NioEventLoopGroup(1);
 
         final EventLoop el = group.next();
@@ -102,7 +83,7 @@ public class NioEventLoopTest extends AbstractEventLoopTest {
             public void run() {
                 // NOOP
             }
-        }, NioEventLoop.MAX_SCHEDULED_DAYS, TimeUnit.DAYS);
+        }, Long.MAX_VALUE, TimeUnit.MILLISECONDS);
 
         assertFalse(future.awaitUninterruptibly(1000));
         assertTrue(future.cancel(true));


### PR DESCRIPTION
Motivation:

We should allow to schedule tasks with a delay up to Long.MAX_VALUE as we did pre 4.1.25.Final.

Modifications:

Just ensure we not overflow and put the correct max limits in place when schedule a timer. At worse we will get a wakeup to early and then schedule a new timeout.

Result:

Fixes https://github.com/netty/netty/issues/7970.