### PR TITLE
Fix possible NPE introduced by a137291ad161c970259d9a5d7cc206c026f08e…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslX509KeyManagerFactory.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslX509KeyManagerFactory.java
@@ -198,11 +198,14 @@ public final class OpenSslX509KeyManagerFactory extends KeyManagerFactory {
                 @Override
                 OpenSslKeyMaterial chooseKeyMaterial(ByteBufAllocator allocator, String alias) throws Exception {
                     Object value = materialMap.get(alias);
+                    if (value == null) {
+                        // There is no keymaterial for the requested alias, return null
+                        return null;
+                    }
                     if (value instanceof OpenSslKeyMaterial) {
                         return ((OpenSslKeyMaterial) value).retain();
-                    } else {
-                        throw (Exception) value;
                     }
+                    throw (Exception) value;
                 }
 
                 @Override

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslX509KeyManagerFactoryProviderTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslX509KeyManagerFactoryProviderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+import javax.net.ssl.KeyManagerFactory;
+import java.security.KeyStore;
+
+public class OpenSslX509KeyManagerFactoryProviderTest extends OpenSslCachingKeyMaterialProviderTest {
+
+    @Override
+    protected KeyManagerFactory newKeyManagerFactory() throws Exception {
+        char[] password = PASSWORD.toCharArray();
+        final KeyStore keystore = KeyStore.getInstance("PKCS12");
+        keystore.load(getClass().getResourceAsStream("mutual_auth_server.p12"), password);
+
+        OpenSslX509KeyManagerFactory kmf = new OpenSslX509KeyManagerFactory();
+        kmf.init(keystore, password);
+        return kmf;
+    }
+
+    @Override
+    protected OpenSslKeyMaterialProvider newMaterialProvider(KeyManagerFactory kmf, String password) {
+        return ((OpenSslX509KeyManagerFactory) kmf).newProvider();
+    }
+}


### PR DESCRIPTION
…e7 when using SslProvider.OPENSSL and init via files or OpenSslX509KeyManagerFactory

Motivation:

a137291ad161c970259d9a5d7cc206c026f08ee7 introduced a way to get the most speed out of OpenSSL by not only caching keymaterial but pre-compute these. The problem was we missed to check for null before doing an instanceof check and then a cast which could lead to a NPE as we tried to cast null to Exception and throw it.

Modifications:

Add null check and unit test.

Result:

No more NPE when keymaterial was not found for requested alias.