### PR TITLE
Deprecate Unpooled.unmodifiableBuffer(ByteBuf...)

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/Unpooled.java
+++ b/buffer/src/main/java/io/netty/buffer/Unpooled.java
@@ -882,7 +882,10 @@ public final class Unpooled {
     /**
      * Wrap the given {@link ByteBuf}s in an unmodifiable {@link ByteBuf}. Be aware the returned {@link ByteBuf} will
      * not try to slice the given {@link ByteBuf}s to reduce GC-Pressure.
+     *
+     * @deprecated Use {@link #wrappedUnmodifiableBuffer(ByteBuf...)}.
      */
+    @Deprecated
     public static ByteBuf unmodifiableBuffer(ByteBuf... buffers) {
         return wrappedUnmodifiableBuffer(true, buffers);
     }
@@ -891,7 +894,7 @@ public final class Unpooled {
      * Wrap the given {@link ByteBuf}s in an unmodifiable {@link ByteBuf}. Be aware the returned {@link ByteBuf} will
      * not try to slice the given {@link ByteBuf}s to reduce GC-Pressure.
      *
-     * The returned {@link ByteBuf} wraps the provided array directly, and so should not be subsequently modified.
+     * The returned {@link ByteBuf} may wrap the provided array directly, and so should not be subsequently modified.
      */
     public static ByteBuf wrappedUnmodifiableBuffer(ByteBuf... buffers) {
         return wrappedUnmodifiableBuffer(false, buffers);


### PR DESCRIPTION
Motivation:

https://github.com/netty/netty/pull/8040 introduced `Unpooled.wrappedUnmodifiableBuffer(ByteBuf...)` which has the same behaviour but wraps the provided array directly. This is preferred for most uses (including varargs-based use) and if there are any unusual cases of an explicit array which is re-used before the `ByteBuf` is finished with, it can just be copied first.

Modifications:

Added `@Deprecated` annotation and corresponding javadoc addition to `Unpooled.unmodifiableBuffer(ByteBuf...)`.

Result:

`Unpooled.unmodifiableBuffer(ByteBuf...)` will be deprecated.
