### PR TITLE
Get rid of deprecated SslContext methods in handler-proxy tests

### DIFF
--- a/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
+++ b/handler-proxy/src/test/java/io/netty/handler/proxy/ProxyHandlerTest.java
@@ -35,6 +35,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.resolver.NoopAddressResolverGroup;
@@ -91,8 +92,8 @@ public class ProxyHandlerTest {
         SslContext cctx;
         try {
             SelfSignedCertificate ssc = new SelfSignedCertificate();
-            sctx = SslContext.newServerContext(ssc.certificate(), ssc.privateKey());
-            cctx = SslContext.newClientContext(InsecureTrustManagerFactory.INSTANCE);
+            sctx = SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build();
+            cctx = SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build();
         } catch (Exception e) {
             throw new Error(e);
         }


### PR DESCRIPTION
Motivation:

`ProxyHandlerTest` package uses deprecated methods `SslContext.newServerContext` and
`SslContext.newClientContext`.

Modifications:

`SslContextBuilder` is used to build a server and client `SslContext`.

Result:

Reduced the usage of deprecated methods in the code.