### PR TITLE
We should try to load netty-tcnative before using it in OpenSslCertif…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateException.java
+++ b/handler/src/main/java/io/netty/handler/ssl/OpenSslCertificateException.java
@@ -70,7 +70,9 @@ public final class OpenSslCertificateException extends CertificateException {
     }
 
     private static int checkErrorCode(int errorCode) {
-        if (!CertificateVerifier.isValid(errorCode)) {
+        // Call OpenSsl.isAvailable() to ensure we try to load the native lib as CertificateVerifier.isValid(...)
+        // will depend on it. If loading fails we will just skip the validation.
+        if (OpenSsl.isAvailable() && !CertificateVerifier.isValid(errorCode)) {
             throw new IllegalArgumentException("errorCode '" + errorCode +
                     "' invalid, see https://www.openssl.org/docs/man1.0.2/apps/verify.html.");
         }

--- a/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateExceptionTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/OpenSslCertificateExceptionTest.java
@@ -18,20 +18,15 @@ package io.netty.handler.ssl;
 import io.netty.internal.tcnative.CertificateVerifier;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
 
 public class OpenSslCertificateExceptionTest {
 
-    @BeforeClass
-    public static void assumeOpenSsl() {
-        Assume.assumeTrue(OpenSsl.isAvailable());
-    }
-
     @Test
     public void testValidErrorCode() throws Exception {
+        Assume.assumeTrue(OpenSsl.isAvailable());
         Field[] fields = CertificateVerifier.class.getFields();
         for (Field field : fields) {
             if (field.isAccessible()) {
@@ -44,6 +39,13 @@ public class OpenSslCertificateExceptionTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testNonValidErrorCode() {
+        Assume.assumeTrue(OpenSsl.isAvailable());
         new OpenSslCertificateException(Integer.MIN_VALUE);
+    }
+
+    @Test
+    public void testCanBeInstancedWhenOpenSslIsNotAvailable() {
+        Assume.assumeFalse(OpenSsl.isAvailable());
+        new OpenSslCertificateException(0);
     }
 }


### PR DESCRIPTION
…icateException.

Motivation:

In OpenSslCertificateException we should ensure we try to load netty-tcnative before trying to use any class from it as otherwise it may throw an error due missing linking of the native libs.

Modifications:

- Ensure we call OpenSsl.isAvailable() before we try to use netty-tcnative for validation
- Add testcase.

Result:

No more errors causing by not loading native libs before trying to use these.