### PR TITLE
We should prefer direct buffers if we can access the cleaner even if …

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -79,8 +79,7 @@ public final class PlatformDependent {
     private static final boolean CAN_ENABLE_TCP_NODELAY_BY_DEFAULT = !isAndroid();
 
     private static final Throwable UNSAFE_UNAVAILABILITY_CAUSE = unsafeUnavailabilityCause0();
-    private static final boolean DIRECT_BUFFER_PREFERRED =
-            UNSAFE_UNAVAILABILITY_CAUSE == null && !SystemPropertyUtil.getBoolean("io.netty.noPreferDirect", false);
+    private static final boolean DIRECT_BUFFER_PREFERRED;
     private static final long MAX_DIRECT_MEMORY = maxDirectMemory0();
 
     private static final int MPSC_CHUNK_SIZE =  1024;
@@ -127,9 +126,6 @@ public final class PlatformDependent {
                     return ThreadLocalRandom.current();
                 }
             };
-        }
-        if (logger.isDebugEnabled()) {
-            logger.debug("-Dio.netty.noPreferDirect: {}", !DIRECT_BUFFER_PREFERRED);
         }
 
         /*
@@ -189,6 +185,13 @@ public final class PlatformDependent {
             }
         } else {
             CLEANER = NOOP;
+        }
+
+        // We should always prefer direct buffers by default if we can use a Cleaner to release direct buffers.
+        DIRECT_BUFFER_PREFERRED = CLEANER != NOOP
+                                  && !SystemPropertyUtil.getBoolean("io.netty.noPreferDirect", false);
+        if (logger.isDebugEnabled()) {
+            logger.debug("-Dio.netty.noPreferDirect: {}", !DIRECT_BUFFER_PREFERRED);
         }
     }
 


### PR DESCRIPTION
…sun.misc.Unsafe is not present.

Motivation:

We should prefer direct buffers whenever we can use the cleaner even if sun.misc.Unsafe is not present.

Modifications:

Correctly prefer direct buffers in all cases.

Result:

More correct code.