### PR TITLE
Cleanup Log4J2Logger

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/AbstractInternalLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/AbstractInternalLogger.java
@@ -29,7 +29,7 @@ public abstract class AbstractInternalLogger implements InternalLogger, Serializ
 
     private static final long serialVersionUID = -6382972526573193470L;
 
-    private static final String EXCEPTION_MESSAGE = "Unexpected exception:";
+    static final String EXCEPTION_MESSAGE = "Unexpected exception:";
 
     private final String name;
 

--- a/common/src/main/java/io/netty/util/internal/logging/Log4J2Logger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Log4J2Logger.java
@@ -21,12 +21,11 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.spi.ExtendedLogger;
 import org.apache.logging.log4j.spi.ExtendedLoggerWrapper;
 
+import static io.netty.util.internal.logging.AbstractInternalLogger.EXCEPTION_MESSAGE;
+
 class Log4J2Logger extends ExtendedLoggerWrapper implements InternalLogger {
 
     private static final long serialVersionUID = 5485418394879791397L;
-
-    /** {@linkplain AbstractInternalLogger#EXCEPTION_MESSAGE} */
-    private static final String EXCEPTION_MESSAGE = "Unexpected exception:";
 
     Log4J2Logger(Logger logger) {
         super((ExtendedLogger) logger, logger.getName(), logger.getMessageFactory());
@@ -97,7 +96,7 @@ class Log4J2Logger extends ExtendedLoggerWrapper implements InternalLogger {
         log(toLevel(level), EXCEPTION_MESSAGE, t);
     }
 
-    protected Level toLevel(InternalLogLevel level) {
+    private static Level toLevel(InternalLogLevel level) {
         switch (level) {
             case INFO:
                 return Level.INFO;

--- a/common/src/test/java/io/netty/util/internal/logging/Log4J2LoggerTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/Log4J2LoggerTest.java
@@ -17,7 +17,6 @@ package io.netty.util.internal.logging;
 
 import static org.junit.Assert.assertEquals;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
@@ -29,7 +28,6 @@ import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.spi.ExtendedLoggerWrapper;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assume;
-import org.junit.Test;
 
 import io.netty.util.internal.ReflectionUtil;
 
@@ -54,25 +52,6 @@ public class Log4J2LoggerTest extends AbstractInternalLoggerTest<Logger> {
                 super.logMessage(fqcn, level, marker, message, t);
             };
         };
-    }
-
-    @Test
-    public void testEXCEPTION_MESSAGE() {
-        assertEquals(getFieldValue(AbstractInternalLogger.class, "EXCEPTION_MESSAGE"),
-                getFieldValue(Log4J2Logger.class, "EXCEPTION_MESSAGE"));
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T> T getFieldValue(Class<?> clazz, String fieldName) {
-        try {
-            Field field = clazz.getDeclaredField(fieldName);
-            if (!field.isAccessible()) {
-                Assume.assumeThat(ReflectionUtil.trySetAccessible(field, true), CoreMatchers.nullValue());
-            }
-            return (T) field.get(AbstractInternalLogger.class);
-        } catch (ReflectiveOperationException e) {
-            throw new IllegalStateException(e);
-        }
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Log4J2Logger had some code-duplication with AbstractInternalLogger

Modifications:

Reuse AbstractInternaLogger.EXCEPTION_MESSAGE in Log4J2Logger and so remove some code-duplication

Result:

Less duplicated code.