### PR TITLE
Fix incorrect code in javadocs of ChannelHandler.

### DIFF
--- a/transport/src/main/java/io/netty/channel/ChannelHandler.java
+++ b/transport/src/main/java/io/netty/channel/ChannelHandler.java
@@ -73,13 +73,12 @@ import java.lang.annotation.Target;
  *
  *     {@code @Override}
  *     public void channelRead0({@link ChannelHandlerContext} ctx, Message message) {
- *         {@link Channel} ch = e.getChannel();
  *         if (message instanceof LoginMessage) {
  *             authenticate((LoginMessage) message);
  *             <b>loggedIn = true;</b>
  *         } else (message instanceof GetDataMessage) {
  *             if (<b>loggedIn</b>) {
- *                 ch.write(fetchSecret((GetDataMessage) message));
+ *                 ctx.writeAndFlush(fetchSecret((GetDataMessage) message));
  *             } else {
  *                 fail();
  *             }
@@ -123,13 +122,12 @@ import java.lang.annotation.Target;
  *     {@code @Override}
  *     public void channelRead({@link ChannelHandlerContext} ctx, Message message) {
  *         {@link Attribute}&lt;{@link Boolean}&gt; attr = ctx.attr(auth);
- *         {@link Channel} ch = ctx.channel();
  *         if (message instanceof LoginMessage) {
  *             authenticate((LoginMessage) o);
  *             <b>attr.set(true)</b>;
  *         } else (message instanceof GetDataMessage) {
  *             if (<b>Boolean.TRUE.equals(attr.get())</b>) {
- *                 ch.write(fetchSecret((GetDataMessage) o));
+ *                 ctx.writeAndFlush(fetchSecret((GetDataMessage) o));
  *             } else {
  *                 fail();
  *             }


### PR DESCRIPTION
Motivation:

Some code that was shown as part of the ChannelHandler javadoc was not 100 % correct and used some constructs that we used in netty 3. Also we never called flush() in the code which is a bad example for users.

Modifications:

- Remove netty 3 code references
- Replace channel.write(...) with ctx.writeAndFlush(...)

Result:

More correct code in the javadocs.