### PR TITLE
Ensure value of DefaultPromise can not leak when EventExecutor is shu…

### DIFF
--- a/common/src/test/java/io/netty/util/concurrent/EventExecutorTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/EventExecutorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License, version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.netty.util.concurrent;
+
+import io.netty.util.AbstractReferenceCounted;
+import io.netty.util.ReferenceCounted;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class EventExecutorTest {
+    @Test
+    public void notifyAfterShutdown() throws Exception {
+        EventExecutor executor = new DefaultEventExecutor();
+        try {
+            ReferenceCounted data = new AbstractReferenceCounted() {
+                @Override
+                protected void deallocate() {
+                    // noop
+                }
+
+                @Override
+                public ReferenceCounted touch(Object hint) {
+                    return this;
+                }
+            };
+            assertEquals(1, data.refCnt());
+
+            Promise<ReferenceCounted> promise = executor.newPromise();
+            executor.shutdownGracefully(0L, 0L, TimeUnit.MILLISECONDS).sync();
+
+            assertFalse(promise.trySuccess(data));
+            assertEquals(1, data.refCnt());
+            data.release();
+        } finally {
+            executor.shutdownGracefully();
+        }
+    }
+}


### PR DESCRIPTION
…tdown.

Motivation:

If the EventExecutor is shutdown from which a DefaultPromise was created before someone completed the promise, it will not be able to schedule the notification of the attached listeners. This can lead to leaks as the user may expect that its possible to release the passed in value (which may be ReferenceCounted) in a listener.

Modifications:

The modifications needed to make this 100 % safe are much more complicated then I hoped for. The problem is we really need to ensure we can schedule the notification of the listeners before we set the result that is visible by the user as otherwise the ownership of the value (which may be ReferenceCounted) is not clear and so its not clear who is responsible in releasing it. Because of this we need to use a "two-step" process when setting the value when we schedule the notification of the listeners via the EventExecutor.

Result:

Fixes https://github.com/netty/netty/issues/8007.