### PR TITLE
Mention the HttpObjectEncoder's state in the message of the IllegalSt…

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/HttpObjectEncoder.java
@@ -83,7 +83,8 @@ public abstract class HttpObjectEncoder<H extends HttpMessage> extends MessageTo
         ByteBuf buf = null;
         if (msg instanceof HttpMessage) {
             if (state != ST_INIT) {
-                throw new IllegalStateException("unexpected message type: " + StringUtil.simpleClassName(msg));
+                throw new IllegalStateException("unexpected message type: " + StringUtil.simpleClassName(msg)
+                        + ", state: " + state);
             }
 
             @SuppressWarnings({ "unchecked", "CastConflictsWithInstanceof" })


### PR DESCRIPTION
…ateException

Motivation

The HttpObjectEncoder raises an IllegalStateException due to an illegal state but doesn't mention what the state was. It could be useful for debugging purposes to figure out what happened.

Modifications

Mention the HttpObjectEncoder's state in the message of the IllegalStateException.

Result

An exception with more information what caused it.
