### PR TITLE
Correctly implement SelectedSelectionKeySet iterator(), contains(...)…

### DIFF
--- a/transport/src/main/java/io/netty/channel/nio/SelectedSelectionKeySet.java
+++ b/transport/src/main/java/io/netty/channel/nio/SelectedSelectionKeySet.java
@@ -19,6 +19,7 @@ import java.nio.channels.SelectionKey;
 import java.util.AbstractSet;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 final class SelectedSelectionKeySet extends AbstractSet<SelectionKey> {
 
@@ -49,18 +50,23 @@ final class SelectedSelectionKeySet extends AbstractSet<SelectionKey> {
     }
 
     @Override
-    public boolean remove(Object o) {
-        return false;
-    }
-
-    @Override
-    public boolean contains(Object o) {
-        return false;
-    }
-
-    @Override
     public Iterator<SelectionKey> iterator() {
-        throw new UnsupportedOperationException();
+        return new Iterator<SelectionKey>() {
+            private int idx;
+
+            @Override
+            public boolean hasNext() {
+                return idx < size;
+            }
+
+            @Override
+            public SelectionKey next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                return keys[idx++];
+            }
+        };
     }
 
     void reset() {

--- a/transport/src/test/java/io/netty/channel/nio/SelectedSelectionKeySetTest.java
+++ b/transport/src/test/java/io/netty/channel/nio/SelectedSelectionKeySetTest.java
@@ -21,18 +21,19 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.nio.channels.SelectionKey;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class SelectedSelectionKeySetTest {
     @Mock
     private SelectionKey mockKey;
     @Mock
     private SelectionKey mockKey2;
+
+    @Mock
+    private SelectionKey mockKey3;
 
     @Before
     public void setup() {
@@ -62,5 +63,55 @@ public class SelectedSelectionKeySetTest {
         assertNull(set.keys[1]);
         assertEquals(0, set.size());
         assertTrue(set.isEmpty());
+    }
+
+    @Test
+    public void iterator() {
+        SelectedSelectionKeySet set = new SelectedSelectionKeySet();
+        assertTrue(set.add(mockKey));
+        assertTrue(set.add(mockKey2));
+        Iterator<SelectionKey> keys = set.iterator();
+        assertTrue(keys.hasNext());
+        assertSame(mockKey, keys.next());
+        assertTrue(keys.hasNext());
+        assertSame(mockKey2, keys.next());
+        assertFalse(keys.hasNext());
+
+        try {
+            keys.next();
+            fail();
+        } catch (NoSuchElementException expected) {
+            // expected
+        }
+
+        try {
+            keys.remove();
+            fail();
+        } catch (UnsupportedOperationException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void contains() {
+        SelectedSelectionKeySet set = new SelectedSelectionKeySet();
+        assertTrue(set.add(mockKey));
+        assertTrue(set.add(mockKey2));
+        assertTrue(set.contains(mockKey));
+        assertTrue(set.contains(mockKey2));
+        assertFalse(set.contains(mockKey3));
+    }
+
+    @Test
+    public void remove() {
+        SelectedSelectionKeySet set = new SelectedSelectionKeySet();
+        assertTrue(set.add(mockKey));
+        assertFalse(set.remove(mockKey2));
+        try {
+            set.remove(mockKey);
+            fail();
+        } catch (UnsupportedOperationException expected) {
+            // expected
+        }
     }
 }


### PR DESCRIPTION
… and remove(...)

Motivation:

Our SelectedSelectionKeySet does not correctly implement various methods which can be done without any performance overhead.

Modifications:

Implement iterator(), contains(...) and remove(...)

Result:

Related to https://github.com/netty/netty/issues/8242.