### PR TITLE
HTTP/2 goaway connection state update sequencing

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -537,6 +537,9 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                                 ("Stream created after GOAWAY sent. Last known stream by peer " +
                                  connection.remote().lastStreamKnownByPeer()));
                 }
+
+                // If we are ignoring frames for this stream it means that we no longer need to retain state for this
+                // stream and can close it, which should remove it from the active stream map.
                 stream.close();
                 return true;
             }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoder.java
@@ -158,12 +158,8 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
 
     void onGoAwayRead0(ChannelHandlerContext ctx, int lastStreamId, long errorCode, ByteBuf debugData)
             throws Http2Exception {
-        if (connection.goAwayReceived() && connection.local().lastStreamKnownByPeer() < lastStreamId) {
-            throw connectionError(PROTOCOL_ERROR, "lastStreamId MUST NOT increase. Current value: %d new value: %d",
-                    connection.local().lastStreamKnownByPeer(), lastStreamId);
-        }
-        listener.onGoAwayRead(ctx, lastStreamId, errorCode, debugData);
         connection.goAwayReceived(lastStreamId, errorCode, debugData);
+        listener.onGoAwayRead(ctx, lastStreamId, errorCode, debugData);
     }
 
     void onUnknownFrame0(ChannelHandlerContext ctx, byte frameType, int streamId, Http2Flags flags,
@@ -541,6 +537,7 @@ public class DefaultHttp2ConnectionDecoder implements Http2ConnectionDecoder {
                                 ("Stream created after GOAWAY sent. Last known stream by peer " +
                                  connection.remote().lastStreamKnownByPeer()));
                 }
