### PR TITLE
Also clear the authoritativeDnsServerCache when closing the Channel.

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -219,7 +219,7 @@ public class DnsNameResolver extends InetNameResolver {
             EventLoop eventLoop,
             ChannelFactory<? extends DatagramChannel> channelFactory,
             final DnsCache resolveCache,
-            DnsCache authoritativeDnsServerCache,
+            final DnsCache authoritativeDnsServerCache,
             DnsQueryLifecycleObserverFactory dnsQueryLifecycleObserverFactory,
             long queryTimeoutMillis,
             ResolvedAddressTypes resolvedAddressTypes,
@@ -306,8 +306,9 @@ public class DnsNameResolver extends InetNameResolver {
 
         ch.closeFuture().addListener(new ChannelFutureListener() {
             @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
+            public void operationComplete(ChannelFuture future) {
                 resolveCache.clear();
+                authoritativeDnsServerCache.clear();
             }
         });
     }


### PR DESCRIPTION
Motivation:

At the moment we only clear the resolveCache when the Channel is closed. We should also do the same for the authoritativeDnsServerCache.

Modifications:

Add authoritativeDnsServerCache.clear() to the Channel closeFuture.

Result:

Correctly clear all caches.