### PR TITLE
Correctly handle hostnames with and without trailing dot in the DefaultDnsCache and use it for searchdomains.

### DIFF
--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsAddressResolveContext.java
@@ -25,6 +25,7 @@ import java.util.List;
 import io.netty.channel.EventLoop;
 import io.netty.handler.codec.dns.DnsRecord;
 import io.netty.handler.codec.dns.DnsRecordType;
+import io.netty.util.concurrent.Promise;
 
 final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
 
@@ -83,5 +84,13 @@ final class DnsAddressResolveContext extends DnsResolveContext<InetAddress> {
     @Override
     void cache(String hostname, DnsRecord[] additionals, UnknownHostException cause) {
         resolveCache.cache(hostname, additionals, cause, parent.ch.eventLoop());
+    }
+
+    @Override
+    void doSearchDomainQuery(String hostname, Promise<List<InetAddress>> nextPromise) {
+        // Query the cache for the hostname first and only do a query if we could not find it in the cache.
+        if (!parent.doResolveAllCached(hostname, additionals, nextPromise, resolveCache)) {
+            super.doSearchDomainQuery(hostname, nextPromise);
+        }
     }
 }

--- a/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
+++ b/resolver-dns/src/main/java/io/netty/resolver/dns/DnsNameResolver.java
@@ -790,7 +790,7 @@ public class DnsNameResolver extends InetNameResolver {
         }
     }
 
-    private boolean doResolveAllCached(String hostname,
+    boolean doResolveAllCached(String hostname,
                                        DnsRecord[] additionals,
                                        Promise<List<InetAddress>> promise,
                                        DnsCache resolveCache) {

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DefaultDnsCacheTest.java
@@ -172,4 +172,30 @@ public class DefaultDnsCacheTest {
             group.shutdownGracefully();
         }
     }
+
+    @Test
+    public void testDotHandling() throws Exception {
+        InetAddress addr1 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 1 });
+        InetAddress addr2 = InetAddress.getByAddress(new byte[] { 10, 0, 0, 2 });
+        EventLoopGroup group = new DefaultEventLoopGroup(1);
+
+        try {
+            EventLoop loop = group.next();
+            final DefaultDnsCache cache = new DefaultDnsCache(1, 100, 100);
+            cache.cache("netty.io", null, addr1, 10000, loop);
+            cache.cache("netty.io.", null, addr2, 10000, loop);
+
+            List<? extends DnsCacheEntry> entries = cache.get("netty.io", null);
+            assertEquals(2, entries.size());
+            assertEntry(entries.get(0), addr1);
+            assertEntry(entries.get(1), addr2);
+
+            List<? extends DnsCacheEntry> entries2 = cache.get("netty.io.", null);
+            assertEquals(2, entries2.size());
+            assertEntry(entries2.get(0), addr1);
+            assertEntry(entries2.get(1), addr2);
+        } finally {
+            group.shutdownGracefully();
+        }
+    }
 }

--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -96,13 +96,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class DnsNameResolverTest {
 
@@ -1746,8 +1740,7 @@ public class DnsNameResolverTest {
                     String hostname, DnsRecord[] additionals, Throwable cause, EventLoop loop) {
                 return null;
             }
-        })
-        .authoritativeDnsServerCache(new DnsCache() {
+        }).authoritativeDnsServerCache(new DnsCache() {
             @Override
             public void clear() {
                 authoritativeLatch.countDown();
@@ -1778,5 +1771,54 @@ public class DnsNameResolverTest {
         resolver.close();
         resolveLatch.await();
         authoritativeLatch.await();
+    }
+
+    @Test
+    public void testResolveACachedWithDot() {
+        final DnsCache cache = new DefaultDnsCache();
+        DnsNameResolver resolver = newResolver(ResolvedAddressTypes.IPV4_ONLY)
+                .resolveCache(cache).build();
+
+        try {
+            String domain = DOMAINS.iterator().next();
+            String domainWithDot = domain + '.';
+
+            resolver.resolve(domain).syncUninterruptibly();
+            List<? extends DnsCacheEntry> cached = cache.get(domain, null);
+            List<? extends DnsCacheEntry> cached2 = cache.get(domainWithDot, null);
+
+            assertEquals(1, cached.size());
+            assertSame(cached, cached2);
+        } finally {
+            resolver.close();
+        }
+    }
+
+    @Test
+    public void testResolveACachedWithDotSearchDomain() throws Exception {
+        final TestDnsCache cache = new TestDnsCache(new DefaultDnsCache());
+        TestDnsServer server = new TestDnsServer(Collections.singleton("test.netty.io"));
+        server.start();
+        DnsNameResolver resolver = newResolver(ResolvedAddressTypes.IPV4_ONLY)
+                .searchDomains(Collections.singletonList("netty.io"))
+                .nameServerProvider(new SingletonDnsServerAddressStreamProvider(server.localAddress()))
+                .resolveCache(cache).build();
+        try {
+            resolver.resolve("test").syncUninterruptibly();
+
+            assertNull(cache.cacheHits.get("test.netty.io"));
+
+            List<? extends DnsCacheEntry> cached = cache.cache.get("test.netty.io", null);
+            List<? extends DnsCacheEntry> cached2 = cache.cache.get("test.netty.io.", null);
+            assertEquals(1, cached.size());
+            assertSame(cached, cached2);
+
+            resolver.resolve("test").syncUninterruptibly();
+            List<? extends DnsCacheEntry> entries = cache.cacheHits.get("test.netty.io");
+            assertFalse(entries.isEmpty());
+        } finally {
+            resolver.close();
+            server.stop();
+        }
     }
 }


### PR DESCRIPTION
    Correctly handle hostnames with and without trailing dot in the DefaultDnsCache and use it for searchdomains.

    Motivation:

    We should ensure we return the same cached entries for the hostname and hostname ending with dot. Beside this we also should use it for the searchdomains as well.

    Modifications:

    - Internally always use hostname with a dot as a key and so ensure we correctly handle it in the cache.
    - Also query the cache for each searchdomain
    - Add unit tests

    Result:

    Use the same cached entries for hostname with and without trailing dot. Query the cache for each searchdomain query as well