### PR TITLE
Correctly let Http2UnkownFrame extend HttpStreamFrame and so be usabl…

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2UnknownFrame.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2UnknownFrame.java
@@ -20,13 +20,12 @@ import io.netty.buffer.ByteBufHolder;
 import io.netty.util.internal.UnstableApi;
 
 @UnstableApi
-public interface Http2UnknownFrame extends Http2Frame, ByteBufHolder {
+public interface Http2UnknownFrame extends Http2StreamFrame, ByteBufHolder {
 
+    @Override
     Http2FrameStream stream();
 
-    /**
-     * Set the {@link Http2FrameStream} object for this frame.
-     */
+    @Override
     Http2UnknownFrame stream(Http2FrameStream stream);
 
     byte frameType();


### PR DESCRIPTION
…e with Http2MultiplexCodec.

Motivation:

This is a followup for #7860. In the fix for #7860 we only partly fixed the problem as Http2UnknownFrame did not correctly extend HttpStreamFrame and so only worked when using the Http2FrameCodec. We need to have it extend HttpStreamFrame as otherwise Http2MultiplexCodec will reject to handle it correctly.

Modifications:

- Let Http2UnknownFrame extend HttpStreamFrame
- Add unit tests for writing and reading Http2UnkownFrame instances when the Http2MultiplexCodec is used.

Result:

Fixes https://github.com/netty/netty/issues/7969.