### PR TITLE
Fix timerfd_settime usage bug in EpollEventLoop

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -229,7 +229,7 @@ final class EpollEventLoop extends SingleThreadEventLoop {
         long totalDelay = delayNanos(System.nanoTime());
         int delaySeconds = (int) min(totalDelay / 1000000000L, Integer.MAX_VALUE);
         return Native.epollWait(epollFd, events, timerFd, delaySeconds,
-                (int) min(totalDelay - delaySeconds * 1000000000L, Integer.MAX_VALUE));
+                (int) min(totalDelay - delaySeconds * 1000000000L, 999999999L));
     }
 
     private int epollWaitNow() throws IOException {


### PR DESCRIPTION
Motivation:

Current integer overflow protection in EpollEventLoop.epollWait(boolean oldWakeup) does not work correctly.
More specifically, tv_nsec can be greater than 999,999,999, which is incorrect.
For details, see: https://linux.die.net/man/2/timerfd_settime

Modifications:

Ensure we not overflow and put the correct max limit.

Result:

Fixes #8134