### PR TITLE
Make object cleaner thread name public

### DIFF
--- a/common/src/main/java/io/netty/util/internal/ObjectCleaner.java
+++ b/common/src/main/java/io/netty/util/internal/ObjectCleaner.java
@@ -35,8 +35,7 @@ public final class ObjectCleaner {
     private static final int REFERENCE_QUEUE_POLL_TIMEOUT_MS =
             max(500, getInt("io.netty.util.internal.ObjectCleaner.refQueuePollTimeout", 10000));
 
-    // Package-private for testing
-    static final String CLEANER_THREAD_NAME = ObjectCleaner.class.getSimpleName() + "Thread";
+    public static final String CLEANER_THREAD_NAME = ObjectCleaner.class.getSimpleName() + "Thread";
     // This will hold a reference to the AutomaticCleanerReference which will be removed once we called cleanup()
     private static final Set<AutomaticCleanerReference> LIVE_SET = new ConcurrentSet<AutomaticCleanerReference>();
     private static final ReferenceQueue<Object> REFERENCE_QUEUE = new ReferenceQueue<Object>();

--- a/common/src/test/java/io/netty/util/internal/ObjectCleanerTest.java
+++ b/common/src/test/java/io/netty/util/internal/ObjectCleanerTest.java
@@ -113,6 +113,12 @@ public class ObjectCleanerTest {
         }
     }
 
+    @Test
+    public void testCleanerThreadName() {
+        // the thread name is part of the public API
+        assertEquals("ObjectCleanerThread", ObjectCleaner.CLEANER_THREAD_NAME);
+    }
+
     @Test(timeout = 5000)
     public void testCleanerThreadIsDaemon() throws Exception {
         temporaryObject = new Object();


### PR DESCRIPTION
Motivation:

The object cleaner thread can not be shutdown. This means that test suites that check for leaked threads fail on the object cleaner thread because it can not be shutdown at the end of a test. For such test suites, the object cleaner thread must be whitelisted to not fail thread leak control. This requires knowing the name of this thread which means that the name of this thread should be part of the public API.

Modifications:

Set the access modifier to public for the object cleaner thread name and add a test that asserts this thread name does not change.

Result:

The object cleaner thread name is part of the public API and subject to the same backwards compatibility guarantees as other components of the public API.

Relates elastic/elasticsearch#31232
