### PR TITLE
Revert "Ignore some test-flakiness when using Java11+ due outstanding…

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketHalfClosedTest.java
@@ -33,9 +33,7 @@ import io.netty.channel.socket.ChannelInputShutdownEvent;
 import io.netty.channel.socket.ChannelInputShutdownReadComplete;
 import io.netty.channel.socket.ChannelOutputShutdownEvent;
 import io.netty.channel.socket.DuplexChannel;
-import io.netty.channel.socket.oio.OioSocketChannel;
 import io.netty.util.UncheckedBooleanSupplier;
-import io.netty.util.internal.PlatformDependent;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -416,26 +414,19 @@ public class SocketHalfClosedTest extends AbstractSocketTest {
 
         @Override
         public void channelInactive(ChannelHandlerContext ctx) {
-            checkPrematureClose(ctx);
+            checkPrematureClose();
         }
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
             ctx.close();
-            checkPrematureClose(ctx);
+            checkPrematureClose();
         }
 
-        private void checkPrematureClose(ChannelHandlerContext ctx) {
+        private void checkPrematureClose() {
             if (bytesRead < expectedBytes || !seenOutputShutdown) {
-                if (ctx.channel() instanceof OioSocketChannel && seenOutputShutdown
-                        && PlatformDependent.javaVersion() >= 11) {
-                    // If we are using OIO and are using Java11 this is expected atm.
-                    // See http://mail.openjdk.java.net/pipermail/net-dev/2018-May/011511.html.
-                    doneLatch.countDown();
-                } else {
-                    causeRef.set(new IllegalStateException("leader premature close"));
-                    doneLatch.countDown();
-                }
+                causeRef.set(new IllegalStateException("leader premature close"));
+                doneLatch.countDown();
             }
         }
     }


### PR DESCRIPTION
… Java11 bug. (#7984)"

Motivation:

This reverts commit 4b728cd5bc53195bced516f33a1ea0a0def5604e as it was fixes in Java 11 ea+17.

Modification:

Revert previous added workaround as this is fixed in Java 11 now.

Result:

No more workaround for test included.