### PR TITLE
Don't send a RST on close if the stream never existed

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2MultiplexCodec.java
@@ -906,9 +906,10 @@ public class Http2MultiplexCodec extends Http2FrameCodec {
 
                 final boolean wasActive = isActive();
 
-                // Only ever send a reset frame if the connection is still alive as otherwise it makes no sense at
-                // all anyway.
-                if (parent().isActive() && !streamClosedWithoutError && isStreamIdValid(stream().id())) {
+                // Only ever send a reset frame if the connection is still alive and if the stream may have existed
+                // as otherwise we may send a RST on a stream in an invalid state and cause a connection error.
+                if (parent().isActive() && !streamClosedWithoutError &&
+                        connection().streamMayHaveExisted(stream().id())) {
                     Http2StreamFrame resetFrame = new DefaultHttp2ResetFrame(Http2Error.CANCEL).stream(stream());
                     write(resetFrame, unsafe().voidPromise());
                     flush();


### PR DESCRIPTION
Motivation:

When a Http2MultiplexCodec stream channel fails to write the first
HEADERS it will forcibly close, and that will trigger sending a
RST_STREAM, which is commonly a connection level protocol error. This is
because it has what looks like a valid stream id, but didn't check with
the connection as to whether the stream may have actually existed.

Modifications:

Instead of checking if the stream was just a valid looking id ( > 0) we
check with the connection as to whether it may have existed at all.

Result:

We no longer send a RST_STREAM frame from Http2MultiplexCodec for idle
streams.

----------------------------

This is mostly for discussion at this time, in part because I don't know the right way to test it. In the Http2MultiplexCodecTest we override the `write` method which is where we get a stream id assigned, so it would need to either be more invasive or go in a different suite. 

The issue is that the stream thinks it's alive because it has a valid looking stream id (set by the [`Http2FrameCodec`](https://github.com/netty/netty/blob/4.1/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2FrameCodec.java#L359)) but it's not. This could be fixed via https://github.com/netty/netty/pull/8067, but not everyone agrees it's the right thing to do. That said, I don't see this commit as been predicated on the other, or vise versa.