### PR TITLE
Update to jmh 1.2.1

### DIFF
--- a/microbench/pom.xml
+++ b/microbench/pom.xml
@@ -31,7 +31,7 @@
   <properties>
     <!-- Skip tests by default; run only if -DskipTests=false is specified -->
     <skipTests>true</skipTests>
-    <jmh.version>1.19</jmh.version>
+    <jmh.version>1.21</jmh.version>
     <!-- This only be set when run on linux as on other platforms we just want to include the jar without native
          code -->
     <epoll.classifier/>


### PR DESCRIPTION
Motivation:

We should use the latest jmh version which also supports -prof dtraceasm on MacOS.

Modifications:

Update to latest jmh version.

Result:

Better benchmark / profiling support on MacOS.