### PR TITLE
OpenSSL (and so netty-tcnative) should allow to use custom engine.

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSsl.java
@@ -105,7 +105,13 @@ public final class OpenSsl {
                 }
 
                 try {
-                    initializeTcNative();
+                    String engine = SystemPropertyUtil.get("io.netty.handler.ssl.openssl.engine", null);
+                    if (engine == null) {
+                        logger.debug("Initialize netty-tcnative using engine: 'default'");
+                    } else {
+                        logger.debug("Initialize netty-tcnative using engine: '{}'", engine);
+                    }
+                    initializeTcNative(engine);
 
                     // The library was initialized successfully. If loading the library failed above,
                     // reset the cause now since it appears that the library was loaded by some other
@@ -435,8 +441,8 @@ public final class OpenSsl {
             libNames.toArray(new String[libNames.size()]));
     }
 
-    private static boolean initializeTcNative() throws Exception {
-        return Library.initialize();
+    private static boolean initializeTcNative(String engine) throws Exception {
+        return Library.initialize("provided", engine);
     }
 
     static void releaseIfNeeded(ReferenceCounted counted) {


### PR DESCRIPTION
Motivation:

OpenSSL allows to use a custom engine for its cryptographic operations. We should allow the user to make use of it if needed.

See also: https://www.openssl.org/docs/man1.0.2/crypto/engine.html.

Modifications:

Add new system property which can be used to specify the engine to use (null is the default and will use the build in default impl).

Result:

More flexible way of using OpenSSL.