### PR TITLE
Avoiding the usage of Jmh Invocation level on setup/teardown 

### DIFF
--- a/microbench/src/main/java/io/netty/handler/codec/CodecOutputListBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/CodecOutputListBenchmark.java
@@ -45,19 +45,19 @@ public class CodecOutputListBenchmark extends AbstractMicrobenchmark {
 
     @Benchmark
     public void codecOutList() {
-    	codecOutputList = CodecOutputList.newInstance();
+        codecOutputList = CodecOutputList.newInstance();
         benchmarkAddAndClear(codecOutputList, elements);
     }
 
     @Benchmark
     public void recyclableArrayList() {
-    	recycleableArrayList = RecyclableArrayList.newInstance(16);
+        recycleableArrayList = RecyclableArrayList.newInstance(16);
         benchmarkAddAndClear(recycleableArrayList, elements);
     }
 
     @Benchmark
     public void arrayList() {
-    	arrayList = new ArrayList<Object>(16);
+        arrayList = new ArrayList<Object>(16);
         benchmarkAddAndClear(arrayList, elements);
     }
 

--- a/microbench/src/main/java/io/netty/handler/codec/CodecOutputListBenchmark.java
+++ b/microbench/src/main/java/io/netty/handler/codec/CodecOutputListBenchmark.java
@@ -18,10 +18,8 @@ package io.netty.handler.codec;
 import io.netty.microbench.util.AbstractMicrobenchmark;
 import io.netty.util.internal.RecyclableArrayList;
 import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 
@@ -39,13 +37,6 @@ public class CodecOutputListBenchmark extends AbstractMicrobenchmark {
     @Param({ "1", "4" })
     public int elements;
 
-    @Setup(Level.Invocation)
-    public void setup() {
-        codecOutputList = CodecOutputList.newInstance();
-        recycleableArrayList = RecyclableArrayList.newInstance(16);
-        arrayList = new ArrayList<Object>(16);
-    }
-
     @TearDown
     public void destroy() {
         codecOutputList.recycle();
@@ -54,16 +45,19 @@ public class CodecOutputListBenchmark extends AbstractMicrobenchmark {
 
     @Benchmark
     public void codecOutList() {
+    	codecOutputList = CodecOutputList.newInstance();
         benchmarkAddAndClear(codecOutputList, elements);
     }
 
     @Benchmark
     public void recyclableArrayList() {
+    	recycleableArrayList = RecyclableArrayList.newInstance(16);
         benchmarkAddAndClear(recycleableArrayList, elements);
     }
 
     @Benchmark
     public void arrayList() {
+    	arrayList = new ArrayList<Object>(16);
         benchmarkAddAndClear(arrayList, elements);
     }
 

--- a/microbench/src/main/java/io/netty/microbench/headers/HeadersBenchmark.java
+++ b/microbench/src/main/java/io/netty/microbench/headers/HeadersBenchmark.java
@@ -102,14 +102,6 @@ public class HeadersBenchmark extends AbstractMicrobenchmark {
         emptyHttp2HeadersNoValidate = new DefaultHttp2Headers(false);
     }
 
-    @Setup(Level.Invocation)
-    public void setupEmptyHeaders() {
-        emptyHttpHeaders.clear();
-        emptyHttp2Headers .clear();
-        emptyHttpHeadersNoValidate.clear();
-        emptyHttp2HeadersNoValidate.clear();
-    }
-
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
     public void httpRemove(Blackhole bh) {
@@ -183,30 +175,35 @@ public class HeadersBenchmark extends AbstractMicrobenchmark {
     @BenchmarkMode(Mode.AverageTime)
     public void httpAddAllFastest(Blackhole bh) {
         bh.consume(emptyHttpHeadersNoValidate.add(httpHeaders));
+        emptyHttpHeadersNoValidate.clear();
     }
 
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
     public void httpAddAllFast(Blackhole bh) {
         bh.consume(emptyHttpHeaders.add(httpHeaders));
+        emptyHttpHeaders.clear();
     }
 
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
     public void http2AddAllFastest(Blackhole bh) {
         bh.consume(emptyHttp2HeadersNoValidate.add(http2Headers));
+        emptyHttp2HeadersNoValidate.clear();
     }
 
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
     public void http2AddAllFast(Blackhole bh) {
         bh.consume(emptyHttp2Headers.add(http2Headers));
+        emptyHttp2Headers.clear();
     }
 
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
     public void http2AddAllSlow(Blackhole bh) {
         bh.consume(emptyHttp2Headers.add(slowHttp2Headers));
+        emptyHttp2Headers.clear();
     }
 
     private static final class SlowHeaders implements Headers<CharSequence, CharSequence, SlowHeaders> {


### PR DESCRIPTION
Motivation:

We are conducting a scientific study to investigate bad practices/anti-patterns on creating micro-benchmarks using JMH, and we found two instances of harmfull usage of Invocation level in your benchmark classes.

The usage of Invocation level for JMH fixture methods (setup/teardown) inccurs in a significant impact in
in the benchmark time (see [JMH Documentation ](http://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-core/src/main/java/org/openjdk/jmh/annotations/Level.java)). 

When the benchmark and the setup/teardown is too small (less than a milisecond) the Invocation level might saturate the system with timestamp requests and iteration synchronizations which introduce artificial latency, throughput, and scalability bottlenecks.

From our experiments Netty has two instances of such case, HeadersBenchmark and CodecInputListBenchmark. On those cases, the benchmark is far too small (<100ns) and the Invocation level setup offsets the measurement considerably.

Modification:

I have applied the simplest fix patch to include what was previously in the setup, inside the benchmark code. 

Result:

In most cases, the benchmarks run faster now, without the artificial latency introduced by the setup code. I have attached a csv with all benchmarks runs and the difference between Netty benchmark on those patches 
- We run the entire benchmark 10 times with default parameters (iterations, forks, warmups kept as default)
- Median score reported 
- Factor = 0 means no significant difference (Moore Median's Test)

Attached Summary: [netty-invocation-10trials-summary.zip](https://github.com/netty/netty/files/2071662/netty-invocation-10trials-summary.zip)

Environment: 
Tests run on a Computational server with CPU: E5-1660-3.3GHZ  (6 cores + HT), 64 GB RAM.