### PR TITLE
Don't fail the deregistration promise in Http2MultiplexCodec

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -966,15 +966,11 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
                         if (fireChannelInactive) {
                             pipeline.fireChannelInactive();
                         }
-                        // Some transports like local and AIO does not allow the deregistration of
-                        // an open channel.  Their doDeregister() calls close(). Consequently,
-                        // close() calls deregister() again - no need to fire channelUnregistered, so check
-                        // if it was registered.
+                        // The user can fire `deregister` events multiple times but we only want to fire the pipeline
+                        // event if the channel was actually registered.
                         if (registered) {
                             registered = false;
                             pipeline.fireChannelUnregistered();
-                        } else {
-                            promise.setFailure(new IllegalStateException("Not registered"));
                         }
                         safeSetSuccess(promise);
                     }


### PR DESCRIPTION
Motivation:

We deviate from the AbstractChannel implementation on deregistration by
failing the provided promise if the channel is already deregistered. In
contrast, AbstractChannel will always set the promise to successfully
done.

Modification:

Change the Http2MultiplexCodec.DefaultHttp2StreamChannel.Http2ChannelUnsafe
to always set the promise provided to deregister as done as is the case in
AbstractChannel.