### PR TITLE
Don't cause ClassCastException if registration fails during constructing…

### DIFF
--- a/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
+++ b/resolver-dns/src/test/java/io/netty/resolver/dns/DnsNameResolverTest.java
@@ -2270,4 +2270,20 @@ public class DnsNameResolverTest {
             server.stop();
         }
     }
+
+    @Test
+    public void testChannelFactoryException() {
+        final IllegalStateException exception = new IllegalStateException();
+        try {
+            newResolver().channelFactory(new ChannelFactory<DatagramChannel>() {
+                @Override
+                public DatagramChannel newChannel() {
+                    throw exception;
+                }
+            }).build();
+            fail();
+        } catch (Exception e) {
+            assertSame(exception, e);
+        }
+    }
 }


### PR DESCRIPTION
… DnsNameResolver.

Motivation:

We should not try to cast the Channel to a DatagramChannel as this will cause a ClassCastException.

Modifications:

- Do not cast
- rethrow from constructor if we detect the registration failed.
- Add unit test.

Result:

Propagate correct exception.