### PR TITLE
Lazily initialize NativeDatagramPacketArray and IovArray in EpollEventLoop

### DIFF
--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/EpollEventLoop.java
@@ -61,8 +61,10 @@ final class EpollEventLoop extends SingleThreadEventLoop {
     private final IntObjectMap<AbstractEpollChannel> channels = new IntObjectHashMap<AbstractEpollChannel>(4096);
     private final boolean allowGrowing;
     private final EpollEventArray events;
-    private final IovArray iovArray = new IovArray();
-    private final NativeDatagramPacketArray datagramPacketArray = new NativeDatagramPacketArray();
+
+    // These are initialized on first use
+    private IovArray iovArray;
+    private NativeDatagramPacketArray datagramPacketArray;
 
     private final SelectStrategy selectStrategy;
     private final IntSupplier selectNowSupplier = new IntSupplier() {
@@ -144,7 +146,11 @@ final class EpollEventLoop extends SingleThreadEventLoop {
      * Return a cleared {@link IovArray} that can be used for writes in this {@link EventLoop}.
      */
     IovArray cleanIovArray() {
-        iovArray.clear();
+        if (iovArray == null) {
+            iovArray = new IovArray();
+        } else {
+            iovArray.clear();
+        }
         return iovArray;
     }
 
@@ -152,7 +158,11 @@ final class EpollEventLoop extends SingleThreadEventLoop {
      * Return a cleared {@link NativeDatagramPacketArray} that can be used for writes in this {@link EventLoop}.
      */
     NativeDatagramPacketArray cleanDatagramPacketArray() {
-        datagramPacketArray.clear();
+        if (datagramPacketArray == null) {
+            datagramPacketArray = new NativeDatagramPacketArray();
+        } else {
+            datagramPacketArray.clear();
+        }
         return datagramPacketArray;
     }
 
@@ -458,8 +468,14 @@ final class EpollEventLoop extends SingleThreadEventLoop {
             }
         } finally {
             // release native memory
-            iovArray.release();
-            datagramPacketArray.release();
+            if (iovArray != null) {
+                iovArray.release();
+                iovArray = null;
+            }
+            if (datagramPacketArray != null) {
+                datagramPacketArray.release();
+                datagramPacketArray = null;
+            }
             events.free();
         }
     }

--- a/transport-native-epoll/src/main/java/io/netty/channel/epoll/NativeDatagramPacketArray.java
+++ b/transport-native-epoll/src/main/java/io/netty/channel/epoll/NativeDatagramPacketArray.java
@@ -100,8 +100,8 @@ final class NativeDatagramPacketArray implements ChannelOutboundBuffer.MessagePr
     @SuppressWarnings("unused")
     static final class NativeDatagramPacket {
         // Each NativeDatagramPackets holds a IovArray which is used for gathering writes.
-        // This is ok as NativeDatagramPacketArray is always obtained via a FastThreadLocal and
-        // so the memory needed is quite small anyway.
+        // This is ok as NativeDatagramPacketArray is always obtained from an EpollEventLoop
+        // field so the memory needed is quite small anyway.
         private final IovArray array = new IovArray();
 
         // This is the actual struct iovec*


### PR DESCRIPTION
Motivation:

Avoid unnecessary native memory allocation if UDP / TCP isn't being used.

Modifications:

Create the reused `NativeDatagramPacketArray` and `IovArray` upon first use instead of `EpollEventLoop` construction. This more closely matches the prior `FastThreadLocal.initialValue()` behaviour changed in #8062.

Also correct related comment in `NativeDatagramPacketArray`.

Result:

Reduced native memory use in many cases when using epoll. Fixes #8159