+                stream.close();
                 return true;
             }
             return false;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -327,7 +327,7 @@ public interface Http2Connection {
     /**
      * Indicates that a {@code GOAWAY} was received from the remote endpoint and sets the last known stream.
      */
-    void goAwayReceived(int lastKnownStream, long errorCode, ByteBuf message);
+    void goAwayReceived(int lastKnownStream, long errorCode, ByteBuf message) throws Http2Exception;
 
     /**
      * Indicates whether or not a {@code GOAWAY} was sent to the remote endpoint.
@@ -335,7 +335,9 @@ public interface Http2Connection {
     boolean goAwaySent();
 
     /**
-     * Indicates that a {@code GOAWAY} was sent to the remote endpoint and sets the last known stream.
+     * Updates the local state of this {@link Http2Connection} as a result of a {@code GOAWAY} to send to the remote
+     * endpoint.
+     * @return {@code true} if the corresponding {@code GOAWAY} frame should be sent to the remote endpoint.
      */
-    void goAwaySent(int lastKnownStream, long errorCode, ByteBuf message);
+    boolean goAwaySent(int lastKnownStream, long errorCode, ByteBuf message) throws Http2Exception;
 }

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2Connection.java
@@ -326,6 +326,13 @@ public interface Http2Connection {
 
     /**
      * Indicates that a {@code GOAWAY} was received from the remote endpoint and sets the last known stream.
+     * @param lastKnownStream The Last-Stream-ID in the
+     * <a href="https://tools.ietf.org/html/rfc7540#section-6.8">GOAWAY</a> frame.
+     * @param errorCode the Error Code in the
+     * <a href="https://tools.ietf.org/html/rfc7540#section-6.8">GOAWAY</a> frame.
+     * @param message The Additional Debug Data in the
+     * <a href="https://tools.ietf.org/html/rfc7540#section-6.8">GOAWAY</a> frame. Note that reference count ownership
+     * belongs to the caller (ownership is not transferred to this method).
      */
     void goAwayReceived(int lastKnownStream, long errorCode, ByteBuf message) throws Http2Exception;
 
@@ -337,6 +344,12 @@ public interface Http2Connection {
     /**
      * Updates the local state of this {@link Http2Connection} as a result of a {@code GOAWAY} to send to the remote
      * endpoint.
+     * @param lastKnownStream The Last-Stream-ID in the
+     * <a href="https://tools.ietf.org/html/rfc7540#section-6.8">GOAWAY</a> frame.
+     * @param errorCode the Error Code in the
+     * <a href="https://tools.ietf.org/html/rfc7540#section-6.8">GOAWAY</a> frame.
+     * <a href="https://tools.ietf.org/html/rfc7540#section-6.8">GOAWAY</a> frame. Note that reference count ownership
+     * belongs to the caller (ownership is not transferred to this method).
      * @return {@code true} if the corresponding {@code GOAWAY} frame should be sent to the remote endpoint.
      */
     boolean goAwaySent(int lastKnownStream, long errorCode, ByteBuf message) throws Http2Exception;

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2ConnectionHandler.java
@@ -794,47 +794,37 @@ public class Http2ConnectionHandler extends ByteToMessageDecoder implements Http
     @Override
     public ChannelFuture goAway(final ChannelHandlerContext ctx, final int lastStreamId, final long errorCode,
                                 final ByteBuf debugData, ChannelPromise promise) {
+        promise = promise.unvoid();
+        final Http2Connection connection = connection();
         try {
-            promise = promise.unvoid();
-            final Http2Connection connection = connection();
-            if (connection().goAwaySent()) {
-                // Protect against re-entrancy. Could happen if writing the frame fails, and error handling
-                // treating this is a connection handler and doing a graceful shutdown...
-                if (lastStreamId == connection().remote().lastStreamKnownByPeer()) {
-                    // Release the data and notify the promise
-                    debugData.release();
-                    return promise.setSuccess();
-                }
-                if (lastStreamId > connection.remote().lastStreamKnownByPeer()) {
-                    throw connectionError(PROTOCOL_ERROR, "Last stream identifier must not increase between " +
-                                                          "sending multiple GOAWAY frames (was '%d', is '%d').",
-                                          connection.remote().lastStreamKnownByPeer(), lastStreamId);
-                }
+            if (!connection.goAwaySent(lastStreamId, errorCode, debugData)) {
+                debugData.release();
+                promise.trySuccess();
+                return promise;
             }
-
-            connection.goAwaySent(lastStreamId, errorCode, debugData);
-
-            // Need to retain before we write the buffer because if we do it after the refCnt could already be 0 and
-            // result in an IllegalRefCountException.
-            debugData.retain();
-            ChannelFuture future = frameWriter().writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
-
-            if (future.isDone()) {
-                processGoAwayWriteResult(ctx, lastStreamId, errorCode, debugData, future);
-            } else {
-                future.addListener(new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
-                        processGoAwayWriteResult(ctx, lastStreamId, errorCode, debugData, future);
-                    }
-                });
-            }
-
-            return future;
-        } catch (Throwable cause) { // Make sure to catch Throwable because we are doing a retain() in this method.
+        } catch (Throwable cause) {
             debugData.release();
-            return promise.setFailure(cause);
+            promise.tryFailure(cause);
+            return promise;
         }
+
+        // Need to retain before we write the buffer because if we do it after the refCnt could already be 0 and
+        // result in an IllegalRefCountException.
+        debugData.retain();
+        ChannelFuture future = frameWriter().writeGoAway(ctx, lastStreamId, errorCode, debugData, promise);
+
+        if (future.isDone()) {
+            processGoAwayWriteResult(ctx, lastStreamId, errorCode, debugData, future);
+        } else {
+            future.addListener(new ChannelFutureListener() {
+                @Override
+                public void operationComplete(ChannelFuture future) throws Exception {
+                    processGoAwayWriteResult(ctx, lastStreamId, errorCode, debugData, future);
+                }
+            });
+        }
+
+        return future;
     }
 
     /**

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionDecoderTest.java
@@ -675,13 +675,6 @@ public class DefaultHttp2ConnectionDecoderTest {
     }
 
     @Test(expected = Http2Exception.class)
-    public void goawayIncreasedLastStreamIdShouldThrow() throws Exception {
-        when(local.lastStreamKnownByPeer()).thenReturn(1);
-        when(connection.goAwayReceived()).thenReturn(true);
-        decode().onGoAwayRead(ctx, 3, 2L, EMPTY_BUFFER);
-    }
-
-    @Test(expected = Http2Exception.class)
     public void rstStreamReadForUnknownStreamShouldThrow() throws Exception {
         when(connection.streamMayHaveExisted(STREAM_ID)).thenReturn(false);
         when(connection.stream(STREAM_ID)).thenReturn(null);

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionEncoderTest.java
@@ -770,7 +770,7 @@ public class DefaultHttp2ConnectionEncoderTest {
     }
 
     @Test
-    public void canWriteHeaderFrameAfterGoAwayReceived() {
+    public void canWriteHeaderFrameAfterGoAwayReceived() throws Http2Exception {
         writeAllFlowControlledFrames();
         goAwayReceived(STREAM_ID);
         ChannelPromise promise = newPromise();
@@ -803,11 +803,11 @@ public class DefaultHttp2ConnectionEncoderTest {
         return connection.stream(streamId);
     }
 
-    private void goAwayReceived(int lastStreamId) {
+    private void goAwayReceived(int lastStreamId) throws Http2Exception {
         connection.goAwayReceived(lastStreamId, 0, EMPTY_BUFFER);
     }
 
-    private void goAwaySent(int lastStreamId) {
+    private void goAwaySent(int lastStreamId) throws Http2Exception {
         connection.goAwaySent(lastStreamId, 0, EMPTY_BUFFER);
     }
 

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -425,7 +425,7 @@ public class DefaultHttp2ConnectionTest {
     @Test(expected = Http2Exception.class)
     public void goAwayReceivedShouldDisallowCreation() throws Http2Exception {
         server.goAwayReceived(0, 1L, Unpooled.EMPTY_BUFFER);
-        server.remote().createStream(3, true);
+        server.local().createStream(3, true);
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/DefaultHttp2ConnectionTest.java
@@ -47,8 +47,8 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -423,9 +423,27 @@ public class DefaultHttp2ConnectionTest {
     }
 
     @Test(expected = Http2Exception.class)
-    public void goAwayReceivedShouldDisallowCreation() throws Http2Exception {
+    public void goAwayReceivedShouldDisallowLocalCreation() throws Http2Exception {
         server.goAwayReceived(0, 1L, Unpooled.EMPTY_BUFFER);
         server.local().createStream(3, true);
+    }
+
+    @Test
+    public void goAwayReceivedShouldAllowRemoteCreation() throws Http2Exception {
+        server.goAwayReceived(0, 1L, Unpooled.EMPTY_BUFFER);
+        server.remote().createStream(3, true);
+    }
+
+    @Test(expected = Http2Exception.class)
+    public void goAwaySentShouldDisallowRemoteCreation() throws Http2Exception {
+        server.goAwaySent(0, 1L, Unpooled.EMPTY_BUFFER);
+        server.remote().createStream(2, true);
+    }
+
+    @Test
+    public void goAwaySentShouldAllowLocalCreation() throws Http2Exception {
+        server.goAwaySent(0, 1L, Unpooled.EMPTY_BUFFER);
+        server.local().createStream(2, true);
     }
 
     @Test

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/Http2ConnectionHandlerTest.java
@@ -189,6 +189,7 @@ public class Http2ConnectionHandlerTest {
         when(connection.stream(NON_EXISTANT_STREAM_ID)).thenReturn(null);
         when(connection.numActiveStreams()).thenReturn(1);
         when(connection.stream(STREAM_ID)).thenReturn(stream);
+        when(connection.goAwaySent(anyInt(), anyLong(), any(ByteBuf.class))).thenReturn(true);
         when(stream.open(anyBoolean())).thenReturn(stream);
         when(encoder.writeSettings(eq(ctx), any(Http2Settings.class), eq(promise))).thenReturn(future);
         when(ctx.alloc()).thenReturn(UnpooledByteBufAllocator.DEFAULT);
@@ -638,6 +639,12 @@ public class Http2ConnectionHandlerTest {
 
         when(connection.goAwaySent()).thenReturn(true);
         when(remote.lastStreamKnownByPeer()).thenReturn(STREAM_ID);
+        doAnswer(new Answer<Boolean>() {
+            @Override
+            public Boolean answer(InvocationOnMock invocationOnMock) {
+                throw new IllegalStateException();
+            }
+        }).when(connection).goAwaySent(anyInt(), anyLong(), any(ByteBuf.class));
         handler.goAway(ctx, STREAM_ID + 2, errorCode, data, promise);
         assertTrue(promise.isDone());
         assertFalse(promise.isSuccess());

--- a/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
+++ b/codec-http2/src/test/java/io/netty/handler/codec/http2/StreamBufferingEncoderTest.java
@@ -222,7 +222,7 @@ public class StreamBufferingEncoderTest {
     }
 
     @Test
-    public void bufferingNewStreamFailsAfterGoAwayReceived() {
+    public void bufferingNewStreamFailsAfterGoAwayReceived() throws Http2Exception {
         encoder.writeSettingsAck(ctx, newPromise());
         setMaxConcurrentStreams(0);
         connection.goAwayReceived(1, 8, EMPTY_BUFFER);
@@ -235,7 +235,7 @@ public class StreamBufferingEncoderTest {
     }
 
     @Test
-    public void receivingGoAwayFailsBufferedStreams() {
+    public void receivingGoAwayFailsBufferedStreams() throws Http2Exception {
         encoder.writeSettingsAck(ctx, newPromise());
         setMaxConcurrentStreams(5);
 


### PR DESCRIPTION
Motivation:
The Http2Connection state is updated by the DefaultHttp2ConnectionDecoder after the frame listener is notified of the goaway frame. If the listener sends a frame synchronously this means the connection state will not know about the goaway it just received and we may send frames that are not allowed on the connection. This may also mean a stream object is created but it may never get taken out of the stream map unless some other event occurs (e.g. timeout).

Modifications:
- The Http2Connection state should be updated before the listener is notified of the goaway
- The Http2Connection state modification and validation should be self contained when processing a goaway instead of partially in the decoder.

Result:
No more creating streams and sending frames after a goaway has been sent or received.