### PR TITLE
CompositeByteBuf nioBuffer doesn't always alloc

### DIFF
--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -1467,9 +1467,14 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
             }
         }
 
-        ByteBuffer merged = ByteBuffer.allocate(length).order(order());
         ByteBuffer[] buffers = nioBuffers(index, length);
 
+        if(buffers.length == 1)
+        {
+            return buffers[0].duplicate();
+        }
+        
+        ByteBuffer merged = ByteBuffer.allocate(length).order(order());
         for (ByteBuffer buf: buffers) {
             merged.put(buf);
         }

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -1469,8 +1469,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
 
         ByteBuffer[] buffers = nioBuffers(index, length);
 
-        if(buffers.length == 1)
-        {
+        if (buffers.length == 1) {
             return buffers[0].duplicate();
         }
         

--- a/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
+++ b/buffer/src/main/java/io/netty/buffer/CompositeByteBuf.java
@@ -1472,7 +1472,7 @@ public class CompositeByteBuf extends AbstractReferenceCountedByteBuf implements
         if (buffers.length == 1) {
             return buffers[0].duplicate();
         }
-        
+
         ByteBuffer merged = ByteBuffer.allocate(length).order(order());
         for (ByteBuffer buf: buffers) {
             merged.put(buf);


### PR DESCRIPTION
In nioBuffer(int,int) in CompositeByteBuf , we create a sub-array of nioBuffers for the components that are in range, then concatenate all the components in range into a single bigger buffer. 
However, if the call to nioBuffers() returned only one sub-buffer, then we are copying it to a newly-allocated buffer "merged" for no reason.

Motivation:

Profiler for Spark shows a lot of time spent in put() method inside nioBuffer(), while usually no copy of data is required.

Modification:
This change skips this last step and just returns a duplicate of the single buffer returned by the call to nioBuffers(), which will in most implementation not copy the data

Result:
No copy when the source is only 1 buffer

