### PR TITLE
Fix CharSequenceValueConverter.convertToByte implementation for Ascii…

### DIFF
--- a/codec/src/main/java/io/netty/handler/codec/CharSequenceValueConverter.java
+++ b/codec/src/main/java/io/netty/handler/codec/CharSequenceValueConverter.java
@@ -77,7 +77,7 @@ public class CharSequenceValueConverter implements ValueConverter<CharSequence> 
 
     @Override
     public byte convertToByte(CharSequence value) {
-        if (value instanceof AsciiString) {
+        if (value instanceof AsciiString && value.length() == 1) {
             return ((AsciiString) value).byteAt(0);
         }
         return Byte.parseByte(value.toString());

--- a/codec/src/test/java/io/netty/handler/codec/CharSequenceValueConverterTest.java
+++ b/codec/src/test/java/io/netty/handler/codec/CharSequenceValueConverterTest.java
@@ -14,6 +14,7 @@
  */
 package io.netty.handler.codec;
 
+import io.netty.util.AsciiString;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -28,6 +29,16 @@ public class CharSequenceValueConverterTest {
     public void testBoolean() {
         assertTrue(converter.convertToBoolean(converter.convertBoolean(true)));
         assertFalse(converter.convertToBoolean(converter.convertBoolean(false)));
+    }
+
+    @Test
+    public void testByteFromAsciiString() {
+        assertEquals(127, converter.convertToByte(AsciiString.of("127")));
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void testByteFromEmptyAsciiString() {
+        converter.convertToByte(AsciiString.EMPTY_STRING);
     }
 
     @Test


### PR DESCRIPTION
…String

Motivation:

The implementation of CharSequenceValueConverter.convertToByte did not correctly handle AsciiString if the length != 1.

Modifications:

- Only use fast-path for AsciiString with length of 1.
- Add unit tests.

Result:

Fixes https://github.com/netty/netty/issues/7990