### PR TITLE
Auto-detect Log4J2 for logging if on the class-path

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/InternalLoggerFactory.java
@@ -41,13 +41,18 @@ public abstract class InternalLoggerFactory {
         try {
             f = new Slf4JLoggerFactory(true);
             f.newInstance(name).debug("Using SLF4J as the default logging framework");
-        } catch (Throwable t1) {
+        } catch (Throwable ignore1) {
             try {
                 f = Log4JLoggerFactory.INSTANCE;
                 f.newInstance(name).debug("Using Log4J as the default logging framework");
-            } catch (Throwable t2) {
-                f = JdkLoggerFactory.INSTANCE;
-                f.newInstance(name).debug("Using java.util.logging as the default logging framework");
+            } catch (Throwable ignore2) {
+                try {
+                    f = Log4J2LoggerFactory.INSTANCE;
+                    f.newInstance(name).debug("Using Log4J2 as the default logging framework");
+                } catch (Throwable ignore3) {
+                    f = JdkLoggerFactory.INSTANCE;
+                    f.newInstance(name).debug("Using java.util.logging as the default logging framework");
+                }
             }
         }
         return f;


### PR DESCRIPTION
Motivation:

https://github.com/netty/netty/pull/5047 added Log4J2 support but missed to add code to try to auto-detect it.

Modifications:

Try to use Log4JLoggerFactory by default.

Result:

Fixes https://github.com/netty/netty/issues/8107.