### PR TITLE
Do not log explicit no unsafe, fixes helper method.

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent0.java
@@ -368,7 +368,7 @@ final class PlatformDependent0 {
     }
 
     static boolean isExplicitNoUnsafe() {
-        return EXPLICIT_NO_UNSAFE_CAUSE == null;
+        return EXPLICIT_NO_UNSAFE_CAUSE != null;
     }
 
     private static Throwable explicitNoUnsafeCause0() {


### PR DESCRIPTION
Motivation:

Users should not see a scary log message when Netty is initialized if
Netty configuration explicitly disables unsafe. The log message that
produces this warning was previously guarded but by recent refactoring
a bug was introduced inside the guard helper method.

Modifications:

This commit brings back the guard against the scary log message if
unsafe is explicitly disabled.

Result:

No log message is produced when unsafe is unavailable because Netty was
told to not look for it.

Relates #5624, #6696