### PR TITLE
Use Java11+ea28 during build.

### DIFF
--- a/docker/docker-compose.centos-6.111.yaml
+++ b/docker/docker-compose.centos-6.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "6"
-        java_version : "1.11.0-19"
+        java_version : "1.11.0-28"
 
   test:
     image: netty:centos-6-1.11

--- a/docker/docker-compose.centos-7.111.yaml
+++ b/docker/docker-compose.centos-7.111.yaml
@@ -7,7 +7,7 @@ services:
     build:
       args:
         centos_version : "7"
-        java_version : "1.11.0-19"
+        java_version : "1.11.0-28"
 
   test:
     image: netty:centos-7-1.11


### PR DESCRIPTION
Motivation:

We should ensure we use the latest Java11 EA during build to catch any regressions etc.

Modifications:

Update from ea19 to ea28.

Result:

Use latest Java11 release.