### PR TITLE
Correctly handle DNS redirects for NS servers that have no ADDITIONAL…

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/AuthoritativeDnsServerCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/AuthoritativeDnsServerCache.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.EventLoop;
+import io.netty.util.internal.UnstableApi;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Cache which stores the nameservers that should be used to resolve a specific hostname.
+ */
+@UnstableApi
+public interface AuthoritativeDnsServerCache {
+
+    /**
+     * Returns the cached nameservers that should be used to resolve the given hostname. The returned
+     * {@link DnsServerAddressStream} may contain unresolved {@link InetSocketAddress}es that will be resolved
+     * when needed while resolving other domain names.
+     *
+     * @param hostname the hostname
+     * @return the cached entries or an {@code null} if none.
+     */
+    DnsServerAddressStream get(String hostname);
+
+    /**
+     * Caches a nameserver that should be used to resolve the given hostname.
+     *
+     * @param hostname the hostname
+     * @param address the nameserver address (which may be unresolved).
+     * @param originalTtl the TTL as returned by the DNS server
+     * @param loop the {@link EventLoop} used to register the TTL timeout
+     */
+    void cache(String hostname, InetSocketAddress address, long originalTtl, EventLoop loop);
+
+    /**
+     * Clears all cached nameservers.
+     *
+     * @see #clear(String)
+     */
+    void clear();
+
+    /**
+     * Clears the cached nameservers for the specified hostname.
+     *
+     * @return {@code true} if and only if there was an entry for the specified host name in the cache and
+     *         it has been removed by this method
+     */
+    boolean clear(String hostname);
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/AuthoritativeDnsServerCacheAdapter.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/AuthoritativeDnsServerCacheAdapter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.EventLoop;
+import io.netty.handler.codec.dns.DnsRecord;
+import io.netty.util.internal.UnstableApi;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * {@link AuthoritativeDnsServerCache} implementation which delegates all operations to a wrapped {@link DnsCache}.
+ * This implementation is only present to preserve a upgrade story.
+ */
+@UnstableApi
+final class AuthoritativeDnsServerCacheAdapter implements AuthoritativeDnsServerCache {
+
+    private static final DnsRecord[] EMPTY = new DnsRecord[0];
+    private final DnsCache cache;
+
+    AuthoritativeDnsServerCacheAdapter(DnsCache cache) {
+        this.cache = checkNotNull(cache, "cache");
+    }
+
+    @Override
+    public DnsServerAddressStream get(String hostname) {
+        List<? extends DnsCacheEntry> entries = cache.get(hostname, EMPTY);
+        if (entries == null || entries.isEmpty()) {
+            return null;
+        }
+        if (entries.get(0).cause() != null) {
+            return null;
+        }
+
+        List<InetSocketAddress> addresses = new ArrayList<InetSocketAddress>(entries.size());
+
+        int i = 0;
+        do {
+            InetAddress addr = entries.get(i).address();
+            addresses.add(new InetSocketAddress(addr, DefaultDnsServerAddressStreamProvider.DNS_PORT));
+        } while (++i < entries.size());
+        return new SequentialDnsServerAddressStream(addresses, 0);
+    }
+
+    @Override
+    public void cache(String hostname, InetSocketAddress address, long originalTtl, EventLoop loop) {
+        // We only cache resolved addresses.
+        if (!address.isUnresolved()) {
+            cache.cache(hostname, EMPTY, address.getAddress(), originalTtl, loop);
+        }
+    }
+
+    @Override
+    public void clear() {
+        cache.clear();
+    }
+
+    @Override
+    public boolean clear(String hostname) {
+        return cache.clear(hostname);
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/Cache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/Cache.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.EventLoop;
+import io.netty.util.internal.PlatformDependent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * Abstract cache that automatically removes entries for a hostname once the TTL for an entry is reached.
+ *
+ * @param <E>
+ */
+abstract class Cache<E> {
+    private static final AtomicReferenceFieldUpdater<Cache.Entries, ScheduledFuture> FUTURE_UPDATER =
+            AtomicReferenceFieldUpdater.newUpdater(Cache.Entries.class, ScheduledFuture.class, "expirationFuture");
+
+    private static final ScheduledFuture<?> CANCELLED = new ScheduledFuture<Object>() {
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return false;
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            // We ignore unit and always return the minimum value to ensure the TTL of the cancelled marker is
+            // the smallest.
+            return Long.MIN_VALUE;
+        }
+
+        @Override
+        public int compareTo(Delayed o) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return true;
+        }
+
+        @Override
+        public boolean isDone() {
+            return true;
+        }
+
+        @Override
+        public Object get() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Object get(long timeout, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+    };
+
+    // Two years are supported by all our EventLoop implementations and so safe to use as maximum.
+    // See also: https://github.com/netty/netty/commit/b47fb817991b42ec8808c7d26538f3f2464e1fa6
+    static final int MAX_SUPPORTED_TTL_SECS = (int) TimeUnit.DAYS.toSeconds(365 * 2);
+
+    private final ConcurrentMap<String, Entries> resolveCache = PlatformDependent.newConcurrentHashMap();
+
+    /**
+     * Remove everything from the cache.
+     */
+    final void clear() {
+        while (!resolveCache.isEmpty()) {
+            for (Iterator<Entry<String, Entries>> i = resolveCache.entrySet().iterator(); i.hasNext();) {
+                Map.Entry<String, Entries> e = i.next();
+                i.remove();
+
+                e.getValue().clearAndCancel();
+            }
+        }
+    }
+
+    /**
+     * Clear all entries (if anything exists) for the given hostname and return {@code true} if anything was removed.
+     */
+    final boolean clear(String hostname) {
+        Entries entries = resolveCache.remove(hostname);
+        return entries != null && entries.clearAndCancel();
+    }
+
+    /**
+     * Returns all caches entries for the given hostname.
+     */
+    final List<? extends E> get(String hostname) {
+        Entries entries = resolveCache.get(hostname);
+        return entries == null ? null : entries.get();
+    }
+
+    /**
+     * Cache a value for the given hostname that will automatically expire once the TTL is reached.
+     */
+    final void cache(String hostname, E value, int ttl, EventLoop loop) {
+        Entries entries = resolveCache.get(hostname);
+        if (entries == null) {
+            entries = new Entries(hostname);
+            Entries oldEntries = resolveCache.putIfAbsent(hostname, entries);
+            if (oldEntries != null) {
+                entries = oldEntries;
+            }
+        }
+        entries.add(value, ttl, loop);
+    }
+
+    /**
+     * Return the number of hostames for which we have cached something.
+     */
+    final int size() {
+        return resolveCache.size();
+    }
+
+    /**
+     * Returns {@code true} if this entry should replace all other entries that are already cached for the hostname.
+     */
+    protected abstract boolean shouldReplaceAll(E entry);
+
+    /**
+     * Sort the {@link List} for a {@code hostname} before caching these.
+     */
+    protected void sortEntries(
+            @SuppressWarnings("unused") String hostname, @SuppressWarnings("unused") List<E> entries) {
+        // NOOP.
+    }
+
+    /**
+     * Returns {@code true} if both entries are equal.
+     */
+    protected abstract boolean equals(E entry, E otherEntry);
+
+    // Directly extend AtomicReference for intrinsics and also to keep memory overhead low.
+    private final class Entries extends AtomicReference<List<E>> implements Runnable {
+
+        private final String hostname;
+        // Needs to be package-private to be able to access it via the AtomicReferenceFieldUpdater
+        volatile ScheduledFuture<?> expirationFuture;
+
+        Entries(String hostname) {
+            super(Collections.<E>emptyList());
+            this.hostname = hostname;
+        }
+
+        void add(E e, int ttl, EventLoop loop) {
+            if (!shouldReplaceAll(e)) {
+                for (;;) {
+                    List<E> entries = get();
+                    if (!entries.isEmpty()) {
+                        final E firstEntry = entries.get(0);
+                        if (shouldReplaceAll(firstEntry)) {
+                            assert entries.size() == 1;
+
+                            if (compareAndSet(entries, singletonList(e))) {
+                                scheduleCacheExpirationIfNeeded(ttl, loop);
+                                return;
+                            } else {
+                                // Need to try again as CAS failed
+                                continue;
+                            }
+                        }
+
+                        // Create a new List for COW semantics
+                        List<E> newEntries = new ArrayList<E>(entries.size() + 1);
+                        int i = 0;
+                        E replacedEntry = null;
+                        do {
+                            E entry = entries.get(i);
+                            // Only add old entry if the address is not the same as the one we try to add as well.
+                            // In this case we will skip it and just add the new entry as this may have
+                            // more up-to-date data and cancel the old after we were able to update the cache.
+                            if (!Cache.this.equals(e, entry)) {
+                                newEntries.add(entry);
+                            } else {
+                                replacedEntry = entry;
+                                newEntries.add(e);
+
+                                ++i;
+                                for (; i < entries.size(); ++i) {
+                                    newEntries.add(entries.get(i));
+                                }
+                                break;
+                            }
+                        } while (++i < entries.size());
+                        if (replacedEntry == null) {
+                            newEntries.add(e);
+                        }
+                        sortEntries(hostname, newEntries);
+
+                        if (compareAndSet(entries, Collections.unmodifiableList(newEntries))) {
+                            scheduleCacheExpirationIfNeeded(ttl, loop);
+                            return;
+                        }
+                    } else if (compareAndSet(entries, singletonList(e))) {
+                        scheduleCacheExpirationIfNeeded(ttl, loop);
+                        return;
+                    }
+                }
+            } else {
+                set(singletonList(e));
+                scheduleCacheExpirationIfNeeded(ttl, loop);
+            }
+        }
+
+        private void scheduleCacheExpirationIfNeeded(int ttl, EventLoop loop) {
+            for (;;) {
+                // We currently don't calculate a new TTL when we need to retry the CAS as we don't expect this to
+                // be invoked very concurrently and also we use SECONDS anyway. If this ever becomes a problem
+                // we can reconsider.
+                ScheduledFuture<?> oldFuture = FUTURE_UPDATER.get(this);
+                if (oldFuture == null || oldFuture.getDelay(TimeUnit.SECONDS) > ttl) {
+                    ScheduledFuture<?> newFuture = loop.schedule(this, ttl, TimeUnit.SECONDS);
+                    // It is possible that
+                    // 1. task will fire in between this line, or
+                    // 2. multiple timers may be set if there is concurrency
+                    // (1) Shouldn't be a problem because we will fail the CAS and then the next loop will see CANCELLED
+                    //     so the ttl will not be less, and we will bail out of the loop.
+                    // (2) This is a trade-off to avoid concurrency resulting in contention on a synchronized block.
+                    if (FUTURE_UPDATER.compareAndSet(this, oldFuture, newFuture)) {
+                        if (oldFuture != null) {
+                            oldFuture.cancel(true);
+                        }
+                        break;
+                    } else {
+                        // There was something else scheduled in the meantime... Cancel and try again.
+                        newFuture.cancel(true);
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+
+        boolean clearAndCancel() {
+            List<E> entries = getAndSet(Collections.<E>emptyList());
+            if (entries.isEmpty()) {
+                return false;
+            }
+
+            ScheduledFuture<?> expirationFuture = FUTURE_UPDATER.getAndSet(this, CANCELLED);
+            if (expirationFuture != null) {
+                expirationFuture.cancel(false);
+            }
+
+            return true;
+        }
+
+        @Override
+        public void run() {
+            // We always remove all entries for a hostname once one entry expire. This is not the
+            // most efficient to do but this way we can guarantee that if a DnsResolver
+            // be configured to prefer one ip family over the other we will not return unexpected
+            // results to the enduser if one of the A or AAAA records has different TTL settings.
+            //
+            // As a TTL is just a hint of the maximum time a cache is allowed to cache stuff it's
+            // completely fine to remove the entry even if the TTL is not reached yet.
+            //
+            // See https://github.com/netty/netty/issues/7329
+            resolveCache.remove(hostname, this);
+
+            clearAndCancel();
+        }
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultAuthoritativeDnsServerCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultAuthoritativeDnsServerCache.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.EventLoop;
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.UnstableApi;
+
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+
+import static io.netty.util.internal.ObjectUtil.*;
+
+/**
+ * Default implementation of {@link AuthoritativeDnsServerCache}, backed by a {@link ConcurrentMap}.
+ */
+@UnstableApi
+public class DefaultAuthoritativeDnsServerCache implements AuthoritativeDnsServerCache {
+
+    private final int minTtl;
+    private final int maxTtl;
+    private final Comparator<InetSocketAddress> comparator;
+    private final Cache<InetSocketAddress> resolveCache = new Cache<InetSocketAddress>() {
+        @Override
+        protected boolean shouldReplaceAll(InetSocketAddress entry) {
+            return false;
+        }
+
+        @Override
+        protected boolean equals(InetSocketAddress entry, InetSocketAddress otherEntry) {
+            if (PlatformDependent.javaVersion() >= 7) {
+                return entry.getHostString().equalsIgnoreCase(otherEntry.getHostString());
+            }
+            return entry.getHostName().equalsIgnoreCase(otherEntry.getHostName());
+        }
+
+        @Override
+        protected void sortEntries(String hostname, List<InetSocketAddress> entries) {
+            if (comparator != null) {
+                Collections.sort(entries, comparator);
+            }
+        }
+    };
+
+    /**
+     * Create a cache that respects the TTL returned by the DNS server.
+     */
+    public DefaultAuthoritativeDnsServerCache() {
+        this(0, Cache.MAX_SUPPORTED_TTL_SECS, null);
+    }
+
+    /**
+     * Create a cache.
+     *
+     * @param minTtl the minimum TTL
+     * @param maxTtl the maximum TTL
+     * @param comparator the {@link Comparator} to order the {@link InetSocketAddress} for a hostname or {@code null}
+     *                   if insertion order should be used.
+     */
+    public DefaultAuthoritativeDnsServerCache(int minTtl, int maxTtl, Comparator<InetSocketAddress> comparator) {
+        this.minTtl = Math.min(Cache.MAX_SUPPORTED_TTL_SECS, checkPositiveOrZero(minTtl, "minTtl"));
+        this.maxTtl = Math.min(Cache.MAX_SUPPORTED_TTL_SECS, checkPositive(maxTtl, "maxTtl"));
+        if (minTtl > maxTtl) {
+            throw new IllegalArgumentException(
+                    "minTtl: " + minTtl + ", maxTtl: " + maxTtl + " (expected: 0 <= minTtl <= maxTtl)");
+        }
+        this.comparator = comparator;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public DnsServerAddressStream get(String hostname) {
+        checkNotNull(hostname, "hostname");
+
+        List<? extends InetSocketAddress> addresses = resolveCache.get(hostname);
+        if (addresses == null || addresses.isEmpty()) {
+            return null;
+        }
+        return new SequentialDnsServerAddressStream(addresses, 0);
+    }
+
+    @Override
+    public void cache(String hostname, InetSocketAddress address, long originalTtl, EventLoop loop) {
+        checkNotNull(hostname, "hostname");
+        checkNotNull(address, "address");
+        checkNotNull(loop, "loop");
+
+        if (PlatformDependent.javaVersion() >= 7 && address.getHostString() == null) {
+            // We only cache addresses that have also a host string as we will need it later when trying to replace
+            // unresolved entries in the cache.
+            return;
+        }
+
+        resolveCache.cache(hostname, address, Math.max(minTtl, (int) Math.min(maxTtl, originalTtl)), loop);
+    }
+
+    @Override
+    public void clear() {
+        resolveCache.clear();
+    }
+
+    @Override
+    public boolean clear(String hostname) {
+        checkNotNull(hostname, "hostname");
+
+        return resolveCache.clear(hostname);
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultAuthoritativeDnsServerCache(minTtl=" + minTtl + ", maxTtl=" + maxTtl + ", cached nameservers=" +
+                resolveCache.size() + ')';
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsCache.java
@@ -17,22 +17,13 @@ package io.netty.resolver.dns;
 
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.dns.DnsRecord;
-import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.StringUtil;
 import io.netty.util.internal.UnstableApi;
 
 import java.net.InetAddress;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Delayed;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import static io.netty.util.internal.ObjectUtil.checkNotNull;
 import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
@@ -43,55 +34,26 @@ import static io.netty.util.internal.ObjectUtil.checkPositiveOrZero;
  */
 @UnstableApi
 public class DefaultDnsCache implements DnsCache {
-    // Two years are supported by all our EventLoop implementations and so safe to use as maximum.
-    // See also: https://github.com/netty/netty/commit/b47fb817991b42ec8808c7d26538f3f2464e1fa6
-    private static final int MAX_SUPPORTED_TTL_SECS = (int) TimeUnit.DAYS.toSeconds(365 * 2);
 
-    private static final ScheduledFuture<?> CANCELLED = new ScheduledFuture<Object>() {
+    private final Cache<DefaultDnsCacheEntry> resolveCache = new Cache<DefaultDnsCacheEntry>() {
 
         @Override
-        public boolean cancel(boolean mayInterruptIfRunning) {
-            return false;
+        protected boolean shouldReplaceAll(DefaultDnsCacheEntry entry) {
+            return entry.cause() != null;
         }
 
         @Override
-        public long getDelay(TimeUnit unit) {
-            // We ignore unit and always return the minimum value to ensure the TTL of the cancelled marker is
-            // the smallest.
-            return Long.MIN_VALUE;
-        }
-
-        @Override
-        public int compareTo(Delayed o) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean isCancelled() {
-            return true;
-        }
-
-        @Override
-        public boolean isDone() {
-            return true;
-        }
-
-        @Override
-        public Object get() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Object get(long timeout, TimeUnit unit) {
-            throw new UnsupportedOperationException();
+        protected boolean equals(DefaultDnsCacheEntry entry, DefaultDnsCacheEntry otherEntry) {
+            if (entry.address() != null) {
+                return entry.address().equals(otherEntry.address());
+            }
+            if (otherEntry.address() != null) {
+                return false;
+            }
+            return entry.cause().equals(otherEntry.cause());
         }
     };
 
-    private static final AtomicReferenceFieldUpdater<DefaultDnsCache.Entries, ScheduledFuture> FUTURE_UPDATER =
-            AtomicReferenceFieldUpdater.newUpdater(
-                    DefaultDnsCache.Entries.class, ScheduledFuture.class, "expirationFuture");
-
-    private final ConcurrentMap<String, Entries> resolveCache = PlatformDependent.newConcurrentHashMap();
     private final int minTtl;
     private final int maxTtl;
     private final int negativeTtl;
@@ -101,7 +63,7 @@ public class DefaultDnsCache implements DnsCache {
      * and doesn't cache negative responses.
      */
     public DefaultDnsCache() {
-        this(0, MAX_SUPPORTED_TTL_SECS, 0);
+        this(0, Cache.MAX_SUPPORTED_TTL_SECS, 0);
     }
 
     /**
@@ -111,8 +73,8 @@ public class DefaultDnsCache implements DnsCache {
      * @param negativeTtl the TTL for failed queries
      */
     public DefaultDnsCache(int minTtl, int maxTtl, int negativeTtl) {
-        this.minTtl = Math.min(MAX_SUPPORTED_TTL_SECS, checkPositiveOrZero(minTtl, "minTtl"));
-        this.maxTtl = Math.min(MAX_SUPPORTED_TTL_SECS, checkPositiveOrZero(maxTtl, "maxTtl"));
+        this.minTtl = Math.min(Cache.MAX_SUPPORTED_TTL_SECS, checkPositiveOrZero(minTtl, "minTtl"));
+        this.maxTtl = Math.min(Cache.MAX_SUPPORTED_TTL_SECS, checkPositiveOrZero(maxTtl, "maxTtl"));
         if (minTtl > maxTtl) {
             throw new IllegalArgumentException(
                     "minTtl: " + minTtl + ", maxTtl: " + maxTtl + " (expected: 0 <= minTtl <= maxTtl)");
@@ -148,21 +110,13 @@ public class DefaultDnsCache implements DnsCache {
 
     @Override
     public void clear() {
-        while (!resolveCache.isEmpty()) {
-            for (Iterator<Map.Entry<String, Entries>> i = resolveCache.entrySet().iterator(); i.hasNext();) {
-                Map.Entry<String, Entries> e = i.next();
-                i.remove();
-
-                e.getValue().clearAndCancel();
-            }
-        }
+        resolveCache.clear();
     }
 
     @Override
     public boolean clear(String hostname) {
         checkNotNull(hostname, "hostname");
-        Entries entries = resolveCache.remove(appendDot(hostname));
-        return entries != null && entries.clearAndCancel();
+        return resolveCache.clear(appendDot(hostname));
     }
 
     private static boolean emptyAdditionals(DnsRecord[] additionals) {
@@ -176,8 +130,7 @@ public class DefaultDnsCache implements DnsCache {
             return Collections.<DnsCacheEntry>emptyList();
         }
 
-        Entries entries = resolveCache.get(appendDot(hostname));
-        return entries == null ? null : entries.get();
+        return resolveCache.get(appendDot(hostname));
     }
 
     @Override
@@ -186,12 +139,11 @@ public class DefaultDnsCache implements DnsCache {
         checkNotNull(hostname, "hostname");
         checkNotNull(address, "address");
         checkNotNull(loop, "loop");
-        final DefaultDnsCacheEntry e = new DefaultDnsCacheEntry(hostname, address);
+        DefaultDnsCacheEntry e = new DefaultDnsCacheEntry(hostname, address);
         if (maxTtl == 0 || !emptyAdditionals(additionals)) {
             return e;
         }
-        cache0(appendDot(hostname), e,
-                Math.max(minTtl, (int) Math.min(maxTtl, originalTtl)), loop);
+        resolveCache.cache(appendDot(hostname), e, Math.max(minTtl, (int) Math.min(maxTtl, originalTtl)), loop);
         return e;
     }
 
@@ -201,25 +153,13 @@ public class DefaultDnsCache implements DnsCache {
         checkNotNull(cause, "cause");
         checkNotNull(loop, "loop");
 
-        final DefaultDnsCacheEntry e = new DefaultDnsCacheEntry(hostname, cause);
+        DefaultDnsCacheEntry e = new DefaultDnsCacheEntry(hostname, cause);
         if (negativeTtl == 0 || !emptyAdditionals(additionals)) {
             return e;
         }
 
-        cache0(appendDot(hostname), e, negativeTtl, loop);
+        resolveCache.cache(appendDot(hostname), e, negativeTtl, loop);
         return e;
-    }
-
-    private void cache0(String hostname, DefaultDnsCacheEntry e, int ttl, EventLoop loop) {
-        Entries entries = resolveCache.get(hostname);
-        if (entries == null) {
-            entries = new Entries(hostname);
-            Entries oldEntries = resolveCache.putIfAbsent(hostname, entries);
-            if (oldEntries != null) {
-                entries = oldEntries;
-            }
-        }
-        entries.add(e, ttl, loop);
     }
 
     @Override
@@ -229,7 +169,7 @@ public class DefaultDnsCache implements DnsCache {
                 .append(minTtl).append(", maxTtl=")
                 .append(maxTtl).append(", negativeTtl=")
                 .append(negativeTtl).append(", cached resolved hostname=")
-                .append(resolveCache.size()).append(")")
+                .append(resolveCache.size()).append(')')
                 .toString();
     }
 
@@ -239,14 +179,14 @@ public class DefaultDnsCache implements DnsCache {
         private final Throwable cause;
 
         DefaultDnsCacheEntry(String hostname, InetAddress address) {
-            this.hostname = checkNotNull(hostname, "hostname");
-            this.address = checkNotNull(address, "address");
+            this.hostname = hostname;
+            this.address = address;
             cause = null;
         }
 
         DefaultDnsCacheEntry(String hostname, Throwable cause) {
-            this.hostname = checkNotNull(hostname, "hostname");
-            this.cause = checkNotNull(cause, "cause");
+            this.hostname = hostname;
+            this.cause = cause;
             address = null;
         }
 
@@ -271,124 +211,6 @@ public class DefaultDnsCache implements DnsCache {
             } else {
                 return address.toString();
             }
-        }
-    }
-
-    // Directly extend AtomicReference for intrinsics and also to keep memory overhead low.
-    private final class Entries extends AtomicReference<List<DefaultDnsCacheEntry>> implements Runnable {
-
-        private final String hostname;
-        // Needs to be package-private to be able to access it via the AtomicReferenceFieldUpdater
-        volatile ScheduledFuture<?> expirationFuture;
-
-        Entries(String hostname) {
-            super(Collections.<DefaultDnsCacheEntry>emptyList());
-            this.hostname = hostname;
-        }
-
-        void add(DefaultDnsCacheEntry e, int ttl, EventLoop loop) {
-            if (e.cause() == null) {
-                for (;;) {
-                    List<DefaultDnsCacheEntry> entries = get();
-                    if (!entries.isEmpty()) {
-                        final DefaultDnsCacheEntry firstEntry = entries.get(0);
-                        if (firstEntry.cause() != null) {
-                            assert entries.size() == 1;
-
-                            if (compareAndSet(entries, Collections.singletonList(e))) {
-                                scheduleCacheExpirationIfNeeded(ttl, loop);
-                                return;
-                            } else {
-                                // Need to try again as CAS failed
-                                continue;
-                            }
-                        }
-
-                        // Create a new List for COW semantics
-                        List<DefaultDnsCacheEntry> newEntries = new ArrayList<DefaultDnsCacheEntry>(entries.size() + 1);
-                        int i = 0;
-                        do {
-                            DefaultDnsCacheEntry entry = entries.get(i);
-                            // Only add old entry if the address is not the same as the one we try to add as well.
-                            // In this case we will skip it and just add the new entry as this may have
-                            // more up-to-date data and cancel the old after we were able to update the cache.
-                            if (!e.address().equals(entry.address())) {
-                                newEntries.add(entry);
-                            }
-                        } while (++i < entries.size());
-                        newEntries.add(e);
-                        if (compareAndSet(entries, Collections.unmodifiableList(newEntries))) {
-                            scheduleCacheExpirationIfNeeded(ttl, loop);
-                            return;
-                        }
-                    } else if (compareAndSet(entries, Collections.singletonList(e))) {
-                        scheduleCacheExpirationIfNeeded(ttl, loop);
-                        return;
-                    }
-                }
-            } else {
-                set(Collections.singletonList(e));
-                scheduleCacheExpirationIfNeeded(ttl, loop);
-            }
-        }
-
-        private void scheduleCacheExpirationIfNeeded(int ttl, EventLoop loop) {
-            for (;;) {
-                // We currently don't calculate a new TTL when we need to retry the CAS as we don't expect this to
-                // be invoked very concurrently and also we use SECONDS anyway. If this ever becomes a problem
-                // we can reconsider.
-                ScheduledFuture<?> oldFuture = FUTURE_UPDATER.get(this);
-                if (oldFuture == null || oldFuture.getDelay(TimeUnit.SECONDS) > ttl) {
-                    ScheduledFuture<?> newFuture = loop.schedule(this, ttl, TimeUnit.SECONDS);
-                    // It is possible that
-                    // 1. task will fire in between this line, or
-                    // 2. multiple timers may be set if there is concurrency
-                    // (1) Shouldn't be a problem because we will fail the CAS and then the next loop will see CANCELLED
-                    //     so the ttl will not be less, and we will bail out of the loop.
-                    // (2) This is a trade-off to avoid concurrency resulting in contention on a synchronized block.
-                    if (FUTURE_UPDATER.compareAndSet(this, oldFuture, newFuture)) {
-                         if (oldFuture != null) {
-                            oldFuture.cancel(true);
-                         }
-                         break;
-                    } else {
-                        // There was something else scheduled in the meantime... Cancel and try again.
-                       newFuture.cancel(true);
-                    }
-                } else {
-                    break;
-                }
-            }
-        }
-
-        boolean clearAndCancel() {
-            List<DefaultDnsCacheEntry> entries = getAndSet(Collections.<DefaultDnsCacheEntry>emptyList());
-            if (entries.isEmpty()) {
-                return false;
-            }
-
-            ScheduledFuture<?> expirationFuture = FUTURE_UPDATER.getAndSet(this, CANCELLED);
-            if (expirationFuture != null) {
-                expirationFuture.cancel(false);
-            }
-
-            return true;
-        }
-
-        @Override
-        public void run() {
-            // We always remove all entries for a hostname once one entry expire. This is not the
-            // most efficient to do but this way we can guarantee that if a DnsResolver
-            // be configured to prefer one ip family over the other we will not return unexpected
-            // results to the enduser if one of the A or AAAA records has different TTL settings.
-            //
-            // As a TTL is just a hint of the maximum time a cache is allowed to cache stuff it's
-            // completely fine to remove the entry even if the TTL is not reached yet.
-            //
-            // See https://github.com/netty/netty/issues/7329
-            resolveCache.remove(hostname, this);
-
-            clearAndCancel();
         }
     }
 

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddressStreamProvider.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddressStreamProvider.java
@@ -50,7 +50,6 @@ public final class DefaultDnsServerAddressStreamProvider implements DnsServerAdd
     public static final DefaultDnsServerAddressStreamProvider INSTANCE = new DefaultDnsServerAddressStreamProvider();
 
     private static final List<InetSocketAddress> DEFAULT_NAME_SERVER_LIST;
-    private static final InetSocketAddress[] DEFAULT_NAME_SERVER_ARRAY;
     private static final DnsServerAddresses DEFAULT_NAME_SERVERS;
     static final int DNS_PORT = 53;
 
@@ -142,8 +141,7 @@ public final class DefaultDnsServerAddressStreamProvider implements DnsServerAdd
         }
 
         DEFAULT_NAME_SERVER_LIST = Collections.unmodifiableList(defaultNameServers);
-        DEFAULT_NAME_SERVER_ARRAY = defaultNameServers.toArray(new InetSocketAddress[0]);
-        DEFAULT_NAME_SERVERS = sequential(DEFAULT_NAME_SERVER_ARRAY);
+        DEFAULT_NAME_SERVERS = sequential(DEFAULT_NAME_SERVER_LIST);
     }
 
     private DefaultDnsServerAddressStreamProvider() {
@@ -176,13 +174,5 @@ public final class DefaultDnsServerAddressStreamProvider implements DnsServerAdd
      */
     public static DnsServerAddresses defaultAddresses() {
         return DEFAULT_NAME_SERVERS;
-    }
-
-    /**
-     * Get the array form of {@link #defaultAddressList()}.
-     * @return The array form of {@link #defaultAddressList()}.
-     */
-    static InetSocketAddress[] defaultAddressArray() {
-        return DEFAULT_NAME_SERVER_ARRAY.clone();
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddresses.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DefaultDnsServerAddresses.java
@@ -17,16 +17,17 @@
 package io.netty.resolver.dns;
 
 import java.net.InetSocketAddress;
+import java.util.List;
 
 abstract class DefaultDnsServerAddresses extends DnsServerAddresses {
 
-    protected final InetSocketAddress[] addresses;
+    protected final List<InetSocketAddress> addresses;
     private final String strVal;
 
-    DefaultDnsServerAddresses(String type, InetSocketAddress[] addresses) {
+    DefaultDnsServerAddresses(String type, List<InetSocketAddress> addresses) {
         this.addresses = addresses;
 
-        final StringBuilder buf = new StringBuilder(type.length() + 2 + addresses.length * 16);
+        final StringBuilder buf = new StringBuilder(type.length() + 2 + addresses.size() * 16);
         buf.append(type).append('(');
 
         for (InetSocketAddress a: addresses) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
@@ -30,11 +30,14 @@ import io.netty.util.concurrent.Promise;
 final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
 
     private final DnsCache resolveCache;
+    private final AuthoritativeDnsServerCache authoritativeDnsServerCache;
 
     DnsAddressResolveContext(DnsNameResolver parent, String hostname, DnsRecord[] additionals,
-                             DnsServerAddressStream nameServerAddrs, DnsCache resolveCache) {
+                             DnsServerAddressStream nameServerAddrs, DnsCache resolveCache,
+                             AuthoritativeDnsServerCache authoritativeDnsServerCache) {
         super(parent, hostname, DnsRecord.CLASS_IN, parent.resolveRecordTypes(), additionals, nameServerAddrs);
         this.resolveCache = resolveCache;
+        this.authoritativeDnsServerCache = authoritativeDnsServerCache;
     }
 
     @Override
@@ -42,7 +45,8 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
                                                       int dnsClass, DnsRecordType[] expectedTypes,
                                                       DnsRecord[] additionals,
                                                       DnsServerAddressStream nameServerAddrs) {
-        return new DnsAddressResolveContext(parent, hostname, additionals, nameServerAddrs, resolveCache);
+        return new DnsAddressResolveContext(parent, hostname, additionals, nameServerAddrs, resolveCache,
+                authoritativeDnsServerCache);
     }
 
     @Override
@@ -89,8 +93,19 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     @Override
     void doSearchDomainQuery(String hostname, Promise<List<InetAddress>> nextPromise) {
         // Query the cache for the hostname first and only do a query if we could not find it in the cache.
-        if (!parent.doResolveAllCached(hostname, additionals, nextPromise, resolveCache)) {
+        if (!DnsNameResolver.doResolveAllCached(
+                hostname, additionals, nextPromise, resolveCache, parent.resolvedInternetProtocolFamiliesUnsafe())) {
             super.doSearchDomainQuery(hostname, nextPromise);
         }
+    }
+
+    @Override
+    DnsCache resolveCache() {
+        return resolveCache;
+    }
+
+    @Override
+    AuthoritativeDnsServerCache authoritativeDnsServerCache() {
+        return authoritativeDnsServerCache;
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddresses.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsServerAddresses.java
@@ -23,8 +23,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider.defaultAddressArray;
-
 /**
  * Provides an infinite sequence of DNS server addresses to {@link DnsNameResolver}.
  */
@@ -77,9 +75,9 @@ public abstract class DnsServerAddresses {
         return sequential0(sanitize(addresses));
     }
 
-    private static DnsServerAddresses sequential0(final InetSocketAddress... addresses) {
-        if (addresses.length == 1) {
-            return singleton(addresses[0]);
+    private static DnsServerAddresses sequential0(final List<InetSocketAddress> addresses) {
+        if (addresses.size() == 1) {
+            return singleton(addresses.get(0));
         }
 
         return new DefaultDnsServerAddresses("sequential", addresses) {
@@ -106,9 +104,9 @@ public abstract class DnsServerAddresses {
         return shuffled0(sanitize(addresses));
     }
 
-    private static DnsServerAddresses shuffled0(final InetSocketAddress[] addresses) {
-        if (addresses.length == 1) {
-            return singleton(addresses[0]);
+    private static DnsServerAddresses shuffled0(List<InetSocketAddress> addresses) {
+        if (addresses.size() == 1) {
+            return singleton(addresses.get(0));
         }
 
         return new DefaultDnsServerAddresses("shuffled", addresses) {
@@ -139,9 +137,9 @@ public abstract class DnsServerAddresses {
         return rotational0(sanitize(addresses));
     }
 
-    private static DnsServerAddresses rotational0(final InetSocketAddress[] addresses) {
-        if (addresses.length == 1) {
-            return singleton(addresses[0]);
+    private static DnsServerAddresses rotational0(List<InetSocketAddress> addresses) {
+        if (addresses.size() == 1) {
+            return singleton(addresses.get(0));
         }
 
         return new RotationalDnsServerAddresses(addresses);
@@ -161,7 +159,7 @@ public abstract class DnsServerAddresses {
         return new SingletonDnsServerAddresses(address);
     }
 
-    private static InetSocketAddress[] sanitize(Iterable<? extends InetSocketAddress> addresses) {
+    private static List<InetSocketAddress> sanitize(Iterable<? extends InetSocketAddress> addresses) {
         if (addresses == null) {
             throw new NullPointerException("addresses");
         }
@@ -187,10 +185,10 @@ public abstract class DnsServerAddresses {
             throw new IllegalArgumentException("empty addresses");
         }
 
-        return list.toArray(new InetSocketAddress[0]);
+        return list;
     }
 
-    private static InetSocketAddress[] sanitize(InetSocketAddress[] addresses) {
+    private static List<InetSocketAddress> sanitize(InetSocketAddress[] addresses) {
         if (addresses == null) {
             throw new NullPointerException("addresses");
         }
@@ -207,10 +205,10 @@ public abstract class DnsServerAddresses {
         }
 
         if (list.isEmpty()) {
-            return defaultAddressArray();
+            return DefaultDnsServerAddressStreamProvider.defaultAddressList();
         }
 
-        return list.toArray(new InetSocketAddress[0]);
+        return list;
     }
 
     /**

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/NameServerComparator.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/NameServerComparator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.util.internal.ObjectUtil;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Special {@link Comparator} implementation to sort the nameservers to use when follow redirects.
+ *
+ * This implementation follows all the semantics listed in the
+ * <a href="https://docs.oracle.com/javase/8/docs/api/java/util/Comparator.html">Comparator apidocs</a>
+ * with the limitation that {@link InetSocketAddress#equals(Object)} will not result in the same return value as
+ * {@link #compare(InetSocketAddress, InetSocketAddress)}. This is completely fine as this should only be used
+ * to sort {@link List}s.
+ */
+public final class NameServerComparator implements Comparator<InetSocketAddress>, Serializable {
+
+    private static final long serialVersionUID = 8372151874317596185L;
+
+    private final Class<? extends InetAddress> preferredAddressType;
+
+    public NameServerComparator(Class<? extends InetAddress> preferredAddressType) {
+        this.preferredAddressType = ObjectUtil.checkNotNull(preferredAddressType, "preferredAddressType");
+    }
+
+    @Override
+    public int compare(InetSocketAddress addr1, InetSocketAddress addr2) {
+        if (addr1.equals(addr2)) {
+            return 0;
+        }
+        if (!addr1.isUnresolved() && !addr2.isUnresolved()) {
+            if (addr1.getAddress().getClass() == addr2.getAddress().getClass()) {
+                return 0;
+            }
+            return preferredAddressType.isAssignableFrom(addr1.getAddress().getClass()) ? -1 : 1;
+        }
+        if (addr1.isUnresolved() && addr2.isUnresolved()) {
+            return 0;
+        }
+        return addr1.isUnresolved() ? 1 : -1;
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/NoopAuthoritativeDnsServerCache.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/NoopAuthoritativeDnsServerCache.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.EventLoop;
+import io.netty.util.internal.UnstableApi;
+
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A noop {@link AuthoritativeDnsServerCache} that actually never caches anything.
+ */
+@UnstableApi
+public final class NoopAuthoritativeDnsServerCache implements AuthoritativeDnsServerCache {
+    public static final NoopAuthoritativeDnsServerCache INSTANCE = new NoopAuthoritativeDnsServerCache();
+
+    private NoopAuthoritativeDnsServerCache() { }
+
+    @Override
+    public DnsServerAddressStream get(String hostname) {
+        return null;
+    }
+
+    @Override
+    public void cache(String hostname, InetSocketAddress address, long originalTtl, EventLoop loop) {
+        // NOOP
+    }
+
+    @Override
+    public void clear() {
+        // NOOP
+    }
+
+    @Override
+    public boolean clear(String hostname) {
+        return false;
+    }
+}

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/RotationalDnsServerAddresses.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/RotationalDnsServerAddresses.java
@@ -17,6 +17,7 @@
 package io.netty.resolver.dns;
 
 import java.net.InetSocketAddress;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 final class RotationalDnsServerAddresses extends DefaultDnsServerAddresses {
@@ -27,7 +28,7 @@ final class RotationalDnsServerAddresses extends DefaultDnsServerAddresses {
     @SuppressWarnings("UnusedDeclaration")
     private volatile int startIdx;
 
-    RotationalDnsServerAddresses(InetSocketAddress[] addresses) {
+    RotationalDnsServerAddresses(List<InetSocketAddress> addresses) {
         super("rotational", addresses);
     }
 
@@ -36,7 +37,7 @@ final class RotationalDnsServerAddresses extends DefaultDnsServerAddresses {
         for (;;) {
             int curStartIdx = startIdx;
             int nextStartIdx = curStartIdx + 1;
-            if (nextStartIdx >= addresses.length) {
+            if (nextStartIdx >= addresses.size()) {
                 nextStartIdx = 0;
             }
             if (startIdxUpdater.compareAndSet(this, curStartIdx, nextStartIdx)) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/SequentialDnsServerAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/SequentialDnsServerAddressStream.java
@@ -17,13 +17,15 @@
 package io.netty.resolver.dns;
 
 import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.List;
 
 final class SequentialDnsServerAddressStream implements DnsServerAddressStream {
 
-    private final InetSocketAddress[] addresses;
+    private final List<? extends InetSocketAddress> addresses;
     private int i;
 
-    SequentialDnsServerAddressStream(InetSocketAddress[] addresses, int startIdx) {
+    SequentialDnsServerAddressStream(List<? extends InetSocketAddress> addresses, int startIdx) {
         this.addresses = addresses;
         i = startIdx;
     }
@@ -31,8 +33,8 @@ final class SequentialDnsServerAddressStream implements DnsServerAddressStream {
     @Override
     public InetSocketAddress next() {
         int i = this.i;
-        InetSocketAddress next = addresses[i];
-        if (++ i < addresses.length) {
+        InetSocketAddress next = addresses.get(i);
+        if (++ i < addresses.size()) {
             this.i = i;
         } else {
             this.i = 0;
@@ -42,7 +44,7 @@ final class SequentialDnsServerAddressStream implements DnsServerAddressStream {
 
     @Override
     public int size() {
-        return addresses.length;
+        return addresses.size();
     }
 
     @Override
@@ -55,8 +57,8 @@ final class SequentialDnsServerAddressStream implements DnsServerAddressStream {
         return toString("sequential", i, addresses);
     }
 
-    static String toString(String type, int index, InetSocketAddress[] addresses) {
-        final StringBuilder buf = new StringBuilder(type.length() + 2 + addresses.length * 16);
+    static String toString(String type, int index, Collection<? extends InetSocketAddress> addresses) {
+        final StringBuilder buf = new StringBuilder(type.length() + 2 + addresses.size() * 16);
         buf.append(type).append("(index: ").append(index);
         buf.append(", addrs: (");
         for (InetSocketAddress a: addresses) {

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/ShuffledDnsServerAddressStream.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/ShuffledDnsServerAddressStream.java
@@ -19,11 +19,13 @@ package io.netty.resolver.dns;
 import io.netty.util.internal.PlatformDependent;
 
 import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.List;
 import java.util.Random;
 
 final class ShuffledDnsServerAddressStream implements DnsServerAddressStream {
 
-    private final InetSocketAddress[] addresses;
+    private final List<InetSocketAddress> addresses;
     private int i;
 
     /**
@@ -31,34 +33,26 @@ final class ShuffledDnsServerAddressStream implements DnsServerAddressStream {
      * @param addresses The addresses are not cloned. It is assumed the caller has cloned this array or otherwise will
      *                  not modify the contents.
      */
-    ShuffledDnsServerAddressStream(InetSocketAddress[] addresses) {
+    ShuffledDnsServerAddressStream(List<InetSocketAddress> addresses) {
         this.addresses = addresses;
 
         shuffle();
     }
 
-    private ShuffledDnsServerAddressStream(InetSocketAddress[] addresses, int startIdx) {
+    private ShuffledDnsServerAddressStream(List<InetSocketAddress> addresses, int startIdx) {
         this.addresses = addresses;
         i = startIdx;
     }
 
     private void shuffle() {
-        final InetSocketAddress[] addresses = this.addresses;
-        final Random r = PlatformDependent.threadLocalRandom();
-
-        for (int i = addresses.length - 1; i >= 0; i --) {
-            InetSocketAddress tmp = addresses[i];
-            int j = r.nextInt(i + 1);
-            addresses[i] = addresses[j];
-            addresses[j] = tmp;
-        }
+        Collections.shuffle(addresses, PlatformDependent.threadLocalRandom());
     }
 
     @Override
     public InetSocketAddress next() {
         int i = this.i;
-        InetSocketAddress next = addresses[i];
-        if (++ i < addresses.length) {
+        InetSocketAddress next = addresses.get(i);
+        if (++ i < addresses.size()) {
             this.i = i;
         } else {
             this.i = 0;
@@ -69,7 +63,7 @@ final class ShuffledDnsServerAddressStream implements DnsServerAddressStream {
 
     @Override
     public int size() {
-        return addresses.length;
+        return addresses.size();
     }
 
     @Override

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultAuthoritativeDnsServerCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultAuthoritativeDnsServerCacheTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.NetUtil;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+public class DefaultAuthoritativeDnsServerCacheTest {
+
+    @Test
+    public void testExpire() throws Throwable {
+        InetSocketAddress resolved1 = new InetSocketAddress(
+                InetAddress.getByAddress("ns1", new byte[] { 10, 0, 0, 1 }), 53);
+        InetSocketAddress resolved2 = new InetSocketAddress(
+                InetAddress.getByAddress("ns2", new byte[] { 10, 0, 0, 2 }), 53);
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final DefaultAuthoritativeDnsServerCache cache = new DefaultAuthoritativeDnsServerCache();
+            cache.cache("netty.io", resolved1, 1, loop);
+            cache.cache("netty.io", resolved2, 10000, loop);
+
+            Throwable error = loop.schedule(new Callable<Throwable>() {
+                @Override
+                public Throwable call() {
+                    try {
+                        assertNull(cache.get("netty.io"));
+                        return null;
+                    } catch (Throwable cause) {
+                        return cause;
+                    }
+                }
+            }, 1, TimeUnit.SECONDS).get();
+            if (error != null) {
+                throw error;
+            }
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testExpireWithDifferentTTLs() {
+        testExpireWithTTL0(1);
+        testExpireWithTTL0(1000);
+        testExpireWithTTL0(1000000);
+    }
+
+    private static void testExpireWithTTL0(int days) {
+        EventLoopGroup group = new NioEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final DefaultAuthoritativeDnsServerCache cache = new DefaultAuthoritativeDnsServerCache();
+            cache.cache("netty.io", new InetSocketAddress(NetUtil.LOCALHOST, 53), days, loop);
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testAddMultipleDnsServerForSameHostname() throws Exception {
+        InetSocketAddress resolved1 = new InetSocketAddress(
+                InetAddress.getByAddress("ns1", new byte[] { 10, 0, 0, 1 }), 53);
+        InetSocketAddress resolved2 = new InetSocketAddress(
+                InetAddress.getByAddress("ns2", new byte[] { 10, 0, 0, 2 }), 53);
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final DefaultAuthoritativeDnsServerCache cache = new DefaultAuthoritativeDnsServerCache();
+            cache.cache("netty.io", resolved1, 100, loop);
+            cache.cache("netty.io", resolved2, 10000, loop);
+
+            DnsServerAddressStream entries = cache.get("netty.io");
+            assertEquals(2, entries.size());
+            assertEquals(resolved1, entries.next());
+            assertEquals(resolved2, entries.next());
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testUnresolvedReplacedByResolved() throws Exception {
+        InetSocketAddress unresolved = InetSocketAddress.createUnresolved("ns1", 53);
+        InetSocketAddress resolved1 = new InetSocketAddress(
+                InetAddress.getByAddress("ns2", new byte[] { 10, 0, 0, 2 }), 53);
+        InetSocketAddress resolved2 = new InetSocketAddress(
+                InetAddress.getByAddress("ns1", new byte[] { 10, 0, 0, 1 }), 53);
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final DefaultAuthoritativeDnsServerCache cache = new DefaultAuthoritativeDnsServerCache();
+            cache.cache("netty.io", unresolved, 100, loop);
+            cache.cache("netty.io", resolved1, 10000, loop);
+
+            DnsServerAddressStream entries = cache.get("netty.io");
+            assertEquals(2, entries.size());
+            assertEquals(unresolved, entries.next());
+            assertEquals(resolved1, entries.next());
+
+            cache.cache("netty.io", resolved2, 100, loop);
+            DnsServerAddressStream entries2 = cache.get("netty.io");
+
+            assertEquals(2, entries2.size());
+            assertEquals(resolved2, entries2.next());
+            assertEquals(resolved1, entries2.next());
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+    @Test
+    public void testUseNoComparator() throws Exception {
+        testUseComparator0(true);
+    }
+
+    @Test
+    public void testUseComparator() throws Exception {
+        testUseComparator0(false);
+    }
+
+    private static void testUseComparator0(boolean noComparator) throws Exception {
+        InetSocketAddress unresolved = InetSocketAddress.createUnresolved("ns1", 53);
+        InetSocketAddress resolved = new InetSocketAddress(
+                InetAddress.getByAddress("ns2", new byte[] { 10, 0, 0, 2 }), 53);
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final DefaultAuthoritativeDnsServerCache cache;
+
+            if (noComparator) {
+                cache = new DefaultAuthoritativeDnsServerCache(10000, 10000, null);
+            }  else {
+                cache = new DefaultAuthoritativeDnsServerCache(10000, 10000,
+                                                               new Comparator<InetSocketAddress>() {
+                    @Override
+                    public int compare(InetSocketAddress o1, InetSocketAddress o2) {
+                        if (o1.equals(o2)) {
+                            return 0;
+                        }
+                        if (o1.isUnresolved()) {
+                            return 1;
+                        } else {
+                            return -1;
+                        }
+                    }
+                });
+            }
+            cache.cache("netty.io", unresolved, 100, loop);
+            cache.cache("netty.io", resolved, 10000, loop);
+
+            DnsServerAddressStream entries = cache.get("netty.io");
+            assertEquals(2, entries.size());
+
+            if (noComparator) {
+                assertEquals(unresolved, entries.next());
+                assertEquals(resolved, entries.next());
+            } else {
+                assertEquals(resolved, entries.next());
+                assertEquals(unresolved, entries.next());
+            }
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
+
+}

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/NameServerComparatorTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/NameServerComparatorTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2018 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.resolver.dns;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+
+public class NameServerComparatorTest {
+
+    private static InetSocketAddress IPV4ADDRESS1;
+    private static InetSocketAddress IPV4ADDRESS2;
+    private static InetSocketAddress IPV4ADDRESS3;
+
+    private static InetSocketAddress IPV6ADDRESS1;
+    private static InetSocketAddress IPV6ADDRESS2;
+
+    private static InetSocketAddress UNRESOLVED1;
+    private static InetSocketAddress UNRESOLVED2;
+    private static InetSocketAddress UNRESOLVED3;
+
+    @BeforeClass
+    public static void before() throws UnknownHostException {
+        IPV4ADDRESS1 = new InetSocketAddress(InetAddress.getByAddress("ns1", new byte[] { 10, 0, 0, 1 }), 53);
+        IPV4ADDRESS2 = new InetSocketAddress(InetAddress.getByAddress("ns2", new byte[] { 10, 0, 0, 2 }), 53);
+        IPV4ADDRESS3 = new InetSocketAddress(InetAddress.getByAddress("ns3", new byte[] { 10, 0, 0, 3 }), 53);
+
+        IPV6ADDRESS1 = new InetSocketAddress(InetAddress.getByAddress(
+                "ns1", new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }), 53);
+        IPV6ADDRESS2 = new InetSocketAddress(InetAddress.getByAddress(
+                "ns2", new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2 }), 53);
+
+        UNRESOLVED1 = InetSocketAddress.createUnresolved("ns3", 53);
+        UNRESOLVED2 = InetSocketAddress.createUnresolved("ns4", 53);
+        UNRESOLVED3 = InetSocketAddress.createUnresolved("ns5", 53);
+    }
+
+    @Test
+    public void testCompareResolvedOnly() {
+        NameServerComparator comparator = new NameServerComparator(Inet4Address.class);
+        int x = comparator.compare(IPV4ADDRESS1, IPV6ADDRESS1);
+        int y = comparator.compare(IPV6ADDRESS1, IPV4ADDRESS1);
+
+        assertEquals(-1, x);
+        assertEquals(x, -y);
+
+        assertEquals(0, comparator.compare(IPV4ADDRESS1, IPV4ADDRESS1));
+        assertEquals(0, comparator.compare(IPV6ADDRESS1, IPV6ADDRESS1));
+    }
+
+    @Test
+    public void testCompareUnresolvedSimple() {
+        NameServerComparator comparator = new NameServerComparator(Inet4Address.class);
+        int x = comparator.compare(IPV4ADDRESS1, UNRESOLVED1);
+        int y = comparator.compare(UNRESOLVED1, IPV4ADDRESS1);
+
+        assertEquals(-1, x);
+        assertEquals(x, -y);
+        assertEquals(0, comparator.compare(IPV4ADDRESS1, IPV4ADDRESS1));
+        assertEquals(0, comparator.compare(UNRESOLVED1, UNRESOLVED1));
+    }
+
+    @Test
+    public void testCompareUnresolvedOnly() {
+        NameServerComparator comparator = new NameServerComparator(Inet4Address.class);
+        int x = comparator.compare(UNRESOLVED1, UNRESOLVED2);
+        int y = comparator.compare(UNRESOLVED2, UNRESOLVED1);
+
+        assertEquals(0, x);
+        assertEquals(x, -y);
+
+        assertEquals(0, comparator.compare(UNRESOLVED1, UNRESOLVED1));
+        assertEquals(0, comparator.compare(UNRESOLVED2, UNRESOLVED2));
+    }
+
+    @Test
+    public void testSortAlreadySortedPreferred() {
+        List<InetSocketAddress> expected = Arrays.asList(IPV4ADDRESS1, IPV4ADDRESS2, IPV4ADDRESS3);
+        List<InetSocketAddress> addresses = new ArrayList<InetSocketAddress>(expected);
+        NameServerComparator comparator = new NameServerComparator(Inet4Address.class);
+
+        Collections.sort(addresses, comparator);
+
+        assertEquals(expected, addresses);
+    }
+
+    @Test
+    public void testSortAlreadySortedNotPreferred() {
+        List<InetSocketAddress> expected = Arrays.asList(IPV4ADDRESS1, IPV4ADDRESS2, IPV4ADDRESS3);
+        List<InetSocketAddress> addresses = new ArrayList<InetSocketAddress>(expected);
+        NameServerComparator comparator = new NameServerComparator(Inet6Address.class);
+
+        Collections.sort(addresses, comparator);
+
+        assertEquals(expected, addresses);
+    }
+
+    @Test
+    public void testSortAlreadySortedUnresolved() {
+        List<InetSocketAddress> expected = Arrays.asList(UNRESOLVED1, UNRESOLVED2, UNRESOLVED3);
+        List<InetSocketAddress> addresses = new ArrayList<InetSocketAddress>(expected);
+        NameServerComparator comparator = new NameServerComparator(Inet6Address.class);
+
+        Collections.sort(addresses, comparator);
+
+        assertEquals(expected, addresses);
+    }
+
+    @Test
+    public void testSortAlreadySortedMixed() {
+        List<InetSocketAddress> expected = Arrays.asList(
+                IPV4ADDRESS1, IPV4ADDRESS2, IPV6ADDRESS1, IPV6ADDRESS2, UNRESOLVED1, UNRESOLVED2);
+
+        List<InetSocketAddress> addresses = new ArrayList<InetSocketAddress>(expected);
+        NameServerComparator comparator = new NameServerComparator(Inet4Address.class);
+
+        Collections.sort(addresses, comparator);
+
+        assertEquals(expected, addresses);
+    }
+
+    @Test
+    public void testSort1() {
+        List<InetSocketAddress> expected = Arrays.asList(
+                IPV4ADDRESS1, IPV4ADDRESS2, IPV6ADDRESS1, IPV6ADDRESS2, UNRESOLVED1, UNRESOLVED2);
+        List<InetSocketAddress> addresses = new ArrayList<InetSocketAddress>(
+                Arrays.asList(IPV6ADDRESS1, IPV4ADDRESS1, IPV6ADDRESS2, UNRESOLVED1, UNRESOLVED2, IPV4ADDRESS2));
+        NameServerComparator comparator = new NameServerComparator(Inet4Address.class);
+
+        Collections.sort(addresses, comparator);
+
+        assertEquals(expected, addresses);
+    }
+
+    @Test
+    public void testSort2() {
+        List<InetSocketAddress> expected = Arrays.asList(
+                IPV4ADDRESS1, IPV4ADDRESS2, IPV6ADDRESS1, IPV6ADDRESS2, UNRESOLVED1, UNRESOLVED2);
+        List<InetSocketAddress> addresses = new ArrayList<InetSocketAddress>(
+                Arrays.asList(IPV4ADDRESS1, IPV6ADDRESS1, IPV6ADDRESS2, UNRESOLVED1, IPV4ADDRESS2, UNRESOLVED2));
+        NameServerComparator comparator = new NameServerComparator(Inet4Address.class);
+
+        Collections.sort(addresses, comparator);
+
+        assertEquals(expected, addresses);
+    }
+}

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/TestDnsServer.java
@@ -26,6 +26,7 @@ import org.apache.directory.server.dns.messages.RecordClass;
 import org.apache.directory.server.dns.messages.RecordType;
 import org.apache.directory.server.dns.messages.ResourceRecord;
 import org.apache.directory.server.dns.messages.ResourceRecordImpl;
+import org.apache.directory.server.dns.messages.ResourceRecordModifier;
 import org.apache.directory.server.dns.protocol.DnsProtocolHandler;
 import org.apache.directory.server.dns.protocol.DnsUdpDecoder;
 import org.apache.directory.server.dns.protocol.DnsUdpEncoder;
@@ -109,6 +110,30 @@ class TestDnsServer extends DnsServer {
 
     protected DnsMessage filterMessage(DnsMessage message) {
         return message;
+    }
+
+    protected static ResourceRecord newARecord(String name, String ipAddress) {
+        return newAddressRecord(name, RecordType.A, ipAddress);
+    }
+
+    protected static ResourceRecord newNsRecord(String dnsname, String domainName) {
+        ResourceRecordModifier rm = new ResourceRecordModifier();
+        rm.setDnsClass(RecordClass.IN);
+        rm.setDnsName(dnsname);
+        rm.setDnsTtl(100);
+        rm.setDnsType(RecordType.NS);
+        rm.put(DnsAttribute.DOMAIN_NAME, domainName);
+        return rm.getEntry();
+    }
+
+    protected static ResourceRecord newAddressRecord(String name, RecordType type, String address) {
+        ResourceRecordModifier rm = new ResourceRecordModifier();
+        rm.setDnsClass(RecordClass.IN);
+        rm.setDnsName(name);
+        rm.setDnsTtl(100);
+        rm.setDnsType(type);
+        rm.put(DnsAttribute.IP_ADDRESS, address);
+        return rm.getEntry();
     }
 
     /**


### PR DESCRIPTION
… record

Motiviation:

We incorrectly did ignore NS servers during redirect which had no ADDITIONAL record. This could at worse have the affect that we failed the query completely as none of the NS servers had a ADDITIONAL record. Beside this using a DnsCache to cache authoritative nameservers does not work in practise as we we need different features and semantics when cache these servers (for example we also want to cache unresolved nameservers and resolve these on the fly when needed).

Modifications:

- Correctly take NS records into account that have no matching ADDITIONAL record
- Correctly handle multiple ADDITIONAL records for the same NS record
- Introduce AuthoritativeDnsServerCache as a replacement of the DnsCache when caching authoritative nameservers + adding default implementation
- Add an adapter layer to reduce API breakage as much as possible
- Replace DnsNameResolver.uncachedRedirectDnsServerStream(...) with uncachedRedirectDnsServerList(...)
- Add unit tests

Result:

Our DnsResolver now correctly handle redirects in all cases.