### PR TITLE
Add integration test for shading native libraries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,7 @@
     <module>testsuite-autobahn</module>
     <module>testsuite-http2</module>
     <module>testsuite-osgi</module>
+    <module>testsuite-shading</module>
     <module>microbench</module>
     <module>bom</module>
   </modules>

--- a/testsuite-shading/pom.xml
+++ b/testsuite-shading/pom.xml
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 The Netty Project
+  ~
+  ~ The Netty Project licenses this file to you under the Apache License,
+  ~ version 2.0 (the "License"); you may not use this file except in compliance
+  ~ with the License. You may obtain a copy of the License at:
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-parent</artifactId>
+    <version>4.1.27.Final-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>netty-testsuite-shading</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Netty/Testsuite/Shading</name>
+
+  <properties>
+    <generatedSourceDir>${project.build.directory}/src</generatedSourceDir>
+    <dependencyVersionsDir>${project.build.directory}/versions</dependencyVersionsDir>
+    <classesShadedDir>${project.build.directory}/classes-shaded</classesShadedDir>
+    <classesShadedNativeDir>${classesShadedDir}/META-INF/native</classesShadedNativeDir>
+    <shadingPrefix>shaded</shadingPrefix>
+    <jarName>${project.artifactId}-${project.version}.jar</jarName>
+    <shadedPackagePrefix>io.netty.</shadedPackagePrefix>
+  </properties>
+
+  <build>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.6.0</version>
+      </extension>
+    </extensions>
+    <plugins>
+      <!-- Do not deploy this module -->
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+  </dependencies>
+  <profiles>
+    <profile>
+      <id>mac</id>
+      <activation>
+        <os>
+          <family>mac</family>
+        </os>
+      </activation>
+      <properties>
+        <nativeLib>netty_transport_native_kqueue_${os.detected.arch}.jnilib</nativeLib>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+          <version>${project.version}</version>
+          <classifier>${jni.classifier}</classifier>
+          <scope>compile</scope>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <artifactSet>
+                    <includes>
+                      <include>${project.groupId}</include>
+                    </includes>
+                  </artifactSet>
+                  <relocations>
+                    <relocation>
+                      <pattern>${shadedPackagePrefix}</pattern>
+                      <shadedPattern>${shadingPrefix}.${shadedPackagePrefix}</shadedPattern>
+                    </relocation>
+                  </relocations>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack-jar-features</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <unzip dest="${classesShadedDir}/">
+                      <fileset dir="${project.build.directory}/">
+                        <include name="${jarName}" />
+                      </fileset>
+                    </unzip>
+                    <move file="${classesShadedNativeDir}/lib${nativeLib}" tofile="${classesShadedNativeDir}/lib${shadingPrefix}_${nativeLib}" />
+                    <jar destfile="${project.build.directory}/${jarName}"
+                         basedir="${classesShadedDir}"/>
+                    <delete dir="${classesShadedDir}"/>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <shadingPrefix>${shadingPrefix}</shadingPrefix>
+              </systemPropertyVariables>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>linux</id>
+      <activation>
+        <os>
+          <family>linux</family>
+        </os>
+      </activation>
+      <properties>
+        <nativeLib>netty_transport_native_epoll_${os.detected.arch}.so</nativeLib>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+          <version>${project.version}</version>
+          <classifier>${jni.classifier}</classifier>
+          <scope>compile</scope>
+        </dependency>
+      </dependencies>
+
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <artifactSet>
+                    <includes>
+                      <include>${project.groupId}</include>
+                    </includes>
+                  </artifactSet>
+                  <relocations>
+                    <relocation>
+                      <pattern>${shadedPackagePrefix}</pattern>
+                      <shadedPattern>${shadingPrefix}.${shadedPackagePrefix}</shadedPattern>
+                    </relocation>
+                  </relocations>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack-jar-features</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <unzip dest="${classesShadedDir}/">
+                      <fileset dir="${project.build.directory}/">
+                        <include name="${jarName}" />
+                      </fileset>
+                    </unzip>
+                    <move file="${classesShadedNativeDir}/lib${nativeLib}" tofile="${classesShadedNativeDir}/lib${shadingPrefix}_${nativeLib}" />
+                    <jar destfile="${project.build.directory}/${jarName}"
+                         basedir="${classesShadedDir}"/>
+                    <delete dir="${classesShadedDir}"/>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <shadingPrefix>${shadingPrefix}</shadingPrefix>
+              </systemPropertyVariables>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>
+

--- a/testsuite-shading/src/test/java/io/netty/testsuite/shading/ShadingIT.java
+++ b/testsuite-shading/src/test/java/io/netty/testsuite/shading/ShadingIT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.testsuite.shading;
+
+import io.netty.util.internal.PlatformDependent;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+public class ShadingIT {
+
+    @Test
+    public void testShadingNativeLibs() throws Exception {
+        String shadingPrefix = System.getProperty("shadingPrefix");
+        final Class<?> clazz = Class.forName(shadingPrefix + '.' + className());
+        Method method = clazz.getMethod("ensureAvailability");
+        method.invoke(null);
+    }
+
+    private static String className() {
+        return PlatformDependent.isOsx() ? "io.netty.channel.kqueue.KQueue" : "io.netty.channel.epoll.Epoll";
+    }
+}


### PR DESCRIPTION
Motivation:

It's easy to break the support for shading native libs as shown in https://github.com/netty/netty/issues/8090. We should have some testing to ensure all works as expected.

Modification:

Add new testsuite which verifies that shading our native transports work as expected.

Result:

Include test to verify shading of native code.