### PR TITLE
Also remove the id from the DnsQueryContextManager if query fails due…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsQueryContext.java
@@ -115,10 +115,13 @@ final class DnsQueryContext {
         } else {
             parent.channelFuture.addListener(new GenericFutureListener<Future<? super Channel>>() {
                 @Override
-                public void operationComplete(Future<? super Channel> future) throws Exception {
+                public void operationComplete(Future<? super Channel> future) {
                     if (future.isSuccess()) {
                         writeQuery(query, writePromise);
                     } else {
+                        // Remove the id from the manager as we fail the query.
+                        parent.queryContextManager.remove(nameServerAddr(), id);
+
                         Throwable cause = future.cause();
                         promise.tryFailure(cause);
                         writePromise.setFailure(cause);


### PR DESCRIPTION
… parent Channel activation error.

Motivation:

Whenever we fail the query we should also remove the id from the DnsQueryContextManager.

Modifications:

Remove the id from the DnsQueryContextManager if we fail the query because the channel failed to become active.

Result:

More correct code.