### PR TITLE
Don't trim stacktrace for exceptions when running mvn test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -864,6 +864,8 @@
             </property>
           </properties>
           <jvm>${testJavaHome}/bin/java</jvm>
+           <!-- Ensure the whole stacktrace is preserved when an exception is thrown. See https://issues.apache.org/jira/browse/SUREFIRE-1457 --> 
+          <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
       <!-- always produce osgi bundles -->


### PR DESCRIPTION
Motivation:

The maven surefire plugin will trim stacktraces by default which makes these kind of use-less when trying to understand why an test failed because one was thrown.

Modifications:

Configure the plugin to not trim the stacktrace.

Result:

Easier to debug test-failures.