### PR TITLE
Correctly release message in MemcacheClientHandler that is used in th…

### DIFF
--- a/example/src/main/java/io/netty/example/memcache/binary/MemcacheClientHandler.java
+++ b/example/src/main/java/io/netty/example/memcache/binary/MemcacheClientHandler.java
@@ -69,6 +69,7 @@ public class MemcacheClientHandler extends ChannelDuplexHandler {
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
         FullBinaryMemcacheResponse res = (FullBinaryMemcacheResponse) msg;
         System.out.println(res.content().toString(CharsetUtil.UTF_8));
+        res.release();
     }
 
     @Override


### PR DESCRIPTION
…e memcache example.

Motivation:

MemcacheClientHandler.channelRead(...) need to release the frame after it prints out its content to not introduce a memory leak.

Modifications:

Call release() on the frame.

Result:

Example has no leak any more.