### PR TITLE
PemPrivateKey.toPem(...) should throw IllegalArgumentException when P…

### DIFF
--- a/handler/src/main/java/io/netty/handler/ssl/PemPrivateKey.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemPrivateKey.java
@@ -62,7 +62,7 @@ public final class PemPrivateKey extends AbstractReferenceCounted implements Pri
 
         byte[] bytes = key.getEncoded();
         if (bytes == null) {
-            throw new IllegalArgumentException(key + " does not support encoding");
+            throw new IllegalArgumentException(key.getClass().getName() + " does not support encoding");
         }
 
         ByteBuf encoded = Unpooled.wrappedBuffer(bytes);

--- a/handler/src/main/java/io/netty/handler/ssl/PemPrivateKey.java
+++ b/handler/src/main/java/io/netty/handler/ssl/PemPrivateKey.java
@@ -60,7 +60,12 @@ public final class PemPrivateKey extends AbstractReferenceCounted implements Pri
             return ((PemEncoded) key).retain();
         }
 
-        ByteBuf encoded = Unpooled.wrappedBuffer(key.getEncoded());
+        byte[] bytes = key.getEncoded();
+        if (bytes == null) {
+            throw new IllegalArgumentException(key + " does not support encoding");
+        }
+
+        ByteBuf encoded = Unpooled.wrappedBuffer(bytes);
         try {
             ByteBuf base64 = SslUtils.toBase64(allocator, encoded);
             try {

--- a/handler/src/test/java/io/netty/handler/ssl/PemEncodedTest.java
+++ b/handler/src/test/java/io/netty/handler/ssl/PemEncodedTest.java
@@ -24,7 +24,10 @@ import static org.junit.Assume.assumeTrue;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.security.PrivateKey;
 
+import io.netty.buffer.Unpooled;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import org.junit.Test;
 
 import io.netty.handler.ssl.util.SelfSignedCertificate;
@@ -67,6 +70,26 @@ public class PemEncodedTest {
             assertRelease(pemKey);
             assertRelease(pemCert);
         }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEncodedReturnsNull() throws Exception {
+        PemPrivateKey.toPEM(UnpooledByteBufAllocator.DEFAULT, true, new PrivateKey() {
+            @Override
+            public String getAlgorithm() {
+                return null;
+            }
+
+            @Override
+            public String getFormat() {
+                return null;
+            }
+
+            @Override
+            public byte[] getEncoded() {
+                return null;
+            }
+        });
     }
 
     private static void assertRelease(PemEncoded encoded) {


### PR DESCRIPTION
…rivateKey which does not support encoding is used.

Motivation:

At the moment when a PrivateKey is used that does not support encoding we throw a NPE when trying to convert the key. We should better throw an IllegalArgumentException with the details about what key we tried to encode.

Modifications:

- Check if PrivateKey.getEncoded() returns null and if so throw an IllegalArgumentException
- Add unit test.

Result:

Better handling of non-supported PrivateKey implementations.