### PR TITLE
Ensure NIO transport can be used on Java6 again.

### DIFF
--- a/transport/src/main/java/io/netty/channel/socket/nio/NioChannelOption.java
+++ b/transport/src/main/java/io/netty/channel/socket/nio/NioChannelOption.java
@@ -19,33 +19,39 @@ import io.netty.channel.ChannelException;
 import io.netty.channel.ChannelOption;
 
 import java.io.IOException;
-import java.net.SocketOption;
-import java.nio.channels.NetworkChannel;
+import java.nio.channels.Channel;
 import java.util.Set;
 
 /**
- * Provides {@link ChannelOption} over a given {@link SocketOption} which is then passed through the underlying
- * {@link NetworkChannel}.
+ * Provides {@link ChannelOption} over a given {@link java.net.SocketOption} which is then passed through the underlying
+ * {@link java.nio.channels.NetworkChannel}.
  */
 public final class NioChannelOption<T> extends ChannelOption<T> {
 
-    private final SocketOption<T> option;
+    private final java.net.SocketOption<T> option;
 
     @SuppressWarnings("deprecation")
-    private NioChannelOption(SocketOption<T> option) {
+    private NioChannelOption(java.net.SocketOption<T> option) {
         super(option.name());
         this.option = option;
     }
 
     /**
-     * Returns a {@link ChannelOption} for the given {@link SocketOption}.
+     * Returns a {@link ChannelOption} for the given {@link java.net.SocketOption}.
      */
-    public static <T> ChannelOption<T> of(SocketOption<T> option) {
+    public static <T> ChannelOption<T> of(java.net.SocketOption<T> option) {
         return new NioChannelOption<T>(option);
     }
 
+    // It's important to not use java.nio.channels.NetworkChannel as otherwise the classes that sometimes call this
+    // method may not be used on Java 6, as method linking can happen eagerly even if this method was not actually
+    // called at runtime.
+    //
+    // See https://github.com/netty/netty/issues/8166
+
     // Internal helper methods to remove code duplication between Nio*Channel implementations.
-    static <T> boolean setOption(NetworkChannel channel, NioChannelOption<T> option, T value) {
+    static <T> boolean setOption(Channel jdkChannel, NioChannelOption<T> option, T value) {
+        java.nio.channels.NetworkChannel channel = (java.nio.channels.NetworkChannel) jdkChannel;
         if (!channel.supportedOptions().contains(option.option)) {
             return false;
         }
@@ -57,7 +63,9 @@ public final class NioChannelOption<T> extends ChannelOption<T> {
         }
     }
 
-    static <T> T getOption(NetworkChannel channel, NioChannelOption<T> option) {
+    static <T> T getOption(Channel jdkChannel, NioChannelOption<T> option) {
+        java.nio.channels.NetworkChannel channel = (java.nio.channels.NetworkChannel) jdkChannel;
+
         if (!channel.supportedOptions().contains(option.option)) {
             return null;
         }
@@ -69,12 +77,13 @@ public final class NioChannelOption<T> extends ChannelOption<T> {
     }
 
     @SuppressWarnings("unchecked")
-    static ChannelOption[] getOptions(NetworkChannel channel) {
-        Set<SocketOption<?>> supportedOpts = channel.supportedOptions();
+    static ChannelOption[] getOptions(Channel jdkChannel) {
+        java.nio.channels.NetworkChannel channel = (java.nio.channels.NetworkChannel) jdkChannel;
+        Set<java.net.SocketOption<?>> supportedOpts = channel.supportedOptions();
         ChannelOption<?>[] extraOpts = new ChannelOption[supportedOpts.size()];
 
         int i = 0;
-        for (SocketOption<?> opt : supportedOpts) {
+        for (java.net.SocketOption<?> opt : supportedOpts) {
             extraOpts[i++] = new NioChannelOption(opt);
         }
         return extraOpts;


### PR DESCRIPTION
Motivation:

952eeb8e1e3706b09d4d3f32f16d7f0e5c540cb5 introduced the possibility to use any JDK SocketOption when using the NIO transport but broke the possibility to use netty with java6.

Modifications:

Do not use java7 types in method signatures of the static methods in NioChannelOption to prevent class-loader issues on java6.

Result:

Fixes https://github.com/netty/netty/issues/8166.