### PR TITLE
Fix length calculation in AsciiString.indexOf(...) and so eliminate A…

### DIFF
--- a/common/src/main/java/io/netty/util/AsciiString.java
+++ b/common/src/main/java/io/netty/util/AsciiString.java
@@ -722,7 +722,7 @@ public final class AsciiString implements CharSequence, Comparable<CharSequence>
         }
 
         final byte chAsByte = c2b0(ch);
-        final int len = offset + start + length;
+        final int len = offset + length;
         for (int i = start + offset; i < len; ++i) {
             if (value[i] == chAsByte) {
                 return i - offset;

--- a/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
+++ b/common/src/test/java/io/netty/util/AsciiStringCharacterTest.java
@@ -398,4 +398,18 @@ public class AsciiStringCharacterTest {
         //two "123"s
         assertEquals(AsciiString.hashCode("123"), AsciiString.hashCode("a123".substring(1)));
     }
+
+    @Test
+    public void testIndexOf() {
+        AsciiString foo = AsciiString.of("This is a test");
+        int i1 = foo.indexOf(' ', 0);
+        assertEquals(4, i1);
+        int i2 = foo.indexOf(' ', i1 + 1);
+        assertEquals(7, i2);
+        int i3 = foo.indexOf(' ', i2 + 1);
+        assertEquals(9, i3);
+        assertTrue(i3 + 1 < foo.length());
+        int i4 = foo.indexOf(' ', i3 + 1);
+        assertEquals(i4, -1);
+    }
 }


### PR DESCRIPTION
…rrayIndexOutOfBoundsException.

Motivation:

We incorrectly calculated the length that was used for our for loop in AsciiString.indexOf(...). This lead to a possible ArrayIndexOutOfBoundsException.

Modifications:

- Not include the start in the length calculation
- Add unit test.

Result:

Fixes https://github.com/netty/netty/issues/8112.