### PR TITLE
Workaround JDK bug that will cause an AssertionError when calling Ser…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -703,6 +703,7 @@
             <ignore>java.net.StandardProtocolFamily</ignore>
             <ignore>java.nio.channels.spi.SelectorProvider</ignore>
             <ignore>java.net.SocketOption</ignore> 
+            <ignore>java.net.StandardSocketOptions</ignore> 
             <ignore>java.nio.channels.NetworkChannel</ignore>
 
             <!-- Self-signed certificate generation -->

--- a/transport/src/test/java/io/netty/channel/socket/nio/AbstractNioChannelTest.java
+++ b/transport/src/test/java/io/netty/channel/socket/nio/AbstractNioChannelTest.java
@@ -66,4 +66,14 @@ public abstract class AbstractNioChannelTest<T extends AbstractNioChannel> {
             channel.unsafe().closeForcibly();
         }
     }
+
+    @Test
+    public void testGetOptions()  {
+        T channel = newNioChannel();
+        try {
+            channel.config().getOptions();
+        } finally {
+            channel.unsafe().closeForcibly();
+        }
+    }
 }


### PR DESCRIPTION
…verSocketChannel.config().getOptions().

Motivation:

There is a JDK bug which will return IP_TOS as supported option for ServerSocketChannel even if its not supported afterwards and cause an AssertionError.
See http://mail.openjdk.java.net/pipermail/nio-dev/2018-August/005365.html.

Modifications:

Add a workaround for the JDK bug.

Result:

ServerSocketChannel.config().getOptions() will not throw anymore and work as expected.