### PR TITLE
Allow to test with boringssl-static and drop into shell

### DIFF
--- a/docker/docker-compose.centos-6.110.yaml
+++ b/docker/docker-compose.centos-6.110.yaml
@@ -11,3 +11,9 @@ services:
 
   test:
     image: netty:centos-6-1.10
+
+  test-boringssl-static:
+    image: netty:centos-6-1.10
+
+  shell:
+    image: netty:centos-6-1.10

--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -11,3 +11,9 @@ services:
 
   test:
     image: netty:centos-6-1.11
+
+  test-boringssl-static:
+    image: netty:centos-6-1.11
+
+  shell:
+    image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-6.18.yaml
+++ b/docker/docker-compose.centos-6.18.yaml
@@ -11,3 +11,9 @@ services:
 
   test:
     image: netty:centos-6-1.8
+
+  test-boringssl-static:
+    image: netty:centos-6-1.8
+
+  shell:
+    image: netty:centos-6-1.8

--- a/docker/docker-compose.centos-6.19.yaml
+++ b/docker/docker-compose.centos-6.19.yaml
@@ -11,3 +11,9 @@ services:
 
   test:
     image: netty:centos-6-1.9
+
+  test-boringssl-static:
+    image: netty:centos-6-1.9
+
+  shell:
+    image: netty:centos-6-1.9

--- a/docker/docker-compose.centos-7.110.yaml
+++ b/docker/docker-compose.centos-7.110.yaml
@@ -11,3 +11,9 @@ services:
 
   test:
     image: netty:centos-7-1.10
+
+  test-boringssl-static:
+    image: netty:centos-7-1.10
+
+  shell:
+    image: netty:centos-7-1.10

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -11,3 +11,9 @@ services:
 
   test:
     image: netty:centos-7-1.11
+
+  test-boringssl-static:
+    image: netty:centos-7-1.11
+
+  shell:
+    image: netty:centos-7-1.11

--- a/docker/docker-compose.centos-7.18.yaml
+++ b/docker/docker-compose.centos-7.18.yaml
@@ -11,3 +11,9 @@ services:
 
   test:
     image: netty:centos-7-1.8
+
+  test-boringssl-static:
+    image: netty:centos-7-1.8
+
+  shell:
+    image: netty:centos-7-1.8

--- a/docker/docker-compose.centos-7.19.yaml
+++ b/docker/docker-compose.centos-7.19.yaml
@@ -11,3 +11,9 @@ services:
 
   test:
     image: netty:centos-7-1.9
+
+  test-boringssl-static:
+    image: netty:centos-7-1.9
+
+  shell:
+    image: netty:centos-7-1.9

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -13,11 +13,23 @@ services:
     depends_on: [runtime-setup]
     volumes:
       - ~/.ssh:/root/.ssh
-      - ~/.m2:/root/.m2
       - ~/.gnupg:/root/.gnupg
       - ..:/code
     working_dir: /code
 
   test:
     <<: *common
-    command: /bin/bash -cl "./mvnw clean package -Dio.netty.testsuite.badHost=netty.io -DskipOsgiTestsuite=true"
+    command: /bin/bash -cl "./mvnw clean install -Dio.netty.testsuite.badHost=netty.io"
+
+  test-boringssl-static:
+    <<: *common
+    command: /bin/bash -cl "./mvnw clean install -Dio.netty.testsuite.badHost=netty.io -Dtcnative.artifactId=netty-tcnative-boringssl-static"
+
+  shell:
+    <<: *common
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ~/.gnupg:/root/.gnupg
+      - ..:/code
+      - ~/.m2:/root/.m2
+    entrypoint: /bin/bash


### PR DESCRIPTION
Motivation:

We also need to run our tests while using boringssl-static to ensure everything works when using it. Beside this its sometimes useful to be able to just get a shell and so interactive work in the docker instance.

Modifications:

- Add configs for shell
- Add configs for testing with boringssl-static
- Ensure we not share .m2 when running tests

Result:

More complete docker setup.