### PR TITLE
Update conscrypt to 1.1.3 which fixes some NPEs during tests when u…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <conscrypt.groupId>org.conscrypt</conscrypt.groupId>
     <conscrypt.artifactId>conscrypt-openjdk-uber</conscrypt.artifactId>
-    <conscrypt.version>1.1.2</conscrypt.version>
+    <conscrypt.version>1.1.3</conscrypt.version>
     <conscrypt.classifier />
     <jni.classifier>${os.detected.name}-${os.detected.arch}</jni.classifier>
     <logging.config>${project.basedir}/../common/src/test/resources/logback-test.xml</logging.config>


### PR DESCRIPTION
…sing conscrypt.

Motivation:

When using conscrypt some NPEs were logged, these were fixed in the latest release.

Modifications:

Update to conscrypt 1.1.3.

Result:

Fixes https://github.com/netty/netty/issues/7988.