### PR TITLE
Avoid ObjectCleaner in FastThreadLocal when onRemoval is ignored

### DIFF
--- a/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
+++ b/common/src/main/java/io/netty/util/concurrent/FastThreadLocal.java
@@ -18,6 +18,8 @@ package io.netty.util.concurrent;
 import io.netty.util.internal.InternalThreadLocalMap;
 import io.netty.util.internal.ObjectCleaner;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -44,6 +46,7 @@ import java.util.Set;
  */
 public class FastThreadLocal<V> {
 
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(FastThreadLocal.class);
     private static final int variablesToRemoveIndex = InternalThreadLocalMap.nextVariableIndex();
 
     /**
@@ -124,13 +127,20 @@ public class FastThreadLocal<V> {
     }
 
     // visible for tests
-    static boolean hasOnRemoval(Class<? extends FastThreadLocal> clazz) {
-      try {
-        Class<?> declaringClass = clazz.getMethod("onRemoval", Object.class).getDeclaringClass();
-        return !declaringClass.equals(FastThreadLocal.class);
-      } catch (Throwable t) {
-        return true;
-      }
+    static boolean hasOnRemoval(Class<? extends FastThreadLocal> origClass) {
+        for (Class<?> clazz = origClass; clazz != FastThreadLocal.class; clazz = clazz.getSuperclass()) {
+            try {
+                // Can't use getMethod since onRemoval is protected
+                clazz.getDeclaredMethod("onRemoval", Object.class);
+                return true;
+            } catch (NoSuchMethodException ignore) {
+                continue;
+            } catch (Throwable t) {
+                logger.info("Failed to determine if onRemoval is overridden", t);
+                return true;
+            }
+        }
+        return false;
     }
 
     private final int index;
@@ -296,5 +306,6 @@ public class FastThreadLocal<V> {
     /**
      * Invoked when this thread local variable is removed by {@link #remove()}.
      */
+    // This method is referenced via reflection in hasOnRemoval()
     protected void onRemoval(@SuppressWarnings("UnusedParameters") V value) throws Exception { }
 }

--- a/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
@@ -137,6 +137,18 @@ public class FastThreadLocalTest {
         assertEquals(4, ObjectCleaner.getLiveSetCount() - sizeWhenStart);
     }
 
+    public void testDetectOnRemoval_whenPresent() {
+        assertThat(FastThreadLocal.hasOnRemoval(TestFastThreadLocal.class), is(true));
+    }
+
+    public void testDetectOnRemoval_whenAbsent() {
+        class ExtendingFastThreadLocal<T> extends FastThreadLocal<T> {
+        }
+
+        assertThat(FastThreadLocal.hasOnRemoval(FastThreadLocal.class), is(false));
+        assertThat(FastThreadLocal.hasOnRemoval(ExtendingFastThreadLocal.class), is(false));
+    }
+
     @Test(timeout = 4000)
     public void testOnRemoveCalledForFastThreadLocalGet() throws Exception {
         testOnRemoveCalled(true, true);

--- a/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
+++ b/common/src/test/java/io/netty/util/concurrent/FastThreadLocalTest.java
@@ -26,7 +26,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class FastThreadLocalTest {
     @Before
@@ -80,7 +82,7 @@ public class FastThreadLocalTest {
 
     @Test
     public void testMultipleSetRemove() throws Exception {
-        final FastThreadLocal<String> threadLocal = new FastThreadLocal<String>();
+        final FastThreadLocal<String> threadLocal = new TestFastThreadLocal();
         final Runnable runnable = new Runnable() {
             @Override
             public void run() {
@@ -107,8 +109,8 @@ public class FastThreadLocalTest {
 
     @Test
     public void testMultipleSetRemove_multipleThreadLocal() throws Exception {
-        final FastThreadLocal<String> threadLocal = new FastThreadLocal<String>();
-        final FastThreadLocal<String> threadLocal2 = new FastThreadLocal<String>();
+        final FastThreadLocal<String> threadLocal = new TestFastThreadLocal();
+        final FastThreadLocal<String> threadLocal2 = new TestFastThreadLocal();
         final Runnable runnable = new Runnable() {
             @Override
             public void run() {
@@ -137,16 +139,18 @@ public class FastThreadLocalTest {
         assertEquals(4, ObjectCleaner.getLiveSetCount() - sizeWhenStart);
     }
 
+    @Test
     public void testDetectOnRemoval_whenPresent() {
-        assertThat(FastThreadLocal.hasOnRemoval(TestFastThreadLocal.class), is(true));
+        assertTrue(FastThreadLocal.hasOnRemoval(TestFastThreadLocal.class));
     }
 
+    @Test
     public void testDetectOnRemoval_whenAbsent() {
         class ExtendingFastThreadLocal<T> extends FastThreadLocal<T> {
         }
 
-        assertThat(FastThreadLocal.hasOnRemoval(FastThreadLocal.class), is(false));
-        assertThat(FastThreadLocal.hasOnRemoval(ExtendingFastThreadLocal.class), is(false));
+        assertFalse(FastThreadLocal.hasOnRemoval(FastThreadLocal.class));
+        assertFalse(FastThreadLocal.hasOnRemoval(ExtendingFastThreadLocal.class));
     }
 
     @Test(timeout = 4000)


### PR DESCRIPTION
Motivation:

As discussed in #8017, ObjectCleaner leaks into the rest of the environment and
interacts with checks in some testing environments.

Modifications:

Avoid using ObjectCleaner in FastThreadLocal when the extending class is
ignoring removal notifications.

Result:

Reduced usage of ObjectCleaner, and when combined with disabling Recycler, may
allow tests to run without ObjectCleaner being used.

------

I've not actually tested that a sane selection of tests can now run without ObjectCleaner,
but even if we wouldn't be 100% there, this still seems like an easy step in the right
direction.

CC @jasontedor, @normanmaurer, @carl-mastrangelo, @hc-codersatlas, @vkostyukov