### PR TITLE
Add headers to MqttMessage returned by MqttDecoder in case of DecoderException

### DIFF
--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttDecoder.java
@@ -82,11 +82,11 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
             }
 
             case READ_VARIABLE_HEADER:  try {
+                final Result<?> decodedVariableHeader = decodeVariableHeader(buffer, mqttFixedHeader);
+                variableHeader = decodedVariableHeader.value;
                 if (bytesRemainingInVariablePart > maxBytesInMessage) {
                     throw new DecoderException("too large message: " + bytesRemainingInVariablePart + " bytes");
                 }
-                final Result<?> decodedVariableHeader = decodeVariableHeader(buffer, mqttFixedHeader);
-                variableHeader = decodedVariableHeader.value;
                 bytesRemainingInVariablePart -= decodedVariableHeader.numberOfBytesConsumed;
                 checkpoint(DecoderState.READ_PAYLOAD);
                 // fall through
@@ -133,7 +133,7 @@ public final class MqttDecoder extends ReplayingDecoder<DecoderState> {
 
     private MqttMessage invalidMessage(Throwable cause) {
       checkpoint(DecoderState.BAD_MESSAGE);
-      return MqttMessageFactory.newInvalidMessage(cause);
+      return MqttMessageFactory.newInvalidMessage(mqttFixedHeader, variableHeader, cause);
     }
 
     /**

--- a/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageFactory.java
+++ b/codec-mqtt/src/main/java/io/netty/handler/codec/mqtt/MqttMessageFactory.java
@@ -85,5 +85,10 @@ public final class MqttMessageFactory {
         return new MqttMessage(null, null, null, DecoderResult.failure(cause));
     }
 
+    public static MqttMessage newInvalidMessage(MqttFixedHeader mqttFixedHeader, Object variableHeader,
+                                                Throwable cause) {
+        return new MqttMessage(mqttFixedHeader, variableHeader, null, DecoderResult.failure(cause));
+    }
+
     private MqttMessageFactory() { }
 }

--- a/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
+++ b/codec-mqtt/src/test/java/io/netty/handler/codec/mqtt/MqttCodecTest.java
@@ -307,17 +307,21 @@ public class MqttCodecTest {
         final MqttConnectMessage message = createConnectMessage(MqttVersion.MQTT_3_1);
         ByteBuf byteBuf = MqttEncoder.doEncode(ALLOCATOR, message);
 
-        final List<Object> out = new LinkedList<Object>();
-        mqttDecoderLimitedMessageSize.decode(ctx, byteBuf, out);
+        try {
+            final List<Object> out = new LinkedList<Object>();
+            mqttDecoderLimitedMessageSize.decode(ctx, byteBuf, out);
 
-        assertEquals("Expected one object but got " + out.size(), 1, out.size());
+            assertEquals("Expected one object but got " + out.size(), 1, out.size());
 
-        final MqttMessage decodedMessage = (MqttMessage) out.get(0);
+            final MqttMessage decodedMessage = (MqttMessage) out.get(0);
 
-        validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
-        validateConnectVariableHeader(message.variableHeader(),
-                (MqttConnectVariableHeader) decodedMessage.variableHeader());
-        validateDecoderExceptionTooLargeMessage(decodedMessage);
+            validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
+            validateConnectVariableHeader(message.variableHeader(),
+                    (MqttConnectVariableHeader) decodedMessage.variableHeader());
+            validateDecoderExceptionTooLargeMessage(decodedMessage);
+        } finally {
+            byteBuf.release();
+        }
     }
 
     @Test
@@ -325,17 +329,21 @@ public class MqttCodecTest {
         final MqttConnectMessage message = createConnectMessage(MqttVersion.MQTT_3_1_1);
         ByteBuf byteBuf = MqttEncoder.doEncode(ALLOCATOR, message);
 
-        final List<Object> out = new LinkedList<Object>();
-        mqttDecoderLimitedMessageSize.decode(ctx, byteBuf, out);
+        try {
+            final List<Object> out = new LinkedList<Object>();
+            mqttDecoderLimitedMessageSize.decode(ctx, byteBuf, out);
 
-        assertEquals("Expected one object but got " + out.size(), 1, out.size());
+            assertEquals("Expected one object but got " + out.size(), 1, out.size());
 
-        final MqttMessage decodedMessage = (MqttMessage) out.get(0);
+            final MqttMessage decodedMessage = (MqttMessage) out.get(0);
 
-        validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
-        validateConnectVariableHeader(message.variableHeader(),
-                (MqttConnectVariableHeader) decodedMessage.variableHeader());
-        validateDecoderExceptionTooLargeMessage(decodedMessage);
+            validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
+            validateConnectVariableHeader(message.variableHeader(),
+                    (MqttConnectVariableHeader) decodedMessage.variableHeader());
+            validateDecoderExceptionTooLargeMessage(decodedMessage);
+        } finally {
+            byteBuf.release();
+        }
     }
 
     @Test
@@ -343,14 +351,18 @@ public class MqttCodecTest {
         final MqttConnAckMessage message = createConnAckMessage();
         ByteBuf byteBuf = MqttEncoder.doEncode(ALLOCATOR, message);
 
-        final List<Object> out = new LinkedList<Object>();
-        mqttDecoderLimitedMessageSize.decode(ctx, byteBuf, out);
+        try {
+            final List<Object> out = new LinkedList<Object>();
+            mqttDecoderLimitedMessageSize.decode(ctx, byteBuf, out);
 
-        assertEquals("Expected one object but got " + out.size(), 1, out.size());
+            assertEquals("Expected one object but got " + out.size(), 1, out.size());
 
-        final MqttMessage decodedMessage = (MqttMessage) out.get(0);
-        validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
-        validateDecoderExceptionTooLargeMessage(decodedMessage);
+            final MqttMessage decodedMessage = (MqttMessage) out.get(0);
+            validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
+            validateDecoderExceptionTooLargeMessage(decodedMessage);
+        } finally {
+            byteBuf.release();
+        }
     }
 
     @Test
@@ -358,17 +370,21 @@ public class MqttCodecTest {
         final MqttPublishMessage message = createPublishMessage();
         ByteBuf byteBuf = MqttEncoder.doEncode(ALLOCATOR, message);
 
-        final List<Object> out = new LinkedList<Object>();
-        mqttDecoderLimitedMessageSize.decode(ctx, byteBuf, out);
+        try {
+            final List<Object> out = new LinkedList<Object>();
+            mqttDecoderLimitedMessageSize.decode(ctx, byteBuf, out);
 
-        assertEquals("Expected one object but got " + out.size(), 1, out.size());
+            assertEquals("Expected one object but got " + out.size(), 1, out.size());
 
-        final MqttMessage decodedMessage = (MqttMessage) out.get(0);
+            final MqttMessage decodedMessage = (MqttMessage) out.get(0);
 
-        validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
-        validatePublishVariableHeader(message.variableHeader(),
-                (MqttPublishVariableHeader) decodedMessage.variableHeader());
-        validateDecoderExceptionTooLargeMessage(decodedMessage);
+            validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
+            validatePublishVariableHeader(message.variableHeader(),
+                    (MqttPublishVariableHeader) decodedMessage.variableHeader());
+            validateDecoderExceptionTooLargeMessage(decodedMessage);
+        } finally {
+            byteBuf.release();
+        }
     }
 
     @Test
@@ -376,16 +392,20 @@ public class MqttCodecTest {
         final MqttSubscribeMessage message = createSubscribeMessage();
         ByteBuf byteBuf = MqttEncoder.doEncode(ALLOCATOR, message);
 
-        final List<Object> out = new LinkedList<Object>();
-        mqttDecoderLimitedMessageSize.decode(ctx, byteBuf, out);
+        try {
+            final List<Object> out = new LinkedList<Object>();
+            mqttDecoderLimitedMessageSize.decode(ctx, byteBuf, out);
 
-        assertEquals("Expected one object but got " + out.size(), 1, out.size());
+            assertEquals("Expected one object but got " + out.size(), 1, out.size());
 
-        final MqttMessage decodedMessage = (MqttMessage) out.get(0);
-        validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
-        validateMessageIdVariableHeader(message.variableHeader(),
-                (MqttMessageIdVariableHeader) decodedMessage.variableHeader());
-        validateDecoderExceptionTooLargeMessage(decodedMessage);
+            final MqttMessage decodedMessage = (MqttMessage) out.get(0);
+            validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
+            validateMessageIdVariableHeader(message.variableHeader(),
+                    (MqttMessageIdVariableHeader) decodedMessage.variableHeader());
+            validateDecoderExceptionTooLargeMessage(decodedMessage);
+        } finally {
+            byteBuf.release();
+        }
     }
 
     @Test
@@ -393,16 +413,20 @@ public class MqttCodecTest {
         final MqttSubAckMessage message = createSubAckMessage();
         ByteBuf byteBuf = MqttEncoder.doEncode(ALLOCATOR, message);
 
-        final List<Object> out = new LinkedList<Object>();
-        mqttDecoderLimitedMessageSize.decode(ctx, byteBuf, out);
+        try {
+            final List<Object> out = new LinkedList<Object>();
+            mqttDecoderLimitedMessageSize.decode(ctx, byteBuf, out);
 
-        assertEquals("Expected one object but got " + out.size(), 1, out.size());
+            assertEquals("Expected one object but got " + out.size(), 1, out.size());
 
-        final MqttMessage decodedMessage = (MqttMessage) out.get(0);
-        validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
-        validateMessageIdVariableHeader(message.variableHeader(),
-                (MqttMessageIdVariableHeader) decodedMessage.variableHeader());
-        validateDecoderExceptionTooLargeMessage(decodedMessage);
+            final MqttMessage decodedMessage = (MqttMessage) out.get(0);
+            validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
+            validateMessageIdVariableHeader(message.variableHeader(),
+                    (MqttMessageIdVariableHeader) decodedMessage.variableHeader());
+            validateDecoderExceptionTooLargeMessage(decodedMessage);
+        } finally {
+            byteBuf.release();
+        }
     }
 
     @Test
@@ -410,16 +434,20 @@ public class MqttCodecTest {
         final MqttUnsubscribeMessage message = createUnsubscribeMessage();
         ByteBuf byteBuf = MqttEncoder.doEncode(ALLOCATOR, message);
 
-        final List<Object> out = new LinkedList<Object>();
-        mqttDecoderLimitedMessageSize.decode(ctx, byteBuf, out);
+        try {
+            final List<Object> out = new LinkedList<Object>();
+            mqttDecoderLimitedMessageSize.decode(ctx, byteBuf, out);
 
-        assertEquals("Expected one object but got " + out.size(), 1, out.size());
+            assertEquals("Expected one object but got " + out.size(), 1, out.size());
 
-        final MqttMessage decodedMessage = (MqttMessage) out.get(0);
-        validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
-        validateMessageIdVariableHeader(message.variableHeader(),
-                (MqttMessageIdVariableHeader) decodedMessage.variableHeader());
-        validateDecoderExceptionTooLargeMessage(decodedMessage);
+            final MqttMessage decodedMessage = (MqttMessage) out.get(0);
+            validateFixedHeaders(message.fixedHeader(), decodedMessage.fixedHeader());
+            validateMessageIdVariableHeader(message.variableHeader(),
+                    (MqttMessageIdVariableHeader) decodedMessage.variableHeader());
+            validateDecoderExceptionTooLargeMessage(decodedMessage);
+        } finally {
+            byteBuf.release();
+        }
     }
 
     private void testMessageWithOnlyFixedHeader(MqttMessageType messageType) throws Exception {
@@ -465,7 +493,7 @@ public class MqttCodecTest {
                 new MqttFixedHeader(
                         messageType,
                         false,
-                        messageType == MqttMessageType.PUBREL ? MqttQoS.AT_LEAST_ONCE :  MqttQoS.AT_MOST_ONCE,
+                        messageType == MqttMessageType.PUBREL ? MqttQoS.AT_LEAST_ONCE : MqttQoS.AT_MOST_ONCE,
                         false,
                         0);
         MqttMessageIdVariableHeader mqttMessageIdVariableHeader = MqttMessageIdVariableHeader.from(12345);
@@ -503,7 +531,7 @@ public class MqttCodecTest {
         MqttFixedHeader mqttFixedHeader =
                 new MqttFixedHeader(MqttMessageType.PUBLISH, false, MqttQoS.AT_LEAST_ONCE, true, 0);
         MqttPublishVariableHeader mqttPublishVariableHeader = new MqttPublishVariableHeader("/abc", 1234);
-        ByteBuf payload =  ALLOCATOR.buffer();
+        ByteBuf payload = ALLOCATOR.buffer();
         payload.writeBytes("whatever".getBytes(CharsetUtil.UTF_8));
         return new MqttPublishMessage(mqttFixedHeader, mqttPublishVariableHeader, payload);
     }


### PR DESCRIPTION
Motivation:
When the MqttDecoder decodes a message larger than the 'maxBytesInMessage' a DecoderException is thrown and a MqttMessage with just the failure cause is returned. Even if I can't handle the message, I might want to send an ACK so that I won't have to worry about it again.

Modification:
The DecoderException is thrown after the variableHeader is decoded. The fixed and variable headers are then added to the MqttMessage along with the failure cause.

Result:
The invalid MqttMessage will have headers if available.
