### PR TITLE
Log the correct line-number when using SLF4j with netty if possible.

### DIFF
--- a/common/src/main/java/io/netty/util/internal/logging/LocationAwareSlf4JLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/LocationAwareSlf4JLogger.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.util.internal.logging;
+
+import org.slf4j.spi.LocationAwareLogger;
+
+import static org.slf4j.spi.LocationAwareLogger.*;
+
+/**
+ * <a href="http://www.slf4j.org/">SLF4J</a> logger which is location aware and so will log the correct origin of the
+ * logging event by filter out the wrapper itself.
+ */
+final class LocationAwareSlf4JLogger extends AbstractInternalLogger {
+
+    // IMPORTANT: All our log methods first check if the log level is enabled before call the wrapped
+    // LocationAwareLogger.log(...) method. This is done to reduce GC creation that is caused by varargs.
+
+    private static final String FQCN = LocationAwareSlf4JLogger.class.getName();
+    private static final long serialVersionUID = -8292030083201538180L;
+
+    private final transient LocationAwareLogger logger;
+
+    LocationAwareSlf4JLogger(LocationAwareLogger logger) {
+        super(logger.getName());
+        this.logger = logger;
+    }
+
+    private void log(final int level, final String message, final Object... params) {
+        logger.log(null, FQCN, level, message, params, null);
+    }
+
+    private void log(final int level, final String message, Throwable throwable, final Object... params) {
+        logger.log(null, FQCN, level, message, params, throwable);
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return logger.isTraceEnabled();
+    }
+
+    @Override
+    public void trace(String msg) {
+        if (isTraceEnabled()) {
+            log(TRACE_INT, msg, null);
+        }
+    }
+
+    @Override
+    public void trace(String format, Object arg) {
+        if (isTraceEnabled()) {
+            log(TRACE_INT, format, arg);
+        }
+    }
+
+    @Override
+    public void trace(String format, Object argA, Object argB) {
+        if (isTraceEnabled()) {
+            log(TRACE_INT, format, argA, argB);
+        }
+    }
+
+    @Override
+    public void trace(String format, Object... argArray) {
+        if (isTraceEnabled()) {
+            log(TRACE_INT, format, argArray);
+        }
+    }
+
+    @Override
+    public void trace(String msg, Throwable t) {
+        if (isTraceEnabled()) {
+            log(TRACE_INT, msg, t);
+        }
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    @Override
+    public void debug(String msg) {
+        if (isDebugEnabled()) {
+            log(DEBUG_INT, msg);
+        }
+    }
+
+    @Override
+    public void debug(String format, Object arg) {
+        if (isDebugEnabled()) {
+            log(DEBUG_INT, format, arg);
+        }
+    }
+
+    @Override
+    public void debug(String format, Object argA, Object argB) {
+        if (isDebugEnabled()) {
+            log(DEBUG_INT, format, argA, argB);
+        }
+    }
+
+    @Override
+    public void debug(String format, Object... argArray) {
+        if (isDebugEnabled()) {
+            log(DEBUG_INT, format, argArray);
+        }
+    }
+
+    @Override
+    public void debug(String msg, Throwable t) {
+        if (isDebugEnabled()) {
+            log(DEBUG_INT, msg, t);
+        }
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return logger.isInfoEnabled();
+    }
+
+    @Override
+    public void info(String msg) {
+        if (isInfoEnabled()) {
+            log(INFO_INT, msg);
+        }
+    }
+
+    @Override
+    public void info(String format, Object arg) {
+        if (isInfoEnabled()) {
+            log(INFO_INT, format, arg);
+        }
+    }
+
+    @Override
+    public void info(String format, Object argA, Object argB) {
+        if (isInfoEnabled()) {
+            log(INFO_INT, format, argA, argB);
+        }
+    }
+
+    @Override
+    public void info(String format, Object... argArray) {
+        if (isInfoEnabled()) {
+            log(INFO_INT, format, argArray);
+        }
+    }
+
+    @Override
+    public void info(String msg, Throwable t) {
+        if (isInfoEnabled()) {
+            log(INFO_INT, msg);
+        }
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return logger.isWarnEnabled();
+    }
+
+    @Override
+    public void warn(String msg) {
+        if (isWarnEnabled()) {
+            log(WARN_INT, msg);
+        }
+    }
+
+    @Override
+    public void warn(String format, Object arg) {
+        if (isWarnEnabled()) {
+            log(WARN_INT, format, arg);
+        }
+    }
+
+    @Override
+    public void warn(String format, Object... argArray) {
+        if (isWarnEnabled()) {
+            log(WARN_INT, format, argArray);
+        }
+    }
+
+    @Override
+    public void warn(String format, Object argA, Object argB) {
+        if (isWarnEnabled()) {
+            log(WARN_INT, format, argA, argB);
+        }
+    }
+
+    @Override
+    public void warn(String msg, Throwable t) {
+        if (isWarnEnabled()) {
+            log(WARN_INT, msg);
+        }
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return logger.isErrorEnabled();
+    }
+
+    @Override
+    public void error(String msg) {
+        if (isErrorEnabled()) {
+            log(ERROR_INT, msg);
+        }
+    }
+
+    @Override
+    public void error(String format, Object arg) {
+        if (isErrorEnabled()) {
+            log(ERROR_INT, format, arg);
+        }
+    }
+
+    @Override
+    public void error(String format, Object argA, Object argB) {
+        if (isErrorEnabled()) {
+            log(ERROR_INT, format, argA, argB);
+        }
+    }
+
+    @Override
+    public void error(String format, Object... argArray) {
+        if (isErrorEnabled()) {
+            log(ERROR_INT, format, argArray);
+        }
+    }
+
+    @Override
+    public void error(String msg, Throwable t) {
+        if (isErrorEnabled()) {
+            log(ERROR_INT, msg, t);
+        }
+    }
+}

--- a/common/src/main/java/io/netty/util/internal/logging/LocationAwareSlf4JLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/LocationAwareSlf4JLogger.java
@@ -162,7 +162,7 @@ final class LocationAwareSlf4JLogger extends AbstractInternalLogger {
     @Override
     public void info(String msg, Throwable t) {
         if (isInfoEnabled()) {
-            log(INFO_INT, msg);
+            log(INFO_INT, msg, t);
         }
     }
 
@@ -202,7 +202,7 @@ final class LocationAwareSlf4JLogger extends AbstractInternalLogger {
     @Override
     public void warn(String msg, Throwable t) {
         if (isWarnEnabled()) {
-            log(WARN_INT, msg);
+            log(WARN_INT, msg, t);
         }
     }
 

--- a/common/src/main/java/io/netty/util/internal/logging/Slf4JLogger.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Slf4JLogger.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 /**
  * <a href="http://www.slf4j.org/">SLF4J</a> logger.
  */
-class Slf4JLogger extends AbstractInternalLogger {
+final class Slf4JLogger extends AbstractInternalLogger {
 
     private static final long serialVersionUID = 108038972685130825L;
 

--- a/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
@@ -51,7 +51,7 @@ public class Slf4JLoggerFactory extends InternalLoggerFactory {
 
     // package-private for testing.
     static InternalLogger wrapLogger(Logger logger) {
-        return  logger instanceof LocationAwareLogger ?
+        return logger instanceof LocationAwareLogger ?
                 new LocationAwareSlf4JLogger((LocationAwareLogger) logger) : new Slf4JLogger(logger);
     }
 }

--- a/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
+++ b/common/src/main/java/io/netty/util/internal/logging/Slf4JLoggerFactory.java
@@ -16,8 +16,10 @@
 package io.netty.util.internal.logging;
 
 
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.NOPLoggerFactory;
+import org.slf4j.spi.LocationAwareLogger;
 
 /**
  * Logger factory which creates a <a href="http://www.slf4j.org/">SLF4J</a>
@@ -44,6 +46,12 @@ public class Slf4JLoggerFactory extends InternalLoggerFactory {
 
     @Override
     public InternalLogger newInstance(String name) {
-        return new Slf4JLogger(LoggerFactory.getLogger(name));
+        return wrapLogger(LoggerFactory.getLogger(name));
+    }
+
+    // package-private for testing.
+    static InternalLogger wrapLogger(Logger logger) {
+        return  logger instanceof LocationAwareLogger ?
+                new LocationAwareSlf4JLogger((LocationAwareLogger) logger) : new Slf4JLogger(logger);
     }
 }

--- a/common/src/test/java/io/netty/util/internal/logging/Slf4JLoggerFactoryTest.java
+++ b/common/src/test/java/io/netty/util/internal/logging/Slf4JLoggerFactoryTest.java
@@ -16,15 +16,38 @@
 package io.netty.util.internal.logging;
 
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.spi.LocationAwareLogger;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class Slf4JLoggerFactoryTest {
 
     @Test
     public void testCreation() {
         InternalLogger logger = Slf4JLoggerFactory.INSTANCE.newInstance("foo");
-        assertTrue(logger instanceof Slf4JLogger);
+        assertTrue(logger instanceof Slf4JLogger || logger instanceof LocationAwareSlf4JLogger);
         assertEquals("foo", logger.name());
+    }
+
+    @Test
+    public void testCreationLogger() {
+        Logger logger = mock(Logger.class);
+        when(logger.getName()).thenReturn("testlogger");
+        InternalLogger internalLogger = Slf4JLoggerFactory.wrapLogger(logger);
+        assertTrue(internalLogger instanceof Slf4JLogger);
+        assertEquals("testlogger", internalLogger.name());
+    }
+
+    @Test
+    public void testCreationLocationAwareLogger() {
+        Logger logger = mock(LocationAwareLogger.class);
+        when(logger.getName()).thenReturn("testlogger");
+        InternalLogger internalLogger = Slf4JLoggerFactory.wrapLogger(logger);
+        assertTrue(internalLogger instanceof LocationAwareSlf4JLogger);
+        assertEquals("testlogger", internalLogger.name());
     }
 }


### PR DESCRIPTION
Motivation:

At the moment we do not log the correct line number in many cases as it will log the line number of the logger wrapper itself. Slf4j does have an extra interface that can be used to filter out these nad make it more usable with logging wrappers.

Modifications:

Detect if the returned logger implements LocationAwareLogger and if so make use of its extra methods to be able to log the correct origin of the log request.

Result:

Better logging when using slf4j.