### PR TITLE
Use jdk-11-ea+15 when try to build with java11

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "1.11.0-14"
+        java_version : "1.11.0-15"
 
   test:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "1.11.0-14"
+        java_version : "1.11.0-15"
 
   test:
     image: netty:centos-7-1.11


### PR DESCRIPTION
Motivation:

A new EA build for java 11 is out.

Modifications:

Update from ea+14 to ea+15

Result:

Use latest ea build