### PR TITLE
add 'oraclejdk10' to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk:
   - oraclejdk7
   - openjdk7
+  - oraclejdk10
 branches:
   only:
     - master


### PR DESCRIPTION
Motivation:

Travis build matrix now includes 'oraclejdk10'

Modification:

tweaked Travis build file

Result:

Travis build matrix now includes 'oraclejdk10'
