### PR TITLE
Use java 11+ea16

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "1.11.0-15"
+        java_version : "1.11.0-16"
 
   test:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "1.11.0-15"
+        java_version : "1.11.0-16"
 
   test:
     image: netty:centos-7-1.11


### PR DESCRIPTION
Motivation:

Java 11+ea16 was released.

Modifications:

Update to latest version.

Result:

Testing with latest java 11 release.