### PR TITLE
Print correct invalid character after unwrapping value in CookieEncoder

### DIFF
--- a/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieEncoder.java
+++ b/codec-http/src/main/java/io/netty/handler/codec/http/cookie/CookieEncoder.java
@@ -44,7 +44,8 @@ public abstract class CookieEncoder {
             }
 
             if ((pos = firstInvalidCookieValueOctet(unwrappedValue)) >= 0) {
-                throw new IllegalArgumentException("Cookie value contains an invalid char: " + value.charAt(pos));
+                throw new IllegalArgumentException("Cookie value contains an invalid char: " +
+                                                   unwrappedValue.charAt(pos));
             }
         }
     }

--- a/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieEncoderTest.java
+++ b/codec-http/src/test/java/io/netty/handler/codec/http/cookie/ServerCookieEncoderTest.java
@@ -18,7 +18,9 @@ package io.netty.handler.codec.http.cookie;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.matchers.JUnitMatchers.containsString;
 import io.netty.handler.codec.DateFormatter;
 
 import java.text.ParseException;
@@ -129,6 +131,15 @@ public class ServerCookieEncoderTest {
         }
 
         assertEquals(illegalChars.size(), exceptions);
+    }
+
+    @Test
+    public void illegalCharInWrappedValueAppearsInException() {
+        try {
+            ServerCookieEncoder.STRICT.encode(new DefaultCookie("name", "\"value,\""));
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage().toLowerCase(), containsString("cookie value contains an invalid char: ,"));
+        }
     }
 
     @Test


### PR DESCRIPTION
Motivation:

If a wrapped cookie value with an invalid charcater is passed to the strict
encoder, an exception is thrown on validation but the error message contains
a character at the wrong position.

Modifications:

Print `unwrappedValue.charAt(pos)` instead of `value.charAt(pos)`.

Result:

The exception indicates the correct invalid character in the unwrapped cookie.