### PR TITLE
DefaultHttp2Connection checks if a GOAWAY has been issued before assigning a new stream id

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2Connection.java
@@ -708,7 +708,8 @@ public class DefaultHttp2Connection implements Http2Connection {
 
         @Override
         public int incrementAndGetNextStreamId() {
-            return nextReservationStreamId >= 0 ? nextReservationStreamId += 2 : nextReservationStreamId;
+            return goAwayReceived() ? -1 :
+                   nextReservationStreamId >= 0 ? nextReservationStreamId += 2 : nextReservationStreamId;
         }
 
         private void incrementExpectedStreamId(int streamId) {


### PR DESCRIPTION
Motivation:

If a GOAWAY has been issued by the peer, the endpoint should no longer issue
new stream id's. If it does we fail during stream creation which can
cause connection tear-down.

Modification:

Change the
DefaultHttp2Connection.DefaultEndpoint.incrementAndGetNextStreamId()
method to consider whether a GOAWAY has been received before
issuing a new stream id.

Result:

The Http2FrameCodec will fail writes that attempt to initialize a new
stream with a `Http2NoMoreStreamIdsException`.

Fixes: #8041.